### PR TITLE
feat(structure): add Triggers tab to Show Structure for MySQL, PostgreSQL, and SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The table structure view has a Triggers tab for MySQL, MariaDB, PostgreSQL, and SQLite. It lists each trigger with its timing and event and shows the full definition in a read-only syntax-highlighted viewer. (#1695)
 - Traditional Chinese (繁體中文) language in Settings > General with full UI translation
 
 ## [0.51.1] - 2026-06-16

--- a/Plugins/MySQLDriverPlugin/MySQLPlugin.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPlugin.swift
@@ -146,6 +146,7 @@ final class MySQLPlugin: NSObject, TableProPlugin, DriverPlugin {
     )
 
     static let supportsDropDatabase = true
+    static let supportsTriggers = true
 
     func createDriver(config: DriverConnectionConfig) -> any PluginDatabaseDriver {
         MySQLPluginDriver(config: config)

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
@@ -388,8 +388,7 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         let escapedTable = table.replacingOccurrences(of: "'", with: "''")
 
         let query = """
-            SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION,
-                   ACTION_STATEMENT, ACTION_ORIENTATION
+            SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION, ACTION_STATEMENT
             FROM information_schema.TRIGGERS
             WHERE EVENT_OBJECT_SCHEMA = '\(escapedDb)'
                 AND EVENT_OBJECT_TABLE = '\(escapedTable)'
@@ -405,7 +404,6 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                   let body = row[safe: 3]?.asText
             else { return nil }
 
-            let orientation = row[safe: 4]?.asText ?? "ROW"
             let statement = """
                 CREATE TRIGGER \(quoteIdentifier(name)) \(timing) \(event)
                 ON \(quoteIdentifier(table)) FOR EACH ROW
@@ -416,7 +414,6 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 name: name,
                 timing: timing,
                 event: event,
-                forEachRow: orientation == "ROW",
                 statement: statement
             )
         }

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
@@ -382,6 +382,48 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         return foreignKeys
     }
 
