### PR TITLE
feat(datagrid): add Add button to status bar to insert a new row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Traditional Chinese (繁體中文) language in Settings > General with full UI translation
+- An Add button in the table status bar inserts a new row at the end of the grid and starts editing it.
 
 ## [0.51.1] - 2026-06-16
 

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -714,7 +714,8 @@ struct MainEditorContentView: View {
                 onRemove: { coordinator.structureActions?.removeRow?() }
             ),
             onToggleFilters: { coordinator.toggleFilterPanel() },
-            onFetchAll: { coordinator.fetchAllRows() }
+            onFetchAll: { coordinator.fetchAllRows() },
+            onAddRow: currentTabAllowsAddRow ? { onAddRow() } : nil
         )
     }
 

--- a/TablePro/Views/Main/Child/MainStatusBarView.swift
+++ b/TablePro/Views/Main/Child/MainStatusBarView.swift
@@ -41,6 +41,7 @@ struct MainStatusBarView: View {
     let structureState: StatusBarStructureState
     let onToggleFilters: () -> Void
     let onFetchAll: (() -> Void)?
+    let onAddRow: (() -> Void)?
 
     @State private var showColumnPopover = false
 
@@ -50,6 +51,15 @@ struct MainStatusBarView: View {
     private var filterToggleHelp: String {
         let label = String(localized: "Toggle Filters")
         guard let combo = AppSettingsManager.shared.keyboard.shortcut(for: .toggleFilters),
+              !combo.isCleared else {
+            return label
+        }
+        return "\(label) (\(combo.displayString))"
+    }
+
+    private var addRowHelp: String {
+        let label = String(localized: "Add Row")
+        guard let combo = AppSettingsManager.shared.keyboard.shortcut(for: .addRow),
               !combo.isCleared else {
             return label
         }
@@ -141,6 +151,20 @@ struct MainStatusBarView: View {
                 }
 
                 if showsDataChrome {
+                    if let onAddRow {
+                        Button {
+                            onAddRow()
+                        } label: {
+                            HStack(spacing: 4) {
+                                Image(systemName: "plus")
+                                Text("Add")
+                            }
+                        }
+                        .controlSize(.small)
+                        .help(addRowHelp)
+                        .accessibilityLabel(String(localized: "Add Row"))
+                    }
+
                     if snapshot.hasColumns {
                         Button {
                             showColumnPopover.toggle()

--- a/TablePro/Views/Main/Child/MainStatusBarView.swift
+++ b/TablePro/Views/Main/Child/MainStatusBarView.swift
@@ -48,18 +48,20 @@ struct MainStatusBarView: View {
     private var isStructureMode: Bool { viewMode == .structure }
     private var showsDataChrome: Bool { !isStructureMode }
 
+    static func showsAddRow(viewMode: ResultsViewMode, canAddRow: Bool) -> Bool {
+        viewMode == .data && canAddRow
+    }
+
     private var filterToggleHelp: String {
-        let label = String(localized: "Toggle Filters")
-        guard let combo = AppSettingsManager.shared.keyboard.shortcut(for: .toggleFilters),
-              !combo.isCleared else {
-            return label
-        }
-        return "\(label) (\(combo.displayString))"
+        helpText(String(localized: "Toggle Filters"), shortcut: .toggleFilters)
     }
 
     private var addRowHelp: String {
-        let label = String(localized: "Add Row")
-        guard let combo = AppSettingsManager.shared.keyboard.shortcut(for: .addRow),
+        helpText(String(localized: "Add Row"), shortcut: .addRow)
+    }
+
+    private func helpText(_ label: String, shortcut action: ShortcutAction) -> String {
+        guard let combo = AppSettingsManager.shared.keyboard.shortcut(for: action),
               !combo.isCleared else {
             return label
         }
@@ -151,7 +153,7 @@ struct MainStatusBarView: View {
                 }
 
                 if showsDataChrome {
-                    if let onAddRow {
+                    if Self.showsAddRow(viewMode: viewMode, canAddRow: onAddRow != nil), let onAddRow {
                         Button {
                             onAddRow()
                         } label: {

--- a/TableProTests/Views/Main/MainStatusBarLayoutTests.swift
+++ b/TableProTests/Views/Main/MainStatusBarLayoutTests.swift
@@ -42,8 +42,23 @@ struct MainStatusBarLayoutTests {
                 onRemove: {}
             ),
             onToggleFilters: {},
-            onFetchAll: nil
+            onFetchAll: nil,
+            onAddRow: nil
         )
         #expect(type(of: view.body) != Never.self)
+    }
+
+    @Test("Add Row button shows only in Data mode when adding is allowed")
+    func addRowVisibilityByMode() {
+        #expect(MainStatusBarView.showsAddRow(viewMode: .data, canAddRow: true))
+        #expect(!MainStatusBarView.showsAddRow(viewMode: .structure, canAddRow: true))
+        #expect(!MainStatusBarView.showsAddRow(viewMode: .json, canAddRow: true))
+    }
+
+    @Test("Add Row button is hidden when adding is not allowed")
+    func addRowHiddenWhenNotAllowed() {
+        #expect(!MainStatusBarView.showsAddRow(viewMode: .data, canAddRow: false))
+        #expect(!MainStatusBarView.showsAddRow(viewMode: .structure, canAddRow: false))
+        #expect(!MainStatusBarView.showsAddRow(viewMode: .json, canAddRow: false))
     }
 }


### PR DESCRIPTION
## Summary

Adds an **Add** button to the table status bar, to the left of the **Columns** button. Clicking it appends a new empty row at the end of the grid and starts inline editing the first cell. Matches the Navicat-style insert-in-place interaction.

## Why

Today you can only add a row via the Edit menu (Cmd+Shift+N), double-clicking the grid's empty area, or the empty-space right-click menu. None of those are discoverable from the status bar, which is where users look for grid actions. A dedicated button makes the most common data-entry action obvious.

## What changed

- `MainStatusBarView`: a `plus` + "Add" button, shown only in Data view mode when the current table is editable (not a view, not read-only, not write-blocked by safe mode, has a table name). Hover shows `Add Row (Cmd+Shift+N)`.
- `MainEditorContentView`: wires the button to the existing `onAddRow` closure via `currentTabAllowsAddRow`.
- `CHANGELOG.md`: one line under `[Unreleased]` > `Added`.

## How it works

The button calls `coordinator.addNewRow()`, which is the same path as the menu item and the existing shortcuts. No new core logic:

- `RowOperationsManager.addNewRow` builds the row (DEFAULT sentinel for columns with defaults, NULL otherwise), appends it, and records the change.
- `beginEditing(displayRow:column:0)` moves focus into the first cell.
- On save, type mismatches (e.g. text in an integer column) are reported by the database via the existing inline error banner and alert sheet, and the transaction rolls back. This reuses the existing feedback path, consistent with delete/duplicate.

The change is purely SwiftUI wiring. The underlying add-row logic is unchanged and already covered by `RowOperationsManagerTests` and the change-tracking tests.

## Verification

- `xcodebuild ... build -skipPackagePluginValidation` with `CODE_SIGNING_ALLOWED=NO` passes (`** BUILD SUCCEEDED **`).
- Manually verified against a SQLite table: the Add button appears in Data view left of Columns; clicking it appends a row at the end and enters edit on the first cell; filling invalid data in a typed column and saving shows the database error and rolls back. The button is absent in Structure/JSON mode and for read-only tables.