### PR TITLE
feat(i18n): add Traditional Chinese (繁體中文) localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Traditional Chinese (繁體中文) language in Settings > General with full UI translation
+
 ## [0.51.1] - 2026-06-16
 
 ### Added

--- a/TablePro.xcodeproj/project.pbxproj
+++ b/TablePro.xcodeproj/project.pbxproj
@@ -1960,6 +1960,7 @@
 				tr,
 				vi,
 				"zh-Hans",
+				"zh-Hant",
 				Base,
 			);
 			mainGroup = 5A1091BE2EF17EDC0055EA7C;

--- a/TablePro/Models/Settings/GeneralSettings.swift
+++ b/TablePro/Models/Settings/GeneralSettings.swift
@@ -26,6 +26,7 @@ enum AppLanguage: String, Codable, CaseIterable, Identifiable {
     case english = "en"
     case vietnamese = "vi"
     case chineseSimplified = "zh-Hans"
+    case chineseTraditional = "zh-Hant"
     case turkish = "tr"
 
     var id: String { rawValue }
@@ -36,6 +37,7 @@ enum AppLanguage: String, Codable, CaseIterable, Identifiable {
         case .english: return "English"
         case .vietnamese: return "Tiếng Việt"
         case .chineseSimplified: return "简体中文"
+        case .chineseTraditional: return "繁體中文"
         case .turkish: return "Türkçe"
         }
     }

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -9367,7 +9367,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "API token"
+            "value" : "API 權杖"
           }
         }
       }
@@ -12004,7 +12004,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Boolean"
+            "value" : "布林值"
           }
         }
       }

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -20,6 +20,12 @@
             "state" : "translated",
             "value" : ""
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
         }
       }
     },
@@ -42,6 +48,12 @@
             "state" : "translated",
             "value" : "\n\n…（还有 %d 个字符未显示）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\n\n…（還有 %d 個字未顯示）"
+          }
         }
       }
     },
@@ -60,6 +72,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " — %@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : " — %@"
@@ -86,6 +104,12 @@
             "state" : "translated",
             "value" : "--"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "--"
+          }
         }
       }
     },
@@ -107,6 +131,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "-- … 还有%d个字符未显示；使用\"全部复制\"获取完整输出。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "-- … 還有 %d 個字未顯示；請使用「全部複製」取得完整輸出。"
           }
         }
       }
@@ -131,6 +161,12 @@
             "state" : "translated",
             "value" : "—"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "—"
+          }
         }
       }
     },
@@ -149,6 +185,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "："
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "："
@@ -178,6 +220,12 @@
             "state" : "translated",
             "value" : ".%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ".%@"
+          }
         }
       }
     },
@@ -196,6 +244,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "·"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "·"
@@ -223,6 +277,12 @@
             "state" : "translated",
             "value" : "''"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "''"
+          }
         }
       }
     },
@@ -244,6 +304,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "'%@' 是 Windows 保留设备名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」是 Windows 保留的裝置名稱"
           }
         }
       }
@@ -267,6 +333,12 @@
             "state" : "translated",
             "value" : "\"%@\"在您打开后已被更改。请查看差异并选择处理方式。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」在你開啟後已被變更。請查看差異並選擇處理方式。"
+          }
         }
       }
     },
@@ -288,6 +360,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "\"%@\" 在此 Mac 和另一台设备上均已修改。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」在這台 Mac 和另一台裝置上都被修改了。"
           }
         }
       }
@@ -311,6 +389,12 @@
             "state" : "translated",
             "value" : "\"%@\"已在磁盘上被修改。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」已在磁碟上被修改。"
+          }
         }
       }
     },
@@ -332,6 +416,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "“%@” 将被断开连接，所有进行中的请求将被取消。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」將會中斷連線，所有進行中的請求都會被取消。"
           }
         }
       }
@@ -355,6 +445,12 @@
             "state" : "translated",
             "value" : "\"%@\"将被移到废纸篓。您可以从那里恢复它。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」將被移到垃圾桶。你可以從那裡復原它。"
+          }
         }
       }
     },
@@ -376,6 +472,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "\"%@\" 将被永久删除。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」將會永久刪除。"
           }
         }
       }
@@ -399,6 +501,12 @@
             "state" : "translated",
             "value" : "“%@” 将被永久删除。使用此令牌的外部客户端将立即失去访问权限。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」將會永久刪除。使用此權杖的外部用戶端將立即失去存取權限。"
+          }
         }
       }
     },
@@ -420,6 +528,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "\"%@\"将从侧边栏中移除。磁盘上的文件不会被删除。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」將從側邊欄移除。磁碟上的檔案不會被刪除。"
           }
         }
       }
@@ -443,6 +557,12 @@
             "state" : "translated",
             "value" : "\"%@\" 将从您的系统中移除。此操作无法撤销。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」將從你的系統中移除。此動作無法復原。"
+          }
         }
       }
     },
@@ -461,6 +581,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%@)"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "(%@)"
@@ -493,6 +619,12 @@
             "state" : "translated",
             "value" : "(%lld %@)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%1$lld %2$@)"
+          }
         }
       }
     },
@@ -515,6 +647,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "(%lld 活跃)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%lld 個使用中)"
           }
         }
       }
@@ -539,6 +677,12 @@
             "state" : "translated",
             "value" : "(%lld 个已隐藏)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%lld 個已隱藏)"
+          }
         }
       }
     },
@@ -557,6 +701,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%lld)"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "(%lld)"
@@ -589,6 +739,12 @@
             "state" : "translated",
             "value" : "(%lld/%lld)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%1$lld/%2$lld)"
+          }
         }
       }
     },
@@ -611,6 +767,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "（可选）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "（選填）"
           }
         }
       }
@@ -640,6 +802,12 @@
             "state" : "translated",
             "value" : "（显示 %d / %d 行）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "（顯示 %1$d / %2$d 列）"
+          }
         }
       }
     },
@@ -668,6 +836,12 @@
             "state" : "translated",
             "value" : "（此 Mac）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "（這台 Mac）"
+          }
         }
       }
     },
@@ -690,6 +864,12 @@
             "state" : "translated",
             "value" : "**可用命令：**"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**可用指令：**"
+          }
         }
       }
     },
@@ -708,6 +888,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/%@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "/%@"
@@ -740,6 +926,12 @@
             "state" : "translated",
             "value" : "/%1$@ · %2$@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/%1$@ · %2$@"
+          }
         }
       }
     },
@@ -762,6 +954,12 @@
             "state" : "translated",
             "value" : "/%@需要一个查询：请在编辑器中或命令后输入。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/%@ 需要一個查詢：請在編輯器中或指令後輸入。"
+          }
         }
       }
     },
@@ -780,6 +978,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/path/to/agent.sock"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "/path/to/agent.sock"
@@ -806,6 +1010,12 @@
             "state" : "translated",
             "value" : "/path/to/ca-cert.pem"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/path/to/ca-cert.pem"
+          }
         }
       }
     },
@@ -825,6 +1035,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/path/to/database.sqlite"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "/path/to/database.sqlite"
@@ -857,6 +1073,12 @@
             "state" : "translated",
             "value" : "%@（%@@%@）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@（%2$@@%3$@）"
+          }
         }
       }
     },
@@ -884,6 +1106,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ (%lld/%lld)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ (%2$lld/%3$lld)"
           }
         }
       }
@@ -913,6 +1141,12 @@
             "state" : "translated",
             "value" : "%@（另外 %d 个）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@（另外 %2$d 個）"
+          }
         }
       }
     },
@@ -931,6 +1165,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@（副本）"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@（副本）"
@@ -954,6 +1194,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@（Pro）"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@（Pro）"
@@ -986,6 +1232,12 @@
             "state" : "translated",
             "value" : "%@ %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@"
+          }
         }
       }
     },
@@ -1010,6 +1262,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ • %2$@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ • %2$@"
@@ -1042,6 +1300,12 @@
             "state" : "translated",
             "value" : "%@ → %@.%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ → %2$@.%3$@"
+          }
         }
       }
     },
@@ -1063,6 +1327,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 不能为空"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 不能為空白"
           }
         }
       }
@@ -1086,6 +1356,12 @@
             "state" : "translated",
             "value" : "%@ 不能为负数"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 不能為負數"
+          }
         }
       }
     },
@@ -1104,6 +1380,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已完成"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 已完成"
@@ -1130,6 +1412,12 @@
             "state" : "translated",
             "value" : "无法加载%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法載入 %@"
+          }
         }
       }
     },
@@ -1151,6 +1439,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@在TablePro中不支持切换Schema。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 在 TablePro 中不支援切換綱要。"
           }
         }
       }
@@ -1174,6 +1468,12 @@
             "state" : "translated",
             "value" : "%@ 次下载"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 次下載"
+          }
         }
       }
     },
@@ -1196,6 +1496,12 @@
             "state" : "translated",
             "value" : "%@ 次下载"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 次下載"
+          }
         }
       }
     },
@@ -1217,6 +1523,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 失敗"
           }
         }
       }
@@ -1247,6 +1559,12 @@
             "state" : "translated",
             "value" : "%@ 已分配给 \"%@\"。重新分配将从该操作中移除它。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ 已指派給「%2$@」。重新指派會將它從該動作中移除。"
+          }
         }
       }
     },
@@ -1275,6 +1593,12 @@
             "state" : "translated",
             "value" : "%1$@已被%3$@中的\"%2$@\"使用。重新指定会将其从该操作中移除。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ 已被 %2$@ 中的「%3$@」使用。重新指派會將它從該動作中移除。"
+          }
         }
       }
     },
@@ -1297,6 +1621,12 @@
             "state" : "translated",
             "value" : "%@为必填项"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 為必填"
+          }
         }
       }
     },
@@ -1316,6 +1646,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ms"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ ms"
@@ -1348,6 +1684,12 @@
             "state" : "translated",
             "value" : "%@不能超过%d个字符"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ 不能超過 %2$d 個字"
+          }
         }
       }
     },
@@ -1377,6 +1719,12 @@
             "state" : "translated",
             "value" : "%@ 必须为 %lld 个字符或更少"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ 不能超過 %2$lld 個字"
+          }
         }
       }
     },
@@ -1404,6 +1752,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 必须在 %@ 和 %@ 之间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ 必須介於 %2$@ 和 %3$@ 之間"
           }
         }
       }
@@ -1436,6 +1790,12 @@
             "state" : "translated",
             "value" : "%@ 在 %@ 上成功完成。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ 上的 %2$@ 已成功完成。"
+          }
         }
       }
     },
@@ -1457,6 +1817,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 预览"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 預覽"
           }
         }
       }
@@ -1480,6 +1846,12 @@
             "state" : "translated",
             "value" : "%@ 查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 查詢"
+          }
         }
       }
     },
@@ -1502,6 +1874,12 @@
             "state" : "translated",
             "value" : "%@ 需要 Pro 许可证"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 需要 Pro 授權"
+          }
         }
       }
     },
@@ -1523,6 +1901,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 列"
           }
         }
       }
@@ -1547,6 +1931,12 @@
             "state" : "translated",
             "value" : "%@ 秒"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 秒"
+          }
         }
       }
     },
@@ -1565,6 +1955,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 秒"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 秒"
@@ -1594,6 +1990,12 @@
             "state" : "translated",
             "value" : "在此系统上未找到%@。请使用`brew install libpq`安装并链接它。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在這個系統上找不到 %@。請使用 `brew install libpq` 安裝並連結它。"
+          }
         }
       }
     },
@@ -1622,6 +2024,12 @@
             "state" : "translated",
             "value" : "%@, %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@, %2$@"
+          }
         }
       }
     },
@@ -1646,6 +2054,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: %2$@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@: %2$@"
@@ -1679,6 +2093,12 @@
             "state" : "translated",
             "value" : "%@: %lld"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: %2$lld"
+          }
         }
       }
     },
@@ -1708,6 +2128,12 @@
             "state" : "translated",
             "value" : "%@:%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@:%2$@"
+          }
         }
       }
     },
@@ -1727,6 +2153,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@."
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@."
@@ -1759,6 +2191,12 @@
             "state" : "translated",
             "value" : "%@/%@ 行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@/%2$@ 列"
+          }
         }
       }
     },
@@ -1787,6 +2225,12 @@
             "state" : "translated",
             "value" : "%@%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@%2$@"
+          }
         }
       }
     },
@@ -1809,6 +2253,12 @@
             "state" : "translated",
             "value" : "%@ms"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ms"
+          }
         }
       }
     },
@@ -1827,6 +2277,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@s"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@s"
@@ -1862,6 +2318,12 @@
             "state" : "translated",
             "value" : "已选择%1$d个单元格，行%2$d至%3$d，列%4$d至%5$d"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已選取 %1$d 個儲存格,第 %2$d 列到第 %3$d 列,第 %4$d 欄到第 %5$d 欄"
+          }
         }
       }
     },
@@ -1883,6 +2345,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%d列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 個欄位"
           }
         }
       }
@@ -1906,6 +2374,12 @@
             "state" : "translated",
             "value" : "已连接%d个"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已連線 %d 個"
+          }
         }
       }
     },
@@ -1927,6 +2401,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "找到 %d 个连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找到 %d 個連線"
           }
         }
       }
@@ -1950,6 +2430,12 @@
             "state" : "translated",
             "value" : "已导入%d个连接。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已匯入 %d 個連線。"
+          }
         }
       }
     },
@@ -1971,6 +2457,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%d 个收藏将被永久删除。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 個我的最愛將會永久刪除。"
           }
         }
       }
@@ -2000,6 +2492,12 @@
             "state" : "translated",
             "value" : "第%1$d个，共%2$d个"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %1$d 個，共 %2$d 個"
+          }
         }
       }
     },
@@ -2027,6 +2525,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示%1$d列，共%2$d列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示 %1$d 個欄位，共 %2$d 個"
           }
         }
       }
@@ -2056,6 +2560,12 @@
             "state" : "translated",
             "value" : "%d / %d 行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d / %2$d 列"
+          }
         }
       }
     },
@@ -2084,6 +2594,12 @@
             "state" : "translated",
             "value" : "已选择%d/%d行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已選取 %1$d / %2$d 列"
+          }
         }
       }
     },
@@ -2107,6 +2623,12 @@
             "state" : "translated",
             "value" : "%d 个插件无法加载"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 個外掛無法載入"
+          }
         }
       }
     },
@@ -2128,6 +2650,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%d个插件无法加载。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 個外掛無法載入。"
           }
         }
       }
@@ -2151,6 +2679,12 @@
             "state" : "translated",
             "value" : "%d个插件需要更新才能加载。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 個外掛需要更新才能載入。"
+          }
         }
       }
     },
@@ -2173,6 +2707,12 @@
             "state" : "translated",
             "value" : "%d 行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 列"
+          }
         }
       }
     },
@@ -2194,6 +2734,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已选择%d个"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已選取 %d 個"
           }
         }
       }
@@ -2223,6 +2769,12 @@
             "state" : "translated",
             "value" : "第%1$d-%2$d行，共?行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d-%2$d / ? 列"
+          }
         }
       }
     },
@@ -2250,6 +2802,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%d-%d / %@%@行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d-%2$d / %3$@%4$@ 列"
           }
         }
       }
@@ -2279,6 +2837,12 @@
             "state" : "translated",
             "value" : "%d分%d秒"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d 分 %2$d 秒"
+          }
         }
       }
     },
@@ -2297,6 +2861,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld"
@@ -2322,6 +2892,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 字节"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 位元組"
           }
         }
       }
@@ -2351,6 +2927,12 @@
             "state" : "translated",
             "value" : "%lld 个连接正在使用此配置。它们将回退为不使用 SSH 隧道。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 個連線正在使用此設定檔。它們將改為不使用 SSH 隧道。"
+          }
         }
       }
     },
@@ -2373,6 +2955,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已导入 %lld 个连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已匯入 %lld 個連線。"
           }
         }
       }
@@ -2401,6 +2989,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 输入 · %lld 输出"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld 輸入 · %2$lld 輸出"
           }
         }
       }
@@ -2431,6 +3025,12 @@
             "state" : "translated",
             "value" : "%lld 输入 / %lld 输出 token"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld 輸入 / %2$lld 輸出 token"
+          }
         }
       }
     },
@@ -2459,6 +3059,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld / %lld"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld / %2$lld"
           }
         }
       }
@@ -2489,6 +3095,12 @@
             "state" : "translated",
             "value" : "已选择 %lld / %lld 行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已選取 %1$lld / %2$lld 列"
+          }
         }
       }
     },
@@ -2517,6 +3129,12 @@
             "state" : "translated",
             "value" : "已选择 %lld / %lld"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已選取 %1$lld / %2$lld"
+          }
         }
       }
     },
@@ -2536,6 +3154,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld pt"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld pt"
@@ -2561,6 +3185,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 行受影响"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已影響 %lld 列"
           }
         }
       }
@@ -2591,6 +3221,12 @@
             "state" : "translated",
             "value" : "%lld 行%@受影响"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已影響 %1$lld 列%2$@"
+          }
         }
       }
     },
@@ -2619,6 +3255,12 @@
             "state" : "translated",
             "value" : "%lld 行%@待导出"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "待匯出 %1$lld 列%2$@"
+          }
         }
       }
     },
@@ -2641,6 +3283,12 @@
             "state" : "translated",
             "value" : "%lld 行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 列"
+          }
         }
       }
     },
@@ -2659,6 +3307,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 秒"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 秒"
@@ -2685,6 +3339,12 @@
             "state" : "translated",
             "value" : "%lld 已跳过（无选项）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已略過 %lld 個（無選項）"
+          }
         }
       }
     },
@@ -2707,6 +3367,12 @@
             "state" : "translated",
             "value" : "%lld 条语句"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 條陳述式"
+          }
         }
       }
     },
@@ -2728,6 +3394,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已执行 %lld 条语句"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已執行 %lld 條陳述式"
           }
         }
       }
@@ -2757,6 +3429,12 @@
             "state" : "translated",
             "value" : "已执行 %lld 条语句，%lld 条失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已執行 %1$lld 條陳述式，%2$lld 條失敗"
+          }
         }
       }
     },
@@ -2785,6 +3463,12 @@
             "state" : "translated",
             "value" : "%lld 个表%@待导出"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "待匯出 %1$lld 個資料表%2$@"
+          }
         }
       }
     },
@@ -2807,6 +3491,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 个表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 個資料表"
           }
         }
       }
@@ -2836,6 +3526,12 @@
             "state" : "translated",
             "value" : "%lld 个表，%lld 个关系"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld 個資料表，%2$lld 個關聯"
+          }
         }
       }
     },
@@ -2854,6 +3550,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld."
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld."
@@ -2881,6 +3583,12 @@
             "state" : "translated",
             "value" : "%lld/5"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld/5"
+          }
         }
       }
     },
@@ -2899,6 +3607,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld%%"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld%%"
@@ -2932,6 +3646,12 @@
             "state" : "translated",
             "value" : "%lldm %llds"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld 分 %2$lld 秒"
+          }
         }
       }
     },
@@ -2951,6 +3671,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "•"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "•"
@@ -2978,6 +3704,12 @@
             "state" : "translated",
             "value" : "••••••••"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "••••••••"
+          }
         }
       }
     },
@@ -3001,6 +3733,12 @@
             "state" : "translated",
             "value" : "© 2026 Ngo Quoc Dat.\n%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "© 2026 Ngo Quoc Dat.\n%@"
+          }
         }
       }
     },
@@ -3019,6 +3757,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "<1ms"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "<1ms"
@@ -3046,6 +3790,12 @@
             "state" : "translated",
             "value" : "="
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "="
+          }
         }
       }
     },
@@ -3068,6 +3818,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "~/.pgpass 已找到 - 存在匹配条目"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已找到 ~/.pgpass，存在相符的項目"
           }
         }
       }
@@ -3092,6 +3848,12 @@
             "state" : "translated",
             "value" : "~/.pgpass 已找到 - 无匹配条目"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已找到 ~/.pgpass，但無相符的項目"
+          }
         }
       }
     },
@@ -3113,6 +3875,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已找到~/.pgpass，存在匹配条目"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已找到 ~/.pgpass，存在相符的項目"
           }
         }
       }
@@ -3136,6 +3904,12 @@
             "state" : "translated",
             "value" : "已找到~/.pgpass，无匹配条目"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已找到 ~/.pgpass，沒有相符的項目"
+          }
         }
       }
     },
@@ -3157,6 +3931,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "~/.pgpass 权限不正确（需要 chmod 0600）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "~/.pgpass 權限不正確（需要 chmod 0600）"
           }
         }
       }
@@ -3180,6 +3960,12 @@
             "state" : "translated",
             "value" : "未找到 ~/.pgpass"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到 ~/.pgpass"
+          }
         }
       }
     },
@@ -3198,6 +3984,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "~/.ssh/id_rsa"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "~/.ssh/id_rsa"
@@ -3224,6 +4016,12 @@
             "state" : "translated",
             "value" : "⌘K"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⌘K"
+          }
         }
       }
     },
@@ -3242,6 +4040,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⌘T"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "⌘T"
@@ -3269,6 +4073,12 @@
             "state" : "translated",
             "value" : "0"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0"
+          }
         }
       }
     },
@@ -3288,6 +4098,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "1"
@@ -3315,6 +4131,12 @@
             "state" : "translated",
             "value" : "1  John Doe  john@example.com  NULL"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1  John Doe  john@example.com  NULL"
+          }
         }
       }
     },
@@ -3334,6 +4156,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1（不分批）"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "1（不分批）"
@@ -3360,6 +4188,12 @@
             "state" : "translated",
             "value" : "找到 1 个连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找到 1 個連線"
+          }
         }
       }
     },
@@ -3382,6 +4216,12 @@
             "state" : "translated",
             "value" : "已导入 1 个连接。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已匯入 1 個連線。"
+          }
         }
       }
     },
@@ -3400,6 +4240,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 天"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "1 天"
@@ -3426,6 +4272,12 @@
             "state" : "translated",
             "value" : "第 1 个冲突，共 %lld 个"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 1 個衝突，共 %lld 個"
+          }
         }
       }
     },
@@ -3447,6 +4299,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "1个插件无法加载。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 個外掛無法載入。"
           }
         }
       }
@@ -3470,6 +4328,12 @@
             "state" : "translated",
             "value" : "1个插件需要更新才能加载。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 個外掛需要更新才能載入。"
+          }
         }
       }
     },
@@ -3488,6 +4352,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 年"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "1 年"
@@ -3514,6 +4384,12 @@
             "state" : "translated",
             "value" : "1,000"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1,000"
+          }
         }
       }
     },
@@ -3536,6 +4412,12 @@
             "state" : "translated",
             "value" : "1,000 行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1,000 列"
+          }
         }
       }
     },
@@ -3554,6 +4436,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1,000,000"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "1,000,000"
@@ -3581,6 +4469,12 @@
             "state" : "translated",
             "value" : "2"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2"
+          }
         }
       }
     },
@@ -3603,6 +4497,12 @@
             "state" : "translated",
             "value" : "2 个空格"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 個空格"
+          }
         }
       }
     },
@@ -3622,6 +4522,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "3"
@@ -3648,6 +4554,12 @@
             "state" : "translated",
             "value" : "4 个空格"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4 個空格"
+          }
         }
       }
     },
@@ -3666,6 +4578,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5,000"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "5,000"
@@ -3692,6 +4610,12 @@
             "state" : "translated",
             "value" : "5,000 行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5,000 列"
+          }
         }
       }
     },
@@ -3710,6 +4634,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "6"
@@ -3736,6 +4666,12 @@
             "state" : "translated",
             "value" : "7 天"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "7 天"
+          }
         }
       }
     },
@@ -3754,6 +4690,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "8"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "8"
@@ -3780,6 +4722,12 @@
             "state" : "translated",
             "value" : "8 个空格"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "8 個空格"
+          }
         }
       }
     },
@@ -3802,6 +4750,12 @@
             "state" : "translated",
             "value" : "至少8个字符"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "至少 8 個字"
+          }
         }
       }
     },
@@ -3820,6 +4774,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10,000"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "10,000"
@@ -3846,6 +4806,12 @@
             "state" : "translated",
             "value" : "10,000 行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10,000 列"
+          }
         }
       }
     },
@@ -3864,6 +4830,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "22"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "22"
@@ -3890,6 +4862,12 @@
             "state" : "translated",
             "value" : "30 天"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30 天"
+          }
         }
       }
     },
@@ -3912,6 +4890,12 @@
             "state" : "translated",
             "value" : "30秒"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30 秒"
+          }
         }
       }
     },
@@ -3930,6 +4914,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "50,000"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "50,000"
@@ -3956,6 +4946,12 @@
             "state" : "translated",
             "value" : "60 天"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "60 天"
+          }
         }
       }
     },
@@ -3978,6 +4974,12 @@
             "state" : "translated",
             "value" : "60秒"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "60 秒"
+          }
         }
       }
     },
@@ -3996,6 +4998,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "90 天"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "90 天"
@@ -4022,6 +5030,12 @@
             "state" : "translated",
             "value" : "100"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "100"
+          }
         }
       }
     },
@@ -4044,6 +5058,12 @@
             "state" : "translated",
             "value" : "100 行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "100 列"
+          }
         }
       }
     },
@@ -4062,6 +5082,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "100,000"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "100,000"
@@ -4088,6 +5114,12 @@
             "state" : "translated",
             "value" : "500"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "500"
+          }
         }
       }
     },
@@ -4110,6 +5142,12 @@
             "state" : "translated",
             "value" : "500 行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "500 列"
+          }
         }
       }
     },
@@ -4128,6 +5166,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "500,000"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "500,000"
@@ -4154,6 +5198,12 @@
             "state" : "translated",
             "value" : "内置插件 \"%@\" 已提供此 bundle ID"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "內建外掛「%@」已提供此 bundle ID"
+          }
         }
       }
     },
@@ -4175,6 +5225,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "该连接已存在Cloudflare隧道：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這個連線已存在 Cloudflare 隧道：%@"
           }
         }
       }
@@ -4198,6 +5254,12 @@
             "state" : "translated",
             "value" : "名为\"/%@\"的命令已存在。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名為「/%@」的指令已存在。"
+          }
         }
       }
     },
@@ -4219,6 +5281,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "一个连接一次只能使用一个隧道。请停用SSH隧道以使用Cloudflare隧道。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一個連線一次只能使用一個隧道。請停用 SSH 隧道以使用 Cloudflare 隧道。"
           }
         }
       }
@@ -4242,6 +5310,12 @@
             "state" : "translated",
             "value" : "连接不能同时使用SSH隧道和Cloudflare隧道。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線無法同時使用 SSH 隧道和 Cloudflare 隧道。"
+          }
         }
       }
     },
@@ -4263,6 +5337,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已存在同名、同主机和同类型的连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已存在同名稱、同主機與同類型的連線。"
           }
         }
       }
@@ -4286,6 +5366,12 @@
             "state" : "translated",
             "value" : "快速、轻量的原生 macOS 数据库客户端"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速、輕量的原生 macOS 資料庫用戶端"
+          }
         }
       }
     },
@@ -4307,6 +5393,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "需要更新版本的TablePro才能加载此插件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要更新版本的 TablePro 才能載入這個外掛。"
           }
         }
       }
@@ -4330,6 +5422,12 @@
             "state" : "translated",
             "value" : "此插件需要更新版本的TablePro。请更新TablePro以继续使用。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這個外掛需要更新版本的 TablePro。請更新 TablePro 以繼續使用。"
+          }
         }
       }
     },
@@ -4352,6 +5450,12 @@
             "state" : "translated",
             "value" : "检测到同步冲突，需要解决。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "偵測到同步衝突，需要解決。"
+          }
         }
       }
     },
@@ -4373,6 +5477,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "关于 TablePro"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關於 TablePro"
           }
         }
       }
@@ -4397,6 +5507,12 @@
             "state" : "translated",
             "value" : "强调色："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "強調色："
+          }
         }
       }
     },
@@ -4419,6 +5535,12 @@
             "state" : "translated",
             "value" : "访问权限"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "存取權限"
+          }
         }
       }
     },
@@ -4440,6 +5562,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Access应用程序"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Access 應用程式"
           }
         }
       }
@@ -4469,6 +5597,12 @@
             "state" : "translated",
             "value" : "Access Key ID"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Access Key ID"
+          }
         }
       }
     },
@@ -4493,6 +5627,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "账户"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "帳號"
           }
         }
       }
@@ -4522,6 +5662,12 @@
             "state" : "translated",
             "value" : "账户 ID"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "帳號 ID"
+          }
         }
       }
     },
@@ -4543,6 +5689,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "账户标识符"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "帳號識別碼"
           }
         }
       }
@@ -4566,6 +5718,12 @@
             "state" : "translated",
             "value" : "账户："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "帳號："
+          }
         }
       }
     },
@@ -4587,6 +5745,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "操作"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動作"
           }
         }
       }
@@ -4610,6 +5774,12 @@
             "state" : "translated",
             "value" : "操作失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作失敗"
+          }
         }
       }
     },
@@ -4631,6 +5801,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "操作：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動作：%@"
           }
         }
       }
@@ -4654,6 +5830,12 @@
             "state" : "translated",
             "value" : "激活"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用"
+          }
         }
       }
     },
@@ -4675,6 +5857,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "激活许可证"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用授權"
           }
         }
       }
@@ -4698,6 +5886,12 @@
             "state" : "translated",
             "value" : "激活许可证…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用授權…"
+          }
         }
       }
     },
@@ -4719,6 +5913,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下次启动TablePro时激活"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下次啟動 TablePro 時啟用"
           }
         }
       }
@@ -4742,6 +5942,12 @@
             "state" : "translated",
             "value" : "立即激活"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即啟用"
+          }
         }
       }
     },
@@ -4763,6 +5969,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "激活失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用失敗"
           }
         }
       }
@@ -4792,6 +6004,12 @@
             "state" : "translated",
             "value" : "激活数（%lld / %lld）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用數（%1$lld / %2$lld）"
+          }
         }
       }
     },
@@ -4813,6 +6031,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "活跃"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用中"
           }
         }
       }
@@ -4836,6 +6060,12 @@
             "state" : "translated",
             "value" : "活跃连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用中的連線"
+          }
         }
       }
     },
@@ -4857,6 +6087,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "活跃连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用中的連線"
           }
         }
       }
@@ -4880,6 +6116,12 @@
             "state" : "translated",
             "value" : "活跃合并"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進行中的合併"
+          }
         }
       }
     },
@@ -4901,6 +6143,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "活动提供方"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用中的供應商"
           }
         }
       }
@@ -4924,6 +6172,12 @@
             "state" : "translated",
             "value" : "活跃查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進行中的查詢"
+          }
         }
       }
     },
@@ -4945,6 +6199,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "活跃会话"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用中的工作階段"
           }
         }
       }
@@ -4968,6 +6228,12 @@
             "state" : "translated",
             "value" : "活动"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "活動"
+          }
         }
       }
     },
@@ -4989,6 +6255,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "活动详情"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "活動詳細資訊"
           }
         }
       }
@@ -5012,6 +6284,12 @@
             "state" : "translated",
             "value" : "活动记录保留 90 天。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "活動記錄保留 90 天。"
+          }
         }
       }
     },
@@ -5033,6 +6311,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "活动日志"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "活動記錄"
           }
         }
       }
@@ -5056,6 +6340,12 @@
             "state" : "translated",
             "value" : "实际"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "實際"
+          }
         }
       }
     },
@@ -5077,6 +6367,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增"
           }
         }
       }
@@ -5100,6 +6396,12 @@
             "state" : "translated",
             "value" : "添加 %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增 %@"
+          }
         }
       }
     },
@@ -5121,6 +6423,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加其他SQL文件夹..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增其他 SQL 資料夾…"
           }
         }
       }
@@ -5144,6 +6452,12 @@
             "state" : "translated",
             "value" : "作为副本添加"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增為副本"
+          }
         }
       }
     },
@@ -5165,6 +6479,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "请至少添加一个包含名称和类型的列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請至少新增一個含名稱與型別的欄位"
           }
         }
       }
@@ -5188,6 +6508,12 @@
             "state" : "translated",
             "value" : "添加检查约束"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增檢查約束"
+          }
         }
       }
     },
@@ -5210,6 +6536,12 @@
             "state" : "translated",
             "value" : "添加列"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增欄位"
+          }
         }
       }
     },
@@ -5231,6 +6563,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加列…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增欄位…"
           }
         }
       }
@@ -5255,6 +6593,12 @@
             "state" : "translated",
             "value" : "请先添加列"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請先新增欄位"
+          }
         }
       }
     },
@@ -5276,6 +6620,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加列以查看 CREATE TABLE 语句"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增欄位以查看 CREATE TABLE 陳述式"
           }
         }
       }
@@ -5299,6 +6649,12 @@
             "state" : "translated",
             "value" : "添加命令"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增指令"
+          }
         }
       }
     },
@@ -5320,6 +6676,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增連線"
           }
         }
       }
@@ -5343,6 +6705,12 @@
             "state" : "translated",
             "value" : "添加自定义提供方…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增自訂供應商…"
+          }
         }
       }
     },
@@ -5365,6 +6733,12 @@
             "state" : "translated",
             "value" : "添加筛选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增篩選"
+          }
         }
       }
     },
@@ -5386,6 +6760,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加筛选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增篩選"
           }
         }
       }
@@ -5410,6 +6790,12 @@
             "state" : "translated",
             "value" : "添加筛选 (Cmd+Shift+F)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增篩選 (Cmd+Shift+F)"
+          }
         }
       }
     },
@@ -5431,6 +6817,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加筛选行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增篩選列"
           }
         }
       }
@@ -5454,6 +6846,12 @@
             "state" : "translated",
             "value" : "添加文件夹…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增資料夾…"
+          }
         }
       }
     },
@@ -5475,6 +6873,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加外键"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增外鍵"
           }
         }
       }
@@ -5498,6 +6902,12 @@
             "state" : "translated",
             "value" : "添加索引"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增索引"
+          }
         }
       }
     },
@@ -5519,6 +6929,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加索引以提升常用搜索列的查询性能"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "為常搜尋的欄位新增索引以提升查詢效能"
           }
         }
       }
@@ -5542,6 +6958,12 @@
             "state" : "translated",
             "value" : "添加跳板机"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增跳板主機"
+          }
         }
       }
     },
@@ -5563,6 +6985,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加链接的SQL文件夹..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增連結的 SQL 資料夾…"
           }
         }
       }
@@ -5587,6 +7015,12 @@
             "state" : "translated",
             "value" : "添加提供商"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增供應商"
+          }
         }
       }
     },
@@ -5610,6 +7044,12 @@
             "state" : "translated",
             "value" : "添加提供商"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增供應商"
+          }
         }
       }
     },
@@ -5631,6 +7071,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加提供方…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增供應商…"
           }
         }
       }
@@ -5654,6 +7100,12 @@
             "state" : "translated",
             "value" : "添加行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增列"
+          }
         }
       }
     },
@@ -5675,6 +7127,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "将下方 JSON 添加到文件中并保存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將下方 JSON 加入檔案中並儲存"
           }
         }
       }
@@ -5700,6 +7158,12 @@
             "state" : "translated",
             "value" : "添加到收藏"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入我的最愛"
+          }
         }
       }
     },
@@ -5721,6 +7185,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加验证规则以确保数据完整性"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增驗證規則以確保資料完整性"
           }
         }
       }
@@ -5744,6 +7214,12 @@
             "state" : "translated",
             "value" : "地址"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "位址"
+          }
         }
       }
     },
@@ -5762,6 +7238,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "admin"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "admin"
@@ -5788,6 +7270,12 @@
             "state" : "translated",
             "value" : "管理"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理"
+          }
         }
       }
     },
@@ -5809,6 +7297,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "高级"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進階"
           }
         }
       }
@@ -5832,6 +7326,12 @@
             "state" : "translated",
             "value" : "高级对象关系型SQL"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進階的物件關聯式 SQL"
+          }
         }
       }
     },
@@ -5850,6 +7350,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Agent"
@@ -5876,6 +7382,12 @@
             "state" : "translated",
             "value" : "Agent Socket"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent Socket"
+          }
         }
       }
     },
@@ -5898,6 +7410,12 @@
             "state" : "translated",
             "value" : "Agent：可使用全部工具，包括破坏性DDL。安全模式仍会控制执行。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent：可使用全部工具，包括破壞性的 DDL。安全模式仍會控管執行。"
+          }
         }
       }
     },
@@ -5916,6 +7434,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "AI"
@@ -5942,6 +7466,12 @@
             "state" : "translated",
             "value" : "此连接的 AI 访问已禁用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線的 AI 存取已停用"
+          }
         }
       }
     },
@@ -5963,6 +7493,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "AI 访问策略在每个连接的设置中单独配置。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 存取原則在每個連線的設定中個別設定。"
           }
         }
       }
@@ -5986,6 +7522,12 @@
             "state" : "translated",
             "value" : "AI 对话"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 對話"
+          }
         }
       }
     },
@@ -6007,6 +7549,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此连接已禁用 AI。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線已停用 AI。"
           }
         }
       }
@@ -6030,6 +7578,12 @@
             "state" : "translated",
             "value" : "AI在一次回复中调用了过多工具。请尝试简化请求。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 在一次回應中呼叫了過多工具。請嘗試簡化請求。"
+          }
         }
       }
     },
@@ -6051,6 +7605,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "AI 未配置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 尚未設定"
           }
         }
       }
@@ -6074,6 +7634,12 @@
             "state" : "translated",
             "value" : "AI 策略"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 政策"
+          }
         }
       }
     },
@@ -6095,6 +7661,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "AI 策略控制应用内 AI 代理。外部客户端控制 Raycast、Cursor、Claude Desktop 及其他 MCP 客户端。实际权限取请求令牌权限与外部客户端级别中的较低值。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 政策控制應用程式內的 AI 代理程式。外部用戶端控制 Raycast、Cursor、Claude Desktop 及其他 MCP 用戶端。實際範圍取請求權杖範圍與外部用戶端層級兩者中較低者。"
           }
         }
       }
@@ -6119,6 +7691,12 @@
             "state" : "translated",
             "value" : "AI 提供商"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 供應商"
+          }
         }
       }
     },
@@ -6140,6 +7718,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "AI回复可能不准确"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 回應可能不準確"
           }
         }
       }
@@ -6163,6 +7747,12 @@
             "state" : "translated",
             "value" : "AI规则"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 規則"
+          }
         }
       }
     },
@@ -6184,6 +7774,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "AI 助手"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 助理"
           }
         }
       }
@@ -6208,6 +7804,12 @@
             "state" : "translated",
             "value" : "AI 驱动的 SQL 补全在输入时以虚影文本显示。按 Tab 接受，按 Escape 关闭。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 驅動的 SQL 補全會在輸入時以淡色文字顯示。按 Tab 接受，按 Escape 關閉。"
+          }
         }
       }
     },
@@ -6229,6 +7831,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "警告"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "警示"
           }
         }
       }
@@ -6252,6 +7860,12 @@
             "state" : "translated",
             "value" : "警告（完整）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "警示（完整）"
+          }
         }
       }
     },
@@ -6274,6 +7888,12 @@
             "state" : "translated",
             "value" : "算法"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "演算法"
+          }
         }
       }
     },
@@ -6292,6 +7912,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "全部"
@@ -6318,6 +7944,12 @@
             "state" : "translated",
             "value" : "已选择全部%d行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已選取全部 %d 列"
+          }
         }
       }
     },
@@ -6341,6 +7973,12 @@
             "state" : "translated",
             "value" : "已选择全部 %lld 行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已選取全部 %lld 列"
+          }
         }
       }
     },
@@ -6362,6 +8000,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "所有分类"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有類別"
           }
         }
       }
@@ -6385,6 +8029,12 @@
             "state" : "translated",
             "value" : "所有列"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有欄位"
+          }
         }
       }
     },
@@ -6406,6 +8056,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "所有连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有連線"
           }
         }
       }
@@ -6430,6 +8086,12 @@
             "state" : "translated",
             "value" : "所有数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有資料庫"
+          }
         }
       }
     },
@@ -6453,6 +8115,12 @@
             "state" : "translated",
             "value" : "保留所有权利。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保留所有權利。"
+          }
         }
       }
     },
@@ -6475,6 +8143,12 @@
             "state" : "translated",
             "value" : "所有行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有列"
+          }
         }
       }
     },
@@ -6496,6 +8170,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "所有行…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有列…"
           }
         }
       }
@@ -6520,6 +8200,12 @@
             "state" : "translated",
             "value" : "所有 SCHEMA"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有綱要"
+          }
         }
       }
     },
@@ -6541,6 +8227,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "所有选中的连接均已跳过。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有選取的連線都已略過。"
           }
         }
       }
@@ -6564,6 +8256,12 @@
             "state" : "translated",
             "value" : "所有表和数据将被永久删除。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有資料表與資料將被永久刪除。"
+          }
         }
       }
     },
@@ -6585,6 +8283,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全部时间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部時間"
           }
         }
       }
@@ -6608,6 +8312,12 @@
             "state" : "translated",
             "value" : "所有时间"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部時間"
+          }
         }
       }
     },
@@ -6629,6 +8339,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "所有令牌"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有權杖"
           }
         }
       }
@@ -6655,6 +8371,12 @@
             "state" : "translated",
             "value" : "允许"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許"
+          }
         }
       }
     },
@@ -6676,6 +8398,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "允许 %@ 访问 TablePro？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許 %@ 存取 TablePro？"
           }
         }
       }
@@ -6699,6 +8427,12 @@
             "state" : "translated",
             "value" : "允许 AI 访问"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許 AI 存取"
+          }
         }
       }
     },
@@ -6720,6 +8454,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "允许远程连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許遠端連線"
           }
         }
       }
@@ -6743,6 +8483,12 @@
             "state" : "translated",
             "value" : "允许的连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許的連線"
+          }
         }
       }
     },
@@ -6764,6 +8510,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "兼容类型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同時支援"
           }
         }
       }
@@ -6788,6 +8540,12 @@
             "state" : "translated",
             "value" : "还支持："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同時支援："
+          }
         }
       }
     },
@@ -6809,6 +8567,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "交替行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "交替列"
           }
         }
       }
@@ -6833,6 +8597,12 @@
             "state" : "translated",
             "value" : "始终"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "永遠"
+          }
         }
       }
     },
@@ -6854,6 +8624,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "始终允许"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "永遠允許"
           }
         }
       }
@@ -6877,6 +8653,12 @@
             "state" : "translated",
             "value" : "对此连接始终允许%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "對這個連線一律允許 %@"
+          }
         }
       }
     },
@@ -6898,6 +8680,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "始终计数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "永遠計數"
           }
         }
       }
@@ -6921,6 +8709,12 @@
             "state" : "translated",
             "value" : "始终用于此连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一律用於這個連線"
+          }
         }
       }
     },
@@ -6942,6 +8736,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "始终隐藏"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "永遠隱藏"
           }
         }
       }
@@ -6965,6 +8765,12 @@
             "state" : "translated",
             "value" : "始终显示"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "永遠顯示"
+          }
         }
       }
     },
@@ -6987,6 +8793,12 @@
             "state" : "translated",
             "value" : "Amazon基于Postgres的列式数据仓库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amazon 基於 Postgres 的欄式資料倉儲"
+          }
         }
       }
     },
@@ -7008,6 +8820,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "外部应用正在请求 API 令牌。请在批准前审核权限。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有外部應用程式正在請求 API 權杖。請在核准前審查權限。"
           }
         }
       }
@@ -7038,6 +8856,12 @@
             "state" : "translated",
             "value" : "外部链接想要添加数据库连接：\n\n名称：%@\n%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有外部連結想要新增資料庫連線：\n\n名稱：%1$@\n%2$@"
+          }
         }
       }
     },
@@ -7060,6 +8884,12 @@
             "state" : "translated",
             "value" : "外部链接要应用筛选条件：\n\n%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有外部連結想要套用篩選：\n\n%@"
+          }
         }
       }
     },
@@ -7069,6 +8899,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "An external link wants to connect to a %1$@ database:\n\n%2$@\n\nConnect only if you trust the source of this link."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一個外部連結想要連線到 %1$@ 資料庫：\n\n%2$@\n\n只有在你信任這個連結的來源時才連線。"
           }
         }
       }
@@ -7097,6 +8933,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "外部链接希望在 \"%@\" 上打开查询：\n\n%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有外部連結想要在「%1$@」上開啟查詢：\n\n%2$@"
           }
         }
       }
@@ -7127,6 +8969,12 @@
             "state" : "translated",
             "value" : "外部链接想要在连接\"%@\"上打开查询：\n\n%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有外部連結想要在連線「%1$@」上開啟查詢：\n\n%2$@"
+          }
         }
       }
     },
@@ -7148,6 +8996,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "MCP 客户端请求访问 '%@'（%@）。是否允许？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有 MCP 用戶端想要存取「%@」（%@）。是否允許？"
           }
         }
       }
@@ -7171,6 +9025,12 @@
             "state" : "translated",
             "value" : "已有操作正在运行。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已有操作正在執行。"
+          }
         }
       }
     },
@@ -7193,6 +9053,12 @@
             "state" : "translated",
             "value" : "发生未知同步错误：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "發生未知的同步錯誤：%@"
+          }
         }
       }
     },
@@ -7211,6 +9077,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分析型"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "分析型"
@@ -7237,6 +9109,12 @@
             "state" : "translated",
             "value" : "ANALYZE（vacuum 后更新统计信息）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ANALYZE（vacuum 後更新統計資訊）"
+          }
         }
       }
     },
@@ -7259,6 +9137,12 @@
             "state" : "translated",
             "value" : "和"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "且"
+          }
         }
       }
     },
@@ -7278,6 +9162,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AND"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "AND"
@@ -7305,6 +9195,12 @@
             "state" : "translated",
             "value" : "动画"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動畫"
+          }
         }
       }
     },
@@ -7326,6 +9222,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此插件已有另一个安装正在进行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這個外掛已有另一個安裝正在進行"
           }
         }
       }
@@ -7349,6 +9251,12 @@
             "state" : "translated",
             "value" : "任意列"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "任一欄位"
+          }
         }
       }
     },
@@ -7367,6 +9275,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API Key"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "API Key"
@@ -7393,6 +9307,12 @@
             "state" : "translated",
             "value" : "需要 API 密钥"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要 API key"
+          }
         }
       }
     },
@@ -7415,6 +9335,12 @@
             "state" : "translated",
             "value" : "已设置 API 密钥"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已設定 API key"
+          }
         }
       }
     },
@@ -7436,6 +9362,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "API 令牌"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API token"
           }
         }
       }
@@ -7465,6 +9397,12 @@
             "state" : "translated",
             "value" : "API Token"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API Token"
+          }
         }
       }
     },
@@ -7486,6 +9424,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "需要 API 令牌"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要 API 權杖"
           }
         }
       }
@@ -7509,6 +9453,12 @@
             "state" : "translated",
             "value" : "应用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App"
+          }
         }
       }
     },
@@ -7530,6 +9480,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "外观"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外觀"
           }
         }
       }
@@ -7554,6 +9510,12 @@
             "state" : "translated",
             "value" : "外观："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外觀："
+          }
         }
       }
     },
@@ -7576,6 +9538,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已应用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已套用"
           }
         }
       }
@@ -7600,6 +9568,12 @@
             "state" : "translated",
             "value" : "在打开表时应用。点按列标题可覆盖。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在開啟資料表時套用。點按欄位標題可覆寫。"
+          }
         }
       }
     },
@@ -7622,6 +9596,12 @@
             "state" : "translated",
             "value" : "应用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用"
+          }
         }
       }
     },
@@ -7643,6 +9623,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "应用启用的筛选 (Cmd+Return)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用啟用的篩選（Cmd+Return）"
           }
         }
       }
@@ -7667,6 +9653,12 @@
             "state" : "translated",
             "value" : "全部应用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部套用"
+          }
         }
       }
     },
@@ -7688,6 +9680,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "应用更改"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用變更"
           }
         }
       }
@@ -7711,6 +9709,12 @@
             "state" : "translated",
             "value" : "应用筛选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用篩選"
+          }
         }
       }
     },
@@ -7732,6 +9736,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从链接应用筛选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從連結套用篩選"
           }
         }
       }
@@ -7756,6 +9766,12 @@
             "state" : "translated",
             "value" : "应用筛选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用篩選"
+          }
         }
       }
     },
@@ -7778,6 +9794,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "仅应用此筛选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅套用這個篩選"
           }
         }
       }
@@ -7804,6 +9826,12 @@
             "state" : "translated",
             "value" : "应用Schema更改"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用綱要變更"
+          }
         }
       }
     },
@@ -7826,6 +9854,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "应用此筛选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用此篩選"
           }
         }
       }
@@ -7850,6 +9884,12 @@
             "state" : "translated",
             "value" : "应用此筛选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用此篩選"
+          }
         }
       }
     },
@@ -7871,6 +9911,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "应用或清除筛选条件将重新加载数据并丢弃所有未保存的更改。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用或清除篩選條件將重新載入資料並捨棄所有未儲存的變更。"
           }
         }
       }
@@ -7894,6 +9940,12 @@
             "state" : "translated",
             "value" : "批准"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "核准"
+          }
         }
       }
     },
@@ -7915,6 +9967,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "批准集成"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "核准整合"
           }
         }
       }
@@ -7938,6 +9996,12 @@
             "state" : "translated",
             "value" : "确定要取消此会话正在运行的查询吗？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確定要取消此工作階段正在執行的查詢嗎？"
+          }
         }
       }
     },
@@ -7959,6 +10023,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "确定要删除 \"%@\" 吗？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確定要刪除「%@」嗎？"
           }
         }
       }
@@ -7988,6 +10058,12 @@
             "state" : "translated",
             "value" : "确定要删除 %lld 个连接吗？此操作无法撤销。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確定要刪除 %lld 個連線嗎？此操作無法復原。"
+          }
         }
       }
     },
@@ -8009,6 +10085,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "确定要删除分组 \"%@\" 吗？该分组中的连接将移至顶层。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確定要刪除群組「%@」嗎？此群組中的連線將移至頂層。"
           }
         }
       }
@@ -8033,6 +10115,12 @@
             "state" : "translated",
             "value" : "确定要删除此连接吗？此操作无法撤消。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確定要刪除此連線嗎？此操作無法復原。"
+          }
         }
       }
     },
@@ -8056,6 +10144,12 @@
             "state" : "translated",
             "value" : "确定要断开与此数据库的连接吗？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確定要中斷與此資料庫的連線嗎？"
+          }
         }
       }
     },
@@ -8077,6 +10171,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "确定要执行此查询吗？\n\n%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確定要執行此查詢嗎？\n\n%@"
           }
         }
       }
@@ -8100,6 +10200,12 @@
             "state" : "translated",
             "value" : "确定要终止此会话吗？正在运行的查询将被中止。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確定要終止此工作階段嗎？正在執行的查詢將被中止。"
+          }
         }
       }
     },
@@ -8122,6 +10228,12 @@
             "state" : "translated",
             "value" : "作为副本"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作為副本"
+          }
         }
       }
     },
@@ -8140,6 +10252,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ask"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ask"
@@ -8166,6 +10284,12 @@
             "state" : "translated",
             "value" : "询问您的数据库..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "詢問關於你的資料庫的問題..."
+          }
         }
       }
     },
@@ -8187,6 +10311,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "向 AI 询问您的数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向 AI 詢問你的資料庫"
           }
         }
       }
@@ -8210,6 +10340,12 @@
             "state" : "translated",
             "value" : "让 AI 修复"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "讓 AI 修正"
+          }
         }
       }
     },
@@ -8231,6 +10367,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "每次询问"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每次詢問"
           }
         }
       }
@@ -8255,6 +10397,12 @@
             "state" : "translated",
             "value" : "每次连接时询问 API 令牌"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每次連線時詢問 API 權杖"
+          }
         }
       }
     },
@@ -8278,6 +10426,12 @@
             "state" : "translated",
             "value" : "每次连接时询问密码"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每次連線時詢問密碼"
+          }
         }
       }
     },
@@ -8299,6 +10453,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ask：只读Schema查看。AI可以浏览但不能运行查询。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ask：唯讀的綱要查看。AI 可以瀏覽但不能執行查詢。"
           }
         }
       }
@@ -8322,6 +10482,12 @@
             "state" : "translated",
             "value" : "附加上下文"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "附加內容"
+          }
         }
       }
     },
@@ -8341,6 +10507,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "附件"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "附件"
@@ -8366,6 +10538,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "认证"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證"
           }
         }
       }
@@ -8395,6 +10573,12 @@
             "state" : "translated",
             "value" : "认证方式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證方式"
+          }
         }
       }
     },
@@ -8416,6 +10600,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "验证身份以执行数据库操作"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證身分以執行資料庫操作"
           }
         }
       }
@@ -8439,6 +10629,12 @@
             "state" : "translated",
             "value" : "身份验证"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "身分驗證"
+          }
         }
       }
     },
@@ -8460,6 +10656,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "身份验证失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "身分驗證失敗：%@"
           }
         }
       }
@@ -8483,6 +10685,12 @@
             "state" : "translated",
             "value" : "身份验证失败。请检查您的 API key。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "身分驗證失敗。請檢查你的 API key。"
+          }
         }
       }
     },
@@ -8504,6 +10712,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此操作需要身份验证"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這項操作需要身分驗證"
           }
         }
       }
@@ -8527,6 +10741,12 @@
             "state" : "translated",
             "value" : "身份验证方式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "身分驗證方式"
+          }
         }
       }
     },
@@ -8548,6 +10768,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "需要认证"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要身分驗證"
           }
         }
       }
@@ -8572,6 +10798,12 @@
             "state" : "translated",
             "value" : "执行操作需要身份验证"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行操作需要身分驗證"
+          }
         }
       }
     },
@@ -8594,6 +10826,12 @@
             "state" : "translated",
             "value" : "执行写入操作需要身份验证"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行寫入操作需要身分驗證"
+          }
         }
       }
     },
@@ -8612,6 +10850,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作者"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "作者"
@@ -8638,6 +10882,12 @@
             "state" : "translated",
             "value" : "自动"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動"
+          }
         }
       }
     },
@@ -8661,6 +10911,12 @@
             "state" : "translated",
             "value" : "自动"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動"
+          }
         }
       }
     },
@@ -8683,6 +10939,12 @@
             "state" : "translated",
             "value" : "启动时自动清理"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟動時自動清理"
+          }
         }
       }
     },
@@ -8704,6 +10966,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自动生成"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動產生"
           }
         }
       }
@@ -8728,6 +10996,12 @@
             "state" : "translated",
             "value" : "自增"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動遞增"
+          }
         }
       }
     },
@@ -8750,6 +11024,12 @@
             "state" : "translated",
             "value" : "自动递增"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動遞增"
+          }
         }
       }
     },
@@ -8771,6 +11051,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自动从 ~/.ssh/config 和默认密钥位置检测。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動從 ~/.ssh/config 和預設金鑰位置偵測。"
           }
         }
       }
@@ -8795,6 +11081,12 @@
             "state" : "translated",
             "value" : "自动缩进"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動縮排"
+          }
         }
       }
     },
@@ -8816,6 +11108,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选中行时自动显示检查器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選取列時自動顯示檢閱器"
           }
         }
       }
@@ -8839,6 +11137,12 @@
             "state" : "translated",
             "value" : "自动大写关键字"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關鍵字自動轉大寫"
+          }
         }
       }
     },
@@ -8860,6 +11164,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動"
           }
         }
       }
@@ -8883,6 +11193,12 @@
             "state" : "translated",
             "value" : "自动检查更新"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動檢查更新"
+          }
         }
       }
     },
@@ -8905,6 +11221,12 @@
             "state" : "translated",
             "value" : "平均行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平均列"
+          }
         }
       }
     },
@@ -8926,6 +11248,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "AWS托管的键值/文档存储"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AWS 託管的鍵值／文件儲存"
           }
         }
       }
@@ -8955,6 +11283,12 @@
             "state" : "translated",
             "value" : "AWS 区域"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AWS 區域"
+          }
         }
       }
     },
@@ -8976,6 +11310,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "AWS SSO登录失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AWS SSO 登入失敗"
           }
         }
       }
@@ -8999,6 +11339,12 @@
             "state" : "translated",
             "value" : "AWS SSO登录已完成。请再次测试连接。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AWS SSO 登入已完成。請再次測試連線。"
+          }
         }
       }
     },
@@ -9021,6 +11367,12 @@
             "state" : "translated",
             "value" : "需要AWS SSO登录"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要 AWS SSO 登入"
+          }
         }
       }
     },
@@ -9039,6 +11391,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "返回"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "返回"
@@ -9065,6 +11423,12 @@
             "state" : "translated",
             "value" : "背景"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "背景"
+          }
         }
       }
     },
@@ -9086,6 +11450,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "备份数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "備份資料庫"
           }
         }
       }
@@ -9111,6 +11481,12 @@
             "state" : "translated",
             "value" : "备份转储已取消"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫備份已取消"
+          }
         }
       }
     },
@@ -9134,6 +11510,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "备份转储完成"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫備份完成"
           }
         }
       }
@@ -9159,6 +11541,12 @@
             "state" : "translated",
             "value" : "备份转储失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫備份失敗"
+          }
         }
       }
     },
@@ -9183,6 +11571,12 @@
             "state" : "translated",
             "value" : "备份转储…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在備份資料庫…"
+          }
         }
       }
     },
@@ -9205,6 +11599,12 @@
             "state" : "translated",
             "value" : "徽章背景"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標記背景"
+          }
         }
       }
     },
@@ -9223,6 +11623,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "徽章"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "徽章"
@@ -9250,6 +11656,12 @@
             "state" : "translated",
             "value" : "条形"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "長條"
+          }
         }
       }
     },
@@ -9272,6 +11684,12 @@
             "state" : "translated",
             "value" : "来自身份验证器设置的 Base32 编码密钥"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "來自你的驗證器設定的 Base32 編碼金鑰"
+          }
         }
       }
     },
@@ -9290,6 +11708,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bastion.example.com"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "bastion.example.com"
@@ -9315,6 +11739,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "介于"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "介於"
           }
         }
       }
@@ -9344,6 +11774,12 @@
             "state" : "translated",
             "value" : "账单："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "帳單："
+          }
         }
       }
     },
@@ -9367,6 +11803,12 @@
             "state" : "translated",
             "value" : "块状"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "區塊"
+          }
         }
       }
     },
@@ -9388,6 +11830,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "块大小"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "區塊大小"
           }
         }
       }
@@ -9411,6 +11859,12 @@
             "state" : "translated",
             "value" : "已阻止"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已封鎖"
+          }
         }
       }
     },
@@ -9432,6 +11886,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "蓝色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "藍色"
           }
         }
       }
@@ -9456,6 +11916,12 @@
             "state" : "translated",
             "value" : "正文"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "內文"
+          }
         }
       }
     },
@@ -9477,6 +11943,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "布尔值 False"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "布林值 False"
           }
         }
       }
@@ -9500,6 +11972,12 @@
             "state" : "translated",
             "value" : "布尔值 True"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "布林值 True"
+          }
         }
       }
     },
@@ -9522,6 +12000,12 @@
             "state" : "translated",
             "value" : "布尔值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Boolean"
+          }
         }
       }
     },
@@ -9543,6 +12027,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "边框"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "邊框"
           }
         }
       }
@@ -9567,6 +12057,12 @@
             "state" : "translated",
             "value" : "问题的简要描述"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "問題的簡要說明"
+          }
         }
       }
     },
@@ -9588,6 +12084,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全部置于最前"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部移至最前"
           }
         }
       }
@@ -9611,6 +12113,12 @@
             "state" : "translated",
             "value" : "浏览"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "瀏覽"
+          }
         }
       }
     },
@@ -9632,6 +12140,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "轻松浏览、编辑和管理数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輕鬆瀏覽、編輯和管理你的資料"
           }
         }
       }
@@ -9655,6 +12169,12 @@
             "state" : "translated",
             "value" : "浏览..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "瀏覽..."
+          }
         }
       }
     },
@@ -9676,6 +12196,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "浏览器登录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "瀏覽器登入"
           }
         }
       }
@@ -9699,6 +12225,12 @@
             "state" : "translated",
             "value" : "内置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "內建"
+          }
         }
       }
     },
@@ -9720,6 +12252,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "内置 CLI"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "內建 CLI"
           }
         }
       }
@@ -9743,6 +12281,12 @@
             "state" : "translated",
             "value" : "无法卸载内置插件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法解除安裝內建外掛"
+          }
         }
       }
     },
@@ -9761,6 +12305,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bundle ID"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bundle ID"
@@ -9788,6 +12338,12 @@
             "state" : "translated",
             "value" : "Bundle ID："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bundle ID："
+          }
         }
       }
     },
@@ -9809,6 +12365,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "接收字节"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接收位元組"
           }
         }
       }
@@ -9832,6 +12394,12 @@
             "state" : "translated",
             "value" : "发送字节"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "傳送位元組"
+          }
         }
       }
     },
@@ -9853,6 +12421,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cassandra的C++重写版，速度更快"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cassandra 的 C++ 重寫版，速度更快"
           }
         }
       }
@@ -9877,6 +12451,12 @@
             "state" : "translated",
             "value" : "CA 证书"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CA 憑證"
+          }
         }
       }
     },
@@ -9898,6 +12478,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "CA 证书"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CA 憑證"
           }
         }
       }
@@ -9921,6 +12507,12 @@
             "state" : "translated",
             "value" : "验证模式需要CA证书"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證模式需要 CA 憑證"
+          }
         }
       }
     },
@@ -9942,6 +12534,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未找到CA证书：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到 CA 憑證：%@"
           }
         }
       }
@@ -9965,6 +12563,12 @@
             "state" : "translated",
             "value" : "缓存命中率"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快取命中率"
+          }
         }
       }
     },
@@ -9986,6 +12590,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "缓存大小"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快取大小"
           }
         }
       }
@@ -10009,6 +12619,12 @@
             "state" : "translated",
             "value" : "调用中"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "呼叫中"
+          }
         }
       }
     },
@@ -10027,6 +12643,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消"
@@ -10055,6 +12677,12 @@
             "state" : "translated",
             "value" : "取消备份转储"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消資料庫備份"
+          }
         }
       }
     },
@@ -10079,6 +12707,12 @@
             "state" : "translated",
             "value" : "要取消备份转储吗？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要取消資料庫備份嗎？"
+          }
         }
       }
     },
@@ -10100,6 +12734,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消查询"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消查詢"
           }
         }
       }
@@ -10123,6 +12763,12 @@
             "state" : "translated",
             "value" : "取消查询 (⌘.)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消查詢 (⌘.)"
+          }
         }
       }
     },
@@ -10144,6 +12790,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消会话 %@ 的查询"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消工作階段 %@ 的查詢"
           }
         }
       }
@@ -10169,6 +12821,12 @@
             "state" : "translated",
             "value" : "取消恢复转储"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消還原備份"
+          }
         }
       }
     },
@@ -10193,6 +12851,12 @@
             "state" : "translated",
             "value" : "要取消恢复转储吗？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要取消還原備份嗎？"
+          }
         }
       }
     },
@@ -10211,6 +12875,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已取消"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "已取消"
@@ -10237,6 +12907,12 @@
             "state" : "translated",
             "value" : "已被用户取消。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已由使用者取消。"
+          }
         }
       }
     },
@@ -10255,6 +12931,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在取消…"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在取消…"
@@ -10281,6 +12963,12 @@
             "state" : "translated",
             "value" : "无法连接到 %@ 上的 Ollama。Ollama 是否正在运行？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法連線到 %@ 上的 Ollama。Ollama 是否正在執行？"
+          }
         }
       }
     },
@@ -10303,6 +12991,12 @@
             "state" : "translated",
             "value" : "无法执行写入查询：连接为只读"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法執行寫入查詢：連線為唯讀"
+          }
         }
       }
     },
@@ -10324,6 +13018,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法格式化空 SQL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法格式化空白的 SQL"
           }
         }
       }
@@ -10348,6 +13048,12 @@
             "state" : "translated",
             "value" : "无法保存更改：连接为只读"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法儲存變更：連線為唯讀"
+          }
         }
       }
     },
@@ -10370,6 +13076,12 @@
             "state" : "translated",
             "value" : "无法保存命令"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法儲存指令"
+          }
         }
       }
     },
@@ -10391,6 +13103,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法保存Schema更改：连接为只读。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法儲存綱要變更：連線為唯讀。"
           }
         }
       }
@@ -10415,6 +13133,12 @@
             "state" : "translated",
             "value" : "无法保存 schema 更改：连接为只读。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法儲存綱要變更：連線為唯讀。"
+          }
         }
       }
     },
@@ -10436,6 +13160,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法显示DDL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法顯示 DDL"
           }
         }
       }
@@ -10459,6 +13189,12 @@
             "state" : "translated",
             "value" : "不能同时使用SSH隧道和Cloudflare隧道"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法同時使用 SSH 隧道與 Cloudflare 隧道"
+          }
         }
       }
     },
@@ -10481,6 +13217,12 @@
             "state" : "translated",
             "value" : "将用户查询结果限制在配置的行数内"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將使用者查詢結果限制在設定的列數內"
+          }
         }
       }
     },
@@ -10499,6 +13241,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "功能"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "功能"
@@ -10526,6 +13274,12 @@
             "state" : "translated",
             "value" : "功能："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "功能："
+          }
         }
       }
     },
@@ -10547,6 +13301,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "受限结果会显示\"获取全部\"按钮以加载完整数据集"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "受限結果會顯示「擷取全部」按鈕以載入完整資料集"
           }
         }
       }
@@ -10571,6 +13331,12 @@
             "state" : "translated",
             "value" : "标题说明"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標題說明"
+          }
         }
       }
     },
@@ -10594,6 +13360,12 @@
             "state" : "translated",
             "value" : "捕获窗口"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "擷取視窗"
+          }
         }
       }
     },
@@ -10612,6 +13384,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "卡片背景"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "卡片背景"
@@ -10638,6 +13416,12 @@
             "state" : "translated",
             "value" : "Cascade"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cascade"
+          }
         }
       }
     },
@@ -10660,6 +13444,12 @@
             "state" : "translated",
             "value" : "分类"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分類"
+          }
         }
       }
     },
@@ -10681,6 +13471,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "类别：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "類別：%@"
           }
         }
       }
@@ -10705,6 +13501,12 @@
             "state" : "translated",
             "value" : "单元格渲染器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存格繪製器"
+          }
         }
       }
     },
@@ -10726,6 +13528,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已清除单元格选择"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已清除儲存格選取"
           }
         }
       }
@@ -10750,6 +13558,12 @@
             "state" : "translated",
             "value" : "单元格值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存格值"
+          }
         }
       }
     },
@@ -10771,6 +13585,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "证书"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "憑證"
           }
         }
       }
@@ -10794,6 +13614,12 @@
             "state" : "translated",
             "value" : "证书信任"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "憑證信任"
+          }
         }
       }
     },
@@ -10815,6 +13641,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更改颜色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "變更顏色"
           }
         }
       }
@@ -10839,6 +13671,12 @@
             "state" : "translated",
             "value" : "更改文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "變更檔案"
+          }
         }
       }
     },
@@ -10860,6 +13698,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更改文件..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "變更檔案…"
           }
         }
       }
@@ -10883,6 +13727,12 @@
             "state" : "translated",
             "value" : "更改主键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "變更主鍵"
+          }
         }
       }
     },
@@ -10904,6 +13754,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已更改"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已變更"
           }
         }
       }
@@ -10928,6 +13784,12 @@
             "state" : "translated",
             "value" : "字符集"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字集"
+          }
         }
       }
     },
@@ -10951,6 +13813,12 @@
             "state" : "translated",
             "value" : "字符集（如 utf8mb4）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字集（如 utf8mb4）"
+          }
         }
       }
     },
@@ -10972,6 +13840,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "字符集："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字集："
           }
         }
       }
@@ -10995,6 +13869,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "对话"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "對話"
           }
         }
       }
@@ -11021,6 +13901,12 @@
             "state" : "translated",
             "value" : "检查更新..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檢查更新…"
+          }
         }
       }
     },
@@ -11042,6 +13928,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "检查模式："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檢查模式："
           }
         }
       }
@@ -11071,6 +13963,12 @@
             "state" : "translated",
             "value" : "检查状态"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檢查狀態"
+          }
         }
       }
     },
@@ -11092,6 +13990,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chinook（示例）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chinook（範例）"
           }
         }
       }
@@ -11117,6 +14021,12 @@
             "state" : "translated",
             "value" : "选择"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇"
+          }
         }
       }
     },
@@ -11138,6 +14048,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择要导入的%@导出文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇要匯入的 %@ 匯出檔案"
           }
         }
       }
@@ -11161,6 +14077,12 @@
             "state" : "translated",
             "value" : "选择证书或密钥文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇憑證或金鑰檔案"
+          }
         }
       }
     },
@@ -11182,6 +14104,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇資料庫"
           }
         }
       }
@@ -11206,6 +14134,12 @@
             "state" : "translated",
             "value" : "选择已获取的模型"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇已擷取的模型"
+          }
         }
       }
     },
@@ -11227,6 +14161,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择包含.sql文件的文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇包含 .sql 檔案的資料夾"
           }
         }
       }
@@ -11250,6 +14190,12 @@
             "state" : "translated",
             "value" : "选择要监视 .tablepro 连接文件的文件夹"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇要監看 .tablepro 連線檔案的資料夾"
+          }
         }
       }
     },
@@ -11271,6 +14217,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择位置将图表保存为 PNG。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇位置以將圖表儲存為 PNG。"
           }
         }
       }
@@ -11294,6 +14246,12 @@
             "state" : "translated",
             "value" : "选择私钥文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇私密金鑰檔案"
+          }
         }
       }
     },
@@ -11315,6 +14273,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从列表中选择一个查询\n以在此处查看其完整内容。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從清單中選擇一個查詢\n以在此處查看其完整內容。"
           }
         }
       }
@@ -11338,6 +14302,12 @@
             "state" : "translated",
             "value" : "从侧边栏选择一个部分。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從側邊欄選擇一個區段。"
+          }
         }
       }
     },
@@ -11359,6 +14329,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择AI提供商和模型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇 AI 供應商與模型"
           }
         }
       }
@@ -11382,6 +14358,12 @@
             "state" : "translated",
             "value" : "选择要导入的导出文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇要匯入的匯出檔案"
+          }
         }
       }
     },
@@ -11403,6 +14385,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择目标位置…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇目的地…"
           }
         }
       }
@@ -11426,6 +14414,12 @@
             "state" : "translated",
             "value" : "选择转储文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇備份檔"
+          }
         }
       }
     },
@@ -11447,6 +14441,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自动选择端口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動選擇連接埠"
           }
         }
       }
@@ -11470,6 +14470,12 @@
             "state" : "translated",
             "value" : "选择“%@”转储文件的保存位置。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇要將「%@」的備份檔儲存至何處。"
+          }
         }
       }
     },
@@ -11491,6 +14497,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择您的客户端并按步骤将其连接到TablePro。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇你的用戶端，並依照步驟將它連線到 TablePro。"
           }
         }
       }
@@ -11514,6 +14526,12 @@
             "state" : "translated",
             "value" : "选择..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇…"
+          }
         }
       }
     },
@@ -11532,6 +14550,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Claude Code"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Claude Code"
@@ -11558,6 +14582,12 @@
             "state" : "translated",
             "value" : "Claude Desktop"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Claude Desktop"
+          }
         }
       }
     },
@@ -11576,6 +14606,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除"
@@ -11602,6 +14638,12 @@
             "state" : "translated",
             "value" : "全部清除"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部清除"
+          }
         }
       }
     },
@@ -11620,6 +14662,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部清除"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "全部清除"
@@ -11646,6 +14694,12 @@
             "state" : "translated",
             "value" : "清除所有对话？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除所有對話？"
+          }
         }
       }
     },
@@ -11667,6 +14721,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除全部历史"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除全部歷程記錄"
           }
         }
       }
@@ -11690,6 +14750,12 @@
             "state" : "translated",
             "value" : "清除全部历史？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除全部歷程記錄？"
+          }
         }
       }
     },
@@ -11711,6 +14777,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除全部查询历史"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除全部查詢歷程記錄"
           }
         }
       }
@@ -11738,6 +14810,12 @@
             "state" : "translated",
             "value" : "清除对话"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除對話"
+          }
         }
       }
     },
@@ -11759,6 +14837,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除筛选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除篩選"
           }
         }
       }
@@ -11782,6 +14866,12 @@
             "state" : "translated",
             "value" : "清除历史..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除歷程記錄…"
+          }
         }
       }
     },
@@ -11803,6 +14893,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除查询"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除查詢"
           }
         }
       }
@@ -11827,6 +14923,12 @@
             "state" : "translated",
             "value" : "清除查询 (⌘+Delete)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除查詢 (⌘+Delete)"
+          }
         }
       }
     },
@@ -11849,6 +14951,12 @@
             "state" : "translated",
             "value" : "清除最近记录"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除最近項目"
+          }
         }
       }
     },
@@ -11870,6 +14978,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除结果"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除結果"
           }
         }
       }
@@ -11894,6 +15008,12 @@
             "state" : "translated",
             "value" : "清除搜索"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除搜尋"
+          }
         }
       }
     },
@@ -11917,6 +15037,12 @@
             "state" : "translated",
             "value" : "清除搜索"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除搜尋"
+          }
         }
       }
     },
@@ -11938,6 +15064,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消选择"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除選取範圍"
           }
         }
       }
@@ -11962,6 +15094,12 @@
             "state" : "translated",
             "value" : "清除表筛选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除資料表篩選"
+          }
         }
       }
     },
@@ -11983,6 +15121,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "CLI连接名称"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CLI 連線名稱"
           }
         }
       }
@@ -12007,6 +15151,12 @@
             "state" : "translated",
             "value" : "CLI 路径"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CLI 路徑"
+          }
         }
       }
     },
@@ -12030,6 +15180,12 @@
             "state" : "translated",
             "value" : "在 PATH 中未找到 CLI 工具 \"%@\""
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 PATH 中找不到 CLI 工具「%@」"
+          }
         }
       }
     },
@@ -12051,6 +15207,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "点击 \"+ Add new global MCP server\""
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點按「+ Add new global MCP server」"
           }
         }
       }
@@ -12074,6 +15236,12 @@
             "state" : "translated",
             "value" : "点击 \"Edit Config\" 打开 claude_desktop_config.json"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點按「Edit Config」以開啟 claude_desktop_config.json"
+          }
         }
       }
     },
@@ -12095,6 +15263,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "点击 + 添加此表与其他表之间的关系"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點按 + 以新增此資料表與另一個資料表之間的關聯"
           }
         }
       }
@@ -12119,6 +15293,12 @@
             "state" : "translated",
             "value" : "点击 + 创建您的第一个连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點按 + 以建立你的第一個連線"
+          }
         }
       }
     },
@@ -12141,6 +15321,12 @@
             "state" : "translated",
             "value" : "点击一个表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點按一個資料表"
+          }
         }
       }
     },
@@ -12162,6 +15348,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "点按Agent面板标题栏中的菜单并选择\"设置\""
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點按 Agent 面板標題列中的選單，然後選擇「設定」"
           }
         }
       }
@@ -12186,6 +15378,12 @@
             "state" : "translated",
             "value" : "点击加载模型"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點按以載入模型"
+          }
         }
       }
     },
@@ -12209,6 +15407,12 @@
             "state" : "translated",
             "value" : "点击显示所有表及其元数据"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點按以顯示所有資料表及其中繼資料"
+          }
         }
       }
     },
@@ -12230,6 +15434,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "客户端"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用戶端"
           }
         }
       }
@@ -12254,6 +15464,12 @@
             "state" : "translated",
             "value" : "客户端证书"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用戶端憑證"
+          }
         }
       }
     },
@@ -12275,6 +15491,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "客户端证书"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用戶端憑證"
           }
         }
       }
@@ -12298,6 +15520,12 @@
             "state" : "translated",
             "value" : "未找到客户端证书：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到用戶端憑證：%@"
+          }
         }
       }
     },
@@ -12319,6 +15547,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "客户端证书"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用戶端憑證"
           }
         }
       }
@@ -12343,6 +15577,12 @@
             "state" : "translated",
             "value" : "客户端证书（可选）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用戶端憑證（選填）"
+          }
         }
       }
     },
@@ -12364,6 +15604,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "客户端ID"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用戶端 ID"
           }
         }
       }
@@ -12387,6 +15633,12 @@
             "state" : "translated",
             "value" : "客户端密钥"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用戶端金鑰"
+          }
         }
       }
     },
@@ -12408,6 +15660,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "设置客户端证书时需要客户端私钥"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定用戶端憑證時需要用戶端金鑰"
           }
         }
       }
@@ -12431,6 +15689,12 @@
             "state" : "translated",
             "value" : "未找到客户端私钥：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到用戶端金鑰：%@"
+          }
         }
       }
     },
@@ -12452,6 +15716,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "客户端密钥"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用戶端金鑰"
           }
         }
       }
@@ -12476,6 +15746,12 @@
             "state" : "translated",
             "value" : "客户端："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用戶端："
+          }
         }
       }
     },
@@ -12497,6 +15773,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "客户端在拥有活跃的MCP会话期间会显示在这里。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用戶端在擁有作用中的 MCP 工作階段期間會顯示在這裡。"
           }
         }
       }
@@ -12520,6 +15802,12 @@
             "state" : "translated",
             "value" : "剪贴板为空或不包含文本数据。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剪貼簿為空白或不包含文字資料。"
+          }
         }
       }
     },
@@ -12541,6 +15829,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "关闭"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉"
           }
         }
       }
@@ -12565,6 +15859,12 @@
             "state" : "translated",
             "value" : "关闭 (ESC)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉 (ESC)"
+          }
         }
       }
     },
@@ -12586,6 +15886,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "关闭活跃连接后生效。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉作用中的連線以套用。"
           }
         }
       }
@@ -12609,6 +15915,12 @@
             "state" : "translated",
             "value" : "关闭其他"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉其他"
+          }
         }
       }
     },
@@ -12630,6 +15942,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "关闭参数面板"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉參數面板"
           }
         }
       }
@@ -12654,6 +15972,12 @@
             "state" : "translated",
             "value" : "关闭预览"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉預覽"
+          }
         }
       }
     },
@@ -12675,6 +15999,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "关闭结果标签页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉結果分頁"
           }
         }
       }
@@ -12698,6 +16028,12 @@
             "state" : "translated",
             "value" : "关闭结果标签页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉結果分頁"
+          }
         }
       }
     },
@@ -12720,6 +16056,12 @@
             "state" : "translated",
             "value" : "关闭标签页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉分頁"
+          }
         }
       }
     },
@@ -12741,6 +16083,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置前请先关闭已打开的示例连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重設前請先關閉已開啟的範例連線。"
           }
         }
       }
@@ -12765,6 +16113,12 @@
             "state" : "translated",
             "value" : "关闭此标签页将丢弃所有未保存的更改。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉此分頁將捨棄所有未儲存的變更。"
+          }
         }
       }
     },
@@ -12786,6 +16140,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "云数据仓库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "雲端資料倉儲"
           }
         }
       }
@@ -12809,6 +16169,12 @@
             "state" : "translated",
             "value" : "云原生"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "雲端原生"
+          }
         }
       }
     },
@@ -12830,6 +16196,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cloudflare Access需要浏览器登录。请在%@登录，然后重新连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloudflare Access 需要瀏覽器登入。請在 %@ 登入，然後重新連線。"
           }
         }
       }
@@ -12853,6 +16225,12 @@
             "state" : "translated",
             "value" : "需要Cloudflare主机名"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要 Cloudflare 主機名稱"
+          }
         }
       }
     },
@@ -12874,6 +16252,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cloudflare隧道"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloudflare 隧道"
           }
         }
       }
@@ -12897,6 +16281,12 @@
             "state" : "translated",
             "value" : "Cloudflare隧道已断开。点按以重新连接。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloudflare 隧道已中斷。點按以重新連線。"
+          }
         }
       }
     },
@@ -12918,6 +16308,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "cloudflared启动失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "cloudflared 啟動失敗：%@"
           }
         }
       }
@@ -12941,6 +16337,12 @@
             "state" : "translated",
             "value" : "cloudflared启动失败。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "cloudflared 啟動失敗。"
+          }
         }
       }
     },
@@ -12962,6 +16364,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未找到cloudflared。请使用`brew install cloudflared`安装，或在上方选择其二进制文件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到 cloudflared。請使用 `brew install cloudflared` 安裝，或在上方選擇其二進位檔。"
           }
         }
       }
@@ -12985,6 +16393,12 @@
             "state" : "translated",
             "value" : "未找到cloudflared。请使用`brew install cloudflared`安装，或在该连接的Cloudflare隧道设置中设置其路径。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到 cloudflared。請使用 `brew install cloudflared` 安裝，或在該連線的 Cloudflare 隧道設定中設定其路徑。"
+          }
         }
       }
     },
@@ -13007,6 +16421,12 @@
             "state" : "translated",
             "value" : "未找到cloudflared。请先在下方设置其路径。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到 cloudflared。請先在下方設定其路徑。"
+          }
         }
       }
     },
@@ -13026,6 +16446,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CMD"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "CMD"
@@ -13052,6 +16478,12 @@
             "state" : "translated",
             "value" : "代码已过期"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證碼已過期"
+          }
         }
       }
     },
@@ -13073,6 +16505,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "代码将在 %d 秒后过期"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證碼將在 %d 秒後過期"
           }
         }
       }
@@ -13096,6 +16534,12 @@
             "state" : "translated",
             "value" : "收起"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "收合"
+          }
         }
       }
     },
@@ -13117,6 +16561,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全部折叠"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部收合"
           }
         }
       }
@@ -13140,6 +16590,12 @@
             "state" : "translated",
             "value" : "排序规则"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "定序"
+          }
         }
       }
     },
@@ -13161,6 +16617,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "排序规则："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "定序："
           }
         }
       }
@@ -13184,6 +16646,12 @@
             "state" : "translated",
             "value" : "颜色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顏色"
+          }
         }
       }
     },
@@ -13205,6 +16673,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "颜色 %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顏色 %@"
           }
         }
       }
@@ -13228,6 +16702,12 @@
             "state" : "translated",
             "value" : "颜色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顏色"
+          }
         }
       }
     },
@@ -13249,6 +16729,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位"
           }
         }
       }
@@ -13277,6 +16763,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "第%d行列数不匹配：期望%d列，实际%d列。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %1$d 行欄位數不符：預期 %2$d 個欄位,實際 %3$d 個。"
           }
         }
       }
@@ -13307,6 +16799,12 @@
             "state" : "translated",
             "value" : "第 %lld 行列数不匹配：期望 %lld 列，实际 %lld 列。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %1$lld 行欄位數不符：預期 %2$lld 個欄位,實際 %3$lld 個。"
+          }
         }
       }
     },
@@ -13330,6 +16828,12 @@
             "state" : "translated",
             "value" : "列详情"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位詳細資料"
+          }
         }
       }
     },
@@ -13351,6 +16855,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "列名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位名稱"
           }
         }
       }
@@ -13375,6 +16885,12 @@
             "state" : "translated",
             "value" : "列名"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位名稱"
+          }
         }
       }
     },
@@ -13396,6 +16912,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "列名必须唯一。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位名稱必須是唯一的。"
           }
         }
       }
@@ -13419,6 +16941,12 @@
             "state" : "translated",
             "value" : "列重排序失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位重新排序失敗"
+          }
         }
       }
     },
@@ -13440,6 +16968,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "列重排序失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位重新排序失敗：%@"
           }
         }
       }
@@ -13463,6 +16997,12 @@
             "state" : "translated",
             "value" : "此数据库类型不支持列重排序"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此資料庫類型不支援欄位重新排序"
+          }
         }
       }
     },
@@ -13484,6 +17024,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "面向大数据的列式OLAP"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "適用於大數據的欄式 OLAP"
           }
         }
       }
@@ -13507,6 +17053,12 @@
             "state" : "translated",
             "value" : "列：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位：%@"
+          }
         }
       }
     },
@@ -13528,6 +17080,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位"
           }
         }
       }
@@ -13552,6 +17110,12 @@
             "state" : "translated",
             "value" : "列（逗号分隔）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位（以逗號分隔）"
+          }
         }
       }
     },
@@ -13574,6 +17138,12 @@
             "state" : "translated",
             "value" : "舒适"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寬鬆"
+          }
         }
       }
     },
@@ -13595,6 +17165,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "逗号分隔值。兼容 Excel 和大多数工具。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "逗號分隔值。相容於 Excel 與大多數工具。"
           }
         }
       }
@@ -13619,6 +17195,12 @@
             "state" : "translated",
             "value" : "命令预览"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "指令預覽"
+          }
         }
       }
     },
@@ -13640,6 +17222,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "注释"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "註解"
           }
         }
       }
@@ -13663,6 +17251,12 @@
             "state" : "translated",
             "value" : "紧凑"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "緊湊"
+          }
         }
       }
     },
@@ -13685,6 +17279,12 @@
             "state" : "translated",
             "value" : "紧凑模式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "緊湊模式"
+          }
         }
       }
     },
@@ -13706,6 +17306,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "完成登录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成登入"
           }
         }
       }
@@ -13730,6 +17336,12 @@
             "state" : "translated",
             "value" : "使用 Gzip 压缩文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 Gzip 壓縮檔案"
+          }
         }
       }
     },
@@ -13751,6 +17363,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "压缩失败，退出状态 %d"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "壓縮失敗,結束狀態 %d"
           }
         }
       }
@@ -13774,6 +17392,12 @@
             "state" : "translated",
             "value" : "条件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "條件"
+          }
         }
       }
     },
@@ -13795,6 +17419,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "配置主机"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定主機"
           }
         }
       }
@@ -13818,6 +17448,12 @@
             "state" : "translated",
             "value" : "配置活动提供方以启用内联建议。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定一個啟用中的供應商以開啟行內建議。"
+          }
         }
       }
     },
@@ -13839,6 +17475,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在设置中配置 AI 提供商以开始对话。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在設定中設定 AI 供應商以開始對話。"
           }
         }
       }
@@ -13862,6 +17504,12 @@
             "state" : "translated",
             "value" : "确认"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確認"
+          }
         }
       }
     },
@@ -13883,6 +17531,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "确认破坏性操作"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確認破壞性操作"
           }
         }
       }
@@ -13907,6 +17561,12 @@
             "state" : "translated",
             "value" : "确认密码短语"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確認密碼短語"
+          }
         }
       }
     },
@@ -13928,6 +17588,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此操作需要确认"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作需要確認"
           }
         }
       }
@@ -13951,6 +17617,12 @@
             "state" : "translated",
             "value" : "连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線"
+          }
         }
       }
     },
@@ -13972,6 +17644,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接%d个连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線 %d 個連線"
           }
         }
       }
@@ -14014,6 +17692,12 @@
             "state" : "translated",
             "value" : "连接 %lld 个连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線 %lld 個連線"
+          }
         }
       }
     },
@@ -14035,6 +17719,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接客户端"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線用戶端"
           }
         }
       }
@@ -14058,6 +17748,12 @@
             "state" : "translated",
             "value" : "连接客户端…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線用戶端…"
+          }
         }
       }
     },
@@ -14080,6 +17776,12 @@
             "state" : "translated",
             "value" : "仍然连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仍要連線"
+          }
         }
       }
     },
@@ -14101,6 +17803,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接到已保存的数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線到已儲存的資料庫"
           }
         }
       }
@@ -14127,6 +17835,12 @@
             "state" : "translated",
             "value" : "连接主流数据库，功能全面"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線主流資料庫,功能完整支援"
+          }
         }
       }
     },
@@ -14148,6 +17862,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "开始此操作前请先连接数据库。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始此操作前請先連線資料庫。"
           }
         }
       }
@@ -14177,6 +17897,12 @@
             "state" : "translated",
             "value" : "请连接互联网以验证您的许可证。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請連線到網際網路以驗證你的授權。"
+          }
         }
       }
     },
@@ -14198,6 +17924,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已連線"
           }
         }
       }
@@ -14221,6 +17953,12 @@
             "state" : "translated",
             "value" : "已连接客户端"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已連線的用戶端"
+          }
         }
       }
     },
@@ -14242,6 +17980,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已连接线程"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已連線的執行緒"
           }
         }
       }
@@ -14265,6 +18009,12 @@
             "state" : "translated",
             "value" : "连接中"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線中"
+          }
         }
       }
     },
@@ -14286,6 +18036,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接'%@'超时。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線到 '%@' 已逾時。"
           }
         }
       }
@@ -14309,6 +18065,12 @@
             "state" : "translated",
             "value" : "正在连接%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在連線到 %@"
+          }
         }
       }
     },
@@ -14331,6 +18093,12 @@
             "state" : "translated",
             "value" : "连接中..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線中..."
+          }
         }
       }
     },
@@ -14352,6 +18120,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線"
           }
         }
       }
@@ -14381,6 +18155,12 @@
             "state" : "translated",
             "value" : "连接\"%@\"有一个将在连接前运行的脚本：\n\n%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線「%1$@」有一個將在連線前執行的指令碼：\n\n%2$@"
+          }
         }
       }
     },
@@ -14402,6 +18182,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接访问权限"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線存取權限"
           }
         }
       }
@@ -14425,6 +18211,12 @@
             "state" : "translated",
             "value" : "连接失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線失敗"
+          }
         }
       }
     },
@@ -14446,6 +18238,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接对外部客户端为只读"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線對外部用戶端為唯讀"
           }
         }
       }
@@ -14470,6 +18268,12 @@
             "state" : "translated",
             "value" : "对外部客户端而言，该连接为只读"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線對外部用戶端為唯讀"
+          }
         }
       }
     },
@@ -14491,6 +18295,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接为只读。不允许破坏性操作。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線為唯讀。不允許破壞性操作。"
           }
         }
       }
@@ -14514,6 +18324,12 @@
             "state" : "translated",
             "value" : "连接为只读。请将安全模式设为\"确认写入\"或更高级别以允许此工具。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線為唯讀。請將安全模式設為「確認寫入」或更高層級以允許此工具。"
+          }
         }
       }
     },
@@ -14536,6 +18352,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接丢失"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線中斷"
           }
         }
       }
@@ -14562,6 +18384,12 @@
             "state" : "translated",
             "value" : "连接名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線名稱"
+          }
         }
       }
     },
@@ -14584,6 +18412,12 @@
             "state" : "translated",
             "value" : "连接名称为必填项"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線名稱為必填項目"
+          }
         }
       }
     },
@@ -14605,6 +18439,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未找到连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到連線"
           }
         }
       }
@@ -14629,6 +18469,12 @@
             "state" : "translated",
             "value" : "未找到连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到連線"
+          }
         }
       }
     },
@@ -14651,6 +18497,12 @@
             "state" : "translated",
             "value" : "连接选项"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線選項"
+          }
         }
       }
     },
@@ -14672,6 +18524,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接策略"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線原則"
           }
         }
       }
@@ -14696,6 +18554,12 @@
             "state" : "translated",
             "value" : "连接状态"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線狀態"
+          }
         }
       }
     },
@@ -14718,6 +18582,12 @@
             "state" : "translated",
             "value" : "连接成功"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線成功"
+          }
         }
       }
     },
@@ -14739,6 +18609,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接成功"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線成功"
           }
         }
       }
@@ -14763,6 +18639,12 @@
             "state" : "translated",
             "value" : "切换连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換連線"
+          }
         }
       }
     },
@@ -14784,6 +18666,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接测试失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線測試失敗"
           }
         }
       }
@@ -14807,6 +18695,12 @@
             "state" : "translated",
             "value" : "连接测试失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線測試失敗"
+          }
         }
       }
     },
@@ -14828,6 +18722,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接 URL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線 URL"
           }
         }
       }
@@ -14851,6 +18751,12 @@
             "state" : "translated",
             "value" : "连接 URL 不能为空"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線 URL 不能為空"
+          }
         }
       }
     },
@@ -14873,6 +18779,12 @@
             "state" : "translated",
             "value" : "连接 URL 必须包含主机"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線 URL 必須包含主機"
+          }
         }
       }
     },
@@ -14894,6 +18806,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線：%@"
           }
         }
       }
@@ -14923,6 +18841,12 @@
             "state" : "translated",
             "value" : "连接：%1$@，%2$@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線：%1$@, %2$@"
+          }
         }
       }
     },
@@ -14945,6 +18869,12 @@
             "state" : "translated",
             "value" : "连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線"
+          }
         }
       }
     },
@@ -14966,6 +18896,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線："
           }
         }
       }
@@ -14990,6 +18926,12 @@
             "state" : "translated",
             "value" : "约束名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "約束名稱"
+          }
         }
       }
     },
@@ -15008,6 +18950,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "包含"
@@ -15034,6 +18982,12 @@
             "state" : "translated",
             "value" : "上下文"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "內容脈絡"
+          }
         }
       }
     },
@@ -15055,6 +19009,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "继续"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "繼續"
           }
         }
       }
@@ -15078,6 +19038,12 @@
             "state" : "translated",
             "value" : "控件背景"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "控制項背景"
+          }
         }
       }
     },
@@ -15100,6 +19066,12 @@
             "state" : "translated",
             "value" : "控制外部客户端（Raycast、Cursor、Claude Desktop）如何访问该连接。即使具有完全访问权限，令牌也无法超出此级别。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "控制外部用戶端（Raycast、Cursor、Claude Desktop）如何存取此連線。即使具有完整存取範圍,權杖也無法超出此層級。"
+          }
         }
       }
     },
@@ -15121,6 +19093,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "对话历史"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "對話記錄"
           }
         }
       }
@@ -15145,6 +19123,12 @@
             "state" : "translated",
             "value" : "对话历史"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "對話記錄"
+          }
         }
       }
     },
@@ -15167,6 +19151,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "将换行转换为空格"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將換行轉換為空格"
           }
         }
       }
@@ -15191,6 +19181,12 @@
             "state" : "translated",
             "value" : "将 NULL 转换为空"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將 NULL 轉換為空"
+          }
         }
       }
     },
@@ -15214,6 +19210,12 @@
             "state" : "translated",
             "value" : "将 NULL 转换为空"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將 NULL 轉換為空"
+          }
         }
       }
     },
@@ -15235,6 +19237,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "协调与配置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "協調與設定"
           }
         }
       }
@@ -15258,6 +19266,12 @@
             "state" : "translated",
             "value" : "已复制"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已複製"
+          }
         }
       }
     },
@@ -15279,6 +19293,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已复制到剪贴板"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已複製到剪貼簿"
           }
         }
       }
@@ -15302,6 +19322,12 @@
             "state" : "translated",
             "value" : "已复制！"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已複製！"
+          }
         }
       }
     },
@@ -15323,6 +19349,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未找到 Copilot 语言服务器可执行文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到 Copilot 語言伺服器執行檔"
           }
         }
       }
@@ -15346,6 +19378,12 @@
             "state" : "translated",
             "value" : "Copilot 服务器未运行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copilot 伺服器未執行"
+          }
         }
       }
     },
@@ -15367,6 +19405,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Copilot 订阅未激活"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copilot 訂閱未啟用"
           }
         }
       }
@@ -15390,6 +19434,12 @@
             "state" : "translated",
             "value" : "复制"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製"
+          }
         }
       }
     },
@@ -15411,6 +19461,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全部复制"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部複製"
           }
         }
       }
@@ -15434,6 +19490,12 @@
             "state" : "translated",
             "value" : "复制为"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製為"
+          }
         }
       }
     },
@@ -15456,6 +19518,12 @@
             "state" : "translated",
             "value" : "复制为"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製為"
+          }
         }
       }
     },
@@ -15477,6 +19545,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制为十六进制"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製為十六進位"
           }
         }
       }
@@ -15501,6 +19575,12 @@
             "state" : "translated",
             "value" : "复制为导入链接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製為匯入連結"
+          }
         }
       }
     },
@@ -15522,6 +19602,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制为 JSON"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製為 JSON"
           }
         }
       }
@@ -15546,6 +19632,12 @@
             "state" : "translated",
             "value" : "复制为 URL"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製為 URL"
+          }
         }
       }
     },
@@ -15567,6 +19659,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制列名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製欄位名稱"
           }
         }
       }
@@ -15590,6 +19688,12 @@
             "state" : "translated",
             "value" : "复制列值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製欄位值"
+          }
         }
       }
     },
@@ -15611,6 +19715,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制连接ID"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製連線 ID"
           }
         }
       }
@@ -15634,6 +19744,12 @@
             "state" : "translated",
             "value" : "复制连接字符串"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製連線字串"
+          }
         }
       }
     },
@@ -15655,6 +19771,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制定义"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製定義"
           }
         }
       }
@@ -15678,6 +19800,12 @@
             "state" : "translated",
             "value" : "复制详细信息"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製詳細資訊"
+          }
         }
       }
     },
@@ -15699,6 +19827,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制诊断信息"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製診斷資訊"
           }
         }
       }
@@ -15722,6 +19856,12 @@
             "state" : "translated",
             "value" : "复制错误信息"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製錯誤訊息"
+          }
         }
       }
     },
@@ -15743,6 +19883,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制错误到剪贴板"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將錯誤複製到剪貼簿"
           }
         }
       }
@@ -15766,6 +19912,12 @@
             "state" : "translated",
             "value" : "将 EXPLAIN 输出复制到剪贴板"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將 EXPLAIN 輸出複製到剪貼簿"
+          }
         }
       }
     },
@@ -15787,6 +19939,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制 ID"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製 ID"
           }
         }
       }
@@ -15813,6 +19971,12 @@
             "state" : "translated",
             "value" : "复制 JSON"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製 JSON"
+          }
         }
       }
     },
@@ -15834,6 +19998,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制键"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製鍵"
           }
         }
       }
@@ -15857,6 +20027,12 @@
             "state" : "translated",
             "value" : "复制键路径"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製鍵路徑"
+          }
         }
       }
     },
@@ -15878,6 +20054,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制名称"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製名稱"
           }
         }
       }
@@ -15901,6 +20083,12 @@
             "state" : "translated",
             "value" : "复制路径"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製路徑"
+          }
         }
       }
     },
@@ -15923,6 +20111,12 @@
             "state" : "translated",
             "value" : "复制查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製查詢"
+          }
         }
       }
     },
@@ -15944,6 +20138,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製列"
           }
         }
       }
@@ -15968,6 +20168,12 @@
             "state" : "translated",
             "value" : "复制 SQL"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製 SQL"
+          }
         }
       }
     },
@@ -15989,6 +20195,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制 TablePro 链接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製 TablePro 連結"
           }
         }
       }
@@ -16013,6 +20225,12 @@
             "state" : "translated",
             "value" : "将此语句复制到剪贴板"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將此陳述式複製到剪貼簿"
+          }
         }
       }
     },
@@ -16034,6 +20252,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制到剪贴板"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製到剪貼簿"
           }
         }
       }
@@ -16057,6 +20281,12 @@
             "state" : "translated",
             "value" : "复制令牌"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製權杖"
+          }
         }
       }
     },
@@ -16078,6 +20308,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制令牌"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製權杖"
           }
         }
       }
@@ -16101,6 +20337,12 @@
             "state" : "translated",
             "value" : "复制值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製值"
+          }
         }
       }
     },
@@ -16123,6 +20365,12 @@
             "state" : "translated",
             "value" : "复制（含表头）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製（含標題）"
+          }
         }
       }
     },
@@ -16144,6 +20392,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "带签名复制"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連同簽章一起複製"
           }
         }
       }
@@ -16168,6 +20422,12 @@
             "state" : "translated",
             "value" : "圆角半径"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圓角半徑"
+          }
         }
       }
     },
@@ -16189,6 +20449,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法生成CREATE TABLE语句"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法建立 CREATE TABLE 陳述式"
           }
         }
       }
@@ -16212,6 +20478,12 @@
             "state" : "translated",
             "value" : "无法创建目标文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法建立目的檔案"
+          }
         }
       }
     },
@@ -16233,6 +20505,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法解码图像"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法解碼影像"
           }
         }
       }
@@ -16256,6 +20534,12 @@
             "state" : "translated",
             "value" : "无法编码图像"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法編碼影像"
+          }
         }
       }
     },
@@ -16277,6 +20561,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法导出活动日志"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法匯出活動記錄"
           }
         }
       }
@@ -16300,6 +20590,12 @@
             "state" : "translated",
             "value" : "无法获取插件注册表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法取得外掛註冊"
+          }
         }
       }
     },
@@ -16321,6 +20617,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "找不到 %@ 数据文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到 %@ 資料檔案"
           }
         }
       }
@@ -16344,6 +20646,12 @@
             "state" : "translated",
             "value" : "无法为更改生成 SQL。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法為變更產生 SQL。"
+          }
         }
       }
     },
@@ -16365,6 +20673,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法安装示例数据库：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法安裝範例資料庫：%@"
           }
         }
       }
@@ -16388,6 +20702,12 @@
             "state" : "translated",
             "value" : "无法打开文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法開啟檔案"
+          }
         }
       }
     },
@@ -16409,6 +20729,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法打开示例"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法開啟範例"
           }
         }
       }
@@ -16432,6 +20758,12 @@
             "state" : "translated",
             "value" : "无法解析数据库 URL：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法解析資料庫 URL：%@"
+          }
         }
       }
     },
@@ -16453,6 +20785,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法连接许可证服务器。请检查网络连接后重试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法連線授權伺服器。請檢查網際網路連線後再試一次。"
           }
         }
       }
@@ -16476,6 +20814,12 @@
             "state" : "translated",
             "value" : "无法读取密码文件：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法讀取密碼檔案：%@"
+          }
         }
       }
     },
@@ -16497,6 +20841,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法读取文件。文件可能已被删除或移动。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法讀取檔案。檔案可能已被刪除或移動。"
           }
         }
       }
@@ -16520,6 +20870,12 @@
             "state" : "translated",
             "value" : "无法读取服务器响应。请稍后重试。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法讀取伺服器回應。請稍後再試一次。"
+          }
         }
       }
     },
@@ -16541,6 +20897,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法重置示例"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法重設範例"
           }
         }
       }
@@ -16564,6 +20926,12 @@
             "state" : "translated",
             "value" : "无法保存连接。请检查磁盘空间和权限，然后重试。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法儲存連線。請檢查磁碟空間與權限，然後再試一次。"
+          }
         }
       }
     },
@@ -16585,6 +20953,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法启动新的TablePro实例。请手动退出并重新打开。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法啟動新的 TablePro 實例。請手動結束並重新開啟。"
           }
         }
       }
@@ -16608,6 +20982,12 @@
             "state" : "translated",
             "value" : "无法写入文件。请检查文件是否可写。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法寫入檔案。請檢查檔案是否可寫入。"
+          }
         }
       }
     },
@@ -16629,6 +21009,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "统计全部行数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計算所有列數"
           }
         }
       }
@@ -16652,6 +21038,12 @@
             "state" : "translated",
             "value" : "估算值小于此值时计数行："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "估算值小於此值時計算列數："
+          }
         }
       }
     },
@@ -16674,6 +21066,12 @@
             "state" : "translated",
             "value" : "统计中..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計算中..."
+          }
         }
       }
     },
@@ -16695,6 +21093,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "创建"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立"
           }
         }
       }
@@ -16719,6 +21123,12 @@
             "state" : "translated",
             "value" : "创建连接以开始使用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立連線以開始使用"
+          }
         }
       }
     },
@@ -16740,6 +21150,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "创建连接以开始使用\n您的数据库。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立連線以開始使用\n你的資料庫。"
           }
         }
       }
@@ -16763,6 +21179,12 @@
             "state" : "translated",
             "value" : "新建表或视图"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立新的資料表或檢視表"
+          }
         }
       }
     },
@@ -16784,6 +21206,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "创建所有列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立所有欄位"
           }
         }
       }
@@ -16808,6 +21236,12 @@
             "state" : "translated",
             "value" : "创建连接..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立連線..."
+          }
         }
       }
     },
@@ -16829,6 +21263,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "创建连接..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立連線…"
           }
         }
       }
@@ -16853,6 +21293,12 @@
             "state" : "translated",
             "value" : "创建数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立資料庫"
+          }
         }
       }
     },
@@ -16876,6 +21322,12 @@
             "state" : "translated",
             "value" : "创建新数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立新資料庫"
+          }
         }
       }
     },
@@ -16898,6 +21350,12 @@
             "state" : "translated",
             "value" : "创建新分组"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立新群組"
+          }
         }
       }
     },
@@ -16919,6 +21377,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "创建新分组..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立新群組..."
           }
         }
       }
@@ -16948,6 +21412,12 @@
             "state" : "translated",
             "value" : "新建配置…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立新設定檔..."
+          }
         }
       }
     },
@@ -16971,6 +21441,12 @@
             "state" : "translated",
             "value" : "新建表..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立新資料表..."
+          }
         }
       }
     },
@@ -16992,6 +21468,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "创建新标签"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立新標籤"
           }
         }
       }
@@ -17015,6 +21497,12 @@
             "state" : "translated",
             "value" : "创建新标签..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立新標籤..."
+          }
         }
       }
     },
@@ -17036,6 +21524,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "创建新视图..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立新檢視表..."
           }
         }
       }
@@ -17059,6 +21553,12 @@
             "state" : "translated",
             "value" : "创建表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立資料表"
+          }
         }
       }
     },
@@ -17080,6 +21580,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "创建表失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立資料表失敗"
           }
         }
       }
@@ -17103,6 +21609,12 @@
             "state" : "translated",
             "value" : "创建您自己的斜杠命令。在模板中使用 {{query}}、{{schema}}、{{database}} 或 {{body}}，即可在运行时插入聊天上下文。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立你自己的斜線指令。在範本中使用 {{query}}、{{schema}}、{{database}} 或 {{body}}，即可在執行時插入聊天上下文。"
+          }
         }
       }
     },
@@ -17124,6 +21636,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已创建"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已建立"
           }
         }
       }
@@ -17147,6 +21665,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已创建为 GitHub issue #%d"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已建立為 GitHub issue #%d"
           }
         }
       }
@@ -17172,6 +21696,12 @@
             "state" : "translated",
             "value" : "正在创建备份转储"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在建立資料庫備份"
+          }
         }
       }
     },
@@ -17193,6 +21723,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "创建中..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立中..."
           }
         }
       }
@@ -17217,6 +21753,12 @@
             "state" : "translated",
             "value" : "严重：事务回滚失败 - 数据库可能处于不一致状态：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "嚴重：交易還原失敗 - 資料庫可能處於不一致狀態：%@"
+          }
         }
       }
     },
@@ -17235,6 +21777,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CSV"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "CSV"
@@ -17261,6 +21809,12 @@
             "state" : "translated",
             "value" : "带标题行的 CSV"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "含標題列的 CSV"
+          }
         }
       }
     },
@@ -17280,6 +21834,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CURDATE()"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "CURDATE()"
@@ -17306,6 +21866,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "当前"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前"
           }
         }
       }
@@ -17335,6 +21901,12 @@
             "state" : "translated",
             "value" : "当前%1$@：%2$@（⌘K 可%3$@）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前的 %1$@：%2$@（⌘K 可%3$@）"
+          }
         }
       }
     },
@@ -17363,6 +21935,12 @@
             "state" : "translated",
             "value" : "当前%1$@：%2$@（只读，⌘K 可%3$@）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前的 %1$@：%2$@（唯讀，⌘K 可%3$@）"
+          }
         }
       }
     },
@@ -17385,6 +21963,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "当前数据库：%@（⌘K 切换）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前的資料庫：%@（⌘K 切換）"
           }
         }
       }
@@ -17409,6 +21993,12 @@
             "state" : "translated",
             "value" : "当前数据库：%@（只读，⌘K 切换）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前的資料庫：%@（唯讀，⌘K 切換）"
+          }
         }
       }
     },
@@ -17430,6 +22020,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "当前行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前的列"
           }
         }
       }
@@ -17453,6 +22049,12 @@
             "state" : "translated",
             "value" : "当前查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前查詢"
+          }
         }
       }
     },
@@ -17474,6 +22076,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "当前 Schema"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前的綱要"
           }
         }
       }
@@ -17498,6 +22106,12 @@
             "state" : "translated",
             "value" : "当前 schema：%@（⌘K 切换）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前的綱要：%@（⌘K 切換）"
+          }
         }
       }
     },
@@ -17521,6 +22135,12 @@
             "state" : "translated",
             "value" : "当前 schema：%@（只读，⌘K 切换）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前的綱要：%@（唯讀，⌘K 切換）"
+          }
         }
       }
     },
@@ -17540,6 +22160,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CURRENT_TIMESTAMP()"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "CURRENT_TIMESTAMP()"
@@ -17566,6 +22192,12 @@
             "state" : "translated",
             "value" : "光标"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "游標"
+          }
         }
       }
     },
@@ -17588,6 +22220,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "光标闪烁"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "游標閃爍"
           }
         }
       }
@@ -17620,6 +22258,12 @@
             "state" : "translated",
             "value" : "光标位置%d超出SQL长度（%d）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "游標位置 %1$d 超出 SQL 長度（%2$d）"
+          }
         }
       }
     },
@@ -17649,6 +22293,12 @@
             "state" : "translated",
             "value" : "光标位置 %lld 超出 SQL 长度（%lld）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "游標位置 %1$lld 超出 SQL 長度（%2$lld）"
+          }
         }
       }
     },
@@ -17675,6 +22325,12 @@
             "state" : "translated",
             "value" : "光标样式："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "游標樣式："
+          }
         }
       }
     },
@@ -17694,6 +22350,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CURTIME()"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "CURTIME()"
@@ -17719,6 +22381,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定义"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂"
           }
         }
       }
@@ -17748,6 +22416,12 @@
             "state" : "translated",
             "value" : "自定义端点"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂端點"
+          }
         }
       }
     },
@@ -17769,6 +22443,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "AI 在此连接的每轮聊天中都会看到的自定义指引。可用于说明表约定、命名规范、应避免的列（PII、软删除行）、联结提示，或 Schema 中未体现的业务规则。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 在此連線的每一輪聊天中都會看到的自訂指引。可用於說明資料表慣例、命名規則、應避免的欄位（PII、軟刪除的列）、JOIN 提示，或綱要未顯示的商業規則。"
           }
         }
       }
@@ -17792,6 +22472,12 @@
             "state" : "translated",
             "value" : "自定义路径"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂路徑"
+          }
         }
       }
     },
@@ -17813,6 +22499,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定义斜杠命令"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂斜線指令"
           }
         }
       }
@@ -17836,6 +22528,12 @@
             "state" : "translated",
             "value" : "自定义…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂…"
+          }
         }
       }
     },
@@ -17857,6 +22555,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定义"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂"
           }
         }
       }
@@ -17880,6 +22584,12 @@
             "state" : "translated",
             "value" : "剪切"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剪下"
+          }
         }
       }
     },
@@ -17898,6 +22608,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "深色"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "深色"
@@ -17924,6 +22640,12 @@
             "state" : "translated",
             "value" : "仪表盘"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儀表板"
+          }
         }
       }
     },
@@ -17945,6 +22667,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "仪表盘不可用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儀表板無法使用"
           }
         }
       }
@@ -17968,6 +22696,12 @@
             "state" : "translated",
             "value" : "数据"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料"
+          }
         }
       }
     },
@@ -17989,6 +22723,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "数据网格"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料格"
           }
         }
       }
@@ -18012,6 +22752,12 @@
             "state" : "translated",
             "value" : "数据网格"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料格"
+          }
         }
       }
     },
@@ -18034,6 +22780,12 @@
             "state" : "translated",
             "value" : "数据表格字体"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料格字型"
+          }
         }
       }
     },
@@ -18055,6 +22807,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "数据大小"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料大小"
           }
         }
       }
@@ -18079,6 +22837,12 @@
             "state" : "translated",
             "value" : "数据类型:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料型別："
+          }
         }
       }
     },
@@ -18100,6 +22864,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫"
           }
         }
       }
@@ -18123,6 +22893,12 @@
             "state" : "translated",
             "value" : "数据库驱动"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫驅動程式"
+          }
         }
       }
     },
@@ -18144,6 +22920,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "数据库驱动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫驅動程式"
           }
         }
       }
@@ -18167,6 +22949,12 @@
             "state" : "translated",
             "value" : "数据库文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫檔案"
+          }
         }
       }
     },
@@ -18188,6 +22976,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未找到数据库文件: %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到資料庫檔案：%@"
           }
         }
       }
@@ -18211,6 +23005,12 @@
             "state" : "translated",
             "value" : "必须填写数据库文件路径"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "必須填寫資料庫檔案路徑"
+          }
         }
       }
     },
@@ -18232,6 +23032,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "数据库索引"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫索引"
           }
         }
       }
@@ -18256,6 +23062,12 @@
             "state" : "translated",
             "value" : "数据库索引: %lld"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫索引：%lld"
+          }
         }
       }
     },
@@ -18278,6 +23090,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "数据库名称"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫名稱"
           }
         }
       }
@@ -18302,6 +23120,12 @@
             "state" : "translated",
             "value" : "数据库名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫名稱"
+          }
         }
       }
     },
@@ -18323,6 +23147,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "数据库名称（留空时使用连接的当前数据库）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫名稱（留空時使用連線目前的資料庫）"
           }
         }
       }
@@ -18346,6 +23176,12 @@
             "state" : "translated",
             "value" : "数据库名称（留空时使用当前数据库）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫名稱（留空時使用目前的資料庫）"
+          }
         }
       }
     },
@@ -18367,6 +23203,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "必须填写数据库名称"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "必須填寫資料庫名稱"
           }
         }
       }
@@ -18390,6 +23232,12 @@
             "state" : "translated",
             "value" : "要切换到的数据库名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要切換到的資料庫名稱"
+          }
         }
       }
     },
@@ -18412,6 +23260,12 @@
             "state" : "translated",
             "value" : "数据库 Schema"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫綱要"
+          }
         }
       }
     },
@@ -18433,6 +23287,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "数据库大小"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫大小"
           }
         }
       }
@@ -18457,6 +23317,12 @@
             "state" : "translated",
             "value" : "切换数据库失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換資料庫失敗"
+          }
         }
       }
     },
@@ -18480,6 +23346,12 @@
             "state" : "translated",
             "value" : "数据库切换器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫切換器"
+          }
         }
       }
     },
@@ -18502,6 +23374,12 @@
             "state" : "translated",
             "value" : "数据库类型"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫類型"
+          }
         }
       }
     },
@@ -18523,6 +23401,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "数据库类型 \"%@\" 未安装"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫類型「%@」未安裝"
           }
         }
       }
@@ -18547,6 +23431,12 @@
             "state" : "translated",
             "value" : "数据库类型:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫類型："
+          }
         }
       }
     },
@@ -18570,6 +23460,12 @@
             "state" : "translated",
             "value" : "数据库类型: %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫類型：%@"
+          }
         }
       }
     },
@@ -18592,6 +23488,12 @@
             "state" : "translated",
             "value" : "数据库 URL"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫 URL"
+          }
         }
       }
     },
@@ -18610,6 +23512,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "database_name"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "database_name"
@@ -18636,6 +23544,12 @@
             "state" : "translated",
             "value" : "数据库: %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫：%@"
+          }
         }
       }
     },
@@ -18659,6 +23573,12 @@
             "state" : "translated",
             "value" : "数据库/Schema:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫/綱要："
+          }
         }
       }
     },
@@ -18681,6 +23601,12 @@
             "state" : "translated",
             "value" : "数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫"
+          }
         }
       }
     },
@@ -18699,6 +23625,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日期"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "日期"
@@ -18725,6 +23657,12 @@
             "state" : "translated",
             "value" : "日期格式:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日期格式："
+          }
         }
       }
     },
@@ -18743,6 +23681,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "db %d"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "db %d"
@@ -18769,6 +23713,12 @@
             "state" : "translated",
             "value" : "停用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用"
+          }
         }
       }
     },
@@ -18790,6 +23740,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "停用许可证?"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用授權？"
           }
         }
       }
@@ -18813,6 +23769,12 @@
             "state" : "translated",
             "value" : "停用..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用..."
+          }
         }
       }
     },
@@ -18831,6 +23793,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已停用"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "已停用"
@@ -18858,6 +23826,12 @@
             "state" : "translated",
             "value" : "停用失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用失敗"
+          }
         }
       }
     },
@@ -18879,6 +23853,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "防抖：%d 毫秒"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "去抖動：%d 毫秒"
           }
         }
       }
@@ -18903,6 +23883,12 @@
             "state" : "translated",
             "value" : "十进制"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "十進位"
+          }
         }
       }
     },
@@ -18924,6 +23910,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "解压失败，退出状态 %d"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解壓縮失敗,結束狀態 %d"
           }
         }
       }
@@ -18947,6 +23939,12 @@
             "state" : "translated",
             "value" : "减小字号"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "縮小字型大小"
+          }
         }
       }
     },
@@ -18969,6 +23967,12 @@
             "state" : "translated",
             "value" : "减小文字大小"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "縮小文字大小"
+          }
         }
       }
     },
@@ -18987,6 +23991,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解密"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "解密"
@@ -19013,6 +24023,12 @@
             "state" : "translated",
             "value" : "解密失败：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解密失敗：%@"
+          }
         }
       }
     },
@@ -19034,6 +24050,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "默认"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設"
           }
         }
       }
@@ -19057,6 +24079,12 @@
             "state" : "translated",
             "value" : "默认"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設"
+          }
         }
       }
     },
@@ -19078,6 +24106,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "默认列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設欄位"
           }
         }
       }
@@ -19102,6 +24136,12 @@
             "state" : "translated",
             "value" : "默认连接策略"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設連線原則"
+          }
         }
       }
     },
@@ -19123,6 +24163,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新连接的默认布局："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新連線的預設版面配置："
           }
         }
       }
@@ -19146,6 +24192,12 @@
             "state" : "translated",
             "value" : "默认运算符"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設運算子"
+          }
         }
       }
     },
@@ -19168,6 +24220,12 @@
             "state" : "translated",
             "value" : "默认页面大小:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設頁面大小："
+          }
         }
       }
     },
@@ -19189,6 +24247,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "默认端口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設連接埠"
           }
         }
       }
@@ -19213,6 +24277,12 @@
             "state" : "translated",
             "value" : "默认端口:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設連接埠："
+          }
         }
       }
     },
@@ -19234,6 +24304,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "默认行数限制"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設列數上限"
           }
         }
       }
@@ -19260,6 +24336,12 @@
             "state" : "translated",
             "value" : "默认行排序："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設的列排序："
+          }
         }
       }
     },
@@ -19281,6 +24363,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "默认令牌"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設權杖"
           }
         }
       }
@@ -19305,6 +24393,12 @@
             "state" : "translated",
             "value" : "默认值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設值"
+          }
         }
       }
     },
@@ -19328,6 +24422,12 @@
             "state" : "translated",
             "value" : "默认值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設值"
+          }
         }
       }
     },
@@ -19349,6 +24449,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "默认视图："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設檢視："
           }
         }
       }
@@ -19373,6 +24479,12 @@
             "state" : "translated",
             "value" : "默认:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設："
+          }
         }
       }
     },
@@ -19395,6 +24507,12 @@
             "state" : "translated",
             "value" : "删除"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除"
+          }
         }
       }
     },
@@ -19416,6 +24534,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除「%@」"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除「%@」"
           }
         }
       }
@@ -19440,6 +24564,12 @@
             "state" : "translated",
             "value" : "删除 (⌫)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除 (⌫)"
+          }
         }
       }
     },
@@ -19461,6 +24591,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除%d个连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除 %d 個連線"
           }
         }
       }
@@ -19503,6 +24639,12 @@
             "state" : "translated",
             "value" : "删除 %lld 个连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除 %lld 個連線"
+          }
         }
       }
     },
@@ -19526,6 +24668,12 @@
             "state" : "translated",
             "value" : "删除检查约束"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除檢查約束"
+          }
         }
       }
     },
@@ -19547,6 +24695,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除欄位"
           }
         }
       }
@@ -19570,6 +24724,12 @@
             "state" : "translated",
             "value" : "删除连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除連線"
+          }
         }
       }
     },
@@ -19591,6 +24751,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除收藏？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除我的最愛？"
           }
         }
       }
@@ -19614,6 +24780,12 @@
             "state" : "translated",
             "value" : "删除文件夹"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除資料夾"
+          }
         }
       }
     },
@@ -19635,6 +24807,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除文件夹？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除資料夾？"
           }
         }
       }
@@ -19658,6 +24836,12 @@
             "state" : "translated",
             "value" : "删除外键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除外鍵"
+          }
         }
       }
     },
@@ -19679,6 +24863,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除分组"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除群組"
           }
         }
       }
@@ -19702,6 +24892,12 @@
             "state" : "translated",
             "value" : "删除索引"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除索引"
+          }
         }
       }
     },
@@ -19724,6 +24920,12 @@
             "state" : "translated",
             "value" : "删除行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除行"
+          }
         }
       }
     },
@@ -19745,6 +24947,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除预设"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除預設組合"
           }
         }
       }
@@ -19774,6 +24982,12 @@
             "state" : "translated",
             "value" : "删除配置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除設定檔"
+          }
         }
       }
     },
@@ -19795,6 +25009,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除列"
           }
         }
       }
@@ -19818,6 +25038,12 @@
             "state" : "translated",
             "value" : "删除行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除列"
+          }
         }
       }
     },
@@ -19839,6 +25065,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除所选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除所選"
           }
         }
       }
@@ -19868,6 +25100,12 @@
             "state" : "translated",
             "value" : "删除 SSH 配置？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除 SSH 設定檔？"
+          }
         }
       }
     },
@@ -19889,6 +25127,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除主题"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除主題"
           }
         }
       }
@@ -19912,6 +25156,12 @@
             "state" : "translated",
             "value" : "删除令牌？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除權杖？"
+          }
         }
       }
     },
@@ -19933,6 +25183,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除…"
           }
         }
       }
@@ -19956,6 +25212,12 @@
             "state" : "translated",
             "value" : "已删除"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已刪除"
+          }
         }
       }
     },
@@ -19978,6 +25240,12 @@
             "state" : "translated",
             "value" : "已删除的连接（%@）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已刪除的連線 (%@)"
+          }
         }
       }
     },
@@ -19999,6 +25267,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已删除文本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已刪除文字"
           }
         }
       }
@@ -20023,6 +25297,12 @@
             "state" : "translated",
             "value" : "分隔符"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分隔符號"
+          }
         }
       }
     },
@@ -20044,6 +25324,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已拒绝"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已拒絕"
           }
         }
       }
@@ -20067,6 +25353,12 @@
             "state" : "translated",
             "value" : "拒绝"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拒絕"
+          }
         }
       }
     },
@@ -20088,6 +25380,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "描述表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "描述資料表"
           }
         }
       }
@@ -20111,6 +25409,12 @@
             "state" : "translated",
             "value" : "描述表或视图的列。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "描述資料表或檢視表的欄位。"
+          }
         }
       }
     },
@@ -20129,6 +25433,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "描述"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "描述"
@@ -20155,6 +25465,12 @@
             "state" : "translated",
             "value" : "取消全选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消全選"
+          }
         }
       }
     },
@@ -20176,6 +25492,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "目标："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目的地："
           }
         }
       }
@@ -20199,6 +25521,12 @@
             "state" : "translated",
             "value" : "破坏性更改"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "破壞性變更"
+          }
         }
       }
     },
@@ -20220,6 +25548,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此客户端不允许执行破坏性操作"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此用戶端不允許執行破壞性操作"
           }
         }
       }
@@ -20243,6 +25577,12 @@
             "state" : "translated",
             "value" : "分离"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分離"
+          }
         }
       }
     },
@@ -20264,6 +25604,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分离分区"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分離分割區"
           }
         }
       }
@@ -20287,6 +25633,12 @@
             "state" : "translated",
             "value" : "分离分区？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要分離分割區嗎？"
+          }
         }
       }
     },
@@ -20308,6 +25660,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分离选定的分区"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分離選取的分割區"
           }
         }
       }
@@ -20331,6 +25689,12 @@
             "state" : "translated",
             "value" : "详情"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "詳細資訊"
+          }
         }
       }
     },
@@ -20352,6 +25716,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "详细信息：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "詳細資訊：%@"
           }
         }
       }
@@ -20375,6 +25745,12 @@
             "state" : "translated",
             "value" : "已检测到"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已偵測到"
+          }
         }
       }
     },
@@ -20396,6 +25772,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "诊断信息"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "診斷資訊"
           }
         }
       }
@@ -20419,6 +25801,12 @@
             "state" : "translated",
             "value" : "图表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圖表"
+          }
         }
       }
     },
@@ -20441,6 +25829,12 @@
             "state" : "translated",
             "value" : "位数"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "位數"
+          }
         }
       }
     },
@@ -20462,6 +25856,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "禁用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用"
           }
         }
       }
@@ -20486,6 +25886,12 @@
             "state" : "translated",
             "value" : "禁用外键检查"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用外鍵檢查"
+          }
         }
       }
     },
@@ -20507,6 +25913,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "禁用 SSH 隧道"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用 SSH 隧道"
           }
         }
       }
@@ -20530,6 +25942,12 @@
             "state" : "translated",
             "value" : "已禁用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已停用"
+          }
         }
       }
     },
@@ -20551,6 +25969,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已禁用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已停用"
           }
         }
       }
@@ -20574,6 +25998,12 @@
             "state" : "translated",
             "value" : "丢弃"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "捨棄"
+          }
         }
       }
     },
@@ -20595,6 +26025,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "丢弃更改?"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要捨棄變更嗎？"
           }
         }
       }
@@ -20618,6 +26054,12 @@
             "state" : "translated",
             "value" : "丢弃未保存的更改?"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要捨棄未儲存的變更嗎？"
+          }
         }
       }
     },
@@ -20639,6 +26081,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "断开连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中斷連線"
           }
         }
       }
@@ -20662,6 +26110,12 @@
             "state" : "translated",
             "value" : "断开客户端连接？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要中斷用戶端連線嗎？"
+          }
         }
       }
     },
@@ -20683,6 +26137,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "断开数据库连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中斷與資料庫的連線"
           }
         }
       }
@@ -20706,6 +26166,12 @@
             "state" : "translated",
             "value" : "断开所选客户端的连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中斷所選用戶端的連線"
+          }
         }
       }
     },
@@ -20727,6 +26193,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已断开连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已中斷連線"
           }
         }
       }
@@ -20750,6 +26222,12 @@
             "state" : "translated",
             "value" : "磁盘使用量"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "磁碟使用量"
+          }
         }
       }
     },
@@ -20772,6 +26250,12 @@
             "state" : "translated",
             "value" : "关闭"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉"
+          }
         }
       }
     },
@@ -20793,6 +26277,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "关闭错误"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉錯誤"
           }
         }
       }
@@ -20817,6 +26307,12 @@
             "state" : "translated",
             "value" : "显示"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示"
+          }
         }
       }
     },
@@ -20838,6 +26334,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示为"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示為"
           }
         }
       }
@@ -20861,6 +26363,12 @@
             "state" : "translated",
             "value" : "用于服务发现的分布式键值存储"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用於服務探索的分散式鍵值儲存"
+          }
         }
       }
     },
@@ -20882,6 +26390,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分布式 SQL，兼容 PostgreSQL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分散式 SQL，相容 PostgreSQL"
           }
         }
       }
@@ -20905,6 +26419,12 @@
             "state" : "translated",
             "value" : "Turso 出品的分布式 SQLite"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Turso 推出的分散式 SQLite"
+          }
         }
       }
     },
@@ -20926,6 +26446,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分布式宽列存储"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分散式寬欄儲存"
           }
         }
       }
@@ -20949,6 +26475,12 @@
             "state" : "translated",
             "value" : "是否保存更改?"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "是否要儲存變更？"
+          }
         }
       }
     },
@@ -20970,6 +26502,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文档"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件"
           }
         }
       }
@@ -20993,6 +26531,12 @@
             "state" : "translated",
             "value" : "文档检查器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件檢閱器"
+          }
         }
       }
     },
@@ -21014,6 +26558,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文档"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件"
           }
         }
       }
@@ -21037,6 +26587,12 @@
             "state" : "translated",
             "value" : "不等于"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不等於"
+          }
         }
       }
     },
@@ -21058,6 +26614,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不允许"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不允許"
           }
         }
       }
@@ -21081,6 +26643,12 @@
             "state" : "translated",
             "value" : "不保存"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不要儲存"
+          }
         }
       }
     },
@@ -21103,6 +26671,12 @@
             "state" : "translated",
             "value" : "不再显示"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不再顯示"
+          }
         }
       }
     },
@@ -21121,6 +26695,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不排序"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "不排序"
@@ -21147,6 +26727,12 @@
             "state" : "translated",
             "value" : "完成"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成"
+          }
         }
       }
     },
@@ -21168,6 +26754,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下载次数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載次數"
           }
         }
       }
@@ -21191,6 +26783,12 @@
             "state" : "translated",
             "value" : "驱动插件未加载。请打开设置进行更新。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驅動程式外掛未載入。請開啟設定進行更新。"
+          }
         }
       }
     },
@@ -21212,6 +26810,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除"
           }
         }
       }
@@ -21244,6 +26848,12 @@
             "state" : "translated",
             "value" : "删除%d个表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除 %d 個資料表"
+          }
         }
       }
     },
@@ -21267,6 +26877,12 @@
             "state" : "translated",
             "value" : "删除 %lld 个表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除 %lld 個資料表"
+          }
         }
       }
     },
@@ -21288,6 +26904,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除所有依赖此表的表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除所有依賴此資料表的資料表"
           }
         }
       }
@@ -21312,6 +26934,12 @@
             "state" : "translated",
             "value" : "删除数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除資料庫"
+          }
         }
       }
     },
@@ -21334,6 +26962,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除数据库 '%@'？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要刪除資料庫「%@」嗎？"
           }
         }
       }
@@ -21358,6 +26992,12 @@
             "state" : "translated",
             "value" : "要删除数据库“%@”吗？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要捨棄資料庫「%@」嗎？"
+          }
         }
       }
     },
@@ -21380,6 +27020,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除数据库…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除資料庫…"
           }
         }
       }
@@ -21404,6 +27050,12 @@
             "state" : "translated",
             "value" : "删除数据库…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "捨棄資料庫…"
+          }
         }
       }
     },
@@ -21425,6 +27077,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "捨棄失敗"
           }
         }
       }
@@ -21448,6 +27106,12 @@
             "state" : "translated",
             "value" : "删除外部表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "捨棄外部資料表"
+          }
         }
       }
     },
@@ -21469,6 +27133,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除物化视图"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "捨棄具體化檢視表"
           }
         }
       }
@@ -21492,6 +27162,12 @@
             "state" : "translated",
             "value" : "删除分区"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除分割區"
+          }
         }
       }
     },
@@ -21513,6 +27189,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除分区？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要刪除分割區嗎？"
           }
         }
       }
@@ -21537,6 +27219,12 @@
             "state" : "translated",
             "value" : "删除选定的数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除選取的資料庫"
+          }
         }
       }
     },
@@ -21558,6 +27246,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除选定的分区"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除選取的分割區"
           }
         }
       }
@@ -21581,6 +27275,12 @@
             "state" : "translated",
             "value" : "删除表 '%@'"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除資料表「%@」"
+          }
         }
       }
     },
@@ -21602,6 +27302,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除视图"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除檢視表"
           }
         }
       }
@@ -21626,6 +27332,12 @@
             "state" : "translated",
             "value" : "正在删除…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在刪除…"
+          }
         }
       }
     },
@@ -21648,6 +27360,12 @@
             "state" : "translated",
             "value" : "转储操作仅支持 PostgreSQL 和 Redshift 连接。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "備份/還原操作僅支援 PostgreSQL 和 Redshift 連線。"
+          }
         }
       }
     },
@@ -21666,6 +27384,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "副本"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "副本"
@@ -21692,6 +27416,12 @@
             "state" : "translated",
             "value" : "复制"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "製作複本"
+          }
         }
       }
     },
@@ -21714,6 +27444,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制现有表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製現有資料表"
           }
         }
       }
@@ -21738,6 +27474,12 @@
             "state" : "translated",
             "value" : "复制筛选条件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製篩選條件"
+          }
         }
       }
     },
@@ -21759,6 +27501,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制筛选条件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製篩選條件"
           }
         }
       }
@@ -21783,6 +27531,12 @@
             "state" : "translated",
             "value" : "复制后可自定义颜色和布局。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "製作複本即可自訂顏色與版面配置。"
+          }
         }
       }
     },
@@ -21804,6 +27558,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制以自定义颜色。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "製作複本即可自訂顏色。"
           }
         }
       }
@@ -21827,6 +27587,12 @@
             "state" : "translated",
             "value" : "复制行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製一行"
+          }
         }
       }
     },
@@ -21848,6 +27614,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製列"
           }
         }
       }
@@ -21872,6 +27644,12 @@
             "state" : "translated",
             "value" : "复制表结构"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製資料表結構"
+          }
         }
       }
     },
@@ -21893,6 +27671,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制主题"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製佈景主題"
           }
         }
       }
@@ -21916,6 +27700,12 @@
             "state" : "translated",
             "value" : "持续时间"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "持續時間"
+          }
         }
       }
     },
@@ -21938,6 +27728,12 @@
             "state" : "translated",
             "value" : "例如，VPS 上的 Claude Code"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "例如：VPS 上的 Claude Code"
+          }
         }
       }
     },
@@ -21959,6 +27755,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "每列只能映射自一个字段。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每個欄位只能對應自一個欄位。"
           }
         }
       }
@@ -21983,6 +27785,12 @@
             "state" : "translated",
             "value" : "每个 SQLite 文件是一个独立的数据库。\n要打开其他数据库，请创建新连接。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每個 SQLite 檔案都是獨立的資料庫。\n若要開啟其他資料庫，請建立新連線。"
+          }
         }
       }
     },
@@ -22004,6 +27812,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "要包含的最早 executed_at，Unix 纪元秒（含，可选）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要納入的最早 executed_at，Unix 紀元秒（含，選用）"
           }
         }
       }
@@ -22027,6 +27841,12 @@
             "state" : "translated",
             "value" : "编辑"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯"
+          }
         }
       }
     },
@@ -22048,6 +27868,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编辑 %@ 连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯 %@ 連線"
           }
         }
       }
@@ -22071,6 +27897,12 @@
             "state" : "translated",
             "value" : "编辑单元格"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯儲存格"
+          }
         }
       }
     },
@@ -22092,6 +27924,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编辑列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯欄位"
           }
         }
       }
@@ -22116,6 +27954,12 @@
             "state" : "translated",
             "value" : "编辑连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯連線"
+          }
         }
       }
     },
@@ -22139,6 +27983,12 @@
             "state" : "translated",
             "value" : "编辑详情（双击）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯詳細資訊（按兩下）"
+          }
         }
       }
     },
@@ -22160,6 +28010,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编辑收藏"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯我的最愛"
           }
         }
       }
@@ -22183,6 +28039,12 @@
             "state" : "translated",
             "value" : "编辑外键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯外鍵"
+          }
         }
       }
     },
@@ -22204,6 +28066,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编辑索引"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯索引"
           }
         }
       }
@@ -22227,6 +28095,12 @@
             "state" : "translated",
             "value" : "编辑消息"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯訊息"
+          }
         }
       }
     },
@@ -22249,6 +28123,12 @@
             "state" : "translated",
             "value" : "编辑元数据"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯中繼資料"
+          }
         }
       }
     },
@@ -22270,6 +28150,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编辑元数据..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯中繼資料…"
           }
         }
       }
@@ -22299,6 +28185,12 @@
             "state" : "translated",
             "value" : "编辑配置…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯設定檔…"
+          }
         }
       }
     },
@@ -22321,6 +28213,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编辑提供商"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯供應商"
           }
         }
       }
@@ -22345,6 +28243,12 @@
             "state" : "translated",
             "value" : "编辑提供商"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯供應商"
+          }
         }
       }
     },
@@ -22368,6 +28272,12 @@
             "state" : "translated",
             "value" : "编辑行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯列"
+          }
         }
       }
     },
@@ -22389,6 +28299,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编辑值…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯值…"
           }
         }
       }
@@ -22412,6 +28328,12 @@
             "state" : "translated",
             "value" : "编辑视图定义"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯檢視表定義"
+          }
         }
       }
     },
@@ -22433,6 +28355,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编辑：只读工具加运行查询。破坏性 DDL 仍被阻止。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯：唯讀工具加上執行查詢。破壞性 DDL 仍會被封鎖。"
           }
         }
       }
@@ -22456,6 +28384,12 @@
             "state" : "translated",
             "value" : "编辑…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯…"
+          }
         }
       }
     },
@@ -22477,6 +28411,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "可编辑十六进制"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可編輯十六進位"
           }
         }
       }
@@ -22501,6 +28441,12 @@
             "state" : "translated",
             "value" : "编辑中"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯中"
+          }
         }
       }
     },
@@ -22522,6 +28468,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编辑器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯器"
           }
         }
       }
@@ -22545,6 +28497,12 @@
             "state" : "translated",
             "value" : "编辑器与查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯器與查詢"
+          }
         }
       }
     },
@@ -22566,6 +28524,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编辑器字体"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯器字型"
           }
         }
       }
@@ -22589,6 +28553,12 @@
             "state" : "translated",
             "value" : "ElastiCache IAM 认证需要 TLS。请在连接的 SSL 设置中启用 SSL。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ElastiCache IAM 驗證需要 TLS。請在連線的 SSL 設定中啟用 SSL。"
+          }
         }
       }
     },
@@ -22610,6 +28580,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "邮箱:"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電子郵件："
           }
         }
       }
@@ -22633,6 +28609,12 @@
             "state" : "translated",
             "value" : "嵌入式分析型 SQL"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "內嵌式分析型 SQL"
+          }
         }
       }
     },
@@ -22655,6 +28637,12 @@
             "state" : "translated",
             "value" : "嵌入式零配置 SQL 数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "內嵌式零設定 SQL 資料庫"
+          }
         }
       }
     },
@@ -22676,6 +28664,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "空"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "空白"
           }
         }
       }
@@ -22700,6 +28694,12 @@
             "state" : "translated",
             "value" : "Redis 命令为空"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redis 命令為空"
+          }
         }
       }
     },
@@ -22721,6 +28721,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用"
           }
         }
       }
@@ -22744,6 +28750,12 @@
             "state" : "translated",
             "value" : "启用 %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用 %@"
+          }
         }
       }
     },
@@ -22765,6 +28777,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用 AI 功能"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用 AI 功能"
           }
         }
       }
@@ -22788,6 +28806,12 @@
             "state" : "translated",
             "value" : "启用 Cloudflare Tunnel"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用 Cloudflare 隧道"
+          }
         }
       }
     },
@@ -22809,6 +28833,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用筛选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用篩選"
           }
         }
       }
@@ -22833,6 +28863,12 @@
             "state" : "translated",
             "value" : "启用行内建议"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用行內建議"
+          }
         }
       }
     },
@@ -22855,6 +28891,12 @@
             "state" : "translated",
             "value" : "在输入时启用内联建议"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入時啟用行內建議"
+          }
         }
       }
     },
@@ -22876,6 +28918,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用 MCP 服务器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用 MCP 伺服器"
           }
         }
       }
@@ -22902,6 +28950,12 @@
             "state" : "translated",
             "value" : "启用预览标签页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用預覽分頁"
+          }
         }
       }
     },
@@ -22923,6 +28977,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用 SSH 隧道"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用 SSH 隧道"
           }
         }
       }
@@ -22947,6 +29007,12 @@
             "state" : "translated",
             "value" : "已启用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已啟用"
+          }
         }
       }
     },
@@ -22968,6 +29034,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编码:"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編碼："
           }
         }
       }
@@ -22991,6 +29063,12 @@
             "state" : "translated",
             "value" : "编码：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編碼：%@"
+          }
         }
       }
     },
@@ -23013,6 +29091,12 @@
             "state" : "translated",
             "value" : "加密导出"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加密匯出"
+          }
         }
       }
     },
@@ -23031,6 +29115,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Endpoint"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Endpoint"
@@ -23057,6 +29147,12 @@
             "state" : "translated",
             "value" : "以...结尾"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結尾為"
+          }
         }
       }
     },
@@ -23075,6 +29171,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Engine"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Engine"
@@ -23102,6 +29204,12 @@
             "state" : "translated",
             "value" : "Engine（如 InnoDB）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Engine（例如 InnoDB）"
+          }
         }
       }
     },
@@ -23120,6 +29228,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "引擎："
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "引擎："
@@ -23146,6 +29260,12 @@
             "state" : "translated",
             "value" : "输入此筛选预设的名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入此篩選預設組合的名稱"
+          }
         }
       }
     },
@@ -23167,6 +29287,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "输入分组的新名称。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入群組的新名稱。"
           }
         }
       }
@@ -23191,6 +29317,12 @@
             "state" : "translated",
             "value" : "输入数据库名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入資料庫名稱"
+          }
         }
       }
     },
@@ -23212,6 +29344,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "输入表名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入資料表名稱"
           }
         }
       }
@@ -23241,6 +29379,12 @@
             "state" : "translated",
             "value" : "输入\"%@\"的 %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入「%1$@」的 %2$@"
+          }
         }
       }
     },
@@ -23262,6 +29406,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "输入 ElastiCache 缓存名称（复制组 ID）以使用 IAM 认证。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入 ElastiCache 快取名稱（複寫群組 ID）以使用 IAM 驗證。"
           }
         }
       }
@@ -23285,6 +29435,12 @@
             "state" : "translated",
             "value" : "请输入 SSH 密钥 \"%@\" 的密码："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請輸入 SSH 金鑰「%@」的密碼短語："
+          }
         }
       }
     },
@@ -23306,6 +29462,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "输入密码短语以解密并导入连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入密碼短語以解密並匯入連線。"
           }
         }
       }
@@ -23329,6 +29491,12 @@
             "state" : "translated",
             "value" : "输入 TOTP 验证码以进行 SSH 身份验证。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入 TOTP 驗證碼以進行 SSH 驗證。"
+          }
         }
       }
     },
@@ -23350,6 +29518,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在 GitHub 上输入此代码："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 GitHub 上輸入此代碼："
           }
         }
       }
@@ -23373,6 +29547,12 @@
             "state" : "translated",
             "value" : "输入许可证密钥以解锁 Pro 功能。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入授權金鑰以解鎖 Pro 功能。"
+          }
         }
       }
     },
@@ -23394,6 +29574,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "支持 PL/SQL 的企业级 SQL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支援 PL/SQL 的企業級 SQL"
           }
         }
       }
@@ -23417,6 +29603,12 @@
             "state" : "translated",
             "value" : "环境变量 %@ 未在 TablePro 的环境中设置。从 Dock 启动的应用不会继承 shell 导出的变量。请从终端启动 TablePro，或使用 launchctl setenv 设置该变量。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "環境變數 %@ 未在 TablePro 的環境中設定。從 Dock 啟動的應用程式不會繼承 shell 匯出的變數。請從終端機啟動 TablePro，或使用 launchctl setenv 設定該變數。"
+          }
         }
       }
     },
@@ -23438,6 +29630,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "环境变量"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "環境變數"
           }
         }
       }
@@ -23461,6 +29659,12 @@
             "state" : "translated",
             "value" : "等于"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等於"
+          }
         }
       }
     },
@@ -23482,6 +29686,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ER 图"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ER 圖"
           }
         }
       }
@@ -23505,6 +29715,12 @@
             "state" : "translated",
             "value" : "错误"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "錯誤"
+          }
         }
       }
     },
@@ -23526,6 +29742,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "应用更改时出错"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用變更時發生錯誤"
           }
         }
       }
@@ -23549,6 +29771,12 @@
             "state" : "translated",
             "value" : "错误:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "錯誤："
+          }
         }
       }
     },
@@ -23570,6 +29798,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "错误: %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "錯誤：%@"
           }
         }
       }
@@ -23593,6 +29827,12 @@
             "state" : "translated",
             "value" : "错误: 所选路径不是常规文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "錯誤：所選路徑不是一般檔案"
+          }
         }
       }
     },
@@ -23614,6 +29854,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "欧洲长格式 (31/12/2024 23:59:59)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歐洲長格式 (31/12/2024 23:59:59)"
           }
         }
       }
@@ -23637,6 +29883,12 @@
             "state" : "translated",
             "value" : "欧洲短格式 (31/12/2024)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歐洲短格式 (31/12/2024)"
+          }
         }
       }
     },
@@ -23658,6 +29910,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "每个包含的列都需要名称。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每個納入的欄位都需要名稱。"
           }
         }
       }
@@ -23681,6 +29939,12 @@
             "state" : "translated",
             "value" : "每个表至少需要一列。点击 + 开始添加"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每個資料表至少需要一個欄位。點按 + 開始新增"
+          }
         }
       }
     },
@@ -23702,6 +29966,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "示例"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "範例"
           }
         }
       }
@@ -23725,6 +29995,12 @@
             "state" : "translated",
             "value" : "支持格式化的 Excel 电子表格。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支援格式設定的 Excel 試算表。"
+          }
         }
       }
     },
@@ -23746,6 +30022,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "排除 iCloud 同步"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排除於 iCloud 同步"
           }
         }
       }
@@ -23769,6 +30051,12 @@
             "state" : "translated",
             "value" : "执行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行"
+          }
         }
       }
     },
@@ -23790,6 +30078,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在明确确认后执行破坏性 DDL 查询（DROP、TRUNCATE、ALTER...DROP）。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在明確確認後執行破壞性 DDL 查詢（DROP、TRUNCATE、ALTER...DROP）。"
           }
         }
       }
@@ -23813,6 +30107,12 @@
             "state" : "translated",
             "value" : "在明确确认后执行破坏性 DDL 查询（DROP、TRUNCATE、ALTER...DROP）。confirmation_phrase 必须严格传入：I understand this is irreversible"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在明確確認後執行破壞性 DDL 查詢（DROP、TRUNCATE、ALTER...DROP）。confirmation_phrase 必須完全照這樣傳入：I understand this is irreversible"
+          }
         }
       }
     },
@@ -23834,6 +30134,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "执行查询以 JSON 形式查看结果"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行查詢以 JSON 形式檢視結果"
           }
         }
       }
@@ -23857,6 +30163,12 @@
             "state" : "translated",
             "value" : "对连接执行 SQL 查询。受连接的安全模式策略约束。多语句查询会被拒绝。破坏性操作（DROP、TRUNCATE、ALTER...DROP）在此被阻止；请改用 confirm_destructive_operation。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "對連線執行 SQL 查詢。會套用連線的安全模式原則。多陳述式查詢會被拒絕。破壞性操作（DROP、TRUNCATE、ALTER...DROP）在此會被封鎖；請改用 confirm_destructive_operation。"
+          }
         }
       }
     },
@@ -23878,6 +30190,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "执行 SQL 查询。所有查询都受连接的安全模式策略约束。DROP/TRUNCATE/ALTER...DROP 必须使用 confirm_destructive_operation 工具。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行 SQL 查詢。所有查詢都受連線的安全模式原則約束。DROP/TRUNCATE/ALTER...DROP 必須使用 confirm_destructive_operation 工具。"
           }
         }
       }
@@ -23902,6 +30220,12 @@
             "state" : "translated",
             "value" : "全部执行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部執行"
+          }
         }
       }
     },
@@ -23923,6 +30247,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "执行所有语句"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行所有陳述式"
           }
         }
       }
@@ -23947,6 +30277,12 @@
             "state" : "translated",
             "value" : "在单个事务中执行所有语句。如果任一语句失败，所有更改将回滚。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在單一交易中執行所有陳述式。若任一陳述式失敗，所有變更都會回復。"
+          }
         }
       }
     },
@@ -23968,6 +30304,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "执行查询"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行查詢"
           }
         }
       }
@@ -23991,6 +30333,12 @@
             "state" : "translated",
             "value" : "已执行 %lld 条语句"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已執行 %lld 條陳述式"
+          }
         }
       }
     },
@@ -24012,6 +30360,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已执行：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已執行：%@"
           }
         }
       }
@@ -24035,6 +30389,12 @@
             "state" : "translated",
             "value" : "执行中"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行中"
+          }
         }
       }
     },
@@ -24056,6 +30416,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在执行..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在執行…"
           }
         }
       }
@@ -24079,6 +30445,12 @@
             "state" : "translated",
             "value" : "执行: %.3fms"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行：%.3fms"
+          }
         }
       }
     },
@@ -24100,6 +30472,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "现有表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現有資料表"
           }
         }
       }
@@ -24123,6 +30501,12 @@
             "state" : "translated",
             "value" : "展开"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "展開"
+          }
         }
       }
     },
@@ -24145,6 +30529,12 @@
             "state" : "translated",
             "value" : "全部展开"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部展開"
+          }
         }
       }
     },
@@ -24166,6 +30556,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在侧边栏中展开"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在側邊欄中展開"
           }
         }
       }
@@ -24190,6 +30586,12 @@
             "state" : "translated",
             "value" : "预期行为"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預期行為"
+          }
         }
       }
     },
@@ -24211,6 +30613,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "过期时间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到期時間"
           }
         }
       }
@@ -24234,6 +30642,12 @@
             "state" : "translated",
             "value" : "过期日期"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到期日期"
+          }
         }
       }
     },
@@ -24256,6 +30670,12 @@
             "state" : "translated",
             "value" : "已过期"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已過期"
+          }
         }
       }
     },
@@ -24277,6 +30697,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "过期时间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到期時間"
           }
         }
       }
@@ -24306,6 +30732,12 @@
             "state" : "translated",
             "value" : "到期时间："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到期時間："
+          }
         }
       }
     },
@@ -24327,6 +30759,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "解释"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解釋"
           }
         }
       }
@@ -24350,6 +30788,12 @@
             "state" : "translated",
             "value" : "此数据库类型不支持 EXPLAIN。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此資料庫類型不支援 EXPLAIN。"
+          }
         }
       }
     },
@@ -24372,6 +30816,12 @@
             "state" : "translated",
             "value" : "解释查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解釋查詢"
+          }
         }
       }
     },
@@ -24393,6 +30843,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "解释当前查询"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解釋目前的查詢"
           }
         }
       }
@@ -24417,6 +30873,12 @@
             "state" : "translated",
             "value" : "请解释以下 SQL 查询:\n\n```sql\n%@\n```"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請解釋以下 SQL 查詢：\n\n```sql\n%@\n```"
+          }
         }
       }
     },
@@ -24438,6 +30900,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "AI 解释"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "以 AI 解釋"
           }
         }
       }
@@ -24461,6 +30929,12 @@
             "state" : "translated",
             "value" : "导出"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出"
+          }
         }
       }
     },
@@ -24482,6 +30956,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导出"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出"
           }
         }
       }
@@ -24505,6 +30985,12 @@
             "state" : "translated",
             "value" : "导出与导入"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出與匯入"
+          }
         }
       }
     },
@@ -24526,6 +31012,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导出 %d 个连接到文件…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出 %d 個連線至檔案…"
           }
         }
       }
@@ -24549,6 +31041,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导出%d个连接..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出 %d 個連線…"
           }
         }
       }
@@ -24578,6 +31076,12 @@
             "state" : "translated",
             "value" : "导出%d行到%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出 %1$d 列至 %2$@"
+          }
         }
       }
     },
@@ -24606,6 +31110,12 @@
             "state" : "translated",
             "value" : "导出%d个表到%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出 %1$d 個資料表至 %2$@"
+          }
         }
       }
     },
@@ -24628,6 +31138,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导出 %lld 个连接…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出 %lld 個連線…"
           }
         }
       }
@@ -24658,6 +31174,12 @@
             "state" : "translated",
             "value" : "导出 %lld 行到 %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出 %1$lld 列至 %2$@"
+          }
         }
       }
     },
@@ -24687,6 +31209,12 @@
             "state" : "translated",
             "value" : "导出 %lld 张表到 %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出 %1$lld 個資料表至 %2$@"
+          }
         }
       }
     },
@@ -24708,6 +31236,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导出活动日志"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出活動記錄"
           }
         }
       }
@@ -24732,6 +31266,12 @@
             "state" : "translated",
             "value" : "将活动导出为 CSV"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將活動匯出為 CSV"
+          }
         }
       }
     },
@@ -24753,6 +31293,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导出为 PNG"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出為 PNG"
           }
         }
       }
@@ -24776,6 +31322,12 @@
             "state" : "translated",
             "value" : "导出成功"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出成功完成"
+          }
         }
       }
     },
@@ -24798,6 +31350,12 @@
             "state" : "translated",
             "value" : "导出连接并加密凭据。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出連線並加密憑證。"
+          }
         }
       }
     },
@@ -24819,6 +31377,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导出连接…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出連線…"
           }
         }
       }
@@ -24843,6 +31407,12 @@
             "state" : "translated",
             "value" : "导出数据"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出資料"
+          }
         }
       }
     },
@@ -24864,6 +31434,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导出数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出資料"
           }
         }
       }
@@ -24887,6 +31463,12 @@
             "state" : "translated",
             "value" : "导出数据 (⌘⇧E)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出資料 (⌘⇧E)"
+          }
         }
       }
     },
@@ -24908,6 +31490,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导出 ER 图"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出 ER 圖"
           }
         }
       }
@@ -24931,6 +31519,12 @@
             "state" : "translated",
             "value" : "导出错误"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出錯誤"
+          }
         }
       }
     },
@@ -24952,6 +31546,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导出失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出失敗"
           }
         }
       }
@@ -24975,6 +31575,12 @@
             "state" : "translated",
             "value" : "导出失败: %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出失敗：%@"
+          }
         }
       }
     },
@@ -24996,6 +31602,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导出格式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出格式"
           }
         }
       }
@@ -25019,6 +31631,12 @@
             "state" : "translated",
             "value" : "未找到导出格式 '%@'"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到匯出格式「%@」"
+          }
         }
       }
     },
@@ -25040,6 +31658,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导出格式：csv、json 或 sql"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出格式：csv、json 或 sql"
           }
         }
       }
@@ -25063,6 +31687,12 @@
             "state" : "translated",
             "value" : "导出格式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出格式"
+          }
         }
       }
     },
@@ -25085,6 +31715,12 @@
             "state" : "translated",
             "value" : "导出多个表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出多個資料表"
+          }
         }
       }
     },
@@ -25106,6 +31742,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导出选项"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出選項"
           }
         }
       }
@@ -25130,6 +31772,12 @@
             "state" : "translated",
             "value" : "将查询结果和表导出为 Excel 格式。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將查詢結果與資料表匯出為 Excel 格式。"
+          }
         }
       }
     },
@@ -25151,6 +31799,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "将查询结果或表数据导出为 CSV、JSON 或 SQL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將查詢結果或資料表資料匯出為 CSV、JSON 或 SQL"
           }
         }
       }
@@ -25174,6 +31828,12 @@
             "state" : "translated",
             "value" : "将查询结果导出为 %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將查詢結果匯出為 %@"
+          }
         }
       }
     },
@@ -25195,6 +31855,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导出结果..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出結果..."
           }
         }
       }
@@ -25218,6 +31884,12 @@
             "state" : "translated",
             "value" : "导出表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出資料表"
+          }
         }
       }
     },
@@ -25239,6 +31911,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "将筛选后的活动日志导出为 CSV"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將篩選後的活動記錄匯出為 CSV"
           }
         }
       }
@@ -25262,6 +31940,12 @@
             "state" : "translated",
             "value" : "导出到文件…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出至檔案…"
+          }
         }
       }
     },
@@ -25283,6 +31967,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导出..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出..."
           }
         }
       }
@@ -25307,6 +31997,12 @@
             "state" : "translated",
             "value" : "导出…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出…"
+          }
         }
       }
     },
@@ -25330,6 +32026,12 @@
             "state" : "translated",
             "value" : "将数据导出为 mongosh 兼容的脚本。Drop、Indexes 和 Data 选项可在集合列表中按集合配置。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將資料匯出為 mongosh 相容的指令碼。Drop、Indexes 與 Data 選項可在集合清單中依集合個別設定。"
+          }
         }
       }
     },
@@ -25351,6 +32053,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "开放给本地网络"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開放給本機網路"
           }
         }
       }
@@ -25375,6 +32083,12 @@
             "state" : "translated",
             "value" : "表达式（如 age >= 0）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "運算式（例如 age >= 0）"
+          }
         }
       }
     },
@@ -25396,6 +32110,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "扩展"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "擴充"
           }
         }
       }
@@ -25419,6 +32139,12 @@
             "state" : "translated",
             "value" : "外部访问"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部存取"
+          }
         }
       }
     },
@@ -25440,6 +32166,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "该连接已禁用外部访问"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線已停用外部存取"
           }
         }
       }
@@ -25463,6 +32195,12 @@
             "state" : "translated",
             "value" : "外部客户端"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部用戶端"
+          }
         }
       }
     },
@@ -25485,6 +32223,12 @@
             "state" : "translated",
             "value" : "外部集成和 MCP 客户端请求将显示在此处。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部整合與 MCP 用戶端要求將顯示於此處。"
+          }
         }
       }
     },
@@ -25503,6 +32247,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "超高"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "超高"
@@ -25530,6 +32280,12 @@
             "state" : "translated",
             "value" : "特大"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "特大"
+          }
         }
       }
     },
@@ -25552,6 +32308,12 @@
             "state" : "translated",
             "value" : "在第 %lld 行失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在第 %lld 行失敗"
+          }
         }
       }
     },
@@ -25573,6 +32335,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "压缩数据失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "壓縮資料失敗"
           }
         }
       }
@@ -25597,6 +32365,12 @@
             "state" : "translated",
             "value" : "创建终端进程失败 (errno: %d)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立終端機處理程序失敗 (errno: %d)"
+          }
         }
       }
     },
@@ -25619,6 +32393,12 @@
             "state" : "translated",
             "value" : "解压 .gz 文件失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解壓縮 .gz 檔案失敗"
+          }
         }
       }
     },
@@ -25640,6 +32420,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "解压文件失败: %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解壓縮檔案失敗：%@"
           }
         }
       }
@@ -25664,6 +32450,12 @@
             "state" : "translated",
             "value" : "删除模板失败: %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除範本失敗：%@"
+          }
         }
       }
     },
@@ -25685,6 +32477,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法编码连接数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法編碼連線資料"
           }
         }
       }
@@ -25708,6 +32506,12 @@
             "state" : "translated",
             "value" : "无法将内容编码为 UTF-8"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法將內容編碼為 UTF-8"
+          }
         }
       }
     },
@@ -25729,6 +32533,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "同步数据编码失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步資料編碼失敗：%@"
           }
         }
       }
@@ -25752,6 +32562,12 @@
             "state" : "translated",
             "value" : "获取 DDL 失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "擷取 DDL 失敗"
+          }
         }
       }
     },
@@ -25773,6 +32589,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法从 %@ 获取模型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法從 %@ 擷取模型"
           }
         }
       }
@@ -25802,6 +32624,12 @@
             "state" : "translated",
             "value" : "从 %@ 获取模型失败 (HTTP %d)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從 %1$@ 取得模型失敗 (HTTP %2$d)"
+          }
         }
       }
     },
@@ -25825,6 +32653,12 @@
             "state" : "translated",
             "value" : "获取表结构失败: %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取得資料表結構失敗：%@"
+          }
         }
       }
     },
@@ -25846,6 +32680,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法生成列重排序的 SQL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法產生欄位重新排序的 SQL"
           }
         }
       }
@@ -25869,6 +32709,12 @@
             "state" : "translated",
             "value" : "生成 TLS 证书失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "產生 TLS 憑證失敗"
+          }
         }
       }
     },
@@ -25890,6 +32736,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "生成 TLS 私钥失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "產生 TLS 私密金鑰失敗"
           }
         }
       }
@@ -25914,6 +32766,12 @@
             "state" : "translated",
             "value" : "导入 DDL 失败: %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入 DDL 失敗：%@"
+          }
         }
       }
     },
@@ -25936,6 +32794,12 @@
             "state" : "translated",
             "value" : "将 TLS 身份导入钥匙串失败（错误 %d）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將 TLS 身分匯入鑰匙圈失敗（錯誤 %d）"
+          }
         }
       }
     },
@@ -25957,6 +32821,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "加载失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入失敗"
           }
         }
       }
@@ -25983,6 +32853,12 @@
             "state" : "translated",
             "value" : "加载数据库列表失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入資料庫清單失敗"
+          }
         }
       }
     },
@@ -26004,6 +32880,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "加载数据库列表失败: %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入資料庫清單失敗：%@"
           }
         }
       }
@@ -26028,6 +32910,12 @@
             "state" : "translated",
             "value" : "无法加载完整值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法載入完整值"
+          }
         }
       }
     },
@@ -26049,6 +32937,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "加载选项失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入選項失敗"
           }
         }
       }
@@ -26073,6 +32967,12 @@
             "state" : "translated",
             "value" : "无法加载插件注册表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法載入外掛註冊"
+          }
         }
       }
     },
@@ -26096,6 +32996,12 @@
             "state" : "translated",
             "value" : "使用编码 %@ 加载预览失败。请尝试从编码选择器中选择其他文本编码并重新加载预览。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用編碼 %@ 載入預覽失敗。請嘗試從編碼選擇器中選擇其他文字編碼，並重新載入預覽。"
+          }
         }
       }
     },
@@ -26117,6 +33023,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法使用编码 %@ 加载预览。请尝试选择其他文本编码。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用編碼 %@ 載入預覽失敗。請嘗試選擇其他文字編碼。"
           }
         }
       }
@@ -26140,6 +33052,12 @@
             "state" : "translated",
             "value" : "加载预览失败: %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入預覽失敗：%@"
+          }
         }
       }
     },
@@ -26161,6 +33079,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法加载引用行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法載入參照的列"
           }
         }
       }
@@ -26185,6 +33109,12 @@
             "state" : "translated",
             "value" : "无法加载 Schema 列表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法載入綱要清單"
+          }
         }
       }
     },
@@ -26207,6 +33137,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "加载表列表失败: %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入資料表清單失敗：%@"
           }
         }
       }
@@ -26231,6 +33167,12 @@
             "state" : "translated",
             "value" : "加载模板失败: %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入範本失敗：%@"
+          }
         }
       }
     },
@@ -26252,6 +33194,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法打开 SSH 通道进行端口转发"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法開啟 SSH 隧道以進行連接埠轉送"
           }
         }
       }
@@ -26276,6 +33224,12 @@
             "state" : "translated",
             "value" : "无法从表 '%@' 解析任何列。请检查控制台获取调试信息。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法從資料表「%@」解析任何欄位。請檢查主控台以取得偵錯資訊。"
+          }
         }
       }
     },
@@ -26297,6 +33251,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法解析连接文件：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法解析連線檔案：%@"
           }
         }
       }
@@ -26320,6 +33280,12 @@
             "state" : "translated",
             "value" : "解析连接失败：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解析連線失敗：%@"
+          }
         }
       }
     },
@@ -26342,6 +33308,12 @@
             "state" : "translated",
             "value" : "无法解析插件注册表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法解析外掛註冊"
+          }
         }
       }
     },
@@ -26363,6 +33335,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "服务器响应解析失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解析伺服器回應失敗：%@"
           }
         }
       }
@@ -26393,6 +33371,12 @@
             "state" : "translated",
             "value" : "在第 %lld 行解析语句失败: %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在第 %1$lld 行解析陳述式失敗：%2$@"
+          }
         }
       }
     },
@@ -26414,6 +33398,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "读取文件失败: %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "讀取檔案失敗：%@"
           }
         }
       }
@@ -26437,6 +33427,12 @@
             "state" : "translated",
             "value" : "无法渲染图表图像。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法繪製圖表影像。"
+          }
         }
       }
     },
@@ -26458,6 +33454,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保存更改失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存變更失敗"
           }
         }
       }
@@ -26482,6 +33484,12 @@
             "state" : "translated",
             "value" : "保存模板失败: %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存範本失敗：%@"
+          }
         }
       }
     },
@@ -26503,6 +33511,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "写入文件失败: %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寫入檔案失敗：%@"
           }
         }
       }
@@ -26526,6 +33540,12 @@
             "state" : "translated",
             "value" : "失败：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "失敗：%@"
+          }
         }
       }
     },
@@ -26544,6 +33564,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "false"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "false"
@@ -26571,6 +33597,12 @@
             "state" : "translated",
             "value" : "FALSE"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FALSE"
+          }
         }
       }
     },
@@ -26592,6 +33624,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "字体族"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字型家族"
           }
         }
       }
@@ -26616,6 +33654,12 @@
             "state" : "translated",
             "value" : "快速"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速"
+          }
         }
       }
     },
@@ -26634,6 +33678,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "快速"
@@ -26662,6 +33712,12 @@
             "state" : "translated",
             "value" : "收藏"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "我的最愛"
+          }
         }
       }
     },
@@ -26683,6 +33739,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已收藏"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已加入我的最愛"
           }
         }
       }
@@ -26706,6 +33768,12 @@
             "state" : "translated",
             "value" : "收藏"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "我的最愛"
+          }
         }
       }
     },
@@ -26725,6 +33793,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "功能路由"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "功能路由"
@@ -26752,6 +33826,12 @@
             "state" : "translated",
             "value" : "反馈已提交！"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "意見回饋已送出！"
+          }
         }
       }
     },
@@ -26773,6 +33853,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "获取全部"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取得全部"
           }
         }
       }
@@ -26796,6 +33882,12 @@
             "state" : "translated",
             "value" : "获取所有行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取得所有列"
+          }
         }
       }
     },
@@ -26817,6 +33909,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在获取模型…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在擷取模型…"
           }
         }
       }
@@ -26840,6 +33938,12 @@
             "state" : "translated",
             "value" : "字段"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位"
+          }
         }
       }
     },
@@ -26861,6 +33965,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "字段"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位"
           }
         }
       }
@@ -26885,6 +33995,12 @@
             "state" : "translated",
             "value" : "字段"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位"
+          }
         }
       }
     },
@@ -26907,6 +34023,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "字段 (%lld)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位 (%lld)"
           }
         }
       }
@@ -26931,6 +34053,12 @@
             "state" : "translated",
             "value" : "文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檔案"
+          }
         }
       }
     },
@@ -26952,6 +34080,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文件编码（%@）无法表示这些字符。请将文件转换为 UTF-8 后再保存。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檔案編碼（%@）無法表示這些字。請將檔案轉換為 UTF-8 後再儲存。"
           }
         }
       }
@@ -26975,6 +34109,12 @@
             "state" : "translated",
             "value" : "文件已在外部被修改"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檔案已在外部被修改"
+          }
         }
       }
     },
@@ -26996,6 +34136,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文件名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檔案名稱"
           }
         }
       }
@@ -27020,6 +34166,12 @@
             "state" : "translated",
             "value" : "未找到文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到檔案"
+          }
         }
       }
     },
@@ -27041,6 +34193,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文件路径"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檔案路徑"
           }
         }
       }
@@ -27064,6 +34222,12 @@
             "state" : "translated",
             "value" : "用户“下载”目录内的文件路径（留空则返回内联数据）。“下载”目录之外的路径会被拒绝。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用者「下載」資料夾內的檔案路徑（留空則回傳內嵌資料）。「下載」資料夾之外的路徑會被拒絕。"
+          }
         }
       }
     },
@@ -27085,6 +34249,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文件名不能是 '.' 或 '..'，且不能包含路径遍历"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檔案名稱不能是「.」或「..」，且不能包含路徑遍歷"
           }
         }
       }
@@ -27108,6 +34278,12 @@
             "state" : "translated",
             "value" : "文件名不能为空"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檔案名稱不能為空"
+          }
         }
       }
     },
@@ -27129,6 +34305,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文件名包含无效字符：/ \\ : * ? \" < > |"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檔案名稱包含無效字：/ \\ : * ? \" < > |"
           }
         }
       }
@@ -27152,6 +34334,12 @@
             "state" : "translated",
             "value" : "文件名过长（最大 255 字节）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檔案名稱過長（最多 255 位元組）"
+          }
         }
       }
     },
@@ -27173,6 +34361,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "填充"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "填入"
           }
         }
       }
@@ -27196,6 +34390,12 @@
             "state" : "translated",
             "value" : "填充列"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "填入欄位"
+          }
         }
       }
     },
@@ -27217,6 +34417,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "填充列 \"%@\""
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "填入欄位「%@」"
           }
         }
       }
@@ -27240,6 +34446,12 @@
             "state" : "translated",
             "value" : "填充列…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "填入欄位…"
+          }
         }
       }
     },
@@ -27262,6 +34474,12 @@
             "state" : "translated",
             "value" : "筛选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選"
+          }
         }
       }
     },
@@ -27283,6 +34501,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "筛选活动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選活動"
           }
         }
       }
@@ -27307,6 +34531,12 @@
             "state" : "translated",
             "value" : "仅按此行筛选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅依此列篩選"
+          }
         }
       }
     },
@@ -27328,6 +34558,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "筛选列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選欄位"
           }
         }
       }
@@ -27351,6 +34587,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "筛选列: %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選欄位：%@"
           }
         }
       }
@@ -27377,6 +34619,12 @@
             "state" : "translated",
             "value" : "筛选收藏"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選我的最愛"
+          }
         }
       }
     },
@@ -27398,6 +34646,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "筛选键或值…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選鍵或值…"
           }
         }
       }
@@ -27421,6 +34675,12 @@
             "state" : "translated",
             "value" : "筛选逻辑模式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選邏輯模式"
+          }
         }
       }
     },
@@ -27442,6 +34702,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "筛选运算符"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選運算子"
           }
         }
       }
@@ -27466,6 +34732,12 @@
             "state" : "translated",
             "value" : "筛选运算符: %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選運算子：%@"
+          }
         }
       }
     },
@@ -27487,6 +34759,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "筛选选项"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選選項"
           }
         }
       }
@@ -27511,6 +34789,12 @@
             "state" : "translated",
             "value" : "筛选预设"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選預設組"
+          }
         }
       }
     },
@@ -27533,6 +34817,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "筛选设置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選設定"
           }
         }
       }
@@ -27557,6 +34847,12 @@
             "state" : "translated",
             "value" : "筛选设置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選設定"
+          }
         }
       }
     },
@@ -27578,6 +34874,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "筛选设置..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選設定…"
           }
         }
       }
@@ -27601,6 +34903,12 @@
             "state" : "translated",
             "value" : "筛选值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選值"
+          }
         }
       }
     },
@@ -27623,6 +34931,12 @@
             "state" : "translated",
             "value" : "按列筛选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "依欄位篩選"
+          }
         }
       }
     },
@@ -27644,6 +34958,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "筛选..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選…"
           }
         }
       }
@@ -27668,6 +34988,12 @@
             "state" : "translated",
             "value" : "正在仅按此行筛选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在僅依此列篩選"
+          }
         }
       }
     },
@@ -27689,6 +35015,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "筛选条件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選條件"
           }
         }
       }
@@ -27712,6 +35044,12 @@
             "state" : "translated",
             "value" : "查找"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尋找"
+          }
         }
       }
     },
@@ -27733,6 +35071,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查找下一个"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尋找下一個"
           }
         }
       }
@@ -27756,6 +35100,12 @@
             "state" : "translated",
             "value" : "查找上一个"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尋找上一個"
+          }
         }
       }
     },
@@ -27777,6 +35127,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查找…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尋找…"
           }
         }
       }
@@ -27800,6 +35156,12 @@
             "state" : "translated",
             "value" : "第一列"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第一欄"
+          }
         }
       }
     },
@@ -27821,6 +35183,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "第一页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第一頁"
           }
         }
       }
@@ -27844,6 +35212,12 @@
             "state" : "translated",
             "value" : "第一页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第一頁"
+          }
         }
       }
     },
@@ -27865,6 +35239,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "适合窗口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "符合視窗"
           }
         }
       }
@@ -27889,6 +35269,12 @@
             "state" : "translated",
             "value" : "修复错误"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "修正錯誤"
+          }
         }
       }
     },
@@ -27910,6 +35296,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "修复当前查询的最后一个错误"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "修正目前查詢的最後一個錯誤"
           }
         }
       }
@@ -27933,6 +35325,12 @@
             "state" : "translated",
             "value" : "按 id 聚焦已打开的标签页（id 由 list_recent_tabs 返回）。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "依 id 聚焦已開啟的分頁（id 由 list_recent_tabs 回傳）。"
+          }
         }
       }
     },
@@ -27954,6 +35352,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "焦点边框"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "焦點邊框"
           }
         }
       }
@@ -27977,6 +35381,12 @@
             "state" : "translated",
             "value" : "聚焦查询标签页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "聚焦查詢分頁"
+          }
         }
       }
     },
@@ -27998,6 +35408,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "聚焦侧边栏筛选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "聚焦側邊欄篩選"
           }
         }
       }
@@ -28022,6 +35438,12 @@
             "state" : "translated",
             "value" : "聚焦查询编辑器以插入"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "聚焦查詢編輯器以插入"
+          }
         }
       }
     },
@@ -28044,6 +35466,12 @@
             "state" : "translated",
             "value" : "文件夹"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料夾"
+          }
         }
       }
     },
@@ -28065,6 +35493,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文件夹名称"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料夾名稱"
           }
         }
       }
@@ -28089,6 +35523,12 @@
             "state" : "translated",
             "value" : "字体"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字型"
+          }
         }
       }
     },
@@ -28111,6 +35551,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "字体大小："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字型大小："
           }
         }
       }
@@ -28135,6 +35581,12 @@
             "state" : "translated",
             "value" : "字体:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字型："
+          }
         }
       }
     },
@@ -28156,6 +35608,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "字体"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字型"
           }
         }
       }
@@ -28179,6 +35637,12 @@
             "state" : "translated",
             "value" : "外键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外鍵"
+          }
         }
       }
     },
@@ -28200,6 +35664,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "外部表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部資料表"
           }
         }
       }
@@ -28223,6 +35693,12 @@
             "state" : "translated",
             "value" : "外部表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部資料表"
+          }
         }
       }
     },
@@ -28241,6 +35717,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "永久"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "永久"
@@ -28268,6 +35750,12 @@
             "state" : "translated",
             "value" : "格式化 JSON"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "格式化 JSON"
+          }
         }
       }
     },
@@ -28289,6 +35777,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "格式化查询"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "格式化查詢"
           }
         }
       }
@@ -28313,6 +35807,12 @@
             "state" : "translated",
             "value" : "格式化查询 (⇧⌘L)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "格式化查詢 (⇧⌘L)"
+          }
         }
       }
     },
@@ -28336,6 +35836,12 @@
             "state" : "translated",
             "value" : "格式化查询 (⌥⌘F)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "格式化查詢 (⌥⌘F)"
+          }
         }
       }
     },
@@ -28354,6 +35860,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "格式化 SQL"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "格式化 SQL"
@@ -28380,6 +35892,12 @@
             "state" : "translated",
             "value" : "格式："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "格式："
+          }
         }
       }
     },
@@ -28401,6 +35919,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "格式化错误: %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "格式化錯誤：%@"
           }
         }
       }
@@ -28424,6 +35948,12 @@
             "state" : "translated",
             "value" : "不支持 %@ 的格式化"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支援 %@ 的格式化"
+          }
         }
       }
     },
@@ -28445,6 +35975,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从 %@…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從 %@…"
           }
         }
       }
@@ -28468,6 +36004,12 @@
             "state" : "translated",
             "value" : "FULL（重写整个表，阻止访问）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FULL(重寫整個資料表,封鎖存取)"
+          }
         }
       }
     },
@@ -28489,6 +36031,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "完全访问"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完整存取"
           }
         }
       }
@@ -28512,6 +36060,12 @@
             "state" : "translated",
             "value" : "完全访问，包含需要明确确认的破坏性 DDL。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完整存取,包含需明確確認的破壞性 DDL。"
+          }
         }
       }
     },
@@ -28533,6 +36087,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "函数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "函式"
           }
         }
       }
@@ -28556,6 +36116,12 @@
             "state" : "translated",
             "value" : "函数：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "函式：%@"
+          }
         }
       }
     },
@@ -28577,6 +36143,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "函数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "函式"
           }
         }
       }
@@ -28600,6 +36172,12 @@
             "state" : "translated",
             "value" : "通用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般"
+          }
         }
       }
     },
@@ -28621,6 +36199,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "生成"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "產生"
           }
         }
       }
@@ -28644,6 +36228,12 @@
             "state" : "translated",
             "value" : "生成令牌，让外部客户端使用自己的凭据进行连接。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "產生權杖,讓外部用戶端可使用自己的憑證連線。"
+          }
         }
       }
     },
@@ -28665,6 +36255,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "生成令牌"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "產生權杖"
           }
         }
       }
@@ -28688,6 +36284,12 @@
             "state" : "translated",
             "value" : "生成令牌"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "產生權杖"
+          }
         }
       }
     },
@@ -28709,6 +36311,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "生成的 WHERE 子句"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "產生的 WHERE 子句"
           }
         }
       }
@@ -28732,6 +36340,12 @@
             "state" : "translated",
             "value" : "生成失败。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "產生失敗。"
+          }
         }
       }
     },
@@ -28753,6 +36367,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "获取连接状态"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取得連線狀態"
           }
         }
       }
@@ -28776,6 +36396,12 @@
             "state" : "translated",
             "value" : "获取特定数据库连接的详细状态。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取得特定資料庫連線的詳細狀態。"
+          }
         }
       }
     },
@@ -28798,6 +36424,12 @@
             "state" : "translated",
             "value" : "获取数据库连接的详细状态"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取得資料庫連線的詳細狀態"
+          }
         }
       }
     },
@@ -28819,6 +36451,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "获取详细的表结构：列、索引、外键和 DDL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取得詳細的資料表結構：欄位、索引、外鍵和 DDL"
           }
         }
       }
@@ -28843,6 +36481,12 @@
             "state" : "translated",
             "value" : "获取编写查询、解释 Schema 或修复错误方面的帮助。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取得撰寫查詢、解釋綱要或修正錯誤的協助。"
+          }
         }
       }
     },
@@ -28864,6 +36508,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "获取智能 SQL 建议和查询辅助"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取得智慧 SQL 建議與查詢輔助"
           }
         }
       }
@@ -28887,6 +36537,12 @@
             "state" : "translated",
             "value" : "开始使用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始使用"
+          }
         }
       }
     },
@@ -28908,6 +36564,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "获取表 DDL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取得資料表 DDL"
           }
         }
       }
@@ -28931,6 +36593,12 @@
             "state" : "translated",
             "value" : "获取表的 CREATE TABLE DDL 语句"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取得資料表的 CREATE TABLE DDL 陳述式"
+          }
         }
       }
     },
@@ -28952,6 +36620,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "获取表的 DDL（CREATE 语句）。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取得資料表的 DDL（CREATE 陳述式）。"
           }
         }
       }
@@ -28975,6 +36649,12 @@
             "state" : "translated",
             "value" : "GitHub 仓库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub 儲存庫"
+          }
         }
       }
     },
@@ -28997,6 +36677,12 @@
             "state" : "translated",
             "value" : "全局"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全域"
+          }
         }
       }
     },
@@ -29018,6 +36704,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全局"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全域"
           }
         }
       }
@@ -29042,6 +36734,12 @@
             "state" : "translated",
             "value" : "全局："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全域："
+          }
         }
       }
     },
@@ -29060,6 +36758,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前往"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "前往"
@@ -29086,6 +36790,12 @@
             "state" : "translated",
             "value" : "跳转到指定页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳至指定頁"
+          }
         }
       }
     },
@@ -29107,6 +36817,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "前往设置…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前往設定…"
           }
         }
       }
@@ -29130,6 +36846,12 @@
             "state" : "translated",
             "value" : "Google Cloud 无服务器数据仓库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Google Cloud 無伺服器資料倉儲"
+          }
         }
       }
     },
@@ -29149,6 +36871,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "石墨"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "石墨"
@@ -29175,6 +36903,12 @@
             "state" : "translated",
             "value" : "灰色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "灰色"
+          }
         }
       }
     },
@@ -29196,6 +36930,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "大于或等于"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大於或等於"
           }
         }
       }
@@ -29219,6 +36959,12 @@
             "state" : "translated",
             "value" : "大于"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大於"
+          }
         }
       }
     },
@@ -29240,6 +36986,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "绿色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "綠色"
           }
         }
       }
@@ -29263,6 +37015,12 @@
             "state" : "translated",
             "value" : "分组"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "群組"
+          }
         }
       }
     },
@@ -29284,6 +37042,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "将所有连接分组到一个窗口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將所有連線群組到同一個視窗"
           }
         }
       }
@@ -29307,6 +37071,12 @@
             "state" : "translated",
             "value" : "分组名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "群組名稱"
+          }
         }
       }
     },
@@ -29328,6 +37098,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分组与标签："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "群組與標籤："
           }
         }
       }
@@ -29351,6 +37127,12 @@
             "state" : "translated",
             "value" : "未找到 gzip 可执行文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到 gzip 執行檔"
+          }
         }
       }
     },
@@ -29372,6 +37154,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "通过分享匿名使用统计数据帮助改进 TablePro（不包含个人数据或查询内容）。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分享匿名使用統計協助改善 TablePro(不含個人資料或查詢內容)。"
           }
         }
       }
@@ -29395,6 +37183,12 @@
             "state" : "translated",
             "value" : "十六进制字节"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "十六進位位元組"
+          }
         }
       }
     },
@@ -29416,6 +37210,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隐藏全部"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部隱藏"
           }
         }
       }
@@ -29439,6 +37239,12 @@
             "state" : "translated",
             "value" : "隐藏列"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱藏欄位"
+          }
         }
       }
     },
@@ -29461,6 +37267,12 @@
             "state" : "translated",
             "value" : "隐藏令牌"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱藏權杖"
+          }
         }
       }
     },
@@ -29479,6 +37291,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "高"
@@ -29506,6 +37324,12 @@
             "state" : "translated",
             "value" : "值越大，生成的 INSERT 语句越少，文件更小，导入更快"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "值越大,產生的 INSERT 陳述式越少,檔案更小且匯入更快"
+          }
         }
       }
     },
@@ -29527,6 +37351,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "高亮当前行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標示目前行"
           }
         }
       }
@@ -29550,6 +37380,12 @@
             "state" : "translated",
             "value" : "历史记录"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歷程記錄"
+          }
         }
       }
     },
@@ -29572,6 +37408,12 @@
             "state" : "translated",
             "value" : "条历史记录"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "筆歷程記錄"
+          }
         }
       }
     },
@@ -29593,6 +37435,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "条历史记录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "筆歷程記錄"
           }
         }
       }
@@ -29617,6 +37465,12 @@
             "state" : "translated",
             "value" : "历史记录上限："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歷程記錄上限："
+          }
         }
       }
     },
@@ -29639,6 +37493,12 @@
             "state" : "translated",
             "value" : "主页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "首頁"
+          }
         }
       }
     },
@@ -29660,6 +37520,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "主机"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主機"
           }
         }
       }
@@ -29686,6 +37552,12 @@
             "state" : "translated",
             "value" : "主机名"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主機名稱"
+          }
         }
       }
     },
@@ -29705,6 +37577,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "hostname:%lld"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "hostname:%lld"
@@ -29731,6 +37609,12 @@
             "state" : "translated",
             "value" : "主机"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主機"
+          }
         }
       }
     },
@@ -29753,6 +37637,12 @@
             "state" : "translated",
             "value" : "悬停"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停留"
+          }
         }
       }
     },
@@ -29772,6 +37662,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "超大"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "超大"
@@ -29798,6 +37694,12 @@
             "state" : "translated",
             "value" : "iCloud 账户不可用。请在系统设置中登录 iCloud。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 帳號無法使用。請在「系統設定」中登入 iCloud。"
+          }
         }
       }
     },
@@ -29819,6 +37721,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "iCloud 已连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 已連線"
           }
         }
       }
@@ -29842,6 +37750,12 @@
             "state" : "translated",
             "value" : "iCloud 服务器错误：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 伺服器錯誤：%@"
+          }
         }
       }
     },
@@ -29864,6 +37778,12 @@
             "state" : "translated",
             "value" : "iCloud 储存空间已满。请释放空间或减少历史记录同步上限。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 儲存空間已滿。請釋出空間或降低歷程記錄同步上限。"
+          }
         }
       }
     },
@@ -29882,6 +37802,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 同步"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "iCloud 同步"
@@ -29908,6 +37834,12 @@
             "state" : "translated",
             "value" : "iCloud 同步已启用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 同步已啟用"
+          }
         }
       }
     },
@@ -29926,6 +37858,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 同步："
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "iCloud 同步："
@@ -29953,6 +37891,12 @@
             "state" : "translated",
             "value" : "图标大小"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圖示大小"
+          }
         }
       }
     },
@@ -29974,6 +37918,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "如果 macOS 要求输入登录密码，请在每个提示中点按“始终允许”。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果 macOS 要求輸入登入密碼，請在每個提示中點按「總是允許」。"
           }
         }
       }
@@ -29997,6 +37947,12 @@
             "state" : "translated",
             "value" : "忽略外键检查"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "忽略外鍵檢查"
+          }
         }
       }
     },
@@ -30018,6 +37974,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导入"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入"
           }
         }
       }
@@ -30041,6 +38003,12 @@
             "state" : "translated",
             "value" : "导入 %@…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入 %@…"
+          }
         }
       }
     },
@@ -30062,6 +38030,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导入所有字段"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入所有欄位"
           }
         }
       }
@@ -30086,6 +38060,12 @@
             "state" : "translated",
             "value" : "用户已取消导入"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用者已取消匯入"
+          }
         }
       }
     },
@@ -30108,6 +38088,12 @@
             "state" : "translated",
             "value" : "导入完成"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入完成"
+          }
         }
       }
     },
@@ -30129,6 +38115,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导入完成但有错误"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入完成但有錯誤"
           }
         }
       }
@@ -30153,6 +38145,12 @@
             "state" : "translated",
             "value" : "从链接导入连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從連結匯入連線"
+          }
         }
       }
     },
@@ -30175,6 +38173,12 @@
             "state" : "translated",
             "value" : "导入连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入連線"
+          }
         }
       }
     },
@@ -30196,6 +38200,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导入连接…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入連線…"
           }
         }
       }
@@ -30220,6 +38230,12 @@
             "state" : "translated",
             "value" : "导入数据"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入資料"
+          }
         }
       }
     },
@@ -30243,6 +38259,12 @@
             "state" : "translated",
             "value" : "导入数据"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入資料"
+          }
         }
       }
     },
@@ -30265,6 +38287,12 @@
             "state" : "translated",
             "value" : "导入数据 (⌘⇧I)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入資料 (⌘⇧I)"
+          }
         }
       }
     },
@@ -30286,6 +38314,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导入失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入失敗"
           }
         }
       }
@@ -30316,6 +38350,12 @@
             "state" : "translated",
             "value" : "在第 %lld 行导入失败: %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在第 %1$lld 行匯入失敗：%2$@"
+          }
         }
       }
     },
@@ -30337,6 +38377,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导入格式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入格式"
           }
         }
       }
@@ -30360,6 +38406,12 @@
             "state" : "translated",
             "value" : "导入格式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入格式"
+          }
         }
       }
     },
@@ -30381,6 +38433,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从 %@ 导入"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從 %@ 匯入"
           }
         }
       }
@@ -30408,6 +38466,12 @@
             "state" : "translated",
             "value" : "从 DDL 导入"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從 DDL 匯入"
+          }
         }
       }
     },
@@ -30429,6 +38493,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从其他应用导入"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從其他 App 匯入"
           }
         }
       }
@@ -30452,6 +38522,12 @@
             "state" : "translated",
             "value" : "从其他应用导入…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從其他 App 匯入…"
+          }
         }
       }
     },
@@ -30473,6 +38549,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从 URL 导入"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從 URL 匯入"
           }
         }
       }
@@ -30496,6 +38578,12 @@
             "state" : "translated",
             "value" : "从 URL 导入..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從 URL 匯入..."
+          }
         }
       }
     },
@@ -30517,6 +38605,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导入到："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入到："
           }
         }
       }
@@ -30540,6 +38634,12 @@
             "state" : "translated",
             "value" : "%@ 连接不支持导入。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 連線不支援匯入。"
+          }
         }
       }
     },
@@ -30562,6 +38662,12 @@
             "state" : "translated",
             "value" : "不支持导入"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支援匯入"
+          }
         }
       }
     },
@@ -30583,6 +38689,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "将行导入表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將列匯入資料表"
           }
         }
       }
@@ -30607,6 +38719,12 @@
             "state" : "translated",
             "value" : "导入 SQL"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入 SQL"
+          }
         }
       }
     },
@@ -30628,6 +38746,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导入成功"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入成功"
           }
         }
       }
@@ -30651,6 +38775,12 @@
             "state" : "translated",
             "value" : "导入..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入…"
+          }
         }
       }
     },
@@ -30672,6 +38802,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导入…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入…"
           }
         }
       }
@@ -30695,6 +38831,12 @@
             "state" : "translated",
             "value" : "从 %1$@ 导入密码最多会读取 %2$d 个钥匙串项。由于每一项都归 %1$@ 所有，macOS 会针对每一项要求输入一次登录密码。请在每个提示中点按“始终允许”以授予 TablePro 永久访问权限。取消任一提示将跳过其余项。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從 %1$@ 匯入密碼最多會讀取 %2$d 個鑰匙圈項目。由於每一項都歸 %1$@ 所有，macOS 會針對每一項要求輸入一次登入密碼。請在每個提示中點按「總是允許」以授予 TablePro 永久存取權限。取消任一提示將略過其餘項目。"
+          }
         }
       }
     },
@@ -30717,6 +38859,12 @@
             "state" : "translated",
             "value" : "导入中..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入中…"
+          }
         }
       }
     },
@@ -30735,6 +38883,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IN 子句"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "IN 子句"
@@ -30761,6 +38915,12 @@
             "state" : "translated",
             "value" : "在列表中"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在清單中"
+          }
         }
       }
     },
@@ -30782,6 +38942,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "内存数据存储与缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記憶體內資料儲存與快取"
           }
         }
       }
@@ -30805,6 +38971,12 @@
             "state" : "translated",
             "value" : "非活跃"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "非作用中"
+          }
         }
       }
     },
@@ -30826,6 +38998,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "包含近似行数（默认 false）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含近似列數（預設為 false）"
           }
         }
       }
@@ -30850,6 +39028,12 @@
             "state" : "translated",
             "value" : "包含列标题"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含欄位標題"
+          }
         }
       }
     },
@@ -30871,6 +39055,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "包含凭据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含認證資訊"
           }
         }
       }
@@ -30894,6 +39084,12 @@
             "state" : "translated",
             "value" : "包含当前查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含目前查詢"
+          }
         }
       }
     },
@@ -30915,6 +39111,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "包含数据库 Schema"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含資料庫綱要"
           }
         }
       }
@@ -30939,6 +39141,12 @@
             "state" : "translated",
             "value" : "包含诊断信息"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含診斷資訊"
+          }
         }
       }
     },
@@ -30961,6 +39169,12 @@
             "state" : "translated",
             "value" : "包含在 iCloud 同步中"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "納入 iCloud 同步"
+          }
         }
       }
     },
@@ -30980,6 +39194,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含 NULL 值"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "包含 NULL 值"
@@ -31006,6 +39226,12 @@
             "state" : "translated",
             "value" : "包含密码"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含密碼"
+          }
         }
       }
     },
@@ -31028,6 +39254,12 @@
             "state" : "translated",
             "value" : "包含查询结果"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含查詢結果"
+          }
         }
       }
     },
@@ -31049,6 +39281,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "应用时包含此筛选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用時包含這個篩選條件"
           }
         }
       }
@@ -31073,6 +39311,12 @@
             "state" : "translated",
             "value" : "插件版本不兼容"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛版本不相容"
+          }
         }
       }
     },
@@ -31094,6 +39338,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "密码短语不正确"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密碼短語不正確"
           }
         }
       }
@@ -31117,6 +39367,12 @@
             "state" : "translated",
             "value" : "增大字号"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "增大字型大小"
+          }
         }
       }
     },
@@ -31135,6 +39391,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "增大文字大小"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "增大文字大小"
@@ -31161,6 +39423,12 @@
             "state" : "translated",
             "value" : "缩进"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "縮排"
+          }
         }
       }
     },
@@ -31180,6 +39448,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "索引"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "索引"
@@ -31207,6 +39481,12 @@
             "state" : "translated",
             "value" : "索引名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "索引名稱"
+          }
         }
       }
     },
@@ -31225,6 +39505,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "索引大小"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "索引大小"
@@ -31251,6 +39537,12 @@
             "state" : "translated",
             "value" : "索引"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "索引"
+          }
         }
       }
     },
@@ -31272,6 +39564,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "信息"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資訊"
           }
         }
       }
@@ -31301,6 +39599,12 @@
             "state" : "translated",
             "value" : "内联配置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行內設定"
+          }
         }
       }
     },
@@ -31322,6 +39626,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "内联 SQL 建议会在输入时出现。按 Tab 接受，按 Esc 取消。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行內 SQL 建議會在輸入時出現。按 Tab 接受，按 Esc 關閉。"
           }
         }
       }
@@ -31345,6 +39655,12 @@
             "state" : "translated",
             "value" : "行内建议"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行內建議"
+          }
         }
       }
     },
@@ -31363,6 +39679,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "插入"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "插入"
@@ -31389,6 +39711,12 @@
             "state" : "translated",
             "value" : "插入列"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "插入欄位"
+          }
         }
       }
     },
@@ -31410,6 +39738,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在后面插入列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在後方插入欄位"
           }
         }
       }
@@ -31433,6 +39767,12 @@
             "state" : "translated",
             "value" : "在前面插入列"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在前方插入欄位"
+          }
         }
       }
     },
@@ -31454,6 +39794,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "插入到编辑器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "插入到編輯器"
           }
         }
       }
@@ -31477,6 +39823,12 @@
             "state" : "translated",
             "value" : "插入到编辑器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "插入到編輯器"
+          }
         }
       }
     },
@@ -31498,6 +39850,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "插入行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "插入列"
           }
         }
       }
@@ -31521,6 +39879,12 @@
             "state" : "translated",
             "value" : "插入行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "插入列"
+          }
         }
       }
     },
@@ -31543,6 +39907,12 @@
             "state" : "translated",
             "value" : "INSERT 语句"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "INSERT 陳述式"
+          }
         }
       }
     },
@@ -31561,6 +39931,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已插入"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "已插入"
@@ -31587,6 +39963,12 @@
             "state" : "translated",
             "value" : "检查器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檢閱器"
+          }
         }
       }
     },
@@ -31608,6 +39990,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "安装"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安裝"
           }
         }
       }
@@ -31632,6 +40020,12 @@
             "state" : "translated",
             "value" : "从文件安装..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從檔案安裝…"
+          }
         }
       }
     },
@@ -31654,6 +40048,12 @@
             "state" : "translated",
             "value" : "安装插件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安裝外掛"
+          }
         }
       }
     },
@@ -31675,6 +40075,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从文件安装插件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從檔案安裝外掛"
           }
         }
       }
@@ -31699,6 +40105,12 @@
             "state" : "translated",
             "value" : "安装 %@ 的 CLI 客户端"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安裝 %@ 的 CLI 用戶端"
+          }
         }
       }
     },
@@ -31720,6 +40132,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "安装主题"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安裝主題"
           }
         }
       }
@@ -31743,6 +40161,12 @@
             "state" : "translated",
             "value" : "安装失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安裝失敗"
+          }
         }
       }
     },
@@ -31764,6 +40188,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已安装"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已安裝"
           }
         }
       }
@@ -31788,6 +40218,12 @@
             "state" : "translated",
             "value" : "已安装的插件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已安裝的外掛"
+          }
         }
       }
     },
@@ -31809,6 +40245,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "安装中..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安裝中…"
           }
         }
       }
@@ -31833,6 +40275,12 @@
             "state" : "translated",
             "value" : "正在安装…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安裝中…"
+          }
         }
       }
     },
@@ -31854,6 +40302,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "整数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "整數"
           }
         }
       }
@@ -31877,6 +40331,12 @@
             "state" : "translated",
             "value" : "集成"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "整合"
+          }
         }
       }
     },
@@ -31898,6 +40358,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "集成活动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "整合活動"
           }
         }
       }
@@ -31921,6 +40387,12 @@
             "state" : "translated",
             "value" : "集成：失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "整合：失敗"
+          }
         }
       }
     },
@@ -31942,6 +40414,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "集成：运行中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "整合：執行中"
           }
         }
       }
@@ -31965,6 +40443,12 @@
             "state" : "translated",
             "value" : "集成：运行中（%d 个客户端）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "整合：執行中（%d 個用戶端）"
+          }
         }
       }
     },
@@ -31986,6 +40470,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "集成：启动中…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "整合：啟動中…"
           }
         }
       }
@@ -32009,6 +40499,12 @@
             "state" : "translated",
             "value" : "集成：已停止"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "整合：已停止"
+          }
         }
       }
     },
@@ -32031,6 +40527,12 @@
             "state" : "translated",
             "value" : "交互式数据网格"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "互動式資料格線"
+          }
         }
       }
     },
@@ -32052,6 +40554,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "界面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "介面"
           }
         }
       }
@@ -32076,6 +40584,12 @@
             "state" : "translated",
             "value" : "无效的参数: %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無效的引數：%@"
+          }
         }
       }
     },
@@ -32097,6 +40611,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重排序操作的列索引无效"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新排序操作的欄位索引無效"
           }
         }
       }
@@ -32120,6 +40640,12 @@
             "state" : "translated",
             "value" : "连接 URL 格式无效"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線 URL 格式無效"
+          }
         }
       }
     },
@@ -32142,6 +40668,12 @@
             "state" : "translated",
             "value" : "数据格式无效: %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料格式無效：%@"
+          }
         }
       }
     },
@@ -32163,6 +40695,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无效的 Endpoint: %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無效的 Endpoint：%@"
           }
         }
       }
@@ -32187,6 +40725,12 @@
             "state" : "translated",
             "value" : "文件编码无效。请尝试其他编码选项。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檔案編碼無效。請嘗試其他編碼選項。"
+          }
         }
       }
     },
@@ -32209,6 +40753,12 @@
             "state" : "translated",
             "value" : "无效的十六进制"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "十六進位無效"
+          }
         }
       }
     },
@@ -32230,6 +40780,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无效的 JSON"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON 無效"
           }
         }
       }
@@ -32254,6 +40810,12 @@
             "state" : "translated",
             "value" : "无效的 JSON: %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON 無效：%@"
+          }
         }
       }
     },
@@ -32276,6 +40838,12 @@
             "state" : "translated",
             "value" : "许可证密钥格式无效。请检查是否有拼写错误后重试。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權金鑰格式無效。請檢查是否有拼字錯誤後再試一次。"
+          }
         }
       }
     },
@@ -32297,6 +40865,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无效的 LSP 响应"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LSP 回應無效"
           }
         }
       }
@@ -32321,6 +40895,12 @@
             "state" : "translated",
             "value" : "无效的 MongoDB 语法: %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MongoDB 語法無效：%@"
+          }
         }
       }
     },
@@ -32342,6 +40922,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无效的 PHP 序列化值"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無效的 PHP 序列化值"
           }
         }
       }
@@ -32365,6 +40951,12 @@
             "state" : "translated",
             "value" : "无效的插件包: %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛套件無效：%@"
+          }
         }
       }
     },
@@ -32386,6 +40978,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "用户名或密码无效"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用者名稱或密碼無效"
           }
         }
       }
@@ -32409,6 +41007,12 @@
             "state" : "translated",
             "value" : "无效的 UUID：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "UUID 無效：%@"
+          }
         }
       }
     },
@@ -32430,6 +41034,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不可见字符"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不可見字"
           }
         }
       }
@@ -32453,6 +41063,12 @@
             "state" : "translated",
             "value" : "为空"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "為空"
+          }
         }
       }
     },
@@ -32474,6 +41090,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不为空"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不為空"
           }
         }
       }
@@ -32497,6 +41119,12 @@
             "state" : "translated",
             "value" : "不为 NULL"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不為 NULL"
+          }
         }
       }
     },
@@ -32519,6 +41147,12 @@
             "state" : "translated",
             "value" : "为 NULL"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "為 NULL"
+          }
         }
       }
     },
@@ -32537,6 +41171,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ISO 8601 (2024-12-31 23:59:59)"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ISO 8601 (2024-12-31 23:59:59)"
@@ -32563,6 +41203,12 @@
             "state" : "translated",
             "value" : "ISO 日期 (2024-12-31)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ISO 日期 (2024-12-31)"
+          }
         }
       }
     },
@@ -32584,6 +41230,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "项目"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "項目"
           }
         }
       }
@@ -32607,6 +41259,12 @@
             "state" : "translated",
             "value" : "日志模式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日誌模式"
+          }
         }
       }
     },
@@ -32625,6 +41283,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "JSON"
@@ -32651,6 +41315,12 @@
             "state" : "translated",
             "value" : "JSON 过大"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON 過大"
+          }
         }
       }
     },
@@ -32672,6 +41342,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "JSON 查看器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON 檢視器"
           }
         }
       }
@@ -32695,6 +41371,12 @@
             "state" : "translated",
             "value" : "JSON 风格的文档数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON 風格的文件資料庫"
+          }
         }
       }
     },
@@ -32716,6 +41398,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "跳板主机配置无效"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳板主機設定無效"
           }
         }
       }
@@ -32739,6 +41427,12 @@
             "state" : "translated",
             "value" : "未找到跳板主机密钥：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到跳板主機金鑰：%@"
+          }
         }
       }
     },
@@ -32760,6 +41454,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Jump Host"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳板主機"
           }
         }
       }
@@ -32783,6 +41483,12 @@
             "state" : "translated",
             "value" : "Jump Host 按顺序连接后再连接到上方的 SSH 服务器。跳转仅支持密钥和 Agent 认证。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳板主機會依序連線,之後才連到上方的 SSH 伺服器。跳板僅支援金鑰與 Agent 認證。"
+          }
         }
       }
     },
@@ -32805,6 +41511,12 @@
             "state" : "translated",
             "value" : "继续备份"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "繼續備份"
+          }
         }
       }
     },
@@ -32826,6 +41538,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保留记录:"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保留記錄："
           }
         }
       }
@@ -32850,6 +41568,12 @@
             "state" : "translated",
             "value" : "通过将所有值输出为字符串来保留邮编、电话号码和 ID 中的前导零"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將所有值輸出為字串,以保留郵遞區號、電話號碼和 ID 中的前導零"
+          }
         }
       }
     },
@@ -32872,6 +41596,12 @@
             "state" : "translated",
             "value" : "保留我的更改"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保留我的變更"
+          }
         }
       }
     },
@@ -32890,6 +41620,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保留其他版本"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "保留其他版本"
@@ -32916,6 +41652,12 @@
             "state" : "translated",
             "value" : "继续恢复"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "繼續還原"
+          }
         }
       }
     },
@@ -32938,6 +41680,12 @@
             "state" : "translated",
             "value" : "继续运行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "繼續執行"
+          }
         }
       }
     },
@@ -32956,6 +41704,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保留此 Mac 的版本"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "保留此 Mac 的版本"
@@ -32982,6 +41736,12 @@
             "state" : "translated",
             "value" : "键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鍵"
+          }
         }
       }
     },
@@ -33004,6 +41764,12 @@
             "state" : "translated",
             "value" : "密钥文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "金鑰檔案"
+          }
         }
       }
     },
@@ -33025,6 +41791,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "密钥口令"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "金鑰密碼短語"
           }
         }
       }
@@ -33054,6 +41826,12 @@
             "state" : "translated",
             "value" : "键前缀根"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "索引鍵前綴根目錄"
+          }
         }
       }
     },
@@ -33075,6 +41853,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "键值"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鍵值"
           }
         }
       }
@@ -33098,6 +41882,12 @@
             "state" : "translated",
             "value" : "键盘"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鍵盤"
+          }
         }
       }
     },
@@ -33116,6 +41906,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keyboard Interactive"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Keyboard Interactive"
@@ -33142,6 +41938,12 @@
             "state" : "translated",
             "value" : "键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鍵"
+          }
         }
       }
     },
@@ -33163,6 +41965,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "密钥由 SSH Agent 提供（如 1Password、ssh-agent）。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "金鑰由 SSH Agent 提供(如 1Password、ssh-agent)。"
           }
         }
       }
@@ -33186,6 +41994,12 @@
             "state" : "translated",
             "value" : "关键字"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關鍵字"
+          }
         }
       }
     },
@@ -33207,6 +42021,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "关键字不能包含空格"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關鍵字不能包含空格"
           }
         }
       }
@@ -33231,6 +42051,12 @@
             "state" : "translated",
             "value" : "关键字："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關鍵字:"
+          }
         }
       }
     },
@@ -33252,6 +42078,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "关键字：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關鍵字:%@"
           }
         }
       }
@@ -33275,6 +42107,12 @@
             "state" : "translated",
             "value" : "语言:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "語言:"
+          }
         }
       }
     },
@@ -33294,6 +42132,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "大"
@@ -33320,6 +42164,12 @@
             "state" : "translated",
             "value" : "过去 7 天"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過去 7 天"
+          }
         }
       }
     },
@@ -33341,6 +42191,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "过去 24 小时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過去 24 小時"
           }
         }
       }
@@ -33364,6 +42220,12 @@
             "state" : "translated",
             "value" : "过去 30 天"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過去 30 天"
+          }
         }
       }
     },
@@ -33385,6 +42247,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最近活动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近活動"
           }
         }
       }
@@ -33408,6 +42276,12 @@
             "state" : "translated",
             "value" : "最后一页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最後一頁"
+          }
         }
       }
     },
@@ -33429,6 +42303,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最后一页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最後一頁"
           }
         }
       }
@@ -33452,6 +42332,12 @@
             "state" : "translated",
             "value" : "上次查询执行摘要"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上次查詢執行摘要"
+          }
         }
       }
     },
@@ -33473,6 +42359,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上次查询执行时间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上次查詢執行時間"
           }
         }
       }
@@ -33496,6 +42388,12 @@
             "state" : "translated",
             "value" : "上次查询耗时 %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上次查詢耗時 %@"
+          }
         }
       }
     },
@@ -33518,6 +42416,12 @@
             "state" : "translated",
             "value" : "上次查询: %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上次查詢:%@"
+          }
         }
       }
     },
@@ -33536,6 +42440,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上次同步 %@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "上次同步 %@"
@@ -33562,6 +42472,12 @@
             "state" : "translated",
             "value" : "上次同步："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上次同步:"
+          }
         }
       }
     },
@@ -33583,6 +42499,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "延迟：%dms"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "延遲:%dms"
           }
         }
       }
@@ -33607,6 +42529,12 @@
             "state" : "translated",
             "value" : "延迟: %lldms"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "延遲:%lldms"
+          }
         }
       }
     },
@@ -33628,6 +42556,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "要包含的最晚 executed_at，Unix 纪元秒（含，可选）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要包含的最晚 executed_at，Unix 紀元秒（含此值，選填）"
           }
         }
       }
@@ -33652,6 +42586,12 @@
             "state" : "translated",
             "value" : "布局"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版面配置"
+          }
         }
       }
     },
@@ -33673,6 +42613,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "支持数据库树的服务器上新建连接所用的布局。可在“视图”菜单中切换当前连接的布局。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支援資料庫樹狀結構的伺服器上，新連線所用的版面配置。可從「檢視」選單切換目前連線的版面配置。"
           }
         }
       }
@@ -33697,6 +42643,12 @@
             "state" : "translated",
             "value" : "长度"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "長度"
+          }
         }
       }
     },
@@ -33720,6 +42672,12 @@
             "state" : "translated",
             "value" : "长度:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "長度:"
+          }
         }
       }
     },
@@ -33741,6 +42699,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "小于或等于"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小於或等於"
           }
         }
       }
@@ -33764,6 +42728,12 @@
             "state" : "translated",
             "value" : "小于"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小於"
+          }
         }
       }
     },
@@ -33785,6 +42755,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "许可证"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權"
           }
         }
       }
@@ -33809,6 +42785,12 @@
             "state" : "translated",
             "value" : "许可证已过期 - 同步已暂停"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權已過期,同步已暫停"
+          }
         }
       }
     },
@@ -33830,6 +42812,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "许可证已过期，同步已暂停"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權已過期，同步已暫停"
           }
         }
       }
@@ -33859,6 +42847,12 @@
             "state" : "translated",
             "value" : "许可证将在 %lld 天后过期"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權將在 %lld 天後過期"
+          }
         }
       }
     },
@@ -33880,6 +42874,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "许可证密钥:"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權金鑰:"
           }
         }
       }
@@ -33903,6 +42903,12 @@
             "state" : "translated",
             "value" : "许可证公钥无效。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權公開金鑰無效。"
+          }
         }
       }
     },
@@ -33924,6 +42930,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "应用包中未找到许可证公钥。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在應用程式套件中找不到授權公開金鑰。"
           }
         }
       }
@@ -33947,6 +42959,12 @@
             "state" : "translated",
             "value" : "许可证已移除"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權已移除"
+          }
         }
       }
     },
@@ -33969,6 +42987,12 @@
             "state" : "translated",
             "value" : "许可证已从此 Mac 移除，但无法连接服务器。激活位可能需要到期后才能释放。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權已從此 Mac 移除,但無法連線到伺服器。啟用名額可能要到期後才會釋出。"
+          }
         }
       }
     },
@@ -33990,6 +43014,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "许可证签名验证失败。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權簽章驗證失敗。"
           }
         }
       }
@@ -34019,6 +43049,12 @@
             "state" : "translated",
             "value" : "许可证验证失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權驗證失敗"
+          }
         }
       }
     },
@@ -34040,6 +43076,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "许可证验证失败。请尝试更新到最新版本。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權驗證失敗。請嘗試將應用程式更新到最新版本。"
           }
         }
       }
@@ -34069,6 +43111,12 @@
             "state" : "translated",
             "value" : "终身"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "終身"
+          }
         }
       }
     },
@@ -34091,6 +43139,12 @@
             "state" : "translated",
             "value" : "浅色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "淺色"
+          }
         }
       }
     },
@@ -34110,6 +43164,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "限制"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "限制"
@@ -34142,6 +43202,12 @@
             "state" : "translated",
             "value" : "第 %lld 行：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %1$lld 行：%2$@"
+          }
         }
       }
     },
@@ -34165,6 +43231,12 @@
             "state" : "translated",
             "value" : "换行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "換行"
+          }
         }
       }
     },
@@ -34186,6 +43258,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "行号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行號"
           }
         }
       }
@@ -34209,6 +43287,12 @@
             "state" : "translated",
             "value" : "链接文件夹..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連結資料夾…"
+          }
         }
       }
     },
@@ -34230,6 +43314,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已链接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已連結"
           }
         }
       }
@@ -34253,6 +43343,12 @@
             "state" : "translated",
             "value" : "链接的文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已連結的檔案"
+          }
         }
       }
     },
@@ -34274,6 +43370,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "链接文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已連結資料夾"
           }
         }
       }
@@ -34297,6 +43399,12 @@
             "state" : "translated",
             "value" : "列表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清單"
+          }
         }
       }
     },
@@ -34318,6 +43426,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "列出服务器上的所有数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列出伺服器上的所有資料庫"
           }
         }
       }
@@ -34341,6 +43455,12 @@
             "state" : "translated",
             "value" : "列出所有已保存的数据库连接及其当前状态。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列出所有已儲存的資料庫連線及其目前狀態。"
+          }
         }
       }
     },
@@ -34362,6 +43482,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "列出所有已保存的数据库连接及其状态"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列出所有已儲存的資料庫連線及其狀態"
           }
         }
       }
@@ -34385,6 +43511,12 @@
             "state" : "translated",
             "value" : "列出可用命令"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列出可用的指令"
+          }
         }
       }
     },
@@ -34406,6 +43538,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "列出连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列出連線"
           }
         }
       }
@@ -34429,6 +43567,12 @@
             "state" : "translated",
             "value" : "列出所有 TablePro 窗口中当前打开的标签页。返回每个标签页的连接、标签页类型、表名和标题。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列出所有 TablePro 視窗中目前開啟的分頁。會回傳每個分頁的連線、分頁類型、資料表名稱與標題。"
+          }
         }
       }
     },
@@ -34450,6 +43594,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "列出数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列出資料庫"
           }
         }
       }
@@ -34473,6 +43623,12 @@
             "state" : "translated",
             "value" : "列出连接上可用的数据库。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列出連線上可用的資料庫。"
+          }
         }
       }
     },
@@ -34494,6 +43650,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "所有已保存数据库连接及其元数据的列表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有已儲存的資料庫連線及其中繼資料的清單"
           }
         }
       }
@@ -34517,6 +43679,12 @@
             "state" : "translated",
             "value" : "列出最近标签页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列出最近的分頁"
+          }
         }
       }
     },
@@ -34538,6 +43706,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "列出 Schema"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列出綱要"
           }
         }
       }
@@ -34561,6 +43735,12 @@
             "state" : "translated",
             "value" : "列出连接当前数据库中可用的 Schema。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列出連線目前資料庫中可用的綱要。"
+          }
         }
       }
     },
@@ -34582,6 +43762,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "列出数据库中的 Schema"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列出資料庫中的綱要"
           }
         }
       }
@@ -34605,6 +43791,12 @@
             "state" : "translated",
             "value" : "列出表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列出資料表"
+          }
         }
       }
     },
@@ -34626,6 +43818,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "列出数据库中的表和视图"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列出資料庫中的資料表與檢視表"
           }
         }
       }
@@ -34649,6 +43847,12 @@
             "state" : "translated",
             "value" : "列出连接当前数据库中的表和视图。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列出連線目前資料庫中的資料表與檢視表。"
+          }
         }
       }
     },
@@ -34671,6 +43875,12 @@
             "state" : "translated",
             "value" : "监听所有网络接口（0.0.0.0），可从本地网络访问。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "監聽所有網路介面（0.0.0.0），可從你的區域網路存取。"
+          }
         }
       }
     },
@@ -34692,6 +43902,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "仅监听 127.0.0.1。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只監聽 127.0.0.1。"
           }
         }
       }
@@ -34716,6 +43932,12 @@
             "state" : "translated",
             "value" : "加载"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入"
+          }
         }
       }
     },
@@ -34737,6 +43959,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在编辑器中加载"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在編輯器中載入"
           }
         }
       }
@@ -34760,6 +43988,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "加载模型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入模型"
           }
         }
       }
@@ -34787,6 +44021,12 @@
             "state" : "translated",
             "value" : "加载表模板"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入資料表範本"
+          }
         }
       }
     },
@@ -34809,6 +44049,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "加载模板"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入範本"
           }
         }
       }
@@ -34835,6 +44081,12 @@
             "state" : "translated",
             "value" : "正在加载仪表盘…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入儀表板…"
+          }
         }
       }
     },
@@ -34856,6 +44108,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在加载数据库..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入資料庫…"
           }
         }
       }
@@ -34879,6 +44137,12 @@
             "state" : "translated",
             "value" : "正在载入数据库…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入資料庫…"
+          }
         }
       }
     },
@@ -34901,6 +44165,12 @@
             "state" : "translated",
             "value" : "正在加载键…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入鍵…"
+          }
         }
       }
     },
@@ -34922,6 +44192,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在载入更多行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入更多列"
           }
         }
       }
@@ -34946,6 +44222,12 @@
             "state" : "translated",
             "value" : "正在加载选项…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入選項…"
+          }
         }
       }
     },
@@ -34968,6 +44250,12 @@
             "state" : "translated",
             "value" : "正在载入选项…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入選項…"
+          }
         }
       }
     },
@@ -34989,6 +44277,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在载入页面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入頁面"
           }
         }
       }
@@ -35013,6 +44307,12 @@
             "state" : "translated",
             "value" : "正在加载插件..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入外掛…"
+          }
         }
       }
     },
@@ -35034,6 +44334,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在加载架构..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入綱要…"
           }
         }
       }
@@ -35058,6 +44364,12 @@
             "state" : "translated",
             "value" : "正在加载 Schema..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入綱要…"
+          }
         }
       }
     },
@@ -35079,6 +44391,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在载入 Schema…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入綱要…"
           }
         }
       }
@@ -35103,6 +44421,12 @@
             "state" : "translated",
             "value" : "正在加载表..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入資料表…"
+          }
         }
       }
     },
@@ -35124,6 +44448,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在载入表…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入資料表…"
           }
         }
       }
@@ -35148,6 +44478,12 @@
             "state" : "translated",
             "value" : "加载中..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入中…"
+          }
         }
       }
     },
@@ -35170,6 +44506,12 @@
             "state" : "translated",
             "value" : "正在加载…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入…"
+          }
         }
       }
     },
@@ -35191,6 +44533,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "本地"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本機"
           }
         }
       }
@@ -35217,6 +44565,12 @@
             "state" : "translated",
             "value" : "本地监听器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本機監聽器"
+          }
         }
       }
     },
@@ -35238,6 +44592,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "仅本地"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅限本機"
           }
         }
       }
@@ -35262,6 +44622,12 @@
             "state" : "translated",
             "value" : "仅本地 - 不同步到 iCloud"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅限本機，不同步至 iCloud"
+          }
         }
       }
     },
@@ -35283,6 +44649,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "仅本地存储，不同步到 iCloud"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅儲存於本機，不會同步到 iCloud"
           }
         }
       }
@@ -35306,6 +44678,12 @@
             "state" : "translated",
             "value" : "本地端口"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本機連接埠"
+          }
         }
       }
     },
@@ -35328,6 +44706,12 @@
             "state" : "translated",
             "value" : "本地端口必须介于 1 到 65535 之间"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本機連接埠必須介於 1 到 65535 之間"
+          }
         }
       }
     },
@@ -35346,6 +44730,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "localhost"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "localhost"
@@ -35372,6 +44762,12 @@
             "state" : "translated",
             "value" : "位置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "位置"
+          }
         }
       }
     },
@@ -35394,6 +44790,12 @@
             "state" : "translated",
             "value" : "在历史记录中记录 MCP 查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在歷史紀錄中記錄 MCP 查詢"
+          }
         }
       }
     },
@@ -35412,6 +44814,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "低"
@@ -35438,6 +44846,12 @@
             "state" : "translated",
             "value" : "LSP 进程已退出，代码为 %d"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LSP 處理程序已結束，結束代碼為 %d"
+          }
         }
       }
     },
@@ -35460,6 +44874,12 @@
             "state" : "translated",
             "value" : "LSP 进程未运行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LSP 處理程序未在執行"
+          }
         }
       }
     },
@@ -35481,6 +44901,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "LSP 请求已取消"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LSP 要求已取消"
           }
         }
       }
@@ -35510,6 +44936,12 @@
             "state" : "translated",
             "value" : "LSP 服务器错误（%d）：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LSP 伺服器錯誤（%1$d）：%2$@"
+          }
         }
       }
     },
@@ -35531,6 +44963,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "macOS 将要求输入您的登录密码"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "macOS 會要求你輸入登入密碼"
           }
         }
       }
@@ -35554,6 +44992,12 @@
             "state" : "translated",
             "value" : "维护"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "維護"
+          }
         }
       }
     },
@@ -35573,6 +45017,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Majority"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Majority"
@@ -35599,6 +45049,12 @@
             "state" : "translated",
             "value" : "深层链接路径格式错误：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "深層連結路徑格式錯誤：%@"
+          }
         }
       }
     },
@@ -35620,6 +45076,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "管理连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理連線"
           }
         }
       }
@@ -35643,6 +45105,12 @@
             "state" : "translated",
             "value" : "管理连接..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理連線…"
+          }
         }
       }
     },
@@ -35664,6 +45132,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "管理标签"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理標籤"
           }
         }
       }
@@ -35687,6 +45161,12 @@
             "state" : "translated",
             "value" : "手动"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "手動"
+          }
         }
       }
     },
@@ -35705,6 +45185,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Markdown"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Markdown"
@@ -35732,6 +45218,12 @@
             "state" : "translated",
             "value" : "巨大"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "巨大"
+          }
         }
       }
     },
@@ -35753,6 +45245,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "匹配全部"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部符合"
           }
         }
       }
@@ -35777,6 +45275,12 @@
             "state" : "translated",
             "value" : "匹配所有筛选条件 (AND) 或任意筛选条件 (OR)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "符合所有篩選條件 (AND) 或任一篩選條件 (OR)"
+          }
         }
       }
     },
@@ -35798,6 +45302,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "匹配全部筛选条件或任一筛选条件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "符合所有篩選條件或任一篩選條件"
           }
         }
       }
@@ -35821,6 +45331,12 @@
             "state" : "translated",
             "value" : "匹配任一"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "符合任一"
+          }
         }
       }
     },
@@ -35842,6 +45358,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "匹配正则"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "符合正規表示式"
           }
         }
       }
@@ -35865,6 +45387,12 @@
             "state" : "translated",
             "value" : "物化视图"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "具體化檢視表"
+          }
         }
       }
     },
@@ -35886,6 +45414,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "物化视图"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "具體化檢視表"
           }
         }
       }
@@ -35909,6 +45443,12 @@
             "state" : "translated",
             "value" : "最多 %lld 个字符"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最多 %lld 個字"
+          }
         }
       }
     },
@@ -35930,6 +45470,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最大计费字节数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大計費位元組數"
           }
         }
       }
@@ -35953,6 +45499,12 @@
             "state" : "translated",
             "value" : "最大连接数"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大連線數"
+          }
         }
       }
     },
@@ -35975,6 +45527,12 @@
             "state" : "translated",
             "value" : "最大输出令牌数"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大輸出權杖數"
+          }
         }
       }
     },
@@ -35996,6 +45554,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最大架构表数：%d"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "綱要資料表上限：%d"
           }
         }
       }
@@ -36020,6 +45584,12 @@
             "state" : "translated",
             "value" : "Schema 最大表数：%lld"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "綱要資料表上限：%lld"
+          }
         }
       }
     },
@@ -36041,6 +45611,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最大天数不能为负数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大天數不能為負數"
           }
         }
       }
@@ -36064,6 +45640,12 @@
             "state" : "translated",
             "value" : "已达到最大深度"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已達到最大深度"
+          }
         }
       }
     },
@@ -36085,6 +45667,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最大条目数不能为负数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大項目數不能為負數"
           }
         }
       }
@@ -36108,6 +45696,12 @@
             "state" : "translated",
             "value" : "最大条目数："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大項目數："
+          }
         }
       }
     },
@@ -36129,6 +45723,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已达到最大激活数。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已達到最大啟用次數。"
           }
         }
       }
@@ -36152,6 +45752,12 @@
             "state" : "translated",
             "value" : "返回条目的最大数量（默认 50，最大 500）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回傳項目的最大數量（預設 50，最大 500）"
+          }
         }
       }
     },
@@ -36173,6 +45779,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最大行数限制"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大列數限制"
           }
         }
       }
@@ -36196,6 +45808,12 @@
             "state" : "translated",
             "value" : "导出行数上限（默认 50000）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出列數上限（預設 50000）"
+          }
         }
       }
     },
@@ -36217,6 +45835,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "返回行数上限（默认 500，最大 10000）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回傳列數上限（預設 500，最大 10000）"
           }
         }
       }
@@ -36240,6 +45864,12 @@
             "state" : "translated",
             "value" : "等待查询完成的最长时间。设为 0 表示不限制。应用于新连接。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等待查詢完成的最長時間。設為 0 表示不限制。套用至新連線。"
+          }
         }
       }
     },
@@ -36261,6 +45891,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "MCP 访问请求"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MCP 存取要求"
           }
         }
       }
@@ -36285,6 +45921,12 @@
             "state" : "translated",
             "value" : "MCP 配置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MCP 設定"
+          }
         }
       }
     },
@@ -36306,6 +45948,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "MCP 查询执行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MCP 查詢執行"
           }
         }
       }
@@ -36330,6 +45978,12 @@
             "state" : "translated",
             "value" : "MCP 服务器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MCP 伺服器"
+          }
         }
       }
     },
@@ -36352,6 +46006,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "MCP 服务器：失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MCP 伺服器：失敗"
           }
         }
       }
@@ -36376,6 +46036,12 @@
             "state" : "translated",
             "value" : "MCP 服务器：运行中"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MCP 伺服器：執行中"
+          }
         }
       }
     },
@@ -36398,6 +46064,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "MCP 服务器：运行中（%d 个客户端）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MCP 伺服器：執行中（%d 個用戶端）"
           }
         }
       }
@@ -36422,6 +46094,12 @@
             "state" : "translated",
             "value" : "MCP 服务器：正在启动…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MCP 伺服器：正在啟動…"
+          }
         }
       }
     },
@@ -36444,6 +46122,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "MCP 服务器：已停止"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MCP 伺服器：已停止"
           }
         }
       }
@@ -36468,6 +46152,12 @@
             "state" : "translated",
             "value" : "MCP 设置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MCP 設定"
+          }
         }
       }
     },
@@ -36486,6 +46176,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中等"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "中等"
@@ -36512,6 +46208,12 @@
             "state" : "translated",
             "value" : "中等"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中等"
+          }
         }
       }
     },
@@ -36533,6 +46235,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "内存限制"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記憶體限制"
           }
         }
       }
@@ -36556,6 +46264,12 @@
             "state" : "translated",
             "value" : "消息过大。请尝试在 AI 设置中禁用“包含 schema”或“包含查询结果”。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "訊息過大。請嘗試在 AI 設定中停用「包含綱要」或「包含查詢結果」。"
+          }
         }
       }
     },
@@ -36578,6 +46292,12 @@
             "state" : "translated",
             "value" : "元数据"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中繼資料"
+          }
         }
       }
     },
@@ -36596,6 +46316,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "方法"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "方法"
@@ -36622,6 +46348,12 @@
             "state" : "translated",
             "value" : "MFA 验证码（TOTP）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MFA 驗證碼（TOTP）"
+          }
         }
       }
     },
@@ -36644,6 +46376,12 @@
             "state" : "translated",
             "value" : "Microsoft 的企业级 SQL 数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Microsoft 的企業級 SQL 資料庫"
+          }
         }
       }
     },
@@ -36665,6 +46403,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "极简"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "極簡"
           }
         }
       }
@@ -36689,6 +46433,12 @@
             "state" : "translated",
             "value" : "缺少参数：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缺少引數：%@"
+          }
         }
       }
     },
@@ -36710,6 +46460,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "缺少必需参数：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缺少必要參數：%@"
           }
         }
       }
@@ -36733,6 +46489,12 @@
             "state" : "translated",
             "value" : "参数缺少值：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "參數缺少值：%@"
+          }
         }
       }
     },
@@ -36751,6 +46513,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模式"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "模式"
@@ -36777,6 +46545,12 @@
             "state" : "translated",
             "value" : "Model"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Model"
+          }
         }
       }
     },
@@ -36795,6 +46569,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模型 ID"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "模型 ID"
@@ -36822,6 +46602,12 @@
             "state" : "translated",
             "value" : "模型名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模型名稱"
+          }
         }
       }
     },
@@ -36844,6 +46630,12 @@
             "state" : "translated",
             "value" : "未找到模型：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到模型：%@"
+          }
         }
       }
     },
@@ -36862,6 +46654,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已修改"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "已修改"
@@ -36888,6 +46686,12 @@
             "state" : "translated",
             "value" : "修改时间："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "修改時間："
+          }
         }
       }
     },
@@ -36910,6 +46714,12 @@
             "state" : "translated",
             "value" : "需要修饰键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要修飾鍵"
+          }
         }
       }
     },
@@ -36929,6 +46739,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MongoDB"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "MongoDB"
@@ -36955,6 +46771,12 @@
             "state" : "translated",
             "value" : "MongoDB 驱动没有 TLS 回退。“首选”和“必需”都会强制使用 TLS。连接 MongoDB Atlas 和其他托管实例时请使用“必需”。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MongoDB 驅動程式沒有 TLS 後備機制。「偏好」和「必要」都會強制使用 TLS。連接 MongoDB Atlas 與其他託管執行個體時請使用「必要」。"
+          }
         }
       }
     },
@@ -36976,6 +46798,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "MongoDB 查询语言。用于导入到 MongoDB。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MongoDB 查詢語言。用於匯入 MongoDB。"
           }
         }
       }
@@ -36999,6 +46827,12 @@
             "state" : "translated",
             "value" : "最流行的开源 SQL 数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最熱門的開放原始碼 SQL 資料庫"
+          }
         }
       }
     },
@@ -37018,6 +46852,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下移"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "下移"
@@ -37045,6 +46885,12 @@
             "state" : "translated",
             "value" : "下移 (⌘↓)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下移 (⌘↓)"
+          }
         }
       }
     },
@@ -37066,6 +46912,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "将文件移到废纸篓"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將檔案移到垃圾桶"
           }
         }
       }
@@ -37089,6 +46941,12 @@
             "state" : "translated",
             "value" : "要将文件移到废纸篓吗？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要將檔案移到垃圾桶嗎？"
+          }
         }
       }
     },
@@ -37110,6 +46968,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "移动分组到..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移動群組至…"
           }
         }
       }
@@ -37133,6 +46997,12 @@
             "state" : "translated",
             "value" : "下移一行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將該行下移"
+          }
         }
       }
     },
@@ -37154,6 +47024,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上移一行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將該行上移"
           }
         }
       }
@@ -37177,6 +47053,12 @@
             "state" : "translated",
             "value" : "移动到"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移動至"
+          }
         }
       }
     },
@@ -37198,6 +47080,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "移动到分组"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移動至群組"
           }
         }
       }
@@ -37221,6 +47109,12 @@
             "state" : "translated",
             "value" : "移到废纸篓"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移到垃圾桶"
+          }
         }
       }
     },
@@ -37240,6 +47134,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上移"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "上移"
@@ -37267,6 +47167,12 @@
             "state" : "translated",
             "value" : "上移 (⌘↑)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上移 (⌘↑)"
+          }
         }
       }
     },
@@ -37286,6 +47192,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MQL"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "MQL"
@@ -37313,6 +47225,12 @@
             "state" : "translated",
             "value" : "MQL 预览"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MQL 預覽"
+          }
         }
       }
     },
@@ -37334,6 +47252,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此客户端不允许执行多条语句"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此用戶端不允許執行多條語句"
           }
         }
       }
@@ -37357,6 +47281,12 @@
             "state" : "translated",
             "value" : "多个值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "多個值"
+          }
         }
       }
     },
@@ -37378,6 +47308,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "必须完全输入：I understand this is irreversible"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "必須完全輸入：I understand this is irreversible"
           }
         }
       }
@@ -37407,6 +47343,12 @@
             "state" : "translated",
             "value" : "我的服务器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "我的伺服器"
+          }
         }
       }
     },
@@ -37425,6 +47367,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MySQL、PostgreSQL 和 SQLite"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "MySQL、PostgreSQL 和 SQLite"
@@ -37451,6 +47399,12 @@
             "state" : "translated",
             "value" : "名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名稱"
+          }
         }
       }
     },
@@ -37472,6 +47426,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "名称"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名稱"
           }
         }
       }
@@ -37496,6 +47456,12 @@
             "state" : "translated",
             "value" : "名称："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名稱："
+          }
         }
       }
     },
@@ -37518,6 +47484,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "跳转到引用行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前往參照的列"
           }
         }
       }
@@ -37542,6 +47514,12 @@
             "state" : "translated",
             "value" : "翻页将重新加载数据并丢弃所有未保存的更改。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻頁將重新載入資料並捨棄所有未儲存的變更。"
+          }
         }
       }
     },
@@ -37563,6 +47541,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导航到其他页面将丢弃所有未保存的更改。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前往其他頁面將捨棄所有未儲存的變更。"
           }
         }
       }
@@ -37586,6 +47570,12 @@
             "state" : "translated",
             "value" : "导航"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "導覽"
+          }
         }
       }
     },
@@ -37605,6 +47595,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nearest"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nearest"
@@ -37631,6 +47627,12 @@
             "state" : "translated",
             "value" : "网络"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網路"
+          }
         }
       }
     },
@@ -37652,6 +47654,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "网络错误：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網路錯誤：%@"
           }
         }
       }
@@ -37675,6 +47683,12 @@
             "state" : "translated",
             "value" : "网络不可用。恢复连接后将自动同步更改。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網路無法使用。連線恢復後將自動同步變更。"
+          }
         }
       }
     },
@@ -37696,6 +47710,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从不"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "永不"
           }
         }
       }
@@ -37719,6 +47739,12 @@
             "state" : "translated",
             "value" : "从未使用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從未使用"
+          }
         }
       }
     },
@@ -37740,6 +47766,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新建"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增"
           }
         }
       }
@@ -37769,6 +47801,12 @@
             "state" : "translated",
             "value" : "新建%@连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增 %@ 連線"
+          }
         }
       }
     },
@@ -37795,6 +47833,12 @@
             "state" : "translated",
             "value" : "新建对话"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增對話"
+          }
         }
       }
     },
@@ -37816,6 +47860,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新建连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增連線"
           }
         }
       }
@@ -37839,6 +47889,12 @@
             "state" : "translated",
             "value" : "新建连接 (⌘N)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增連線 (⌘N)"
+          }
         }
       }
     },
@@ -37861,6 +47917,12 @@
             "state" : "translated",
             "value" : "新建连接..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增連線…"
+          }
         }
       }
     },
@@ -37882,6 +47944,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新建会话"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增對話"
           }
         }
       }
@@ -37906,6 +47974,12 @@
             "state" : "translated",
             "value" : "新建数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增資料庫"
+          }
         }
       }
     },
@@ -37928,6 +48002,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新建数据库 (⌘N)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增資料庫（⌘N）"
           }
         }
       }
@@ -37952,6 +48032,12 @@
             "state" : "translated",
             "value" : "新建数据库…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增資料庫…"
+          }
         }
       }
     },
@@ -37973,6 +48059,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新建收藏"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增我的最愛"
           }
         }
       }
@@ -37996,6 +48088,12 @@
             "state" : "translated",
             "value" : "新建收藏…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增我的最愛…"
+          }
         }
       }
     },
@@ -38017,6 +48115,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新建文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增資料夾"
           }
         }
       }
@@ -38040,6 +48144,12 @@
             "state" : "translated",
             "value" : "新建分组"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增群組"
+          }
         }
       }
     },
@@ -38062,6 +48172,12 @@
             "state" : "translated",
             "value" : "新建分组…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增群組…"
+          }
         }
       }
     },
@@ -38083,6 +48199,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新建 Jump Host"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增 Jump Host"
           }
         }
       }
@@ -38107,6 +48229,12 @@
             "state" : "translated",
             "value" : "新建查询标签页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增查詢分頁"
+          }
         }
       }
     },
@@ -38130,6 +48258,12 @@
             "state" : "translated",
             "value" : "新建查询标签页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增查詢分頁"
+          }
         }
       }
     },
@@ -38151,6 +48285,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新建查询标签页 (⌘T)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增查詢分頁 (⌘T)"
           }
         }
       }
@@ -38174,6 +48314,12 @@
             "state" : "translated",
             "value" : "新建子文件夹"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增子資料夾"
+          }
         }
       }
     },
@@ -38195,6 +48341,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新建子分组"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增子群組"
           }
         }
       }
@@ -38218,6 +48370,12 @@
             "state" : "translated",
             "value" : "新建标签页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增分頁"
+          }
         }
       }
     },
@@ -38239,6 +48397,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新建表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增資料表"
           }
         }
       }
@@ -38262,6 +48426,12 @@
             "state" : "translated",
             "value" : "新建表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增資料表"
+          }
         }
       }
     },
@@ -38283,6 +48453,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新建表："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增資料表："
           }
         }
       }
@@ -38306,6 +48482,12 @@
             "state" : "translated",
             "value" : "新建主题"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增主題"
+          }
         }
       }
     },
@@ -38327,6 +48509,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新建视图"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增檢視表"
           }
         }
       }
@@ -38350,6 +48538,12 @@
             "state" : "translated",
             "value" : "新建视图..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增檢視表…"
+          }
         }
       }
     },
@@ -38372,6 +48566,12 @@
             "state" : "translated",
             "value" : "下一页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一頁"
+          }
         }
       }
     },
@@ -38393,6 +48593,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下一页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一頁"
           }
         }
       }
@@ -38417,6 +48623,12 @@
             "state" : "translated",
             "value" : "下一页 (⌘])"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一頁 (⌘])"
+          }
         }
       }
     },
@@ -38438,6 +48650,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下一个结果"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一個結果"
           }
         }
       }
@@ -38462,6 +48680,12 @@
             "state" : "translated",
             "value" : "下一个标签页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一個分頁"
+          }
         }
       }
     },
@@ -38485,6 +48709,12 @@
             "state" : "translated",
             "value" : "下一个标签页 (Alt)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一個分頁 (Alt)"
+          }
         }
       }
     },
@@ -38506,6 +48736,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "没有%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有 %@"
           }
         }
       }
@@ -38538,6 +48774,12 @@
             "state" : "translated",
             "value" : "未找到激活记录"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到啟用記錄"
+          }
         }
       }
     },
@@ -38559,6 +48801,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无活动连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無使用中的連線"
           }
         }
       }
@@ -38582,6 +48830,12 @@
             "state" : "translated",
             "value" : "没有活动的数据库连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有使用中的資料庫連線"
+          }
         }
       }
     },
@@ -38603,6 +48857,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "没有与当前筛选条件匹配的活动。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有符合目前篩選條件的活動。"
           }
         }
       }
@@ -38626,6 +48886,12 @@
             "state" : "translated",
             "value" : "暂无活动"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚無活動"
+          }
         }
       }
     },
@@ -38647,6 +48913,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "尚未配置 AI 提供商。前往设置 > AI 添加。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚未設定 AI 供應商。請前往「設定 > AI」新增。"
           }
         }
       }
@@ -38670,6 +48942,12 @@
             "state" : "translated",
             "value" : "没有可用的本地端口用于 SSH 隧道"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有可用的本機連接埠供 SSH 隧道使用"
+          }
         }
       }
     },
@@ -38691,6 +48969,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "没有可用于 Cloudflare 隧道的本地端口。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有可用於 Cloudflare 隧道的本機連接埠。"
           }
         }
       }
@@ -38715,6 +48999,12 @@
             "state" : "translated",
             "value" : "无可预览的更改"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有可預覽的變更"
+          }
         }
       }
     },
@@ -38737,6 +49027,12 @@
             "state" : "translated",
             "value" : "无检查约束"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無檢查約束"
+          }
         }
       }
     },
@@ -38758,6 +49054,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "没有已连接的客户端"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有已連線的用戶端"
           }
         }
       }
@@ -38784,6 +49086,12 @@
             "state" : "translated",
             "value" : "尚未定义列"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚未定義欄位"
+          }
         }
       }
     },
@@ -38805,6 +49113,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "目前还没有兼容的构建版本。发布后此插件将自动更新。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前還沒有相容的建置版本。發布後此外掛將自動更新。"
           }
         }
       }
@@ -38828,6 +49142,12 @@
             "state" : "translated",
             "value" : "没有连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有連線"
+          }
         }
       }
     },
@@ -38849,6 +49169,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無連線"
           }
         }
       }
@@ -38872,6 +49198,12 @@
             "state" : "translated",
             "value" : "没有找到可导入的连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到可匯入的連線"
+          }
         }
       }
     },
@@ -38894,6 +49226,12 @@
             "state" : "translated",
             "value" : "未导入任何连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未匯入任何連線"
+          }
         }
       }
     },
@@ -38915,6 +49253,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "没有与“%@”匹配的连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有符合「%@」的連線"
           }
         }
       }
@@ -38939,6 +49283,12 @@
             "state" : "translated",
             "value" : "暂无连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚無連線"
+          }
         }
       }
     },
@@ -38960,6 +49310,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "还没有自定义命令。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "還沒有自訂指令。"
           }
         }
       }
@@ -38983,6 +49339,12 @@
             "state" : "translated",
             "value" : "无数据"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無資料"
+          }
         }
       }
     },
@@ -39004,6 +49366,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未连接数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未連線資料庫"
           }
         }
       }
@@ -39027,6 +49395,12 @@
             "state" : "translated",
             "value" : "没有数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有資料庫"
+          }
         }
       }
     },
@@ -39048,6 +49422,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "没有数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有資料庫"
           }
         }
       }
@@ -39072,6 +49452,12 @@
             "state" : "translated",
             "value" : "未找到数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到資料庫"
+          }
         }
       }
     },
@@ -39095,6 +49481,12 @@
             "state" : "translated",
             "value" : "没有匹配 \"%@\" 的数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有符合「%@」的資料庫"
+          }
         }
       }
     },
@@ -39116,6 +49508,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "没有与“%@”匹配的数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有符合「%@」的資料庫"
           }
         }
       }
@@ -39142,6 +49540,12 @@
             "state" : "translated",
             "value" : "没有数据集"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有資料集"
+          }
         }
       }
     },
@@ -39163,6 +49567,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无可用 DDL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無可用的 DDL"
           }
         }
       }
@@ -39186,6 +49596,12 @@
             "state" : "translated",
             "value" : "无可用的导出格式。请在设置 > 插件中启用导出插件。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有可用的匯出格式。請在「設定 > 外掛」中啟用匯出外掛。"
+          }
         }
       }
     },
@@ -39208,6 +49624,12 @@
             "state" : "translated",
             "value" : "无收藏"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無我的最愛"
+          }
         }
       }
     },
@@ -39229,6 +49651,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "尚无外键"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚無外鍵"
           }
         }
       }
@@ -39258,6 +49686,12 @@
             "state" : "translated",
             "value" : "在 %d-%d 范围内没有可用端口"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 %1$d-%2$d 範圍內沒有可用的連接埠"
+          }
         }
       }
     },
@@ -39279,6 +49713,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无 iCloud"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無 iCloud"
           }
         }
       }
@@ -39302,6 +49742,12 @@
             "state" : "translated",
             "value" : "尚未定义索引"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚未定義索引"
+          }
         }
       }
     },
@@ -39323,6 +49769,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "没有项目"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有項目"
           }
         }
       }
@@ -39346,6 +49798,12 @@
             "state" : "translated",
             "value" : "没有键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有鍵"
+          }
         }
       }
     },
@@ -39364,6 +49822,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不限制"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "不限制"
@@ -39390,6 +49854,12 @@
             "state" : "translated",
             "value" : "没有链接文件夹。添加文件夹以监视共享连接文件。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有已連結的資料夾。新增資料夾以監看共用的連線檔案。"
+          }
         }
       }
     },
@@ -39413,6 +49883,12 @@
             "state" : "translated",
             "value" : "没有匹配的%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有符合的 %@"
+          }
         }
       }
     },
@@ -39434,6 +49910,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "没有匹配的活动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有符合的活動"
           }
         }
       }
@@ -39458,6 +49940,12 @@
             "state" : "translated",
             "value" : "无匹配连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無符合的連線"
+          }
         }
       }
     },
@@ -39479,6 +49967,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无匹配连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無符合的連線"
           }
         }
       }
@@ -39503,6 +49997,12 @@
             "state" : "translated",
             "value" : "无匹配数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無符合的資料庫"
+          }
         }
       }
     },
@@ -39526,6 +50026,12 @@
             "state" : "translated",
             "value" : "无匹配的收藏"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無符合的我的最愛"
+          }
         }
       }
     },
@@ -39547,6 +50053,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无匹配字段"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無符合的欄位"
           }
         }
       }
@@ -39571,6 +50083,12 @@
             "state" : "translated",
             "value" : "没有匹配的对象"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有符合的物件"
+          }
         }
       }
     },
@@ -39593,6 +50111,12 @@
             "state" : "translated",
             "value" : "无匹配查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無符合的查詢"
+          }
         }
       }
     },
@@ -39614,6 +50138,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "没有匹配的行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有符合的列"
           }
         }
       }
@@ -39638,6 +50168,12 @@
             "state" : "translated",
             "value" : "无匹配 Schema"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無符合的綱要"
+          }
         }
       }
     },
@@ -39660,6 +50196,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无匹配表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無符合的資料表"
           }
         }
       }
@@ -39684,6 +50226,12 @@
             "state" : "translated",
             "value" : "未选择模型"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未選擇模型"
+          }
         }
       }
     },
@@ -39706,6 +50254,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未加载模型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未載入模型"
           }
         }
       }
@@ -39730,6 +50284,12 @@
             "state" : "translated",
             "value" : "未找到对象"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到物件"
+          }
         }
       }
     },
@@ -39753,6 +50313,12 @@
             "state" : "translated",
             "value" : "没有匹配\"%@\"的对象"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有符合「%@」的物件"
+          }
         }
       }
     },
@@ -39775,6 +50341,12 @@
             "state" : "translated",
             "value" : "未找到分区"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到分割區"
+          }
         }
       }
     },
@@ -39796,6 +50368,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无待处理的更改"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無待處理的變更"
           }
         }
       }
@@ -39820,6 +50398,12 @@
             "state" : "translated",
             "value" : "未找到插件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到外掛"
+          }
         }
       }
     },
@@ -39843,6 +50427,12 @@
             "state" : "translated",
             "value" : "未选择主键（不推荐）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未選擇主鍵（不建議）"
+          }
         }
       }
     },
@@ -39864,6 +50454,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未配置提供商"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未設定供應商"
           }
         }
       }
@@ -39887,6 +50483,12 @@
             "state" : "translated",
             "value" : "尚未执行查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚未執行查詢"
+          }
         }
       }
     },
@@ -39908,6 +50510,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暂无查询历史"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚無查詢記錄"
           }
         }
       }
@@ -39934,6 +50542,12 @@
             "state" : "translated",
             "value" : "无行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有資料列"
+          }
         }
       }
     },
@@ -39955,6 +50569,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未返回任何行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未傳回任何列"
           }
         }
       }
@@ -39979,6 +50599,12 @@
             "state" : "translated",
             "value" : "没有名为 \"%@\" 的已保存连接。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有名為「%@」的已儲存連線。"
+          }
         }
       }
     },
@@ -40001,6 +50627,12 @@
             "state" : "translated",
             "value" : "未找到 ID 为 \"%@\" 的已保存连接。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到 ID 為「%@」的已儲存連線。"
+          }
         }
       }
     },
@@ -40022,6 +50654,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "没有已保存的连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有已儲存的連線"
           }
         }
       }
@@ -40046,6 +50684,12 @@
             "state" : "translated",
             "value" : "无已保存的模板"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無已儲存的範本"
+          }
         }
       }
     },
@@ -40067,6 +50711,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "没有 Schema"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有綱要"
           }
         }
       }
@@ -40091,6 +50741,12 @@
             "state" : "translated",
             "value" : "未找到 Schema"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到綱要"
+          }
         }
       }
     },
@@ -40114,6 +50770,12 @@
             "state" : "translated",
             "value" : "没有匹配 \"%@\" 的 Schema"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有符合「%@」的綱要"
+          }
         }
       }
     },
@@ -40135,6 +50797,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未选择"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未選取"
           }
         }
       }
@@ -40158,6 +50826,12 @@
             "state" : "translated",
             "value" : "未选择"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未選取"
+          }
         }
       }
     },
@@ -40179,6 +50853,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "没有慢查询"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有慢查詢"
           }
         }
       }
@@ -40202,6 +50882,12 @@
             "state" : "translated",
             "value" : "不排序（引擎顺序）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不排序（引擎順序）"
+          }
         }
       }
     },
@@ -40224,6 +50910,12 @@
             "state" : "translated",
             "value" : "无 SSL 加密"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無 SSL 加密"
+          }
         }
       }
     },
@@ -40245,6 +50937,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "没有表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有資料表"
           }
         }
       }
@@ -40269,6 +50967,12 @@
             "state" : "translated",
             "value" : "无表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有資料表"
+          }
         }
       }
     },
@@ -40290,6 +50994,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未找到表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到資料表"
           }
         }
       }
@@ -40313,6 +51023,12 @@
             "state" : "translated",
             "value" : "未选择要导出的表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未選取要匯出的資料表"
+          }
         }
       }
     },
@@ -40334,6 +51050,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "没有打开的标签页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有開啟的分頁"
           }
         }
       }
@@ -40357,6 +51079,12 @@
             "state" : "translated",
             "value" : "未创建令牌"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚未建立權杖"
+          }
         }
       }
     },
@@ -40378,6 +51106,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "剪贴板数据中未找到有效行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在剪貼簿資料中找不到有效的列。"
           }
         }
       }
@@ -40402,6 +51136,12 @@
             "state" : "translated",
             "value" : "未找到值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到值"
+          }
         }
       }
     },
@@ -40423,6 +51163,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "非 UTF-8 文件（%@）。保存可能会改变编码。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "非 UTF-8 檔案（%@）。儲存可能會改變編碼。"
           }
         }
       }
@@ -40446,6 +51192,12 @@
             "state" : "translated",
             "value" : "无"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無"
+          }
         }
       }
     },
@@ -40467,6 +51219,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无（顶级）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無（最上層）"
           }
         }
       }
@@ -40490,6 +51248,12 @@
             "state" : "translated",
             "value" : "正常"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般"
+          }
         }
       }
     },
@@ -40512,6 +51276,12 @@
             "state" : "translated",
             "value" : "不可用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法使用"
+          }
         }
       }
     },
@@ -40533,6 +51303,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未配置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未設定"
           }
         }
       }
@@ -40557,6 +51333,12 @@
             "state" : "translated",
             "value" : "未连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未連線"
+          }
         }
       }
     },
@@ -40578,6 +51360,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未连接到 ClickHouse"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未連線到 ClickHouse"
           }
         }
       }
@@ -40601,6 +51389,12 @@
             "state" : "translated",
             "value" : "未连接到数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未連線到資料庫"
+          }
         }
       }
     },
@@ -40619,6 +51413,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不包含"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "不包含"
@@ -40645,6 +51445,12 @@
             "state" : "translated",
             "value" : "不等于"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不等於"
+          }
         }
       }
     },
@@ -40666,6 +51472,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不在列表中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不在清單中"
           }
         }
       }
@@ -40689,6 +51501,12 @@
             "state" : "translated",
             "value" : "未安装"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未安裝"
+          }
         }
       }
     },
@@ -40711,6 +51529,12 @@
             "state" : "translated",
             "value" : "未安装"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未安裝"
+          }
         }
       }
     },
@@ -40730,6 +51554,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NOT NULL"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "NOT NULL"
@@ -40755,6 +51585,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未登录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未登入"
           }
         }
       }
@@ -40784,6 +51620,12 @@
             "state" : "translated",
             "value" : "未登录 GitHub Copilot"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未登入 GitHub Copilot"
+          }
         }
       }
     },
@@ -40805,6 +51647,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此数据库不支持。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此資料庫不支援。"
           }
         }
       }
@@ -40828,6 +51676,12 @@
             "state" : "translated",
             "value" : "此数据库不支持。请使用 CASCADE 代替。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此資料庫不支援。請改用 CASCADE。"
+          }
         }
       }
     },
@@ -40850,6 +51704,12 @@
             "state" : "translated",
             "value" : "此数据库不支持 TRUNCATE"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此資料庫不支援 TRUNCATE"
+          }
         }
       }
     },
@@ -40869,6 +51729,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NOW()"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "NOW()"
@@ -40895,6 +51761,12 @@
             "state" : "translated",
             "value" : "Null"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Null"
+          }
         }
       }
     },
@@ -40913,6 +51785,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NULL"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "NULL"
@@ -40939,6 +51817,12 @@
             "state" : "translated",
             "value" : "NULL — 无引用行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NULL，沒有參照的列"
+          }
         }
       }
     },
@@ -40960,6 +51844,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "NULL 显示不能为空"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NULL 顯示不能為空"
           }
         }
       }
@@ -40983,6 +51873,12 @@
             "state" : "translated",
             "value" : "NULL 显示包含无效字符（换行符/制表符）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NULL 顯示包含無效字（換行符／定位字）"
+          }
         }
       }
     },
@@ -41004,6 +51900,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "NULL显示不能超过%d个字符"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NULL 顯示不能超過 %d 個字"
           }
         }
       }
@@ -41028,6 +51930,12 @@
             "state" : "translated",
             "value" : "NULL 显示不能超过 %lld 个字符"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NULL 顯示不能超過 %lld 個字"
+          }
         }
       }
     },
@@ -41050,6 +51958,12 @@
             "state" : "translated",
             "value" : "NULL 显示："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NULL 顯示："
+          }
         }
       }
     },
@@ -41068,6 +51982,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NULL 值"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "NULL 值"
@@ -41095,6 +52015,12 @@
             "state" : "translated",
             "value" : "允许 NULL"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許 NULL"
+          }
         }
       }
     },
@@ -41116,6 +52042,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "数字"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "數字"
           }
         }
       }
@@ -41140,6 +52072,12 @@
             "state" : "translated",
             "value" : "每个 insertMany 语句的文档数量。值越大生成的语句越少。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每個 insertMany 陳述式的文件數量。值越大產生的陳述式越少。"
+          }
         }
       }
     },
@@ -41158,6 +52096,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OAuth Client ID"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "OAuth Client ID"
@@ -41184,6 +52128,12 @@
             "state" : "translated",
             "value" : "OAuth Client Secret"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OAuth Client Secret"
+          }
         }
       }
     },
@@ -41205,6 +52155,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "OAuth 令牌"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OAuth 權杖"
           }
         }
       }
@@ -41228,6 +52184,12 @@
             "state" : "translated",
             "value" : "关"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉"
+          }
         }
       }
     },
@@ -41247,6 +52209,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "偏移量"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "偏移量"
@@ -41273,6 +52241,12 @@
             "state" : "translated",
             "value" : "OK"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "好"
+          }
         }
       }
     },
@@ -41294,6 +52268,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ollama 正在运行但没有模型。运行 \"ollama pull <model>\" 下载一个。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ollama 正在執行但沒有模型。請執行 \"ollama pull <model>\" 下載一個。"
           }
         }
       }
@@ -41317,6 +52297,12 @@
             "state" : "translated",
             "value" : "删除时"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除時"
+          }
         }
       }
     },
@@ -41338,6 +52324,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "磁盘上"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在磁碟上"
           }
         }
       }
@@ -41361,6 +52353,12 @@
             "state" : "translated",
             "value" : "退出时"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結束時"
+          }
         }
       }
     },
@@ -41382,6 +52380,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新時"
           }
         }
       }
@@ -41405,6 +52409,12 @@
             "state" : "translated",
             "value" : "仅影响新保存的内容。重新保存密码以更新其同步状态。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅影響新儲存的內容。重新儲存密碼以更新其同步狀態。"
+          }
         }
       }
     },
@@ -41427,6 +52437,12 @@
             "state" : "translated",
             "value" : "打开"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟"
+          }
         }
       }
     },
@@ -41448,6 +52464,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打开 %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟 %@"
           }
         }
       }
@@ -41474,6 +52496,12 @@
             "state" : "translated",
             "value" : "打开 %@ 编辑器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟 %@ 編輯器"
+          }
         }
       }
     },
@@ -41495,6 +52523,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在新标签页中打开%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在新分頁中開啟 %@"
           }
         }
       }
@@ -41521,6 +52555,12 @@
             "state" : "translated",
             "value" : "打开一个连接以插入"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟一個連線以插入"
+          }
         }
       }
     },
@@ -41542,6 +52582,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从欢迎窗口打开其他文件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從歡迎視窗開啟其他檔案。"
           }
         }
       }
@@ -41565,6 +52611,12 @@
             "state" : "translated",
             "value" : "在 TablePro 中为指定连接打开一个表标签页。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 TablePro 中為指定的連線開啟資料表分頁。"
+          }
         }
       }
     },
@@ -41586,6 +52638,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "为已保存的连接打开 TablePro 窗口（如已打开则切换到该窗口）。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "為已儲存的連線開啟 TablePro 視窗（如已開啟則切換到該視窗）。"
           }
         }
       }
@@ -41609,6 +52667,12 @@
             "state" : "translated",
             "value" : "打开 Claude Desktop，进入 Settings > Developer"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟 Claude Desktop，前往 Settings > Developer"
+          }
         }
       }
     },
@@ -41630,6 +52694,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打开连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟連線"
           }
         }
       }
@@ -41653,6 +52723,12 @@
             "state" : "translated",
             "value" : "打开连接窗口"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟連線視窗"
+          }
         }
       }
     },
@@ -41675,6 +52751,12 @@
             "state" : "translated",
             "value" : "打开所在文件夹"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟所在資料夾"
+          }
         }
       }
     },
@@ -41696,6 +52778,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打开 Cursor，进入 Settings > MCP"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟 Cursor，前往 Settings > MCP"
           }
         }
       }
@@ -41720,6 +52808,12 @@
             "state" : "translated",
             "value" : "打开数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟資料庫"
+          }
         }
       }
     },
@@ -41741,6 +52835,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打开数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟資料庫"
           }
         }
       }
@@ -41765,6 +52865,12 @@
             "state" : "translated",
             "value" : "打开数据库 (⌘K)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟資料庫 (⌘K)"
+          }
         }
       }
     },
@@ -41788,6 +52894,12 @@
             "state" : "translated",
             "value" : "打开数据库..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟資料庫…"
+          }
         }
       }
     },
@@ -41810,6 +52922,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打开编辑器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟編輯器"
           }
         }
       }
@@ -41836,6 +52954,12 @@
             "state" : "translated",
             "value" : "打开文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟檔案"
+          }
         }
       }
     },
@@ -41858,6 +52982,12 @@
             "state" : "translated",
             "value" : "打开文件..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟檔案…"
+          }
         }
       }
     },
@@ -41879,6 +53009,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在编辑器中打开"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在編輯器中開啟"
           }
         }
       }
@@ -41905,6 +53041,12 @@
             "state" : "translated",
             "value" : "在窗口中打开"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在視窗中開啟"
+          }
         }
       }
     },
@@ -41926,6 +53068,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打开问题跟踪器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟問題追蹤器"
           }
         }
       }
@@ -41950,6 +53098,12 @@
             "state" : "translated",
             "value" : "打开 JSON 查看器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟 JSON 檢視器"
+          }
         }
       }
     },
@@ -41973,6 +53127,12 @@
             "state" : "translated",
             "value" : "打开 MQL 编辑器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟 MQL 編輯器"
+          }
         }
       }
     },
@@ -41994,6 +53154,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打开插件设置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟外掛設定"
           }
         }
       }
@@ -42017,6 +53183,12 @@
             "state" : "translated",
             "value" : "打开查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟查詢"
+          }
         }
       }
     },
@@ -42038,6 +53210,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从链接打开查询"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從連結開啟查詢"
           }
         }
       }
@@ -42062,6 +53240,12 @@
             "state" : "translated",
             "value" : "打开 Redis CLI"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟 Redis CLI"
+          }
         }
       }
     },
@@ -42083,6 +53267,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打开示例数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟範例資料庫"
           }
         }
       }
@@ -42107,6 +53297,12 @@
             "state" : "translated",
             "value" : "打开 Schema"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟綱要"
+          }
         }
       }
     },
@@ -42129,6 +53325,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打开 SQL 编辑器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟 SQL 編輯器"
           }
         }
       }
@@ -42157,6 +53359,12 @@
             "state" : "translated",
             "value" : "打开表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟資料表"
+          }
         }
       }
     },
@@ -42178,6 +53386,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打开表标签页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟資料表分頁"
           }
         }
       }
@@ -42202,6 +53416,12 @@
             "state" : "translated",
             "value" : "打开终端"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟終端機"
+          }
         }
       }
     },
@@ -42224,6 +53444,12 @@
             "state" : "translated",
             "value" : "打开 Zed，点按标题栏右侧的 Agent Panel 图标"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟 Zed，點按標題列右側的 Agent Panel 圖示"
+          }
         }
       }
     },
@@ -42245,6 +53471,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "MySQL 的开源分支"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MySQL 的開源分支"
           }
         }
       }
@@ -42271,6 +53503,12 @@
             "state" : "translated",
             "value" : "操作已被用户取消"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用者已取消操作"
+          }
         }
       }
     },
@@ -42292,6 +53530,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "操作失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作失敗"
           }
         }
       }
@@ -42315,6 +53559,12 @@
             "state" : "translated",
             "value" : "操作不被允许"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作不被允許"
+          }
         }
       }
     },
@@ -42337,6 +53587,12 @@
             "state" : "translated",
             "value" : "运算符"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "運算子"
+          }
         }
       }
     },
@@ -42358,6 +53614,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "优化"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最佳化"
           }
         }
       }
@@ -42382,6 +53644,12 @@
             "state" : "translated",
             "value" : "优化查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最佳化查詢"
+          }
         }
       }
     },
@@ -42403,6 +53671,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "优化表（合并分区）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最佳化資料表（合併分割區）"
           }
         }
       }
@@ -42427,6 +53701,12 @@
             "state" : "translated",
             "value" : "优化以下 SQL 查询以提升性能：\n\n```sql\n%@\n```"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最佳化以下 SQL 查詢以提升效能：\n\n```sql\n%@\n```"
+          }
         }
       }
     },
@@ -42448,6 +53728,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "AI 优化"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "以 AI 最佳化"
           }
         }
       }
@@ -42472,6 +53758,12 @@
             "state" : "translated",
             "value" : "将 Option 用作 Meta 键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將 Option 作為 Meta 鍵"
+          }
         }
       }
     },
@@ -42493,6 +53785,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "可选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選用"
           }
         }
       }
@@ -42517,6 +53815,12 @@
             "state" : "translated",
             "value" : "可选描述"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選填描述"
+          }
         }
       }
     },
@@ -42538,6 +53842,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "可选的单行描述"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選用的單行描述"
           }
         }
       }
@@ -42564,6 +53874,12 @@
             "state" : "translated",
             "value" : "选项"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選項"
+          }
         }
       }
     },
@@ -42583,6 +53899,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OR"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "OR"
@@ -42610,6 +53932,12 @@
             "state" : "translated",
             "value" : "Oracle"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle"
+          }
         }
       }
     },
@@ -42631,6 +53959,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "OracleNIO 没有 TLS 回退。“首选”将使用纯 TCP 连接。通过 TCPS 连接 Oracle Autonomous Database 时请使用“必需”。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OracleNIO 沒有 TLS 回退。「首選」將使用純 TCP 連線。透過 TCPS 連線 Oracle Autonomous Database 時請使用「必要」。"
           }
         }
       }
@@ -42654,6 +53988,12 @@
             "state" : "translated",
             "value" : "橙色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "橘色"
+          }
         }
       }
     },
@@ -42672,6 +54012,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "其他"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "其他"
@@ -42698,6 +54044,12 @@
             "state" : "translated",
             "value" : "其他设备"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "其他裝置"
+          }
         }
       }
     },
@@ -42716,6 +54068,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "其他…"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "其他…"
@@ -42742,6 +54100,12 @@
             "state" : "translated",
             "value" : "结果"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結果"
+          }
         }
       }
     },
@@ -42763,6 +54127,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "结果：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結果：%@"
           }
         }
       }
@@ -42786,6 +54156,12 @@
             "state" : "translated",
             "value" : "减少缩进"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "減少縮排"
+          }
         }
       }
     },
@@ -42807,6 +54183,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "输出已截断显示"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸出已截斷顯示"
           }
         }
       }
@@ -42834,6 +54216,12 @@
             "state" : "translated",
             "value" : "按数据库类型覆盖自动检测的 CLI 路径。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "依資料庫型別覆寫自動偵測的 CLI 路徑。"
+          }
         }
       }
     },
@@ -42855,6 +54243,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "第 %d 页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %d 頁"
           }
         }
       }
@@ -42884,6 +54278,12 @@
             "state" : "translated",
             "value" : "第 %1$d 页，共 %2$d 页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %1$d 頁，共 %2$d 頁"
+          }
         }
       }
     },
@@ -42905,6 +54305,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "页面数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "頁數"
           }
         }
       }
@@ -42928,6 +54334,12 @@
             "state" : "translated",
             "value" : "页码"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "頁碼"
+          }
         }
       }
     },
@@ -42949,6 +54361,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "页面大小"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "頁面大小"
           }
         }
       }
@@ -42978,6 +54396,12 @@
             "state" : "translated",
             "value" : "页面大小必须在 %@ 和 %@ 之间"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "頁面大小必須介於 %1$@ 與 %2$@ 之間"
+          }
         }
       }
     },
@@ -43000,6 +54424,12 @@
             "state" : "translated",
             "value" : "页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "頁"
+          }
         }
       }
     },
@@ -43021,6 +54451,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分頁"
           }
         }
       }
@@ -43045,6 +54481,12 @@
             "state" : "translated",
             "value" : "分页设置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分頁設定"
+          }
         }
       }
     },
@@ -43066,6 +54508,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "配对失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配對失敗"
           }
         }
       }
@@ -43089,6 +54537,12 @@
             "state" : "translated",
             "value" : "面板状态"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "面板狀態"
+          }
         }
       }
     },
@@ -43110,6 +54564,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "参数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "參數"
           }
         }
       }
@@ -43133,6 +54593,12 @@
             "state" : "translated",
             "value" : "父分组"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上層群組"
+          }
         }
       }
     },
@@ -43154,6 +54620,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分区变更"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分割區異動"
           }
         }
       }
@@ -43177,6 +54649,12 @@
             "state" : "translated",
             "value" : "部分文件可能仍留在磁盘上。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "磁碟上可能殘留部分檔案。"
+          }
         }
       }
     },
@@ -43199,6 +54677,12 @@
             "state" : "translated",
             "value" : "分区"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分割區"
+          }
         }
       }
     },
@@ -43220,6 +54704,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "密码短语"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通關密語"
           }
         }
       }
@@ -43244,6 +54734,12 @@
             "state" : "translated",
             "value" : "密码短语（8 个以上字符）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通關密語（8 個以上字）"
+          }
         }
       }
     },
@@ -43265,6 +54761,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "密码短语不匹配"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通關密語不相符"
           }
         }
       }
@@ -43288,6 +54790,12 @@
             "state" : "translated",
             "value" : "密码"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密碼"
+          }
         }
       }
     },
@@ -43309,6 +54817,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "密码"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密碼"
           }
         }
       }
@@ -43338,6 +54852,12 @@
             "state" : "translated",
             "value" : "密码命令失败（退出码 %1$d）：%2$@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密碼命令失敗（退出碼 %1$d）：%2$@"
+          }
         }
       }
     },
@@ -43359,6 +54879,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "密码命令失败，退出码 %d"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密碼指令失敗，結束代碼 %d"
           }
         }
       }
@@ -43382,6 +54908,12 @@
             "state" : "translated",
             "value" : "密码命令产生的输出过多"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密碼指令產生的輸出過多"
+          }
         }
       }
     },
@@ -43403,6 +54935,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "密码命令在 30 秒后超时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密碼指令在 30 秒後逾時"
           }
         }
       }
@@ -43426,6 +54964,12 @@
             "state" : "translated",
             "value" : "未找到密码文件：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到密碼檔案：%@"
+          }
         }
       }
     },
@@ -43447,6 +54991,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "密码通过 keyboard-interactive 质询-响应方式发送。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密碼透過 keyboard-interactive 質詢-回應方式傳送。"
           }
         }
       }
@@ -43470,6 +55020,12 @@
             "state" : "translated",
             "value" : "需要密码"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要密碼"
+          }
         }
       }
     },
@@ -43491,6 +55047,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "密码将使用您提供的密码短语进行加密。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密碼將使用你提供的通關密語加密。"
           }
         }
       }
@@ -43520,6 +55082,12 @@
             "state" : "translated",
             "value" : "密码："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密碼："
+          }
         }
       }
     },
@@ -43541,6 +55109,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "粘贴"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "貼上"
           }
         }
       }
@@ -43565,6 +55139,12 @@
             "state" : "translated",
             "value" : "粘贴连接 URL 以自动填充表单字段。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "貼上連線 URL 以自動填入表單欄位。"
+          }
         }
       }
     },
@@ -43586,6 +55166,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "粘贴连接 URL 以检测类型并预填字段"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "貼上連線 URL 以偵測類型並預先填入欄位"
           }
         }
       }
@@ -43609,6 +55195,12 @@
             "state" : "translated",
             "value" : "粘贴连接 URL，将自动检测数据库类型并预填表单。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "貼上連線 URL，將自動偵測資料庫類型並預先填入表單。"
+          }
         }
       }
     },
@@ -43631,6 +55223,12 @@
             "state" : "translated",
             "value" : "粘贴单元格"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "貼上儲存格"
+          }
         }
       }
     },
@@ -43652,6 +55250,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "粘贴下方 JSON 并保存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在下方貼上 JSON 並儲存"
           }
         }
       }
@@ -43676,6 +55280,12 @@
             "state" : "translated",
             "value" : "在下方粘贴 CREATE TABLE 语句："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在下方貼上你的 CREATE TABLE 陳述式："
+          }
         }
       }
     },
@@ -43697,6 +55307,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "路径"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路徑"
           }
         }
       }
@@ -43720,6 +55336,12 @@
             "state" : "translated",
             "value" : "暂停"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫停"
+          }
         }
       }
     },
@@ -43741,6 +55363,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "等待批准："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等待核准："
           }
         }
       }
@@ -43764,6 +55392,12 @@
             "state" : "translated",
             "value" : "待删除"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "待刪除"
+          }
         }
       }
     },
@@ -43782,6 +55416,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "待清空"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "待清空"
@@ -43808,6 +55448,12 @@
             "state" : "translated",
             "value" : "周期"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "週期"
+          }
         }
       }
     },
@@ -43829,6 +55475,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "权限"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "權限"
           }
         }
       }
@@ -43852,6 +55504,12 @@
             "state" : "translated",
             "value" : "权限级别"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "權限層級"
+          }
         }
       }
     },
@@ -43870,6 +55528,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PHP — %@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "PHP — %@"
@@ -43896,6 +55560,12 @@
             "state" : "translated",
             "value" : "PHP 序列化"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PHP 序列化"
+          }
         }
       }
     },
@@ -43917,6 +55587,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "PHP 查看器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PHP 檢視器"
           }
         }
       }
@@ -43940,6 +55616,12 @@
             "state" : "translated",
             "value" : "选择要连接的数据库类型。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇你要連線的資料庫類型。"
+          }
         }
       }
     },
@@ -43958,6 +55640,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PID"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "PID"
@@ -43984,6 +55672,12 @@
             "state" : "translated",
             "value" : "固定结果"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "釘選結果"
+          }
         }
       }
     },
@@ -44006,6 +55700,12 @@
             "state" : "translated",
             "value" : "粉色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "粉紅色"
+          }
         }
       }
     },
@@ -44027,6 +55727,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "纯文本。Markdown 按原样保留。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "純文字。Markdown 按原樣保留。"
           }
         }
       }
@@ -44053,6 +55759,12 @@
             "state" : "translated",
             "value" : "规划: %.3fms"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "規劃：%.3fms"
+          }
         }
       }
     },
@@ -44074,6 +55786,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "请选择一列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請選擇一個欄位"
           }
         }
       }
@@ -44097,6 +55815,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "插件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛"
           }
         }
       }
@@ -44126,6 +55850,12 @@
             "state" : "translated",
             "value" : "插件 '%@' 的描述符无效：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛「%1$@」的描述元無效：%2$@"
+          }
         }
       }
     },
@@ -44147,6 +55877,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "插件校验和与期望值不匹配"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛總和檢查碼與預期值不符"
           }
         }
       }
@@ -44170,6 +55906,12 @@
             "state" : "translated",
             "value" : "插件代码签名验证失败：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛程式碼簽章驗證失敗：%@"
+          }
         }
       }
     },
@@ -44191,6 +55933,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "插件不包含兼容此架构的二进制文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛未包含相容此架構的二進位檔"
           }
         }
       }
@@ -44214,6 +55962,12 @@
             "state" : "translated",
             "value" : "插件下载失败：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛下載失敗：%@"
+          }
         }
       }
     },
@@ -44235,6 +55989,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "插件有活跃的连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛有作用中的連線"
           }
         }
       }
@@ -44258,6 +56018,12 @@
             "state" : "translated",
             "value" : "插件安装失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛安裝失敗"
+          }
         }
       }
     },
@@ -44279,6 +56045,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "插件安装失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛安裝失敗：%@"
           }
         }
       }
@@ -44302,6 +56074,12 @@
             "state" : "translated",
             "value" : "未找到插件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到外掛"
+          }
         }
       }
     },
@@ -44324,6 +56102,12 @@
             "state" : "translated",
             "value" : "插件未安装"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛未安裝"
+          }
         }
       }
     },
@@ -44345,6 +56129,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "插件未加载"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛未載入"
           }
         }
       }
@@ -44374,6 +56164,12 @@
             "state" : "translated",
             "value" : "插件未加载：%1$@。%2$@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛未載入：%1$@。%2$@"
+          }
         }
       }
     },
@@ -44395,6 +56191,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "插件注册表需要更新版本的应用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛註冊需要更新版本的應用程式"
           }
         }
       }
@@ -44424,6 +56226,12 @@
             "state" : "translated",
             "value" : "插件需要应用版本 %@ 或更高，但当前版本为 %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛需要應用程式版本 %1$@ 或更新版本，但目前版本為 %2$@"
+          }
         }
       }
     },
@@ -44451,6 +56259,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "插件需要PluginKit版本%d，但应用提供版本%d"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛需要 PluginKit 版本 %1$d，但應用程式提供的版本為 %2$d"
           }
         }
       }
@@ -44481,6 +56295,12 @@
             "state" : "translated",
             "value" : "插件需要 PluginKit 版本 %lld，但应用提供的版本为 %lld"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛需要 PluginKit 版本 %1$lld，但應用程式提供的版本為 %2$lld"
+          }
         }
       }
     },
@@ -44502,6 +56322,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "插件更新失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛更新失敗"
           }
         }
       }
@@ -44530,6 +56356,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "插件是为 PluginKit 版本 %1$d 构建的；此版本的 TablePro 需要版本 %2$d。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛是為 PluginKit 版本 %1$d 建置的；此版本的 TablePro 需要版本 %2$d。"
           }
         }
       }
@@ -44560,6 +56392,12 @@
             "state" : "translated",
             "value" : "插件使用PluginKit版本%d构建，但需要版本%d。请更新插件。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛是以 PluginKit 版本 %1$d 建置的，但需要版本 %2$d。請更新外掛。"
+          }
         }
       }
     },
@@ -44589,6 +56427,12 @@
             "state" : "translated",
             "value" : "插件使用 PluginKit 版本 %lld 构建，但需要版本 %lld。请更新插件。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛是以 PluginKit 版本 %1$lld 建置的，但需要版本 %2$lld。請更新外掛。"
+          }
         }
       }
     },
@@ -44611,6 +56455,12 @@
             "state" : "translated",
             "value" : "插件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛"
+          }
         }
       }
     },
@@ -44632,6 +56482,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "端口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連接埠"
           }
         }
       }
@@ -44658,6 +56514,12 @@
             "state" : "translated",
             "value" : "端口已被占用。请尝试其他端口或关闭占用端口的进程。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連接埠已被佔用。請改用其他連接埠或關閉佔用的處理程序。"
+          }
         }
       }
     },
@@ -44677,6 +56539,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "postgresql://user:password@host:5432/database"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "postgresql://user:password@host:5432/database"
@@ -44704,6 +56572,12 @@
             "state" : "translated",
             "value" : "潜在危险查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "潛在危險查詢"
+          }
         }
       }
     },
@@ -44727,6 +56601,12 @@
             "state" : "translated",
             "value" : "潜在危险查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "潛在危險查詢"
+          }
         }
       }
     },
@@ -44748,6 +56628,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接前脚本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線前指令稿"
           }
         }
       }
@@ -44777,6 +56663,12 @@
             "state" : "translated",
             "value" : "连接前脚本失败（退出码 %d）：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線前指令稿失敗（退出碼 %1$d）：%2$@"
+          }
         }
       }
     },
@@ -44800,6 +56692,12 @@
             "state" : "translated",
             "value" : "连接前脚本失败（退出码 %lld）：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線前指令稿失敗（退出碼 %lld）：%@"
+          }
         }
       }
     },
@@ -44821,6 +56719,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接前脚本失败，退出码 %d"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線前指令稿失敗，退出碼 %d"
           }
         }
       }
@@ -44845,6 +56749,12 @@
             "state" : "translated",
             "value" : "连接前脚本失败，退出码 %lld"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線前指令稿失敗，退出碼 %lld"
+          }
         }
       }
     },
@@ -44867,6 +56777,12 @@
             "state" : "translated",
             "value" : "连接前脚本超时（10秒后）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線前指令稿在 10 秒後逾時"
+          }
         }
       }
     },
@@ -44888,6 +56804,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接前脚本已取消"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線前指令稿已取消"
           }
         }
       }
@@ -44912,6 +56834,12 @@
             "state" : "translated",
             "value" : "精度"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "精確度"
+          }
         }
       }
     },
@@ -44935,6 +56863,12 @@
             "state" : "translated",
             "value" : "精度："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "精確度："
+          }
         }
       }
     },
@@ -44956,6 +56890,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "首选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "偏好"
           }
         }
       }
@@ -44979,6 +56919,12 @@
             "state" : "translated",
             "value" : "对于此驱动，“首选”将使用纯 TCP 连接。请使用“必需”来强制 TCPS。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "對於此驅動程式，「首選」將使用純 TCP 連線。請使用「必要」來強制 TCPS。"
+          }
         }
       }
     },
@@ -45000,6 +56946,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "“首选”执行两阶段连接：先尝试 TLS，仅在 SSL 握手出错时回退到明文。Cloud SQL 和 Azure MySQL 要求使用“必需”。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「首選」執行兩階段連線：先嘗試 TLS，僅在 SSL 交握出錯時回退到明文。Cloud SQL 與 Azure MySQL 要求使用「必要」。"
           }
         }
       }
@@ -45023,6 +56975,12 @@
             "state" : "translated",
             "value" : "“首选”会请求 TLS，由服务器决定。SQL Server 2022 和 Azure SQL Database 要求使用“必需”。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「首選」會請求 TLS，由伺服器決定。SQL Server 2022 與 Azure SQL Database 要求使用「必要」。"
+          }
         }
       }
     },
@@ -45044,6 +57002,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "“首选”先尝试 TLS，失败后回退到明文，与 psql 和 DataGrip 的默认行为一致。AWS RDS、Cloud SQL、Heroku、Supabase、Neon 要求使用“必需”。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「Preferred」會先嘗試 TLS，失敗後改用純文字連線，與 psql 和 DataGrip 的預設行為一致。AWS RDS、Cloud SQL、Heroku、Supabase、Neon 要求使用「Required」。"
           }
         }
       }
@@ -45068,6 +57032,12 @@
             "state" : "translated",
             "value" : "将所有值保留为字符串"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將所有值保留為字串"
+          }
         }
       }
     },
@@ -45090,6 +57060,12 @@
             "state" : "translated",
             "value" : "预设名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設集名稱"
+          }
         }
       }
     },
@@ -45111,6 +57087,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "格式化输出"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "美化輸出"
           }
         }
       }
@@ -45135,6 +57117,12 @@
             "state" : "translated",
             "value" : "格式化输出（带格式）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "美化輸出（格式化輸出）"
+          }
         }
       }
     },
@@ -45157,6 +57145,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "通过在以 =、+、-、@ 开头的值前添加单引号来防止 CSV 公式注入"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在以 =、+、-、@ 開頭的值前加上單引號，以防止 CSV 公式注入"
           }
         }
       }
@@ -45181,6 +57175,12 @@
             "state" : "translated",
             "value" : "禁止写操作（INSERT、UPDATE、DELETE、DROP 等）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "禁止寫入操作（INSERT、UPDATE、DELETE、DROP 等）"
+          }
         }
       }
     },
@@ -45202,6 +57202,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "预览"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽"
           }
         }
       }
@@ -45225,6 +57231,12 @@
             "state" : "translated",
             "value" : "预览 %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽 %@"
+          }
         }
       }
     },
@@ -45246,6 +57258,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "预览 %@ (⌘⇧P)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽 %@ (⌘⇧P)"
           }
         }
       }
@@ -45270,6 +57288,12 @@
             "state" : "translated",
             "value" : "预览命令"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽命令"
+          }
         }
       }
     },
@@ -45293,6 +57317,12 @@
             "state" : "translated",
             "value" : "预览命令 (⌘⇧P)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽命令 (⌘⇧P)"
+          }
         }
       }
     },
@@ -45314,6 +57344,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "预览外键引用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽外鍵參照"
           }
         }
       }
@@ -45338,6 +57374,12 @@
             "state" : "translated",
             "value" : "预览 MQL"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽 MQL"
+          }
         }
       }
     },
@@ -45361,6 +57403,12 @@
             "state" : "translated",
             "value" : "预览 MQL (⌘⇧P)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽 MQL (⌘⇧P)"
+          }
         }
       }
     },
@@ -45383,6 +57431,12 @@
             "state" : "translated",
             "value" : "预览查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽查詢"
+          }
         }
       }
     },
@@ -45404,6 +57458,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "预览引用行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽參照列"
           }
         }
       }
@@ -45428,6 +57488,12 @@
             "state" : "translated",
             "value" : "预览结构更改"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽綱要變更"
+          }
         }
       }
     },
@@ -45449,6 +57515,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "预览 SQL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽 SQL"
           }
         }
       }
@@ -45473,6 +57545,12 @@
             "state" : "translated",
             "value" : "预览 SQL (⌘⇧P)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽 SQL (⌘⇧P)"
+          }
         }
       }
     },
@@ -45495,6 +57573,12 @@
             "state" : "translated",
             "value" : "上一页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一頁"
+          }
         }
       }
     },
@@ -45516,6 +57600,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上一页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一頁"
           }
         }
       }
@@ -45540,6 +57630,12 @@
             "state" : "translated",
             "value" : "上一页 (⌘[)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一頁 (⌘[)"
+          }
         }
       }
     },
@@ -45561,6 +57657,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上一个结果"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一個結果"
           }
         }
       }
@@ -45585,6 +57687,12 @@
             "state" : "translated",
             "value" : "上一个标签页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一個分頁"
+          }
         }
       }
     },
@@ -45608,6 +57716,12 @@
             "state" : "translated",
             "value" : "上一个标签页 (Alt)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一個分頁 (Alt)"
+          }
         }
       }
     },
@@ -45627,6 +57741,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Primary"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Primary"
@@ -45653,6 +57773,12 @@
             "state" : "translated",
             "value" : "主键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主鍵"
+          }
         }
       }
     },
@@ -45675,6 +57801,12 @@
             "state" : "translated",
             "value" : "主键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主鍵"
+          }
         }
       }
     },
@@ -45694,6 +57826,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Primary Preferred"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Primary Preferred"
@@ -45720,6 +57858,12 @@
             "state" : "translated",
             "value" : "主要文本"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主要文字"
+          }
         }
       }
     },
@@ -45741,6 +57885,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "优先级 %d"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "優先順序 %d"
           }
         }
       }
@@ -45764,6 +57914,12 @@
             "state" : "translated",
             "value" : "隐私"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱私"
+          }
         }
       }
     },
@@ -45782,6 +57938,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "私有（%@）"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "私有（%@）"
@@ -45808,6 +57970,12 @@
             "state" : "translated",
             "value" : "私钥"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "私鑰"
+          }
         }
       }
     },
@@ -45829,6 +57997,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "私钥文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "私密金鑰檔案"
           }
         }
       }
@@ -45852,6 +58026,12 @@
             "state" : "translated",
             "value" : "私钥口令"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "私密金鑰密碼"
+          }
         }
       }
     },
@@ -45870,6 +58050,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pro"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pro"
@@ -45896,6 +58082,12 @@
             "state" : "translated",
             "value" : "PRO"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PRO"
+          }
         }
       }
     },
@@ -45914,6 +58106,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pro 功能"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pro 功能"
@@ -45941,6 +58139,12 @@
             "state" : "translated",
             "value" : "需要 Pro 许可证"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要 Pro 授權"
+          }
         }
       }
     },
@@ -45962,6 +58166,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "iCloud 同步需要 Pro 许可证"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 同步需要 Pro 授權"
           }
         }
       }
@@ -45985,6 +58195,12 @@
             "state" : "translated",
             "value" : "存储过程"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預存程序"
+          }
         }
       }
     },
@@ -46006,6 +58222,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "存储过程：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預存程序：%@"
           }
         }
       }
@@ -46029,6 +58251,12 @@
             "state" : "translated",
             "value" : "存储过程"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預存程序"
+          }
         }
       }
     },
@@ -46050,6 +58278,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "进程退出，退出码 %d"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "處理程序結束，結束碼 %d"
           }
         }
       }
@@ -46079,6 +58313,12 @@
             "state" : "translated",
             "value" : "配置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定檔"
+          }
         }
       }
     },
@@ -46100,6 +58340,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "配置详情"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定檔詳細資料"
           }
         }
       }
@@ -46128,6 +58374,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "配置名称"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定檔名稱"
           }
         }
       }
@@ -46158,6 +58410,12 @@
             "state" : "translated",
             "value" : "配置设置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定檔設定"
+          }
         }
       }
     },
@@ -46179,6 +58437,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "进度为估算值（%d 个表无法计数）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進度為估計值（%d 個資料表無法計數）"
           }
         }
       }
@@ -46202,6 +58466,12 @@
             "state" : "translated",
             "value" : "项目 ID"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "專案 ID"
+          }
         }
       }
     },
@@ -46223,6 +58493,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接时提示"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線時提示"
           }
         }
       }
@@ -46246,6 +58522,12 @@
             "state" : "translated",
             "value" : "提示输入 API 令牌"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提示輸入 API 權杖"
+          }
         }
       }
     },
@@ -46267,6 +58549,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "提示输入密码"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提示輸入密碼"
           }
         }
       }
@@ -46290,6 +58578,12 @@
             "state" : "translated",
             "value" : "提示词模板"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提示詞範本"
+          }
         }
       }
     },
@@ -46311,6 +58605,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "受保护"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "受保護"
           }
         }
       }
@@ -46334,6 +58634,12 @@
             "state" : "translated",
             "value" : "提供商"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "供應商"
+          }
         }
       }
     },
@@ -46356,6 +58662,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "公钥认证失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "公鑰驗證失敗：%@"
           }
         }
       }
@@ -46385,6 +58697,12 @@
             "state" : "translated",
             "value" : "购买许可证"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購買授權"
+          }
         }
       }
     },
@@ -46403,6 +58721,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "紫色"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "紫色"
@@ -46430,6 +58754,12 @@
             "state" : "translated",
             "value" : "将字段名放在第一行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將欄位名稱放在第一列"
+          }
         }
       }
     },
@@ -46454,6 +58784,12 @@
             "state" : "translated",
             "value" : "查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢"
+          }
         }
       }
     },
@@ -46476,6 +58812,12 @@
             "state" : "translated",
             "value" : "查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢"
+          }
         }
       }
     },
@@ -46497,6 +58839,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查询行为"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢行為"
           }
         }
       }
@@ -46521,6 +58869,12 @@
             "state" : "translated",
             "value" : "查询已取消"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢已取消"
+          }
         }
       }
     },
@@ -46543,6 +58897,12 @@
             "state" : "translated",
             "value" : "查询执行成功"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢執行成功"
+          }
         }
       }
     },
@@ -46564,6 +58924,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在执行查询"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在執行查詢"
           }
         }
       }
@@ -46588,6 +58954,12 @@
             "state" : "translated",
             "value" : "正在执行查询..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在執行查詢…"
+          }
         }
       }
     },
@@ -46609,6 +58981,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查询执行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢執行"
           }
         }
       }
@@ -46632,6 +59010,12 @@
             "state" : "translated",
             "value" : "查询执行失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢執行失敗"
+          }
         }
       }
     },
@@ -46654,6 +59038,12 @@
             "state" : "translated",
             "value" : "查询历史"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢歷史"
+          }
         }
       }
     },
@@ -46675,6 +59065,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@的查询历史"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@的查詢記錄"
           }
         }
       }
@@ -46699,6 +59095,12 @@
             "state" : "translated",
             "value" : "查询历史："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢歷史："
+          }
         }
       }
     },
@@ -46720,6 +59122,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查询参数（:name 语法）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢參數（:name 語法）"
           }
         }
       }
@@ -46743,6 +59151,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查询结果限制"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢結果上限"
           }
         }
       }
@@ -46773,6 +59187,12 @@
             "state" : "translated",
             "value" : "查询结果限制必须在 %@ 到 %@ 之间"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢結果上限必須介於 %1$@ 到 %2$@ 之間"
+          }
         }
       }
     },
@@ -46794,6 +59214,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查询结果行数上限"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢結果列數上限"
           }
         }
       }
@@ -46823,6 +59249,12 @@
             "state" : "translated",
             "value" : "查询结果行数上限必须在 %@ 和 %@ 之间"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢結果列數上限必須介於 %1$@ 到 %2$@ 之間"
+          }
         }
       }
     },
@@ -46844,6 +59276,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查询结果"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢結果"
           }
         }
       }
@@ -46867,6 +59305,12 @@
             "state" : "translated",
             "value" : "查询超时"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢逾時"
+          }
         }
       }
     },
@@ -46889,6 +59333,12 @@
             "state" : "translated",
             "value" : "查询超时秒数（默认 30，最大 300）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢逾時秒數（預設 30，最大 300）"
+          }
         }
       }
     },
@@ -46910,6 +59360,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查询超时："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢逾時："
           }
         }
       }
@@ -46934,6 +59390,12 @@
             "state" : "translated",
             "value" : "查询："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢："
+          }
         }
       }
     },
@@ -46952,6 +59414,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "快速"
@@ -46979,6 +59447,12 @@
             "state" : "translated",
             "value" : "快速搜索所有列..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在所有欄位中快速搜尋…"
+          }
         }
       }
     },
@@ -47001,6 +59475,12 @@
             "state" : "translated",
             "value" : "快速切换"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速切換器"
+          }
         }
       }
     },
@@ -47022,6 +59502,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "快速切换 (⇧⌘O)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速切換器 (⇧⌘O)"
           }
         }
       }
@@ -47046,6 +59532,12 @@
             "state" : "translated",
             "value" : "快速切换 (⌘P)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速切換器 (⌘P)"
+          }
         }
       }
     },
@@ -47067,6 +59559,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "快速切换..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速切換器…"
           }
         }
       }
@@ -47090,6 +59588,12 @@
             "state" : "translated",
             "value" : "退出并重新打开"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結束並重新開啟"
+          }
         }
       }
     },
@@ -47111,6 +59615,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "仍然退出"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仍要結束"
           }
         }
       }
@@ -47135,6 +59645,12 @@
             "state" : "translated",
             "value" : "引号"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "引號"
+          }
         }
       }
     },
@@ -47158,6 +59674,12 @@
             "state" : "translated",
             "value" : "按需加引号"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "必要時加引號"
+          }
         }
       }
     },
@@ -47179,6 +59701,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "范围"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "範圍"
           }
         }
       }
@@ -47202,6 +59730,12 @@
             "state" : "translated",
             "value" : "已限流"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已達速率限制"
+          }
         }
       }
     },
@@ -47224,6 +59758,12 @@
             "state" : "translated",
             "value" : "请求频率超限。请稍后再试。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已達速率限制。請稍後再試。"
+          }
         }
       }
     },
@@ -47242,6 +59782,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原始"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "原始"
@@ -47268,6 +59814,12 @@
             "state" : "translated",
             "value" : "原始 SQL"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原始 SQL"
+          }
         }
       }
     },
@@ -47290,6 +59842,12 @@
             "state" : "translated",
             "value" : "原始 SQL 不能为空"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原始 SQL 不可為空"
+          }
         }
       }
     },
@@ -47308,6 +59866,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原始值"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "原始值"
@@ -47334,6 +59898,12 @@
             "state" : "translated",
             "value" : "再次输入口令"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再次輸入密碼"
+          }
         }
       }
     },
@@ -47355,6 +59925,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "读写"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "讀寫"
           }
         }
       }
@@ -47378,6 +59954,12 @@
             "state" : "translated",
             "value" : "只读"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "唯讀"
+          }
         }
       }
     },
@@ -47400,6 +59982,12 @@
             "state" : "translated",
             "value" : "只读连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "唯讀連線"
+          }
         }
       }
     },
@@ -47419,6 +60007,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Read Preference"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Read Preference"
@@ -47445,6 +60039,12 @@
             "state" : "translated",
             "value" : "从钥匙串读取已保存的密码（需要权限）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從鑰匙圈讀取已儲存的密碼（需要權限）"
+          }
         }
       }
     },
@@ -47467,6 +60067,12 @@
             "state" : "translated",
             "value" : "读取架构并运行任意非破坏性查询，包括 INSERT、UPDATE 和 DELETE。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "讀取綱要並執行任何非破壞性查詢，包括 INSERT、UPDATE 和 DELETE。"
+          }
         }
       }
     },
@@ -47488,6 +60094,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "读取架构并运行 SELECT 查询。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "讀取綱要並執行 SELECT 查詢。"
           }
         }
       }
@@ -47512,6 +60124,12 @@
             "state" : "translated",
             "value" : "只读"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "唯讀"
+          }
         }
       }
     },
@@ -47533,6 +60151,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "只读"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "唯讀"
           }
         }
       }
@@ -47557,6 +60181,12 @@
             "state" : "translated",
             "value" : "只读连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "唯讀連線"
+          }
         }
       }
     },
@@ -47579,6 +60209,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "只读连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "唯讀連線"
           }
         }
       }
@@ -47603,6 +60239,12 @@
             "state" : "translated",
             "value" : "读写"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "讀寫"
+          }
         }
       }
     },
@@ -47624,6 +60266,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在从%@读取连接…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在從%@讀取連線…"
           }
         }
       }
@@ -47648,6 +60296,12 @@
             "state" : "translated",
             "value" : "正在读取连接…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在讀取連線…"
+          }
         }
       }
     },
@@ -47666,6 +60320,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Real"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Real"
@@ -47692,6 +60352,12 @@
             "state" : "translated",
             "value" : "推理"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推理"
+          }
         }
       }
     },
@@ -47710,6 +60376,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推理中…"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "推理中…"
@@ -47736,6 +60408,12 @@
             "state" : "translated",
             "value" : "重新分配"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新指派"
+          }
         }
       }
     },
@@ -47754,6 +60432,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "最近"
@@ -47781,6 +60465,12 @@
             "state" : "translated",
             "value" : "最近"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近"
+          }
         }
       }
     },
@@ -47802,6 +60492,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最近的会话"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近的對話"
           }
         }
       }
@@ -47825,6 +60521,12 @@
             "state" : "translated",
             "value" : "最近的查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近的查詢"
+          }
         }
       }
     },
@@ -47847,6 +60549,12 @@
             "state" : "translated",
             "value" : "连接的最近查询历史（支持 ?limit=、?search=、?date_filter=）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線的最近查詢記錄（支援 ?limit=、?search=、?date_filter=）"
+          }
         }
       }
     },
@@ -47868,6 +60576,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此连接的最近查询历史"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線的最近查詢記錄"
           }
         }
       }
@@ -47895,6 +60609,12 @@
             "state" : "translated",
             "value" : "重新连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新連線"
+          }
         }
       }
     },
@@ -47916,6 +60636,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重新连接失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新連線失敗：%@"
           }
         }
       }
@@ -47940,6 +60666,12 @@
             "state" : "translated",
             "value" : "重新连接数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新連線資料庫"
+          }
         }
       }
     },
@@ -47961,6 +60693,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在录制快捷键"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在錄製快速鍵"
           }
         }
       }
@@ -47984,6 +60722,12 @@
             "state" : "translated",
             "value" : "红色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "紅色"
+          }
         }
       }
     },
@@ -48003,6 +60747,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redis"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Redis"
@@ -48029,6 +60779,12 @@
             "state" : "translated",
             "value" : "Redis 驱动没有 TLS 回退。“首选”和“必需”都会强制使用 TLS。连接 Redis Cloud、Upstash 和 AWS ElastiCache 加密端点时请使用“必需”。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redis 驅動程式沒有 TLS 備援。「Preferred」和「Required」都會強制使用 TLS。連接 Redis Cloud、Upstash 和 AWS ElastiCache 加密端點時請使用「Required」。"
+          }
         }
       }
     },
@@ -48047,6 +60803,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重做"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "重做"
@@ -48073,6 +60835,12 @@
             "state" : "translated",
             "value" : "引用列"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "參考欄位"
+          }
         }
       }
     },
@@ -48095,6 +60863,12 @@
             "state" : "translated",
             "value" : "参考 Schema"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "參考綱要"
+          }
         }
       }
     },
@@ -48116,6 +60890,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "引用表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "參考資料表"
           }
         }
       }
@@ -48140,6 +60920,12 @@
             "state" : "translated",
             "value" : "引用列（逗号分隔）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "參考欄位（以逗號分隔）"
+          }
         }
       }
     },
@@ -48161,6 +60947,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未找到引用行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到參考的列"
           }
         }
       }
@@ -48185,6 +60977,12 @@
             "state" : "translated",
             "value" : "引用表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "參考的資料表"
+          }
         }
       }
     },
@@ -48206,6 +61004,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刷新"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新整理"
           }
         }
       }
@@ -48229,6 +61033,12 @@
             "state" : "translated",
             "value" : "刷新 (⌘R)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新整理 (⌘R)"
+          }
         }
       }
     },
@@ -48250,6 +61060,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刷新并保存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新整理並儲存"
           }
         }
       }
@@ -48274,6 +61090,12 @@
             "state" : "translated",
             "value" : "刷新数据"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新整理資料"
+          }
         }
       }
     },
@@ -48296,6 +61118,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刷新数据库列表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新整理資料庫清單"
           }
         }
       }
@@ -48325,6 +61153,12 @@
             "state" : "translated",
             "value" : "从服务器刷新许可证状态"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從伺服器重新整理授權狀態"
+          }
         }
       }
     },
@@ -48346,6 +61180,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "立即刷新"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即重新整理"
           }
         }
       }
@@ -48369,6 +61209,12 @@
             "state" : "translated",
             "value" : "刷新将丢弃所有未保存的更改。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新整理將捨棄所有未儲存的變更。"
+          }
         }
       }
     },
@@ -48390,6 +61236,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重新生成"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新產生"
           }
         }
       }
@@ -48413,6 +61265,12 @@
             "state" : "translated",
             "value" : "插件仓库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外掛註冊"
+          }
         }
       }
     },
@@ -48434,6 +61292,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "关系型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關聯式"
           }
         }
       }
@@ -48457,6 +61321,12 @@
             "state" : "translated",
             "value" : "重新启动失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新啟動失敗"
+          }
         }
       }
     },
@@ -48479,6 +61349,12 @@
             "state" : "translated",
             "value" : "重新加载"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新載入"
+          }
         }
       }
     },
@@ -48500,6 +61376,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从磁盘重新载入"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從磁碟重新載入"
           }
         }
       }
@@ -48526,6 +61408,12 @@
             "state" : "translated",
             "value" : "移除"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除"
+          }
         }
       }
     },
@@ -48547,6 +61435,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "要移除“%@”吗？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要移除「%@」嗎？"
           }
         }
       }
@@ -48570,6 +61464,12 @@
             "state" : "translated",
             "value" : "移除%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除%@"
+          }
         }
       }
     },
@@ -48588,6 +61488,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除 %@？"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "移除 %@？"
@@ -48618,6 +61524,12 @@
             "state" : "translated",
             "value" : "移除所有筛选并重新加载"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除所有篩選並重新載入"
+          }
         }
       }
     },
@@ -48636,6 +61548,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除附件"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "移除附件"
@@ -48662,6 +61580,12 @@
             "state" : "translated",
             "value" : "移除列"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除欄位"
+          }
         }
       }
     },
@@ -48683,6 +61607,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "移除失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除失敗"
           }
         }
       }
@@ -48706,6 +61636,12 @@
             "state" : "translated",
             "value" : "移除筛选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除篩選"
+          }
         }
       }
     },
@@ -48727,6 +61663,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "移除筛选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除篩選"
           }
         }
       }
@@ -48750,6 +61692,12 @@
             "state" : "translated",
             "value" : "移除筛选行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除篩選列"
+          }
         }
       }
     },
@@ -48771,6 +61719,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "移除文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除資料夾"
           }
         }
       }
@@ -48794,6 +61748,12 @@
             "state" : "translated",
             "value" : "移除文件夹"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除資料夾"
+          }
         }
       }
     },
@@ -48815,6 +61775,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "移除外键"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除外鍵"
           }
         }
       }
@@ -48840,6 +61806,12 @@
             "state" : "translated",
             "value" : "从收藏中移除"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從收藏中移除"
+          }
         }
       }
     },
@@ -48861,6 +61833,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从分组移除"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從群組移除"
           }
         }
       }
@@ -48884,6 +61862,12 @@
             "state" : "translated",
             "value" : "从侧边栏移除"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從側邊欄移除"
+          }
         }
       }
     },
@@ -48906,6 +61890,12 @@
             "state" : "translated",
             "value" : "移除图像"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除圖片"
+          }
         }
       }
     },
@@ -48924,6 +61914,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除索引"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "移除索引"
@@ -48950,6 +61946,12 @@
             "state" : "translated",
             "value" : "移除跳板机"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除跳板主機"
+          }
         }
       }
     },
@@ -48972,6 +61974,12 @@
             "state" : "translated",
             "value" : "从此设备移除许可证"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從此機器移除授權"
+          }
         }
       }
     },
@@ -48993,6 +62001,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "要移除链接的文件夹吗？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要移除連結的資料夾嗎？"
           }
         }
       }
@@ -49017,6 +62031,12 @@
             "state" : "translated",
             "value" : "移除提供商"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除供應商"
+          }
         }
       }
     },
@@ -49038,6 +62058,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "移除提供方"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除供應商"
           }
         }
       }
@@ -49061,6 +62087,12 @@
             "state" : "translated",
             "value" : "移除提供方？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除供應商？"
+          }
         }
       }
     },
@@ -49082,6 +62114,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重命名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新命名"
           }
         }
       }
@@ -49105,6 +62143,12 @@
             "state" : "translated",
             "value" : "重命名列"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新命名欄位"
+          }
         }
       }
     },
@@ -49127,6 +62171,12 @@
             "state" : "translated",
             "value" : "重命名分组"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新命名群組"
+          }
         }
       }
     },
@@ -49148,6 +62198,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重命名…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新命名…"
           }
         }
       }
@@ -49177,6 +62233,12 @@
             "state" : "translated",
             "value" : "续期"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "續訂"
+          }
         }
       }
     },
@@ -49205,6 +62267,12 @@
             "state" : "translated",
             "value" : "续期许可证"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "續訂授權"
+          }
         }
       }
     },
@@ -49226,6 +62294,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "续期许可证…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "續訂授權…"
           }
         }
       }
@@ -49249,6 +62323,12 @@
             "state" : "translated",
             "value" : "重新打开上次会话"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新開啟上次工作階段"
+          }
         }
       }
     },
@@ -49270,6 +62350,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "调整列顺序"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "調整欄位順序"
           }
         }
       }
@@ -49293,6 +62379,12 @@
             "state" : "translated",
             "value" : "替换"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取代"
+          }
         }
       }
     },
@@ -49314,6 +62406,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制延迟：%d秒"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複寫延遲：%d 秒"
           }
         }
       }
@@ -49338,6 +62436,12 @@
             "state" : "translated",
             "value" : "复制延迟：%llds"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複寫延遲：%lld 秒"
+          }
         }
       }
     },
@@ -49360,6 +62464,12 @@
             "state" : "translated",
             "value" : "报告问题"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回報問題"
+          }
         }
       }
     },
@@ -49381,6 +62491,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "需要认证"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要驗證"
           }
         }
       }
@@ -49405,6 +62521,12 @@
             "state" : "translated",
             "value" : "执行查询前需要确认或 Touch ID。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行查詢前需要確認或 Touch ID。"
+          }
         }
       }
     },
@@ -49426,6 +62548,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "要求 SSL，跳过验证"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要求 SSL，略過驗證"
           }
         }
       }
@@ -49449,6 +62577,12 @@
             "state" : "translated",
             "value" : "必需（跳过验证）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "必要（略過驗證）"
+          }
         }
       }
     },
@@ -49470,6 +62604,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "仅加密密钥需要"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅加密金鑰需要"
           }
         }
       }
@@ -49493,6 +62633,12 @@
             "state" : "translated",
             "value" : "仅当服务器强制双向 TLS 认证时需要。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅當伺服器強制雙向 TLS 驗證時需要。"
+          }
         }
       }
     },
@@ -49511,6 +62657,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "需要"
@@ -49537,6 +62689,12 @@
             "state" : "translated",
             "value" : "保留的快捷键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保留的快速鍵"
+          }
         }
       }
     },
@@ -49558,6 +62716,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重設"
           }
         }
       }
@@ -49581,6 +62745,12 @@
             "state" : "translated",
             "value" : "重置所有设置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重設所有設定"
+          }
         }
       }
     },
@@ -49602,6 +62772,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "将所有设置重置为默认值"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將所有設定重設為預設值"
           }
         }
       }
@@ -49625,6 +62801,12 @@
             "state" : "translated",
             "value" : "重置布局"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重設版面配置"
+          }
         }
       }
     },
@@ -49646,6 +62828,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置示例"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重設範例"
           }
         }
       }
@@ -49669,6 +62857,12 @@
             "state" : "translated",
             "value" : "要重置示例数据库吗？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要重設範例資料庫嗎？"
+          }
         }
       }
     },
@@ -49690,6 +62884,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置示例数据库..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重設範例資料庫…"
           }
         }
       }
@@ -49713,6 +62913,12 @@
             "state" : "translated",
             "value" : "重置为默认值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重設為預設值"
+          }
         }
       }
     },
@@ -49734,6 +62940,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "恢复默认"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重設為預設值"
           }
         }
       }
@@ -49757,6 +62969,12 @@
             "state" : "translated",
             "value" : "重置为推断值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重設為推斷值"
+          }
         }
       }
     },
@@ -49778,6 +62996,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置为系统默认"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重設為系統預設值"
           }
         }
       }
@@ -49801,6 +63025,12 @@
             "state" : "translated",
             "value" : "重置缩放"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重設縮放"
+          }
         }
       }
     },
@@ -49822,6 +63052,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "资源"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資源"
           }
         }
       }
@@ -49845,6 +63081,12 @@
             "state" : "translated",
             "value" : "响应失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回應失敗"
+          }
         }
       }
     },
@@ -49866,6 +63108,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重启 Claude Desktop"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新啟動 Claude Desktop"
           }
         }
       }
@@ -49889,6 +63137,12 @@
             "state" : "translated",
             "value" : "重启 TablePro 以使语言更改完全生效。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新啟動 TablePro 以讓語言變更完全生效。"
+          }
         }
       }
     },
@@ -49911,6 +63165,12 @@
             "state" : "translated",
             "value" : "重启 TablePro 以完全卸载已移除的插件。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新啟動 TablePro 以完全解除載入已移除的外掛。"
+          }
         }
       }
     },
@@ -49932,6 +63192,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "恢复数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "還原資料庫"
           }
         }
       }
@@ -49957,6 +63223,12 @@
             "state" : "translated",
             "value" : "转储恢复已取消"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "還原備份已取消"
+          }
         }
       }
     },
@@ -49980,6 +63252,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "转储恢复完成"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "還原備份完成"
           }
         }
       }
@@ -50005,6 +63283,12 @@
             "state" : "translated",
             "value" : "转储恢复失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "還原備份失敗"
+          }
         }
       }
     },
@@ -50028,6 +63312,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "恢复转储…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在還原備份…"
           }
         }
       }
@@ -50053,6 +63343,12 @@
             "state" : "translated",
             "value" : "恢复来源"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "還原來源"
+          }
         }
       }
     },
@@ -50075,6 +63371,12 @@
             "state" : "translated",
             "value" : "恢复上次筛选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "還原上次篩選"
+          }
         }
       }
     },
@@ -50096,6 +63398,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "恢复…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "還原…"
           }
         }
       }
@@ -50125,6 +63433,12 @@
             "state" : "translated",
             "value" : "已从%2$@恢复“%1$@”"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已從 %1$@ 還原「%2$@」"
+          }
         }
       }
     },
@@ -50149,6 +63463,12 @@
             "state" : "translated",
             "value" : "正在恢复转储"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在還原資料庫"
+          }
         }
       }
     },
@@ -50170,6 +63490,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "限制为特定连接（UUID，可选）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "限制為特定連線（UUID，選用）"
           }
         }
       }
@@ -50193,6 +63519,12 @@
             "state" : "translated",
             "value" : "结果"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結果"
+          }
         }
       }
     },
@@ -50214,6 +63546,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "结果"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結果"
           }
         }
       }
@@ -50237,6 +63575,12 @@
             "state" : "translated",
             "value" : "继续"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "繼續"
+          }
         }
       }
     },
@@ -50256,6 +63600,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保留"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "保留"
@@ -50282,6 +63632,12 @@
             "state" : "translated",
             "value" : "重试"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重試"
+          }
         }
       }
     },
@@ -50304,6 +63660,12 @@
             "state" : "translated",
             "value" : "重试安装"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重試安裝"
+          }
         }
       }
     },
@@ -50325,6 +63687,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重试更新"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重試更新"
           }
         }
       }
@@ -50354,6 +63722,12 @@
             "state" : "translated",
             "value" : "重试验证"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重試驗證"
+          }
         }
       }
     },
@@ -50377,6 +63751,12 @@
             "state" : "translated",
             "value" : "复用空白表标签页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重複使用空白資料表分頁"
+          }
         }
       }
     },
@@ -50398,6 +63778,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示令牌"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示權杖"
           }
         }
       }
@@ -50421,6 +63807,12 @@
             "state" : "translated",
             "value" : "审查"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "審查"
+          }
         }
       }
     },
@@ -50442,6 +63834,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "撤销"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "撤銷"
           }
         }
       }
@@ -50465,6 +63863,12 @@
             "state" : "translated",
             "value" : "已撤销"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已撤銷"
+          }
         }
       }
     },
@@ -50486,6 +63890,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "右键点击显示全部%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按右鍵以顯示全部 %@"
           }
         }
       }
@@ -50510,6 +63920,12 @@
             "state" : "translated",
             "value" : "右键单击显示所有表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按右鍵顯示所有資料表"
+          }
         }
       }
     },
@@ -50528,6 +63944,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "角色"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "角色"
@@ -50554,6 +63976,12 @@
             "state" : "translated",
             "value" : "root"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "root"
+          }
         }
       }
     },
@@ -50576,6 +64004,12 @@
             "state" : "translated",
             "value" : "根级别"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "根層級"
+          }
         }
       }
     },
@@ -50597,6 +64031,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "第%d行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %d 列"
           }
         }
       }
@@ -50626,6 +64066,12 @@
             "state" : "translated",
             "value" : "第%d行，第%d列：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %1$d 列，第 %2$d 欄：%3$@"
+          }
         }
       }
     },
@@ -50648,6 +64094,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "行 %lld"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %lld 列"
           }
         }
       }
@@ -50678,6 +64130,12 @@
             "state" : "translated",
             "value" : "行 %lld，列 %lld：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %1$lld 列，第 %2$lld 欄：%3$@"
+          }
         }
       }
     },
@@ -50699,6 +64157,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "行数上限："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列數上限："
           }
         }
       }
@@ -50723,6 +64187,12 @@
             "state" : "translated",
             "value" : "行详情"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列詳細資訊"
+          }
         }
       }
     },
@@ -50744,6 +64214,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "行高："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列高："
           }
         }
       }
@@ -50768,6 +64244,12 @@
             "state" : "translated",
             "value" : "行高"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列高"
+          }
         }
       }
     },
@@ -50791,6 +64273,12 @@
             "state" : "translated",
             "value" : "行数限制："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列數限制："
+          }
         }
       }
     },
@@ -50812,6 +64300,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "行号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列號"
           }
         }
       }
@@ -50835,6 +64329,12 @@
             "state" : "translated",
             "value" : "行号"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列號"
+          }
         }
       }
     },
@@ -50856,6 +64356,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列"
           }
         }
       }
@@ -50880,6 +64386,12 @@
             "state" : "translated",
             "value" : "每条 INSERT 的行数"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每筆 INSERT 的列數"
+          }
         }
       }
     },
@@ -50903,6 +64415,12 @@
             "state" : "translated",
             "value" : "每条 insertMany 的行数"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每筆 insertMany 的列數"
+          }
         }
       }
     },
@@ -50924,6 +64442,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "每页行数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每頁列數"
           }
         }
       }
@@ -50947,6 +64471,12 @@
             "state" : "translated",
             "value" : "规则"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "規則"
+          }
         }
       }
     },
@@ -50968,6 +64498,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "运行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行"
           }
         }
       }
@@ -50991,6 +64527,12 @@
             "state" : "translated",
             "value" : "运行查询以查看执行时间"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行查詢以查看執行時間"
+          }
         }
       }
     },
@@ -51012,6 +64554,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在新标签页中运行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在新分頁中執行"
           }
         }
       }
@@ -51035,6 +64583,12 @@
             "state" : "translated",
             "value" : "运行脚本"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行指令碼"
+          }
         }
       }
     },
@@ -51056,6 +64610,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在终端中运行以下命令"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在終端機中執行以下指令"
           }
         }
       }
@@ -51079,6 +64639,12 @@
             "state" : "translated",
             "value" : "运行在端口 %d"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行於連接埠 %d"
+          }
         }
       }
     },
@@ -51100,6 +64666,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "运行中的线程"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行中的執行緒"
           }
         }
       }
@@ -51123,6 +64695,12 @@
             "state" : "translated",
             "value" : "安全模式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安全模式"
+          }
         }
       }
     },
@@ -51141,6 +64719,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安全模式（完整）"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "安全模式（完整）"
@@ -51168,6 +64752,12 @@
             "state" : "translated",
             "value" : "安全模式、安全模式（完整）和只读模式需要 Pro 许可证。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安全模式、安全模式（完整）和唯讀模式需要 Pro 授權。"
+          }
         }
       }
     },
@@ -51186,6 +64776,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安全模式：%@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "安全模式：%@"
@@ -51212,6 +64808,12 @@
             "state" : "translated",
             "value" : "相同选项将应用于所有选中的表。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "相同的選項將套用至所有選取的資料表。"
+          }
         }
       }
     },
@@ -51235,6 +64837,12 @@
             "state" : "translated",
             "value" : "清理类公式值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清理類公式值"
+          }
         }
       }
     },
@@ -51257,6 +64865,12 @@
             "state" : "translated",
             "value" : "保存"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存"
+          }
         }
       }
     },
@@ -51278,6 +64892,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保存并连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存並連線"
           }
         }
       }
@@ -51302,6 +64922,12 @@
             "state" : "translated",
             "value" : "保存和加载筛选预设"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存並載入篩選預設集"
+          }
         }
       }
     },
@@ -51323,6 +64949,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "仍然保存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仍要儲存"
           }
         }
       }
@@ -51346,6 +64978,12 @@
             "state" : "translated",
             "value" : "另存为"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "另存新檔"
+          }
         }
       }
     },
@@ -51367,6 +65005,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保存为收藏"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存為我的最愛"
           }
         }
       }
@@ -51390,6 +65034,12 @@
             "state" : "translated",
             "value" : "保存为收藏…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存為我的最愛…"
+          }
         }
       }
     },
@@ -51411,6 +65061,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "另存为预设..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "另存為預設集…"
           }
         }
       }
@@ -51435,6 +65091,12 @@
             "state" : "translated",
             "value" : "另存为模板"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "另存為範本"
+          }
         }
       }
     },
@@ -51456,6 +65118,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "另存为..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "另存新檔…"
           }
         }
       }
@@ -51479,6 +65147,12 @@
             "state" : "translated",
             "value" : "保存更改"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存變更"
+          }
         }
       }
     },
@@ -51500,6 +65174,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保存更改 (⌘S)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存變更 (⌘S)"
           }
         }
       }
@@ -51529,6 +65209,12 @@
             "state" : "translated",
             "value" : "将当前设置保存为配置…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將目前設定儲存為設定檔…"
+          }
         }
       }
     },
@@ -51550,6 +65236,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保存转储"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存備份檔"
           }
         }
       }
@@ -51573,6 +65265,12 @@
             "state" : "translated",
             "value" : "保存失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存失敗"
+          }
         }
       }
     },
@@ -51595,6 +65293,12 @@
             "state" : "translated",
             "value" : "保存失败：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存失敗：%@"
+          }
         }
       }
     },
@@ -51616,6 +65320,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保存筛选预设"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存篩選預設集"
           }
         }
       }
@@ -51640,6 +65350,12 @@
             "state" : "translated",
             "value" : "保存常用查询\n以便快速访问。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存常用查詢\n以便快速存取。"
+          }
         }
       }
     },
@@ -51663,6 +65379,12 @@
             "state" : "translated",
             "value" : "保存常用查询以便快速访问。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存常用查詢以便快速存取。"
+          }
         }
       }
     },
@@ -51684,6 +65406,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保存常用查询，或链接包含 .sql 文件的文件夹以与团队共享。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存常用查詢，或連結包含 .sql 檔案的資料夾以與你的團隊共用。"
           }
         }
       }
@@ -51707,6 +65435,12 @@
             "state" : "translated",
             "value" : "将密码保存到钥匙串"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將通關密語儲存至鑰匙圈"
+          }
         }
       }
     },
@@ -51728,6 +65462,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保存侧边栏更改"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存側邊欄變更"
           }
         }
       }
@@ -51751,6 +65491,12 @@
             "state" : "translated",
             "value" : "保存 SQL 文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存 SQL 檔案"
+          }
         }
       }
     },
@@ -51773,6 +65519,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保存表模板"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存資料表範本"
           }
         }
       }
@@ -51804,6 +65556,12 @@
             "state" : "translated",
             "value" : "已将“%2$@”的 %1$@ 保存到 %3$@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已將「%1$@」的 %2$@ 儲存至 %3$@"
+          }
         }
       }
     },
@@ -51825,6 +65583,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已保存的连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已儲存的連線"
           }
         }
       }
@@ -51848,6 +65612,12 @@
             "state" : "translated",
             "value" : "已保存的连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已儲存的連線"
+          }
         }
       }
     },
@@ -51869,6 +65639,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导入时会解密已保存的密码"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入時會解密已儲存的密碼"
           }
         }
       }
@@ -51895,6 +65671,12 @@
             "state" : "translated",
             "value" : "已保存的查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已儲存的查詢"
+          }
         }
       }
     },
@@ -51917,6 +65699,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "小数位数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小數位數"
           }
         }
       }
@@ -51941,6 +65729,12 @@
             "state" : "translated",
             "value" : "小数位数："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小數位數："
+          }
         }
       }
     },
@@ -51962,6 +65756,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schema"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "綱要"
           }
         }
       }
@@ -51985,6 +65785,12 @@
             "state" : "translated",
             "value" : "Schema 更改未获授权"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "綱要變更未獲授權"
+          }
         }
       }
     },
@@ -52006,6 +65812,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 的 Schema"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 的綱要"
           }
         }
       }
@@ -52029,6 +65841,12 @@
             "state" : "translated",
             "value" : "Schema 名称（用于多 Schema 数据库）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "綱要名稱（用於多綱要資料庫）"
+          }
         }
       }
     },
@@ -52051,6 +65869,12 @@
             "state" : "translated",
             "value" : "Schema 名称（省略时使用当前 Schema）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "綱要名稱（省略時使用目前的綱要）"
+          }
         }
       }
     },
@@ -52072,6 +65896,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "要切换到的 Schema 名称"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要切換到的綱要名稱"
           }
         }
       }
@@ -52096,6 +65926,12 @@
             "state" : "translated",
             "value" : "切换 Schema 失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換綱要失敗"
+          }
         }
       }
     },
@@ -52117,6 +65953,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不支持切换 Schema"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支援切換綱要"
           }
         }
       }
@@ -52140,6 +65982,12 @@
             "state" : "translated",
             "value" : "Schema：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "綱要：%@"
+          }
         }
       }
     },
@@ -52162,6 +66010,12 @@
             "state" : "translated",
             "value" : "Schema"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "綱要"
+          }
         }
       }
     },
@@ -52183,6 +66037,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "滚动到最新消息"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "捲動到最新訊息"
           }
         }
       }
@@ -52207,6 +66067,12 @@
             "state" : "translated",
             "value" : "回滚行数："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向後捲動行數："
+          }
         }
       }
     },
@@ -52228,6 +66094,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜索"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋"
           }
         }
       }
@@ -52254,6 +66126,12 @@
             "state" : "translated",
             "value" : "搜索活动"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋活動"
+          }
         }
       }
     },
@@ -52275,6 +66153,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜索列..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋欄位…"
           }
         }
       }
@@ -52298,6 +66182,12 @@
             "state" : "translated",
             "value" : "搜索连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋連線"
+          }
         }
       }
     },
@@ -52319,6 +66209,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜索数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋資料庫"
           }
         }
       }
@@ -52343,6 +66239,12 @@
             "state" : "translated",
             "value" : "搜索数据库..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋資料庫…"
+          }
         }
       }
     },
@@ -52365,6 +66267,12 @@
             "state" : "translated",
             "value" : "搜索字段…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋欄位…"
+          }
         }
       }
     },
@@ -52386,6 +66294,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜索连接..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋連線…"
           }
         }
       }
@@ -52410,6 +66324,12 @@
             "state" : "translated",
             "value" : "搜索字段..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋欄位…"
+          }
         }
       }
     },
@@ -52431,6 +66351,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜索或输入..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋或輸入…"
           }
         }
       }
@@ -52455,6 +66381,12 @@
             "state" : "translated",
             "value" : "搜索插件..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋外掛…"
+          }
         }
       }
     },
@@ -52476,6 +66408,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜索查询..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋查詢…"
           }
         }
       }
@@ -52499,6 +66437,12 @@
             "state" : "translated",
             "value" : "搜索查询历史记录"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋查詢歷程記錄"
+          }
         }
       }
     },
@@ -52520,6 +66464,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜索已保存的查询历史记录。返回匹配条目及其执行时间、行数和结果。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋已儲存的查詢歷程記錄。傳回相符的項目，包含執行時間、列數和結果。"
           }
         }
       }
@@ -52544,6 +66494,12 @@
             "state" : "translated",
             "value" : "搜索 Schema..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋綱要…"
+          }
         }
       }
     },
@@ -52565,6 +66521,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜索快捷键..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋快速鍵…"
           }
         }
       }
@@ -52592,6 +66554,12 @@
             "state" : "translated",
             "value" : "搜索表、视图、数据库..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋資料表、檢視表、資料庫…"
+          }
         }
       }
     },
@@ -52613,6 +66581,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜索文本（对 query 列进行全文匹配）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋文字（對 query 欄位進行全文比對）"
           }
         }
       }
@@ -52636,6 +66610,12 @@
             "state" : "translated",
             "value" : "搜索..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋…"
+          }
         }
       }
     },
@@ -52657,6 +66637,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "第二个筛选值"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第二個篩選值"
           }
         }
       }
@@ -52680,6 +66666,12 @@
             "state" : "translated",
             "value" : "BETWEEN 需要第二个值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BETWEEN 需要第二個值"
+          }
         }
       }
     },
@@ -52699,6 +66691,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secondary"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Secondary"
@@ -52726,6 +66724,12 @@
             "state" : "translated",
             "value" : "Secondary Preferred"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secondary Preferred"
+          }
         }
       }
     },
@@ -52748,6 +66752,12 @@
             "state" : "translated",
             "value" : "次要文本"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次要文字"
+          }
         }
       }
     },
@@ -52766,6 +66776,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "秒"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "秒"
@@ -52798,6 +66814,12 @@
             "state" : "translated",
             "value" : "Secret Access Key"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secret Access Key"
+          }
         }
       }
     },
@@ -52819,6 +66841,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分区标题"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "區段標題"
           }
         }
       }
@@ -52842,6 +66870,12 @@
             "state" : "translated",
             "value" : "安全连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安全連線"
+          }
         }
       }
     },
@@ -52861,6 +66895,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SELECT * FROM users WHERE id = 1;"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "SELECT * FROM users WHERE id = 1;"
@@ -52887,6 +66927,12 @@
             "state" : "translated",
             "value" : "SELECT * FROM users WHERE id = 42;"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SELECT * FROM users WHERE id = 42;"
+          }
         }
       }
     },
@@ -52908,6 +66954,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择要导入的 %@ 文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇要匯入的 %@ 檔案"
           }
         }
       }
@@ -52931,6 +66983,12 @@
             "state" : "translated",
             "value" : "选择由 pg_dump 以自定义归档格式生成的转储文件。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請選擇由 pg_dump 產生的自訂封存格式備份檔。"
+          }
         }
       }
     },
@@ -52952,6 +67010,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择一个插件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇外掛"
           }
         }
       }
@@ -52975,6 +67039,12 @@
             "state" : "translated",
             "value" : "选择插件查看详情"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇外掛以檢視詳細資訊"
+          }
         }
       }
     },
@@ -52997,6 +67067,12 @@
             "state" : "translated",
             "value" : "选择一个查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇查詢"
+          }
         }
       }
     },
@@ -53018,6 +67094,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择一行或一个表以查看详情"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇一列或資料表以檢視詳細資訊"
           }
         }
       }
@@ -53042,6 +67124,12 @@
             "state" : "translated",
             "value" : "选择要复制结构的表："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇要複製結構的資料表："
+          }
         }
       }
     },
@@ -53063,6 +67151,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择表…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇資料表…"
           }
         }
       }
@@ -53086,6 +67180,12 @@
             "state" : "translated",
             "value" : "全选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全選"
+          }
         }
       }
     },
@@ -53107,6 +67207,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择一个活动条目以查看详细信息。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇一個活動項目以查看詳細資訊。"
           }
         }
       }
@@ -53130,6 +67236,12 @@
             "state" : "translated",
             "value" : "选择连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇連線"
+          }
         }
       }
     },
@@ -53151,6 +67263,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择筛选列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇篩選欄位"
           }
         }
       }
@@ -53175,6 +67293,12 @@
             "state" : "translated",
             "value" : "为 %@ 选择筛选条件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "為 %@ 選擇篩選條件"
+          }
         }
       }
     },
@@ -53196,6 +67320,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择筛选运算符"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇篩選運算子"
           }
         }
       }
@@ -53220,6 +67350,12 @@
             "state" : "translated",
             "value" : "选择要附加的图片"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇要附加的圖片"
+          }
         }
       }
     },
@@ -53241,6 +67377,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择模型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇模型"
           }
         }
       }
@@ -53264,6 +67406,12 @@
             "state" : "translated",
             "value" : "选择插件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇外掛"
+          }
         }
       }
     },
@@ -53285,6 +67433,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择 Schema"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇綱要"
           }
         }
       }
@@ -53309,6 +67463,12 @@
             "state" : "translated",
             "value" : "选择 SQL 文件..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇 SQL 檔案…"
+          }
         }
       }
     },
@@ -53330,6 +67490,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择要打开的 SQL 文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇要開啟的 SQL 檔案"
           }
         }
       }
@@ -53353,6 +67519,12 @@
             "state" : "translated",
             "value" : "选择标签页 %d"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇分頁 %d"
+          }
         }
       }
     },
@@ -53375,6 +67547,12 @@
             "state" : "translated",
             "value" : "选择标签页 %lld"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇分頁 %lld"
+          }
         }
       }
     },
@@ -53396,6 +67574,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选中项"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選取的項目"
           }
         }
       }
@@ -53425,6 +67609,12 @@
             "state" : "translated",
             "value" : "所选 SSH 配置已不存在。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選取的 SSH 設定檔已不存在。"
+          }
         }
       }
     },
@@ -53446,6 +67636,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选区"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選取範圍"
           }
         }
       }
@@ -53469,6 +67665,12 @@
             "state" : "translated",
             "value" : "发送消息"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "傳送訊息"
+          }
         }
       }
     },
@@ -53490,6 +67692,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "向 GitHub 发送遥测数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向 GitHub 傳送遙測資料"
           }
         }
       }
@@ -53513,6 +67721,12 @@
             "state" : "translated",
             "value" : "服务器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伺服器"
+          }
         }
       }
     },
@@ -53535,6 +67749,12 @@
             "state" : "translated",
             "value" : "服务器配置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伺服器設定"
+          }
         }
       }
     },
@@ -53556,6 +67776,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "服务器仪表盘"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伺服器儀表板"
           }
         }
       }
@@ -53584,6 +67810,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "服务器错误（%d）：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伺服器錯誤（%1$d）：%2$@"
           }
         }
       }
@@ -53614,6 +67846,12 @@
             "state" : "translated",
             "value" : "服务器错误 (%lld)：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伺服器錯誤（%1$lld）：%2$@"
+          }
         }
       }
     },
@@ -53635,6 +67873,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "服务器指标"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伺服器指標"
           }
         }
       }
@@ -53658,6 +67902,12 @@
             "state" : "translated",
             "value" : "此数据库类型不支持服务器监控。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此資料庫類型不支援伺服器監控。"
+          }
         }
       }
     },
@@ -53679,6 +67929,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "边缘端的无服务器 SQLite"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "邊緣端的無伺服器 SQLite"
           }
         }
       }
@@ -53702,6 +67958,12 @@
             "state" : "translated",
             "value" : "服务"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服務"
+          }
         }
       }
     },
@@ -53723,6 +67985,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "服务账号密钥"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服務帳戶金鑰"
           }
         }
       }
@@ -53747,6 +68015,12 @@
             "state" : "translated",
             "value" : "服务名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服務名稱"
+          }
         }
       }
     },
@@ -53768,6 +68042,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "服务已停止"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服務已停止"
           }
         }
       }
@@ -53791,6 +68071,12 @@
             "state" : "translated",
             "value" : "服务令牌"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服務權杖"
+          }
         }
       }
     },
@@ -53812,6 +68098,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "需要服务令牌 ID 和密钥"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要服務權杖 ID 和金鑰"
           }
         }
       }
@@ -53841,6 +68133,12 @@
             "state" : "translated",
             "value" : "Session Token"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session Token"
+          }
         }
       }
     },
@@ -53862,6 +68160,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "设为活动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設為使用中"
           }
         }
       }
@@ -53885,6 +68189,12 @@
             "state" : "translated",
             "value" : "设为 DEFAULT"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設為 DEFAULT"
+          }
         }
       }
     },
@@ -53907,6 +68217,12 @@
             "state" : "translated",
             "value" : "设为空"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設為空"
+          }
         }
       }
     },
@@ -53928,6 +68244,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "设为 NULL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設為 NULL"
           }
         }
       }
@@ -53952,6 +68274,12 @@
             "state" : "translated",
             "value" : "设置特殊值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定特殊值"
+          }
         }
       }
     },
@@ -53973,6 +68301,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "设为 NULL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設為 NULL"
           }
         }
       }
@@ -53997,6 +68331,12 @@
             "state" : "translated",
             "value" : "设置 AI 提供商"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定 AI 供應商"
+          }
         }
       }
     },
@@ -54018,6 +68358,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "设置值"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定值"
           }
         }
       }
@@ -54041,6 +68387,12 @@
             "state" : "translated",
             "value" : "设置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定"
+          }
         }
       }
     },
@@ -54062,6 +68414,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "设置已更改"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定已變更"
           }
         }
       }
@@ -54085,6 +68443,12 @@
             "state" : "translated",
             "value" : "设置在此 Mac 和另一台设备上均已更改。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定在此 Mac 和另一台裝置上都已變更。"
+          }
         }
       }
     },
@@ -54106,6 +68470,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "设置："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定："
           }
         }
       }
@@ -54129,6 +68499,12 @@
             "state" : "translated",
             "value" : "设置说明"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定說明"
+          }
         }
       }
     },
@@ -54151,6 +68527,12 @@
             "state" : "translated",
             "value" : "与 SQL 关键字 '%@' 冲突"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "與 SQL 關鍵字「%@」衝突"
+          }
         }
       }
     },
@@ -54169,6 +68551,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分享"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "分享"
@@ -54195,6 +68583,12 @@
             "state" : "translated",
             "value" : "共享匿名使用数据"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分享匿名使用資料"
+          }
         }
       }
     },
@@ -54216,6 +68610,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接前运行的 Shell 脚本。非零退出码将中止连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線前執行的 Shell 指令稿。非零結束碼會中止連線。"
           }
         }
       }
@@ -54239,6 +68639,12 @@
             "state" : "translated",
             "value" : "快捷键冲突"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速鍵衝突"
+          }
         }
       }
     },
@@ -54260,6 +68666,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "快捷键录制"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速鍵錄製器"
           }
         }
       }
@@ -54283,6 +68695,12 @@
             "state" : "translated",
             "value" : "显示全部"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示全部"
+          }
         }
       }
     },
@@ -54304,6 +68722,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示全部%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示全部 %@"
           }
         }
       }
@@ -54328,6 +68752,12 @@
             "state" : "translated",
             "value" : "显示所有集合"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示所有集合"
+          }
         }
       }
     },
@@ -54349,6 +68779,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示所有列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示所有欄位"
           }
         }
       }
@@ -54372,6 +68808,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示所有数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示所有資料庫"
           }
         }
       }
@@ -54398,6 +68840,12 @@
             "state" : "translated",
             "value" : "显示所有行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示所有列"
+          }
         }
       }
     },
@@ -54421,6 +68869,12 @@
             "state" : "translated",
             "value" : "显示所有表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示所有資料表"
+          }
         }
       }
     },
@@ -54442,6 +68896,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示交替行背景"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示交替列背景"
           }
         }
       }
@@ -54465,6 +68925,12 @@
             "state" : "translated",
             "value" : "显示补全"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示自動完成"
+          }
         }
       }
     },
@@ -54486,6 +68952,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示 DDL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示 DDL"
           }
         }
       }
@@ -54509,6 +68981,12 @@
             "state" : "translated",
             "value" : "显示详细信息"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示詳細資訊"
+          }
         }
       }
     },
@@ -54530,6 +69008,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示 ER 图"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示 ER 圖"
           }
         }
       }
@@ -54553,6 +69037,12 @@
             "state" : "translated",
             "value" : "显示收藏侧边栏"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示我的最愛側邊欄"
+          }
         }
       }
     },
@@ -54574,6 +69064,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在访达中显示"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Finder 中顯示"
           }
         }
       }
@@ -54597,6 +69093,12 @@
             "state" : "translated",
             "value" : "显示行号"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示行號"
+          }
         }
       }
     },
@@ -54618,6 +69120,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示下一个标签页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示下一個分頁"
           }
         }
       }
@@ -54641,6 +69149,12 @@
             "state" : "translated",
             "value" : "显示上一个标签页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示上一個分頁"
+          }
         }
       }
     },
@@ -54662,6 +69176,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示行号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示列號"
           }
         }
       }
@@ -54685,6 +69205,12 @@
             "state" : "translated",
             "value" : "显示结构"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示結構"
+          }
         }
       }
     },
@@ -54706,6 +69232,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示系统 Schema"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示系統綱要"
           }
         }
       }
@@ -54729,6 +69261,12 @@
             "state" : "translated",
             "value" : "显示表侧边栏"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示資料表側邊欄"
+          }
         }
       }
     },
@@ -54750,6 +69288,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示欢迎屏幕"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示歡迎畫面"
           }
         }
       }
@@ -54773,6 +69317,12 @@
             "state" : "translated",
             "value" : "显示欢迎窗口"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示歡迎視窗"
+          }
         }
       }
     },
@@ -54794,6 +69344,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示 %@ 行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示 %@ 列"
           }
         }
       }
@@ -54823,6 +69379,12 @@
             "state" : "translated",
             "value" : "显示前 50,000 个键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示前 50,000 個鍵"
+          }
         }
       }
     },
@@ -54844,6 +69406,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "侧边栏"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "側邊欄"
           }
         }
       }
@@ -54867,6 +69435,12 @@
             "state" : "translated",
             "value" : "侧边栏显示为列表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "側邊欄顯示為清單"
+          }
         }
       }
     },
@@ -54889,6 +69463,12 @@
             "state" : "translated",
             "value" : "侧边栏显示为树状"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "側邊欄顯示為樹狀"
+          }
         }
       }
     },
@@ -54910,6 +69490,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "侧边栏布局"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "側邊欄版面配置"
           }
         }
       }
@@ -54934,6 +69520,12 @@
             "state" : "translated",
             "value" : "侧边栏"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "側邊欄"
+          }
         }
       }
     },
@@ -54955,6 +69547,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "登录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登入"
           }
         }
       }
@@ -54978,6 +69576,12 @@
             "state" : "translated",
             "value" : "请在系统设置中登录 iCloud 以启用同步。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請在系統設定中登入 iCloud 以啟用同步。"
+          }
         }
       }
     },
@@ -54999,6 +69603,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "登录 iCloud 以启用同步"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登入 iCloud 以啟用同步"
           }
         }
       }
@@ -55024,6 +69634,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "通过浏览器登录..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "透過瀏覽器登入..."
           }
         }
       }
@@ -55053,6 +69669,12 @@
             "state" : "translated",
             "value" : "使用 GitHub 登录"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 GitHub 登入"
+          }
         }
       }
     },
@@ -55075,6 +69697,12 @@
             "state" : "translated",
             "value" : "退出登录"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登出"
+          }
         }
       }
     },
@@ -55096,6 +69724,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "登录已取消"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登入已取消"
           }
         }
       }
@@ -55121,6 +69755,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "登录超时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登入逾時"
           }
         }
       }
@@ -55150,6 +69790,12 @@
             "state" : "translated",
             "value" : "已登录"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已登入"
+          }
         }
       }
     },
@@ -55171,6 +69817,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已登录为 %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已登入為 %@"
           }
         }
       }
@@ -55197,6 +69849,12 @@
             "state" : "translated",
             "value" : "正在登录…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在登入…"
+          }
         }
       }
     },
@@ -55218,6 +69876,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "登录 Cloudflare Access 一次并缓存令牌，连接时不再打开浏览器。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登入 Cloudflare Access 一次並快取權杖，這樣連線時就不會開啟瀏覽器。"
           }
         }
       }
@@ -55241,6 +69905,12 @@
             "state" : "translated",
             "value" : "静默"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "靜音"
+          }
         }
       }
     },
@@ -55263,6 +69933,12 @@
             "state" : "translated",
             "value" : "单击表时打开临时标签页，下次点击时会被替换。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按一下資料表會開啟暫時分頁，下次按一下時會被取代。"
+          }
         }
       }
     },
@@ -55281,6 +69957,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大小"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "大小"
@@ -55307,6 +69989,12 @@
             "state" : "translated",
             "value" : "大小"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大小"
+          }
         }
       }
     },
@@ -55328,6 +70016,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自动调整所有列宽"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動調整所有欄位寬度"
           }
         }
       }
@@ -55351,6 +70045,12 @@
             "state" : "translated",
             "value" : "自动调整"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動調整大小"
+          }
         }
       }
     },
@@ -55370,6 +70070,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大小："
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "大小："
@@ -55396,6 +70102,12 @@
             "state" : "translated",
             "value" : "跳过"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "略過"
+          }
         }
       }
     },
@@ -55417,6 +70129,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此操作将跳过外键约束检查"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作會跳過外鍵約束檢查"
           }
         }
       }
@@ -55440,6 +70158,12 @@
             "state" : "translated",
             "value" : "斜杠命令"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "斜線命令"
+          }
         }
       }
     },
@@ -55459,6 +70183,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "慢速"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "慢速"
@@ -55485,6 +70215,12 @@
             "state" : "translated",
             "value" : "慢查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "緩慢查詢"
+          }
         }
       }
     },
@@ -55504,6 +70240,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "小"
@@ -55530,6 +70272,12 @@
             "state" : "translated",
             "value" : "智能 SQL 编辑器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "智慧 SQL 編輯器"
+          }
         }
       }
     },
@@ -55552,6 +70300,12 @@
             "state" : "translated",
             "value" : "智能值识别"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "智慧值偵測"
+          }
         }
       }
     },
@@ -55571,6 +70325,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平滑"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "平滑"
@@ -55597,6 +70357,12 @@
             "state" : "translated",
             "value" : "软件更新"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "軟體更新"
+          }
         }
       }
     },
@@ -55618,6 +70384,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此预设中的某些列在当前表中不存在"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此預設集中的某些欄位在目前資料表中不存在"
           }
         }
       }
@@ -55641,6 +70413,12 @@
             "state" : "translated",
             "value" : "部分密码未能读取。导入后可在连接编辑器中输入。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分密碼未能讀取。你可以在匯入後於連線編輯器中輸入。"
+          }
         }
       }
     },
@@ -55663,6 +70441,12 @@
             "state" : "translated",
             "value" : "部分标签页有未保存的编辑。退出将丢弃这些更改。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分分頁有未儲存的編輯。結束將捨棄這些變更。"
+          }
         }
       }
     },
@@ -55684,6 +70468,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "出错了（错误%d），请稍后重试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "發生錯誤（錯誤 %d）。請稍後再試。"
           }
         }
       }
@@ -55708,6 +70498,12 @@
             "state" : "translated",
             "value" : "出现问题（错误 %lld）。请稍后重试。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "發生錯誤（錯誤 %lld）。請稍後再試。"
+          }
         }
       }
     },
@@ -55729,6 +70525,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "升序排列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "遞增排序"
           }
         }
       }
@@ -55752,6 +70554,12 @@
             "state" : "translated",
             "value" : "降序排列"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "遞減排序"
+          }
         }
       }
     },
@@ -55773,6 +70581,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "升序排序"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已遞增排序"
           }
         }
       }
@@ -55796,6 +70610,12 @@
             "state" : "translated",
             "value" : "降序排序"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已遞減排序"
+          }
         }
       }
     },
@@ -55818,6 +70638,12 @@
             "state" : "translated",
             "value" : "排序将重新加载数据并丢弃所有未保存的更改。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排序將重新載入資料並捨棄所有未儲存的變更。"
+          }
         }
       }
     },
@@ -55839,6 +70665,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "来源"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "來源"
           }
         }
       }
@@ -55863,6 +70695,12 @@
             "state" : "translated",
             "value" : "来源："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "來源："
+          }
         }
       }
     },
@@ -55886,6 +70724,12 @@
             "state" : "translated",
             "value" : "间距"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "間距"
+          }
         }
       }
     },
@@ -55908,6 +70752,12 @@
             "state" : "translated",
             "value" : "宽松"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寬鬆"
+          }
         }
       }
     },
@@ -55929,6 +70779,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "赞助"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "贊助"
           }
         }
       }
@@ -55953,6 +70809,12 @@
             "state" : "translated",
             "value" : "赞助 TablePro"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "贊助 TablePro"
+          }
         }
       }
     },
@@ -55972,6 +70834,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "SQL"
@@ -55998,6 +70866,12 @@
             "state" : "translated",
             "value" : "连接后执行的 SQL 命令，例如 SET time_zone = 'Asia/Ho_Chi_Minh'。每行一条或用分号分隔。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線後執行的 SQL 指令，例如 SET time_zone = 'Asia/Ho_Chi_Minh'。每行一條或以分號分隔。"
+          }
         }
       }
     },
@@ -56017,6 +70891,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL 方言"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "SQL 方言"
@@ -56043,6 +70923,12 @@
             "state" : "translated",
             "value" : "%@ 的 SQL 方言不可用。插件可能未安装或未加载。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 的 SQL 方言無法使用。外掛可能尚未安裝或載入。"
+          }
         }
       }
     },
@@ -56065,6 +70951,12 @@
             "state" : "translated",
             "value" : "SQL 编辑器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL 編輯器"
+          }
         }
       }
     },
@@ -56086,6 +70978,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SQL 函数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL 函式"
           }
         }
       }
@@ -56110,6 +71008,12 @@
             "state" : "translated",
             "value" : "不支持对 %@ 连接进行 SQL 导入。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 連線不支援 SQL 匯入。"
+          }
         }
       }
     },
@@ -56131,6 +71035,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SQL INSERT 语句。用于在其他数据库中重建数据。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL INSERT 陳述式。用於在其他資料庫中重建資料。"
           }
         }
       }
@@ -56160,6 +71070,12 @@
             "state" : "translated",
             "value" : "SQL 过长：%d 个字符（上限 %d）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL 過長：%1$d 個字（上限 %2$d）"
+          }
         }
       }
     },
@@ -56181,6 +71097,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SQL 或 NoSQL 查询文本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL 或 NoSQL 查詢文字"
           }
         }
       }
@@ -56204,6 +71126,12 @@
             "state" : "translated",
             "value" : "SQL 预览"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL 預覽"
+          }
         }
       }
     },
@@ -56225,6 +71153,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SQL 查询"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL 查詢"
           }
         }
       }
@@ -56248,6 +71182,12 @@
             "state" : "translated",
             "value" : "SQL 查询编辑器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL 查詢編輯器"
+          }
         }
       }
     },
@@ -56270,6 +71210,12 @@
             "state" : "translated",
             "value" : "要导出结果的 SQL 查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要匯出結果的 SQL 查詢"
+          }
         }
       }
     },
@@ -56289,6 +71235,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL Server"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "SQL Server"
@@ -56315,6 +71267,12 @@
             "state" : "translated",
             "value" : "SQL Server 连接使用系统信任存储。FreeTDS dblib 不支持按连接配置 CA 和客户端证书路径；如需自定义信任锚，请在 `freetds.conf` 中配置。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL Server 連線使用系統信任存放區。FreeTDS dblib 不支援按連線設定 CA 和用戶端憑證路徑；如果你需要自訂信任錨點，請在 `freetds.conf` 中設定。"
+          }
         }
       }
     },
@@ -56336,6 +71294,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SQLite 基于文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQLite 以檔案為基礎"
           }
         }
       }
@@ -56360,6 +71324,12 @@
             "state" : "translated",
             "value" : "sqlite3 已包含在 macOS 中"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sqlite3 已內建於 macOS"
+          }
         }
       }
     },
@@ -56378,6 +71348,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "SSH"
@@ -56404,6 +71380,12 @@
             "state" : "translated",
             "value" : "SSH Agent"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH Agent"
+          }
         }
       }
     },
@@ -56426,6 +71408,12 @@
             "state" : "translated",
             "value" : "SSH 代理未通过身份验证。运行 ssh-add -l 检查已加载的密钥。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 代理未通過驗證。請執行 ssh-add -l 檢查已載入的金鑰。"
+          }
         }
       }
     },
@@ -56447,6 +71435,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SSH 认证失败。请检查您的凭据或私钥。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 驗證失敗。請檢查你的憑證或私鑰。"
           }
         }
       }
@@ -56471,6 +71465,12 @@
             "state" : "translated",
             "value" : "未找到 SSH 命令。请确保已安装 OpenSSH。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到 SSH 指令。請確認已安裝 OpenSSH。"
+          }
         }
       }
     },
@@ -56494,6 +71494,12 @@
             "state" : "translated",
             "value" : "SSH 连接测试失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 連線測試失敗"
+          }
         }
       }
     },
@@ -56515,6 +71521,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SSH 连接超时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 連線逾時"
           }
         }
       }
@@ -56538,6 +71550,12 @@
             "state" : "translated",
             "value" : "SSH 主机"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 主機"
+          }
         }
       }
     },
@@ -56559,6 +71577,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "需要 SSH 主机"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要 SSH 主機"
           }
         }
       }
@@ -56582,6 +71606,12 @@
             "state" : "translated",
             "value" : "SSH 主机密钥已更改"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 主機金鑰已變更"
+          }
         }
       }
     },
@@ -56603,6 +71633,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SSH 主机密钥验证失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 主機金鑰驗證失敗"
           }
         }
       }
@@ -56626,6 +71662,12 @@
             "state" : "translated",
             "value" : "需要 SSH 密钥密码"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要 SSH 金鑰密碼短語"
+          }
         }
       }
     },
@@ -56647,6 +71689,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SSH 密码被拒绝。请检查密码后重试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 密碼被拒絕。請檢查密碼後再試一次。"
           }
         }
       }
@@ -56670,6 +71718,12 @@
             "state" : "translated",
             "value" : "SSH 端口"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 連接埠"
+          }
         }
       }
     },
@@ -56691,6 +71745,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SSH 端口必须在 1 到 65535 之间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 連接埠必須在 1 到 65535 之間"
           }
         }
       }
@@ -56714,6 +71774,12 @@
             "state" : "translated",
             "value" : "未找到 SSH 私钥：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到 SSH 私密金鑰：%@"
+          }
         }
       }
     },
@@ -56735,6 +71801,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SSH 私钥被拒绝。请检查密钥文件或密码短语。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 私密金鑰被拒絕。請檢查金鑰檔案或密碼短語。"
           }
         }
       }
@@ -56765,6 +71837,12 @@
             "state" : "translated",
             "value" : "SSH 配置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 設定檔"
+          }
         }
       }
     },
@@ -56793,6 +71871,12 @@
             "state" : "translated",
             "value" : "SSH 配置："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 設定檔："
+          }
         }
       }
     },
@@ -56811,6 +71895,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 隧道"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "SSH 隧道"
@@ -56837,6 +71927,12 @@
             "state" : "translated",
             "value" : "连接已存在 SSH 隧道：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線已存在 SSH 隧道：%@"
+          }
         }
       }
     },
@@ -56858,6 +71954,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "创建 SSH 隧道失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立 SSH 隧道失敗：%@"
           }
         }
       }
@@ -56882,6 +71984,12 @@
             "state" : "translated",
             "value" : "SSH 隧道在 30 秒内未能连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 隧道未能在 30 秒內連線"
+          }
         }
       }
     },
@@ -56904,6 +72012,12 @@
             "state" : "translated",
             "value" : "SSH 隧道已断开。点按以重新连接。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 隧道已中斷連線。點按以重新連線。"
+          }
         }
       }
     },
@@ -56925,6 +72039,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SSH 隧道和 SSL/TLS 加密支持"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支援 SSH 隧道與 SSL/TLS 加密"
           }
         }
       }
@@ -56949,6 +72069,12 @@
             "state" : "translated",
             "value" : "SSH 隧道仅转发第一个主机。其他副本集成员必须能从 SSH 服务器直接访问。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 隧道僅會轉送第一個主機。其他複本集成員必須能從 SSH 伺服器直接連線。"
+          }
         }
       }
     },
@@ -56971,6 +72097,12 @@
             "state" : "translated",
             "value" : "SSH 用户"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 使用者"
+          }
         }
       }
     },
@@ -56989,6 +72121,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ssh.example.com"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ssh.example.com"
@@ -57015,6 +72153,12 @@
             "state" : "translated",
             "value" : "SSL"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSL"
+          }
         }
       }
     },
@@ -57033,6 +72177,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSL 模式"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "SSL 模式"
@@ -57059,6 +72209,12 @@
             "state" : "translated",
             "value" : "SSL/TLS"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSL/TLS"
+          }
         }
       }
     },
@@ -57080,6 +72236,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在启动服务…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在啟動服務…"
           }
         }
       }
@@ -57103,6 +72265,12 @@
             "state" : "translated",
             "value" : "正在启动…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在啟動…"
+          }
         }
       }
     },
@@ -57124,6 +72292,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "随此连接启动和停止 `cloudflared access tcp`，并通过本地端口路由。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隨此連線啟動和停止 `cloudflared access tcp`，並透過本機連接埠路由。"
           }
         }
       }
@@ -57147,6 +72321,12 @@
             "state" : "translated",
             "value" : "以...开头"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開頭為"
+          }
         }
       }
     },
@@ -57168,6 +72348,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启动命令"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟動指令"
           }
         }
       }
@@ -57191,6 +72377,12 @@
             "state" : "translated",
             "value" : "状态"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態"
+          }
         }
       }
     },
@@ -57212,6 +72404,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "条语句"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "陳述式"
           }
         }
       }
@@ -57235,6 +72433,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "语句 %lld"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "陳述式 %lld"
           }
         }
       }
@@ -57265,6 +72469,12 @@
             "state" : "translated",
             "value" : "语句 %lld / %lld"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "陳述式 %1$lld / %2$lld"
+          }
         }
       }
     },
@@ -57286,6 +72496,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "语句："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "陳述式："
           }
         }
       }
@@ -57309,6 +72525,12 @@
             "state" : "translated",
             "value" : "条语句"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "陳述式"
+          }
         }
       }
     },
@@ -57330,6 +72552,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "统计信息"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "統計資訊"
           }
         }
       }
@@ -57353,6 +72581,12 @@
             "state" : "translated",
             "value" : "状态"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態"
+          }
         }
       }
     },
@@ -57374,6 +72608,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "状态颜色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態顏色"
           }
         }
       }
@@ -57397,6 +72637,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "状态指示点"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態指示點"
           }
         }
       }
@@ -57426,6 +72672,12 @@
             "state" : "translated",
             "value" : "状态："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態："
+          }
         }
       }
     },
@@ -57447,6 +72699,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "状态：活动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態：使用中"
           }
         }
       }
@@ -57470,6 +72728,12 @@
             "state" : "translated",
             "value" : "状态：错误"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態：錯誤"
+          }
         }
       }
     },
@@ -57491,6 +72755,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "状态：已过期"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態：已過期"
           }
         }
       }
@@ -57514,6 +72784,12 @@
             "state" : "translated",
             "value" : "状态：失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態：失敗"
+          }
         }
       }
     },
@@ -57535,6 +72811,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "状态：已撤销"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態：已撤銷"
           }
         }
       }
@@ -57558,6 +72840,12 @@
             "state" : "translated",
             "value" : "状态：运行中"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態：執行中"
+          }
         }
       }
     },
@@ -57579,6 +72867,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "状态：启动中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態：啟動中"
           }
         }
       }
@@ -57602,6 +72896,12 @@
             "state" : "translated",
             "value" : "状态：已停止"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態：已停止"
+          }
         }
       }
     },
@@ -57624,6 +72924,12 @@
             "state" : "translated",
             "value" : "状态：成功"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態：成功"
+          }
         }
       }
     },
@@ -57645,6 +72951,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "状态：警告"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態：警告"
           }
         }
       }
@@ -57669,6 +72981,12 @@
             "state" : "translated",
             "value" : "重现步骤"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重現步驟"
+          }
         }
       }
     },
@@ -57687,6 +73005,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "停止"
@@ -57713,6 +73037,12 @@
             "state" : "translated",
             "value" : "停止导出？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止匯出？"
+          }
         }
       }
     },
@@ -57731,6 +73061,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止生成"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "停止生成"
@@ -57757,6 +73093,12 @@
             "state" : "translated",
             "value" : "已停止"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已停止"
+          }
         }
       }
     },
@@ -57778,6 +73120,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "流式传输失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "串流失敗：%@"
           }
         }
       }
@@ -57801,6 +73149,12 @@
             "state" : "translated",
             "value" : "字符串"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字串"
+          }
         }
       }
     },
@@ -57822,6 +73176,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "结构"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結構"
           }
         }
       }
@@ -57846,6 +73206,12 @@
             "state" : "translated",
             "value" : "结构、删除和数据选项在表列表中按表单独配置。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結構、刪除與資料選項會在資料表清單中針對每個資料表個別設定。"
+          }
         }
       }
     },
@@ -57868,6 +73234,12 @@
             "state" : "translated",
             "value" : "结构化数据格式。适用于 API 和 Web 应用。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結構化資料格式。適合用於 API 與網頁應用程式。"
+          }
         }
       }
     },
@@ -57887,6 +73259,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提交"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "提交"
@@ -57914,6 +73292,12 @@
             "state" : "translated",
             "value" : "提交另一个"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再提交一筆"
+          }
         }
       }
     },
@@ -57933,6 +73317,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在提交…"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在提交…"
@@ -57959,6 +73349,12 @@
             "state" : "translated",
             "value" : "成功"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "成功"
+          }
         }
       }
     },
@@ -57980,6 +73376,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "为当前查询提供优化建议"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "為目前的查詢提供最佳化建議"
           }
         }
       }
@@ -58003,6 +73405,12 @@
             "state" : "translated",
             "value" : "建议的操作"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建議的操作"
+          }
         }
       }
     },
@@ -58024,6 +73432,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已暂停"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已暫停"
           }
         }
       }
@@ -58057,6 +73471,12 @@
             "state" : "translated",
             "value" : "切换连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換連線"
+          }
         }
       }
     },
@@ -58078,6 +73498,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切换连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換連線"
           }
         }
       }
@@ -58101,6 +73527,12 @@
             "state" : "translated",
             "value" : "切换连接 (⌘⌥C)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換連線 (⌘⌥C)"
+          }
         }
       }
     },
@@ -58122,6 +73554,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切换连接..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換連線…"
           }
         }
       }
@@ -58146,6 +73584,12 @@
             "state" : "translated",
             "value" : "切换数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換資料庫"
+          }
         }
       }
     },
@@ -58167,6 +73611,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切换数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換資料庫"
           }
         }
       }
@@ -58191,6 +73641,12 @@
             "state" : "translated",
             "value" : "切换数据库 (⌘K)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換資料庫 (⌘K)"
+          }
         }
       }
     },
@@ -58212,6 +73668,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切换失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換失敗"
           }
         }
       }
@@ -58235,6 +73697,12 @@
             "state" : "translated",
             "value" : "切换 Schema"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換綱要"
+          }
         }
       }
     },
@@ -58256,6 +73724,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切换 Schema"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換綱要"
           }
         }
       }
@@ -58279,6 +73753,12 @@
             "state" : "translated",
             "value" : "切换连接的活动数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換連線上使用中的資料庫"
+          }
         }
       }
     },
@@ -58300,6 +73780,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切换连接的活动 Schema"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換連線上使用中的綱要"
           }
         }
       }
@@ -58329,6 +73815,12 @@
             "state" : "translated",
             "value" : "切换为内联配置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換為內嵌設定"
+          }
         }
       }
     },
@@ -58354,6 +73846,12 @@
             "state" : "translated",
             "value" : "执行前切换到此数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行前切換到此資料庫"
+          }
         }
       }
     },
@@ -58376,6 +73874,12 @@
             "state" : "translated",
             "value" : "执行前切换到此 Schema"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行前切換到此綱要"
+          }
         }
       }
     },
@@ -58395,6 +73899,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "同步"
@@ -58422,6 +73932,12 @@
             "state" : "translated",
             "value" : "同步（Pro）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步（Pro）"
+          }
         }
       }
     },
@@ -58443,6 +73959,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "同步分类"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步分類"
           }
         }
       }
@@ -58466,6 +73988,12 @@
             "state" : "translated",
             "value" : "同步冲突"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步衝突"
+          }
         }
       }
     },
@@ -58487,6 +74015,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在多台 Mac 之间同步连接、设置和历史记录。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在你的多台 Mac 之間同步連線、設定與歷程記錄。"
           }
         }
       }
@@ -58510,6 +74044,12 @@
             "state" : "translated",
             "value" : "同步错误"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步錯誤"
+          }
         }
       }
     },
@@ -58528,6 +74068,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即同步"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "立即同步"
@@ -58554,6 +74100,12 @@
             "state" : "translated",
             "value" : "同步已关闭"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步已關閉"
+          }
         }
       }
     },
@@ -58575,6 +74127,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "同步已暂停 - Pro 许可证已过期"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步已暫停，Pro 授權已過期"
           }
         }
       }
@@ -58598,6 +74156,12 @@
             "state" : "translated",
             "value" : "同步状态"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步狀態"
+          }
         }
       }
     },
@@ -58620,6 +74184,12 @@
             "state" : "translated",
             "value" : "未找到同步区域。将执行完整同步。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到同步區域。將執行完整同步。"
+          }
         }
       }
     },
@@ -58638,6 +74208,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已同步"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "已同步"
@@ -58664,6 +74240,12 @@
             "state" : "translated",
             "value" : "正在与 iCloud 同步…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在與 iCloud 同步…"
+          }
         }
       }
     },
@@ -58682,6 +74264,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在同步…"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在同步…"
@@ -58709,6 +74297,12 @@
             "state" : "translated",
             "value" : "通过 iCloud 在多台 Mac 之间同步连接、设置和历史记录。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "透過 iCloud 在你的多台 Mac 之間同步連線、設定與歷程記錄。"
+          }
         }
       }
     },
@@ -58731,6 +74325,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "通过 iCloud 在多台 Mac 之间同步连接、设置和 SSH 配置。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "透過 iCloud 在你的多台 Mac 之間同步連線、設定與 SSH 設定檔。"
           }
         }
       }
@@ -58755,6 +74355,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "通过 iCloud 在你的多台 Mac 之间同步连接、表收藏、设置和 SSH 配置。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "透過 iCloud 在你的多台 Mac 之間同步連線、資料表我的最愛、設定和 SSH 設定檔。"
           }
         }
       }
@@ -58784,6 +74390,12 @@
             "state" : "translated",
             "value" : "通过 iCloud 钥匙串同步密码（端到端加密）。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "透過 iCloud 鑰匙圈同步密碼（端對端加密）。"
+          }
         }
       }
     },
@@ -58805,6 +74417,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "语法颜色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "語法顏色"
           }
         }
       }
@@ -58828,6 +74446,12 @@
             "state" : "translated",
             "value" : "语法高亮、自动补全和多标签编辑"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "語法上色、自動完成與多分頁編輯"
+          }
         }
       }
     },
@@ -58849,6 +74473,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "系统"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系統"
           }
         }
       }
@@ -58872,6 +74502,12 @@
             "state" : "translated",
             "value" : "系统保留快捷键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系統保留快速鍵"
+          }
         }
       }
     },
@@ -58894,6 +74530,12 @@
             "state" : "translated",
             "value" : "系统表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系統資料表"
+          }
         }
       }
     },
@@ -58915,6 +74557,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "系统表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系統資料表"
           }
         }
       }
@@ -58939,6 +74587,12 @@
             "state" : "translated",
             "value" : "标签页行为"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分頁行為"
+          }
         }
       }
     },
@@ -58961,6 +74615,12 @@
             "state" : "translated",
             "value" : "制表符宽度："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tab 寬度："
+          }
         }
       }
     },
@@ -58982,6 +74642,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表"
           }
         }
       }
@@ -59006,6 +74672,12 @@
             "state" : "translated",
             "value" : "表 '%@' 没有列或不存在"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表「%@」沒有欄位或不存在"
+          }
         }
       }
     },
@@ -59029,6 +74701,12 @@
             "state" : "translated",
             "value" : "表创建选项不可用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法使用資料表建立選項"
+          }
         }
       }
     },
@@ -59050,6 +74728,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "表收藏："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表我的最愛："
           }
         }
       }
@@ -59074,6 +74758,12 @@
             "state" : "translated",
             "value" : "表信息"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表資訊"
+          }
         }
       }
     },
@@ -59095,6 +74785,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "表名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表名稱"
           }
         }
       }
@@ -59119,6 +74815,12 @@
             "state" : "translated",
             "value" : "表名"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表名稱"
+          }
         }
       }
     },
@@ -59140,6 +74842,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "要打开的表名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要開啟的資料表名稱"
           }
         }
       }
@@ -59163,6 +74871,12 @@
             "state" : "translated",
             "value" : "表名："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表名稱："
+          }
         }
       }
     },
@@ -59185,6 +74899,12 @@
             "state" : "translated",
             "value" : "要导出的表名（可代替查询）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要匯出的資料表名稱（可代替查詢）"
+          }
         }
       }
     },
@@ -59203,6 +74923,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "table_name"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "table_name"
@@ -59230,6 +74956,12 @@
             "state" : "translated",
             "value" : "表：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表：%@"
+          }
         }
       }
     },
@@ -59249,6 +74981,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "TablePro"
@@ -59275,6 +75013,12 @@
             "state" : "translated",
             "value" : "TablePro 无法访问插件注册表来更新此插件。请检查网络连接并重新打开 TablePro。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 無法連上外掛註冊來更新此外掛。請檢查你的網路連線並重新開啟 TablePro。"
+          }
         }
       }
     },
@@ -59296,6 +75040,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "TablePro 网站"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 網站"
           }
         }
       }
@@ -59319,6 +75069,12 @@
             "state" : "translated",
             "value" : "表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表"
+          }
         }
       }
     },
@@ -59340,6 +75096,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "估算行数较多的表使用近似计数以避免慢速 COUNT(*) 查询"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "估算列數較多的資料表會使用近似計數,以避免緩慢的 COUNT(*) 查詢"
           }
         }
       }
@@ -59363,6 +75125,12 @@
             "state" : "translated",
             "value" : "某个已连接数据库的表、列、索引和外键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "某個已連線資料庫的資料表、欄位、索引和外鍵"
+          }
         }
       }
     },
@@ -59384,6 +75152,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已连接数据库的表、列、索引和外键"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已連線資料庫的資料表、欄位、索引和外鍵"
           }
         }
       }
@@ -59408,6 +75182,12 @@
             "state" : "translated",
             "value" : "表空间"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表空間"
+          }
         }
       }
     },
@@ -59429,6 +75209,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "标签页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分頁"
           }
         }
       }
@@ -59452,6 +75238,12 @@
             "state" : "translated",
             "value" : "标签"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標籤"
+          }
         }
       }
     },
@@ -59474,6 +75266,12 @@
             "state" : "translated",
             "value" : "标签名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標籤名稱"
+          }
         }
       }
     },
@@ -59495,6 +75293,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "标签：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標籤：%@"
           }
         }
       }
@@ -59519,6 +75323,12 @@
             "state" : "translated",
             "value" : "模板"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "範本"
+          }
         }
       }
     },
@@ -59541,6 +75351,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "模板名称"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "範本名稱"
           }
         }
       }
@@ -59565,6 +75381,12 @@
             "state" : "translated",
             "value" : "导入时临时禁用外键约束。适用于导入具有循环依赖的数据。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入時暫時停用外鍵限制。適合用於匯入有循環相依關係的資料。"
+          }
         }
       }
     },
@@ -59587,6 +75409,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "终端"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "終端機"
           }
         }
       }
@@ -59611,6 +75439,12 @@
             "state" : "translated",
             "value" : "终端响铃"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "終端機提示音"
+          }
         }
       }
     },
@@ -59634,6 +75468,12 @@
             "state" : "translated",
             "value" : "终端不可用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "終端機無法使用"
+          }
         }
       }
     },
@@ -59655,6 +75495,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "终止"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "終止"
           }
         }
       }
@@ -59678,6 +75524,12 @@
             "state" : "translated",
             "value" : "终止会话"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "終止工作階段"
+          }
         }
       }
     },
@@ -59700,6 +75552,12 @@
             "state" : "translated",
             "value" : "终止会话 %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "終止工作階段 %@"
+          }
         }
       }
     },
@@ -59721,6 +75579,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "辅助文本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第三層文字"
           }
         }
       }
@@ -59745,6 +75609,12 @@
             "state" : "translated",
             "value" : "测试"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "測試"
+          }
         }
       }
     },
@@ -59766,6 +75636,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "测试连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "測試連線"
           }
         }
       }
@@ -59789,6 +75665,12 @@
             "state" : "translated",
             "value" : "测试当前连接设置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "測試目前的連線設定"
+          }
         }
       }
     },
@@ -59810,6 +75692,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在测试连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在測試連線"
           }
         }
       }
@@ -59833,6 +75721,12 @@
             "state" : "translated",
             "value" : "文本"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字"
+          }
         }
       }
     },
@@ -59854,6 +75748,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "这看起来不是有效的许可证密钥。请检查是否有拼写错误后重试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這看起來不是有效的授權金鑰。請檢查是否有拼字錯誤後再試一次。"
           }
         }
       }
@@ -59877,6 +75777,12 @@
             "state" : "translated",
             "value" : "%@ 插件未安装。是否要从插件市场下载？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚未安裝 %@ 外掛。是否要從外掛市集下載？"
+          }
         }
       }
     },
@@ -59898,6 +75804,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 插件未安装。您可以从插件市场下载。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚未安裝 %@ 外掛。你可以從外掛市集下載。"
           }
         }
       }
@@ -59921,6 +75833,12 @@
             "state" : "translated",
             "value" : "Access 应用策略必须使用 Service Auth 规则，否则 Cloudflare 仍会要求浏览器登录。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Access 應用程式原則必須使用 Service Auth 規則，否則 Cloudflare 仍會要求透過瀏覽器登入。"
+          }
         }
       }
     },
@@ -59942,6 +75860,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "API 密钥将被永久删除。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API 金鑰將被永久刪除。"
           }
         }
       }
@@ -59971,6 +75895,12 @@
             "state" : "translated",
             "value" : "无法确认主机 '%@' 的真实性。\n\n%@ 密钥指纹为：\n%@\n\n确定要继续连接吗？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法確認主機「%1$@」的真實性。\n\n%2$@ 金鑰指紋為：\n%3$@\n\n你確定要繼續連線嗎？"
+          }
         }
       }
     },
@@ -59992,6 +75922,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "应用中缺少内置的示例数据库。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "應用程式中缺少內建的範例資料庫。"
           }
         }
       }
@@ -60021,6 +75957,12 @@
             "state" : "translated",
             "value" : "Cloudflare 隧道未能及时就绪：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloudflare 隧道未能及時就緒：%@"
+          }
         }
       }
     },
@@ -60042,6 +75984,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cloudflare 隧道未能及时就绪。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloudflare 隧道未能及時就緒。"
           }
         }
       }
@@ -60065,6 +76013,12 @@
             "state" : "translated",
             "value" : "代码将在 15 分钟后过期。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證碼將在 15 分鐘後過期。"
+          }
         }
       }
     },
@@ -60086,6 +76040,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "代码已复制到剪贴板。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證碼已複製到剪貼簿。"
           }
         }
       }
@@ -60121,6 +76081,12 @@
             "state" : "translated",
             "value" : "要执行的破坏性查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要執行的破壞性查詢"
+          }
         }
       }
     },
@@ -60143,6 +76109,12 @@
             "state" : "translated",
             "value" : "加密文件已损坏或不完整"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加密的檔案已損毀或不完整"
+          }
         }
       }
     },
@@ -60164,6 +76136,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文件夹 \"%@\" 将被删除。其中的项目将移至上一级。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料夾「%@」將被刪除。其中的項目將移至上一層。"
           }
         }
       }
@@ -60194,6 +76172,12 @@
             "state" : "translated",
             "value" : "以下 %d 条查询可能永久修改或删除数据。此操作无法撤销。\n\n%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下列 %1$d 個查詢可能會永久修改或刪除資料。此動作無法復原。\n\n%2$@"
+          }
         }
       }
     },
@@ -60223,6 +76207,12 @@
             "state" : "translated",
             "value" : "以下 %lld 个查询可能会永久修改或删除数据。此操作无法撤销。\n\n%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下列 %1$lld 個查詢可能會永久修改或刪除資料。此動作無法復原。\n\n%2$@"
+          }
         }
       }
     },
@@ -60244,6 +76234,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "以下更改可能导致数据丢失：\n\n%@\n\n是否继续？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下列變更可能導致資料遺失：\n\n%@\n\n是否要繼續？"
           }
         }
       }
@@ -60268,6 +76264,12 @@
             "state" : "translated",
             "value" : "以下插件被拒绝：\n\n%@\n\n请从插件注册表中更新它们。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下列外掛已遭拒絕：\n\n%@\n\n請從外掛註冊更新它們。"
+          }
         }
       }
     },
@@ -60291,6 +76293,12 @@
             "state" : "translated",
             "value" : "以下插件已被拒绝：\n\n%@\n\n你可以在设置中的插件注册表更新它们。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下列外掛已遭拒絕：\n\n%@\n\n你可以在「設定」的外掛註冊更新它們。"
+          }
         }
       }
     },
@@ -60312,6 +76320,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "许可证已被暂停。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權已遭停用。"
           }
         }
       }
@@ -60335,6 +76349,12 @@
             "state" : "translated",
             "value" : "许可证已过期。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權已過期。"
+          }
         }
       }
     },
@@ -60356,6 +76376,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "许可证密钥无效。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權金鑰無效。"
           }
         }
       }
@@ -60381,6 +76407,12 @@
             "state" : "translated",
             "value" : "未完成的备份文件将被移除。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未完成的備份檔案將被移除。"
+          }
         }
       }
     },
@@ -60402,6 +76434,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "密码来源返回了空密码"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密碼來源產生了空白密碼"
           }
         }
       }
@@ -60425,6 +76463,12 @@
             "state" : "translated",
             "value" : "上一个验证码未被接受。请等待验证器刷新后输入新验证码。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一個驗證碼未被接受。請等待你的驗證器重新整理後，再輸入新的驗證碼。"
+          }
         }
       }
     },
@@ -60446,6 +76490,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "将删除提供商配置和已存储的 API 密钥。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "供應商設定與已儲存的 API 金鑰將被刪除。"
           }
         }
       }
@@ -60469,6 +76519,12 @@
             "state" : "translated",
             "value" : "所选备份文件不可读。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所選的備份檔案無法讀取。"
+          }
         }
       }
     },
@@ -60491,6 +76547,12 @@
             "state" : "translated",
             "value" : "服务器将可被网络上的其他设备访问。认证和 TLS 会自动启用。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伺服器將可由網路上的其他裝置存取。驗證與 TLS 會自動啟用。"
+          }
         }
       }
     },
@@ -60512,6 +76574,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "配置文件 \"%@\" 的 SSO 会话已过期。要通过浏览器登录吗？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定檔「%@」的 SSO 工作階段已過期。要透過瀏覽器登入嗎？"
           }
         }
       }
@@ -60537,6 +76605,12 @@
             "state" : "translated",
             "value" : "目标数据库可能处于不完整状态。请检查数据库并按需清理。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標資料庫可能處於不完整的狀態。請檢查資料庫並視需要清理。"
+          }
         }
       }
     },
@@ -60561,6 +76635,12 @@
             "state" : "translated",
             "value" : "目标数据库可能会处于不完整状态。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標資料庫可能會處於不完整的狀態。"
+          }
         }
       }
     },
@@ -60582,6 +76662,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法将文本解析为 JSON。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法將文字剖析為 JSON。"
           }
         }
       }
@@ -60605,6 +76691,12 @@
             "state" : "translated",
             "value" : "文本无法解析为 JSON。请使用文本模式查看或编辑。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法將文字剖析為 JSON。請使用文字模式檢視或編輯。"
+          }
         }
       }
     },
@@ -60626,6 +76718,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "该文本看起来不是连接 URL。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這段文字看起來不像連線 URL。"
           }
         }
       }
@@ -60649,6 +76747,12 @@
             "state" : "translated",
             "value" : "文本不是有效的 JSON。仍然保存？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字並非有效的 JSON。仍要儲存嗎？"
+          }
         }
       }
     },
@@ -60670,6 +76774,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法解析该值。请使用原始模式以文本形式查看。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法解析該值。請使用原始模式以文字形式檢視。"
           }
         }
       }
@@ -60694,6 +76804,12 @@
             "state" : "translated",
             "value" : "主题"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "佈景主題"
+          }
         }
       }
     },
@@ -60715,6 +76831,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "主题更新失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "佈景主題更新失敗"
           }
         }
       }
@@ -60739,6 +76861,12 @@
             "state" : "translated",
             "value" : "主题："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "佈景主題："
+          }
         }
       }
     },
@@ -60760,6 +76888,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "主题"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "佈景主題"
           }
         }
       }
@@ -60786,6 +76920,12 @@
             "state" : "translated",
             "value" : "此操作需要 ⌘ 或 ⌥ 等修饰键。单个普通按键无法可靠地触发菜单。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作需要 ⌘ 或 ⌥ 之類的輔助按鍵。單獨的普通按鍵無法可靠地觸發選單。"
+          }
         }
       }
     },
@@ -60808,6 +76948,12 @@
             "state" : "translated",
             "value" : "此连接已在其他设备或窗口中被删除。你的更改未保存。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線已在其他裝置或視窗中被刪除。你的變更未儲存。"
+          }
         }
       }
     },
@@ -60829,6 +76975,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此连接不会通过 iCloud 同步到其他设备。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線不會透過 iCloud 同步到其他裝置。"
           }
         }
       }
@@ -60853,6 +77005,12 @@
             "state" : "translated",
             "value" : "此数据库还没有%@。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此資料庫尚未有任何%@。"
+          }
         }
       }
     },
@@ -60875,6 +77033,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此数据库还没有表。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此資料庫尚未有任何資料表。"
           }
         }
       }
@@ -60899,6 +77063,12 @@
             "state" : "translated",
             "value" : "此 DELETE 查询没有 WHERE 子句，将删除表中的所有行。此操作无法撤销。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此 DELETE 查詢沒有 WHERE 子句，將刪除資料表中的所有列。此動作無法復原。"
+          }
         }
       }
     },
@@ -60920,6 +77090,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "这将放弃你对 Chinook 示例的编辑并恢复原始副本。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這會放棄你對 Chinook 範例的編輯，並還原成原始副本。"
           }
         }
       }
@@ -60943,6 +77119,12 @@
             "state" : "translated",
             "value" : "此驱动不提供例程 DDL。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此驅動程式不提供常式 DDL。"
+          }
         }
       }
     },
@@ -60964,6 +77146,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此驱动没有 TLS 回退。“首选”会强制使用 TLS，与“必需”相同。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此驅動程式沒有 TLS 回退機制。「偏好」會強制使用 TLS，與「必要」相同。"
           }
         }
       }
@@ -60988,6 +77176,12 @@
             "state" : "translated",
             "value" : "此 DROP 查询将永久删除数据库对象。此操作无法撤销。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此 DROP 查詢將永久移除資料庫物件。此動作無法復原。"
+          }
         }
       }
     },
@@ -61009,6 +77203,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此引擎不支持创建数据库。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此引擎不支援建立資料庫。"
           }
         }
       }
@@ -61032,6 +77232,12 @@
             "state" : "translated",
             "value" : "此文件已加密"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此檔案已加密"
+          }
         }
       }
     },
@@ -61053,6 +77259,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此文件已加密，需要密码短语"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此檔案已加密，需要通關密語"
           }
         }
       }
@@ -61076,6 +77288,12 @@
             "state" : "translated",
             "value" : "此文件不是有效的 TablePro 导出文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此檔案不是有效的 TablePro 匯出檔"
+          }
         }
       }
     },
@@ -61097,6 +77315,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此文件需要更新版本的TablePro（格式版本%d）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此檔案需要較新版本的 TablePro（格式版本 %d）"
           }
         }
       }
@@ -61121,6 +77345,12 @@
             "state" : "translated",
             "value" : "此文件需要更新版本的 TablePro（格式版本 %lld）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此檔案需要較新版本的 TablePro（格式版本 %lld）"
+          }
         }
       }
     },
@@ -61142,6 +77372,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "这是内置主题。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這是內建的佈景主題。"
           }
         }
       }
@@ -61165,6 +77401,12 @@
             "state" : "translated",
             "value" : "这是插件仓库主题。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這是外掛註冊的佈景主題。"
+          }
         }
       }
     },
@@ -61186,6 +77428,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此 JSON 文档对于树形视图过大，请使用文本模式。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此 JSON 文件對樹狀檢視而言過大。請改用文字模式。"
           }
         }
       }
@@ -61209,6 +77457,12 @@
             "state" : "translated",
             "value" : "此关键字已被使用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此關鍵字已被使用"
+          }
         }
       }
     },
@@ -61230,6 +77484,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此许可证已被暂停。请联系支持团队获取帮助。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此授權已遭停用。請聯絡支援團隊尋求協助。"
           }
         }
       }
@@ -61253,6 +77513,12 @@
             "state" : "translated",
             "value" : "此许可证已过期。请续期以继续使用 Pro 功能。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此授權已過期。請續訂以繼續使用 Pro 功能。"
+          }
         }
       }
     },
@@ -61274,6 +77540,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此许可证已达到激活上限。请先停用另一台 Mac。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此授權已達啟用上限。請先停用另一台 Mac。"
           }
         }
       }
@@ -61297,6 +77569,12 @@
             "state" : "translated",
             "value" : "此 Mac"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這台 Mac"
+          }
         }
       }
     },
@@ -61318,6 +77596,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此设备未激活该许可证。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此機器尚未針對此授權啟用。"
           }
         }
       }
@@ -61341,6 +77625,12 @@
             "state" : "translated",
             "value" : "此设备未激活。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此機器尚未啟用。"
+          }
         }
       }
     },
@@ -61359,6 +77649,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本月"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "本月"
@@ -61385,6 +77681,12 @@
             "state" : "translated",
             "value" : "不支持此操作"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支援此操作"
+          }
         }
       }
     },
@@ -61407,6 +77709,12 @@
             "state" : "translated",
             "value" : "此插件不在注册表中，无法自动更新。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此外掛不在外掛註冊中，因此無法自動更新。"
+          }
         }
       }
     },
@@ -61428,6 +77736,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此插件需要 TablePro %@ 或更高版本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此外掛需要 TablePro %@ 或更新版本"
           }
         }
       }
@@ -61457,6 +77771,12 @@
             "state" : "translated",
             "value" : "此配置将被永久删除。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此設定檔將被永久刪除。"
+          }
         }
       }
     },
@@ -61479,6 +77799,12 @@
             "state" : "translated",
             "value" : "此项目还没有数据集。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此專案還沒有資料集。"
+          }
         }
       }
     },
@@ -61500,6 +77826,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此查询可能永久修改或删除数据，且无法撤销。\n\n%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此查詢可能會永久修改或刪除資料，且無法復原。\n\n%@"
           }
         }
       }
@@ -61524,6 +77856,12 @@
             "state" : "translated",
             "value" : "此查询可能会永久修改或删除数据。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此查詢可能會永久修改或刪除資料。"
+          }
         }
       }
     },
@@ -61545,6 +77883,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此服务器还没有数据库。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此伺服器還沒有資料庫。"
           }
         }
       }
@@ -61568,6 +77912,12 @@
             "state" : "translated",
             "value" : "这将设置 %lld 个已加载的行。请检查后保存以应用。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這會設定 %lld 列已載入的資料。請檢查後儲存以套用。"
+          }
         }
       }
     },
@@ -61589,6 +77939,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "这将设置 1 个已加载的行。请检查后保存以应用。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這會設定 1 列已載入的資料。請檢查後儲存以套用。"
           }
         }
       }
@@ -61612,6 +77968,12 @@
             "state" : "translated",
             "value" : "此快捷键已被 macOS 保留，无法分配。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此快速鍵已由 macOS 保留，無法指派。"
+          }
         }
       }
     },
@@ -61633,6 +77995,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此快捷键已保留给 \"%@\"，无法分配。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此快速鍵已保留給「%@」，無法指派。"
           }
         }
       }
@@ -61663,6 +78031,12 @@
             "state" : "translated",
             "value" : "此 SQL 查询执行失败并报错。请修复。\n\n查询：\n```sql\n%@\n```\n\n错误：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此 SQL 查詢執行失敗並出現錯誤。請修正。\n\n查詢：\n```sql\n%1$@\n```\n\n錯誤：%2$@"
+          }
         }
       }
     },
@@ -61684,6 +78058,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此令牌将不再显示"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此權杖將不會再次顯示"
           }
         }
       }
@@ -61708,6 +78088,12 @@
             "state" : "translated",
             "value" : "此 TRUNCATE 查询将永久删除表中的所有行。此操作无法撤销。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此 TRUNCATE 查詢將永久刪除資料表中的所有列。此動作無法復原。"
+          }
         }
       }
     },
@@ -61729,6 +78115,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此值太大，无法解析。请使用原始模式以文本形式查看。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此值太大，無法解析。請使用原始模式以文字形式檢視。"
           }
         }
       }
@@ -61752,6 +78144,12 @@
             "state" : "translated",
             "value" : "本周"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本週"
+          }
         }
       }
     },
@@ -61773,6 +78171,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此操作将分离分区 '%@'。数据将被保留但在重新挂载前不可访问。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作將分離分割區「%@」。資料會保留，但在重新附加前無法存取。"
           }
         }
       }
@@ -61796,6 +78200,12 @@
             "state" : "translated",
             "value" : "此操作将获取所有剩余行。大量结果会占用较多内存。是否继续？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作將擷取所有剩餘的列。大量結果集會佔用大量記憶體。是否繼續？"
+          }
         }
       }
     },
@@ -61818,6 +78228,12 @@
             "state" : "translated",
             "value" : "此操作将获取约 %@ 行更多数据。大量结果会占用较多内存。是否继续？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作將額外擷取約 %@ 列。大量結果集會佔用大量記憶體。是否繼續？"
+          }
         }
       }
     },
@@ -61839,6 +78255,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "这将在单个页面加载全部 %@ 行。大型结果集会占用大量内存。要继续吗？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這會在單一頁面載入全部 %@ 列。大型結果集會佔用大量記憶體。要繼續嗎？"
           }
         }
       }
@@ -61868,6 +78290,12 @@
             "state" : "translated",
             "value" : "此操作将永久删除 %lld 个%@。无法撤销。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作將永久刪除 %1$lld 個%2$@。此動作無法復原。"
+          }
         }
       }
     },
@@ -61889,6 +78317,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "这将永久删除所有对话历史。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作將永久刪除所有對話記錄。"
           }
         }
       }
@@ -61912,6 +78346,12 @@
             "state" : "translated",
             "value" : "此操作将永久删除分区 '%@' 中的所有数据。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作將永久刪除分割區「%@」中的所有資料。"
+          }
         }
       }
     },
@@ -61933,6 +78373,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此操作将永久删除所有查询历史记录。无法撤销。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作將永久刪除所有查詢歷程記錄項目。此動作無法復原。"
           }
         }
       }
@@ -61956,6 +78402,12 @@
             "state" : "translated",
             "value" : "此操作将从本机移除许可证。您可以稍后重新激活。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作將從這台機器移除授權。你可以稍後重新啟用。"
+          }
         }
       }
     },
@@ -61978,6 +78430,12 @@
             "state" : "translated",
             "value" : "这将把所有部分的设置重置为默认值。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作會將所有區段的設定重設為預設值。"
+          }
         }
       }
     },
@@ -61999,6 +78457,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "线程"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行緒"
           }
         }
       }
@@ -62028,6 +78492,12 @@
             "state" : "translated",
             "value" : "等级："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等級："
+          }
         }
       }
     },
@@ -62049,6 +78519,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "时间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "時間"
           }
         }
       }
@@ -62072,6 +78548,12 @@
             "state" : "translated",
             "value" : "时间：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "時間：%@"
+          }
         }
       }
     },
@@ -62093,6 +78575,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "时间戳"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "時間戳記"
           }
         }
       }
@@ -62117,6 +78605,12 @@
             "state" : "translated",
             "value" : "极小"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "極小"
+          }
         }
       }
     },
@@ -62139,6 +78633,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "极小圆点"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "極小圓點"
           }
         }
       }
@@ -62163,6 +78663,12 @@
             "state" : "translated",
             "value" : "标题"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標題"
+          }
         }
       }
     },
@@ -62185,6 +78691,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "标题 2"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標題 2"
           }
         }
       }
@@ -62209,6 +78721,12 @@
             "state" : "translated",
             "value" : "标题 3"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標題 3"
+          }
         }
       }
     },
@@ -62230,6 +78748,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "TLS 证书已过期或即将过期"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TLS 憑證已過期或即將過期"
           }
         }
       }
@@ -62253,6 +78777,12 @@
             "state" : "translated",
             "value" : "在钥匙串中未找到 TLS 身份"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在鑰匙圈中找不到 TLS 身分"
+          }
         }
       }
     },
@@ -62271,6 +78801,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TLS 模式"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "TLS 模式"
@@ -62297,6 +78833,12 @@
             "state" : "translated",
             "value" : "以查看数据"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "以檢視資料"
+          }
         }
       }
     },
@@ -62315,6 +78857,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今天"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "今天"
@@ -62342,6 +78890,12 @@
             "state" : "translated",
             "value" : "切换 AI 聊天"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換 AI 聊天"
+          }
         }
       }
     },
@@ -62365,6 +78919,12 @@
             "state" : "translated",
             "value" : "切换 AI 聊天 (⌘⇧L)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換 AI 聊天 (⌘⇧L)"
+          }
         }
       }
     },
@@ -62386,6 +78946,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切换注释"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換註解"
           }
         }
       }
@@ -62410,6 +78976,12 @@
             "state" : "translated",
             "value" : "切换筛选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換篩選"
+          }
         }
       }
     },
@@ -62431,6 +79003,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切换筛选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換篩選"
           }
         }
       }
@@ -62455,6 +79033,12 @@
             "state" : "translated",
             "value" : "切换筛选 (⇧⌘F)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換篩選 (⇧⌘F)"
+          }
         }
       }
     },
@@ -62477,6 +79061,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切换筛选 (⌘F)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換篩選 (⌘F)"
           }
         }
       }
@@ -62501,6 +79091,12 @@
             "state" : "translated",
             "value" : "切换筛选 (Cmd+F)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換篩選 (Cmd+F)"
+          }
         }
       }
     },
@@ -62522,6 +79118,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切换历史记录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換歷程記錄"
           }
         }
       }
@@ -62546,6 +79148,12 @@
             "state" : "translated",
             "value" : "切换检查器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換檢閱器"
+          }
         }
       }
     },
@@ -62567,6 +79175,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切换检查器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換檢閱器"
           }
         }
       }
@@ -62591,6 +79205,12 @@
             "state" : "translated",
             "value" : "切换检查器 (⌘⌥I)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換檢閱器 (⌘⌥I)"
+          }
         }
       }
     },
@@ -62613,6 +79233,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切换查询历史"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換查詢歷史"
           }
         }
       }
@@ -62637,6 +79263,12 @@
             "state" : "translated",
             "value" : "切换查询历史 (⌘⇧H)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換查詢歷史 (⌘⇧H)"
+          }
         }
       }
     },
@@ -62658,6 +79290,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切换查询历史 (⌘Y)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換查詢歷史 (⌘Y)"
           }
         }
       }
@@ -62681,6 +79319,12 @@
             "state" : "translated",
             "value" : "显示/隐藏结果"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示/隱藏結果"
+          }
         }
       }
     },
@@ -62702,6 +79346,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示/隐藏结果（⌘⌥R）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示/隱藏結果 (⌘⌥R)"
           }
         }
       }
@@ -62725,6 +79375,12 @@
             "state" : "translated",
             "value" : "切换侧栏"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換側邊欄"
+          }
         }
       }
     },
@@ -62747,6 +79403,12 @@
             "state" : "translated",
             "value" : "切换表浏览器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換資料表瀏覽器"
+          }
         }
       }
     },
@@ -62768,6 +79430,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "令牌"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "權杖"
           }
         }
       }
@@ -62798,6 +79466,12 @@
             "state" : "translated",
             "value" : "权限为 '%@' 的令牌 '%@' 无法访问 '%@'"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "權限為 '%1$@' 的權杖 '%2$@' 無法存取 '%3$@'"
+          }
         }
       }
     },
@@ -62819,6 +79493,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "令牌没有访问此连接的权限"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "權杖沒有存取此連線的權限"
           }
         }
       }
@@ -62842,6 +79522,12 @@
             "state" : "translated",
             "value" : "令牌名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "權杖名稱"
+          }
         }
       }
     },
@@ -62863,6 +79549,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "令牌：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "權杖：%@"
           }
         }
       }
@@ -62886,6 +79578,12 @@
             "state" : "translated",
             "value" : "待处理的配对代码过多。请稍后重试。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "待處理的配對碼過多。請稍後再試。"
+          }
         }
       }
     },
@@ -62904,6 +79602,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工具"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "工具"
@@ -62930,6 +79634,12 @@
             "state" : "translated",
             "value" : "工具栏"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工具列"
+          }
         }
       }
     },
@@ -62951,6 +79661,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顶级"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "頂層"
           }
         }
       }
@@ -62974,6 +79690,12 @@
             "state" : "translated",
             "value" : "总块数"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "區塊總數"
+          }
         }
       }
     },
@@ -62995,6 +79717,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "总查询数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢總數"
           }
         }
       }
@@ -63018,6 +79746,12 @@
             "state" : "translated",
             "value" : "总大小"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "總大小"
+          }
         }
       }
     },
@@ -63036,6 +79770,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TOTP"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "TOTP"
@@ -63062,6 +79802,12 @@
             "state" : "translated",
             "value" : "TOTP 密钥"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TOTP 金鑰"
+          }
         }
       }
     },
@@ -63084,6 +79830,12 @@
             "state" : "translated",
             "value" : "树形"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "樹狀"
+          }
         }
       }
     },
@@ -63102,6 +79854,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "true"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "true"
@@ -63129,6 +79887,12 @@
             "state" : "translated",
             "value" : "TRUE"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TRUE"
+          }
         }
       }
     },
@@ -63147,6 +79911,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清空"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "清空"
@@ -63173,6 +79943,12 @@
             "state" : "translated",
             "value" : "清空%d个表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清空 %d 個資料表"
+          }
         }
       }
     },
@@ -63196,6 +79972,12 @@
             "state" : "translated",
             "value" : "清空 %lld 个表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清空 %lld 個資料表"
+          }
         }
       }
     },
@@ -63217,6 +79999,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清空所有通过外键关联的表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清空所有透過外鍵關聯的資料表"
           }
         }
       }
@@ -63240,6 +80028,12 @@
             "state" : "translated",
             "value" : "截断查询结果"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截斷查詢結果"
+          }
         }
       }
     },
@@ -63261,6 +80055,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清空表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清空資料表"
           }
         }
       }
@@ -63284,6 +80084,12 @@
             "state" : "translated",
             "value" : "清空表 '%@'"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清空資料表 '%@'"
+          }
         }
       }
     },
@@ -63305,6 +80111,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已截断"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已截斷"
           }
         }
       }
@@ -63329,6 +80141,12 @@
             "state" : "translated",
             "value" : "已截断 - 只读"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已截斷，唯讀"
+          }
         }
       }
     },
@@ -63351,6 +80169,12 @@
             "state" : "translated",
             "value" : "已截断，只读"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已截斷，唯讀"
+          }
         }
       }
     },
@@ -63369,6 +80193,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "信任"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "信任"
@@ -63396,6 +80226,12 @@
             "state" : "translated",
             "value" : "尝试其他搜索词"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請嘗試其他搜尋字詞"
+          }
         }
       }
     },
@@ -63417,6 +80253,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "请尝试其他搜索词。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請嘗試其他搜尋詞。"
           }
         }
       }
@@ -63440,6 +80282,12 @@
             "state" : "translated",
             "value" : "尝试调整搜索词\n或日期筛选。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請嘗試調整搜尋字詞\n或日期篩選。"
+          }
         }
       }
     },
@@ -63461,6 +80309,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重试"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重試"
           }
         }
       }
@@ -63484,6 +80338,12 @@
             "state" : "translated",
             "value" : "试用示例数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "試用範例資料庫"
+          }
         }
       }
     },
@@ -63505,6 +80365,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "试用示例数据库，或点按上方的 + 添加你自己的数据库。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "試用範例資料庫，或點按上方的 + 來新增你自己的資料庫。"
           }
         }
       }
@@ -63528,6 +80394,12 @@
             "state" : "translated",
             "value" : "双因素认证"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "雙重驗證"
+          }
         }
       }
     },
@@ -63549,6 +80421,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "类型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "類型"
           }
         }
       }
@@ -63572,6 +80450,12 @@
             "state" : "translated",
             "value" : "输入快捷键..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入快速鍵…"
+          }
         }
       }
     },
@@ -63594,6 +80478,12 @@
             "state" : "translated",
             "value" : "类型：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "類型：%@"
+          }
         }
       }
     },
@@ -63613,6 +80503,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排版"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "排版"
@@ -63639,6 +80535,12 @@
             "state" : "translated",
             "value" : "在 MCP Servers 下点按 \"+ Add Custom Server\"，选择 Local 标签页，粘贴下方的 JSON，然后点按 Add Server"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 MCP Servers 下點按「+ Add Custom Server」，選擇 Local 標籤頁，貼上下方的 JSON，然後點按 Add Server"
+          }
         }
       }
     },
@@ -63662,6 +80564,12 @@
             "state" : "translated",
             "value" : "下划线"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "底線"
+          }
         }
       }
     },
@@ -63683,6 +80591,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "撤销"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "復原"
           }
         }
       }
@@ -63706,6 +80620,12 @@
             "state" : "translated",
             "value" : "撤销删除"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "復原刪除"
+          }
         }
       }
     },
@@ -63727,6 +80647,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "卸载"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解除安裝"
           }
         }
       }
@@ -63750,6 +80676,12 @@
             "state" : "translated",
             "value" : "卸载 %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解除安裝 %@"
+          }
         }
       }
     },
@@ -63771,6 +80703,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "卸载失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解除安裝失敗"
           }
         }
       }
@@ -63794,6 +80732,12 @@
             "state" : "translated",
             "value" : "卸载插件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解除安裝外掛"
+          }
         }
       }
     },
@@ -63816,6 +80760,12 @@
             "state" : "translated",
             "value" : "卸载插件？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解除安裝外掛？"
+          }
         }
       }
     },
@@ -63834,6 +80784,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "唯一"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "唯一"
@@ -63861,6 +80817,12 @@
             "state" : "translated",
             "value" : "UNIQUE"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "UNIQUE"
+          }
         }
       }
     },
@@ -63882,6 +80844,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Unix时间戳（毫秒）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unix 時間戳記（毫秒）"
           }
         }
       }
@@ -63905,6 +80873,12 @@
             "state" : "translated",
             "value" : "Unix时间戳（秒）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unix 時間戳記（秒）"
+          }
         }
       }
     },
@@ -63923,6 +80897,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "未知"
@@ -63949,6 +80929,12 @@
             "state" : "translated",
             "value" : "未知的深层链接主机：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知的深層連結主機：%@"
+          }
         }
       }
     },
@@ -63970,6 +80956,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未知错误"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知錯誤"
           }
         }
       }
@@ -63993,6 +80985,12 @@
             "state" : "translated",
             "value" : "未知 SSH 主机"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知的 SSH 主機"
+          }
         }
       }
     },
@@ -64011,6 +81009,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知的 URL scheme：%@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "未知的 URL scheme：%@"
@@ -64037,6 +81041,12 @@
             "state" : "translated",
             "value" : "未授权"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未授權"
+          }
         }
       }
     },
@@ -64059,6 +81069,12 @@
             "state" : "translated",
             "value" : "无限制"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無限制"
+          }
         }
       }
     },
@@ -64080,6 +81096,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消固定"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消釘選"
           }
         }
       }
@@ -64104,6 +81126,12 @@
             "state" : "translated",
             "value" : "取消设置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消設定"
+          }
         }
       }
     },
@@ -64127,6 +81155,12 @@
             "state" : "translated",
             "value" : "无符号"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無符號"
+          }
         }
       }
     },
@@ -64148,6 +81182,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不支持的连接协议：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支援的連線協定：%@"
           }
         }
       }
@@ -64171,6 +81211,12 @@
             "state" : "translated",
             "value" : "不支持的数据库方案：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支援的資料庫 scheme：%@"
+          }
         }
       }
     },
@@ -64193,6 +81239,12 @@
             "state" : "translated",
             "value" : "不支持的数据库类型：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支援的資料庫類型：%@"
+          }
         }
       }
     },
@@ -64214,6 +81266,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不支持的加密版本%d"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支援的加密版本 %d"
           }
         }
       }
@@ -64238,6 +81296,12 @@
             "state" : "translated",
             "value" : "不支持的加密版本 %u"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支援的加密版本 %u"
+          }
         }
       }
     },
@@ -64259,6 +81323,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不支持的文件格式：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支援的檔案格式：%@"
           }
         }
       }
@@ -64282,6 +81352,12 @@
             "state" : "translated",
             "value" : "不支持的图像格式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支援的影像格式"
+          }
         }
       }
     },
@@ -64303,6 +81379,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不支持的 intent：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支援的 intent：%@"
           }
         }
       }
@@ -64327,6 +81409,12 @@
             "state" : "translated",
             "value" : "不支持的 MongoDB 方法：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支援的 MongoDB 方法：%@"
+          }
         }
       }
     },
@@ -64348,6 +81436,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不支持的 Schema 操作：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支援的綱要操作：%@"
           }
         }
       }
@@ -64371,6 +81465,12 @@
             "state" : "translated",
             "value" : "不支持的标记：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支援的權杖：%@"
+          }
         }
       }
     },
@@ -64389,6 +81489,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未命名"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "未命名"
@@ -64415,6 +81521,12 @@
             "state" : "translated",
             "value" : "更新"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新"
+          }
         }
       }
     },
@@ -64433,6 +81545,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新 %@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新 %@"
@@ -64459,6 +81577,12 @@
             "state" : "translated",
             "value" : "更新 %@ 插件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新 %@ 外掛"
+          }
         }
       }
     },
@@ -64477,6 +81601,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即更新"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "立即更新"
@@ -64503,6 +81633,12 @@
             "state" : "translated",
             "value" : "更新插件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新外掛"
+          }
         }
       }
     },
@@ -64525,6 +81661,12 @@
             "state" : "translated",
             "value" : "UPDATE 语句"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "UPDATE 陳述式"
+          }
         }
       }
     },
@@ -64543,6 +81685,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新 TablePro"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新 TablePro"
@@ -64569,6 +81717,12 @@
             "state" : "translated",
             "value" : "更新到 v%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新至 v%@"
+          }
         }
       }
     },
@@ -64587,6 +81741,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已更新"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "已更新"
@@ -64613,6 +81773,12 @@
             "state" : "translated",
             "value" : "已更新到 v%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已更新至 v%@"
+          }
         }
       }
     },
@@ -64635,6 +81801,12 @@
             "state" : "translated",
             "value" : "此插件更新未完成。TablePro 将在下次启动时重试。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此外掛的更新尚未完成。TablePro 會在下次啟動時重試。"
+          }
         }
       }
     },
@@ -64653,6 +81825,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在更新…"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在更新…"
@@ -64679,6 +81857,12 @@
             "state" : "translated",
             "value" : "正在更新…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在更新…"
+          }
         }
       }
     },
@@ -64700,6 +81884,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "运行时间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "運作時間"
           }
         }
       }
@@ -64723,6 +81913,12 @@
             "state" : "translated",
             "value" : "美式长格式 (12/31/2024 11:59:59 PM)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "美式長格式 (12/31/2024 11:59:59 PM)"
+          }
         }
       }
     },
@@ -64741,6 +81937,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "美式短格式 (12/31/2024)"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "美式短格式 (12/31/2024)"
@@ -64767,6 +81969,12 @@
             "state" : "translated",
             "value" : "使用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用"
+          }
         }
       }
     },
@@ -64789,6 +81997,12 @@
             "state" : "translated",
             "value" : "使用 {{query}} 表示当前编辑器查询，{{schema}} 表示活动 Schema，{{database}} 表示活动数据库名称，{{body}} 表示命令后输入的任意文本。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 {{query}} 代表目前編輯器的查詢，{{schema}} 代表使用中的綱要，{{database}} 代表使用中的資料庫名稱，{{body}} 代表指令後輸入的任何文字。"
+          }
         }
       }
     },
@@ -64808,6 +82022,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 ~/.pgpass"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用 ~/.pgpass"
@@ -64834,6 +82054,12 @@
             "state" : "translated",
             "value" : "用作活动数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用作使用中的資料庫"
+          }
         }
       }
     },
@@ -64855,6 +82081,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "用作活动 Schema"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用作使用中的綱要"
           }
         }
       }
@@ -64878,6 +82110,12 @@
             "state" : "translated",
             "value" : "使用剪贴板中的 URL"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用剪貼簿中的 URL"
+          }
         }
       }
     },
@@ -64899,6 +82137,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用默认"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用預設"
           }
         }
       }
@@ -64922,6 +82166,12 @@
             "state" : "translated",
             "value" : "在连接字段中使用环境变量。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在連線欄位中使用環境變數。"
+          }
         }
       }
     },
@@ -64943,6 +82193,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用密码文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用密碼檔案"
           }
         }
       }
@@ -64966,6 +82222,12 @@
             "state" : "translated",
             "value" : "对于 AstraDB、DataStax Astra 和其他托管 Cassandra 部署，请使用“必需”。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "對於 AstraDB、DataStax Astra 和其他託管的 Cassandra 部署，請使用「必要」。"
+          }
         }
       }
     },
@@ -64988,6 +82250,12 @@
             "state" : "translated",
             "value" : "对于 ClickHouse Cloud 和其他托管实例，请使用“必需”。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "對於 ClickHouse Cloud 和其他託管執行個體，請使用「必要」。"
+          }
         }
       }
     },
@@ -65009,6 +82277,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "可用时使用 SSL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可用時使用 SSL"
           }
         }
       }
@@ -65035,6 +82309,12 @@
             "state" : "translated",
             "value" : "用户"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用者"
+          }
         }
       }
     },
@@ -65056,6 +82336,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "用户审批在 30 秒后超时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用者核准在 30 秒後逾時"
           }
         }
       }
@@ -65079,6 +82365,12 @@
             "state" : "translated",
             "value" : "用户拒绝了此连接的 MCP 访问"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用者拒絕了此連線的 MCP 存取"
+          }
         }
       }
     },
@@ -65101,6 +82393,12 @@
             "state" : "translated",
             "value" : "用户会话"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用者工作階段"
+          }
         }
       }
     },
@@ -65122,6 +82420,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "用户安装"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用者安裝"
           }
         }
       }
@@ -65148,6 +82452,12 @@
             "state" : "translated",
             "value" : "username"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "username"
+          }
         }
       }
     },
@@ -65170,6 +82480,12 @@
             "state" : "translated",
             "value" : "用户名"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用者名稱"
+          }
         }
       }
     },
@@ -65188,6 +82504,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 %@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用 %@"
@@ -65215,6 +82537,12 @@
             "state" : "translated",
             "value" : "UTC_TIMESTAMP()"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "UTC_TIMESTAMP()"
+          }
         }
       }
     },
@@ -65233,6 +82561,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "UUID"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "UUID"
@@ -65259,6 +82593,12 @@
             "state" : "translated",
             "value" : "活动连接的 UUID"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用中連線的 UUID"
+          }
         }
       }
     },
@@ -65280,6 +82620,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接的 UUID"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線的 UUID"
           }
         }
       }
@@ -65303,6 +82649,12 @@
             "state" : "translated",
             "value" : "要断开的连接的 UUID"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要中斷的連線的 UUID"
+          }
         }
       }
     },
@@ -65325,6 +82677,12 @@
             "state" : "translated",
             "value" : "已保存连接的 UUID"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已儲存連線的 UUID"
+          }
         }
       }
     },
@@ -65343,6 +82701,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "v%@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "v%@"
@@ -65375,6 +82739,12 @@
             "state" : "translated",
             "value" : "v%@ · %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "v%1$@ · %2$@"
+          }
         }
       }
     },
@@ -65393,6 +82763,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "v%@ 可用"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "v%@ 可用"
@@ -65419,6 +82795,12 @@
             "state" : "translated",
             "value" : "v%@ 准备就绪，可激活"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "v%@ 已就緒，可啟用"
+          }
         }
       }
     },
@@ -65437,6 +82819,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "v%@+"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "v%@+"
@@ -65463,6 +82851,12 @@
             "state" : "translated",
             "value" : "验证失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證失敗"
+          }
         }
       }
     },
@@ -65481,6 +82875,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "值"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "值"
@@ -65508,6 +82908,12 @@
             "state" : "translated",
             "value" : "从查询中排除的值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已從查詢中排除的值"
+          }
         }
       }
     },
@@ -65529,6 +82935,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "该值不在声明的枚举中。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該值不在宣告的列舉中。"
           }
         }
       }
@@ -65552,6 +82964,12 @@
             "state" : "translated",
             "value" : "该值不在声明的集合中。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該值不在宣告的集合中。"
+          }
         }
       }
     },
@@ -65574,6 +82992,12 @@
             "state" : "translated",
             "value" : "值为必填项"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "值為必填"
+          }
         }
       }
     },
@@ -65592,6 +83016,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "值太大"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "值太大"
@@ -65618,6 +83048,12 @@
             "state" : "translated",
             "value" : "值太大，无法解析"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "值太大，無法解析"
+          }
         }
       }
     },
@@ -65639,6 +83075,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "VERBOSE（打印进度）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "VERBOSE（輸出進度）"
           }
         }
       }
@@ -65662,6 +83104,12 @@
             "state" : "translated",
             "value" : "验证码被拒绝"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證碼被拒絕"
+          }
         }
       }
     },
@@ -65683,6 +83131,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "验证码被拒绝。请从验证器应用获取新验证码后重试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證碼被拒絕。請從你的驗證器應用程式取得新的驗證碼後再試一次。"
           }
         }
       }
@@ -65706,6 +83160,12 @@
             "state" : "translated",
             "value" : "需要验证码"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要驗證碼"
+          }
         }
       }
     },
@@ -65727,6 +83187,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已验证"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已驗證"
           }
         }
       }
@@ -65751,6 +83217,12 @@
             "state" : "translated",
             "value" : "已通过 TablePro 验证"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已通過 TablePro 驗證"
+          }
         }
       }
     },
@@ -65772,6 +83244,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "验证 CA"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證 CA"
           }
         }
       }
@@ -65795,6 +83273,12 @@
             "state" : "translated",
             "value" : "验证证书和主机名"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證憑證與主機名稱"
+          }
         }
       }
     },
@@ -65816,6 +83300,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "验证身份"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證身分"
           }
         }
       }
@@ -65839,6 +83329,12 @@
             "state" : "translated",
             "value" : "验证服务器证书"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證伺服器憑證"
+          }
         }
       }
     },
@@ -65861,6 +83357,12 @@
             "state" : "translated",
             "value" : "版本"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版本"
+          }
         }
       }
     },
@@ -65879,6 +83381,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版本 %@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "版本 %@"
@@ -65912,6 +83420,12 @@
             "state" : "translated",
             "value" : "版本 %@（构建 %@）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版本 %1$@（組建 %2$@）"
+          }
         }
       }
     },
@@ -65931,6 +83445,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版本："
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "版本："
@@ -65957,6 +83477,12 @@
             "state" : "translated",
             "value" : "通过 %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "透過 %@"
+          }
         }
       }
     },
@@ -65978,6 +83504,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "视图"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檢視"
           }
         }
       }
@@ -66001,6 +83533,12 @@
             "state" : "translated",
             "value" : "查看活动…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檢視活動…"
+          }
         }
       }
     },
@@ -66023,6 +83561,12 @@
             "state" : "translated",
             "value" : "查看 ER 图"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檢視 ER 圖"
+          }
         }
       }
     },
@@ -66044,6 +83588,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "视图模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檢視模式"
           }
         }
       }
@@ -66068,6 +83618,12 @@
             "state" : "translated",
             "value" : "在 GitHub 上查看"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 GitHub 上檢視"
+          }
         }
       }
     },
@@ -66091,6 +83647,12 @@
             "state" : "translated",
             "value" : "视图：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檢視表：%@"
+          }
         }
       }
     },
@@ -66113,6 +83675,12 @@
             "state" : "translated",
             "value" : "视图"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檢視表"
+          }
         }
       }
     },
@@ -66131,6 +83699,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vim 模式"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vim 模式"
@@ -66157,6 +83731,12 @@
             "state" : "translated",
             "value" : "仓库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "倉儲"
+          }
         }
       }
     },
@@ -66175,6 +83755,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "警告"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "警告"
@@ -66201,6 +83787,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "警告：重新启用外键检查失败：%@。请手动验证外键约束已启用。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "警告：重新啟用外鍵檢查失敗：%@。請手動確認外鍵約束已啟用。"
           }
         }
       }
@@ -66230,6 +83822,12 @@
             "state" : "translated",
             "value" : "警告：主机 '%@' 的密钥已更改！\n\n这可能意味着有人进行恶意操作，或者服务器已被重新安装。\n\n之前的指纹：%@\n当前指纹：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "警告：主機 '%1$@' 的主機金鑰已變更！\n\n這可能表示有人正進行惡意操作，或伺服器已重新安裝。\n\n先前的指紋：%2$@\n目前的指紋：%3$@"
+          }
         }
       }
     },
@@ -66252,6 +83850,12 @@
             "state" : "translated",
             "value" : "监视共享文件夹中的连接文件。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "監看共用資料夾中的連線檔案。"
+          }
         }
       }
     },
@@ -66273,6 +83877,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "会扫描受监视文件夹中的 .tablepro 文件。这些连接在侧边栏中以只读方式显示。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "受監視的資料夾會被掃描以尋找 .tablepro 檔案。這些連線會在側邊欄中以唯讀方式顯示。"
           }
         }
       }
@@ -66297,6 +83907,12 @@
             "state" : "translated",
             "value" : "监视的文件夹会扫描 .tablepro 文件。连接在侧边栏中以只读方式显示。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "受監看的資料夾會掃描 .tablepro 檔案。連線會在側邊欄中以唯讀方式顯示。"
+          }
         }
       }
     },
@@ -66320,6 +83936,12 @@
             "state" : "translated",
             "value" : "网站"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網站"
+          }
         }
       }
     },
@@ -66342,6 +83964,12 @@
             "state" : "translated",
             "value" : "欢迎使用 TablePro"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歡迎使用 TablePro"
+          }
         }
       }
     },
@@ -66363,6 +83991,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "您可以做什么"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你可以做什麼"
           }
         }
       }
@@ -66387,6 +84021,12 @@
             "state" : "translated",
             "value" : "启用后，点击新表将替换当前空白表标签页，而不是打开新标签页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用後，點按新的資料表會取代目前的乾淨資料表分頁，而不是開啟新分頁"
+          }
         }
       }
     },
@@ -66410,6 +84050,12 @@
             "state" : "translated",
             "value" : "启用后，点击侧边栏中的表将替换当前标签页（如果没有未保存的更改且您未与之交互过，如排序、筛选等）。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用後，若目前分頁沒有未儲存的變更且你尚未與其互動（排序、篩選等），點按側邊欄中的資料表會取代目前的分頁。"
+          }
         }
       }
     },
@@ -66431,6 +84077,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用后，不同连接的标签页将共享同一窗口，而不是打开单独的窗口。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用後，不同連線的分頁會共用同一個視窗，而不是各自開啟獨立視窗。"
           }
         }
       }
@@ -66454,6 +84106,12 @@
             "state" : "translated",
             "value" : "启用后，此收藏在所有连接中可见"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用後，此我的最愛會在所有連線中顯示"
+          }
         }
       }
     },
@@ -66476,6 +84134,12 @@
             "state" : "translated",
             "value" : "TablePro 启动时："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 啟動時："
+          }
         }
       }
     },
@@ -66494,6 +84158,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WHERE 子句"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "WHERE 子句"
@@ -66521,6 +84191,12 @@
             "state" : "translated",
             "value" : "WHERE 子句..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WHERE 子句..."
+          }
         }
       }
     },
@@ -66542,6 +84218,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "宽列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寬欄"
           }
         }
       }
@@ -66565,6 +84247,12 @@
             "state" : "translated",
             "value" : "窗口背景"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "視窗背景"
+          }
         }
       }
     },
@@ -66587,6 +84275,12 @@
             "state" : "translated",
             "value" : "含表头"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "含標題列"
+          }
         }
       }
     },
@@ -66608,6 +84302,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自动换行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動換行"
           }
         }
       }
@@ -66632,6 +84332,12 @@
             "state" : "translated",
             "value" : "包裹在事务中 (BEGIN/COMMIT)"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包覆於交易中 (BEGIN/COMMIT)"
+          }
         }
       }
     },
@@ -66651,6 +84357,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Write Concern"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Write Concern"
@@ -66677,6 +84389,12 @@
             "state" : "translated",
             "value" : "此客户端不允许写入操作"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此用戶端不允許寫入操作"
+          }
         }
       }
     },
@@ -66695,6 +84413,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "XXXXX-XXXXX-XXXXX-XXXXX-XXXXX"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "XXXXX-XXXXX-XXXXX-XXXXX-XXXXX"
@@ -66721,6 +84445,12 @@
             "state" : "translated",
             "value" : "黄色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "黃色"
+          }
         }
       }
     },
@@ -66739,6 +84469,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "你"
@@ -66766,6 +84502,12 @@
             "state" : "translated",
             "value" : "您可以在设置中重新启用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你可以在「設定」中重新啟用"
+          }
         }
       }
     },
@@ -66787,6 +84529,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "您有未保存的更改"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你有未儲存的變更"
           }
         }
       }
@@ -66810,6 +84558,12 @@
             "state" : "translated",
             "value" : "您有未保存的表结构更改。刷新将丢弃这些更改。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你對資料表結構有未儲存的變更。重新整理會捨棄這些變更。"
+          }
         }
       }
     },
@@ -66831,6 +84585,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "每次连接时都会要求您输入验证码。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每次連線時都會要求你輸入驗證碼。"
           }
         }
       }
@@ -66854,6 +84614,12 @@
             "state" : "translated",
             "value" : "一切就绪！"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一切就緒！"
+          }
         }
       }
     },
@@ -66875,6 +84641,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "你的更改"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你的變更"
           }
         }
       }
@@ -66898,6 +84670,12 @@
             "state" : "translated",
             "value" : "如果不保存，您的更改将会丢失。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "若不儲存，你的變更將會遺失。"
+          }
         }
       }
     },
@@ -66919,6 +84697,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "您的数据库结构和查询数据将被发送给 AI 提供商进行分析。是否允许此连接？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你的資料庫綱要與查詢資料將傳送給 AI 供應商進行分析。要允許此連線嗎？"
           }
         }
       }
@@ -66942,6 +84726,12 @@
             "state" : "translated",
             "value" : "已执行的查询将\n显示在此处以便快速访问。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你執行過的查詢將\n顯示於此處以便快速存取。"
+          }
         }
       }
     },
@@ -66964,6 +84754,12 @@
             "state" : "translated",
             "value" : "您的许可证已过期"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你的授權已過期"
+          }
         }
       }
     },
@@ -66982,6 +84778,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zed"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zed"
@@ -67009,6 +84811,12 @@
             "state" : "translated",
             "value" : "零填充"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "零填補"
+          }
         }
       }
     },
@@ -67027,6 +84835,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "放大"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "放大"
@@ -67053,6 +84867,12 @@
             "state" : "translated",
             "value" : "放大"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "放大"
+          }
         }
       }
     },
@@ -67075,6 +84895,12 @@
             "state" : "translated",
             "value" : "缩小"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "縮小"
+          }
         }
       }
     },
@@ -67096,6 +84922,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "缩小"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "縮小"
           }
         }
       }

--- a/TableProMobile/TableProMobile.xcodeproj/project.pbxproj
+++ b/TableProMobile/TableProMobile.xcodeproj/project.pbxproj
@@ -1794,6 +1794,9 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				vi,
+				"zh-Hans",
+				"zh-Hant",
 				Base,
 			);
 			mainGroup = 5AB9F3D02F7C1C12001F3337;

--- a/TableProMobile/TableProMobile/Localizable.xcstrings
+++ b/TableProMobile/TableProMobile/Localizable.xcstrings
@@ -8,6 +8,12 @@
             "state" : "translated",
             "value" : ""
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
         }
       }
     },
@@ -20,6 +26,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@"
@@ -40,6 +52,12 @@
             "state" : "translated",
             "value" : "%@ -> %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ -> %2$@"
+          }
         }
       }
     },
@@ -58,6 +76,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ · %2$@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ · %2$@"
@@ -85,6 +109,12 @@
             "state" : "translated",
             "value" : "%1$@ → %2$@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ → %2$@"
+          }
         }
       }
     },
@@ -100,6 +130,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@, %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@, %2$@"
           }
         }
       }
@@ -117,6 +153,12 @@
             "state" : "translated",
             "value" : "%@, %@, %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@, %2$@, %3$@"
+          }
         }
       }
     },
@@ -133,6 +175,12 @@
             "state" : "translated",
             "value" : "%@, %@, %@, thẻ %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@, %2$@, %3$@, 標籤 %4$@"
+          }
         }
       }
     },
@@ -148,6 +196,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@, %@, %lld hàng"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@, %2$@, %3$lld 列"
           }
         }
       }
@@ -171,6 +225,12 @@
             "state" : "translated",
             "value" : "%1$@.%2$@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@.%2$@"
+          }
         }
       }
     },
@@ -180,6 +240,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%d hàng bị ảnh hưởng"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已影響 %d 列"
           }
         }
       }
@@ -193,6 +259,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld"
@@ -219,6 +291,12 @@
             "state" : "translated",
             "value" : "%1$lld / %2$lld"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld / %2$lld"
+          }
         }
       }
     },
@@ -234,6 +312,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 列"
           }
         }
       }
@@ -251,6 +335,12 @@
             "state" : "translated",
             "value" : "还有%lld列"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "另外 %lld 個欄位"
+          }
         }
       }
     },
@@ -266,6 +356,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "适用于iPhone和iPad的快速轻量数据库客户端。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "適用於 iPhone 與 iPad 的快速輕量資料庫用戶端。"
           }
         }
       }
@@ -283,6 +379,12 @@
             "state" : "translated",
             "value" : "关于"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關於"
+          }
         }
       }
     },
@@ -292,6 +394,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "DB đang dùng"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用中的資料庫"
           }
         }
       }
@@ -309,6 +417,12 @@
             "state" : "translated",
             "value" : "添加数据库连接以开始使用。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增資料庫連線以開始使用。"
+          }
         }
       }
     },
@@ -324,6 +438,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增連線"
           }
         }
       }
@@ -341,6 +461,12 @@
             "state" : "translated",
             "value" : "添加筛选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增篩選"
+          }
         }
       }
     },
@@ -350,6 +476,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sau 1 giờ"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 小時後"
           }
         }
       }
@@ -361,6 +493,12 @@
             "state" : "translated",
             "value" : "Sau 1 phút"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 分鐘後"
+          }
         }
       }
     },
@@ -371,6 +509,12 @@
             "state" : "translated",
             "value" : "Sau 5 phút"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5 分鐘後"
+          }
         }
       }
     },
@@ -380,6 +524,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sau 15 phút"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "15 分鐘後"
           }
         }
       }
@@ -393,6 +543,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "全部"
@@ -413,6 +569,12 @@
             "state" : "translated",
             "value" : "\"%@\"中的所有数据将被永久删除。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」中的所有資料將被永久刪除。"
+          }
         }
       }
     },
@@ -428,6 +590,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "所有筛选条件将被移除。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有篩選條件將被移除。"
           }
         }
       }
@@ -446,6 +614,12 @@
             "state" : "translated",
             "value" : "发生未知错误。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "發生未知錯誤。"
+          }
         }
       }
     },
@@ -458,6 +632,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AND"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "AND"
@@ -478,6 +658,12 @@
             "state" : "translated",
             "value" : "应用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用"
+          }
         }
       }
     },
@@ -493,6 +679,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "确定要删除此连接吗？已保存的凭据将被永久移除。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確定要刪除此連線嗎？已儲存的憑證將被永久移除。"
           }
         }
       }
@@ -510,6 +702,12 @@
             "state" : "translated",
             "value" : "确定要删除此行吗？此操作无法撤销。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確定要刪除此列嗎？此動作無法復原。"
+          }
         }
       }
     },
@@ -526,6 +724,12 @@
             "state" : "translated",
             "value" : "升序"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "遞增"
+          }
         }
       }
     },
@@ -535,6 +739,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Xác thực"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證"
           }
         }
       }
@@ -552,6 +762,12 @@
             "state" : "translated",
             "value" : "认证方式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證方式"
+          }
         }
       }
     },
@@ -561,6 +777,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Xác thực để truy cập các kết nối cơ sở dữ liệu."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進行驗證以存取你的資料庫連線。"
           }
         }
       }
@@ -578,6 +800,12 @@
             "state" : "translated",
             "value" : "认证失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證失敗"
+          }
         }
       }
     },
@@ -594,6 +822,12 @@
             "state" : "translated",
             "value" : "自增"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動遞增"
+          }
         }
       }
     },
@@ -603,6 +837,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tự khóa"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動鎖定"
           }
         }
       }
@@ -620,6 +860,12 @@
             "state" : "translated",
             "value" : "构建版本"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建置版本"
+          }
         }
       }
     },
@@ -632,6 +878,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消"
@@ -652,6 +904,12 @@
             "state" : "translated",
             "value" : "无法保存"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法儲存"
+          }
         }
       }
     },
@@ -667,6 +925,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "请检查%@的用户名和密码。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請檢查 %@ 的使用者名稱與密碼。"
           }
         }
       }
@@ -684,6 +948,12 @@
             "state" : "translated",
             "value" : "请检查连接设置。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請檢查連線設定。"
+          }
         }
       }
     },
@@ -699,6 +969,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "请检查网络连接和服务器状态。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請檢查網路連線與伺服器是否可用。"
           }
         }
       }
@@ -716,6 +992,12 @@
             "state" : "translated",
             "value" : "请检查查询后重试。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請檢查查詢後再試一次。"
+          }
         }
       }
     },
@@ -731,6 +1013,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "请检查SQL语法。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請檢查 SQL 語法。"
           }
         }
       }
@@ -748,6 +1036,12 @@
             "state" : "translated",
             "value" : "请检查SSH主机、端口和凭证。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請檢查 SSH 主機、連接埠與憑證。"
+          }
         }
       }
     },
@@ -763,6 +1057,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "请检查SSH用户名、密码或私钥。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請檢查 SSH 使用者名稱、密碼或私鑰。"
           }
         }
       }
@@ -780,6 +1080,12 @@
             "state" : "translated",
             "value" : "从侧栏选择一个连接。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從側邊欄選擇一個連線。"
+          }
         }
       }
     },
@@ -792,6 +1098,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除"
@@ -812,6 +1124,12 @@
             "state" : "translated",
             "value" : "全部清除"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部清除"
+          }
         }
       }
     },
@@ -827,6 +1145,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除所有筛选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除所有篩選"
           }
         }
       }
@@ -844,6 +1168,12 @@
             "state" : "translated",
             "value" : "清除所有历史"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除所有記錄"
+          }
         }
       }
     },
@@ -859,6 +1189,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除历史"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除記錄"
           }
         }
       }
@@ -876,6 +1212,12 @@
             "state" : "translated",
             "value" : "清除查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除查詢"
+          }
         }
       }
     },
@@ -892,6 +1234,12 @@
             "state" : "translated",
             "value" : "颜色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顏色"
+          }
         }
       }
     },
@@ -907,6 +1255,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位"
           }
         }
       }
@@ -925,6 +1279,12 @@
             "state" : "translated",
             "value" : "列"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位"
+          }
         }
       }
     },
@@ -941,6 +1301,12 @@
             "state" : "translated",
             "value" : "配置错误"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定錯誤"
+          }
         }
       }
     },
@@ -950,6 +1316,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đã kết nối"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已連線"
           }
         }
       }
@@ -967,6 +1339,12 @@
             "state" : "translated",
             "value" : "正在连接%@..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在連線至 %@..."
+          }
         }
       }
     },
@@ -976,6 +1354,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang kết nối…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在連線…"
           }
         }
       }
@@ -993,6 +1377,12 @@
             "state" : "translated",
             "value" : "连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線"
+          }
         }
       }
     },
@@ -1002,6 +1392,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kết nối đã bị xóa"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線已刪除"
           }
         }
       }
@@ -1019,6 +1415,12 @@
             "state" : "translated",
             "value" : "连接失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線失敗"
+          }
         }
       }
     },
@@ -1034,6 +1436,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接被拒绝。服务器可能未运行或端口不正确。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線遭拒。伺服器可能未執行或連接埠不正確。"
           }
         }
       }
@@ -1051,6 +1459,12 @@
             "state" : "translated",
             "value" : "连接成功"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線成功"
+          }
         }
       }
     },
@@ -1066,6 +1480,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線"
           }
         }
       }
@@ -1083,6 +1503,12 @@
             "state" : "translated",
             "value" : "此分组中的连接将被移至未分组。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此群組中的連線將被移至未分組。"
+          }
         }
       }
     },
@@ -1098,6 +1524,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "继续"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "繼續"
           }
         }
       }
@@ -1115,6 +1547,12 @@
             "state" : "translated",
             "value" : "复制列名"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製欄位名稱"
+          }
         }
       }
     },
@@ -1130,6 +1568,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "拷贝名称"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製名稱"
           }
         }
       }
@@ -1147,6 +1591,12 @@
             "state" : "translated",
             "value" : "复制查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製查詢"
+          }
         }
       }
     },
@@ -1162,6 +1612,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制结果"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製結果"
           }
         }
       }
@@ -1179,6 +1635,12 @@
             "state" : "translated",
             "value" : "复制行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製列"
+          }
         }
       }
     },
@@ -1194,6 +1656,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "拷贝到剪贴板"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製到剪貼簿"
           }
         }
       }
@@ -1211,6 +1679,12 @@
             "state" : "translated",
             "value" : "复制值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製值"
+          }
         }
       }
     },
@@ -1226,6 +1700,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "创建"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立"
           }
         }
       }
@@ -1243,6 +1723,12 @@
             "state" : "translated",
             "value" : "创建分组来整理连接。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立群組來整理你的連線。"
+          }
         }
       }
     },
@@ -1259,6 +1745,12 @@
             "state" : "translated",
             "value" : "创建标签来整理连接。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立標籤來整理你的連線。"
+          }
         }
       }
     },
@@ -1268,6 +1760,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tạo nhóm"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立群組"
           }
         }
       }
@@ -1285,6 +1783,12 @@
             "state" : "translated",
             "value" : "创建新数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立新資料庫"
+          }
         }
       }
     },
@@ -1294,6 +1798,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tạo thẻ"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立標籤"
           }
         }
       }
@@ -1311,6 +1821,12 @@
             "state" : "translated",
             "value" : "数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫"
+          }
         }
       }
     },
@@ -1326,6 +1842,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "数据库文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫檔案"
           }
         }
       }
@@ -1343,6 +1865,12 @@
             "state" : "translated",
             "value" : "数据库名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫名稱"
+          }
         }
       }
     },
@@ -1358,6 +1886,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "数据库名称"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫名稱"
           }
         }
       }
@@ -1375,6 +1909,12 @@
             "state" : "translated",
             "value" : "数据库类型"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫類型"
+          }
         }
       }
     },
@@ -1384,6 +1924,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cơ sở dữ liệu"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫"
           }
         }
       }
@@ -1401,6 +1947,12 @@
             "state" : "translated",
             "value" : "默认"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設"
+          }
         }
       }
     },
@@ -1411,6 +1963,12 @@
             "state" : "translated",
             "value" : "DB mặc định"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設資料庫"
+          }
         }
       }
     },
@@ -1420,6 +1978,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chế độ an toàn mặc định"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設安全模式"
           }
         }
       }
@@ -1437,6 +2001,12 @@
             "state" : "translated",
             "value" : "默认：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設：%@"
+          }
         }
       }
     },
@@ -1446,6 +2016,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mặc định áp dụng khi thêm kết nối mới và khi mở bảng lần đầu tiên."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在新增連線及首次開啟資料表時套用的預設值。"
           }
         }
       }
@@ -1463,6 +2039,12 @@
             "state" : "translated",
             "value" : "删除"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除"
+          }
         }
       }
     },
@@ -1479,6 +2061,12 @@
             "state" : "translated",
             "value" : "删除连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除連線"
+          }
         }
       }
     },
@@ -1488,6 +2076,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Xóa nhóm"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除群組"
           }
         }
       }
@@ -1505,6 +2099,12 @@
             "state" : "translated",
             "value" : "删除分组"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除群組"
+          }
         }
       }
     },
@@ -1514,6 +2114,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Xóa hàng"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除列"
           }
         }
       }
@@ -1531,6 +2137,12 @@
             "state" : "translated",
             "value" : "删除行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除列"
+          }
         }
       }
     },
@@ -1540,6 +2152,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Xóa thẻ"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除標籤"
           }
         }
       }
@@ -1557,6 +2175,12 @@
             "state" : "translated",
             "value" : "降序"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "遞減"
+          }
         }
       }
     },
@@ -1570,6 +2194,12 @@
             "state" : "translated",
             "value" : "Mất kết nối"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已中斷連線"
+          }
         }
       }
     },
@@ -1582,6 +2212,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "完成"
@@ -1602,6 +2238,12 @@
             "state" : "translated",
             "value" : "删除"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除"
+          }
         }
       }
     },
@@ -1617,6 +2259,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除資料表"
           }
         }
       }
@@ -1634,6 +2282,12 @@
             "state" : "translated",
             "value" : "复制"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製"
+          }
         }
       }
     },
@@ -1649,6 +2303,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编辑"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯"
           }
         }
       }
@@ -1666,6 +2326,12 @@
             "state" : "translated",
             "value" : "编辑连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯連線"
+          }
         }
       }
     },
@@ -1681,6 +2347,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编辑分组"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯群組"
           }
         }
       }
@@ -1698,6 +2370,12 @@
             "state" : "translated",
             "value" : "编辑标签"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯標籤"
+          }
         }
       }
     },
@@ -1707,6 +2385,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bật"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已啟用"
           }
         }
       }
@@ -1728,6 +2412,12 @@
             "state" : "translated",
             "value" : "输入新SQLite数据库的名称。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入新 SQLite 資料庫的名稱。"
+          }
         }
       }
     },
@@ -1744,6 +2434,12 @@
             "state" : "translated",
             "value" : "输入页码"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入頁碼"
+          }
         }
       }
     },
@@ -1753,6 +2449,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nhập số trang (1-%lld)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入頁碼（1-%lld）"
           }
         }
       }
@@ -1771,6 +2473,12 @@
             "state" : "translated",
             "value" : "输入页码（1–%lld）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入頁碼（1–%lld）"
+          }
         }
       }
     },
@@ -1786,6 +2494,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "错误"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "錯誤"
           }
         }
       }
@@ -1803,6 +2517,12 @@
             "state" : "translated",
             "value" : "执行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行"
+          }
         }
       }
     },
@@ -1818,6 +2538,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "执行写入查询？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行寫入查詢？"
           }
         }
       }
@@ -1835,6 +2561,12 @@
             "state" : "translated",
             "value" : "已执行的查询将显示在这里。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已執行的查詢會顯示在這裡。"
+          }
         }
       }
     },
@@ -1851,6 +2583,12 @@
             "state" : "translated",
             "value" : "正在执行..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在執行…"
+          }
         }
       }
     },
@@ -1866,6 +2604,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导出"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出"
           }
         }
       }
@@ -1884,6 +2628,12 @@
             "state" : "translated",
             "value" : "加载更多行失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入更多列失敗"
+          }
         }
       }
     },
@@ -1899,6 +2649,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刷新表失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新整理資料表失敗"
           }
         }
       }
@@ -1917,6 +2673,12 @@
             "state" : "translated",
             "value" : "保存凭证失败。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存憑證失敗。"
+          }
         }
       }
     },
@@ -1932,6 +2694,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切换数据库失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換資料庫失敗"
           }
         }
       }
@@ -1949,6 +2717,12 @@
             "state" : "translated",
             "value" : "切换架构失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換綱要失敗"
+          }
         }
       }
     },
@@ -1958,6 +2732,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tệp"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檔案"
           }
         }
       }
@@ -1975,6 +2755,12 @@
             "state" : "translated",
             "value" : "筛选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選"
+          }
         }
       }
     },
@@ -1990,6 +2776,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "按标签筛选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "依標籤篩選"
           }
         }
       }
@@ -2007,6 +2799,12 @@
             "state" : "translated",
             "value" : "筛选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選"
+          }
         }
       }
     },
@@ -2016,6 +2814,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tập trung tìm kiếm"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "聚焦搜尋"
           }
         }
       }
@@ -2034,6 +2838,12 @@
             "state" : "translated",
             "value" : "外键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外鍵"
+          }
         }
       }
     },
@@ -2050,6 +2860,12 @@
             "state" : "translated",
             "value" : "开始使用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始使用"
+          }
         }
       }
     },
@@ -2062,6 +2878,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前往"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "前往"
@@ -2082,6 +2904,12 @@
             "state" : "translated",
             "value" : "返回并重新连接数据库。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "返回並重新連線至資料庫。"
+          }
         }
       }
     },
@@ -2097,6 +2925,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "跳转到页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前往頁面"
           }
         }
       }
@@ -2114,6 +2948,12 @@
             "state" : "translated",
             "value" : "跳转到页..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前往頁面…"
+          }
         }
       }
     },
@@ -2129,6 +2969,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分组"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "群組"
           }
         }
       }
@@ -2146,6 +2992,12 @@
             "state" : "translated",
             "value" : "按文件夹分组"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "依資料夾分組"
+          }
         }
       }
     },
@@ -2161,6 +3013,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分组"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "群組"
           }
         }
       }
@@ -2178,6 +3036,12 @@
             "state" : "translated",
             "value" : "通过共享匿名使用统计信息帮助改进TablePro（不包含个人数据或查询）。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分享匿名使用統計資料來協助改進 TablePro（不含個人資料或查詢）。"
+          }
         }
       }
     },
@@ -2188,6 +3052,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ẩn truy vấn trong Live Activity"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在即時動態中隱藏查詢"
           }
         }
       }
@@ -2205,6 +3075,12 @@
             "state" : "translated",
             "value" : "历史"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歷程記錄"
+          }
         }
       }
     },
@@ -2221,6 +3097,12 @@
             "state" : "translated",
             "value" : "主机"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主機"
+          }
         }
       }
     },
@@ -2230,6 +3112,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đồng bộ iCloud"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 同步"
           }
         }
       }
@@ -2243,6 +3131,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ngay lập tức"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即"
           }
         }
       }
@@ -2259,6 +3153,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从Mac导入连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從你的 Mac 匯入連線"
           }
         }
       }
@@ -2280,6 +3180,12 @@
             "state" : "translated",
             "value" : "索引"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "索引"
+          }
         }
       }
     },
@@ -2289,6 +3195,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thông tin"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資訊"
           }
         }
       }
@@ -2305,6 +3217,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "输入方式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入方式"
           }
         }
       }
@@ -2325,6 +3243,12 @@
             "state" : "translated",
             "value" : "插入行"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "插入列"
+          }
         }
       }
     },
@@ -2344,6 +3268,12 @@
             "state" : "translated",
             "value" : "钥匙串警告"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鑰匙圈警告"
+          }
         }
       }
     },
@@ -2357,6 +3287,12 @@
             "state" : "translated",
             "value" : "Tải thất bại"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入失敗"
+          }
         }
       }
     },
@@ -2366,6 +3302,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tải đầy đủ"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入完整值"
           }
         }
       }
@@ -2384,6 +3326,12 @@
             "state" : "translated",
             "value" : "加载更多"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入更多"
+          }
         }
       }
     },
@@ -2401,6 +3349,12 @@
             "state" : "translated",
             "value" : "正在加载数据..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入資料…"
+          }
         }
       }
     },
@@ -2416,6 +3370,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在加载结构..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入結構…"
           }
         }
       }
@@ -2434,6 +3394,12 @@
             "state" : "translated",
             "value" : "正在加载..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入…"
+          }
         }
       }
     },
@@ -2443,6 +3409,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cần truy cập Mạng nội bộ. Mở Cài đặt > Quyền riêng tư & Bảo mật > Mạng nội bộ và bật TablePro."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要區域網路存取權限。請開啟「設定」>「隱私權與安全性」>「區域網路」並開啟 TablePro。"
           }
         }
       }
@@ -2454,6 +3426,12 @@
             "state" : "translated",
             "value" : "Truy cập Mạng nội bộ có thể bị chặn. Mở Cài đặt > Quyền riêng tư & Bảo mật > Mạng nội bộ và bật TablePro."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "區域網路存取可能被封鎖。請開啟「設定」>「隱私權與安全性」>「區域網路」並開啟 TablePro。"
+          }
         }
       }
     },
@@ -2464,6 +3442,12 @@
             "state" : "translated",
             "value" : "Yêu cầu truy cập mạng nội bộ"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要區域網路存取權限"
+          }
         }
       }
     },
@@ -2473,6 +3457,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Khóa TablePro khi mở lại sau khoảng thời gian không hoạt động đã chọn. Khởi động lạnh luôn yêu cầu xác thực."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閒置超過所選時間後重新開啟時鎖定 TablePro。冷啟動一律需要驗證。"
           }
         }
       }
@@ -2490,6 +3480,12 @@
             "state" : "translated",
             "value" : "逻辑"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "邏輯"
+          }
         }
       }
     },
@@ -2506,6 +3502,12 @@
             "state" : "translated",
             "value" : "管理分组"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理群組"
+          }
         }
       }
     },
@@ -2521,6 +3523,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "管理标签"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理標籤"
           }
         }
       }
@@ -2541,6 +3549,12 @@
             "state" : "translated",
             "value" : "名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名稱"
+          }
         }
       }
     },
@@ -2560,6 +3574,12 @@
             "state" : "translated",
             "value" : "新建连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增連線"
+          }
         }
       }
     },
@@ -2569,6 +3589,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kết nối mới"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增連線"
           }
         }
       }
@@ -2586,6 +3612,12 @@
             "state" : "translated",
             "value" : "新建数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增資料庫"
+          }
         }
       }
     },
@@ -2601,6 +3633,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新建分组"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增群組"
           }
         }
       }
@@ -2618,6 +3656,12 @@
             "state" : "translated",
             "value" : "新建标签"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增標籤"
+          }
         }
       }
     },
@@ -2633,6 +3677,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无活动的数据库会话。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有作用中的資料庫工作階段。"
           }
         }
       }
@@ -2650,6 +3700,12 @@
             "state" : "translated",
             "value" : "无连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有連線"
+          }
         }
       }
     },
@@ -2665,6 +3721,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "没有连接匹配所选筛选条件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有連線符合所選的篩選條件。"
           }
         }
       }
@@ -2682,6 +3744,12 @@
             "state" : "translated",
             "value" : "无数据"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有資料"
+          }
         }
       }
     },
@@ -2697,6 +3765,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无外键"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有外鍵"
           }
         }
       }
@@ -2714,6 +3788,12 @@
             "state" : "translated",
             "value" : "无分组"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有群組"
+          }
         }
       }
     },
@@ -2729,6 +3809,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无历史记录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有歷程記錄"
           }
         }
       }
@@ -2746,6 +3832,12 @@
             "state" : "translated",
             "value" : "无索引"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有索引"
+          }
         }
       }
     },
@@ -2761,6 +3853,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无匹配的连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有符合的連線"
           }
         }
       }
@@ -2778,6 +3876,12 @@
             "state" : "translated",
             "value" : "未找到主键值。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到主鍵值。"
+          }
         }
       }
     },
@@ -2793,6 +3897,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无引用行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無參照列"
           }
         }
       }
@@ -2810,6 +3920,12 @@
             "state" : "translated",
             "value" : "无结果"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無結果"
+          }
         }
       }
     },
@@ -2825,6 +3941,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在%@中未找到%@ = '%@'的行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 %@ 中找不到 %@ = '%@' 的列"
           }
         }
       }
@@ -2842,6 +3964,12 @@
             "state" : "translated",
             "value" : "无表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無資料表"
+          }
         }
       }
     },
@@ -2857,6 +3985,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无标签"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無標籤"
           }
         }
       }
@@ -2874,6 +4008,12 @@
             "state" : "translated",
             "value" : "无"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無"
+          }
         }
       }
     },
@@ -2890,6 +4030,12 @@
             "state" : "translated",
             "value" : "未连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未連線"
+          }
         }
       }
     },
@@ -2902,6 +4048,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NULL"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "NULL"
@@ -2922,6 +4074,12 @@
             "state" : "translated",
             "value" : "可为空"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可為空"
+          }
         }
       }
     },
@@ -2931,6 +4089,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tắt"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉"
           }
         }
       }
@@ -2944,6 +4108,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "好"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "好"
@@ -2964,6 +4134,12 @@
             "state" : "translated",
             "value" : "ON DELETE %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ON DELETE %@"
+          }
         }
       }
     },
@@ -2976,6 +4152,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ON UPDATE %@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ON UPDATE %@"
@@ -2996,6 +4178,12 @@
             "state" : "translated",
             "value" : "打开连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟連線"
+          }
         }
       }
     },
@@ -3012,6 +4200,12 @@
             "state" : "translated",
             "value" : "打开数据库文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟資料庫檔案"
+          }
         }
       }
     },
@@ -3021,6 +4215,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mở Cài đặt > Quyền riêng tư & Bảo mật > Mạng nội bộ, bật TablePro, sau đó thử lại."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請開啟「設定」>「隱私權與安全性」>「區域網路」並開啟 TablePro，然後再試一次。"
           }
         }
       }
@@ -3038,6 +4238,12 @@
             "state" : "translated",
             "value" : "在TablePro中打开数据库连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 TablePro 中開啟資料庫連線"
+          }
         }
       }
     },
@@ -3048,6 +4254,12 @@
             "state" : "translated",
             "value" : "Mở dữ liệu bảng"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟資料表資料"
+          }
         }
       }
     },
@@ -3057,6 +4269,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mở kết nối này"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟此連線"
           }
         }
       }
@@ -3074,6 +4292,12 @@
             "state" : "translated",
             "value" : "运算符"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "運算子"
+          }
         }
       }
     },
@@ -3086,6 +4310,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OR"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "OR"
@@ -3106,6 +4336,12 @@
             "state" : "translated",
             "value" : "排序"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排序"
+          }
         }
       }
     },
@@ -3121,6 +4357,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "组织"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "組織"
           }
         }
       }
@@ -3138,6 +4380,12 @@
             "state" : "translated",
             "value" : "页码"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "頁碼"
+          }
         }
       }
     },
@@ -3153,6 +4401,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "密码短语（可选）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通關密語（選填）"
           }
         }
       }
@@ -3170,6 +4424,12 @@
             "state" : "translated",
             "value" : "密码"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密碼"
+          }
         }
       }
     },
@@ -3186,6 +4446,12 @@
             "state" : "translated",
             "value" : "粘贴私钥（PEM格式）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "貼上私密金鑰（PEM 格式）"
+          }
         }
       }
     },
@@ -3195,6 +4461,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đường dẫn"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路徑"
           }
         }
       }
@@ -3211,6 +4483,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "端口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連接埠"
           }
         }
       }
@@ -3229,6 +4507,12 @@
             "state" : "translated",
             "value" : "主键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主鍵"
+          }
         }
       }
     },
@@ -3244,6 +4528,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "主键"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主鍵"
           }
         }
       }
@@ -3261,6 +4551,12 @@
             "state" : "translated",
             "value" : "主键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主鍵"
+          }
         }
       }
     },
@@ -3276,6 +4572,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隐私"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱私權"
           }
         }
       }
@@ -3293,6 +4595,12 @@
             "state" : "translated",
             "value" : "私钥"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "私密金鑰"
+          }
         }
       }
     },
@@ -3309,6 +4617,12 @@
             "state" : "translated",
             "value" : "查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢"
+          }
         }
       }
     },
@@ -3324,6 +4638,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查询错误"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢錯誤"
           }
         }
       }
@@ -3342,6 +4662,12 @@
             "state" : "translated",
             "value" : "查询历史"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢記錄"
+          }
         }
       }
     },
@@ -3357,6 +4683,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查询文本和结果将被清除。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢文字與結果將被清除。"
           }
         }
       }
@@ -3374,6 +4706,12 @@
             "state" : "translated",
             "value" : "只读"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "唯讀"
+          }
         }
       }
     },
@@ -3389,6 +4727,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在重新连接..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在重新連線…"
           }
         }
       }
@@ -3412,6 +4756,12 @@
             "state" : "translated",
             "value" : "重新加载"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新載入"
+          }
         }
       }
     },
@@ -3421,6 +4771,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Yêu cầu Face ID"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要 Face ID"
           }
         }
       }
@@ -3432,6 +4788,12 @@
             "state" : "translated",
             "value" : "Yêu cầu Optic ID"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要 Optic ID"
+          }
         }
       }
     },
@@ -3441,6 +4803,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Yêu cầu Touch ID"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要 Touch ID"
           }
         }
       }
@@ -3461,6 +4829,12 @@
             "state" : "translated",
             "value" : "结果已清除"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結果已清除"
+          }
         }
       }
     },
@@ -3478,6 +4852,12 @@
             "state" : "translated",
             "value" : "因内存不足，结果已清除。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "因記憶體不足，結果已清除。"
+          }
         }
       }
     },
@@ -3487,6 +4867,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đã cắt bớt kết quả do áp lực bộ nhớ."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "因記憶體不足，結果已縮減。"
           }
         }
       }
@@ -3504,6 +4890,12 @@
             "state" : "translated",
             "value" : "重试"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重試"
+          }
         }
       }
     },
@@ -3519,6 +4911,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "第%d行 / 共%d行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %d 列 / 共 %d 列"
           }
         }
       }
@@ -3536,6 +4934,12 @@
             "state" : "translated",
             "value" : "行已更新"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列已更新"
+          }
         }
       }
     },
@@ -3552,6 +4956,12 @@
             "state" : "translated",
             "value" : "每页行数"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每頁列數"
+          }
         }
       }
     },
@@ -3561,6 +4971,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chạy"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行"
           }
         }
       }
@@ -3578,6 +4994,12 @@
             "state" : "translated",
             "value" : "运行查询"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行查詢"
+          }
         }
       }
     },
@@ -3588,6 +5010,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang chạy truy vấn"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在執行查詢"
           }
         }
       }
@@ -3601,6 +5029,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安全模式"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "安全模式"
@@ -3621,6 +5055,12 @@
             "state" : "translated",
             "value" : "保存"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存"
+          }
         }
       }
     },
@@ -3634,6 +5074,12 @@
             "state" : "translated",
             "value" : "Schema"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "綱要"
+          }
         }
       }
     },
@@ -3643,6 +5089,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schemas"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "綱要"
           }
         }
       }
@@ -3660,6 +5112,12 @@
             "state" : "translated",
             "value" : "搜索所有列"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋所有欄位"
+          }
         }
       }
     },
@@ -3675,6 +5133,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜索表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋資料表"
           }
         }
       }
@@ -3692,6 +5156,12 @@
             "state" : "translated",
             "value" : "第二个值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第二個值"
+          }
         }
       }
     },
@@ -3708,6 +5178,12 @@
             "state" : "translated",
             "value" : "分区"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "區段"
+          }
         }
       }
     },
@@ -3717,6 +5193,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bảo mật"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安全性"
           }
         }
       }
@@ -3730,6 +5212,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SELECT * FROM ..."
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "SELECT * FROM ..."
@@ -3750,6 +5238,12 @@
             "state" : "translated",
             "value" : "选择连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇連線"
+          }
         }
       }
     },
@@ -3767,6 +5261,12 @@
             "state" : "translated",
             "value" : "选择私钥"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇私密金鑰"
+          }
         }
       }
     },
@@ -3782,6 +5282,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "服务器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伺服器"
           }
         }
       }
@@ -3799,6 +5305,12 @@
             "state" : "translated",
             "value" : "设置新的数据库连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定新的資料庫連線"
+          }
         }
       }
     },
@@ -3814,6 +5326,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "设置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定"
           }
         }
       }
@@ -3831,6 +5349,12 @@
             "state" : "translated",
             "value" : "共享"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分享"
+          }
         }
       }
     },
@@ -3846,6 +5370,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "共享匿名使用数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分享匿名使用資料"
           }
         }
       }
@@ -3863,6 +5393,12 @@
             "state" : "translated",
             "value" : "共享结果"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分享結果"
+          }
         }
       }
     },
@@ -3878,6 +5414,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "共享行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分享列"
           }
         }
       }
@@ -3898,6 +5440,12 @@
             "state" : "translated",
             "value" : "跳过"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "略過"
+          }
         }
       }
     },
@@ -3914,6 +5462,12 @@
             "state" : "translated",
             "value" : "部分凭证无法保存到钥匙串，稍后可能需要重新输入。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分憑證無法儲存至鑰匙圈，稍後可能需要重新輸入。"
+          }
         }
       }
     },
@@ -3926,6 +5480,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排序"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "排序"
@@ -3946,6 +5506,12 @@
             "state" : "translated",
             "value" : "排序方式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排序依據"
+          }
         }
       }
     },
@@ -3961,6 +5527,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SSH主机"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 主機"
           }
         }
       }
@@ -3978,6 +5550,12 @@
             "state" : "translated",
             "value" : "SSH密码"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 密碼"
+          }
         }
       }
     },
@@ -3993,6 +5571,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SSH端口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 連接埠"
           }
         }
       }
@@ -4010,6 +5594,12 @@
             "state" : "translated",
             "value" : "SSH服务器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 伺服器"
+          }
         }
       }
     },
@@ -4025,6 +5615,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SSH隧道"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 隧道"
           }
         }
       }
@@ -4042,6 +5638,12 @@
             "state" : "translated",
             "value" : "SSH隧道失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 隧道失敗"
+          }
         }
       }
     },
@@ -4057,6 +5659,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SSH用户名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 使用者名稱"
           }
         }
       }
@@ -4074,6 +5682,12 @@
             "state" : "translated",
             "value" : "SSL"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSL"
+          }
         }
       }
     },
@@ -4087,6 +5701,12 @@
             "state" : "translated",
             "value" : "Thống kê"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "統計"
+          }
         }
       }
     },
@@ -4097,6 +5717,12 @@
             "state" : "translated",
             "value" : "Trạng thái"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態"
+          }
         }
       }
     },
@@ -4106,6 +5732,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dừng"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止"
           }
         }
       }
@@ -4130,6 +5762,12 @@
             "state" : "translated",
             "value" : "正在切换..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在切換…"
+          }
         }
       }
     },
@@ -4139,6 +5777,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đồng bộ"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步"
           }
         }
       }
@@ -4156,6 +5800,12 @@
             "state" : "translated",
             "value" : "从iCloud同步"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從 iCloud 同步"
+          }
         }
       }
     },
@@ -4168,6 +5818,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đồng bộ với iCloud"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "與 iCloud 同步"
           }
         }
       }
@@ -4184,6 +5840,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在从iCloud同步..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在從 iCloud 同步…"
           }
         }
       }
@@ -4205,6 +5867,12 @@
             "state" : "translated",
             "value" : "标签页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分頁"
+          }
         }
       }
     },
@@ -4214,6 +5882,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bảng"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表"
           }
         }
       }
@@ -4231,6 +5905,12 @@
             "state" : "translated",
             "value" : "表结构"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表結構"
+          }
         }
       }
     },
@@ -4240,6 +5920,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "TablePro đã khóa"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 已鎖定"
           }
         }
       }
@@ -4260,6 +5946,12 @@
             "state" : "translated",
             "value" : "表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表"
+          }
         }
       }
     },
@@ -4275,6 +5967,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "标签"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標籤"
           }
         }
       }
@@ -4292,6 +5990,12 @@
             "state" : "translated",
             "value" : "标签"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標籤"
+          }
         }
       }
     },
@@ -4308,6 +6012,12 @@
             "state" : "translated",
             "value" : "测试连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "測試連線"
+          }
         }
       }
     },
@@ -4323,6 +6033,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在测试..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在測試…"
           }
         }
       }
@@ -4343,6 +6059,12 @@
             "state" : "translated",
             "value" : "操作违反了数据库约束。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作違反了資料庫限制條件。"
+          }
         }
       }
     },
@@ -4352,6 +6074,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Truy vấn không trả về hàng nào."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢未傳回任何列。"
           }
         }
       }
@@ -4369,6 +6097,12 @@
             "state" : "translated",
             "value" : "服务器无响应。请检查主机和端口。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伺服器沒有回應。請檢查主機與連接埠。"
+          }
         }
       }
     },
@@ -4384,6 +6118,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SSH服务器可能无法访问或运行了不同的协议。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 伺服器可能無法連線，或正在執行不同的通訊協定。"
           }
         }
       }
@@ -4401,6 +6141,12 @@
             "state" : "translated",
             "value" : "SSH隧道已连接但无法转发到数据库端口。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 隧道已連線，但無法轉送至資料庫連接埠。"
+          }
         }
       }
     },
@@ -4416,6 +6162,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "表\"%@\"及其所有数据将被永久删除。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表「%@」及其所有資料將被永久刪除。"
           }
         }
       }
@@ -4433,6 +6185,12 @@
             "state" : "translated",
             "value" : "表或列不存在。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表或欄位不存在。"
+          }
         }
       }
     },
@@ -4449,6 +6207,12 @@
             "state" : "translated",
             "value" : "此连接为只读模式，不允许写入查询。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線為唯讀模式，不允許寫入查詢。"
+          }
         }
       }
     },
@@ -4458,6 +6222,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kết nối này không còn tồn tại. Có thể đã bị xóa từ thiết bị khác."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線已不存在，可能已從其他裝置移除。"
           }
         }
       }
@@ -4475,6 +6245,12 @@
             "state" : "translated",
             "value" : "此数据库没有表。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此資料庫沒有資料表。"
+          }
         }
       }
     },
@@ -4490,6 +6266,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此查询将修改数据，确定要继续吗？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此查詢將會修改資料。確定要繼續嗎？"
           }
         }
       }
@@ -4507,6 +6289,12 @@
             "state" : "translated",
             "value" : "此表没有外键关系。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此資料表沒有外鍵關聯。"
+          }
         }
       }
     },
@@ -4522,6 +6310,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此表没有索引。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此資料表沒有索引。"
           }
         }
       }
@@ -4539,6 +6333,12 @@
             "state" : "translated",
             "value" : "此表为空。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此資料表是空的。"
+          }
         }
       }
     },
@@ -4554,6 +6354,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此表需要主键来标识行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此資料表需要主鍵來識別該列。"
           }
         }
       }
@@ -4577,6 +6383,12 @@
             "state" : "translated",
             "value" : "清空"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清空"
+          }
         }
       }
     },
@@ -4593,6 +6405,12 @@
             "state" : "translated",
             "value" : "清空表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清空資料表"
+          }
         }
       }
     },
@@ -4602,6 +6420,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thử lại"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再試一次"
           }
         }
       }
@@ -4613,6 +6437,12 @@
             "state" : "translated",
             "value" : "Thử lại hoặc kiểm tra kết nối."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請再試一次或檢查你的連線。"
+          }
         }
       }
     },
@@ -4622,6 +6452,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Loại"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "型別"
           }
         }
       }
@@ -4638,6 +6474,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未分组"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未分組"
           }
         }
       }
@@ -4656,6 +6498,12 @@
             "state" : "translated",
             "value" : "唯一"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "唯一"
+          }
         }
       }
     },
@@ -4665,6 +6513,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mở khóa"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解鎖"
           }
         }
       }
@@ -4676,6 +6530,12 @@
             "state" : "translated",
             "value" : "Mở khóa TablePro để truy cập các kết nối cơ sở dữ liệu."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解鎖 TablePro 以存取你的資料庫連線。"
+          }
         }
       }
     },
@@ -4685,6 +6545,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dùng mật mã"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用密碼"
           }
         }
       }
@@ -4702,6 +6568,12 @@
             "state" : "translated",
             "value" : "用户名"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用者名稱"
+          }
         }
       }
     },
@@ -4714,6 +6586,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "值"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "值"
@@ -4734,6 +6612,12 @@
             "state" : "translated",
             "value" : "版本"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版本"
+          }
         }
       }
     },
@@ -4743,6 +6627,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "View"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檢視表"
           }
         }
       }
@@ -4761,6 +6651,12 @@
             "state" : "translated",
             "value" : "视图"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檢視表"
+          }
         }
       }
     },
@@ -4777,6 +6673,12 @@
             "state" : "translated",
             "value" : "欢迎使用TablePro"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歡迎使用 TablePro"
+          }
         }
       }
     },
@@ -4786,6 +6688,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Khi tắt, các kết nối, nhóm và thẻ chỉ ở trên thiết bị này. Dữ liệu iCloud hiện có sẽ không bị xóa."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉時，連線、群組與標籤只會保留在此裝置上。現有的 iCloud 資料不會被刪除。"
           }
         }
       }
@@ -4797,6 +6705,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Khi bật, màn hình khóa và Dynamic Island hiển thị \"Đang chạy truy vấn\" thay cho nội dung SQL."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟時，鎖定畫面與動態島會顯示「正在執行查詢」，而非 SQL 預覽。"
           }
         }
       }
@@ -4814,6 +6728,12 @@
             "state" : "translated",
             "value" : "写入查询被阻止"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寫入查詢已封鎖"
+          }
         }
       }
     },
@@ -4829,6 +6749,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编写SQL并点击运行按钮。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入 SQL 並點按播放按鈕。"
           }
         }
       }

--- a/docs/customization/settings.mdx
+++ b/docs/customization/settings.mdx
@@ -23,7 +23,7 @@ Open with `Cmd+,`. Settings are grouped into tabs.
 
 ### Language
 
-System (default), English, Tiếng Việt, Türkçe. Changing the language requires restarting TablePro.
+System (default), English, Tiếng Việt, Türkçe, 简体中文, 繁體中文. Changing the language requires restarting TablePro.
 
 ### Startup Behavior
 


### PR DESCRIPTION
This PR adds Traditional Chinese (zh-Hant) localization to the macOS and iOS apps.

It also registers the iOS project's existing vi and zh-Hans locales in knownRegions, which had translations but were never listed.