+    func fetchTriggers(table: String, schema: String?) async throws -> [PluginTriggerInfo] {
+        let dbName = _activeDatabase
+        let escapedDb = dbName.replacingOccurrences(of: "'", with: "''")
+        let escapedTable = table.replacingOccurrences(of: "'", with: "''")
+
+        let query = """
+            SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION,
+                   ACTION_STATEMENT, ACTION_ORIENTATION
+            FROM information_schema.TRIGGERS
+            WHERE EVENT_OBJECT_SCHEMA = '\(escapedDb)'
+                AND EVENT_OBJECT_TABLE = '\(escapedTable)'
+            ORDER BY TRIGGER_NAME
+            """
+
+        let result = try await execute(query: query)
+
+        let triggers: [PluginTriggerInfo] = result.rows.compactMap { row in
+            guard let name = row[safe: 0]?.asText,
+                  let timing = row[safe: 1]?.asText,
+                  let event = row[safe: 2]?.asText,
+                  let body = row[safe: 3]?.asText
+            else { return nil }
+
+            let orientation = row[safe: 4]?.asText ?? "ROW"
+            let statement = """
+                CREATE TRIGGER \(quoteIdentifier(name)) \(timing) \(event)
+                ON \(quoteIdentifier(table)) FOR EACH ROW
+                \(body)
+                """
+
+            return PluginTriggerInfo(
+                name: name,
+                timing: timing,
+                event: event,
+                forEachRow: orientation == "ROW",
+                statement: statement
+            )
+        }
+        Self.logger.info("[trigger] mysql fetchTriggers db=\(dbName, privacy: .public) table=\(table, privacy: .public) rows=\(result.rows.count) parsed=\(triggers.count)")
+        return triggers
+    }
+
     func fetchAllForeignKeys(schema: String?) async throws -> [String: [PluginForeignKeyInfo]] {
         let dbName = _activeDatabase
         let escapedDb = dbName.replacingOccurrences(of: "'", with: "''")

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPlugin.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPlugin.swift
@@ -124,6 +124,7 @@ final class PostgreSQLPlugin: NSObject, TableProPlugin, DriverPlugin {
     static let requiresReconnectForDatabaseSwitch = true
     static let parameterStyle: ParameterStyle = .dollar
     static let supportsDropDatabase = true
+    static let supportsTriggers = true
 
     static let sqlDialect: SQLDialectDescriptor? = SQLDialectDescriptor(
         identifierQuote: "\"",

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
@@ -307,8 +307,6 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
                      WHEN (t.tgtype & 16) != 0 THEN 'DELETE'
                      WHEN (t.tgtype & 32) != 0 THEN 'TRUNCATE'
                      ELSE '' END AS event,
-                (t.tgtype & 1) = 1 AS for_each_row,
-                pg_get_expr(t.tgqual, t.tgrelid) AS when_clause,
                 pg_get_triggerdef(t.oid) AS definition
             FROM pg_catalog.pg_trigger t
             JOIN pg_catalog.pg_class c ON c.oid = t.tgrelid
@@ -320,20 +318,16 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
             """
         let result = try await execute(query: query)
         let triggers: [PluginTriggerInfo] = result.rows.compactMap { row -> PluginTriggerInfo? in
-            guard row.count >= 6,
+            guard row.count >= 4,
                   let name = row[0].asText,
                   let timing = row[1].asText,
                   let event = row[2].asText,
-                  let definition = row[5].asText
+                  let definition = row[3].asText
             else { return nil }
-            let forEachRow = row[3].asText == "t"
-            let whenClause = row[4].asText
             return PluginTriggerInfo(
                 name: name,
                 timing: timing,
                 event: event,
-                forEachRow: forEachRow,
-                whenClause: whenClause,
                 statement: definition
             )
         }

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
@@ -287,6 +287,60 @@ final class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
         return foreignKeys
     }
 
+    func fetchTriggers(table: String, schema: String?) async throws -> [PluginTriggerInfo] {
+        let resolvedSchema = schema ?? core.currentSchema
+        let schemaLiteral = escapeLiteral(resolvedSchema)
+        let tableLiteral = escapeLiteral(table)
+        let query = """
+            SELECT
+                t.tgname,
+                CASE WHEN (t.tgtype & 64) != 0 THEN 'INSTEAD OF'
+                     WHEN (t.tgtype & 2)  != 0 THEN 'BEFORE'
+                     ELSE 'AFTER' END AS timing,
+                CASE WHEN (t.tgtype & 4) != 0 AND (t.tgtype & 8) != 0 AND (t.tgtype & 16) != 0
+                          THEN 'INSERT OR UPDATE OR DELETE'
+                     WHEN (t.tgtype & 4) != 0 AND (t.tgtype & 8) != 0  THEN 'INSERT OR UPDATE'
+                     WHEN (t.tgtype & 4) != 0 AND (t.tgtype & 16) != 0 THEN 'INSERT OR DELETE'
+                     WHEN (t.tgtype & 8) != 0 AND (t.tgtype & 16) != 0 THEN 'UPDATE OR DELETE'
+                     WHEN (t.tgtype & 4) != 0  THEN 'INSERT'
+                     WHEN (t.tgtype & 8) != 0  THEN 'UPDATE'
+                     WHEN (t.tgtype & 16) != 0 THEN 'DELETE'
+                     WHEN (t.tgtype & 32) != 0 THEN 'TRUNCATE'
+                     ELSE '' END AS event,
+                (t.tgtype & 1) = 1 AS for_each_row,
+                pg_get_expr(t.tgqual, t.tgrelid) AS when_clause,
+                pg_get_triggerdef(t.oid) AS definition
+            FROM pg_catalog.pg_trigger t
+            JOIN pg_catalog.pg_class c ON c.oid = t.tgrelid
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.relname = '\(tableLiteral)'
+                AND n.nspname = '\(schemaLiteral)'
+                AND NOT t.tgisinternal
+            ORDER BY t.tgname
+            """
+        let result = try await execute(query: query)
+        let triggers: [PluginTriggerInfo] = result.rows.compactMap { row -> PluginTriggerInfo? in
+            guard row.count >= 6,
+                  let name = row[0].asText,
+                  let timing = row[1].asText,
+                  let event = row[2].asText,
+                  let definition = row[5].asText
+            else { return nil }
+            let forEachRow = row[3].asText == "t"
+            let whenClause = row[4].asText
+            return PluginTriggerInfo(
+                name: name,
+                timing: timing,
+                event: event,
+                forEachRow: forEachRow,
+                whenClause: whenClause,
+                statement: definition
+            )
+        }
+        Self.logger.info("[trigger] postgres fetchTriggers schema=\(resolvedSchema, privacy: .public) table=\(table, privacy: .public) rows=\(result.rows.count) parsed=\(triggers.count)")
+        return triggers
+    }
+
     func fetchAllForeignKeys(schema: String?) async throws -> [String: [PluginForeignKeyInfo]] {
         let schemaLiteral = escapeLiteral(schema ?? core.currentSchema)
         let query = """

--- a/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
+++ b/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
@@ -35,6 +35,7 @@ final class SQLitePlugin: NSObject, TableProPlugin, DriverPlugin {
     static let fileExtensions: [String] = ["db", "db3", "s3db", "sl3", "sqlite", "sqlite3", "sqlitedb"]
     static let brandColorHex = "#003B57"
     static let supportsDatabaseSwitching = false
+    static let supportsTriggers = true
     static let databaseGroupingStrategy: GroupingStrategy = .flat
     static let columnTypesByCategory: [String: [String]] = [
         "Integer": ["INTEGER", "INT", "TINYINT", "SMALLINT", "MEDIUMINT", "BIGINT"],
@@ -822,6 +823,61 @@ final class SQLitePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 onUpdate: onUpdate
             )
         }
+    }
+
+    func fetchTriggers(table: String, schema: String?) async throws -> [PluginTriggerInfo] {
+        let safeTable = escapeStringLiteral(table)
+        let query = """
+            SELECT name, sql FROM sqlite_master
+            WHERE type = 'trigger' AND tbl_name = '\(safeTable)'
+            ORDER BY name
+            """
+        let result = try await execute(query: query)
+
+        return result.rows.compactMap { row -> PluginTriggerInfo? in
+            guard row.count >= 2,
+                  let name = row[0].asText,
+                  let sql = row[1].asText else {
+                return nil
+            }
+
+            let (timing, event) = Self.parseTimingAndEvent(from: sql)
+            return PluginTriggerInfo(
+                name: name,
+                timing: timing,
+                event: event,
+                statement: sql
+            )
+        }
+    }
+
+    private static func parseTimingAndEvent(from sql: String) -> (timing: String, event: String) {
+        let upper = sql.uppercased()
+        let headerEnd = upper.range(of: " ON ")?.lowerBound ?? upper.endIndex
+        let tokens = upper[upper.startIndex..<headerEnd]
+            .split(whereSeparator: { $0.isWhitespace || $0 == "," })
+            .map(String.init)
+
+        let eventIndex = tokens.lastIndex(where: { $0 == "INSERT" || $0 == "UPDATE" || $0 == "DELETE" })
+        let event = eventIndex.map { tokens[$0] } ?? ""
+
+        let timingSearchEnd = eventIndex ?? tokens.endIndex
+        var timing = "AFTER"
+        for token in tokens[tokens.startIndex..<timingSearchEnd].reversed() {
+            if token == "INSTEAD" {
+                timing = "INSTEAD OF"
+                break
+            }
+            if token == "BEFORE" {
+                timing = "BEFORE"
+                break
+            }
+            if token == "AFTER" {
+                timing = "AFTER"
+                break
+            }
+        }
+        return (timing, event)
     }
 
     func fetchTableDDL(table: String, schema: String?) async throws -> String {

--- a/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
+++ b/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
@@ -841,7 +841,7 @@ final class SQLitePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 return nil
             }
 
-            let (timing, event) = Self.parseTimingAndEvent(from: sql)
+            let (timing, event) = TriggerSQLParser.timingAndEvent(from: sql)
             return PluginTriggerInfo(
                 name: name,
                 timing: timing,
@@ -849,35 +849,6 @@ final class SQLitePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 statement: sql
             )
         }
-    }
-
-    private static func parseTimingAndEvent(from sql: String) -> (timing: String, event: String) {
-        let upper = sql.uppercased()
-        let headerEnd = upper.range(of: " ON ")?.lowerBound ?? upper.endIndex
-        let tokens = upper[upper.startIndex..<headerEnd]
-            .split(whereSeparator: { $0.isWhitespace || $0 == "," })
-            .map(String.init)
-
-        let eventIndex = tokens.lastIndex(where: { $0 == "INSERT" || $0 == "UPDATE" || $0 == "DELETE" })
-        let event = eventIndex.map { tokens[$0] } ?? ""
-
-        let timingSearchEnd = eventIndex ?? tokens.endIndex
-        var timing = "AFTER"
-        for token in tokens[tokens.startIndex..<timingSearchEnd].reversed() {
-            if token == "INSTEAD" {
-                timing = "INSTEAD OF"
-                break
-            }
-            if token == "BEFORE" {
-                timing = "BEFORE"
-                break
-            }
-            if token == "AFTER" {
-                timing = "AFTER"
-                break
-            }
-        }
-        return (timing, event)
     }
 
     func fetchTableDDL(table: String, schema: String?) async throws -> String {

--- a/Plugins/TableProPluginKit/DriverPlugin.swift
+++ b/Plugins/TableProPluginKit/DriverPlugin.swift
@@ -23,6 +23,7 @@ public protocol DriverPlugin: TableProPlugin {
     static var queryLanguageName: String { get }
     static var editorLanguage: EditorLanguage { get }
     static var supportsForeignKeys: Bool { get }
+    static var supportsTriggers: Bool { get }
     static var supportsSchemaEditing: Bool { get }
     static var supportsDatabaseSwitching: Bool { get }
     static var supportsSchemaSwitching: Bool { get }
@@ -82,6 +83,7 @@ public extension DriverPlugin {
     static var queryLanguageName: String { "SQL" }
     static var editorLanguage: EditorLanguage { .sql }
     static var supportsForeignKeys: Bool { true }
+    static var supportsTriggers: Bool { false }
     static var supportsSchemaEditing: Bool { true }
     static var supportsDatabaseSwitching: Bool { true }
     static var supportsSchemaSwitching: Bool { false }

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -88,6 +88,7 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
     func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo]
     func fetchIndexes(table: String, schema: String?) async throws -> [PluginIndexInfo]
     func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo]
+    func fetchTriggers(table: String, schema: String?) async throws -> [PluginTriggerInfo]
     func fetchTableDDL(table: String, schema: String?) async throws -> String
     func fetchViewDefinition(view: String, schema: String?) async throws -> String
     func fetchTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata
@@ -196,6 +197,8 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
 
 public extension PluginDatabaseDriver {
     var capabilities: PluginCapabilities { [] }
+
+    func fetchTriggers(table: String, schema: String?) async throws -> [PluginTriggerInfo] { [] }
 
     var supportsSchemas: Bool { false }
 

--- a/Plugins/TableProPluginKit/PluginTriggerInfo.swift
+++ b/Plugins/TableProPluginKit/PluginTriggerInfo.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public struct PluginTriggerInfo: Codable, Sendable {
+    public let name: String
+    public let timing: String
+    public let event: String
+    public let forEachRow: Bool
+    public let whenClause: String?
+    public let statement: String
+
+    public init(
+        name: String,
+        timing: String,
+        event: String,
+        forEachRow: Bool = true,
+        whenClause: String? = nil,
+        statement: String
+    ) {
+        self.name = name
+        self.timing = timing
+        self.event = event
+        self.forEachRow = forEachRow
+        self.whenClause = whenClause
+        self.statement = statement
+    }
+}

--- a/Plugins/TableProPluginKit/PluginTriggerInfo.swift
+++ b/Plugins/TableProPluginKit/PluginTriggerInfo.swift
@@ -1,26 +1,27 @@
+//
+//  PluginTriggerInfo.swift
+//  TableProPluginKit
+//
+//  Transfer type describing a database trigger.
+//
+
 import Foundation
 
 public struct PluginTriggerInfo: Codable, Sendable {
     public let name: String
     public let timing: String
     public let event: String
-    public let forEachRow: Bool
-    public let whenClause: String?
     public let statement: String
 
     public init(
         name: String,
         timing: String,
         event: String,
-        forEachRow: Bool = true,
-        whenClause: String? = nil,
         statement: String
     ) {
         self.name = name
         self.timing = timing
         self.event = event
-        self.forEachRow = forEachRow
-        self.whenClause = whenClause
         self.statement = statement
     }
 }

--- a/Plugins/TableProPluginKit/TriggerSQLParser.swift
+++ b/Plugins/TableProPluginKit/TriggerSQLParser.swift
@@ -1,0 +1,33 @@
+//
+//  TriggerSQLParser.swift
+//  TableProPluginKit
+//
+//  Extracts trigger timing and event from a CREATE TRIGGER statement.
+//
+
+import Foundation
+
+public enum TriggerSQLParser {
+    private static let events: Set<String> = ["INSERT", "UPDATE", "DELETE"]
+
+    public static func timingAndEvent(from sql: String) -> (timing: String, event: String) {
+        let upper = sql.uppercased()
+        let headerEnd = upper.range(of: " ON ")?.lowerBound ?? upper.endIndex
+        let tokens = upper[upper.startIndex..<headerEnd]
+            .split(whereSeparator: { $0.isWhitespace || $0 == "," })
+            .map(String.init)
+
+        for index in tokens.indices {
+            let token = tokens[index]
+            if token == "INSTEAD", index + 2 < tokens.count, tokens[index + 1] == "OF",
+               events.contains(tokens[index + 2]) {
+                return ("INSTEAD OF", tokens[index + 2])
+            }
+            if token == "BEFORE" || token == "AFTER", index + 1 < tokens.count,
+               events.contains(tokens[index + 1]) {
+                return (token, tokens[index + 1])
+            }
+        }
+        return ("", "")
+    }
+}

--- a/TablePro/Core/Database/DatabaseDriver.swift
+++ b/TablePro/Core/Database/DatabaseDriver.swift
@@ -83,6 +83,9 @@ protocol DatabaseDriver: AnyObject {
     /// Fetch foreign keys for a specific table
     func fetchForeignKeys(table: String) async throws -> [ForeignKeyInfo]
 
+    /// Fetch triggers for a specific table
+    func fetchTriggers(table: String) async throws -> [TriggerInfo]
+
     /// Fetch foreign keys for all tables in the current database/schema in bulk.
     /// Default implementation falls back to per-table fetchForeignKeys.
     func fetchAllForeignKeys() async throws -> [String: [ForeignKeyInfo]]
@@ -243,6 +246,8 @@ extension DatabaseDriver {
     func fetchColumns(table: String, schema: String?) async throws -> [ColumnInfo] {
         try await fetchColumns(table: table)
     }
+
+    func fetchTriggers(table: String) async throws -> [TriggerInfo] { [] }
 
     func testConnection() async throws -> Bool {
         try await connect()

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -251,6 +251,20 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable {
         }
     }
 
+    func fetchTriggers(table: String) async throws -> [TriggerInfo] {
+        let pluginTriggers = try await pluginDriver.fetchTriggers(table: table, schema: pluginDriver.currentSchema)
+        return pluginTriggers.map { trigger in
+            TriggerInfo(
+                name: trigger.name,
+                timing: trigger.timing,
+                event: trigger.event,
+                forEachRow: trigger.forEachRow,
+                whenClause: trigger.whenClause,
+                statement: trigger.statement
+            )
+        }
+    }
+
     func fetchApproximateRowCount(table: String) async throws -> Int? {
         try await pluginDriver.fetchApproximateRowCount(table: table, schema: pluginDriver.currentSchema)
     }

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -258,8 +258,6 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable {
                 name: trigger.name,
                 timing: trigger.timing,
                 event: trigger.event,
-                forEachRow: trigger.forEachRow,
-                whenClause: trigger.whenClause,
                 statement: trigger.statement
             )
         }

--- a/TablePro/Core/Plugins/PluginMetadataRegistry.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry.swift
@@ -54,6 +54,7 @@ struct PluginMetadataSnapshot: Sendable {
         var supportsAddIndex: Bool = true
         var supportsDropIndex: Bool = true
         var supportsModifyPrimaryKey: Bool = true
+        var supportsTriggers: Bool = false
         var defaultSSLMode: SSLMode = .disabled
         var supportsOpportunisticTLS: Bool = true
         var supportsCloudflareTunnel: Bool = true
@@ -449,6 +450,7 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                     requiresReconnectForDatabaseSwitch: false,
                     supportsDropDatabase: true,
                     supportsRenameColumn: true,
+                    supportsTriggers: true,
                     defaultSSLMode: .preferred
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
@@ -498,6 +500,7 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                     requiresReconnectForDatabaseSwitch: false,
                     supportsDropDatabase: true,
                     supportsRenameColumn: true,
+                    supportsTriggers: true,
                     defaultSSLMode: .preferred
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
@@ -548,6 +551,7 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                     requiresReconnectForDatabaseSwitch: true,
                     supportsDropDatabase: true,
                     supportsRenameColumn: true,
+                    supportsTriggers: true,
                     defaultSSLMode: .preferred
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
@@ -709,6 +713,7 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                     supportsModifyColumn: false,
                     supportsRenameColumn: true,
                     supportsModifyPrimaryKey: false,
+                    supportsTriggers: true,
                     supportsCloudflareTunnel: false
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
@@ -894,6 +899,7 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                 supportsAddIndex: driverType.supportsAddIndex,
                 supportsDropIndex: driverType.supportsDropIndex,
                 supportsModifyPrimaryKey: driverType.supportsModifyPrimaryKey,
+                supportsTriggers: driverType.supportsTriggers,
                 defaultSSLMode: existingSnapshot?.capabilities.defaultSSLMode ?? .disabled,
                 supportsOpportunisticTLS: existingSnapshot?.capabilities.supportsOpportunisticTLS ?? true,
                 supportsCloudflareTunnel: driverType.supportsSSH,

--- a/TablePro/Core/SchemaTracking/StructureChangeManager.swift
+++ b/TablePro/Core/SchemaTracking/StructureChangeManager.swift
@@ -402,7 +402,7 @@ final class StructureChangeManager: ChangeManaging {
         case .foreignKeys:
             guard row < workingForeignKeys.count else { return }
             key = .foreignKey(workingForeignKeys[row].id)
-        case .ddl, .parts:
+        case .ddl, .parts, .triggers:
             return
         }
         guard pendingChanges[key]?.isDelete == true else { return }
@@ -789,7 +789,7 @@ final class StructureChangeManager: ChangeManaging {
             let isDeleted = change?.isDelete ?? false
             let isInserted = !currentForeignKeys.contains(where: { $0.id == fk.id })
             return (isDeleted, isInserted)
-        case .ddl, .parts:
+        case .ddl, .parts, .triggers:
             return (false, false)
         }
     }

--- a/TablePro/Models/Connection/DatabaseConnection.swift
+++ b/TablePro/Models/Connection/DatabaseConnection.swift
@@ -196,6 +196,10 @@ extension DatabaseType {
         PluginMetadataRegistry.shared.snapshot(forTypeId: pluginTypeId)?.supportsForeignKeys ?? true
     }
 
+    var supportsTriggers: Bool {
+        PluginMetadataRegistry.shared.snapshot(forTypeId: pluginTypeId)?.capabilities.supportsTriggers ?? false
+    }
+
     var supportsSchemaEditing: Bool {
         PluginMetadataRegistry.shared.snapshot(forTypeId: rawValue)?.supportsSchemaEditing ?? true
     }

--- a/TablePro/Models/Query/QueryResult.swift
+++ b/TablePro/Models/Query/QueryResult.swift
@@ -218,7 +218,7 @@ struct ForeignKeyInfo: Identifiable, Hashable {
 }
 
 struct TriggerInfo: Identifiable, Hashable {
-    let id = UUID()
+    var id: String { name }
     let name: String
     let timing: String
     let event: String

--- a/TablePro/Models/Query/QueryResult.swift
+++ b/TablePro/Models/Query/QueryResult.swift
@@ -222,23 +222,17 @@ struct TriggerInfo: Identifiable, Hashable {
     let name: String
     let timing: String
     let event: String
-    let forEachRow: Bool
-    let whenClause: String?
     let statement: String
 
     init(
         name: String,
         timing: String,
         event: String,
-        forEachRow: Bool = true,
-        whenClause: String? = nil,
         statement: String
     ) {
         self.name = name
         self.timing = timing
         self.event = event
-        self.forEachRow = forEachRow
-        self.whenClause = whenClause
         self.statement = statement
     }
 }

--- a/TablePro/Models/Query/QueryResult.swift
+++ b/TablePro/Models/Query/QueryResult.swift
@@ -217,6 +217,32 @@ struct ForeignKeyInfo: Identifiable, Hashable {
     }
 }
 
+struct TriggerInfo: Identifiable, Hashable {
+    let id = UUID()
+    let name: String
+    let timing: String
+    let event: String
+    let forEachRow: Bool
+    let whenClause: String?
+    let statement: String
+
+    init(
+        name: String,
+        timing: String,
+        event: String,
+        forEachRow: Bool = true,
+        whenClause: String? = nil,
+        statement: String
+    ) {
+        self.name = name
+        self.timing = timing
+        self.event = event
+        self.forEachRow = forEachRow
+        self.whenClause = whenClause
+        self.statement = statement
+    }
+}
+
 /// Connection status
 enum ConnectionStatus: Equatable, Sendable {
     case disconnected

--- a/TablePro/Models/Schema/StructureTab.swift
+++ b/TablePro/Models/Schema/StructureTab.swift
@@ -12,6 +12,7 @@ enum StructureTab: String, CaseIterable, Hashable {
     case columns
     case indexes
     case foreignKeys
+    case triggers
     case ddl
     case parts
 
@@ -20,6 +21,7 @@ enum StructureTab: String, CaseIterable, Hashable {
         case .columns: String(localized: "Columns")
         case .indexes: String(localized: "Indexes")
         case .foreignKeys: String(localized: "Foreign Keys")
+        case .triggers: String(localized: "Triggers")
         case .ddl: "DDL"
         case .parts: "Parts"
         }

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -29892,6 +29892,9 @@
         }
       }
     },
+    "Event" : {
+
+    },
     "Every included column needs a name." : {
       "localizations" : {
         "tr" : {
@@ -51088,7 +51091,7 @@
         }
       }
     },
-    "No triggers" : {
+    "No Triggers" : {
 
     },
     "No valid rows found in clipboard data." : {
@@ -78043,6 +78046,9 @@
         }
       }
     },
+    "This table has no triggers. Triggers run automatically when rows are inserted, updated, or deleted." : {
+
+    },
     "This token will not be shown again" : {
       "localizations" : {
         "tr" : {
@@ -78587,6 +78593,9 @@
           }
         }
       }
+    },
+    "Timing" : {
+
     },
     "Tiny" : {
       "extractionState" : "stale",

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -51088,6 +51088,9 @@
         }
       }
     },
