### PR TITLE
refactor(datagrid): merge the row count into the page-size control and regroup the bottom bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The data view bottom bar groups the row count with the pagination controls, and the rows-per-page menu shows plain numbers instead of locale-grouped values like "1.000". Click the row range to change rows per page.
 - Selecting a Redis namespace in the sidebar key tree now filters the open database view to that prefix, with paging, instead of opening a separate tab limited to one batch of keys. (#1701)
 
 ### Fixed

--- a/TablePro/Models/Query/PaginationState+Display.swift
+++ b/TablePro/Models/Query/PaginationState+Display.swift
@@ -1,0 +1,25 @@
+//
+//  PaginationState+Display.swift
+//  TablePro
+//
+
+import Foundation
+
+extension PaginationState {
+    func rangeText(loadedRowCount: Int) -> String? {
+        if let total = totalRowCount, total > 0 {
+            let formattedTotal = total.formatted(.number.grouping(.automatic))
+            let prefix = isApproximateRowCount ? "~" : ""
+            return String(format: String(localized: "%d-%d of %@%@ rows"), rangeStart, rangeEnd, prefix, formattedTotal)
+        }
+        if currentPage > 1 || loadedRowCount >= pageSize {
+            let end = currentOffset + loadedRowCount
+            return String(format: String(localized: "%d-%d of ? rows"), rangeStart, end)
+        }
+        return nil
+    }
+
+    static func pageSizeLabel(_ size: Int) -> String {
+        size.formatted(.number.grouping(.never))
+    }
+}

--- a/TablePro/Views/Components/PaginationControlsView.swift
+++ b/TablePro/Views/Components/PaginationControlsView.swift
@@ -29,6 +29,8 @@ struct PaginationControlsView: View {
         HStack(spacing: 8) {
             rangeMenu
             navigationCluster
+                .fixedSize()
+                .layoutPriority(1)
         }
     }
 
@@ -54,9 +56,10 @@ struct PaginationControlsView: View {
         } label: {
             Text(rangeLabel)
                 .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(minWidth: 60, alignment: .leading)
         }
         .menuStyle(.borderlessButton)
-        .fixedSize()
         .controlSize(.small)
         .help(String(localized: "Rows per page"))
         .accessibilityLabel(rangeLabel)

--- a/TablePro/Views/Components/PaginationControlsView.swift
+++ b/TablePro/Views/Components/PaginationControlsView.swift
@@ -27,18 +27,18 @@ struct PaginationControlsView: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            pageSizeMenu
+            rangeMenu
             navigationCluster
         }
     }
 
-    // MARK: - Page Size Menu
+    // MARK: - Range / Page Size Menu
 
