### PR TITLE
[codex] Refactor plugin SQL builders

### DIFF
--- a/Plugins/BigQueryDriverPlugin/BigQueryPluginDriver.swift
+++ b/Plugins/BigQueryDriverPlugin/BigQueryPluginDriver.swift
@@ -748,21 +748,25 @@ internal final class BigQueryPluginDriver: PluginDatabaseDriver, @unchecked Send
         guard let conn = connection else { return nil }
         let dataset = lock.withLock { _currentDataset } ?? ""
         let fqTable = "`\(conn.projectId).\(dataset).\(table)`"
-        var sql = "ALTER TABLE \(fqTable) ADD COLUMN \(quoteIdentifier(column.name)) \(column.dataType)"
+        var columnSQL = "\(quoteIdentifier(column.name)) \(column.dataType)"
         if !column.isNullable {
-            sql += " NOT NULL"
+            columnSQL += " NOT NULL"
         }
         if let comment = column.comment, !comment.isEmpty {
-            sql += " OPTIONS(description='\(escapeStringLiteral(comment))')"
+            columnSQL += " OPTIONS(description='\(escapeStringLiteral(comment))')"
         }
-        return sql
+        return PluginSQLDDLBuilder.alterTableAddColumnDefinition(tableSQL: fqTable, columnSQL: columnSQL)
     }
 
     func generateDropColumnSQL(table: String, columnName: String) -> String? {
         guard let conn = connection else { return nil }
         let dataset = lock.withLock { _currentDataset } ?? ""
         let fqTable = "`\(conn.projectId).\(dataset).\(table)`"
-        return "ALTER TABLE \(fqTable) DROP COLUMN \(quoteIdentifier(columnName))"
+        return PluginSQLDDLBuilder.alterTableDropColumnDefinition(
+            tableSQL: fqTable,
+            columnName: columnName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     func allTablesMetadataSQL(schema: String?) -> String? {

--- a/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
+++ b/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
@@ -557,11 +557,20 @@ internal final class CassandraPluginDriver: PluginDatabaseDriver, @unchecked Sen
     // MARK: - ALTER TABLE DDL
 
     func generateAddColumnSQL(table: String, column: PluginColumnDefinition) -> String? {
-        "ALTER TABLE \(qualifiedTableName(table)) ADD \(quoteIdentifier(column.name)) \(column.dataType)"
+        PluginSQLDDLBuilder.alterTableAddColumnDefinition(
+            tableSQL: qualifiedTableName(table),
+            columnSQL: "\(quoteIdentifier(column.name)) \(column.dataType)",
+            addKeyword: "ADD"
+        )
     }
 
     func generateDropColumnSQL(table: String, columnName: String) -> String? {
-        "ALTER TABLE \(qualifiedTableName(table)) DROP \(quoteIdentifier(columnName))"
+        PluginSQLDDLBuilder.alterTableDropColumnDefinition(
+            tableSQL: qualifiedTableName(table),
+            columnName: columnName,
+            quoteIdentifier: quoteIdentifier,
+            dropKeyword: "DROP"
+        )
     }
 
     private func qualifiedTableName(_ table: String) -> String {
@@ -603,4 +612,3 @@ internal final class CassandraPluginDriver: PluginDatabaseDriver, @unchecked Sen
         }
     }
 }
-

--- a/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
+++ b/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
@@ -669,25 +669,34 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     private func clickhouseDefaultValue(_ value: String) -> String {
-        let upper = value.uppercased()
-        if upper == "NULL" || upper == "NOW()" || upper == "TODAY()"
-            || value.hasPrefix("'") || Int64(value) != nil || Double(value) != nil {
-            return value
-        }
-        return "'\(escapeStringLiteral(value))'"
+        PluginSQLDDLBuilder.defaultValue(
+            value,
+            rawUppercaseValues: ["NULL", "NOW()", "TODAY()"],
+            escapeStringLiteral: escapeStringLiteral
+        )
     }
 
     // MARK: - ALTER TABLE DDL
 
     func generateAddColumnSQL(table: String, column: PluginColumnDefinition) -> String? {
-        "ALTER TABLE \(quoteIdentifier(table)) ADD COLUMN \(clickhouseColumnDefinition(column))"
+        PluginSQLDDLBuilder.alterTableAddColumnDefinition(
+            tableSQL: quoteIdentifier(table),
+            columnSQL: clickhouseColumnDefinition(column)
+        )
     }
 
     func generateModifyColumnSQL(table: String, oldColumn: PluginColumnDefinition, newColumn: PluginColumnDefinition) -> String? {
         let tableName = quoteIdentifier(table)
         var stmts: [String] = []
         if oldColumn.name != newColumn.name {
-            stmts.append("ALTER TABLE \(tableName) RENAME COLUMN \(quoteIdentifier(oldColumn.name)) TO \(quoteIdentifier(newColumn.name))")
+            stmts.append(
+                PluginSQLDDLBuilder.alterTableRenameColumnDefinition(
+                    tableSQL: tableName,
+                    oldColumnName: oldColumn.name,
+                    newColumnName: newColumn.name,
+                    quoteIdentifier: quoteIdentifier
+                )
+            )
         }
         if oldColumn.dataType != newColumn.dataType || oldColumn.isNullable != newColumn.isNullable
             || oldColumn.defaultValue != newColumn.defaultValue || oldColumn.comment != newColumn.comment {
@@ -697,7 +706,11 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func generateDropColumnSQL(table: String, columnName: String) -> String? {
-        "ALTER TABLE \(quoteIdentifier(table)) DROP COLUMN \(quoteIdentifier(columnName))"
+        PluginSQLDDLBuilder.alterTableDropColumnDefinition(
+            tableSQL: quoteIdentifier(table),
+            columnName: columnName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     func generateAddIndexSQL(table: String, index: PluginIndexDefinition) -> String? {
@@ -707,7 +720,12 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func generateDropIndexSQL(table: String, indexName: String) -> String? {
-        "ALTER TABLE \(quoteIdentifier(table)) DROP INDEX \(quoteIdentifier(indexName))"
+        PluginSQLDDLBuilder.alterTableDropObjectDefinition(
+            tableSQL: quoteIdentifier(table),
+            objectKind: "INDEX",
+            objectName: indexName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     static func classifySSLError(_ error: Error) -> SSLHandshakeError? {

--- a/Plugins/CloudflareD1DriverPlugin/CloudflareD1PluginDriver.swift
+++ b/Plugins/CloudflareD1DriverPlugin/CloudflareD1PluginDriver.swift
@@ -701,21 +701,35 @@ final class CloudflareD1PluginDriver: PluginDatabaseDriver, @unchecked Sendable 
         if let defaultValue = column.defaultValue, !defaultValue.isEmpty {
             def += " DEFAULT \(d1DefaultValue(defaultValue))"
         }
-        return "ALTER TABLE \(quoteIdentifier(table)) ADD COLUMN \(def)"
+        return PluginSQLDDLBuilder.alterTableAddColumnDefinition(
+            tableSQL: quoteIdentifier(table),
+            columnSQL: def
+        )
     }
 
     func generateDropColumnSQL(table: String, columnName: String) -> String? {
-        "ALTER TABLE \(quoteIdentifier(table)) DROP COLUMN \(quoteIdentifier(columnName))"
+        PluginSQLDDLBuilder.alterTableDropColumnDefinition(
+            tableSQL: quoteIdentifier(table),
+            columnName: columnName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     func generateAddIndexSQL(table: String, index: PluginIndexDefinition) -> String? {
-        let uniqueStr = index.isUnique ? "UNIQUE " : ""
-        let cols = index.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        return "CREATE \(uniqueStr)INDEX \(quoteIdentifier(index.name)) ON \(quoteIdentifier(table)) (\(cols))"
+        PluginSQLDDLBuilder.createIndexDefinition(
+            index,
+            quoteIdentifier: quoteIdentifier,
+            tableSQL: quoteIdentifier(table),
+            includeWhereClause: false
+        )
     }
 
     func generateDropIndexSQL(table: String, indexName: String) -> String? {
-        "DROP INDEX IF EXISTS \(quoteIdentifier(indexName))"
+        PluginSQLDDLBuilder.dropIndexDefinition(
+            indexName: indexName,
+            quoteIdentifier: quoteIdentifier,
+            ifExists: true
+        )
     }
 
     func generateColumnDefinitionSQL(column: PluginColumnDefinition) -> String? {
@@ -723,10 +737,12 @@ final class CloudflareD1PluginDriver: PluginDatabaseDriver, @unchecked Sendable 
     }
 
     func generateIndexDefinitionSQL(index: PluginIndexDefinition, tableName: String?) -> String? {
-        let uniqueStr = index.isUnique ? "UNIQUE " : ""
-        let cols = index.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let onClause = tableName.map { " ON \(quoteIdentifier($0))" } ?? ""
-        return "CREATE \(uniqueStr)INDEX \(quoteIdentifier(index.name))\(onClause) (\(cols))"
+        PluginSQLDDLBuilder.createIndexDefinition(
+            index,
+            quoteIdentifier: quoteIdentifier,
+            tableSQL: tableName.map { quoteIdentifier($0) },
+            includeWhereClause: false
+        )
     }
 
     func generateForeignKeyDefinitionSQL(fk: PluginForeignKeyDefinition) -> String? {
@@ -736,42 +752,31 @@ final class CloudflareD1PluginDriver: PluginDatabaseDriver, @unchecked Sendable 
     // MARK: - Private Helpers
 
     private func d1ColumnDefinition(_ col: PluginColumnDefinition, inlinePK: Bool) -> String {
-        var def = "\(quoteIdentifier(col.name)) \(col.dataType)"
-        if inlinePK && col.isPrimaryKey {
-            def += " PRIMARY KEY"
-            if col.autoIncrement {
-                def += " AUTOINCREMENT"
-            }
-        }
-        if !col.isNullable {
-            def += " NOT NULL"
-        }
-        if let defaultValue = col.defaultValue {
-            def += " DEFAULT \(d1DefaultValue(defaultValue))"
-        }
-        return def
+        PluginSQLDDLBuilder.columnDefinition(
+            col,
+            inlinePrimaryKey: inlinePK,
+            quoteIdentifier: quoteIdentifier,
+            formatDefaultValue: d1DefaultValue,
+            emitsNullableKeyword: false,
+            primaryKeyClausePosition: .afterDataType,
+            postPrimaryKeySQL: { $0.autoIncrement ? "AUTOINCREMENT" : nil }
+        )
     }
 
     private func d1DefaultValue(_ value: String) -> String {
-        let upper = value.uppercased()
-        if upper == "NULL" || upper == "CURRENT_TIMESTAMP" || upper == "CURRENT_DATE" || upper == "CURRENT_TIME"
-            || value.hasPrefix("'") || Int64(value) != nil || Double(value) != nil {
-            return value
-        }
-        return "'\(escapeStringLiteral(value))'"
+        PluginSQLDDLBuilder.defaultValue(
+            value,
+            rawUppercaseValues: ["NULL", "CURRENT_TIMESTAMP", "CURRENT_DATE", "CURRENT_TIME"],
+            escapeStringLiteral: escapeStringLiteral
+        )
     }
 
     private func d1ForeignKeyDefinition(_ fk: PluginForeignKeyDefinition) -> String {
-        let cols = fk.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let refCols = fk.referencedColumns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        var def = "FOREIGN KEY (\(cols)) REFERENCES \(quoteIdentifier(fk.referencedTable)) (\(refCols))"
-        if fk.onDelete != "NO ACTION" {
-            def += " ON DELETE \(fk.onDelete)"
-        }
-        if fk.onUpdate != "NO ACTION" {
-            def += " ON UPDATE \(fk.onUpdate)"
-        }
-        return def
+        PluginSQLDDLBuilder.foreignKeyDefinition(
+            fk,
+            quoteIdentifier: quoteIdentifier,
+            includeConstraintName: false
+        )
     }
 
     private func getClient() -> D1HttpClient? {

--- a/Plugins/DuckDBDriverPlugin/DuckDBPlugin.swift
+++ b/Plugins/DuckDBDriverPlugin/DuckDBPlugin.swift
@@ -723,60 +723,39 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     private func duckdbColumnDefinition(_ col: PluginColumnDefinition, inlinePK: Bool) -> String {
-        var dataType = col.dataType
-        if col.autoIncrement {
-            let upper = dataType.uppercased()
-            if upper == "BIGINT" || upper == "INT8" {
-                dataType = "BIGSERIAL"
-            } else {
-                dataType = "SERIAL"
-            }
-        }
-
-        var def = "\(quoteIdentifier(col.name)) \(dataType)"
-        if !col.autoIncrement {
-            if col.isNullable {
-                def += " NULL"
-            } else {
-                def += " NOT NULL"
-            }
-        }
-        if let defaultValue = col.defaultValue {
-            def += " DEFAULT \(duckdbDefaultValue(defaultValue))"
-        }
-        if inlinePK && col.isPrimaryKey {
-            def += " PRIMARY KEY"
-        }
-        return def
+        PluginSQLDDLBuilder.columnDefinition(
+            col,
+            inlinePrimaryKey: inlinePK,
+            quoteIdentifier: quoteIdentifier,
+            formatDefaultValue: duckdbDefaultValue,
+            dataTypeSQL: { column in
+                guard column.autoIncrement else { return column.dataType }
+                let upper = column.dataType.uppercased()
+                return upper == "BIGINT" || upper == "INT8" ? "BIGSERIAL" : "SERIAL"
+            },
+            suppressNullability: { $0.autoIncrement }
+        )
     }
 
     private func duckdbDefaultValue(_ value: String) -> String {
-        let upper = value.uppercased()
-        if upper == "NULL" || upper == "TRUE" || upper == "FALSE"
-            || upper == "CURRENT_TIMESTAMP" || upper == "NOW()"
-            || value.hasPrefix("'") || Int64(value) != nil || Double(value) != nil {
-            return value
-        }
-        return "'\(escapeStringLiteral(value))'"
+        PluginSQLDDLBuilder.defaultValue(
+            value,
+            rawUppercaseValues: ["NULL", "TRUE", "FALSE", "CURRENT_TIMESTAMP", "NOW()"],
+            escapeStringLiteral: escapeStringLiteral
+        )
     }
 
     private func duckdbIndexDefinition(_ index: PluginIndexDefinition, qualifiedTable: String) -> String {
-        let cols = index.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let unique = index.isUnique ? "UNIQUE " : ""
-        return "CREATE \(unique)INDEX \(quoteIdentifier(index.name)) ON \(qualifiedTable) (\(cols))"
+        PluginSQLDDLBuilder.createIndexDefinition(
+            index,
+            quoteIdentifier: quoteIdentifier,
+            tableSQL: qualifiedTable,
+            includeWhereClause: false
+        )
     }
 
     private func duckdbForeignKeyDefinition(_ fk: PluginForeignKeyDefinition) -> String {
-        let cols = fk.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let refCols = fk.referencedColumns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        var def = "CONSTRAINT \(quoteIdentifier(fk.name)) FOREIGN KEY (\(cols)) REFERENCES \(quoteIdentifier(fk.referencedTable)) (\(refCols))"
-        if fk.onDelete != "NO ACTION" {
-            def += " ON DELETE \(fk.onDelete)"
-        }
-        if fk.onUpdate != "NO ACTION" {
-            def += " ON UPDATE \(fk.onUpdate)"
-        }
-        return def
+        PluginSQLDDLBuilder.foreignKeyDefinition(fk, quoteIdentifier: quoteIdentifier)
     }
 
     private func qualifiedTableName(_ table: String) -> String {
@@ -788,7 +767,7 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     func generateAddColumnSQL(table: String, column: PluginColumnDefinition) -> String? {
         let qt = qualifiedTableName(table)
         let colDef = duckdbColumnDefinition(column, inlinePK: false)
-        return "ALTER TABLE \(qt) ADD COLUMN \(colDef)"
+        return PluginSQLDDLBuilder.alterTableAddColumnDefinition(tableSQL: qt, columnSQL: colDef)
     }
 
     func generateModifyColumnSQL(table: String, oldColumn: PluginColumnDefinition, newColumn: PluginColumnDefinition) -> String? {
@@ -796,7 +775,14 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         var stmts: [String] = []
 
         if oldColumn.name != newColumn.name {
-            stmts.append("ALTER TABLE \(qt) RENAME COLUMN \(quoteIdentifier(oldColumn.name)) TO \(quoteIdentifier(newColumn.name))")
+            stmts.append(
+                PluginSQLDDLBuilder.alterTableRenameColumnDefinition(
+                    tableSQL: qt,
+                    oldColumnName: oldColumn.name,
+                    newColumnName: newColumn.name,
+                    quoteIdentifier: quoteIdentifier
+                )
+            )
         }
 
         let colName = quoteIdentifier(newColumn.name)
@@ -822,7 +808,11 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func generateDropColumnSQL(table: String, columnName: String) -> String? {
-        "ALTER TABLE \(qualifiedTableName(table)) DROP COLUMN \(quoteIdentifier(columnName))"
+        PluginSQLDDLBuilder.alterTableDropColumnDefinition(
+            tableSQL: qualifiedTableName(table),
+            columnName: columnName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     func generateAddIndexSQL(table: String, index: PluginIndexDefinition) -> String? {
@@ -830,7 +820,7 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func generateDropIndexSQL(table: String, indexName: String) -> String? {
-        "DROP INDEX \(quoteIdentifier(indexName))"
+        PluginSQLDDLBuilder.dropIndexDefinition(indexName: indexName, quoteIdentifier: quoteIdentifier)
     }
 
     func generateAddForeignKeySQL(table: String, fk: PluginForeignKeyDefinition) -> String? {
@@ -838,21 +828,22 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func generateDropForeignKeySQL(table: String, constraintName: String) -> String? {
-        "ALTER TABLE \(qualifiedTableName(table)) DROP CONSTRAINT \(quoteIdentifier(constraintName))"
+        PluginSQLDDLBuilder.alterTableDropObjectDefinition(
+            tableSQL: qualifiedTableName(table),
+            objectKind: "CONSTRAINT",
+            objectName: constraintName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     func generateModifyPrimaryKeySQL(table: String, oldColumns: [String], newColumns: [String], constraintName: String?) -> [String]? {
-        let qt = qualifiedTableName(table)
-        var stmts: [String] = []
-        if !oldColumns.isEmpty {
-            let name = constraintName.map { quoteIdentifier($0) } ?? "/* unknown constraint */"
-            stmts.append("ALTER TABLE \(qt) DROP CONSTRAINT \(name)")
-        }
-        if !newColumns.isEmpty {
-            let cols = newColumns.map { quoteIdentifier($0) }.joined(separator: ", ")
-            stmts.append("ALTER TABLE \(qt) ADD PRIMARY KEY (\(cols))")
-        }
-        return stmts.isEmpty ? nil : stmts
+        PluginSQLDDLBuilder.modifyPrimaryKeyDefinitions(
+            tableSQL: qualifiedTableName(table),
+            oldColumns: oldColumns,
+            newColumns: newColumns,
+            constraintName: constraintName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     private static let indexColumnsRegex = try? NSRegularExpression(
@@ -876,4 +867,3 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         }
     }
 }
-

--- a/Plugins/LibSQLDriverPlugin/LibSQLPluginDriver.swift
+++ b/Plugins/LibSQLDriverPlugin/LibSQLPluginDriver.swift
@@ -603,21 +603,35 @@ final class LibSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         if let defaultValue = column.defaultValue, !defaultValue.isEmpty {
             def += " DEFAULT \(sqlDefaultValue(defaultValue))"
         }
-        return "ALTER TABLE \(quoteIdentifier(table)) ADD COLUMN \(def)"
+        return PluginSQLDDLBuilder.alterTableAddColumnDefinition(
+            tableSQL: quoteIdentifier(table),
+            columnSQL: def
+        )
     }
 
     func generateDropColumnSQL(table: String, columnName: String) -> String? {
-        "ALTER TABLE \(quoteIdentifier(table)) DROP COLUMN \(quoteIdentifier(columnName))"
+        PluginSQLDDLBuilder.alterTableDropColumnDefinition(
+            tableSQL: quoteIdentifier(table),
+            columnName: columnName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     func generateAddIndexSQL(table: String, index: PluginIndexDefinition) -> String? {
-        let uniqueStr = index.isUnique ? "UNIQUE " : ""
-        let cols = index.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        return "CREATE \(uniqueStr)INDEX \(quoteIdentifier(index.name)) ON \(quoteIdentifier(table)) (\(cols))"
+        PluginSQLDDLBuilder.createIndexDefinition(
+            index,
+            quoteIdentifier: quoteIdentifier,
+            tableSQL: quoteIdentifier(table),
+            includeWhereClause: false
+        )
     }
 
     func generateDropIndexSQL(table: String, indexName: String) -> String? {
-        "DROP INDEX IF EXISTS \(quoteIdentifier(indexName))"
+        PluginSQLDDLBuilder.dropIndexDefinition(
+            indexName: indexName,
+            quoteIdentifier: quoteIdentifier,
+            ifExists: true
+        )
     }
 
     func generateColumnDefinitionSQL(column: PluginColumnDefinition) -> String? {
@@ -625,10 +639,12 @@ final class LibSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func generateIndexDefinitionSQL(index: PluginIndexDefinition, tableName: String?) -> String? {
-        let uniqueStr = index.isUnique ? "UNIQUE " : ""
-        let cols = index.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let onClause = tableName.map { " ON \(quoteIdentifier($0))" } ?? ""
-        return "CREATE \(uniqueStr)INDEX \(quoteIdentifier(index.name))\(onClause) (\(cols))"
+        PluginSQLDDLBuilder.createIndexDefinition(
+            index,
+            quoteIdentifier: quoteIdentifier,
+            tableSQL: tableName.map { quoteIdentifier($0) },
+            includeWhereClause: false
+        )
     }
 
     func generateForeignKeyDefinitionSQL(fk: PluginForeignKeyDefinition) -> String? {
@@ -638,42 +654,31 @@ final class LibSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     // MARK: - Private Helpers
 
     private func columnDefinition(_ col: PluginColumnDefinition, inlinePK: Bool) -> String {
-        var def = "\(quoteIdentifier(col.name)) \(col.dataType)"
-        if inlinePK && col.isPrimaryKey {
-            def += " PRIMARY KEY"
-            if col.autoIncrement {
-                def += " AUTOINCREMENT"
-            }
-        }
-        if !col.isNullable {
-            def += " NOT NULL"
-        }
-        if let defaultValue = col.defaultValue {
-            def += " DEFAULT \(sqlDefaultValue(defaultValue))"
-        }
-        return def
+        PluginSQLDDLBuilder.columnDefinition(
+            col,
+            inlinePrimaryKey: inlinePK,
+            quoteIdentifier: quoteIdentifier,
+            formatDefaultValue: sqlDefaultValue,
+            emitsNullableKeyword: false,
+            primaryKeyClausePosition: .afterDataType,
+            postPrimaryKeySQL: { $0.autoIncrement ? "AUTOINCREMENT" : nil }
+        )
     }
 
     private func sqlDefaultValue(_ value: String) -> String {
-        let upper = value.uppercased()
-        if upper == "NULL" || upper == "CURRENT_TIMESTAMP" || upper == "CURRENT_DATE" || upper == "CURRENT_TIME"
-            || value.hasPrefix("'") || Int64(value) != nil || Double(value) != nil {
-            return value
-        }
-        return "'\(escapeStringLiteral(value))'"
+        PluginSQLDDLBuilder.defaultValue(
+            value,
+            rawUppercaseValues: ["NULL", "CURRENT_TIMESTAMP", "CURRENT_DATE", "CURRENT_TIME"],
+            escapeStringLiteral: escapeStringLiteral
+        )
     }
 
     private func foreignKeyDefinition(_ fk: PluginForeignKeyDefinition) -> String {
-        let cols = fk.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let refCols = fk.referencedColumns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        var def = "FOREIGN KEY (\(cols)) REFERENCES \(quoteIdentifier(fk.referencedTable)) (\(refCols))"
-        if fk.onDelete != "NO ACTION" {
-            def += " ON DELETE \(fk.onDelete)"
-        }
-        if fk.onUpdate != "NO ACTION" {
-            def += " ON UPDATE \(fk.onUpdate)"
-        }
-        return def
+        PluginSQLDDLBuilder.foreignKeyDefinition(
+            fk,
+            quoteIdentifier: quoteIdentifier,
+            includeConstraintName: false
+        )
     }
 
     private func getClient() -> HranaHttpClient? {

--- a/Plugins/MSSQLDriverPlugin/MSSQLPlugin.swift
+++ b/Plugins/MSSQLDriverPlugin/MSSQLPlugin.swift
@@ -165,7 +165,7 @@ final class MSSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     private var _serverVersion: String?
 
     /// IDENTITY columns observed during `fetchColumns`, keyed by table name.
-    /// `generateMssqlInsert` reads this to skip IDENTITY columns: SQL Server
+    /// DML statement generation reads this to skip IDENTITY columns: SQL Server
     /// rejects explicit values for IDENTITY columns unless IDENTITY_INSERT is ON,
     /// and the value the user typed is server-allocated anyway.
     var identityColumnsByTable: [String: Set<String>] = [:]
@@ -313,153 +313,23 @@ final class MSSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         deletedRowIndices: Set<Int>,
         insertedRowIndices: Set<Int>
     ) -> [(statement: String, parameters: [PluginCellValue])]? {
-        var statements: [(statement: String, parameters: [PluginCellValue])] = []
-
-        var deleteChanges: [PluginRowChange] = []
-
-        for change in changes {
-            switch change.type {
-            case .insert:
-                guard insertedRowIndices.contains(change.rowIndex) else { continue }
-                if let values = insertedRowData[change.rowIndex] {
-                    if let stmt = generateMssqlInsert(table: table, columns: columns, values: values) {
-                        statements.append(stmt)
-                    }
-                }
-            case .update:
-                if let stmt = generateMssqlUpdate(
-                    table: table, columns: columns,
-                    primaryKeyColumns: primaryKeyColumns, change: change
-                ) {
-                    statements.append(stmt)
-                }
-            case .delete:
-                guard deletedRowIndices.contains(change.rowIndex) else { continue }
-                deleteChanges.append(change)
-            }
-        }
-
-        if !deleteChanges.isEmpty {
-            for change in deleteChanges {
-                if let stmt = generateMssqlDelete(
-                    table: table, columns: columns,
-                    primaryKeyColumns: primaryKeyColumns, change: change
-                ) {
-                    statements.append(stmt)
-                }
-            }
-        }
-
-        return statements.isEmpty ? nil : statements
-    }
-
-    private func generateMssqlInsert(
-        table: String,
-        columns: [String],
-        values: [PluginCellValue]
-    ) -> (statement: String, parameters: [PluginCellValue])? {
-        var nonDefaultColumns: [String] = []
-        var parameters: [PluginCellValue] = []
         let identityColumns = cachedIdentityColumns(for: table)
-
-        for (index, value) in values.enumerated() {
-            if value.asText == "__DEFAULT__" { continue }
-            guard index < columns.count else { continue }
-            let columnName = columns[index]
-            // SQL Server IDENTITY columns are server-allocated. INSERTs that include
-            // an explicit value fail unless `SET IDENTITY_INSERT <table> ON` was issued,
-            // so always omit them and let the server assign the next value.
-            if identityColumns.contains(columnName) { continue }
-            nonDefaultColumns.append("[\(columnName.replacingOccurrences(of: "]", with: "]]"))]")
-            parameters.append(value)
-        }
-
-        guard !nonDefaultColumns.isEmpty else { return nil }
-
-        let columnList = nonDefaultColumns.joined(separator: ", ")
-        let placeholders = parameters.map { _ in "?" }.joined(separator: ", ")
-        let escapedTable = "[\(table.replacingOccurrences(of: "]", with: "]]"))]"
-        let sql = "INSERT INTO \(escapedTable) (\(columnList)) VALUES (\(placeholders))"
-        return (statement: sql, parameters: parameters)
-    }
-
-    private func generateMssqlUpdate(
-        table: String,
-        columns: [String],
-        primaryKeyColumns: [String],
-        change: PluginRowChange
-    ) -> (statement: String, parameters: [PluginCellValue])? {
-        guard !change.cellChanges.isEmpty else { return nil }
-        guard let originalRow = change.originalRow else { return nil }
-
-        let escapedTable = "[\(table.replacingOccurrences(of: "]", with: "]]"))]"
-        var parameters: [PluginCellValue] = []
-
-        let setClauses = change.cellChanges.map { cellChange -> String in
-            let col = "[\(cellChange.columnName.replacingOccurrences(of: "]", with: "]]"))]"
-            parameters.append(cellChange.newValue)
-            return "\(col) = ?"
-        }.joined(separator: ", ")
-
-        let whereColumns: [String] = primaryKeyColumns.isEmpty ? columns : primaryKeyColumns
-
-        var conditions: [String] = []
-        for whereColumn in whereColumns {
-            guard let columnIndex = columns.firstIndex(of: whereColumn),
-                  columnIndex < originalRow.count
-            else { continue }
-            let col = "[\(whereColumn.replacingOccurrences(of: "]", with: "]]"))]"
-            let value = originalRow[columnIndex]
-            if value.isNull {
-                conditions.append("\(col) IS NULL")
-            } else {
-                parameters.append(value)
-                conditions.append("\(col) = ?")
-            }
-        }
-
-        guard !conditions.isEmpty else { return nil }
-
-        let whereClause = conditions.joined(separator: " AND ")
-        let topClause = primaryKeyColumns.isEmpty ? "TOP (1) " : ""
-        let sql = "UPDATE \(topClause)\(escapedTable) SET \(setClauses) WHERE \(whereClause)"
-        return (statement: sql, parameters: parameters)
-    }
-
-    private func generateMssqlDelete(
-        table: String,
-        columns: [String],
-        primaryKeyColumns: [String],
-        change: PluginRowChange
-    ) -> (statement: String, parameters: [PluginCellValue])? {
-        guard let originalRow = change.originalRow else { return nil }
-
-        let escapedTable = "[\(table.replacingOccurrences(of: "]", with: "]]"))]"
-        var parameters: [PluginCellValue] = []
-        var conditions: [String] = []
-
-        let whereColumns: [String] = primaryKeyColumns.isEmpty ? columns : primaryKeyColumns
-
-        for whereColumn in whereColumns {
-            guard let columnIndex = columns.firstIndex(of: whereColumn),
-                  columnIndex < originalRow.count
-            else { continue }
-            let col = "[\(whereColumn.replacingOccurrences(of: "]", with: "]]"))]"
-            let value = originalRow[columnIndex]
-            if value.isNull {
-                conditions.append("\(col) IS NULL")
-            } else {
-                parameters.append(value)
-                conditions.append("\(col) = ?")
-            }
-        }
-
-        guard !conditions.isEmpty else { return nil }
-
-        let whereClause = conditions.joined(separator: " AND ")
-        let topClause = primaryKeyColumns.isEmpty ? "TOP (1) " : ""
-        let sql = "DELETE \(topClause)FROM \(escapedTable) WHERE \(whereClause)"
-        return (statement: sql, parameters: parameters)
+        return PluginSQLStatementBuilder.generateStatements(
+            table: table,
+            columns: columns,
+            primaryKeyColumns: primaryKeyColumns,
+            changes: changes,
+            insertedRowData: insertedRowData,
+            deletedRowIndices: deletedRowIndices,
+            insertedRowIndices: insertedRowIndices,
+            quoteIdentifier: quoteIdentifier,
+            insertDefaultStrategy: .omitColumn,
+            includeInsertedColumn: { !identityColumns.contains($0) },
+            whereColumnStrategy: .primaryKeyOrAll,
+            collectDeletesLast: true,
+            singleRowUpdatePrefixWhenNoPrimaryKey: "TOP (1) ",
+            singleRowDeletePrefixWhenNoPrimaryKey: "TOP (1) "
+        )
     }
 
     // MARK: - Streaming
@@ -563,13 +433,15 @@ final class MSSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         limit: Int,
         offset: Int
     ) -> String? {
-        let quotedTable = mssqlQuoteIdentifier(table)
-        var query = "SELECT * FROM \(quotedTable)"
-        let orderBy = PluginSQLFilter.buildOrderByClause(
-            sortColumns: sortColumns, columns: columns, quoteIdentifier: mssqlQuoteIdentifier
-        ) ?? "ORDER BY (SELECT NULL)"
-        query += " \(orderBy) OFFSET \(offset) ROWS FETCH NEXT \(limit) ROWS ONLY"
-        return query
+        guard let dialect = MSSQLPlugin.sqlDialect else { return nil }
+        return PluginSQLFilter.buildBrowseQuery(
+            table: table,
+            dialect: dialect,
+            sortColumns: sortColumns,
+            columns: columns,
+            limit: limit,
+            offset: offset
+        )
     }
 
     func buildFilteredQuery(
@@ -581,42 +453,21 @@ final class MSSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         limit: Int,
         offset: Int
     ) -> String? {
-        let quotedTable = mssqlQuoteIdentifier(table)
-        var query = "SELECT * FROM \(quotedTable)"
-        let whereClause = PluginSQLFilter.buildWhereClause(
+        guard let dialect = MSSQLPlugin.sqlDialect else { return nil }
+        return PluginSQLFilter.buildFilteredQuery(
+            table: table,
             filters: filters,
             logicMode: logicMode,
-            quoteIdentifier: mssqlQuoteIdentifier,
-            escapeValue: mssqlEscapeValue,
+            dialect: dialect,
+            sortColumns: sortColumns,
+            columns: columns,
+            limit: limit,
+            offset: offset,
             regexCondition: { quoted, value in
                 "\(quoted) LIKE '%\(value.replacingOccurrences(of: "'", with: "''"))%'"
             }
         )
-        if !whereClause.isEmpty {
-            query += " WHERE \(whereClause)"
-        }
-        let orderBy = PluginSQLFilter.buildOrderByClause(
-            sortColumns: sortColumns, columns: columns, quoteIdentifier: mssqlQuoteIdentifier
-        ) ?? "ORDER BY (SELECT NULL)"
-        query += " \(orderBy) OFFSET \(offset) ROWS FETCH NEXT \(limit) ROWS ONLY"
-        return query
     }
-
-    // MARK: - Query Building Helpers
-
-    private func mssqlQuoteIdentifier(_ identifier: String) -> String {
-        quoteIdentifier(identifier)
-    }
-
-    private func mssqlEscapeValue(_ value: String) -> String {
-        let trimmed = value.trimmingCharacters(in: .whitespaces)
-        if trimmed.caseInsensitiveCompare("NULL") == .orderedSame { return "NULL" }
-        if trimmed.caseInsensitiveCompare("TRUE") == .orderedSame { return "1" }
-        if trimmed.caseInsensitiveCompare("FALSE") == .orderedSame { return "0" }
-        if Int(trimmed) != nil || Double(trimmed) != nil { return trimmed }
-        return "'\(trimmed.replacingOccurrences(of: "'", with: "''"))'"
-    }
-
 
     // MARK: - Private Helpers
 

--- a/Plugins/MSSQLDriverPlugin/MSSQLPluginDriver+DDL.swift
+++ b/Plugins/MSSQLDriverPlugin/MSSQLPluginDriver+DDL.swift
@@ -45,56 +45,44 @@ extension MSSQLPluginDriver {
     }
 
     private func mssqlColumnDefinition(_ col: PluginColumnDefinition, inlinePK: Bool) -> String {
-        var def = "\(quoteIdentifier(col.name)) \(col.dataType)"
-        if col.autoIncrement {
-            def += " IDENTITY(1,1)"
-        }
-        if col.isNullable {
-            def += " NULL"
-        } else {
-            def += " NOT NULL"
-        }
-        if let defaultValue = col.defaultValue {
-            def += " DEFAULT \(mssqlDefaultValue(defaultValue))"
-        }
-        if inlinePK && col.isPrimaryKey {
-            def += " PRIMARY KEY"
-        }
-        return def
+        PluginSQLDDLBuilder.columnDefinition(
+            col,
+            inlinePrimaryKey: inlinePK,
+            quoteIdentifier: quoteIdentifier,
+            formatDefaultValue: mssqlDefaultValue,
+            postDataTypeSQL: { $0.autoIncrement ? "IDENTITY(1,1)" : nil }
+        )
     }
 
     private func mssqlDefaultValue(_ value: String) -> String {
-        let upper = value.uppercased()
-        if upper == "NULL" || upper == "GETDATE()" || upper == "NEWID()" || upper == "GETUTCDATE()"
-            || value.hasPrefix("'") || value.hasPrefix("(") || Int64(value) != nil || Double(value) != nil {
-            return value
-        }
-        return "'\(escapeStringLiteral(value))'"
+        PluginSQLDDLBuilder.defaultValue(
+            value,
+            rawUppercaseValues: ["NULL", "GETDATE()", "NEWID()", "GETUTCDATE()"],
+            allowsParenthesizedExpressions: true,
+            escapeStringLiteral: escapeStringLiteral
+        )
     }
 
     private func mssqlIndexDefinition(_ index: PluginIndexDefinition, qualifiedTable: String) -> String {
-        let cols = index.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let unique = index.isUnique ? "UNIQUE " : ""
-        var def = "CREATE \(unique)INDEX \(quoteIdentifier(index.name)) ON \(qualifiedTable) (\(cols))"
-        if let type = index.indexType?.uppercased(), type == "CLUSTERED" {
-            def = "CREATE \(unique)CLUSTERED INDEX \(quoteIdentifier(index.name)) ON \(qualifiedTable) (\(cols))"
-        } else if let type = index.indexType?.uppercased(), type == "NONCLUSTERED" {
-            def = "CREATE \(unique)NONCLUSTERED INDEX \(quoteIdentifier(index.name)) ON \(qualifiedTable) (\(cols))"
-        }
-        return def
+        PluginSQLDDLBuilder.createIndexDefinition(
+            index,
+            quoteIdentifier: quoteIdentifier,
+            tableSQL: qualifiedTable,
+            indexKindSQL: { index in
+                let unique = index.isUnique ? "UNIQUE " : ""
+                if let type = index.indexType?.uppercased(), type == "CLUSTERED" {
+                    return "\(unique)CLUSTERED INDEX"
+                } else if let type = index.indexType?.uppercased(), type == "NONCLUSTERED" {
+                    return "\(unique)NONCLUSTERED INDEX"
+                }
+                return "\(unique)INDEX"
+            },
+            includeWhereClause: false
+        )
     }
 
     private func mssqlForeignKeyDefinition(_ fk: PluginForeignKeyDefinition) -> String {
-        let cols = fk.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let refCols = fk.referencedColumns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        var def = "CONSTRAINT \(quoteIdentifier(fk.name)) FOREIGN KEY (\(cols)) REFERENCES \(quoteIdentifier(fk.referencedTable)) (\(refCols))"
-        if fk.onDelete != "NO ACTION" {
-            def += " ON DELETE \(fk.onDelete)"
-        }
-        if fk.onUpdate != "NO ACTION" {
-            def += " ON UPDATE \(fk.onUpdate)"
-        }
-        return def
+        PluginSQLDDLBuilder.foreignKeyDefinition(fk, quoteIdentifier: quoteIdentifier)
     }
 
     // MARK: - ALTER TABLE DDL
@@ -104,7 +92,11 @@ extension MSSQLPluginDriver {
     }
 
     func generateAddColumnSQL(table: String, column: PluginColumnDefinition) -> String? {
-        "ALTER TABLE \(mssqlQualifiedTable(table)) ADD \(mssqlColumnDefinition(column, inlinePK: false))"
+        PluginSQLDDLBuilder.alterTableAddColumnDefinition(
+            tableSQL: mssqlQualifiedTable(table),
+            columnSQL: mssqlColumnDefinition(column, inlinePK: false),
+            addKeyword: "ADD"
+        )
     }
 
     func generateModifyColumnSQL(table: String, oldColumn: PluginColumnDefinition, newColumn: PluginColumnDefinition) -> String? {
@@ -147,7 +139,11 @@ extension MSSQLPluginDriver {
     }
 
     func generateDropColumnSQL(table: String, columnName: String) -> String? {
-        "ALTER TABLE \(mssqlQualifiedTable(table)) DROP COLUMN \(quoteIdentifier(columnName))"
+        PluginSQLDDLBuilder.alterTableDropColumnDefinition(
+            tableSQL: mssqlQualifiedTable(table),
+            columnName: columnName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     func generateAddIndexSQL(table: String, index: PluginIndexDefinition) -> String? {
@@ -155,7 +151,11 @@ extension MSSQLPluginDriver {
     }
 
     func generateDropIndexSQL(table: String, indexName: String) -> String? {
-        "DROP INDEX \(quoteIdentifier(indexName)) ON \(mssqlQualifiedTable(table))"
+        PluginSQLDDLBuilder.dropIndexDefinition(
+            indexName: indexName,
+            quoteIdentifier: quoteIdentifier,
+            tableSQL: mssqlQualifiedTable(table)
+        )
     }
 
     func generateAddForeignKeySQL(table: String, fk: PluginForeignKeyDefinition) -> String? {
@@ -163,22 +163,23 @@ extension MSSQLPluginDriver {
     }
 
     func generateDropForeignKeySQL(table: String, constraintName: String) -> String? {
-        "ALTER TABLE \(mssqlQualifiedTable(table)) DROP CONSTRAINT \(quoteIdentifier(constraintName))"
+        PluginSQLDDLBuilder.alterTableDropObjectDefinition(
+            tableSQL: mssqlQualifiedTable(table),
+            objectKind: "CONSTRAINT",
+            objectName: constraintName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     func generateModifyPrimaryKeySQL(table: String, oldColumns: [String], newColumns: [String], constraintName: String?) -> [String]? {
-        let qt = mssqlQualifiedTable(table)
-        var stmts: [String] = []
-        if !oldColumns.isEmpty {
-            let name = constraintName.map { quoteIdentifier($0) } ?? "/* unknown constraint */"
-            stmts.append("ALTER TABLE \(qt) DROP CONSTRAINT \(name)")
-        }
-        if !newColumns.isEmpty {
-            let cols = newColumns.map { quoteIdentifier($0) }.joined(separator: ", ")
-            let pkName = constraintName.map { quoteIdentifier($0) } ?? quoteIdentifier("PK_\(table)")
-            stmts.append("ALTER TABLE \(qt) ADD CONSTRAINT \(pkName) PRIMARY KEY (\(cols))")
-        }
-        return stmts.isEmpty ? nil : stmts
+        PluginSQLDDLBuilder.modifyPrimaryKeyDefinitions(
+            tableSQL: mssqlQualifiedTable(table),
+            oldColumns: oldColumns,
+            newColumns: newColumns,
+            constraintName: constraintName,
+            quoteIdentifier: quoteIdentifier,
+            addConstraintNameSQL: constraintName.map { quoteIdentifier($0) } ?? quoteIdentifier("PK_\(table)")
+        )
     }
 
 }

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
@@ -694,15 +694,11 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             def += " NOT NULL"
         }
         if let defaultValue = column.defaultValue {
-            let upper = defaultValue.uppercased()
-            if upper == "NULL" || upper == "CURRENT_TIMESTAMP" || upper == "CURRENT_TIMESTAMP()"
-                || defaultValue.hasPrefix("'") {
-                def += " DEFAULT \(defaultValue)"
-            } else if Int64(defaultValue) != nil || Double(defaultValue) != nil {
-                def += " DEFAULT \(defaultValue)"
-            } else {
-                def += " DEFAULT '\(escapeStringLiteral(defaultValue))'"
-            }
+            def += " DEFAULT " + PluginSQLDDLBuilder.defaultValue(
+                defaultValue,
+                rawUppercaseValues: ["NULL", "CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP()"],
+                escapeStringLiteral: escapeStringLiteral
+            )
         }
         if column.autoIncrement {
             def += " AUTO_INCREMENT"
@@ -722,58 +718,47 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     private func buildIndexDefinitionSQL(_ index: PluginIndexDefinition) -> String {
-        let cols = index.columns.map { col -> String in
-            let quoted = quoteIdentifier(col)
-            if let prefixes = index.columnPrefixes, let prefix = prefixes[col] {
-                return "\(quoted)(\(prefix))"
-            }
-            return quoted
-        }.joined(separator: ", ")
-        var def = ""
-
-        let upperType = index.indexType?.uppercased() ?? ""
-        if upperType == "FULLTEXT" {
-            def += "FULLTEXT INDEX"
-        } else if upperType == "SPATIAL" {
-            def += "SPATIAL INDEX"
-        } else if index.isUnique {
-            def += "UNIQUE INDEX"
-        } else {
-            def += "INDEX"
-        }
-
-        def += " \(quoteIdentifier(index.name)) (\(cols))"
-
-        if upperType == "BTREE" || upperType == "HASH" {
-            def += " USING \(upperType)"
-        }
-
-        return def
+        PluginSQLDDLBuilder.indexDefinitionFragment(
+            index,
+            quoteIdentifier: quoteIdentifier,
+            indexKindSQL: { index in
+                let upperType = index.indexType?.uppercased() ?? ""
+                if upperType == "FULLTEXT" {
+                    return "FULLTEXT INDEX"
+                } else if upperType == "SPATIAL" {
+                    return "SPATIAL INDEX"
+                } else if index.isUnique {
+                    return "UNIQUE INDEX"
+                }
+                return "INDEX"
+            },
+            indexMethodSQL: { index in
+                let upperType = index.indexType?.uppercased() ?? ""
+                return upperType == "BTREE" || upperType == "HASH" ? "USING \(upperType)" : nil
+            },
+            formatColumnSQL: { col in
+                let quoted = self.quoteIdentifier(col)
+                if let prefixes = index.columnPrefixes, let prefix = prefixes[col] {
+                    return "\(quoted)(\(prefix))"
+                }
+                return quoted
+            },
+            includeWhereClause: false
+        )
     }
 
     private func buildForeignKeyDefinitionSQL(_ fk: PluginForeignKeyDefinition) -> String {
-        let cols = fk.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let refCols = fk.referencedColumns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let refTable: String
-        if let schema = fk.referencedSchema, !schema.isEmpty {
-            refTable = "\(quoteIdentifier(schema)).\(quoteIdentifier(fk.referencedTable))"
-        } else {
-            refTable = quoteIdentifier(fk.referencedTable)
-        }
-
-        var def = "CONSTRAINT \(quoteIdentifier(fk.name)) FOREIGN KEY (\(cols)) REFERENCES \(refTable) (\(refCols))"
-
-        let onDelete = fk.onDelete.uppercased()
-        if onDelete != "NO ACTION" {
-            def += " ON DELETE \(onDelete)"
-        }
-
-        let onUpdate = fk.onUpdate.uppercased()
-        if onUpdate != "NO ACTION" {
-            def += " ON UPDATE \(onUpdate)"
-        }
-
-        return def
+        PluginSQLDDLBuilder.foreignKeyDefinition(
+            fk,
+            quoteIdentifier: quoteIdentifier,
+            referencedTableSQL: { foreignKey in
+                if let schema = foreignKey.referencedSchema, !schema.isEmpty {
+                    return "\(self.quoteIdentifier(schema)).\(self.quoteIdentifier(foreignKey.referencedTable))"
+                }
+                return self.quoteIdentifier(foreignKey.referencedTable)
+            },
+            normalizeAction: { $0.uppercased() }
+        )
     }
 
     // MARK: - Definition SQL (clipboard copy)
@@ -793,7 +778,10 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     // MARK: - ALTER TABLE DDL
 
     func generateAddColumnSQL(table: String, column: PluginColumnDefinition) -> String? {
-        "ALTER TABLE \(quoteIdentifier(table)) ADD COLUMN \(buildColumnDefinitionSQL(column))"
+        PluginSQLDDLBuilder.alterTableAddColumnDefinition(
+            tableSQL: quoteIdentifier(table),
+            columnSQL: buildColumnDefinitionSQL(column)
+        )
     }
 
     func generateModifyColumnSQL(table: String, oldColumn: PluginColumnDefinition, newColumn: PluginColumnDefinition) -> String? {
@@ -805,7 +793,11 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func generateDropColumnSQL(table: String, columnName: String) -> String? {
-        "ALTER TABLE \(quoteIdentifier(table)) DROP COLUMN \(quoteIdentifier(columnName))"
+        PluginSQLDDLBuilder.alterTableDropColumnDefinition(
+            tableSQL: quoteIdentifier(table),
+            columnName: columnName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     func generateAddIndexSQL(table: String, index: PluginIndexDefinition) -> String? {
@@ -813,7 +805,12 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func generateDropIndexSQL(table: String, indexName: String) -> String? {
-        "ALTER TABLE \(quoteIdentifier(table)) DROP INDEX \(quoteIdentifier(indexName))"
+        PluginSQLDDLBuilder.alterTableDropObjectDefinition(
+            tableSQL: quoteIdentifier(table),
+            objectKind: "INDEX",
+            objectName: indexName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     func generateAddForeignKeySQL(table: String, fk: PluginForeignKeyDefinition) -> String? {
@@ -821,20 +818,23 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func generateDropForeignKeySQL(table: String, constraintName: String) -> String? {
-        "ALTER TABLE \(quoteIdentifier(table)) DROP FOREIGN KEY \(quoteIdentifier(constraintName))"
+        PluginSQLDDLBuilder.alterTableDropObjectDefinition(
+            tableSQL: quoteIdentifier(table),
+            objectKind: "FOREIGN KEY",
+            objectName: constraintName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     func generateModifyPrimaryKeySQL(table: String, oldColumns: [String], newColumns: [String], constraintName: String?) -> [String]? {
-        let tableName = quoteIdentifier(table)
-        var stmts: [String] = []
-        if !oldColumns.isEmpty {
-            stmts.append("ALTER TABLE \(tableName) DROP PRIMARY KEY")
-        }
-        if !newColumns.isEmpty {
-            let cols = newColumns.map { quoteIdentifier($0) }.joined(separator: ", ")
-            stmts.append("ALTER TABLE \(tableName) ADD PRIMARY KEY (\(cols))")
-        }
-        return stmts.isEmpty ? nil : stmts
+        PluginSQLDDLBuilder.modifyPrimaryKeyDefinitions(
+            tableSQL: quoteIdentifier(table),
+            oldColumns: oldColumns,
+            newColumns: newColumns,
+            constraintName: constraintName,
+            quoteIdentifier: quoteIdentifier,
+            dropPrimaryKeyClauseSQL: "DROP PRIMARY KEY"
+        )
     }
 
     // MARK: - Column Reorder DDL
@@ -859,15 +859,11 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             def += " NOT NULL"
         }
         if let defaultValue = column.defaultValue {
-            let upper = defaultValue.uppercased()
-            if upper == "NULL" || upper == "CURRENT_TIMESTAMP" || upper == "CURRENT_TIMESTAMP()"
-                || defaultValue.hasPrefix("'") {
-                def += " DEFAULT \(defaultValue)"
-            } else if Int64(defaultValue) != nil || Double(defaultValue) != nil {
-                def += " DEFAULT \(defaultValue)"
-            } else {
-                def += " DEFAULT '\(escapeStringLiteral(defaultValue))'"
-            }
+            def += " DEFAULT " + PluginSQLDDLBuilder.defaultValue(
+                defaultValue,
+                rawUppercaseValues: ["NULL", "CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP()"],
+                escapeStringLiteral: escapeStringLiteral
+            )
         }
         if column.autoIncrement {
             def += " AUTO_INCREMENT"

--- a/Plugins/OracleDriverPlugin/OraclePlugin.swift
+++ b/Plugins/OracleDriverPlugin/OraclePlugin.swift
@@ -703,128 +703,20 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         deletedRowIndices: Set<Int>,
         insertedRowIndices: Set<Int>
     ) -> [(statement: String, parameters: [PluginCellValue])]? {
-        var statements: [(statement: String, parameters: [PluginCellValue])] = []
-
-        for change in changes {
-            switch change.type {
-            case .insert:
-                guard insertedRowIndices.contains(change.rowIndex) else { continue }
-                if let values = insertedRowData[change.rowIndex] {
-                    if let stmt = generateOracleInsert(table: table, columns: columns, values: values) {
-                        statements.append(stmt)
-                    }
-                }
-            case .update:
-                if let stmt = generateOracleUpdate(table: table, columns: columns, change: change) {
-                    statements.append(stmt)
-                }
-            case .delete:
-                guard deletedRowIndices.contains(change.rowIndex) else { continue }
-                if let stmt = generateOracleDelete(table: table, columns: columns, change: change) {
-                    statements.append(stmt)
-                }
-            }
-        }
-
-        return statements.isEmpty ? nil : statements
-    }
-
-    private func escapeOracleIdentifier(_ name: String) -> String {
-        "\"\(name.replacingOccurrences(of: "\"", with: "\"\""))\""
-    }
-
-    private func generateOracleInsert(
-        table: String,
-        columns: [String],
-        values: [PluginCellValue]
-    ) -> (statement: String, parameters: [PluginCellValue])? {
-        var insertColumns: [String] = []
-        var valuesSQL: [String] = []
-        var parameters: [PluginCellValue] = []
-
-        for (index, value) in values.enumerated() {
-            guard index < columns.count else { continue }
-            insertColumns.append(escapeOracleIdentifier(columns[index]))
-            if value.asText == "__DEFAULT__" {
-                valuesSQL.append("DEFAULT")
-            } else {
-                valuesSQL.append("?")
-                parameters.append(value)
-            }
-        }
-
-        guard !insertColumns.isEmpty else { return nil }
-
-        let columnList = insertColumns.joined(separator: ", ")
-        let valueList = valuesSQL.joined(separator: ", ")
-        let sql = "INSERT INTO \(escapeOracleIdentifier(table)) (\(columnList)) VALUES (\(valueList))"
-        return (statement: sql, parameters: parameters)
-    }
-
-    private func generateOracleUpdate(
-        table: String,
-        columns: [String],
-        change: PluginRowChange
-    ) -> (statement: String, parameters: [PluginCellValue])? {
-        guard !change.cellChanges.isEmpty, let originalRow = change.originalRow else { return nil }
-
-        let escapedTable = escapeOracleIdentifier(table)
-        var parameters: [PluginCellValue] = []
-
-        let setClauses = change.cellChanges.map { cellChange -> String in
-            let col = escapeOracleIdentifier(cellChange.columnName)
-            parameters.append(cellChange.newValue)
-            return "\(col) = ?"
-        }.joined(separator: ", ")
-
-        var conditions: [String] = []
-        for (index, columnName) in columns.enumerated() {
-            guard index < originalRow.count else { continue }
-            let col = escapeOracleIdentifier(columnName)
-            let value = originalRow[index]
-            if value.isNull {
-                conditions.append("\(col) IS NULL")
-            } else {
-                parameters.append(value)
-                conditions.append("\(col) = ?")
-            }
-        }
-
-        guard !conditions.isEmpty else { return nil }
-
-        let whereClause = conditions.joined(separator: " AND ")
-        let sql = "UPDATE \(escapedTable) SET \(setClauses) WHERE \(whereClause) AND ROWNUM = 1"
-        return (statement: sql, parameters: parameters)
-    }
-
-    private func generateOracleDelete(
-        table: String,
-        columns: [String],
-        change: PluginRowChange
-    ) -> (statement: String, parameters: [PluginCellValue])? {
-        guard let originalRow = change.originalRow else { return nil }
-
-        let escapedTable = escapeOracleIdentifier(table)
-        var parameters: [PluginCellValue] = []
-        var conditions: [String] = []
-
-        for (index, columnName) in columns.enumerated() {
-            guard index < originalRow.count else { continue }
-            let col = escapeOracleIdentifier(columnName)
-            let value = originalRow[index]
-            if value.isNull {
-                conditions.append("\(col) IS NULL")
-            } else {
-                parameters.append(value)
-                conditions.append("\(col) = ?")
-            }
-        }
-
-        guard !conditions.isEmpty else { return nil }
-
-        let whereClause = conditions.joined(separator: " AND ")
-        let sql = "DELETE FROM \(escapedTable) WHERE \(whereClause) AND ROWNUM = 1"
-        return (statement: sql, parameters: parameters)
+        PluginSQLStatementBuilder.generateStatements(
+            table: table,
+            columns: columns,
+            primaryKeyColumns: primaryKeyColumns,
+            changes: changes,
+            insertedRowData: insertedRowData,
+            deletedRowIndices: deletedRowIndices,
+            insertedRowIndices: insertedRowIndices,
+            quoteIdentifier: quoteIdentifier,
+            insertDefaultStrategy: .useDefaultKeyword,
+            whereColumnStrategy: .allColumns,
+            updateWhereSuffix: " AND ROWNUM = 1",
+            deleteWhereSuffix: " AND ROWNUM = 1"
+        )
     }
 
     // MARK: - Create Table DDL
@@ -881,7 +773,11 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     func generateAddColumnSQL(table: String, column: PluginColumnDefinition) -> String? {
         let qt = oracleQualifiedTable(table)
         let colDef = oracleColumnDefinition(column, inlinePK: false)
-        return "ALTER TABLE \(qt) ADD (\(colDef))"
+        return PluginSQLDDLBuilder.alterTableAddColumnDefinition(
+            tableSQL: qt,
+            columnSQL: "(\(colDef))",
+            addKeyword: "ADD"
+        )
     }
 
     func generateModifyColumnSQL(table: String, oldColumn: PluginColumnDefinition, newColumn: PluginColumnDefinition) -> String? {
@@ -889,7 +785,14 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         var stmts: [String] = []
 
         if oldColumn.name != newColumn.name {
-            stmts.append("ALTER TABLE \(qt) RENAME COLUMN \(quoteIdentifier(oldColumn.name)) TO \(quoteIdentifier(newColumn.name))")
+            stmts.append(
+                PluginSQLDDLBuilder.alterTableRenameColumnDefinition(
+                    tableSQL: qt,
+                    oldColumnName: oldColumn.name,
+                    newColumnName: newColumn.name,
+                    quoteIdentifier: quoteIdentifier
+                )
+            )
         }
 
         var modifyParts: [String] = []
@@ -922,7 +825,11 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func generateDropColumnSQL(table: String, columnName: String) -> String? {
-        "ALTER TABLE \(oracleQualifiedTable(table)) DROP COLUMN \(quoteIdentifier(columnName))"
+        PluginSQLDDLBuilder.alterTableDropColumnDefinition(
+            tableSQL: oracleQualifiedTable(table),
+            columnName: columnName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     func generateAddIndexSQL(table: String, index: PluginIndexDefinition) -> String? {
@@ -930,7 +837,7 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func generateDropIndexSQL(table: String, indexName: String) -> String? {
-        "DROP INDEX \(quoteIdentifier(indexName))"
+        PluginSQLDDLBuilder.dropIndexDefinition(indexName: indexName, quoteIdentifier: quoteIdentifier)
     }
 
     func generateAddForeignKeySQL(table: String, fk: PluginForeignKeyDefinition) -> String? {
@@ -938,7 +845,12 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func generateDropForeignKeySQL(table: String, constraintName: String) -> String? {
-        "ALTER TABLE \(oracleQualifiedTable(table)) DROP CONSTRAINT \(quoteIdentifier(constraintName))"
+        PluginSQLDDLBuilder.alterTableDropObjectDefinition(
+            tableSQL: oracleQualifiedTable(table),
+            objectKind: "CONSTRAINT",
+            objectName: constraintName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     // MARK: - DDL Helpers
@@ -949,49 +861,46 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     private func oracleColumnDefinition(_ col: PluginColumnDefinition, inlinePK: Bool) -> String {
-        var def = "\(quoteIdentifier(col.name)) \(col.dataType.uppercased())"
-        if let defaultValue = col.defaultValue {
-            def += " DEFAULT \(oracleDefaultValue(defaultValue))"
-        }
-        if !col.isNullable {
-            def += " NOT NULL"
-        }
-        if inlinePK && col.isPrimaryKey {
-            def += " PRIMARY KEY"
-        }
-        return def
+        PluginSQLDDLBuilder.columnDefinition(
+            col,
+            inlinePrimaryKey: inlinePK,
+            quoteIdentifier: quoteIdentifier,
+            formatDefaultValue: oracleDefaultValue,
+            dataTypeSQL: { $0.dataType.uppercased() },
+            emitsNullableKeyword: false,
+            defaultClausePosition: .beforeNullability
+        )
     }
 
     private func oracleDefaultValue(_ value: String) -> String {
-        let upper = value.uppercased()
-        if upper == "NULL" || upper == "SYSDATE" || upper == "SYSTIMESTAMP"
-            || upper == "SYS_GUID()" || upper == "USER"
-            || value.hasPrefix("'") || Int64(value) != nil || Double(value) != nil {
-            return value
-        }
-        return "'\(escapeStringLiteral(value))'"
+        PluginSQLDDLBuilder.defaultValue(
+            value,
+            rawUppercaseValues: ["NULL", "SYSDATE", "SYSTIMESTAMP", "SYS_GUID()", "USER"],
+            escapeStringLiteral: escapeStringLiteral
+        )
     }
 
     private func oracleIndexDefinition(_ index: PluginIndexDefinition, qualifiedTable: String) -> String {
-        let cols = index.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let unique = index.isUnique ? "UNIQUE " : ""
-        return "CREATE \(unique)INDEX \(quoteIdentifier(index.name)) ON \(qualifiedTable) (\(cols))"
+        PluginSQLDDLBuilder.createIndexDefinition(
+            index,
+            quoteIdentifier: quoteIdentifier,
+            tableSQL: qualifiedTable,
+            includeWhereClause: false
+        )
     }
 
     private func oracleForeignKeyConstraint(_ fk: PluginForeignKeyDefinition) -> String {
-        let cols = fk.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let refCols = fk.referencedColumns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let refTable: String
-        if let schema = fk.referencedSchema, !schema.isEmpty {
-            refTable = "\(quoteIdentifier(schema)).\(quoteIdentifier(fk.referencedTable))"
-        } else {
-            refTable = quoteIdentifier(fk.referencedTable)
-        }
-        var def = "CONSTRAINT \(quoteIdentifier(fk.name)) FOREIGN KEY (\(cols)) REFERENCES \(refTable) (\(refCols))"
-        if fk.onDelete != "NO ACTION" {
-            def += " ON DELETE \(fk.onDelete)"
-        }
-        return def
+        PluginSQLDDLBuilder.foreignKeyDefinition(
+            fk,
+            quoteIdentifier: quoteIdentifier,
+            referencedTableSQL: { foreignKey in
+                if let schema = foreignKey.referencedSchema, !schema.isEmpty {
+                    return "\(self.quoteIdentifier(schema)).\(self.quoteIdentifier(foreignKey.referencedTable))"
+                }
+                return self.quoteIdentifier(foreignKey.referencedTable)
+            },
+            includeOnUpdate: false
+        )
     }
 
     // MARK: - Schema Switching
@@ -1034,13 +943,15 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         limit: Int,
         offset: Int
     ) -> String? {
-        let quotedTable = oracleQuoteIdentifier(table)
-        var query = "SELECT * FROM \(quotedTable)"
-        let orderBy = PluginSQLFilter.buildOrderByClause(
-            sortColumns: sortColumns, columns: columns, quoteIdentifier: oracleQuoteIdentifier
-        ) ?? "ORDER BY 1"
-        query += " \(orderBy) OFFSET \(offset) ROWS FETCH NEXT \(limit) ROWS ONLY"
-        return query
+        guard let dialect = OraclePlugin.sqlDialect else { return nil }
+        return PluginSQLFilter.buildBrowseQuery(
+            table: table,
+            dialect: dialect,
+            sortColumns: sortColumns,
+            columns: columns,
+            limit: limit,
+            offset: offset
+        )
     }
 
     func buildFilteredQuery(
@@ -1052,40 +963,21 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         limit: Int,
         offset: Int
     ) -> String? {
-        let quotedTable = oracleQuoteIdentifier(table)
-        var query = "SELECT * FROM \(quotedTable)"
-        let whereClause = PluginSQLFilter.buildWhereClause(
+        guard let dialect = OraclePlugin.sqlDialect else { return nil }
+        return PluginSQLFilter.buildFilteredQuery(
+            table: table,
             filters: filters,
             logicMode: logicMode,
-            quoteIdentifier: oracleQuoteIdentifier,
-            escapeValue: oracleEscapeValue,
+            dialect: dialect,
+            sortColumns: sortColumns,
+            columns: columns,
+            limit: limit,
+            offset: offset,
             regexCondition: { quoted, value in
                 "REGEXP_LIKE(\(quoted), '\(value.replacingOccurrences(of: "'", with: "''"))')"
             }
         )
-        if !whereClause.isEmpty {
-            query += " WHERE \(whereClause)"
-        }
-        let orderBy = PluginSQLFilter.buildOrderByClause(
-            sortColumns: sortColumns, columns: columns, quoteIdentifier: oracleQuoteIdentifier
-        ) ?? "ORDER BY 1"
-        query += " \(orderBy) OFFSET \(offset) ROWS FETCH NEXT \(limit) ROWS ONLY"
-        return query
     }
-
-    // MARK: - Query Building Helpers
-
-    private func oracleQuoteIdentifier(_ identifier: String) -> String {
-        "\"\(identifier.replacingOccurrences(of: "\"", with: "\"\""))\""
-    }
-
-    private func oracleEscapeValue(_ value: String) -> String {
-        let trimmed = value.trimmingCharacters(in: .whitespaces)
-        if trimmed.caseInsensitiveCompare("NULL") == .orderedSame { return "NULL" }
-        if Int(trimmed) != nil || Double(trimmed) != nil { return trimmed }
-        return "'\(trimmed.replacingOccurrences(of: "'", with: "''"))'"
-    }
-
 
     // MARK: - Private Helpers
 

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
@@ -916,76 +916,56 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     private func pgColumnDefinition(_ col: PluginColumnDefinition, inlinePK: Bool) -> String {
-        var dataType = col.dataType
-        if col.autoIncrement {
-            let upper = dataType.uppercased()
-            if upper == "BIGINT" || upper == "INT8" {
-                dataType = "BIGSERIAL"
-            } else {
-                dataType = "SERIAL"
-            }
-        }
-
-        var def = "\(quoteIdentifier(col.name)) \(dataType)"
-        if !col.autoIncrement {
-            if col.isNullable {
-                def += " NULL"
-            } else {
-                def += " NOT NULL"
-            }
-        }
-        if let defaultValue = col.defaultValue {
-            def += " DEFAULT \(pgDefaultValue(defaultValue))"
-        }
-        if inlinePK && col.isPrimaryKey {
-            def += " PRIMARY KEY"
-        }
-        return def
+        PluginSQLDDLBuilder.columnDefinition(
+            col,
+            inlinePrimaryKey: inlinePK,
+            quoteIdentifier: quoteIdentifier,
+            formatDefaultValue: pgDefaultValue,
+            dataTypeSQL: { column in
+                guard column.autoIncrement else { return column.dataType }
+                let upper = column.dataType.uppercased()
+                return upper == "BIGINT" || upper == "INT8" ? "BIGSERIAL" : "SERIAL"
+            },
+            suppressNullability: { $0.autoIncrement }
+        )
     }
 
     private func pgDefaultValue(_ value: String) -> String {
-        let upper = value.uppercased()
-        if upper == "NULL" || upper == "TRUE" || upper == "FALSE"
-            || upper == "CURRENT_TIMESTAMP" || upper == "NOW()"
-            || value.hasPrefix("'") || Int64(value) != nil || Double(value) != nil
-            || upper.hasSuffix("::REGCLASS") {
-            return value
-        }
-        return "'\(escapeLiteral(value))'"
+        PluginSQLDDLBuilder.defaultValue(
+            value,
+            rawUppercaseValues: ["NULL", "TRUE", "FALSE", "CURRENT_TIMESTAMP", "NOW()"],
+            rawUppercaseSuffixes: ["::REGCLASS"],
+            escapeStringLiteral: escapeLiteral
+        )
     }
 
     private func pgIndexDefinition(_ index: PluginIndexDefinition, qualifiedTable: String) -> String {
-        let cols = index.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let unique = index.isUnique ? "UNIQUE " : ""
-        var def = "CREATE \(unique)INDEX \(quoteIdentifier(index.name)) ON \(qualifiedTable)"
-        if let type = index.indexType?.uppercased(),
-           ["BTREE", "HASH", "GIN", "GIST", "BRIN"].contains(type) {
-            def += " USING \(type.lowercased())"
-        }
-        def += " (\(cols))"
-        if let whereClause = index.whereClause, !whereClause.isEmpty {
-            def += " WHERE \(whereClause)"
-        }
-        return def
+        PluginSQLDDLBuilder.createIndexDefinition(
+            index,
+            quoteIdentifier: quoteIdentifier,
+            tableSQL: qualifiedTable,
+            indexMethodSQL: { index in
+                guard let type = index.indexType?.uppercased(),
+                      ["BTREE", "HASH", "GIN", "GIST", "BRIN"].contains(type) else {
+                    return nil
+                }
+                return "USING \(type.lowercased())"
+            },
+            includeWhereClause: true
+        )
     }
 
     private func pgForeignKeyDefinition(_ fk: PluginForeignKeyDefinition) -> String {
-        let cols = fk.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let refCols = fk.referencedColumns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let refTable: String
-        if let schema = fk.referencedSchema, !schema.isEmpty {
-            refTable = "\(quoteIdentifier(schema)).\(quoteIdentifier(fk.referencedTable))"
-        } else {
-            refTable = quoteIdentifier(fk.referencedTable)
-        }
-        var def = "CONSTRAINT \(quoteIdentifier(fk.name)) FOREIGN KEY (\(cols)) REFERENCES \(refTable) (\(refCols))"
-        if fk.onDelete != "NO ACTION" {
-            def += " ON DELETE \(fk.onDelete)"
-        }
-        if fk.onUpdate != "NO ACTION" {
-            def += " ON UPDATE \(fk.onUpdate)"
-        }
-        return def
+        PluginSQLDDLBuilder.foreignKeyDefinition(
+            fk,
+            quoteIdentifier: quoteIdentifier,
+            referencedTableSQL: { foreignKey in
+                if let schema = foreignKey.referencedSchema, !schema.isEmpty {
+                    return "\(self.quoteIdentifier(schema)).\(self.quoteIdentifier(foreignKey.referencedTable))"
+                }
+                return self.quoteIdentifier(foreignKey.referencedTable)
+            }
+        )
     }
 
     // MARK: - Definition SQL (clipboard copy)
@@ -1012,7 +992,7 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     func generateAddColumnSQL(table: String, column: PluginColumnDefinition) -> String? {
         let qt = qualifiedTableName(table)
         let colDef = pgColumnDefinition(column, inlinePK: false)
-        return "ALTER TABLE \(qt) ADD COLUMN \(colDef)"
+        return PluginSQLDDLBuilder.alterTableAddColumnDefinition(tableSQL: qt, columnSQL: colDef)
     }
 
     func generateModifyColumnSQL(table: String, oldColumn: PluginColumnDefinition, newColumn: PluginColumnDefinition) -> String? {
@@ -1020,7 +1000,14 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
         var stmts: [String] = []
 
         if oldColumn.name != newColumn.name {
-            stmts.append("ALTER TABLE \(qt) RENAME COLUMN \(quoteIdentifier(oldColumn.name)) TO \(quoteIdentifier(newColumn.name))")
+            stmts.append(
+                PluginSQLDDLBuilder.alterTableRenameColumnDefinition(
+                    tableSQL: qt,
+                    oldColumnName: oldColumn.name,
+                    newColumnName: newColumn.name,
+                    quoteIdentifier: quoteIdentifier
+                )
+            )
         }
 
         let colName = quoteIdentifier(newColumn.name)
@@ -1052,7 +1039,11 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     func generateDropColumnSQL(table: String, columnName: String) -> String? {
-        "ALTER TABLE \(qualifiedTableName(table)) DROP COLUMN \(quoteIdentifier(columnName))"
+        PluginSQLDDLBuilder.alterTableDropColumnDefinition(
+            tableSQL: qualifiedTableName(table),
+            columnName: columnName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     func generateAddIndexSQL(table: String, index: PluginIndexDefinition) -> String? {
@@ -1060,7 +1051,11 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     func generateDropIndexSQL(table: String, indexName: String) -> String? {
-        "DROP INDEX \(quoteIdentifier(core.currentSchema)).\(quoteIdentifier(indexName))"
+        PluginSQLDDLBuilder.dropIndexDefinition(
+            indexName: indexName,
+            quoteIdentifier: quoteIdentifier,
+            qualifiedIndexSQL: "\(quoteIdentifier(core.currentSchema)).\(quoteIdentifier(indexName))"
+        )
     }
 
     func generateAddForeignKeySQL(table: String, fk: PluginForeignKeyDefinition) -> String? {
@@ -1068,20 +1063,21 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     func generateDropForeignKeySQL(table: String, constraintName: String) -> String? {
-        "ALTER TABLE \(qualifiedTableName(table)) DROP CONSTRAINT \(quoteIdentifier(constraintName))"
+        PluginSQLDDLBuilder.alterTableDropObjectDefinition(
+            tableSQL: qualifiedTableName(table),
+            objectKind: "CONSTRAINT",
+            objectName: constraintName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     func generateModifyPrimaryKeySQL(table: String, oldColumns: [String], newColumns: [String], constraintName: String?) -> [String]? {
-        let qt = qualifiedTableName(table)
-        var stmts: [String] = []
-        if !oldColumns.isEmpty {
-            let name = constraintName.map { quoteIdentifier($0) } ?? "/* unknown constraint */"
-            stmts.append("ALTER TABLE \(qt) DROP CONSTRAINT \(name)")
-        }
-        if !newColumns.isEmpty {
-            let cols = newColumns.map { quoteIdentifier($0) }.joined(separator: ", ")
-            stmts.append("ALTER TABLE \(qt) ADD PRIMARY KEY (\(cols))")
-        }
-        return stmts.isEmpty ? nil : stmts
+        PluginSQLDDLBuilder.modifyPrimaryKeyDefinitions(
+            tableSQL: qualifiedTableName(table),
+            oldColumns: oldColumns,
+            newColumns: newColumns,
+            constraintName: constraintName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 }

--- a/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
+++ b/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
@@ -964,68 +964,72 @@ final class SQLitePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     private func sqliteColumnDefinition(_ col: PluginColumnDefinition, inlinePK: Bool) -> String {
-        var def = "\(quoteIdentifier(col.name)) \(col.dataType)"
-        if inlinePK && col.isPrimaryKey {
-            def += " PRIMARY KEY"
-            if col.autoIncrement {
-                def += " AUTOINCREMENT"
-            }
-        }
-        if !col.isNullable {
-            def += " NOT NULL"
-        }
-        if let defaultValue = col.defaultValue {
-            def += " DEFAULT \(sqliteDefaultValue(defaultValue))"
-        }
-        return def
+        PluginSQLDDLBuilder.columnDefinition(
+            col,
+            inlinePrimaryKey: inlinePK,
+            quoteIdentifier: quoteIdentifier,
+            formatDefaultValue: sqliteDefaultValue,
+            emitsNullableKeyword: false,
+            primaryKeyClausePosition: .afterDataType,
+            postPrimaryKeySQL: { $0.autoIncrement ? "AUTOINCREMENT" : nil }
+        )
     }
 
     private func sqliteDefaultValue(_ value: String) -> String {
-        let upper = value.uppercased()
-        if upper == "NULL" || upper == "CURRENT_TIMESTAMP" || upper == "CURRENT_DATE" || upper == "CURRENT_TIME"
-            || value.hasPrefix("'") || Int64(value) != nil || Double(value) != nil {
-            return value
-        }
-        return "'\(escapeStringLiteral(value))'"
+        PluginSQLDDLBuilder.defaultValue(
+            value,
+            rawUppercaseValues: ["NULL", "CURRENT_TIMESTAMP", "CURRENT_DATE", "CURRENT_TIME"],
+            escapeStringLiteral: escapeStringLiteral
+        )
     }
 
     private func sqliteForeignKeyDefinition(_ fk: PluginForeignKeyDefinition) -> String {
-        let cols = fk.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let refCols = fk.referencedColumns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        var def = "FOREIGN KEY (\(cols)) REFERENCES \(quoteIdentifier(fk.referencedTable)) (\(refCols))"
-        if fk.onDelete != "NO ACTION" {
-            def += " ON DELETE \(fk.onDelete)"
-        }
-        if fk.onUpdate != "NO ACTION" {
-            def += " ON UPDATE \(fk.onUpdate)"
-        }
-        return def
+        PluginSQLDDLBuilder.foreignKeyDefinition(
+            fk,
+            quoteIdentifier: quoteIdentifier,
+            includeConstraintName: false
+        )
     }
 
     // MARK: - ALTER TABLE DDL
 
     func generateAddColumnSQL(table: String, column: PluginColumnDefinition) -> String? {
         let colDef = sqliteColumnDefinition(column, inlinePK: false)
-        return "ALTER TABLE \(quoteIdentifier(table)) ADD COLUMN \(colDef)"
+        return PluginSQLDDLBuilder.alterTableAddColumnDefinition(
+            tableSQL: quoteIdentifier(table),
+            columnSQL: colDef
+        )
     }
 
     func generateModifyColumnSQL(table: String, oldColumn: PluginColumnDefinition, newColumn: PluginColumnDefinition) -> String? {
         guard oldColumn.name != newColumn.name else { return nil }
-        return "ALTER TABLE \(quoteIdentifier(table)) RENAME COLUMN \(quoteIdentifier(oldColumn.name)) TO \(quoteIdentifier(newColumn.name))"
+        return PluginSQLDDLBuilder.alterTableRenameColumnDefinition(
+            tableSQL: quoteIdentifier(table),
+            oldColumnName: oldColumn.name,
+            newColumnName: newColumn.name,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     func generateDropColumnSQL(table: String, columnName: String) -> String? {
-        "ALTER TABLE \(quoteIdentifier(table)) DROP COLUMN \(quoteIdentifier(columnName))"
+        PluginSQLDDLBuilder.alterTableDropColumnDefinition(
+            tableSQL: quoteIdentifier(table),
+            columnName: columnName,
+            quoteIdentifier: quoteIdentifier
+        )
     }
 
     func generateAddIndexSQL(table: String, index: PluginIndexDefinition) -> String? {
-        let cols = index.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
-        let unique = index.isUnique ? "UNIQUE " : ""
-        return "CREATE \(unique)INDEX \(quoteIdentifier(index.name)) ON \(quoteIdentifier(table)) (\(cols))"
+        PluginSQLDDLBuilder.createIndexDefinition(
+            index,
+            quoteIdentifier: quoteIdentifier,
+            tableSQL: quoteIdentifier(table),
+            includeWhereClause: false
+        )
     }
 
     func generateDropIndexSQL(table: String, indexName: String) -> String? {
-        "DROP INDEX \(quoteIdentifier(indexName))"
+        PluginSQLDDLBuilder.dropIndexDefinition(indexName: indexName, quoteIdentifier: quoteIdentifier)
     }
 
     private func formatDDL(_ ddl: String) -> String {

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -622,6 +622,77 @@ public enum PluginSQLFilter {
         return "ORDER BY " + parts.joined(separator: ", ")
     }
 
+    public static func buildBrowseQuery(
+        table: String,
+        dialect: SQLDialectDescriptor,
+        sortColumns: [(columnIndex: Int, ascending: Bool)],
+        columns: [String],
+        limit: Int,
+        offset: Int
+    ) -> String {
+        let quotedTable = dialect.quoteIdentifier(table)
+        return appendPagination(
+            to: "SELECT * FROM \(quotedTable)",
+            dialect: dialect,
+            sortColumns: sortColumns,
+            columns: columns,
+            limit: limit,
+            offset: offset
+        )
+    }
+
+    public static func buildFilteredQuery(
+        table: String,
+        filters: [(column: String, op: String, value: String)],
+        logicMode: String,
+        dialect: SQLDialectDescriptor,
+        sortColumns: [(columnIndex: Int, ascending: Bool)],
+        columns: [String],
+        limit: Int,
+        offset: Int,
+        regexCondition: (_ quotedColumn: String, _ value: String) -> String?
+    ) -> String {
+        let quotedTable = dialect.quoteIdentifier(table)
+        let whereClause = buildWhereClause(
+            filters: filters,
+            logicMode: logicMode,
+            dialect: dialect,
+            regexCondition: regexCondition
+        )
+        let baseQuery = whereClause.isEmpty
+            ? "SELECT * FROM \(quotedTable)"
+            : "SELECT * FROM \(quotedTable) WHERE \(whereClause)"
+
+        return appendPagination(
+            to: baseQuery,
+            dialect: dialect,
+            sortColumns: sortColumns,
+            columns: columns,
+            limit: limit,
+            offset: offset
+        )
+    }
+
+    public static func buildWhereClause(
+        filters: [(column: String, op: String, value: String)],
+        logicMode: String,
+        dialect: SQLDialectDescriptor,
+        regexCondition: (_ quotedColumn: String, _ value: String) -> String?
+    ) -> String {
+        let conditions = filters.compactMap { filter in
+            buildFilterCondition(
+                column: filter.column,
+                op: filter.op,
+                value: filter.value,
+                dialect: dialect,
+                regexCondition: regexCondition
+            )
+        }
+        guard !conditions.isEmpty else { return "" }
+        let separator = logicMode == "and" ? " AND " : " OR "
+        return conditions.joined(separator: separator)
+    }
+
     public static func buildWhereClause(
         filters: [(column: String, op: String, value: String)],
         logicMode: String,
@@ -636,6 +707,10 @@ public enum PluginSQLFilter {
                 value: filter.value,
                 quoteIdentifier: quoteIdentifier,
                 escapeValue: escapeValue,
+                escapeLikeWildcards: escapeForLike,
+                likeEscapeClause: " ESCAPE '\\'",
+                quoteLikePattern: false,
+                normalizeNullEquality: false,
                 regexCondition: regexCondition
             )
         }
@@ -648,14 +723,65 @@ public enum PluginSQLFilter {
         column: String,
         op: String,
         value: String,
+        dialect: SQLDialectDescriptor,
+        regexCondition: (_ quotedColumn: String, _ value: String) -> String?
+    ) -> String? {
+        buildFilterCondition(
+            column: column,
+            op: op,
+            value: value,
+            quoteIdentifier: dialect.quoteIdentifier,
+            escapeValue: { dialect.sqlLiteral(for: $0) },
+            escapeLikeWildcards: dialect.escapeLikeWildcards,
+            likeEscapeClause: dialect.likeEscapeClause,
+            quoteLikePattern: true,
+            normalizeNullEquality: true,
+            regexCondition: regexCondition
+        )
+    }
+
+    public static func buildFilterCondition(
+        column: String,
+        op: String,
+        value: String,
         quoteIdentifier: (String) -> String,
         escapeValue: (String) -> String,
         regexCondition: (_ quotedColumn: String, _ value: String) -> String?
     ) -> String? {
+        buildFilterCondition(
+            column: column,
+            op: op,
+            value: value,
+            quoteIdentifier: quoteIdentifier,
+            escapeValue: escapeValue,
+            escapeLikeWildcards: escapeForLike,
+            likeEscapeClause: " ESCAPE '\\'",
+            quoteLikePattern: false,
+            normalizeNullEquality: false,
+            regexCondition: regexCondition
+        )
+    }
+
+    private static func buildFilterCondition(
+        column: String,
+        op: String,
+        value: String,
+        quoteIdentifier: (String) -> String,
+        escapeValue: (String) -> String,
+        escapeLikeWildcards: (String) -> String,
+        likeEscapeClause: String,
+        quoteLikePattern: Bool,
+        normalizeNullEquality: Bool,
+        regexCondition: (_ quotedColumn: String, _ value: String) -> String?
+    ) -> String? {
         let quoted = quoteIdentifier(column)
         switch op {
-        case "=": return "\(quoted) = \(escapeValue(value))"
-        case "!=": return "\(quoted) != \(escapeValue(value))"
+        case "=":
+            if normalizeNullEquality, isNullLiteral(value) { return "\(quoted) IS NULL" }
+            return "\(quoted) = \(escapeValue(value))"
+        case "!=":
+            if normalizeNullEquality, isNullLiteral(value) { return "\(quoted) IS NOT NULL" }
+            return "\(quoted) != \(escapeValue(value))"
         case ">": return "\(quoted) > \(escapeValue(value))"
         case ">=": return "\(quoted) >= \(escapeValue(value))"
         case "<": return "\(quoted) < \(escapeValue(value))"
@@ -665,13 +791,37 @@ public enum PluginSQLFilter {
         case "IS EMPTY": return "(\(quoted) IS NULL OR \(quoted) = '')"
         case "IS NOT EMPTY": return "(\(quoted) IS NOT NULL AND \(quoted) != '')"
         case "CONTAINS":
-            return "\(quoted) LIKE '%\(escapeForLike(value))%' ESCAPE '\\'"
+            return likeCondition(
+                quoted,
+                pattern: "%\(escapeLikeWildcards(value))%",
+                negated: false,
+                likeEscapeClause: likeEscapeClause,
+                quotePattern: quoteLikePattern
+            )
         case "NOT CONTAINS":
-            return "\(quoted) NOT LIKE '%\(escapeForLike(value))%' ESCAPE '\\'"
+            return likeCondition(
+                quoted,
+                pattern: "%\(escapeLikeWildcards(value))%",
+                negated: true,
+                likeEscapeClause: likeEscapeClause,
+                quotePattern: quoteLikePattern
+            )
         case "STARTS WITH":
-            return "\(quoted) LIKE '\(escapeForLike(value))%' ESCAPE '\\'"
+            return likeCondition(
+                quoted,
+                pattern: "\(escapeLikeWildcards(value))%",
+                negated: false,
+                likeEscapeClause: likeEscapeClause,
+                quotePattern: quoteLikePattern
+            )
         case "ENDS WITH":
-            return "\(quoted) LIKE '%\(escapeForLike(value))' ESCAPE '\\'"
+            return likeCondition(
+                quoted,
+                pattern: "%\(escapeLikeWildcards(value))",
+                negated: false,
+                likeEscapeClause: likeEscapeClause,
+                quotePattern: quoteLikePattern
+            )
         case "IN":
             let values = value.split(separator: ",")
                 .map { escapeValue($0.trimmingCharacters(in: .whitespaces)) }
@@ -692,5 +842,288 @@ public enum PluginSQLFilter {
             return regexCondition(quoted, value)
         default: return nil
         }
+    }
+
+    private static func likeCondition(
+        _ column: String,
+        pattern: String,
+        negated: Bool,
+        likeEscapeClause: String,
+        quotePattern: Bool
+    ) -> String {
+        let escapedPattern = quotePattern ? pattern.replacingOccurrences(of: "'", with: "''") : pattern
+        let op = negated ? "NOT LIKE" : "LIKE"
+        return "\(column) \(op) '\(escapedPattern)'\(likeEscapeClause)"
+    }
+
+    private static func appendPagination(
+        to query: String,
+        dialect: SQLDialectDescriptor,
+        sortColumns: [(columnIndex: Int, ascending: Bool)],
+        columns: [String],
+        limit: Int,
+        offset: Int
+    ) -> String {
+        let orderBy = buildOrderByClause(
+            sortColumns: sortColumns,
+            columns: columns,
+            quoteIdentifier: dialect.quoteIdentifier
+        )
+
+        switch dialect.paginationStyle {
+        case .limit:
+            var result = query
+            if let orderBy {
+                result += " \(orderBy)"
+            }
+            result += " LIMIT \(limit)"
+            if offset > 0 {
+                result += " OFFSET \(offset)"
+            }
+            return result
+        case .offsetFetch:
+            let resolvedOrderBy = orderBy ?? dialect.offsetFetchOrderBy
+            return "\(query) \(resolvedOrderBy) OFFSET \(offset) ROWS FETCH NEXT \(limit) ROWS ONLY"
+        }
+    }
+
+    private static func isNullLiteral(_ value: String) -> Bool {
+        value.trimmingCharacters(in: .whitespaces).caseInsensitiveCompare("NULL") == .orderedSame
+    }
+}
+
+public enum PluginSQLStatementBuilder {
+    public enum InsertDefaultStrategy {
+        case omitColumn
+        case useDefaultKeyword
+    }
+
+    public enum WhereColumnStrategy {
+        case primaryKeyOrAll
+        case allColumns
+    }
+
+    public static func generateStatements(
+        table: String,
+        columns: [String],
+        primaryKeyColumns: [String],
+        changes: [PluginRowChange],
+        insertedRowData: [Int: [PluginCellValue]],
+        deletedRowIndices: Set<Int>,
+        insertedRowIndices: Set<Int>,
+        quoteIdentifier: (String) -> String,
+        insertDefaultStrategy: InsertDefaultStrategy,
+        includeInsertedColumn: (String) -> Bool = { _ in true },
+        whereColumnStrategy: WhereColumnStrategy,
+        collectDeletesLast: Bool = false,
+        singleRowUpdatePrefixWhenNoPrimaryKey: String = "",
+        singleRowDeletePrefixWhenNoPrimaryKey: String = "",
+        updateWhereSuffix: String = "",
+        deleteWhereSuffix: String = ""
+    ) -> [(statement: String, parameters: [PluginCellValue])]? {
+        var statements: [(statement: String, parameters: [PluginCellValue])] = []
+        var deferredDeletes: [PluginRowChange] = []
+
+        for change in changes {
+            switch change.type {
+            case .insert:
+                guard insertedRowIndices.contains(change.rowIndex),
+                      let values = insertedRowData[change.rowIndex],
+                      let statement = buildInsert(
+                        table: table,
+                        columns: columns,
+                        values: values,
+                        quoteIdentifier: quoteIdentifier,
+                        defaultStrategy: insertDefaultStrategy,
+                        includeColumn: includeInsertedColumn
+                      )
+                else { continue }
+                statements.append(statement)
+            case .update:
+                if let statement = buildUpdate(
+                    table: table,
+                    columns: columns,
+                    primaryKeyColumns: primaryKeyColumns,
+                    change: change,
+                    quoteIdentifier: quoteIdentifier,
+                    whereColumnStrategy: whereColumnStrategy,
+                    singleRowPrefixWhenNoPrimaryKey: singleRowUpdatePrefixWhenNoPrimaryKey,
+                    whereSuffix: updateWhereSuffix
+                ) {
+                    statements.append(statement)
+                }
+            case .delete:
+                guard deletedRowIndices.contains(change.rowIndex) else { continue }
+                if collectDeletesLast {
+                    deferredDeletes.append(change)
+                } else if let statement = buildDelete(
+                    table: table,
+                    columns: columns,
+                    primaryKeyColumns: primaryKeyColumns,
+                    change: change,
+                    quoteIdentifier: quoteIdentifier,
+                    whereColumnStrategy: whereColumnStrategy,
+                    singleRowPrefixWhenNoPrimaryKey: singleRowDeletePrefixWhenNoPrimaryKey,
+                    whereSuffix: deleteWhereSuffix
+                ) {
+                    statements.append(statement)
+                }
+            }
+        }
+
+        for change in deferredDeletes {
+            if let statement = buildDelete(
+                table: table,
+                columns: columns,
+                primaryKeyColumns: primaryKeyColumns,
+                change: change,
+                quoteIdentifier: quoteIdentifier,
+                whereColumnStrategy: whereColumnStrategy,
+                singleRowPrefixWhenNoPrimaryKey: singleRowDeletePrefixWhenNoPrimaryKey,
+                whereSuffix: deleteWhereSuffix
+            ) {
+                statements.append(statement)
+            }
+        }
+
+        return statements.isEmpty ? nil : statements
+    }
+
+    private static func buildInsert(
+        table: String,
+        columns: [String],
+        values: [PluginCellValue],
+        quoteIdentifier: (String) -> String,
+        defaultStrategy: InsertDefaultStrategy,
+        includeColumn: (String) -> Bool
+    ) -> (statement: String, parameters: [PluginCellValue])? {
+        var insertColumns: [String] = []
+        var valueFragments: [String] = []
+        var parameters: [PluginCellValue] = []
+
+        for (index, value) in values.enumerated() {
+            guard index < columns.count else { continue }
+            let column = columns[index]
+
+            if value.asText == "__DEFAULT__" {
+                switch defaultStrategy {
+                case .omitColumn:
+                    continue
+                case .useDefaultKeyword:
+                    insertColumns.append(quoteIdentifier(column))
+                    valueFragments.append("DEFAULT")
+                    continue
+                }
+            }
+
+            guard includeColumn(column) else { continue }
+            insertColumns.append(quoteIdentifier(column))
+            valueFragments.append("?")
+            parameters.append(value)
+        }
+
+        guard !insertColumns.isEmpty else { return nil }
+
+        let columnList = insertColumns.joined(separator: ", ")
+        let valueList = valueFragments.joined(separator: ", ")
+        let statement = "INSERT INTO \(quoteIdentifier(table)) (\(columnList)) VALUES (\(valueList))"
+        return (statement: statement, parameters: parameters)
+    }
+
+    private static func buildUpdate(
+        table: String,
+        columns: [String],
+        primaryKeyColumns: [String],
+        change: PluginRowChange,
+        quoteIdentifier: (String) -> String,
+        whereColumnStrategy: WhereColumnStrategy,
+        singleRowPrefixWhenNoPrimaryKey: String,
+        whereSuffix: String
+    ) -> (statement: String, parameters: [PluginCellValue])? {
+        guard !change.cellChanges.isEmpty,
+              let originalRow = change.originalRow
+        else { return nil }
+
+        var parameters: [PluginCellValue] = []
+        let setClauses = change.cellChanges.map { cellChange -> String in
+            parameters.append(cellChange.newValue)
+            return "\(quoteIdentifier(cellChange.columnName)) = ?"
+        }.joined(separator: ", ")
+
+        guard let whereClause = buildWhereClause(
+            columns: columns,
+            primaryKeyColumns: primaryKeyColumns,
+            originalRow: originalRow,
+            quoteIdentifier: quoteIdentifier,
+            strategy: whereColumnStrategy,
+            parameters: &parameters
+        ) else { return nil }
+
+        let prefix = primaryKeyColumns.isEmpty ? singleRowPrefixWhenNoPrimaryKey : ""
+        let statement = "UPDATE \(prefix)\(quoteIdentifier(table)) SET \(setClauses) WHERE \(whereClause)\(whereSuffix)"
+        return (statement: statement, parameters: parameters)
+    }
+
+    private static func buildDelete(
+        table: String,
+        columns: [String],
+        primaryKeyColumns: [String],
+        change: PluginRowChange,
+        quoteIdentifier: (String) -> String,
+        whereColumnStrategy: WhereColumnStrategy,
+        singleRowPrefixWhenNoPrimaryKey: String,
+        whereSuffix: String
+    ) -> (statement: String, parameters: [PluginCellValue])? {
+        guard let originalRow = change.originalRow else { return nil }
+
+        var parameters: [PluginCellValue] = []
+        guard let whereClause = buildWhereClause(
+            columns: columns,
+            primaryKeyColumns: primaryKeyColumns,
+            originalRow: originalRow,
+            quoteIdentifier: quoteIdentifier,
+            strategy: whereColumnStrategy,
+            parameters: &parameters
+        ) else { return nil }
+
+        let prefix = primaryKeyColumns.isEmpty ? singleRowPrefixWhenNoPrimaryKey : ""
+        let statement = "DELETE \(prefix)FROM \(quoteIdentifier(table)) WHERE \(whereClause)\(whereSuffix)"
+        return (statement: statement, parameters: parameters)
+    }
+
+    private static func buildWhereClause(
+        columns: [String],
+        primaryKeyColumns: [String],
+        originalRow: [PluginCellValue],
+        quoteIdentifier: (String) -> String,
+        strategy: WhereColumnStrategy,
+        parameters: inout [PluginCellValue]
+    ) -> String? {
+        let whereColumns: [String]
+        switch strategy {
+        case .primaryKeyOrAll:
+            whereColumns = primaryKeyColumns.isEmpty ? columns : primaryKeyColumns
+        case .allColumns:
+            whereColumns = columns
+        }
+
+        var conditions: [String] = []
+        for column in whereColumns {
+            guard let columnIndex = columns.firstIndex(of: column),
+                  columnIndex < originalRow.count
+            else { continue }
+
+            let quotedColumn = quoteIdentifier(column)
+            let value = originalRow[columnIndex]
+            if value.isNull {
+                conditions.append("\(quotedColumn) IS NULL")
+            } else {
+                parameters.append(value)
+                conditions.append("\(quotedColumn) = ?")
+            }
+        }
+
+        guard !conditions.isEmpty else { return nil }
+        return conditions.joined(separator: " AND ")
     }
 }

--- a/Plugins/TableProPluginKit/SQLDialectDescriptor.swift
+++ b/Plugins/TableProPluginKit/SQLDialectDescriptor.swift
@@ -18,6 +18,7 @@ public enum AutoLimitStyle: String, Sendable {
 
 public struct SQLDialectDescriptor: Sendable {
     public let identifierQuote: String
+    public let identifierClosingQuote: String
     public let keywords: Set<String>
     public let functions: Set<String>
     public let dataTypes: Set<String>
@@ -62,6 +63,7 @@ public struct SQLDialectDescriptor: Sendable {
 
     public init(
         identifierQuote: String,
+        identifierClosingQuote: String? = nil,
         keywords: Set<String>,
         functions: Set<String>,
         dataTypes: Set<String>,
@@ -75,6 +77,7 @@ public struct SQLDialectDescriptor: Sendable {
         autoLimitStyle: AutoLimitStyle = .limit
     ) {
         self.identifierQuote = identifierQuote
+        self.identifierClosingQuote = identifierClosingQuote ?? Self.defaultIdentifierClosingQuote(for: identifierQuote)
         self.keywords = keywords
         self.functions = functions
         self.dataTypes = dataTypes
@@ -86,5 +89,77 @@ public struct SQLDialectDescriptor: Sendable {
         self.offsetFetchOrderBy = offsetFetchOrderBy
         self.requiresBackslashEscaping = requiresBackslashEscaping
         self.autoLimitStyle = autoLimitStyle
+    }
+
+    public func quoteIdentifier(_ name: String) -> String {
+        let escaped = name.replacingOccurrences(
+            of: identifierClosingQuote,
+            with: "\(identifierClosingQuote)\(identifierClosingQuote)"
+        )
+        return "\(identifierQuote)\(escaped)\(identifierClosingQuote)"
+    }
+
+    public var likeEscapeClause: String {
+        likeEscapeStyle == .implicit ? "" : " ESCAPE '!'"
+    }
+
+    public func sqlLiteral(
+        for value: String,
+        trimWhitespace: Bool = true,
+        interpretSpecialLiterals: Bool = true
+    ) -> String {
+        let resolved = trimWhitespace ? value.trimmingCharacters(in: .whitespaces) : value
+
+        if interpretSpecialLiterals {
+            if resolved.caseInsensitiveCompare("NULL") == .orderedSame {
+                return "NULL"
+            }
+            if resolved.caseInsensitiveCompare("TRUE") == .orderedSame {
+                return booleanLiteralStyle == .truefalse ? "TRUE" : "1"
+            }
+            if resolved.caseInsensitiveCompare("FALSE") == .orderedSame {
+                return booleanLiteralStyle == .truefalse ? "FALSE" : "0"
+            }
+        }
+
+        if PluginNumericLiteral.isValid(resolved) {
+            return resolved
+        }
+
+        return "'\(escapeStringLiteralContent(resolved))'"
+    }
+
+    public func escapeSQLQuote(_ value: String) -> String {
+        guard value.contains("'") else { return value }
+        return value.replacingOccurrences(of: "'", with: "''")
+    }
+
+    public func escapeStringLiteralContent(_ value: String) -> String {
+        if likeEscapeStyle == .implicit || requiresBackslashEscaping {
+            guard value.contains("\\") || value.contains("'") else { return value }
+            return value
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "'", with: "''")
+        }
+        return escapeSQLQuote(value)
+    }
+
+    public func escapeLikeWildcards(_ value: String) -> String {
+        if likeEscapeStyle == .implicit {
+            guard value.contains("\\") || value.contains("%") || value.contains("_") else { return value }
+            return value
+                .replacingOccurrences(of: "\\", with: "\\\\\\\\")
+                .replacingOccurrences(of: "%", with: "\\\\%")
+                .replacingOccurrences(of: "_", with: "\\\\_")
+        }
+        guard value.contains("!") || value.contains("%") || value.contains("_") else { return value }
+        return value
+            .replacingOccurrences(of: "!", with: "!!")
+            .replacingOccurrences(of: "%", with: "!%")
+            .replacingOccurrences(of: "_", with: "!_")
+    }
+
+    private static func defaultIdentifierClosingQuote(for openingQuote: String) -> String {
+        openingQuote == "[" ? "]" : openingQuote
     }
 }

--- a/Plugins/TableProPluginKit/SchemaTypes.swift
+++ b/Plugins/TableProPluginKit/SchemaTypes.swift
@@ -137,3 +137,318 @@ public struct PluginCreateTableDefinition: Sendable {
         self.ifNotExists = ifNotExists
     }
 }
+
+public enum PluginSQLDDLBuilder {
+    public enum ColumnDefaultClausePosition {
+        case beforeNullability
+        case afterNullability
+    }
+
+    public enum ColumnPrimaryKeyClausePosition {
+        case afterDataType
+        case afterDefaultClause
+    }
+
+    public static func columnDefinition(
+        _ column: PluginColumnDefinition,
+        inlinePrimaryKey: Bool,
+        quoteIdentifier: (String) -> String,
+        formatDefaultValue: (String) -> String,
+        dataTypeSQL: (PluginColumnDefinition) -> String = { $0.dataType },
+        postDataTypeSQL: (PluginColumnDefinition) -> String? = { _ in nil },
+        emitsNullableKeyword: Bool = true,
+        suppressNullability: (PluginColumnDefinition) -> Bool = { _ in false },
+        defaultClausePosition: ColumnDefaultClausePosition = .afterNullability,
+        primaryKeyClausePosition: ColumnPrimaryKeyClausePosition = .afterDefaultClause,
+        primaryKeyClause: String = "PRIMARY KEY",
+        postPrimaryKeySQL: (PluginColumnDefinition) -> String? = { _ in nil }
+    ) -> String {
+        var definition = "\(quoteIdentifier(column.name)) \(dataTypeSQL(column))"
+        if let postDataType = postDataTypeSQL(column), !postDataType.isEmpty {
+            definition += " \(postDataType)"
+        }
+
+        if primaryKeyClausePosition == .afterDataType {
+            appendPrimaryKeyClause(
+                to: &definition,
+                column: column,
+                inlinePrimaryKey: inlinePrimaryKey,
+                primaryKeyClause: primaryKeyClause,
+                postPrimaryKeySQL: postPrimaryKeySQL
+            )
+        }
+        if defaultClausePosition == .beforeNullability {
+            appendDefaultClause(to: &definition, column: column, formatDefaultValue: formatDefaultValue)
+        }
+        if !suppressNullability(column) {
+            if column.isNullable {
+                if emitsNullableKeyword {
+                    definition += " NULL"
+                }
+            } else {
+                definition += " NOT NULL"
+            }
+        }
+        if defaultClausePosition == .afterNullability {
+            appendDefaultClause(to: &definition, column: column, formatDefaultValue: formatDefaultValue)
+        }
+        if primaryKeyClausePosition == .afterDefaultClause {
+            appendPrimaryKeyClause(
+                to: &definition,
+                column: column,
+                inlinePrimaryKey: inlinePrimaryKey,
+                primaryKeyClause: primaryKeyClause,
+                postPrimaryKeySQL: postPrimaryKeySQL
+            )
+        }
+
+        return definition
+    }
+
+    public static func defaultValue(
+        _ value: String,
+        rawUppercaseValues: Set<String>,
+        rawUppercaseSuffixes: [String] = [],
+        preservesQuotedStrings: Bool = true,
+        allowsNumericLiterals: Bool = true,
+        allowsParenthesizedExpressions: Bool = false,
+        escapeStringLiteral: (String) -> String
+    ) -> String {
+        let upper = value.uppercased()
+
+        if rawUppercaseValues.contains(upper) {
+            return value
+        }
+        if rawUppercaseSuffixes.contains(where: { upper.hasSuffix($0) }) {
+            return value
+        }
+        if preservesQuotedStrings, value.hasPrefix("'") {
+            return value
+        }
+        if allowsParenthesizedExpressions, value.hasPrefix("(") {
+            return value
+        }
+        if allowsNumericLiterals, Int64(value) != nil || Double(value) != nil {
+            return value
+        }
+
+        return "'\(escapeStringLiteral(value))'"
+    }
+
+    public static func indexColumnList(
+        _ index: PluginIndexDefinition,
+        quoteIdentifier: (String) -> String,
+        formatColumnSQL: ((String) -> String)? = nil
+    ) -> String {
+        index.columns.map { column in
+            formatColumnSQL?(column) ?? quoteIdentifier(column)
+        }.joined(separator: ", ")
+    }
+
+    public static func createIndexDefinition(
+        _ index: PluginIndexDefinition,
+        quoteIdentifier: (String) -> String,
+        tableSQL: String?,
+        indexKindSQL: ((PluginIndexDefinition) -> String)? = nil,
+        indexMethodSQL: ((PluginIndexDefinition) -> String?)? = nil,
+        formatColumnSQL: ((String) -> String)? = nil,
+        includeWhereClause: Bool = true
+    ) -> String {
+        let indexKind = indexKindSQL?(index) ?? (index.isUnique ? "UNIQUE INDEX" : "INDEX")
+        var definition = "CREATE \(indexKind) \(quoteIdentifier(index.name))"
+        if let tableSQL, !tableSQL.isEmpty {
+            definition += " ON \(tableSQL)"
+        }
+        if let method = indexMethodSQL?(index), !method.isEmpty {
+            definition += " \(method)"
+        }
+
+        let columns = indexColumnList(
+            index,
+            quoteIdentifier: quoteIdentifier,
+            formatColumnSQL: formatColumnSQL
+        )
+        definition += " (\(columns))"
+
+        if includeWhereClause, let whereClause = index.whereClause, !whereClause.isEmpty {
+            definition += " WHERE \(whereClause)"
+        }
+
+        return definition
+    }
+
+    public static func indexDefinitionFragment(
+        _ index: PluginIndexDefinition,
+        quoteIdentifier: (String) -> String,
+        indexKindSQL: ((PluginIndexDefinition) -> String)? = nil,
+        indexMethodSQL: ((PluginIndexDefinition) -> String?)? = nil,
+        formatColumnSQL: ((String) -> String)? = nil,
+        includeWhereClause: Bool = true
+    ) -> String {
+        let indexKind = indexKindSQL?(index) ?? (index.isUnique ? "UNIQUE INDEX" : "INDEX")
+        let columns = indexColumnList(
+            index,
+            quoteIdentifier: quoteIdentifier,
+            formatColumnSQL: formatColumnSQL
+        )
+
+        var definition = "\(indexKind) \(quoteIdentifier(index.name)) (\(columns))"
+        if let method = indexMethodSQL?(index), !method.isEmpty {
+            definition += " \(method)"
+        }
+        if includeWhereClause, let whereClause = index.whereClause, !whereClause.isEmpty {
+            definition += " WHERE \(whereClause)"
+        }
+
+        return definition
+    }
+
+    public static func dropIndexDefinition(
+        indexName: String,
+        quoteIdentifier: (String) -> String,
+        qualifiedIndexSQL: String? = nil,
+        ifExists: Bool = false,
+        tableSQL: String? = nil
+    ) -> String {
+        var definition = "DROP INDEX"
+        if ifExists {
+            definition += " IF EXISTS"
+        }
+        definition += " \(qualifiedIndexSQL ?? quoteIdentifier(indexName))"
+        if let tableSQL, !tableSQL.isEmpty {
+            definition += " ON \(tableSQL)"
+        }
+        return definition
+    }
+
+    public static func alterTableDropObjectDefinition(
+        tableSQL: String,
+        objectKind: String,
+        objectName: String,
+        quoteIdentifier: (String) -> String
+    ) -> String {
+        "ALTER TABLE \(tableSQL) DROP \(objectKind) \(quoteIdentifier(objectName))"
+    }
+
+    public static func alterTableAddColumnDefinition(
+        tableSQL: String,
+        columnSQL: String,
+        addKeyword: String = "ADD COLUMN"
+    ) -> String {
+        "ALTER TABLE \(tableSQL) \(addKeyword) \(columnSQL)"
+    }
+
+    public static func alterTableDropColumnDefinition(
+        tableSQL: String,
+        columnName: String,
+        quoteIdentifier: (String) -> String,
+        dropKeyword: String = "DROP COLUMN"
+    ) -> String {
+        "ALTER TABLE \(tableSQL) \(dropKeyword) \(quoteIdentifier(columnName))"
+    }
+
+    public static func alterTableRenameColumnDefinition(
+        tableSQL: String,
+        oldColumnName: String,
+        newColumnName: String,
+        quoteIdentifier: (String) -> String,
+        renameKeyword: String = "RENAME COLUMN",
+        toKeyword: String = "TO"
+    ) -> String {
+        "ALTER TABLE \(tableSQL) \(renameKeyword) \(quoteIdentifier(oldColumnName)) \(toKeyword) \(quoteIdentifier(newColumnName))"
+    }
+
+    public static func primaryKeyColumnList(
+        _ columns: [String],
+        quoteIdentifier: (String) -> String
+    ) -> String {
+        columns.map { quoteIdentifier($0) }.joined(separator: ", ")
+    }
+
+    public static func modifyPrimaryKeyDefinitions(
+        tableSQL: String,
+        oldColumns: [String],
+        newColumns: [String],
+        constraintName: String?,
+        quoteIdentifier: (String) -> String,
+        dropPrimaryKeyClauseSQL: String? = nil,
+        unnamedConstraintSQL: String = "/* unknown constraint */",
+        addConstraintNameSQL: String? = nil
+    ) -> [String]? {
+        var statements: [String] = []
+        if !oldColumns.isEmpty {
+            if let dropPrimaryKeyClauseSQL, !dropPrimaryKeyClauseSQL.isEmpty {
+                statements.append("ALTER TABLE \(tableSQL) \(dropPrimaryKeyClauseSQL)")
+            } else {
+                let name = constraintName.map { quoteIdentifier($0) } ?? unnamedConstraintSQL
+                statements.append("ALTER TABLE \(tableSQL) DROP CONSTRAINT \(name)")
+            }
+        }
+
+        if !newColumns.isEmpty {
+            let columns = primaryKeyColumnList(newColumns, quoteIdentifier: quoteIdentifier)
+            var addClause = "ADD"
+            if let addConstraintNameSQL, !addConstraintNameSQL.isEmpty {
+                addClause += " CONSTRAINT \(addConstraintNameSQL)"
+            }
+            statements.append("ALTER TABLE \(tableSQL) \(addClause) PRIMARY KEY (\(columns))")
+        }
+
+        return statements.isEmpty ? nil : statements
+    }
+
+    public static func foreignKeyDefinition(
+        _ foreignKey: PluginForeignKeyDefinition,
+        quoteIdentifier: (String) -> String,
+        includeConstraintName: Bool = true,
+        referencedTableSQL: ((PluginForeignKeyDefinition) -> String)? = nil,
+        includeOnUpdate: Bool = true,
+        normalizeAction: (String) -> String = { $0 }
+    ) -> String {
+        let columns = foreignKey.columns.map { quoteIdentifier($0) }.joined(separator: ", ")
+        let referencedColumns = foreignKey.referencedColumns.map { quoteIdentifier($0) }.joined(separator: ", ")
+        let referencedTable = referencedTableSQL?(foreignKey) ?? quoteIdentifier(foreignKey.referencedTable)
+
+        var definition = ""
+        if includeConstraintName {
+            definition += "CONSTRAINT \(quoteIdentifier(foreignKey.name)) "
+        }
+        definition += "FOREIGN KEY (\(columns)) REFERENCES \(referencedTable) (\(referencedColumns))"
+
+        let onDelete = normalizeAction(foreignKey.onDelete)
+        if onDelete != "NO ACTION" {
+            definition += " ON DELETE \(onDelete)"
+        }
+        let onUpdate = normalizeAction(foreignKey.onUpdate)
+        if includeOnUpdate && onUpdate != "NO ACTION" {
+            definition += " ON UPDATE \(onUpdate)"
+        }
+
+        return definition
+    }
+
+    private static func appendDefaultClause(
+        to definition: inout String,
+        column: PluginColumnDefinition,
+        formatDefaultValue: (String) -> String
+    ) {
+        if let defaultValue = column.defaultValue {
+            definition += " DEFAULT \(formatDefaultValue(defaultValue))"
+        }
+    }
+
+    private static func appendPrimaryKeyClause(
+        to definition: inout String,
+        column: PluginColumnDefinition,
+        inlinePrimaryKey: Bool,
+        primaryKeyClause: String,
+        postPrimaryKeySQL: (PluginColumnDefinition) -> String?
+    ) {
+        guard inlinePrimaryKey && column.isPrimaryKey else { return }
+
+        definition += " \(primaryKeyClause)"
+        if let postPrimaryKey = postPrimaryKeySQL(column), !postPrimaryKey.isEmpty {
+            definition += " \(postPrimaryKey)"
+        }
+    }
+}

--- a/TableProTests/Core/Plugins/SQLDialectDescriptorTests.swift
+++ b/TableProTests/Core/Plugins/SQLDialectDescriptorTests.swift
@@ -19,6 +19,7 @@ final class SQLDialectDescriptorTests: XCTestCase {
         )
 
         XCTAssertEqual(descriptor.identifierQuote, "`")
+        XCTAssertEqual(descriptor.identifierClosingQuote, "`")
         XCTAssertEqual(descriptor.keywords, ["SELECT", "FROM", "WHERE"])
         XCTAssertEqual(descriptor.functions, ["COUNT", "SUM"])
         XCTAssertEqual(descriptor.dataTypes, ["INT", "VARCHAR"])
@@ -33,9 +34,847 @@ final class SQLDialectDescriptorTests: XCTestCase {
         )
 
         XCTAssertEqual(descriptor.identifierQuote, "\"")
+        XCTAssertEqual(descriptor.identifierClosingQuote, "\"")
         XCTAssertTrue(descriptor.keywords.isEmpty)
         XCTAssertTrue(descriptor.functions.isEmpty)
         XCTAssertTrue(descriptor.dataTypes.isEmpty)
+    }
+
+    func testDescriptorDefaultsBracketClosingQuote() {
+        let descriptor = SQLDialectDescriptor(
+            identifierQuote: "[",
+            keywords: [],
+            functions: [],
+            dataTypes: []
+        )
+
+        XCTAssertEqual(descriptor.identifierClosingQuote, "]")
+        XCTAssertEqual(descriptor.quoteIdentifier("name]part"), "[name]]part]")
+    }
+
+    func testDescriptorSupportsExplicitClosingQuote() {
+        let descriptor = SQLDialectDescriptor(
+            identifierQuote: "<",
+            identifierClosingQuote: ">",
+            keywords: [],
+            functions: [],
+            dataTypes: []
+        )
+
+        XCTAssertEqual(descriptor.quoteIdentifier("a>b"), "<a>>b>")
+    }
+
+    func testDescriptorBuildsFilterSQLLiterals() {
+        let descriptor = SQLDialectDescriptor(
+            identifierQuote: "`",
+            keywords: [],
+            functions: [],
+            dataTypes: [],
+            booleanLiteralStyle: .numeric,
+            likeEscapeStyle: .implicit
+        )
+
+        XCTAssertEqual(descriptor.sqlLiteral(for: "123"), "123")
+        XCTAssertEqual(descriptor.sqlLiteral(for: "NULL"), "NULL")
+        XCTAssertEqual(descriptor.sqlLiteral(for: "TRUE"), "1")
+        XCTAssertEqual(descriptor.sqlLiteral(for: "O'Brien"), "'O''Brien'")
+        XCTAssertEqual(
+            descriptor.sqlLiteral(for: "NULL", interpretSpecialLiterals: false),
+            "'NULL'"
+        )
+    }
+
+    func testDescriptorEscapesLikeWildcardsByDialect() {
+        let mysql = SQLDialectDescriptor(
+            identifierQuote: "`",
+            keywords: [],
+            functions: [],
+            dataTypes: [],
+            likeEscapeStyle: .implicit
+        )
+        let postgresql = SQLDialectDescriptor(
+            identifierQuote: "\"",
+            keywords: [],
+            functions: [],
+            dataTypes: [],
+            likeEscapeStyle: .explicit
+        )
+
+        XCTAssertEqual(mysql.escapeLikeWildcards("a_b%"), "a\\\\_b\\\\%")
+        XCTAssertEqual(mysql.likeEscapeClause, "")
+        XCTAssertEqual(postgresql.escapeLikeWildcards("a!b%"), "a!!b!%")
+        XCTAssertEqual(postgresql.likeEscapeClause, " ESCAPE '!'")
+    }
+
+    func testPluginSQLFilterUsesDescriptorForNullEquality() {
+        let descriptor = SQLDialectDescriptor(
+            identifierQuote: "\"",
+            keywords: [],
+            functions: [],
+            dataTypes: [],
+            likeEscapeStyle: .explicit
+        )
+
+        let equals = PluginSQLFilter.buildWhereClause(
+            filters: [(column: "deleted_at", op: "=", value: "NULL")],
+            logicMode: "and",
+            dialect: descriptor,
+            regexCondition: { _, _ in nil }
+        )
+        let notEquals = PluginSQLFilter.buildWhereClause(
+            filters: [(column: "deleted_at", op: "!=", value: "NULL")],
+            logicMode: "and",
+            dialect: descriptor,
+            regexCondition: { _, _ in nil }
+        )
+
+        XCTAssertEqual(equals, "\"deleted_at\" IS NULL")
+        XCTAssertEqual(notEquals, "\"deleted_at\" IS NOT NULL")
+    }
+
+    func testPluginSQLFilterUsesDescriptorForLikeEscaping() {
+        let descriptor = SQLDialectDescriptor(
+            identifierQuote: "\"",
+            keywords: [],
+            functions: [],
+            dataTypes: [],
+            likeEscapeStyle: .explicit
+        )
+
+        let result = PluginSQLFilter.buildWhereClause(
+            filters: [(column: "name", op: "CONTAINS", value: "a_b%!x'")],
+            logicMode: "and",
+            dialect: descriptor,
+            regexCondition: { _, _ in nil }
+        )
+
+        XCTAssertEqual(result, "\"name\" LIKE '%a!_b!%!!x''%' ESCAPE '!'")
+    }
+
+    func testPluginSQLFilterLegacyLikeEscapingDoesNotDoubleQuote() {
+        let result = PluginSQLFilter.buildWhereClause(
+            filters: [(column: "name", op: "CONTAINS", value: "O'Brien")],
+            logicMode: "and",
+            quoteIdentifier: { "\"\($0)\"" },
+            escapeValue: { "'\($0.replacingOccurrences(of: "'", with: "''"))'" },
+            regexCondition: { _, _ in nil }
+        )
+
+        XCTAssertEqual(result, "\"name\" LIKE '%O''Brien%' ESCAPE '\\'")
+    }
+
+    func testPluginSQLFilterBuildsOffsetFetchBrowseQuery() {
+        let descriptor = SQLDialectDescriptor(
+            identifierQuote: "[",
+            keywords: [],
+            functions: [],
+            dataTypes: [],
+            paginationStyle: .offsetFetch,
+            offsetFetchOrderBy: "ORDER BY (SELECT NULL)"
+        )
+
+        let result = PluginSQLFilter.buildBrowseQuery(
+            table: "users]archive",
+            dialect: descriptor,
+            sortColumns: [(columnIndex: 1, ascending: false)],
+            columns: ["id", "name"],
+            limit: 25,
+            offset: 50
+        )
+
+        XCTAssertEqual(
+            result,
+            "SELECT * FROM [users]]archive] ORDER BY [name] DESC OFFSET 50 ROWS FETCH NEXT 25 ROWS ONLY"
+        )
+    }
+
+    func testPluginSQLFilterBuildsFilteredOffsetFetchQueryWithDefaultOrder() {
+        let descriptor = SQLDialectDescriptor(
+            identifierQuote: "[",
+            keywords: [],
+            functions: [],
+            dataTypes: [],
+            paginationStyle: .offsetFetch,
+            offsetFetchOrderBy: "ORDER BY (SELECT NULL)"
+        )
+
+        let result = PluginSQLFilter.buildFilteredQuery(
+            table: "users",
+            filters: [(column: "deleted_at", op: "=", value: "NULL")],
+            logicMode: "and",
+            dialect: descriptor,
+            sortColumns: [],
+            columns: ["id", "deleted_at"],
+            limit: 10,
+            offset: 0,
+            regexCondition: { _, _ in nil }
+        )
+
+        XCTAssertEqual(
+            result,
+            "SELECT * FROM [users] WHERE [deleted_at] IS NULL ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY"
+        )
+    }
+
+    func testPluginSQLFilterBuildsLimitQuery() {
+        let descriptor = SQLDialectDescriptor(
+            identifierQuote: "\"",
+            keywords: [],
+            functions: [],
+            dataTypes: [],
+            likeEscapeStyle: .explicit,
+            paginationStyle: .limit
+        )
+
+        let result = PluginSQLFilter.buildFilteredQuery(
+            table: "users",
+            filters: [(column: "name", op: "CONTAINS", value: "a_%")],
+            logicMode: "and",
+            dialect: descriptor,
+            sortColumns: [(columnIndex: 0, ascending: true)],
+            columns: ["id", "name"],
+            limit: 10,
+            offset: 5,
+            regexCondition: { _, _ in nil }
+        )
+
+        XCTAssertEqual(
+            result,
+            "SELECT * FROM \"users\" WHERE \"name\" LIKE '%a!_!%%' ESCAPE '!' ORDER BY \"id\" ASC LIMIT 10 OFFSET 5"
+        )
+    }
+
+    func testPluginSQLStatementBuilderPreservesMSSQLRules() {
+        let descriptor = SQLDialectDescriptor(
+            identifierQuote: "[",
+            keywords: [],
+            functions: [],
+            dataTypes: []
+        )
+        let insert = PluginRowChange(
+            rowIndex: 0,
+            type: .insert,
+            cellChanges: [],
+            originalRow: nil
+        )
+        let delete = PluginRowChange(
+            rowIndex: 1,
+            type: .delete,
+            cellChanges: [],
+            originalRow: ["7", "Old"]
+        )
+        let update = PluginRowChange(
+            rowIndex: 2,
+            type: .update,
+            cellChanges: [
+                (columnIndex: 1, columnName: "name", oldValue: "Old", newValue: "New")
+            ],
+            originalRow: ["7", "Old"]
+        )
+
+        let result = PluginSQLStatementBuilder.generateStatements(
+            table: "users]archive",
+            columns: ["id", "name"],
+            primaryKeyColumns: ["id"],
+            changes: [insert, delete, update],
+            insertedRowData: [0: ["99", "Alice"]],
+            deletedRowIndices: [1],
+            insertedRowIndices: [0],
+            quoteIdentifier: descriptor.quoteIdentifier,
+            insertDefaultStrategy: .omitColumn,
+            includeInsertedColumn: { $0 != "id" },
+            whereColumnStrategy: .primaryKeyOrAll,
+            collectDeletesLast: true,
+            singleRowUpdatePrefixWhenNoPrimaryKey: "TOP (1) ",
+            singleRowDeletePrefixWhenNoPrimaryKey: "TOP (1) "
+        )
+
+        XCTAssertEqual(result?.count, 3)
+        XCTAssertEqual(result?[0].statement, "INSERT INTO [users]]archive] ([name]) VALUES (?)")
+        XCTAssertEqual(result?[0].parameters, ["Alice"])
+        XCTAssertEqual(result?[1].statement, "UPDATE [users]]archive] SET [name] = ? WHERE [id] = ?")
+        XCTAssertEqual(result?[1].parameters, ["New", "7"])
+        XCTAssertEqual(result?[2].statement, "DELETE FROM [users]]archive] WHERE [id] = ?")
+        XCTAssertEqual(result?[2].parameters, ["7"])
+    }
+
+    func testPluginSQLStatementBuilderAddsMSSQLTopWhenNoPrimaryKey() {
+        let descriptor = SQLDialectDescriptor(
+            identifierQuote: "[",
+            keywords: [],
+            functions: [],
+            dataTypes: []
+        )
+        let update = PluginRowChange(
+            rowIndex: 0,
+            type: .update,
+            cellChanges: [
+                (columnIndex: 1, columnName: "name", oldValue: "Old", newValue: "New")
+            ],
+            originalRow: ["7", "Old"]
+        )
+        let delete = PluginRowChange(
+            rowIndex: 1,
+            type: .delete,
+            cellChanges: [],
+            originalRow: ["8", .null]
+        )
+
+        let result = PluginSQLStatementBuilder.generateStatements(
+            table: "users",
+            columns: ["id", "name"],
+            primaryKeyColumns: [],
+            changes: [update, delete],
+            insertedRowData: [:],
+            deletedRowIndices: [1],
+            insertedRowIndices: [],
+            quoteIdentifier: descriptor.quoteIdentifier,
+            insertDefaultStrategy: .omitColumn,
+            whereColumnStrategy: .primaryKeyOrAll,
+            collectDeletesLast: true,
+            singleRowUpdatePrefixWhenNoPrimaryKey: "TOP (1) ",
+            singleRowDeletePrefixWhenNoPrimaryKey: "TOP (1) "
+        )
+
+        XCTAssertEqual(
+            result?[0].statement,
+            "UPDATE TOP (1) [users] SET [name] = ? WHERE [id] = ? AND [name] = ?"
+        )
+        XCTAssertEqual(result?[0].parameters, ["New", "7", "Old"])
+        XCTAssertEqual(result?[1].statement, "DELETE TOP (1) FROM [users] WHERE [id] = ? AND [name] IS NULL")
+        XCTAssertEqual(result?[1].parameters, ["8"])
+    }
+
+    func testPluginSQLStatementBuilderPreservesOracleRules() {
+        let descriptor = SQLDialectDescriptor(
+            identifierQuote: "\"",
+            keywords: [],
+            functions: [],
+            dataTypes: []
+        )
+        let insert = PluginRowChange(
+            rowIndex: 0,
+            type: .insert,
+            cellChanges: [],
+            originalRow: nil
+        )
+        let update = PluginRowChange(
+            rowIndex: 1,
+            type: .update,
+            cellChanges: [
+                (columnIndex: 1, columnName: "name", oldValue: "Old", newValue: "New")
+            ],
+            originalRow: ["7", "Old"]
+        )
+        let delete = PluginRowChange(
+            rowIndex: 2,
+            type: .delete,
+            cellChanges: [],
+            originalRow: ["8", .null]
+        )
+
+        let result = PluginSQLStatementBuilder.generateStatements(
+            table: "users",
+            columns: ["id", "name"],
+            primaryKeyColumns: ["id"],
+            changes: [insert, update, delete],
+            insertedRowData: [0: ["__DEFAULT__", "Alice"]],
+            deletedRowIndices: [2],
+            insertedRowIndices: [0],
+            quoteIdentifier: descriptor.quoteIdentifier,
+            insertDefaultStrategy: .useDefaultKeyword,
+            whereColumnStrategy: .allColumns,
+            updateWhereSuffix: " AND ROWNUM = 1",
+            deleteWhereSuffix: " AND ROWNUM = 1"
+        )
+
+        XCTAssertEqual(result?.count, 3)
+        XCTAssertEqual(result?[0].statement, "INSERT INTO \"users\" (\"id\", \"name\") VALUES (DEFAULT, ?)")
+        XCTAssertEqual(result?[0].parameters, ["Alice"])
+        XCTAssertEqual(
+            result?[1].statement,
+            "UPDATE \"users\" SET \"name\" = ? WHERE \"id\" = ? AND \"name\" = ? AND ROWNUM = 1"
+        )
+        XCTAssertEqual(result?[1].parameters, ["New", "7", "Old"])
+        XCTAssertEqual(
+            result?[2].statement,
+            "DELETE FROM \"users\" WHERE \"id\" = ? AND \"name\" IS NULL AND ROWNUM = 1"
+        )
+        XCTAssertEqual(result?[2].parameters, ["8"])
+    }
+
+    func testPluginSQLDDLBuilderFormatsDefaultValues() {
+        let escape: (String) -> String = {
+            $0.replacingOccurrences(of: "'", with: "''")
+        }
+
+        XCTAssertEqual(
+            PluginSQLDDLBuilder.defaultValue(
+                "CURRENT_TIMESTAMP",
+                rawUppercaseValues: ["NULL", "CURRENT_TIMESTAMP"],
+                escapeStringLiteral: escape
+            ),
+            "CURRENT_TIMESTAMP"
+        )
+        XCTAssertEqual(
+            PluginSQLDDLBuilder.defaultValue(
+                "'already quoted'",
+                rawUppercaseValues: [],
+                escapeStringLiteral: escape
+            ),
+            "'already quoted'"
+        )
+        XCTAssertEqual(
+            PluginSQLDDLBuilder.defaultValue(
+                "12.5",
+                rawUppercaseValues: [],
+                escapeStringLiteral: escape
+            ),
+            "12.5"
+        )
+        XCTAssertEqual(
+            PluginSQLDDLBuilder.defaultValue(
+                "O'Brien",
+                rawUppercaseValues: [],
+                escapeStringLiteral: escape
+            ),
+            "'O''Brien'"
+        )
+    }
+
+    func testPluginSQLDDLBuilderSupportsDialectSpecificRawDefaults() {
+        let escape: (String) -> String = {
+            $0.replacingOccurrences(of: "'", with: "''")
+        }
+
+        XCTAssertEqual(
+            PluginSQLDDLBuilder.defaultValue(
+                "'users_id_seq'::regclass",
+                rawUppercaseValues: [],
+                rawUppercaseSuffixes: ["::REGCLASS"],
+                escapeStringLiteral: escape
+            ),
+            "'users_id_seq'::regclass"
+        )
+        XCTAssertEqual(
+            PluginSQLDDLBuilder.defaultValue(
+                "(newid())",
+                rawUppercaseValues: [],
+                allowsParenthesizedExpressions: true,
+                escapeStringLiteral: escape
+            ),
+            "(newid())"
+        )
+        XCTAssertEqual(
+            PluginSQLDDLBuilder.defaultValue(
+                "(newid())",
+                rawUppercaseValues: [],
+                escapeStringLiteral: escape
+            ),
+            "'(newid())'"
+        )
+    }
+
+    func testPluginSQLDDLBuilderBuildsColumnDefinitionWithPostTypeClause() {
+        let column = PluginColumnDefinition(
+            name: "user]id",
+            dataType: "INT",
+            isNullable: false,
+            defaultValue: "42",
+            isPrimaryKey: true,
+            autoIncrement: true
+        )
+
+        let result = PluginSQLDDLBuilder.columnDefinition(
+            column,
+            inlinePrimaryKey: true,
+            quoteIdentifier: { "[\($0.replacingOccurrences(of: "]", with: "]]"))]" },
+            formatDefaultValue: { $0 },
+            postDataTypeSQL: { $0.autoIncrement ? "IDENTITY(1,1)" : nil }
+        )
+
+        XCTAssertEqual(result, "[user]]id] INT IDENTITY(1,1) NOT NULL DEFAULT 42 PRIMARY KEY")
+    }
+
+    func testPluginSQLDDLBuilderCanTransformAutoIncrementType() {
+        let column = PluginColumnDefinition(
+            name: "id",
+            dataType: "BIGINT",
+            isNullable: false,
+            defaultValue: "nextval('users_id_seq'::regclass)",
+            isPrimaryKey: true,
+            autoIncrement: true
+        )
+
+        let result = PluginSQLDDLBuilder.columnDefinition(
+            column,
+            inlinePrimaryKey: true,
+            quoteIdentifier: { "\"\($0)\"" },
+            formatDefaultValue: { $0 },
+            dataTypeSQL: { column in
+                guard column.autoIncrement else { return column.dataType }
+                return column.dataType.uppercased() == "BIGINT" ? "BIGSERIAL" : "SERIAL"
+            },
+            suppressNullability: { $0.autoIncrement }
+        )
+
+        XCTAssertEqual(result, "\"id\" BIGSERIAL DEFAULT nextval('users_id_seq'::regclass) PRIMARY KEY")
+    }
+
+    func testPluginSQLDDLBuilderSupportsDefaultBeforeNullability() {
+        let column = PluginColumnDefinition(
+            name: "created_at",
+            dataType: "timestamp",
+            isNullable: false,
+            defaultValue: "SYSDATE"
+        )
+
+        let result = PluginSQLDDLBuilder.columnDefinition(
+            column,
+            inlinePrimaryKey: false,
+            quoteIdentifier: { "\"\($0)\"" },
+            formatDefaultValue: { $0 },
+            dataTypeSQL: { $0.dataType.uppercased() },
+            emitsNullableKeyword: false,
+            defaultClausePosition: .beforeNullability
+        )
+
+        XCTAssertEqual(result, "\"created_at\" TIMESTAMP DEFAULT SYSDATE NOT NULL")
+    }
+
+    func testPluginSQLDDLBuilderSupportsPrimaryKeyAfterDataType() {
+        let column = PluginColumnDefinition(
+            name: "id",
+            dataType: "INTEGER",
+            isNullable: false,
+            defaultValue: "1",
+            isPrimaryKey: true,
+            autoIncrement: true
+        )
+
+        let result = PluginSQLDDLBuilder.columnDefinition(
+            column,
+            inlinePrimaryKey: true,
+            quoteIdentifier: { "\"\($0)\"" },
+            formatDefaultValue: { $0 },
+            emitsNullableKeyword: false,
+            primaryKeyClausePosition: .afterDataType,
+            postPrimaryKeySQL: { $0.autoIncrement ? "AUTOINCREMENT" : nil }
+        )
+
+        XCTAssertEqual(result, "\"id\" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL DEFAULT 1")
+    }
+
+    func testPluginSQLDDLBuilderBuildsCreateIndexDefinition() {
+        let index = PluginIndexDefinition(
+            name: "idx_users_email",
+            columns: ["email"],
+            isUnique: true,
+            whereClause: "email IS NOT NULL"
+        )
+
+        let result = PluginSQLDDLBuilder.createIndexDefinition(
+            index,
+            quoteIdentifier: { "\"\($0)\"" },
+            tableSQL: "\"users\"",
+            includeWhereClause: false
+        )
+
+        XCTAssertEqual(result, "CREATE UNIQUE INDEX \"idx_users_email\" ON \"users\" (\"email\")")
+    }
+
+    func testPluginSQLDDLBuilderBuildsIndexMethodAndWhereClause() {
+        let index = PluginIndexDefinition(
+            name: "idx_users_search",
+            columns: ["search_vector"],
+            indexType: "GIN",
+            whereClause: "search_vector IS NOT NULL"
+        )
+
+        let result = PluginSQLDDLBuilder.createIndexDefinition(
+            index,
+            quoteIdentifier: { "\"\($0)\"" },
+            tableSQL: "\"public\".\"users\"",
+            indexMethodSQL: { index in
+                guard let type = index.indexType?.lowercased() else { return nil }
+                return "USING \(type)"
+            },
+            includeWhereClause: true
+        )
+
+        XCTAssertEqual(
+            result,
+            "CREATE INDEX \"idx_users_search\" ON \"public\".\"users\" USING gin (\"search_vector\") WHERE search_vector IS NOT NULL"
+        )
+    }
+
+    func testPluginSQLDDLBuilderBuildsIndexColumnListWithCustomColumnSQL() {
+        let index = PluginIndexDefinition(
+            name: "idx_users_email_name",
+            columns: ["email", "name"],
+            columnPrefixes: ["email": 191]
+        )
+
+        let result = PluginSQLDDLBuilder.indexColumnList(
+            index,
+            quoteIdentifier: { "`\($0)`" },
+            formatColumnSQL: { column in
+                let quoted = "`\(column)`"
+                if let prefix = index.columnPrefixes?[column] {
+                    return "\(quoted)(\(prefix))"
+                }
+                return quoted
+            }
+        )
+
+        XCTAssertEqual(result, "`email`(191), `name`")
+    }
+
+    func testPluginSQLDDLBuilderBuildsIndexDefinitionFragment() {
+        let index = PluginIndexDefinition(
+            name: "idx_users_email",
+            columns: ["email"],
+            indexType: "BTREE",
+            columnPrefixes: ["email": 191],
+            whereClause: "email IS NOT NULL"
+        )
+
+        let result = PluginSQLDDLBuilder.indexDefinitionFragment(
+            index,
+            quoteIdentifier: { "`\($0)`" },
+            indexKindSQL: { _ in "INDEX" },
+            indexMethodSQL: { index in
+                index.indexType.map { "USING \($0.uppercased())" }
+            },
+            formatColumnSQL: { column in
+                let quoted = "`\(column)`"
+                if let prefix = index.columnPrefixes?[column] {
+                    return "\(quoted)(\(prefix))"
+                }
+                return quoted
+            },
+            includeWhereClause: false
+        )
+
+        XCTAssertEqual(result, "INDEX `idx_users_email` (`email`(191)) USING BTREE")
+    }
+
+    func testPluginSQLDDLBuilderBuildsDropIndexDefinition() {
+        XCTAssertEqual(
+            PluginSQLDDLBuilder.dropIndexDefinition(
+                indexName: "idx_users_email",
+                quoteIdentifier: { "`\($0)`" },
+                ifExists: true
+            ),
+            "DROP INDEX IF EXISTS `idx_users_email`"
+        )
+        XCTAssertEqual(
+            PluginSQLDDLBuilder.dropIndexDefinition(
+                indexName: "idx_users_email",
+                quoteIdentifier: { "[\($0)]" },
+                tableSQL: "[dbo].[users]"
+            ),
+            "DROP INDEX [idx_users_email] ON [dbo].[users]"
+        )
+    }
+
+    func testPluginSQLDDLBuilderBuildsAlterTableDropObjectDefinition() {
+        let result = PluginSQLDDLBuilder.alterTableDropObjectDefinition(
+            tableSQL: "`users`",
+            objectKind: "FOREIGN KEY",
+            objectName: "fk_users_roles",
+            quoteIdentifier: { "`\($0)`" }
+        )
+
+        XCTAssertEqual(result, "ALTER TABLE `users` DROP FOREIGN KEY `fk_users_roles`")
+    }
+
+    func testPluginSQLDDLBuilderBuildsAlterTableAddColumnDefinition() {
+        XCTAssertEqual(
+            PluginSQLDDLBuilder.alterTableAddColumnDefinition(
+                tableSQL: "\"users\"",
+                columnSQL: "\"email\" TEXT NOT NULL"
+            ),
+            "ALTER TABLE \"users\" ADD COLUMN \"email\" TEXT NOT NULL"
+        )
+        XCTAssertEqual(
+            PluginSQLDDLBuilder.alterTableAddColumnDefinition(
+                tableSQL: "[dbo].[users]",
+                columnSQL: "[email] NVARCHAR(255)",
+                addKeyword: "ADD"
+            ),
+            "ALTER TABLE [dbo].[users] ADD [email] NVARCHAR(255)"
+        )
+    }
+
+    func testPluginSQLDDLBuilderBuildsAlterTableDropColumnDefinition() {
+        XCTAssertEqual(
+            PluginSQLDDLBuilder.alterTableDropColumnDefinition(
+                tableSQL: "\"users\"",
+                columnName: "email",
+                quoteIdentifier: { "\"\($0)\"" }
+            ),
+            "ALTER TABLE \"users\" DROP COLUMN \"email\""
+        )
+        XCTAssertEqual(
+            PluginSQLDDLBuilder.alterTableDropColumnDefinition(
+                tableSQL: "\"users\"",
+                columnName: "email",
+                quoteIdentifier: { "\"\($0)\"" },
+                dropKeyword: "DROP"
+            ),
+            "ALTER TABLE \"users\" DROP \"email\""
+        )
+    }
+
+    func testPluginSQLDDLBuilderBuildsAlterTableRenameColumnDefinition() {
+        let result = PluginSQLDDLBuilder.alterTableRenameColumnDefinition(
+            tableSQL: "`users`",
+            oldColumnName: "email",
+            newColumnName: "primary_email",
+            quoteIdentifier: { "`\($0)`" }
+        )
+
+        XCTAssertEqual(result, "ALTER TABLE `users` RENAME COLUMN `email` TO `primary_email`")
+    }
+
+    func testPluginSQLDDLBuilderBuildsPrimaryKeyColumnList() {
+        let result = PluginSQLDDLBuilder.primaryKeyColumnList(
+            ["id", "tenant_id"],
+            quoteIdentifier: { "[\($0)]" }
+        )
+
+        XCTAssertEqual(result, "[id], [tenant_id]")
+    }
+
+    func testPluginSQLDDLBuilderBuildsModifyPrimaryKeyDefinitions() {
+        let result = PluginSQLDDLBuilder.modifyPrimaryKeyDefinitions(
+            tableSQL: "\"users\"",
+            oldColumns: ["id"],
+            newColumns: ["id", "tenant_id"],
+            constraintName: "users_pkey",
+            quoteIdentifier: { "\"\($0)\"" }
+        )
+
+        XCTAssertEqual(
+            result,
+            [
+                "ALTER TABLE \"users\" DROP CONSTRAINT \"users_pkey\"",
+                "ALTER TABLE \"users\" ADD PRIMARY KEY (\"id\", \"tenant_id\")"
+            ]
+        )
+    }
+
+    func testPluginSQLDDLBuilderBuildsDialectSpecificPrimaryKeyDefinitions() {
+        let mysql = PluginSQLDDLBuilder.modifyPrimaryKeyDefinitions(
+            tableSQL: "`users`",
+            oldColumns: ["id"],
+            newColumns: ["id"],
+            constraintName: nil,
+            quoteIdentifier: { "`\($0)`" },
+            dropPrimaryKeyClauseSQL: "DROP PRIMARY KEY"
+        )
+        XCTAssertEqual(
+            mysql,
+            [
+                "ALTER TABLE `users` DROP PRIMARY KEY",
+                "ALTER TABLE `users` ADD PRIMARY KEY (`id`)"
+            ]
+        )
+
+        let mssql = PluginSQLDDLBuilder.modifyPrimaryKeyDefinitions(
+            tableSQL: "[dbo].[users]",
+            oldColumns: [],
+            newColumns: ["id"],
+            constraintName: nil,
+            quoteIdentifier: { "[\($0)]" },
+            addConstraintNameSQL: "[PK_users]"
+        )
+        XCTAssertEqual(
+            mssql,
+            ["ALTER TABLE [dbo].[users] ADD CONSTRAINT [PK_users] PRIMARY KEY ([id])"]
+        )
+
+        XCTAssertNil(
+            PluginSQLDDLBuilder.modifyPrimaryKeyDefinitions(
+                tableSQL: "\"users\"",
+                oldColumns: [],
+                newColumns: [],
+                constraintName: nil,
+                quoteIdentifier: { "\"\($0)\"" }
+            )
+        )
+    }
+
+    func testPluginSQLDDLBuilderBuildsForeignKeyWithoutConstraintName() {
+        let foreignKey = PluginForeignKeyDefinition(
+            name: "fk_orders_users",
+            columns: ["user_id"],
+            referencedTable: "users",
+            referencedColumns: ["id"],
+            onDelete: "CASCADE",
+            onUpdate: "SET NULL"
+        )
+
+        let result = PluginSQLDDLBuilder.foreignKeyDefinition(
+            foreignKey,
+            quoteIdentifier: { "\"\($0)\"" },
+            includeConstraintName: false
+        )
+
+        XCTAssertEqual(
+            result,
+            "FOREIGN KEY (\"user_id\") REFERENCES \"users\" (\"id\") ON DELETE CASCADE ON UPDATE SET NULL"
+        )
+    }
+
+    func testPluginSQLDDLBuilderBuildsSchemaQualifiedForeignKeyAndNormalizesActions() {
+        let foreignKey = PluginForeignKeyDefinition(
+            name: "fk_users_roles",
+            columns: ["role_id"],
+            referencedTable: "roles",
+            referencedColumns: ["id"],
+            onDelete: "cascade",
+            onUpdate: "restrict",
+            referencedSchema: "auth"
+        )
+
+        let result = PluginSQLDDLBuilder.foreignKeyDefinition(
+            foreignKey,
+            quoteIdentifier: { "`\($0)`" },
+            referencedTableSQL: { foreignKey in
+                let schema = foreignKey.referencedSchema.map { "`\($0)`." } ?? ""
+                return "\(schema)`\(foreignKey.referencedTable)`"
+            },
+            normalizeAction: { $0.uppercased() }
+        )
+
+        XCTAssertEqual(
+            result,
+            "CONSTRAINT `fk_users_roles` FOREIGN KEY (`role_id`) REFERENCES `auth`.`roles` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT"
+        )
+    }
+
+    func testPluginSQLDDLBuilderCanSuppressForeignKeyOnUpdate() {
+        let foreignKey = PluginForeignKeyDefinition(
+            name: "fk_orders_users",
+            columns: ["user_id"],
+            referencedTable: "users",
+            referencedColumns: ["id"],
+            onDelete: "CASCADE",
+            onUpdate: "CASCADE"
+        )
+
+        let result = PluginSQLDDLBuilder.foreignKeyDefinition(
+            foreignKey,
+            quoteIdentifier: { "\"\($0)\"" },
+            includeOnUpdate: false
+        )
+
+        XCTAssertEqual(
+            result,
+            "CONSTRAINT \"fk_orders_users\" FOREIGN KEY (\"user_id\") REFERENCES \"users\" (\"id\") ON DELETE CASCADE"
+        )
     }
 
     // MARK: - PluginDialectAdapter


### PR DESCRIPTION
## Summary
- Centralize plugin SQL dialect quoting, literal escaping, filter query assembly, and DML statement generation helpers.
- Add shared PluginSQLDDLBuilder helpers for column definitions, default values, indexes, foreign keys, primary keys, and ALTER TABLE column operations.
- Refactor SQL driver plugins to use the shared builders while preserving dialect-specific behavior for SQLite, LibSQL, D1, ClickHouse, PostgreSQL, DuckDB, Oracle, MySQL, MSSQL, BigQuery, and Cassandra.
- Add focused SQLDialectDescriptorTests coverage for the new shared SQL builder behavior.

## Validation
- `git diff --check HEAD^..HEAD`
- Clean worktree build: `xcodebuild build -project TablePro.xcodeproj -target TableProPluginKit -destination 'platform=macOS' -skipPackagePluginValidation -quiet`
- Clean worktree targeted test: `xcodebuild test -project TablePro.xcodeproj -scheme TablePro -destination 'platform=macOS' -only-testing:TableProTests/SQLDialectDescriptorTests -skipPackagePluginValidation -derivedDataPath /tmp/TableProCodexDerivedData-PluginDDLPR-FinalNoSign -quiet CODE_SIGNING_ALLOWED=NO`

## Notes
- Local clean test setup required a gitignored `Secrets.xcconfig` placeholder and local `Libs/` static libraries, matching the repository setup docs.
- Existing SwiftLint, Swift concurrency, linker, and asset catalog warnings are still present and unrelated to this PR.