+    "No triggers" : {
+
+    },
     "No valid rows found in clipboard data." : {
       "localizations" : {
         "tr" : {
@@ -79838,6 +79841,9 @@
           }
         }
       }
+    },
+    "Triggers" : {
+
     },
     "true" : {
       "localizations" : {

--- a/TablePro/Views/Components/EmptyStateView.swift
+++ b/TablePro/Views/Components/EmptyStateView.swift
@@ -120,6 +120,15 @@ extension EmptyStateView {
         )
     }
 
+    /// Empty state for triggers
+    static func triggers() -> EmptyStateView {
+        EmptyStateView(
+            icon: "bolt",
+            title: String(localized: "No Triggers"),
+            description: String(localized: "This table has no triggers. Triggers run automatically when rows are inserted, updated, or deleted.")
+        )
+    }
+
     /// Empty state for check constraints
     static func checkConstraints(onAdd: @escaping () -> Void) -> EmptyStateView {
         EmptyStateView(

--- a/TablePro/Views/Structure/StructureGridDelegate.swift
+++ b/TablePro/Views/Structure/StructureGridDelegate.swift
@@ -94,7 +94,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
             StructureEditingSupport.updateForeignKey(&fk, at: column, with: newValue ?? "")
             structureChangeManager.updateForeignKey(id: fk.id, with: fk)
 
-        case .ddl, .parts:
+        case .ddl, .parts, .triggers:
             break
         }
 
@@ -148,7 +148,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
                 let fk = structureChangeManager.workingForeignKeys[row]
                 structureChangeManager.deleteForeignKey(id: fk.id)
             }
-        case .parts, .ddl:
+        case .parts, .ddl, .triggers:
             onSelectedRowsChanged?([])
             return
         }
