### PR TITLE
fix(tabs): keep a restored table tab on its own database and load it after reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The row detail panel no longer stays blank when a table is opened in a second tab. The panel now shows the selected row right away instead of only after the inspector is toggled.
 - The sidebar filter now stays put when you open another tab. Before, opening a second table tab cleared the filter text and reset the table list to show everything.
 - Fixed a crash when browsing the database tree on servers with many schemas, such as PostgreSQL. The sidebar tree is now a native outline view that loads each database and schema on demand.
+- Reopening the app no longer shows a "Not connected to database" error when it restores a table tab on a connection that is still reconnecting, such as one over SSH. The tab waits for the connection and loads on its own.
 
 ## [0.51.1] - 2026-06-16
 

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
@@ -524,8 +524,11 @@ extension QueryExecutionCoordinator {
     }
 
     func restoreSchemaAndRunQuery(_ schema: String) async {
-        guard let driver = DatabaseManager.shared.driver(for: parent.connectionId),
-              let schemaDriver = driver as? SchemaSwitchable,
+        guard let driver = DatabaseManager.shared.driver(for: parent.connectionId) else {
+            parent.needsLazyLoad = true
+            return
+        }
+        guard let schemaDriver = driver as? SchemaSwitchable,
               schemaDriver.currentSchema != nil else {
             parent.runQuery()
             return

--- a/TablePro/Core/Database/DatabaseManager+Health.swift
+++ b/TablePro/Core/Database/DatabaseManager+Health.swift
@@ -280,6 +280,9 @@ extension DatabaseManager {
                 session.driver = driver
                 session.status = .connected
                 session.effectiveConnection = effectiveConnection
+                if let schemaDriver = driver as? SchemaSwitchable {
+                    session.currentSchema = schemaDriver.currentSchema
+                }
                 if let passwordOverride, !session.connection.usesAWSIAM {
                     session.cachedPassword = passwordOverride
                 }

--- a/TablePro/Core/Database/DatabaseManager+Health.swift
+++ b/TablePro/Core/Database/DatabaseManager+Health.swift
@@ -62,6 +62,9 @@ extension DatabaseManager {
                         session.driver = result.driver
                         session.effectiveConnection = result.effectiveConnection
                         session.status = .connected
+                        if let schemaDriver = result.driver as? SchemaSwitchable {
+                            session.currentSchema = schemaDriver.currentSchema
+                        }
                     }
                     return true
                 } catch {
@@ -155,7 +158,7 @@ extension DatabaseManager {
         await restoreSchemaAndDatabase(
             on: driver,
             savedSchema: session.currentSchema,
-            savedDatabase: session.currentDatabase
+            savedDatabase: databaseSwitchRequiresReconnect(session.connection) ? nil : session.currentDatabase
         )
 
         return ReconnectResult(driver: driver, effectiveConnection: connectionForDriver)
@@ -176,6 +179,11 @@ extension DatabaseManager {
         }
 
         await executeStartupCommands(startupCommands, on: driver, connectionName: connectionName)
+    }
+
+    private func databaseSwitchRequiresReconnect(_ connection: DatabaseConnection) -> Bool {
+        PluginMetadataRegistry.shared.snapshot(forTypeId: connection.type.pluginTypeId)?
+            .capabilities.requiresReconnectForDatabaseSwitch ?? false
     }
 
     func restoreSchemaAndDatabase(
@@ -272,7 +280,7 @@ extension DatabaseManager {
             await restoreSchemaAndDatabase(
                 on: driver,
                 savedSchema: activeSessions[sessionId]?.currentSchema,
-                savedDatabase: activeSessions[sessionId]?.currentDatabase
+                savedDatabase: databaseSwitchRequiresReconnect(session.connection) ? nil : activeSessions[sessionId]?.currentDatabase
             )
 
             // Update session

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -383,19 +383,21 @@ extension MainContentCoordinator {
     }
 
     /// Switch to a different database (called from database switcher)
-    func switchDatabase(to database: String) async {
-        clearFilterState()
+    func switchDatabase(to database: String, clearTabs: Bool = true) async {
+        if clearTabs { clearFilterState() }
         let previousDatabase = toolbarState.currentDatabase
         toolbarState.currentDatabase = database
 
         do {
             try await DatabaseManager.shared.switchDatabase(to: database, for: connectionId)
 
-            closeSiblingNativeWindows()
-            persistence.saveNowSync(tabs: tabManager.tabs, selectedTabId: tabManager.selectedTabId)
-            tabSessionRegistry.removeAll()
-            tabManager.tabs = []
-            tabManager.selectedTabId = nil
+            if clearTabs {
+                closeSiblingNativeWindows()
+                persistence.saveNowSync(tabs: tabManager.tabs, selectedTabId: tabManager.selectedTabId)
+                tabSessionRegistry.removeAll()
+                tabManager.tabs = []
+                tabManager.selectedTabId = nil
+            }
             await SchemaService.shared.invalidate(connectionId: connectionId)
 
             await refreshTables()

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
@@ -96,9 +96,10 @@ extension MainContentCoordinator {
                     )
                     changeManager.reloadVersion += 1
                     Task {
-                        await switchDatabase(to: newTab.tableContext.databaseName)
+                        await switchDatabase(to: newTab.tableContext.databaseName, clearTabs: false)
+                        lazyLoadCurrentTabIfNeeded()
                     }
-                    return  // switchDatabase will re-execute the query
+                    return
                 }
             }
 

--- a/TablePro/Views/Main/Extensions/MainContentView+Helpers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Helpers.swift
@@ -32,7 +32,12 @@ extension MainContentView {
                     !selectedTab.tableContext.databaseName.isEmpty,
                     selectedTab.tableContext.databaseName != session.activeDatabase
                 {
-                    Task { await coordinator.switchDatabase(to: selectedTab.tableContext.databaseName) }
+                    Task {
+                        await coordinator.switchDatabase(
+                            to: selectedTab.tableContext.databaseName, clearTabs: false
+                        )
+                        coordinator.lazyLoadCurrentTabIfNeeded()
+                    }
                 } else if let selectedTab = tabManager.selectedTab,
                     let tabSchema = selectedTab.tableContext.schemaName,
                     !tabSchema.isEmpty,

--- a/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
@@ -188,16 +188,13 @@ extension MainContentView {
             : activeDatabase.flatMap { $0.isEmpty ? nil : $0 }
 
         Task {
-            var contextChanged = false
             if let targetDatabase, targetDatabase != session.activeDatabase {
-                await coordinator.switchDatabase(to: targetDatabase)
-                contextChanged = true
+                await coordinator.switchDatabase(to: targetDatabase, clearTabs: false)
             }
             if let activeSchema, !activeSchema.isEmpty, activeSchema != session.currentSchema {
                 await coordinator.switchSchema(to: activeSchema)
-                contextChanged = true
             }
-            if isTableTab, !contextChanged {
+            if isTableTab {
                 coordinator.lazyLoadCurrentTabIfNeeded()
             }
         }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -963,13 +963,13 @@ final class MainContentCoordinator {
                 )
                 switch decision {
                 case .authorized:
-                    executeQueryInternal(sql)
+                    executeQueryInternal(sql, isAutoLoad: true)
                 case .denied(let reason):
                     tabManager.mutate(at: index) { $0.execution.errorMessage = reason }
                 }
             }
         } else {
-            executeQueryInternal(sql)
+            executeQueryInternal(sql, isAutoLoad: true)
         }
     }
 
@@ -1116,7 +1116,8 @@ final class MainContentCoordinator {
     }
 
     internal func executeQueryInternal(
-        _ sql: String
+        _ sql: String,
+        isAutoLoad: Bool = false
     ) {
         guard let (selectedTab, index) = tabManager.selectedTabAndIndex,
               !selectedTab.execution.isExecuting else { return }
@@ -1168,6 +1169,21 @@ final class MainContentCoordinator {
 
         currentQueryTask = Task { [weak self] in
             guard let self else { return }
+
+            if isAutoLoad {
+                do {
+                    try await services.databaseManager.ensureConnected(conn)
+                } catch {
+                    await MainActor.run { [weak self] in
+                        guard let self else { return }
+                        tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
+                        currentQueryTask = nil
+                        toolbarState.setExecuting(false)
+                        needsLazyLoad = true
+                    }
+                    return
+                }
+            }
 
             let schemaTask: Task<FetchedTableSchema, Error>?
             if needsMetadataFetch, let tableName {
@@ -1262,6 +1278,10 @@ final class MainContentCoordinator {
                     toolbarState.setExecuting(false)
                     if error is CancellationError || Task.isCancelled { return }
                     guard capturedGeneration == queryGeneration else { return }
+                    if isAutoLoad, services.databaseManager.driver(for: connectionId)?.status != .connected {
+                        needsLazyLoad = true
+                        return
+                    }
                     handleQueryExecutionError(error, sql: sql, tabId: tabId, connection: conn)
                 }
             }

--- a/TableProTests/Views/Main/MainContentCoordinatorLazyLoadTests.swift
+++ b/TableProTests/Views/Main/MainContentCoordinatorLazyLoadTests.swift
@@ -165,6 +165,20 @@ struct MainContentCoordinatorLazyLoadTests {
         #expect(coordinator.needsLazyLoad == true)
     }
 
+    @Test("restoreSchemaAndRunQuery defers via needsLazyLoad instead of running a query when the driver is not ready")
+    func restoreSchemaDefersWhenDriverNil() async {
+        let (coordinator, tabManager) = makeCoordinator()
+        let tabId = addTableTab(to: tabManager)
+        coordinator.needsLazyLoad = false
+
+        await coordinator.restoreSchemaAndRunQuery("public")
+
+        #expect(coordinator.needsLazyLoad == true)
+        if let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) {
+            #expect(tabManager.tabs[idx].execution.isExecuting == false)
+        }
+    }
+
     // MARK: - Idempotency
 
     @Test("Idempotent: repeated calls with the same loaded state are no-ops")


### PR DESCRIPTION
## Problem

Reopening the app with a table tab open on a PostgreSQL connection (whose default database differs from the tab's database, e.g. an SSH-tunneled server) showed a "Query Execution Failed / Not connected to database" alert, and the restored tab opened and then closed without loading its data.

## Root cause

Two coupled defects in the restore + reconnect path:

1. When the restored tab's database differed from the connection's active database, the restore selected the tab, which triggered `handleTabChange` to call `switchDatabase`. `switchDatabase` clears all tabs (correct for a deliberate user switch, since old tabs belong to the old database), so it wiped the very tab being restored. The query actually ran and returned rows, but the tab was already gone.
2. During the database-switch reconnect the session briefly held a driver whose connection was not yet up, and the auto-load ran against it. The driver threw a plugin-specific "not connected" error (not the shared `DatabaseError.notConnected`), so it surfaced as the modal. Separately, `reconnectSession` never re-synced `currentSchema` from the driver, leaving a stale mismatch that routed restore through a fragile path.

## Fix

- `switchDatabase(to:clearTabs:)` gains a `clearTabs` flag (default `true`, unchanged for user switches). Selecting a tab and the restore paths now pass `clearTabs: false`, so switching the active database to match a tab keeps that tab and loads it.
- `handleTabChange`, `restoreConnectionContext`, and the deferred `handleConnectionStatusChange` path preserve the tab and call `lazyLoadCurrentTabIfNeeded` after the switch.
- The auto-load now defers and retries (instead of showing a modal) when the driver is not actually `.connected`, keyed on the driver's connection status rather than a specific error type. It loads on its own once the connection is ready.
- `reconnectSession` syncs `currentSchema` from the reconnected driver, matching the initial connect.
- `restoreSchemaAndRunQuery` no longer runs a query when the driver is nil; it defers instead.

User-initiated database switches (toolbar, sidebar "Use as Active Database", quick switcher) keep the tab-clearing behavior.

## Tests

- Added a unit test that `restoreSchemaAndRunQuery` defers via `needsLazyLoad` instead of running a query when the driver is not ready.
- The reconnect schema sync and modal suppression depend on a live driver / alert presentation, so they are verified manually.

## Verification

Verified by hand on an SSH PostgreSQL connection whose default database differs from the open table: quit with the table open, reopen, and the tab stays open and loads its rows with no error alert.