### PR TITLE
fix: keep sidebar filter when opening a table from the filtered list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The sidebar filter no longer clears when you open a table from the filtered list. It only clears when you empty the field. (#1690)
 - DuckDB VARIANT columns now show their value as text instead of an empty cell.
 
 ## [0.51.1] - 2026-06-16

--- a/TablePro/Core/Services/Infrastructure/SidebarContainerViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/SidebarContainerViewController.swift
@@ -131,7 +131,12 @@ extension SidebarContainerViewController: NSSearchFieldDelegate {
     }
 
     func searchFieldDidEndSearching(_ sender: NSSearchField) {
+        guard Self.shouldClearOnEndSearching(fieldValue: sender.stringValue) else { return }
         writeSearchText("")
+    }
+
+    nonisolated static func shouldClearOnEndSearching(fieldValue: String) -> Bool {
+        fieldValue.isEmpty
     }
 
     func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {

--- a/TableProTests/Views/SidebarSearchPersistenceTests.swift
+++ b/TableProTests/Views/SidebarSearchPersistenceTests.swift
@@ -1,0 +1,27 @@
+//
+//  SidebarSearchPersistenceTests.swift
+//  TableProTests
+//
+//  Regression guard for #1690 where opening a table from a filtered sidebar
+//  cleared the active filter. searchFieldDidEndSearching fired on focus loss
+//  and wrote "" back over the persisted filter text. The filter must only be
+//  cleared when the field is actually empty (cancel button / explicit clear).
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("Sidebar search persistence on end editing")
+struct SidebarSearchPersistenceTests {
+    @Test("keeps the filter when the field still has text and focus is lost")
+    func keepsFilterWhenFieldHasText() {
+        #expect(!SidebarContainerViewController.shouldClearOnEndSearching(fieldValue: "dp_"))
+    }
+
+    @Test("clears the filter when the field is empty")
+    func clearsFilterWhenFieldEmpty() {
+        #expect(SidebarContainerViewController.shouldClearOnEndSearching(fieldValue: ""))
+    }
+}


### PR DESCRIPTION
## Summary

In the tables sidebar, typing a filter and then double-clicking a table to open it cleared the active filter text. The table opened but the filter was wiped.

Root cause is in `SidebarContainerViewController`. The `NSSearchFieldDelegate.searchFieldDidEndSearching(_:)` callback unconditionally wrote `""` back to the persisted search text. When a table is opened, focus leaves the search field, AppKit fires `searchFieldDidEndSearching`, and the filter was cleared even though the field still held text.

The fix guards that callback so it only clears the persisted text when the field's `stringValue` is actually empty (the cancel/clear path leaves an empty value). The live-typing path (`controlTextDidChange`) is untouched, so typing and clearing via the cancel button still work, and tab scoping between the tables and favorites filters is preserved.

## Why this matters

The maintainer confirmed in #1690 that the filter pane is scoped per table tab and is expected to persist. Prefix filtering (for example `dp_`) should survive opening a table; clearing it on every open made the feature unusable for its main purpose.

## Testing

- `swiftlint lint --strict` passes on the touched files.
- Added `TableProTests/Views/SidebarSearchPersistenceTests.swift` covering the decision: keep the filter when the field still has text, clear it when the field is empty.
- The clear decision is extracted into a pure `nonisolated` helper (`shouldClearOnEndSearching`) so it is unit-testable without standing up AppKit.

Fixes #1690