@@ -174,7 +174,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
     }
 
     func dataGridCopyRows(_ indices: Set<Int>) {
-        guard selectedTab != .ddl, selectedTab != .parts, !indices.isEmpty else { return }
+        guard selectedTab != .ddl, selectedTab != .parts, selectedTab != .triggers, !indices.isEmpty else { return }
         let translated = sourceRows(for: indices)
 
         var copiedItems: [Any] = []
@@ -195,7 +195,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
                 guard row < structureChangeManager.workingForeignKeys.count else { continue }
                 copiedItems.append(structureChangeManager.workingForeignKeys[row])
             }
-        case .ddl, .parts:
+        case .ddl, .parts, .triggers:
             break
         }
 
@@ -306,13 +306,13 @@ final class StructureGridDelegate: DataGridViewDelegate {
                 structureChangeManager.addForeignKey(newFK)
             }
 
-        case .ddl, .parts:
+        case .ddl, .parts, .triggers:
             break
         }
     }
 
     func dataGridUndo() {
-        guard selectedTab != .ddl else { return }
+        guard selectedTab != .ddl, selectedTab != .triggers else { return }
         structureChangeManager.undo()
         // Undo can revert any row's content and visual state. The SwiftUI
         // re-render driven by `reloadVersion` only invalidates the snapshot;
@@ -322,7 +322,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
     }
 
     func dataGridRedo() {
-        guard selectedTab != .ddl else { return }
+        guard selectedTab != .ddl, selectedTab != .triggers else { return }
         structureChangeManager.redo()
         reloadAllVisibleRows()
     }
@@ -338,7 +338,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
         case .foreignKeys:
             guard connection.type.supportsForeignKeys else { return }
             structureChangeManager.addNewForeignKey()
-        case .ddl, .parts:
+        case .ddl, .parts, .triggers:
             break
         }
     }
@@ -386,7 +386,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
             let working = structureChangeManager.workingForeignKeys[sourceRow]
             guard let original = structureChangeManager.currentForeignKeys.first(where: { $0.id == working.id }) else { return [] }
             return StructureEditingSupport.foreignKeyModifiedIndices(old: original, new: working)
-        case .ddl, .parts:
+        case .ddl, .parts, .triggers:
             return []
         }
     }
@@ -462,7 +462,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
     }
 
     private func makeEmptySpaceMenu() -> NSMenu? {
-        guard selectedTab != .ddl, selectedTab != .parts else { return nil }
+        guard selectedTab != .ddl, selectedTab != .parts, selectedTab != .triggers else { return nil }
         guard connection.type.supportsSchemaEditing else { return nil }
 
         let menu = NSMenu()
@@ -477,7 +477,8 @@ final class StructureGridDelegate: DataGridViewDelegate {
         case .foreignKeys:
             guard connection.type.supportsForeignKeys else { return nil }
             label = String(localized: "Add Foreign Key")
-        case .ddl, .parts: return nil
+        case .ddl, .parts, .triggers:
+            return nil
         }
 
         let target = StructureMenuTarget { [weak self] in self?.dataGridAddRow() }
@@ -524,7 +525,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
                 if let sql = driver.generateForeignKeyDefinitionSQL(fk: fk.toPlugin()) {
                     definitions.append(sql)
                 }
-            case .ddl, .parts:
+            case .ddl, .parts, .triggers:
                 break
             }
         }
@@ -618,7 +619,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
                     referencedSchema: copy.referencedSchema,
                     onDelete: copy.onDelete, onUpdate: copy.onUpdate
                 ))
-            case .ddl, .parts:
+            case .ddl, .parts, .triggers:
                 break
             }
         }

--- a/TablePro/Views/Structure/StructureRowProvider.swift
+++ b/TablePro/Views/Structure/StructureRowProvider.swift
@@ -61,7 +61,7 @@ final class StructureRowProvider {
                 String(localized: "On Delete"),
                 String(localized: "On Update")
             ]
-        case .ddl, .parts:
+        case .ddl, .parts, .triggers:
             return []
         }
     }
@@ -82,7 +82,7 @@ final class StructureRowProvider {
             return [3]
         case .foreignKeys:
             return []
-        case .ddl, .parts:
+        case .ddl, .parts, .triggers:
             return []
         }
     }