-    private var pageSizeMenu: some View {
+    private var rangeMenu: some View {
         Menu {
             Picker(String(localized: "Rows per page"), selection: pageSizeBinding) {
                 ForEach(Self.pageSizePresets, id: \.self) { size in
-                    Text(size.formatted()).tag(size)
+                    Text(PaginationState.pageSizeLabel(size)).tag(size)
                 }
             }
             .pickerStyle(.inline)
@@ -52,13 +52,15 @@ struct PaginationControlsView: View {
                 showCustomPopover = true
             }
         } label: {
-            Text(pageSizeLabel)
+            Text(rangeLabel)
+                .lineLimit(1)
         }
         .menuStyle(.borderlessButton)
         .fixedSize()
         .controlSize(.small)
         .help(String(localized: "Rows per page"))
-        .accessibilityLabel(String(localized: "Rows per page"))
+        .accessibilityLabel(rangeLabel)
+        .accessibilityHint(String(localized: "Rows per page"))
         .overlay(alignment: .bottom) {
             Color.clear
                 .frame(width: 0, height: 0)
@@ -72,8 +74,8 @@ struct PaginationControlsView: View {
         Binding(get: { pagination.pageSize }, set: { onPageSizeChange($0) })
     }
 
-    private var pageSizeLabel: String {
-        pagination.pageSize.formatted()
+    private var rangeLabel: String {
+        pagination.rangeText(loadedRowCount: loadedRowCount) ?? PaginationState.pageSizeLabel(pagination.pageSize)
     }
 
     // MARK: - Navigation

--- a/TablePro/Views/Main/Child/MainStatusBarView.swift
+++ b/TablePro/Views/Main/Child/MainStatusBarView.swift
@@ -52,184 +52,46 @@ struct MainStatusBarView: View {
         viewMode == .data && canAddRow
     }
 
-    private var filterToggleHelp: String {
-        helpText(String(localized: "Toggle Filters"), shortcut: .toggleFilters)
+    private var showsAddButton: Bool {
+        Self.showsAddRow(viewMode: viewMode, canAddRow: onAddRow != nil)
     }
 
-    private var addRowHelp: String {
-        helpText(String(localized: "Add Row"), shortcut: .addRow)
+    private var showsFiltersToggle: Bool {
+        snapshot.tabType == .table && snapshot.hasTableName
     }
 
-    private func helpText(_ label: String, shortcut action: ShortcutAction) -> String {
-        AppSettingsManager.shared.keyboard.shortcutHint(label, for: action)
+    private var showsActionButtons: Bool {
+        showsDataChrome && (showsAddButton || snapshot.hasColumns || showsFiltersToggle)
     }
 
-    private var columnsAccessibilityLabel: String {
-        guard !columnState.hidden.isEmpty else {
-            return String(localized: "Columns")
-        }
-        let visible = columnState.all.count - columnState.hidden.count
-        return String(format: String(localized: "%d of %d columns visible"), visible, columnState.all.count)
+    private var showsPagination: Bool {
+        snapshot.tabType == .table && snapshot.hasTableName && snapshot.showsPaginationControls
+    }
+
+    private var hasStatusText: Bool {
+        snapshot.pagination.isLoadingMore
+            || statusText != nil
+            || (snapshot.tabType == .query && snapshot.pagination.hasMoreRows)
+            || snapshot.statusMessage != nil
+    }
+
+    private var showsDataNavigation: Bool {
+        showsDataChrome && (hasStatusText || showsPagination)
+    }
+
+    private var showsActionDivider: Bool {
+        showsActionButtons && showsDataNavigation
+    }
+
+    private var statusText: String? {
+        snapshot.statusText(selectedCount: selectedRowIndices.count)
     }
 
     var body: some View {
-        HStack {
-            if snapshot.tabId != nil {
-                if snapshot.tabType == .table, snapshot.hasTableName {
-                    Picker(String(localized: "View Mode"), selection: $viewMode) {
-                        Label("Data", systemImage: "tablecells").tag(ResultsViewMode.data)
-                        Label("Structure", systemImage: "list.bullet.rectangle").tag(ResultsViewMode.structure)
-                        Label("JSON", systemImage: "curlybraces").tag(ResultsViewMode.json)
-                    }
-                    .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .frame(width: 260)
-                    .controlSize(.small)
-                } else if snapshot.hasColumns {
-                    Picker(String(localized: "View Mode"), selection: $viewMode) {
-                        Label("Data", systemImage: "tablecells").tag(ResultsViewMode.data)
-                        Label("JSON", systemImage: "curlybraces").tag(ResultsViewMode.json)
-                    }
-                    .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .frame(width: 140)
-                    .controlSize(.small)
-                }
-            }
-
-            Spacer()
-
-            if showsDataChrome, snapshot.hasRows {
-                HStack(spacing: 4) {
-                    if snapshot.pagination.isLoadingMore {
-                        ProgressView()
-                            .controlSize(.small)
-                            .accessibilityHidden(true)
-                        Text("Loading…")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .accessibilityLabel(String(localized: "Loading more rows"))
-                    } else {
-                        Text(snapshot.rowInfoText(selectedCount: selectedRowIndices.count))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-
-                    if snapshot.tabType == .query && snapshot.pagination.hasMoreRows && !snapshot.pagination.isLoadingMore {
-                        Text("·")
-                            .font(.caption)
-                            .foregroundStyle(.quaternary)
-                        Text("truncated")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        Button {
-                            onFetchAll?()
-                        } label: {
-                            Text("Fetch All")
-                                .font(.caption)
-                        }
-                        .buttonStyle(.link)
-                    }
-
-                    if let statusMessage = snapshot.statusMessage {
-                        Text("·")
-                            .foregroundStyle(.tertiary)
-                        Text(statusMessage)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-            }
-
-            Spacer()
-
-            HStack(spacing: 8) {
-                if isStructureMode, structureState.footer.isActive {
-                    structureFooterControls(state: structureState.footer)
-                }
-
-                if showsDataChrome {
-                    if Self.showsAddRow(viewMode: viewMode, canAddRow: onAddRow != nil), let onAddRow {
-                        Button {
-                            onAddRow()
-                        } label: {
-                            HStack(spacing: 4) {
-                                Image(systemName: "plus")
-                                Text("Add")
-                            }
-                        }
-                        .controlSize(.small)
-                        .help(addRowHelp)
-                        .accessibilityLabel(String(localized: "Add Row"))
-                    }
-
-                    if snapshot.hasColumns {
-                        Button {
-                            showColumnPopover.toggle()
-                        } label: {
-                            HStack(spacing: 4) {
-                                Image(systemName: !columnState.hidden.isEmpty
-                                        ? "eye.slash.circle.fill"
-                                        : "eye.circle")
-                                Text("Columns")
-                                if !columnState.hidden.isEmpty {
-                                    let visible = columnState.all.count - columnState.hidden.count
-                                    Text("(\(visible)/\(columnState.all.count))")
-                                        .foregroundStyle(.secondary)
-                                }
-                            }
-                        }
-                        .controlSize(.small)
-                        .accessibilityLabel(columnsAccessibilityLabel)
-                        .popover(isPresented: $showColumnPopover, arrowEdge: .top) {
-                            ColumnVisibilityPopover(
-                                columns: columnState.all,
-                                hiddenColumns: columnState.hidden,
-                                onToggleColumn: columnState.onToggle,
-                                onShowAll: columnState.onShowAll,
-                                onHideAll: columnState.onHideAll
-                            )
-                        }
-                    }
-
-                    if snapshot.tabType == .table, snapshot.hasTableName {
-                        Toggle(isOn: Binding(
-                            get: { filterState.isVisible },
-                            set: { _ in onToggleFilters() }
-                        )) {
-                            HStack(spacing: 4) {
-                                Image(systemName: filterState.hasAppliedFilters
-                                        ? "line.3.horizontal.decrease.circle.fill"
-                                        : "line.3.horizontal.decrease.circle")
-                                Text("Filters")
-                                if filterState.hasAppliedFilters {
-                                    Text("(\(filterState.appliedFilters.count))")
-                                        .foregroundStyle(.secondary)
-                                }
-                            }
-                        }
-                        .toggleStyle(.button)
-                        .controlSize(.small)
-                        .help(filterToggleHelp)
-                        .accessibilityLabel(String(localized: "Filters"))
-                        .accessibilityAddTraits(filterState.isVisible ? .isSelected : [])
-                    }
-
-                    if snapshot.tabType == .table, snapshot.hasTableName, snapshot.showsPaginationControls {
-                        PaginationControlsView(
-                            pagination: snapshot.pagination,
-                            loadedRowCount: snapshot.rowCount,
-                            onFirst: paginationCallbacks.onFirst,
-                            onPrevious: paginationCallbacks.onPrevious,
-                            onNext: paginationCallbacks.onNext,
-                            onLast: paginationCallbacks.onLast,
-                            onPageSizeChange: paginationCallbacks.onPageSizeChange,
-                            onShowAll: paginationCallbacks.onShowAll,
-                            onGoToPage: paginationCallbacks.onGoToPage
-                        )
-                    }
-                }
-            }
+        HStack(spacing: 8) {
+            viewModePicker
+            Spacer(minLength: 8)
+            trailingControls
         }
         .padding(.leading, 8)
         .padding(.trailing, 20)
@@ -237,6 +99,204 @@ struct MainStatusBarView: View {
         .background(Color(nsColor: .controlBackgroundColor))
         .onChange(of: snapshot.tabId) { _, _ in
             showColumnPopover = false
+        }
+    }
+
+    @ViewBuilder
+    private var viewModePicker: some View {
+        if snapshot.tabId != nil {
+            if snapshot.tabType == .table, snapshot.hasTableName {
+                Picker(String(localized: "View Mode"), selection: $viewMode) {
+                    Label("Data", systemImage: "tablecells").tag(ResultsViewMode.data)
+                    Label("Structure", systemImage: "list.bullet.rectangle").tag(ResultsViewMode.structure)
+                    Label("JSON", systemImage: "curlybraces").tag(ResultsViewMode.json)
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .frame(width: 260)
+                .controlSize(.small)
+            } else if snapshot.hasColumns {
+                Picker(String(localized: "View Mode"), selection: $viewMode) {
+                    Label("Data", systemImage: "tablecells").tag(ResultsViewMode.data)
+                    Label("JSON", systemImage: "curlybraces").tag(ResultsViewMode.json)
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .frame(width: 140)
+                .controlSize(.small)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var trailingControls: some View {
+        HStack(spacing: 8) {
+            if isStructureMode {
+                if structureState.footer.isActive {
+                    structureFooterControls(state: structureState.footer)
+                }
+            } else {
+                actionButtons
+                if showsActionDivider {
+                    Divider().frame(height: 16)
+                }
+                dataNavigationGroup
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var actionButtons: some View {
+        if showsAddButton, let onAddRow {
+            Button {
+                onAddRow()
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "plus")
+                    Text("Add")
+                }
+            }
+            .controlSize(.small)
+            .help(addRowHelp)
+            .accessibilityLabel(String(localized: "Add Row"))
+        }
+
+        if snapshot.hasColumns {
+            columnsButton
+        }
+
+        if showsFiltersToggle {
+            filtersToggle
+        }
+    }
+
+    private var columnsButton: some View {
+        Button {
+            showColumnPopover.toggle()
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: !columnState.hidden.isEmpty ? "eye.slash.circle.fill" : "eye.circle")
+                Text("Columns")
+                if !columnState.hidden.isEmpty {
+                    let visible = columnState.all.count - columnState.hidden.count
+                    Text("(\(visible)/\(columnState.all.count))")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .controlSize(.small)
+        .accessibilityLabel(columnsAccessibilityLabel)
+        .popover(isPresented: $showColumnPopover, arrowEdge: .top) {
+            ColumnVisibilityPopover(
+                columns: columnState.all,
+                hiddenColumns: columnState.hidden,
+                onToggleColumn: columnState.onToggle,
+                onShowAll: columnState.onShowAll,
+                onHideAll: columnState.onHideAll
+            )
+        }
+    }
+
+    private var filtersToggle: some View {
+        Toggle(isOn: Binding(
+            get: { filterState.isVisible },
+            set: { _ in onToggleFilters() }
+        )) {
+            HStack(spacing: 4) {
+                Image(systemName: filterState.hasAppliedFilters
+                        ? "line.3.horizontal.decrease.circle.fill"
+                        : "line.3.horizontal.decrease.circle")
+                Text("Filters")
+                if filterState.hasAppliedFilters {
+                    Text("(\(filterState.appliedFilters.count))")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .toggleStyle(.button)
+        .controlSize(.small)
+        .help(filterToggleHelp)
+        .accessibilityLabel(String(localized: "Filters"))
+        .accessibilityAddTraits(filterState.isVisible ? .isSelected : [])
+    }
+
+    @ViewBuilder
+    private var dataNavigationGroup: some View {
+        if showsDataNavigation {
+            HStack(spacing: 4) {
+                statusCluster
+                if showsPagination {
+                    PaginationControlsView(
+                        pagination: snapshot.pagination,
+                        loadedRowCount: snapshot.rowCount,
+                        onFirst: paginationCallbacks.onFirst,
+                        onPrevious: paginationCallbacks.onPrevious,
+                        onNext: paginationCallbacks.onNext,
+                        onLast: paginationCallbacks.onLast,
+                        onPageSizeChange: paginationCallbacks.onPageSizeChange,
+                        onShowAll: paginationCallbacks.onShowAll,
+                        onGoToPage: paginationCallbacks.onGoToPage
+                    )
+                }
+            }
+        }
+    }
+
+    private var hasPrimaryStatus: Bool {
+        snapshot.pagination.isLoadingMore || statusText != nil
+    }
+
+    private var showsTruncation: Bool {
+        snapshot.tabType == .query && snapshot.pagination.hasMoreRows && !snapshot.pagination.isLoadingMore
+    }
+
+    private var statusSeparator: some View {
+        Text("·")
+            .font(.caption)
+            .foregroundStyle(.tertiary)
+    }
+
+    @ViewBuilder
+    private var statusCluster: some View {
+        if snapshot.pagination.isLoadingMore {
+            ProgressView()
+                .controlSize(.small)
+                .accessibilityHidden(true)
+            Text("Loading…")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel(String(localized: "Loading more rows"))
+        } else if let statusText {
+            Text(statusText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+
+        if showsTruncation {
+            if hasPrimaryStatus {
+                statusSeparator
+            }
+            Text("truncated")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Button {
+                onFetchAll?()
+            } label: {
+                Text("Fetch All")
+                    .font(.caption)
+            }
+            .buttonStyle(.link)
+        }
+
+        if let statusMessage = snapshot.statusMessage {
+            if hasPrimaryStatus || showsTruncation {
+                statusSeparator
+            }
+            Text(statusMessage)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
         }
     }
 
@@ -266,5 +326,25 @@ struct MainStatusBarView: View {
         .controlGroupStyle(.navigation)
         .controlSize(.small)
         .fixedSize()
+    }
+
+    private var filterToggleHelp: String {
+        helpText(String(localized: "Toggle Filters"), shortcut: .toggleFilters)
+    }
+
+    private var addRowHelp: String {
+        helpText(String(localized: "Add Row"), shortcut: .addRow)
+    }
+
+    private func helpText(_ label: String, shortcut action: ShortcutAction) -> String {
+        AppSettingsManager.shared.keyboard.shortcutHint(label, for: action)
+    }
+
+    private var columnsAccessibilityLabel: String {
+        guard !columnState.hidden.isEmpty else {
+            return String(localized: "Columns")
+        }
+        let visible = columnState.all.count - columnState.hidden.count
+        return String(format: String(localized: "%d of %d columns visible"), visible, columnState.all.count)
     }
 }

--- a/TablePro/Views/Main/Child/MainStatusBarView.swift
+++ b/TablePro/Views/Main/Child/MainStatusBarView.swift
@@ -68,23 +68,23 @@ struct MainStatusBarView: View {
         snapshot.tabType == .table && snapshot.hasTableName && snapshot.showsPaginationControls
     }
 
-    private var hasStatusText: Bool {
+    private var showsTruncation: Bool {
+        snapshot.tabType == .query && snapshot.pagination.hasMoreRows && !snapshot.pagination.isLoadingMore
+    }
+
+    private func hasStatusText(_ status: String?) -> Bool {
         snapshot.pagination.isLoadingMore
-            || statusText != nil
-            || (snapshot.tabType == .query && snapshot.pagination.hasMoreRows)
+            || status != nil
+            || showsTruncation
             || snapshot.statusMessage != nil
     }
 
-    private var showsDataNavigation: Bool {
-        showsDataChrome && (hasStatusText || showsPagination)
+    private func hasPrimaryStatus(_ status: String?) -> Bool {
+        snapshot.pagination.isLoadingMore || status != nil
     }
 
-    private var showsActionDivider: Bool {
-        showsActionButtons && showsDataNavigation
-    }
-
-    private var statusText: String? {
-        snapshot.statusText(selectedCount: selectedRowIndices.count)
+    private func showsDataNavigation(_ status: String?) -> Bool {
+        showsDataChrome && (hasStatusText(status) || showsPagination)
     }
 
     var body: some View {
@@ -130,6 +130,7 @@ struct MainStatusBarView: View {
 
     @ViewBuilder
     private var trailingControls: some View {
+        let status = snapshot.statusText(selectedCount: selectedRowIndices.count)
         HStack(spacing: 8) {
             if isStructureMode {
                 if structureState.footer.isActive {
@@ -137,10 +138,10 @@ struct MainStatusBarView: View {
                 }
             } else {
                 actionButtons
-                if showsActionDivider {
+                if showsActionButtons, showsDataNavigation(status) {
                     Divider().frame(height: 16)
                 }
-                dataNavigationGroup
+                dataNavigationGroup(status: status)
             }
         }
     }
@@ -221,10 +222,10 @@ struct MainStatusBarView: View {
     }
 
     @ViewBuilder
-    private var dataNavigationGroup: some View {
-        if showsDataNavigation {
+    private func dataNavigationGroup(status: String?) -> some View {
+        if showsDataNavigation(status) {
             HStack(spacing: 4) {
-                statusCluster
+                statusCluster(status: status)
                 if showsPagination {
                     PaginationControlsView(
                         pagination: snapshot.pagination,
@@ -242,14 +243,6 @@ struct MainStatusBarView: View {
         }
     }
 
-    private var hasPrimaryStatus: Bool {
-        snapshot.pagination.isLoadingMore || statusText != nil
-    }
-
-    private var showsTruncation: Bool {
-        snapshot.tabType == .query && snapshot.pagination.hasMoreRows && !snapshot.pagination.isLoadingMore
-    }
-
     private var statusSeparator: some View {
         Text("·")
             .font(.caption)
@@ -257,7 +250,7 @@ struct MainStatusBarView: View {
     }
 
     @ViewBuilder
-    private var statusCluster: some View {
+    private func statusCluster(status: String?) -> some View {
         if snapshot.pagination.isLoadingMore {
             ProgressView()
                 .controlSize(.small)
@@ -266,15 +259,15 @@ struct MainStatusBarView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .accessibilityLabel(String(localized: "Loading more rows"))
-        } else if let statusText {
-            Text(statusText)
+        } else if let status {
+            Text(status)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
         }
 
         if showsTruncation {
-            if hasPrimaryStatus {
+            if hasPrimaryStatus(status) {
                 statusSeparator
             }
             Text("truncated")
@@ -290,7 +283,7 @@ struct MainStatusBarView: View {
         }
 
         if let statusMessage = snapshot.statusMessage {
-            if hasPrimaryStatus || showsTruncation {
+            if hasPrimaryStatus(status) || showsTruncation {
                 statusSeparator
             }
             Text(statusMessage)

--- a/TablePro/Views/Main/Child/StatusBarSnapshot+RowInfo.swift
+++ b/TablePro/Views/Main/Child/StatusBarSnapshot+RowInfo.swift
@@ -6,9 +6,8 @@
 import Foundation
 
 extension StatusBarSnapshot {
-    func rowInfoText(selectedCount: Int) -> String {
+    func statusText(selectedCount: Int) -> String? {
         let loadedCount = rowCount
-        let total = pagination.totalRowCount
 
         if selectedCount > 0 {
             if selectedCount == loadedCount {
@@ -20,14 +19,8 @@ extension StatusBarSnapshot {
             let formattedCount = loadedCount.formatted(.number.grouping(.automatic))
             return String(format: String(localized: "Showing %@ rows"), formattedCount)
         }
-        if tabType == .table, let total, total > 0 {
-            let formattedTotal = total.formatted(.number.grouping(.automatic))
-            let prefix = pagination.isApproximateRowCount ? "~" : ""
-            return String(format: String(localized: "%d-%d of %@%@ rows"), pagination.rangeStart, pagination.rangeEnd, prefix, formattedTotal)
-        }
-        if tabType == .table, isPagedWithUnknownTotal {
-            let rangeEnd = pagination.currentOffset + loadedCount
-            return String(format: String(localized: "%d-%d of ? rows"), pagination.rangeStart, rangeEnd)
+        if tabType == .table, showsPaginationControls {
+            return nil
         }
         if loadedCount > 0 {
             let formattedCount = loadedCount.formatted(.number.grouping(.automatic))

--- a/TableProTests/Models/PaginationStateDisplayTests.swift
+++ b/TableProTests/Models/PaginationStateDisplayTests.swift
@@ -1,0 +1,59 @@
+//
+//  PaginationStateDisplayTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("PaginationState Display")
+struct PaginationStateDisplayTests {
+    @Test("A known total reports the offset range")
+    func rangeWithKnownTotal() {
+        let pagination = PaginationState(totalRowCount: 5_000, pageSize: 1_000, currentPage: 3, currentOffset: 2_000)
+        let text = pagination.rangeText(loadedRowCount: 1_000)
+        #expect(text?.contains("2001-3000") == true)
+        #expect(text?.contains("5,000") == true || text?.contains("5.000") == true)
+    }
+
+    @Test("An approximate total is prefixed with a tilde")
+    func rangeWithApproximateTotal() {
+        var pagination = PaginationState(totalRowCount: 111_559, pageSize: 1_000, currentPage: 1, currentOffset: 0)
+        pagination.isApproximateRowCount = true
+        let text = pagination.rangeText(loadedRowCount: 1_000)
+        #expect(text?.contains("~") == true)
+    }
+
+    @Test("An exact total has no tilde")
+    func rangeWithExactTotal() {
+        let pagination = PaginationState(totalRowCount: 111_559, pageSize: 1_000, currentPage: 1, currentOffset: 0)
+        let text = pagination.rangeText(loadedRowCount: 1_000)
+        #expect(text?.contains("~") == false)
+    }
+
+    @Test("A paged table with unknown total reports a question mark")
+    func rangeWithUnknownTotal() {
+        let pagination = PaginationState(totalRowCount: nil, pageSize: 50, currentPage: 2, currentOffset: 50)
+        let text = pagination.rangeText(loadedRowCount: 50)
+        #expect(text?.contains("51-100") == true)
+        #expect(text?.contains("?") == true)
+    }
+
+    @Test("A small single page has no range")
+    func rangeOnSinglePage() {
+        let pagination = PaginationState(totalRowCount: nil, pageSize: 50, currentPage: 1, currentOffset: 0)
+        #expect(pagination.rangeText(loadedRowCount: 5) == nil)
+    }
+
+    @Test("Page size labels never use a grouping separator")
+    func pageSizeLabelHasNoGrouping() {
+        for size in [5, 100, 1_000, 100_000] {
+            let label = PaginationState.pageSizeLabel(size)
+            #expect(!label.contains(","))
+            #expect(!label.contains("."))
+            #expect(!label.contains(" "))
+        }
+    }
+}

--- a/TableProTests/Models/StatusBarSnapshotTests.swift
+++ b/TableProTests/Models/StatusBarSnapshotTests.swift
@@ -57,40 +57,39 @@ struct StatusBarSnapshotTests {
     @Test("No rows reports an empty state")
     func rowInfoNoRows() {
         let snapshot = makeSnapshot(rowCount: 0)
-        #expect(snapshot.rowInfoText(selectedCount: 0) == String(localized: "No rows"))
+        #expect(snapshot.statusText(selectedCount: 0) == String(localized: "No rows"))
     }
 
     @Test("Selecting every loaded row reports the all-selected text")
     func rowInfoAllSelected() {
         let snapshot = makeSnapshot(rowCount: 5)
-        #expect(snapshot.rowInfoText(selectedCount: 5) == String(format: String(localized: "All %d rows selected"), 5))
+        #expect(snapshot.statusText(selectedCount: 5) == String(format: String(localized: "All %d rows selected"), 5))
     }
 
     @Test("Selecting some rows reports the partial-selection text")
     func rowInfoPartialSelection() {
         let snapshot = makeSnapshot(rowCount: 5)
-        #expect(snapshot.rowInfoText(selectedCount: 2) == String(format: String(localized: "%d of %d rows selected"), 2, 5))
+        #expect(snapshot.statusText(selectedCount: 2) == String(format: String(localized: "%d of %d rows selected"), 2, 5))
     }
 
-    @Test("A table with a known total reports the offset range")
-    func rowInfoTableRange() {
+    @Test("A paginated table defers its range to the pagination control")
+    func tableRangeDefersToPagination() {
         let snapshot = makeSnapshot(
             rowCount: 1_000,
             pagination: PaginationState(totalRowCount: 5_000, pageSize: 1_000, currentPage: 3, currentOffset: 2_000)
         )
-        let text = snapshot.rowInfoText(selectedCount: 0)
-        #expect(text.contains("2001-3000"))
+        #expect(snapshot.showsPaginationControls)
+        #expect(snapshot.statusText(selectedCount: 0) == nil)
     }
 
-    @Test("A paged table with unknown total reports a question mark for the total")
-    func rowInfoUnknownTotalRange() {
+    @Test("A small single-page table reports a plain row count")
+    func tableSinglePageRowCount() {
         let snapshot = makeSnapshot(
-            rowCount: 50,
-            pagination: PaginationState(totalRowCount: nil, pageSize: 50, currentPage: 2, currentOffset: 50)
+            rowCount: 5,
+            pagination: PaginationState(totalRowCount: nil, pageSize: 50, currentPage: 1)
         )
-        let text = snapshot.rowInfoText(selectedCount: 0)
-        #expect(text.contains("51-100"))
-        #expect(text.contains("?"))
+        #expect(!snapshot.showsPaginationControls)
+        #expect(snapshot.statusText(selectedCount: 0) == String(format: String(localized: "%@ rows"), 5.formatted(.number.grouping(.automatic))))
     }
 
     @Test("A truncated query reports the showing-rows text")
@@ -98,7 +97,7 @@ struct StatusBarSnapshotTests {
         var pagination = PaginationState(pageSize: 1_000)
         pagination.hasMoreRows = true
         let snapshot = makeSnapshot(tabType: .query, rowCount: 1_000, pagination: pagination)
-        let text = snapshot.rowInfoText(selectedCount: 0)
-        #expect(text.contains("1,000") || text.contains("1000"))
+        let text = snapshot.statusText(selectedCount: 0)
+        #expect(text?.contains("1,000") == true || text?.contains("1000") == true)
     }
 }

--- a/docs/features/data-grid.mdx
+++ b/docs/features/data-grid.mdx
@@ -375,9 +375,9 @@ Copying rows reflects the grid as shown: hidden columns are left out and the col
 
 ## Pagination
 
-Table tabs paginate large result sets. The status bar shows a rows-per-page menu and First / Previous / Next / Last buttons, with a page indicator between them.
+Table tabs paginate large result sets. The bottom bar shows the row range (e.g. `1-1,000 of ~111,559`) next to the First / Previous / Next / Last buttons, with a page indicator between them.
 
-- **Rows per page**: pick a preset (5, 10, 20, 100, 500, 1,000), enter a custom size, or choose **All rows** to load the whole table on one page. Loading all rows asks for confirmation first, since large tables use a lot of memory.
+- **Rows per page**: click the row range to pick a preset (5, 10, 20, 100, 500, 1,000), enter a custom size, or choose **All rows** to load the whole table on one page. Loading all rows asks for confirmation first, since large tables use a lot of memory.
 - **Page navigation**: jump to the first or last page, step one page at a time, or click the page indicator to go to a specific page.
 - The bar also appears for filtered tables whose total row count is unknown. There the Next button stays available while a full page keeps loading, and the indicator shows the page number without a total.
 


### PR DESCRIPTION
## What

Redesign the data view bottom bar so the row count, page size, and pagination read as one group, and fix the ambiguous page-size label.

Before, the bar split into three zones with two `Spacer`s, stranding the row count in dead center, and the page-size menu showed a bare `1.000` (locale grouping for one thousand) with no unit.

## Changes

- **Merged the row count into the page-size control.** Clicking the range (`1-1,000 of ~111,559`) opens the rows-per-page menu, so the count sits next to the controls that change it. This is the DataGrip pattern; it also matches how TablePlus, Postico 2, and Sequel Ace anchor the count to the pager.
- **Fixed the ambiguous page-size value.** Menu items render with `.grouping(.never)` (`1000`, never `1.000`). The total keeps locale grouping, which is correct for a measured quantity.
- **Regrouped the trailing controls by function** with a divider between grid actions (Add / Columns / Filters) and data navigation, shown only when both groups are present.
- Kept the Data / Structure / JSON switcher bottom-left (the confirmed native DB-client convention).
- Fixed a latent dangling `·` separator that would have appeared once the range left the status text on a table tab carrying a status message.

## Layout

```
[ Data | Structure | JSON ] ──── [Add] [Columns] [Filters] │ [ 1-1,000 of ~111,559 ⌄ ]  ‹‹ ‹ 1/112 › ››
```

## Tests

- New `PaginationStateDisplayTests`: `rangeText` including the previously-untested approximate-count `~` path, and a guarantee that page-size labels never carry a grouping separator (locale-independent).
- Updated `StatusBarSnapshotTests` for the `statusText` refactor (range now deferred to the pagination control).

## Notes

- View-layer only; no model changes to `StatusBarSnapshot` or `PaginationState`.
- SwiftLint `--strict` clean on changed files.
- Docs (`data-grid.mdx`) and CHANGELOG updated.
