### PR TITLE
fix(datagrid): cancel in-progress query before Cmd+R refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Pressing Cmd+R to refresh while a query is executing now cancels the running query and starts a fresh one instead of silently doing nothing.
 - iCloud Sync between the iPhone and Mac apps: the iOS app now uses the Production CloudKit environment, so a development build no longer syncs into a separate database the Mac never reads.
 - Exports no longer fail mid-table on servers that enforce a statement time limit; the export session disables the limit and restores it afterwards, the same way mysqldump does. (#1633)
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Refresh.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Refresh.swift
@@ -34,6 +34,8 @@ extension MainContentCoordinator {
                     if let (tab, tabIndex) = tabManager.selectedTabAndIndex,
                        tab.tabType == .table {
                         currentQueryTask?.cancel()
+                        currentQueryTask = nil
+                        tabManager.mutate(at: tabIndex) { $0.execution.isExecuting = false }
                         rebuildTableQuery(at: tabIndex)
                         runQuery()
                     }
@@ -43,6 +45,8 @@ extension MainContentCoordinator {
             if let (tab, tabIndex) = tabManager.selectedTabAndIndex,
                tab.tabType == .table {
                 currentQueryTask?.cancel()
+                currentQueryTask = nil
+                tabManager.mutate(at: tabIndex) { $0.execution.isExecuting = false }
                 rebuildTableQuery(at: tabIndex)
                 runQuery()
             }


### PR DESCRIPTION
## Root cause

`currentQueryTask?.cancel()` initiates cooperative cancellation but does not synchronously reset `tab.execution.isExecuting`. The subsequent `runQuery()` call hits `guard !tab.execution.isExecuting else { return }` and silently bails, so the refresh never executes when a query is running.

## Fix

After `currentQueryTask?.cancel()`, immediately set `currentQueryTask = nil` and reset `tab.execution.isExecuting = false` before calling `rebuildTableQuery` + `runQuery`. Applied to both the discard-confirmation branch and the no-pending-changes branch of `handleRefresh`.

**File:** `TablePro/Views/Main/Extensions/MainContentCoordinator+Refresh.swift`

## Test plan

- [ ] Open a table, start a slow query, press Cmd+R before it finishes — query cancels, fresh result loads
- [ ] Same scenario with unsaved edits: confirm discard, then Cmd+R produces fresh results