@@ -96,7 +96,7 @@ final class StructureRowProvider {
         case .indexes:
             let types = EditableIndexDefinition.IndexType.allCases.map(\.rawValue)
             return [2: types]
-        case .columns, .ddl, .parts:
+        case .columns, .ddl, .parts, .triggers:
             return [:]
         }
     }
@@ -106,7 +106,7 @@ final class StructureRowProvider {
         case .columns:
             if let i = orderedColumnFields.firstIndex(of: .type) { return [i] }
             return []
-        case .indexes, .foreignKeys, .ddl, .parts:
+        case .indexes, .foreignKeys, .ddl, .parts, .triggers:
             return []
         }
     }
@@ -213,7 +213,7 @@ final class StructureRowProvider {
                     fk.onUpdate.rawValue
                 ])
             }
-        case .ddl, .parts:
+        case .ddl, .parts, .triggers:
             return []
         }
     }

--- a/TablePro/Views/Structure/StructureRowViewWithMenu.swift
+++ b/TablePro/Views/Structure/StructureRowViewWithMenu.swift
@@ -28,7 +28,7 @@ final class StructureRowViewWithMenu: DataGridRowView {
     var onUndoDelete: ((Int) -> Void)?
 
     override func menu(for event: NSEvent) -> NSMenu? {
-        guard structureTab != .ddl, structureTab != .parts else { return nil }
+        guard structureTab != .ddl, structureTab != .parts, structureTab != .triggers else { return nil }
 
         let menu = NSMenu()
 

--- a/TablePro/Views/Structure/TableStructureView+DataLoading.swift
+++ b/TablePro/Views/Structure/TableStructureView+DataLoading.swift
@@ -79,6 +79,10 @@ extension TableStructureView {
                     }
                     return preamble + "\n" + baseDDL
                 }
+            case .triggers:
+                triggers = try await DatabaseManager.shared.withMetadataDriver(connectionId: connection.id) { driver in
+                    try await driver.fetchTriggers(table: tableName)
+                }
             case .parts:
                 return
             }
@@ -176,6 +180,9 @@ extension TableStructureView {
         }
         if selectedTab == .ddl {
             await fetchTabData(.ddl)
+        }
+        if selectedTab == .triggers, connection.type.supportsTriggers {
+            await fetchTabData(.triggers)
         }
     }
 }

--- a/TablePro/Views/Structure/TableStructureView+DataLoading.swift
+++ b/TablePro/Views/Structure/TableStructureView+DataLoading.swift
@@ -80,8 +80,13 @@ extension TableStructureView {
                     return preamble + "\n" + baseDDL
                 }
             case .triggers:
-                triggers = try await DatabaseManager.shared.withMetadataDriver(connectionId: connection.id) { driver in
-                    try await driver.fetchTriggers(table: tableName)
+                do {
+                    triggers = try await DatabaseManager.shared.withMetadataDriver(connectionId: connection.id) { driver in
+                        try await driver.fetchTriggers(table: tableName)
+                    }
+                } catch {
+                    Self.logger.error("Failed to load triggers: \(error.localizedDescription, privacy: .public)")
+                    triggers = []
                 }
             case .parts:
                 return

--- a/TablePro/Views/Structure/TableStructureView+Schema.swift
+++ b/TablePro/Views/Structure/TableStructureView+Schema.swift
@@ -228,6 +228,14 @@ extension TableStructureView {
         )
     }
 
+    func openTriggerInEditor(_ trigger: TriggerInfo) {
+        guard !trigger.statement.isEmpty else { return }
+        coordinator?.tabManager.addTab(
+            initialQuery: trigger.statement,
+            title: trigger.name
+        )
+    }
+
     private func copyDDL() {
         ClipboardService.shared.writeText(ddlStatement)
 

--- a/TablePro/Views/Structure/TableStructureView.swift
+++ b/TablePro/Views/Structure/TableStructureView.swift
@@ -27,6 +27,8 @@ struct TableStructureView: View {
     @State var columns: [ColumnInfo] = []
     @State var indexes: [IndexInfo] = []
     @State var foreignKeys: [ForeignKeyInfo] = []
+    @State var triggers: [TriggerInfo] = []
+    @State private var selectedTriggerName: String?
     @State var ddlStatement: String = ""
     @State var ddlFontSize: CGFloat = 13
     @State var showCopyConfirmation = false
@@ -166,6 +168,9 @@ struct TableStructureView: View {
         if connection.type != .clickhouse {
             tabs = tabs.filter { $0 != .parts }
         }
+        if !connection.type.supportsTriggers {
+            tabs = tabs.filter { $0 != .triggers }
+        }
         return tabs
     }
 
@@ -209,7 +214,7 @@ struct TableStructureView: View {
         case .columns: return connection.type.supportsAddColumn
         case .indexes: return connection.type.supportsAddIndex
         case .foreignKeys: return connection.type.supportsForeignKeys
-        case .ddl, .parts: return false
+        case .ddl, .parts, .triggers: return false
         }
     }
 
@@ -219,7 +224,7 @@ struct TableStructureView: View {
         case .columns: return connection.type.supportsDropColumn
         case .indexes: return connection.type.supportsDropIndex
         case .foreignKeys: return connection.type.supportsForeignKeys
-        case .ddl, .parts: return false
+        case .ddl, .parts, .triggers: return false
         }
     }
 
@@ -231,7 +236,7 @@ struct TableStructureView: View {
             return (String(localized: "Add Index"), String(localized: "Remove Index"))
         case .foreignKeys:
             return (String(localized: "Add Foreign Key"), String(localized: "Remove Foreign Key"))
-        case .ddl, .parts:
+        case .ddl, .parts, .triggers:
             return nil
         }
     }
@@ -247,6 +252,8 @@ struct TableStructureView: View {
             count = loadedTabs.contains(.indexes) ? indexes.count : nil
         case .foreignKeys:
             count = loadedTabs.contains(.foreignKeys) ? foreignKeys.count : nil
+        case .triggers:
+            count = loadedTabs.contains(.triggers) ? triggers.count : nil
         case .ddl, .parts:
             count = nil
         }
@@ -285,6 +292,14 @@ struct TableStructureView: View {
             } else {
                 structureGrid
             }
+        case .triggers:
+            TriggerDetailView(
+                triggers: triggers,
+                selectedName: $selectedTriggerName,
+                fontSize: $ddlFontSize,
+                databaseType: connection.type,
+                isLoading: !loadedTabs.contains(.triggers)
+            )
         case .ddl:
             ddlView
         case .parts:

--- a/TablePro/Views/Structure/TableStructureView.swift
+++ b/TablePro/Views/Structure/TableStructureView.swift
@@ -28,7 +28,7 @@ struct TableStructureView: View {
     @State var indexes: [IndexInfo] = []
     @State var foreignKeys: [ForeignKeyInfo] = []
     @State var triggers: [TriggerInfo] = []
-    @State private var selectedTriggerName: String?
+    @State private var selectedTriggerID: TriggerInfo.ID?
     @State var ddlStatement: String = ""
     @State var ddlFontSize: CGFloat = 13
     @State var showCopyConfirmation = false
@@ -295,10 +295,11 @@ struct TableStructureView: View {
         case .triggers:
             TriggerDetailView(
                 triggers: triggers,
-                selectedName: $selectedTriggerName,
+                selectedTriggerID: $selectedTriggerID,
                 fontSize: $ddlFontSize,
                 databaseType: connection.type,
-                isLoading: !loadedTabs.contains(.triggers)
+                isLoading: !loadedTabs.contains(.triggers),
+                onOpenInEditor: openTriggerInEditor
             )
         case .ddl:
             ddlView

--- a/TablePro/Views/Structure/TriggerDetailView.swift
+++ b/TablePro/Views/Structure/TriggerDetailView.swift
@@ -2,23 +2,24 @@ import SwiftUI
 
 struct TriggerDetailView: View {
     let triggers: [TriggerInfo]
-    @Binding var selectedName: String?
+    @Binding var selectedTriggerID: TriggerInfo.ID?
     @Binding var fontSize: CGFloat
     let databaseType: DatabaseType
     let isLoading: Bool
+    let onOpenInEditor: (TriggerInfo) -> Void
 
     var body: some View {
         if isLoading {
             ProgressView()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if triggers.isEmpty {
-            emptyState
+            EmptyStateView.triggers()
         } else {
-            HSplitView {
-                triggerList
-                    .frame(minWidth: 200, idealWidth: 260)
-                detailPanel
-                    .frame(minWidth: 320)
+            VSplitView {
+                triggerTable
+                    .frame(minHeight: 120, idealHeight: 170)
+                detailPane
+                    .frame(minHeight: 180)
             }
             .onAppear(perform: ensureSelection)
             .onChange(of: triggers) { _, _ in ensureSelection() }
@@ -26,49 +27,40 @@ struct TriggerDetailView: View {
     }
 
     private var selectedTrigger: TriggerInfo? {
-        guard let name = selectedName,
-              let match = triggers.first(where: { $0.name == name }) else {
+        guard let id = selectedTriggerID,
+              let match = triggers.first(where: { $0.id == id }) else {
             return triggers.first
         }
         return match
     }
 
     private func ensureSelection() {
-        guard let name = selectedName,
-              triggers.contains(where: { $0.name == name }) else {
-            selectedName = triggers.first?.name
+        guard let id = selectedTriggerID,
+              triggers.contains(where: { $0.id == id }) else {
+            selectedTriggerID = triggers.first?.id
             return
         }
     }
 
-    private var triggerList: some View {
-        List(triggers, id: \.name, selection: $selectedName) { trigger in
-            VStack(alignment: .leading, spacing: 2) {
-                Text(trigger.name)
-                HStack(spacing: 6) {
-                    if !trigger.timing.isEmpty {
-                        Text(trigger.timing)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    if !trigger.event.isEmpty {
-                        Text(trigger.event)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-            }
-            .padding(.vertical, 2)
+    private var triggerTable: some View {
+        Table(triggers, selection: $selectedTriggerID) {
+            TableColumn(String(localized: "Name"), value: \.name)
+                .width(min: 160, ideal: 240)
+            TableColumn(String(localized: "Timing"), value: \.timing)
+                .width(min: 70, ideal: 90)
+            TableColumn(String(localized: "Event"), value: \.event)
+                .width(min: 90, ideal: 140)
         }
-        .listStyle(.inset)
     }
 
-    private var detailPanel: some View {
-        VStack(spacing: 0) {
+    private var detailPane: some View {
+        Group {
             if let trigger = selectedTrigger {
-                detailToolbar(for: trigger)
-                Divider()
-                DDLTextView(ddl: trigger.statement, fontSize: $fontSize, databaseType: databaseType)
+                VStack(spacing: 0) {
+                    detailToolbar(for: trigger)
+                    Divider()
+                    DDLTextView(ddl: trigger.statement, fontSize: $fontSize, databaseType: databaseType)
+                }
             } else {
                 Color(nsColor: .textBackgroundColor)
             }
@@ -78,7 +70,9 @@ struct TriggerDetailView: View {
     private func detailToolbar(for trigger: TriggerInfo) -> some View {
         HStack(spacing: 12) {
             HStack(spacing: 4) {
-                Button(action: { fontSize = max(10, fontSize - 1) }) {
+                Button {
+                    fontSize = max(10, fontSize - 1)
+                } label: {
                     Image(systemName: "textformat.size.smaller")
                         .frame(width: 24, height: 24)
                 }
@@ -87,7 +81,9 @@ struct TriggerDetailView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .frame(width: 24)
-                Button(action: { fontSize = min(24, fontSize + 1) }) {
+                Button {
+                    fontSize = min(24, fontSize + 1)
+                } label: {
                     Image(systemName: "textformat.size.larger")
                         .frame(width: 24, height: 24)
                 }
@@ -98,6 +94,13 @@ struct TriggerDetailView: View {
             Spacer()
 
             Button {
+                onOpenInEditor(trigger)
+            } label: {
+                Label("Open in Editor", systemImage: "square.and.pencil")
+            }
+            .buttonStyle(.bordered)
+
+            Button {
                 ClipboardService.shared.writeText(trigger.statement)
             } label: {
                 Label("Copy", systemImage: "doc.on.doc")
@@ -106,17 +109,5 @@ struct TriggerDetailView: View {
         }
         .padding()
         .background(Color(nsColor: .controlBackgroundColor))
-    }
-
-    private var emptyState: some View {
-        VStack(spacing: 8) {
-            Image(systemName: "bolt.slash")
-                .font(.largeTitle)
-                .foregroundStyle(.secondary)
-                .accessibilityHidden(true)
-            Text("No triggers")
-                .foregroundStyle(.secondary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/TablePro/Views/Structure/TriggerDetailView.swift
+++ b/TablePro/Views/Structure/TriggerDetailView.swift
@@ -14,6 +14,7 @@ struct TriggerDetailView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if triggers.isEmpty {
             EmptyStateView.triggers()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             VSplitView {
                 triggerTable
@@ -21,6 +22,7 @@ struct TriggerDetailView: View {
                 detailPane
                     .frame(minHeight: 180)
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .onAppear(perform: ensureSelection)
             .onChange(of: triggers) { _, _ in ensureSelection() }
         }

--- a/TablePro/Views/Structure/TriggerDetailView.swift
+++ b/TablePro/Views/Structure/TriggerDetailView.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+
+struct TriggerDetailView: View {
+    let triggers: [TriggerInfo]
+    @Binding var selectedName: String?
+    @Binding var fontSize: CGFloat
+    let databaseType: DatabaseType
+    let isLoading: Bool
+
+    var body: some View {
+        if isLoading {
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if triggers.isEmpty {
+            emptyState
+        } else {
+            HSplitView {
+                triggerList
+                    .frame(minWidth: 200, idealWidth: 260)
+                detailPanel
+                    .frame(minWidth: 320)
+            }
+            .onAppear(perform: ensureSelection)
+            .onChange(of: triggers) { _, _ in ensureSelection() }
+        }
+    }
+
+    private var selectedTrigger: TriggerInfo? {
+        guard let name = selectedName,
+              let match = triggers.first(where: { $0.name == name }) else {
+            return triggers.first
+        }
+        return match
+    }
+
+    private func ensureSelection() {
+        guard let name = selectedName,
+              triggers.contains(where: { $0.name == name }) else {
+            selectedName = triggers.first?.name
+            return
+        }
+    }
+
+    private var triggerList: some View {
+        List(triggers, id: \.name, selection: $selectedName) { trigger in
+            VStack(alignment: .leading, spacing: 2) {
+                Text(trigger.name)
+                HStack(spacing: 6) {
+                    if !trigger.timing.isEmpty {
+                        Text(trigger.timing)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    if !trigger.event.isEmpty {
+                        Text(trigger.event)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .padding(.vertical, 2)
+        }
+        .listStyle(.inset)
+    }
+
+    private var detailPanel: some View {
+        VStack(spacing: 0) {
+            if let trigger = selectedTrigger {
+                detailToolbar(for: trigger)
+                Divider()
+                DDLTextView(ddl: trigger.statement, fontSize: $fontSize, databaseType: databaseType)
+            } else {
+                Color(nsColor: .textBackgroundColor)
+            }
+        }
+    }
+
+    private func detailToolbar(for trigger: TriggerInfo) -> some View {
+        HStack(spacing: 12) {
+            HStack(spacing: 4) {
+                Button(action: { fontSize = max(10, fontSize - 1) }) {
+                    Image(systemName: "textformat.size.smaller")
+                        .frame(width: 24, height: 24)
+                }
+                .accessibilityLabel(String(localized: "Decrease font size"))
+                Text("\(Int(fontSize))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 24)
+                Button(action: { fontSize = min(24, fontSize + 1) }) {
+                    Image(systemName: "textformat.size.larger")
+                        .frame(width: 24, height: 24)
+                }
+                .accessibilityLabel(String(localized: "Increase font size"))
+            }
+            .buttonStyle(.borderless)
+
+            Spacer()
+
+            Button {
+                ClipboardService.shared.writeText(trigger.statement)
+            } label: {
+                Label("Copy", systemImage: "doc.on.doc")
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding()
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "bolt.slash")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            Text("No triggers")
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/TableProTests/Core/Database/TriggerInfoMappingTests.swift
+++ b/TableProTests/Core/Database/TriggerInfoMappingTests.swift
@@ -44,13 +44,12 @@ private final class StubTriggerDriver: PluginDatabaseDriver {
 
 @Suite("Trigger info mapping")
 struct TriggerInfoMappingTests {
-    @Test("PluginTriggerInfo encodes and decodes without a when clause")
-    func codableRoundTripNoWhen() throws {
+    @Test("PluginTriggerInfo encodes and decodes")
+    func codableRoundTrip() throws {
         let original = PluginTriggerInfo(
             name: "trg_audit",
             timing: "AFTER",
             event: "INSERT",
-            forEachRow: true,
             statement: "CREATE TRIGGER trg_audit AFTER INSERT ON t FOR EACH ROW BEGIN END"
         )
         let data = try JSONEncoder().encode(original)
@@ -58,25 +57,7 @@ struct TriggerInfoMappingTests {
         #expect(decoded.name == original.name)
         #expect(decoded.timing == original.timing)
         #expect(decoded.event == original.event)
-        #expect(decoded.forEachRow == original.forEachRow)
-        #expect(decoded.whenClause == nil)
         #expect(decoded.statement == original.statement)
-    }
-
-    @Test("PluginTriggerInfo preserves a when clause through Codable")
-    func codableRoundTripWithWhen() throws {
-        let original = PluginTriggerInfo(
-            name: "trg_check",
-            timing: "BEFORE",
-            event: "UPDATE",
-            forEachRow: false,
-            whenClause: "new.amount > 0",
-            statement: "CREATE TRIGGER trg_check BEFORE UPDATE ON t WHEN new.amount > 0 ..."
-        )
-        let data = try JSONEncoder().encode(original)
-        let decoded = try JSONDecoder().decode(PluginTriggerInfo.self, from: data)
-        #expect(decoded.whenClause == "new.amount > 0")
-        #expect(decoded.forEachRow == false)
     }
 
     @Test("Adapter maps plugin triggers to app TriggerInfo preserving fields")
@@ -87,8 +68,6 @@ struct TriggerInfoMappingTests {
                 name: "trg_audit",
                 timing: "AFTER",
                 event: "INSERT OR UPDATE",
-                forEachRow: true,
-                whenClause: "new.id IS NOT NULL",
                 statement: "CREATE TRIGGER trg_audit ..."
             )
         ]
@@ -101,8 +80,6 @@ struct TriggerInfoMappingTests {
         #expect(trigger.name == "trg_audit")
         #expect(trigger.timing == "AFTER")
         #expect(trigger.event == "INSERT OR UPDATE")
-        #expect(trigger.forEachRow == true)
-        #expect(trigger.whenClause == "new.id IS NOT NULL")
         #expect(trigger.statement == "CREATE TRIGGER trg_audit ...")
     }
 }

--- a/TableProTests/Core/Database/TriggerInfoMappingTests.swift
+++ b/TableProTests/Core/Database/TriggerInfoMappingTests.swift
@@ -1,0 +1,121 @@
+//
+//  TriggerInfoMappingTests.swift
+//  TableProTests
+//
+//  Tests for PluginTriggerInfo encoding and the PluginDriverAdapter trigger bridge.
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+private final class StubTriggerDriver: PluginDatabaseDriver {
+    var supportsSchemas: Bool { false }
+    var supportsTransactions: Bool { false }
+    var currentSchema: String? { nil }
+    var serverVersion: String? { nil }
+
+    var triggersToReturn: [PluginTriggerInfo] = []
+
+    func connect() async throws {}
+    func disconnect() {}
+    func ping() async throws {}
+    func execute(query: String) async throws -> PluginQueryResult {
+        PluginQueryResult(columns: [], columnTypeNames: [], rows: [], rowsAffected: 0, executionTime: 0)
+    }
+
+    func fetchTables(schema: String?) async throws -> [PluginTableInfo] { [] }
+    func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] { [] }
+    func fetchIndexes(table: String, schema: String?) async throws -> [PluginIndexInfo] { [] }
+    func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] { [] }
+    func fetchTriggers(table: String, schema: String?) async throws -> [PluginTriggerInfo] { triggersToReturn }
+    func fetchTableDDL(table: String, schema: String?) async throws -> String { "" }
+    func fetchViewDefinition(view: String, schema: String?) async throws -> String { "" }
+    func fetchTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata {
+        PluginTableMetadata(tableName: table)
+    }
+
+    func fetchDatabases() async throws -> [String] { [] }
+    func fetchDatabaseMetadata(_ database: String) async throws -> PluginDatabaseMetadata {
+        PluginDatabaseMetadata(name: database)
+    }
+}
+
+@Suite("Trigger info mapping")
+struct TriggerInfoMappingTests {
+    @Test("PluginTriggerInfo encodes and decodes without a when clause")
+    func codableRoundTripNoWhen() throws {
+        let original = PluginTriggerInfo(
+            name: "trg_audit",
+            timing: "AFTER",
+            event: "INSERT",
+            forEachRow: true,
+            statement: "CREATE TRIGGER trg_audit AFTER INSERT ON t FOR EACH ROW BEGIN END"
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(PluginTriggerInfo.self, from: data)
+        #expect(decoded.name == original.name)
+        #expect(decoded.timing == original.timing)
+        #expect(decoded.event == original.event)
+        #expect(decoded.forEachRow == original.forEachRow)
+        #expect(decoded.whenClause == nil)
+        #expect(decoded.statement == original.statement)
+    }
+
+    @Test("PluginTriggerInfo preserves a when clause through Codable")
+    func codableRoundTripWithWhen() throws {
+        let original = PluginTriggerInfo(
+            name: "trg_check",
+            timing: "BEFORE",
+            event: "UPDATE",
+            forEachRow: false,
+            whenClause: "new.amount > 0",
+            statement: "CREATE TRIGGER trg_check BEFORE UPDATE ON t WHEN new.amount > 0 ..."
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(PluginTriggerInfo.self, from: data)
+        #expect(decoded.whenClause == "new.amount > 0")
+        #expect(decoded.forEachRow == false)
+    }
+
+    @Test("Adapter maps plugin triggers to app TriggerInfo preserving fields")
+    func adapterMapsTriggers() async throws {
+        let driver = StubTriggerDriver()
+        driver.triggersToReturn = [
+            PluginTriggerInfo(
+                name: "trg_audit",
+                timing: "AFTER",
+                event: "INSERT OR UPDATE",
+                forEachRow: true,
+                whenClause: "new.id IS NOT NULL",
+                statement: "CREATE TRIGGER trg_audit ..."
+            )
+        ]
+        let connection = DatabaseConnection(name: "Test", type: .postgresql)
+        let adapter = PluginDriverAdapter(connection: connection, pluginDriver: driver)
+
+        let triggers = try await adapter.fetchTriggers(table: "t")
+        #expect(triggers.count == 1)
+        let trigger = try #require(triggers.first)
+        #expect(trigger.name == "trg_audit")
+        #expect(trigger.timing == "AFTER")
+        #expect(trigger.event == "INSERT OR UPDATE")
+        #expect(trigger.forEachRow == true)
+        #expect(trigger.whenClause == "new.id IS NOT NULL")
+        #expect(trigger.statement == "CREATE TRIGGER trg_audit ...")
+    }
+}
+
+@Suite("StructureTab triggers")
+struct StructureTabTriggersTests {
+    @Test("Triggers tab is part of the canonical tab set")
+    func triggersInAllCases() {
+        #expect(StructureTab.allCases.contains(.triggers))
+    }
+
+    @Test("Triggers tab has a localized display name")
+    func triggersDisplayName() {
+        #expect(StructureTab.triggers.displayName == "Triggers")
+    }
+}

--- a/TableProTests/Plugins/TriggerSQLParserTests.swift
+++ b/TableProTests/Plugins/TriggerSQLParserTests.swift
@@ -1,0 +1,68 @@
+//
+//  TriggerSQLParserTests.swift
+//  TableProTests
+//
+//  Tests for TriggerSQLParser timing/event extraction from CREATE TRIGGER text.
+//
+
+import TableProPluginKit
+import Testing
+
+@Suite("TriggerSQLParser")
+struct TriggerSQLParserTests {
+    @Test("Parses BEFORE INSERT")
+    func beforeInsert() {
+        let result = TriggerSQLParser.timingAndEvent(from: "CREATE TRIGGER t1 BEFORE INSERT ON users BEGIN END")
+        #expect(result.timing == "BEFORE")
+        #expect(result.event == "INSERT")
+    }
+
+    @Test("Parses AFTER UPDATE")
+    func afterUpdate() {
+        let result = TriggerSQLParser.timingAndEvent(from: "CREATE TRIGGER t1 AFTER UPDATE ON users BEGIN END")
+        #expect(result.timing == "AFTER")
+        #expect(result.event == "UPDATE")
+    }
+
+    @Test("Parses INSTEAD OF DELETE")
+    func insteadOfDelete() {
+        let result = TriggerSQLParser.timingAndEvent(from: "CREATE TRIGGER t1 INSTEAD OF DELETE ON v BEGIN END")
+        #expect(result.timing == "INSTEAD OF")
+        #expect(result.event == "DELETE")
+    }
+
+    @Test("Handles lowercase SQL")
+    func lowercase() {
+        let result = TriggerSQLParser.timingAndEvent(from: "create trigger t1 after delete on users begin end")
+        #expect(result.timing == "AFTER")
+        #expect(result.event == "DELETE")
+    }
+
+    @Test("Handles UPDATE OF columns")
+    func updateOfColumns() {
+        let result = TriggerSQLParser.timingAndEvent(from: "CREATE TRIGGER t1 BEFORE UPDATE OF name, email ON users BEGIN END")
+        #expect(result.timing == "BEFORE")
+        #expect(result.event == "UPDATE")
+    }
+
+    @Test("Trigger name containing a timing keyword does not mislead timing")
+    func nameWithTimingKeyword() {
+        let result = TriggerSQLParser.timingAndEvent(from: "CREATE TRIGGER before_log AFTER UPDATE ON users BEGIN END")
+        #expect(result.timing == "AFTER")
+        #expect(result.event == "UPDATE")
+    }
+
+    @Test("Trigger name containing an event keyword does not mislead event")
+    func nameWithEventKeyword() {
+        let result = TriggerSQLParser.timingAndEvent(from: "CREATE TRIGGER insert_audit AFTER DELETE ON users BEGIN END")
+        #expect(result.timing == "AFTER")
+        #expect(result.event == "DELETE")
+    }
+
+    @Test("Returns empty values when no timing or event present")
+    func malformed() {
+        let result = TriggerSQLParser.timingAndEvent(from: "SOME OTHER STATEMENT")
+        #expect(result.timing.isEmpty)
+        #expect(result.event.isEmpty)
+    }
+}

--- a/TableProTests/Views/Structure/StructureGridDelegateAddRowTests.swift
+++ b/TableProTests/Views/Structure/StructureGridDelegateAddRowTests.swift
@@ -78,6 +78,30 @@ struct StructureGridDelegateAddRowTests {
         #expect(manager.workingForeignKeys.count == fksBefore)
     }
 
+    @Test("Triggers sub-tab: dataGridAddRow is a no-op")
+    func triggersTab_isNoOp() {
+        let (delegate, manager) = makeDelegate(selectedTab: .triggers)
+        let columnsBefore = manager.workingColumns.count
+        let indexesBefore = manager.workingIndexes.count
+        let fksBefore = manager.workingForeignKeys.count
+        delegate.dataGridAddRow()
+        #expect(manager.workingColumns.count == columnsBefore)
+        #expect(manager.workingIndexes.count == indexesBefore)
+        #expect(manager.workingForeignKeys.count == fksBefore)
+    }
+
+    @Test("Delete: triggers sub-tab is a no-op")
+    func triggersTab_deleteIsNoOp() {
+        let (delegate, manager) = makeDelegate(selectedTab: .triggers)
+        let columnsBefore = manager.workingColumns.count
+        let indexesBefore = manager.workingIndexes.count
+        let fksBefore = manager.workingForeignKeys.count
+        delegate.dataGridDeleteRows([0])
+        #expect(manager.workingColumns.count == columnsBefore)
+        #expect(manager.workingIndexes.count == indexesBefore)
+        #expect(manager.workingForeignKeys.count == fksBefore)
+    }
+
     @Test("Indexes sub-tab on SQLite: dataGridAddRow is a no-op (supportsAddIndex == false)")
     func sqliteIndexes_isNoOp() {
         let (delegate, manager) = makeDelegate(selectedTab: .indexes, type: .sqlite)

--- a/docs/features/table-structure.mdx
+++ b/docs/features/table-structure.mdx
@@ -1,11 +1,11 @@
 ---
 title: Table Structure
-description: Browse column definitions, indexes, foreign keys, and DDL with a visual structure editor
+description: Browse column definitions, indexes, foreign keys, triggers, and DDL with a visual structure editor
 ---
 
 # Table Structure
 
-Browse columns, indexes, foreign keys, and DDL for any table. Edit structure visually or with SQL.
+Browse columns, indexes, foreign keys, triggers, and DDL for any table. Edit structure visually or with SQL.
 
 {/* Screenshot: Table structure view showing columns tab */}
 <Frame caption="Table structure view">
@@ -156,6 +156,22 @@ The DDL view uses tree-sitter syntax highlighting with line numbers. Use the too
 - **Copy** the DDL to clipboard
 - **Export** as a `.sql` file
 - **Open in Editor** to send the DDL to a new query tab for editing
+
+## Triggers Tab
+
+The Triggers tab lists the table's triggers and shows the full definition of the selected one. It is read-only.
+
+| Property | Description |
+|----------|-------------|
+| **Name** | Trigger name |
+| **Timing** | BEFORE, AFTER, or INSTEAD OF |
+| **Event** | INSERT, UPDATE, DELETE (PostgreSQL can combine events, such as INSERT OR UPDATE) |
+
+Select a trigger to see its full definition in a syntax-highlighted viewer with a **Copy** button. The definition is the `CREATE TRIGGER` statement (MySQL and MariaDB reconstruct it from the trigger body; PostgreSQL uses `pg_get_triggerdef`; SQLite reads the stored statement).
+
+<Note>
+Available for MySQL, MariaDB, PostgreSQL, and SQLite. The tab is hidden for databases that do not expose triggers.
+</Note>
 
 ## Creating a New Table
 


### PR DESCRIPTION
Closes #1695

## What

Adds a read-only **Triggers** tab to the table Show Structure view, alongside Columns / Indexes / Foreign Keys / DDL. It lists each trigger (name, timing, event) and shows the full definition SQL in the existing read-only syntax-highlighted viewer with a Copy button.

Available for MySQL, MariaDB, PostgreSQL, and SQLite. The tab is hidden for databases that don't expose triggers.

## Why this shape

The trigger body SQL is the point of the feature, so it renders in a master-detail layout (selectable list + full definition pane) rather than as a clipped grid cell. This reuses the read-only `DDLTextView`, following the precedent the `.ddl` and `.parts` tabs already set: read-only tabs bypass the editable `DataGridView` path.

Read-only for v1, matching Beekeeper Studio's model and avoiding the edit/localization bugs the editable tools (TablePlus, Sequel Ace) have hit.

## How it's wired

- **PluginKit (additive, no ABI bump):** new `PluginTriggerInfo`; `fetchTriggers` on `PluginDatabaseDriver` with a default `{ [] }`; `supportsTriggers` on `DriverPlugin` defaulting `false`.
- **App layer:** `TriggerInfo` model; `fetchTriggers` on `DatabaseDriver` (default `[]`) + `PluginDriverAdapter` bridge; `supportsTriggers` capability via `PluginMetadataRegistry` + `DatabaseType`.
- **Bundled drivers:** MySQL (`information_schema.TRIGGERS`), PostgreSQL (`pg_trigger` + `pg_get_triggerdef`, handles multi-event triggers and skips internal ones), SQLite (`sqlite_master` with token-based timing/event parse).
- **UI:** `StructureTab.triggers`, new `TriggerDetailView`, lazy fetch, `availableTabs` filter, count badge, and `.triggers` no-op cases across the grid delegate / row provider / change manager.

Registry-only plugins inherit the empty default, so no plugin rebuild is needed. Plugins like Oracle/MSSQL can add trigger support later per-plugin without an ABI bump.

## Tests

- `PluginTriggerInfo` Codable round-trips (with and without a WHEN clause)
- `PluginDriverAdapter.fetchTriggers` mapping through a stub driver
- `StructureTab.triggers` presence and display name
- `StructureGridDelegate` add/delete are no-ops on the triggers tab

## Docs

- New Triggers section in `docs/features/table-structure.mdx`
- CHANGELOG `[Unreleased] / Added` entry

## Verification

SwiftLint `--strict` clean on all changed lines. Build extracted the new string-catalog keys (`Triggers`, `No triggers`).
