### PR TITLE
perf(sidebar): debounce table search to keep typing responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Typing in the sidebar table search stays responsive on databases with thousands of tables; filtering runs after a short pause instead of on every keystroke.
+
 ### Fixed
 
 - Oracle connections no longer crash the app when the server sends a backend message the driver cannot decode; the query fails with a clear error and the connection reconnects. (#483)

--- a/TablePro/ViewModels/SidebarViewModel.swift
+++ b/TablePro/ViewModels/SidebarViewModel.swift
@@ -10,6 +10,7 @@ import TableProPluginKit
 @MainActor @Observable
 final class SidebarViewModel {
     private static var registry: [UUID: SidebarViewModel] = [:]
+    private static let searchDebounceNanoseconds: UInt64 = 150_000_000
 
     static func shared(
         connectionId: UUID,
@@ -78,8 +79,15 @@ final class SidebarViewModel {
     // MARK: - Published State
 
     var searchText = "" {
+        didSet { scheduleFilterQueryUpdate(oldValue: oldValue) }
+    }
+
+    private(set) var filterQuery = "" {
         didSet { invalidateFilterCaches() }
     }
+
+    @ObservationIgnored private var filterDebounceTask: Task<Void, Never>?
+
     var expanded: ExpansionState {
         didSet { persistExpansion(oldValue: oldValue) }
     }
@@ -329,7 +337,7 @@ final class SidebarViewModel {
     }
 
     func filteredTables(from tables: [TableInfo]) -> [TableInfo] {
-        let query = searchText
+        let query = filterQuery
         let fingerprint = (count: tables.count, generation: schemaGeneration, query: query)
         if let cache = cachedFilteredTables,
            let inputs = cachedFilterInputs,
@@ -359,7 +367,7 @@ final class SidebarViewModel {
     }
 
     func filteredTables(of kind: SidebarObjectKind, from tables: [TableInfo]) -> [TableInfo] {
-        let query = searchText
+        let query = filterQuery
         let fingerprint = (count: tables.count, generation: schemaGeneration, query: query)
         if cachedFilteredByKindFingerprint?.count != fingerprint.count
             || cachedFilteredByKindFingerprint?.generation != fingerprint.generation
@@ -378,7 +386,7 @@ final class SidebarViewModel {
     }
 
     func filteredRoutines(of kind: SidebarObjectKind, from routines: [RoutineInfo]) -> [RoutineInfo] {
-        let query = searchText
+        let query = filterQuery
         let fingerprint = (count: routines.count, generation: schemaGeneration, query: query)
         if cachedFilteredRoutinesFingerprint?.count != fingerprint.count
             || cachedFilteredRoutinesFingerprint?.generation != fingerprint.generation
@@ -393,7 +401,7 @@ final class SidebarViewModel {
     }
 
     func effectiveExpanded(kind: SidebarObjectKind, hasMatches: Bool) -> Bool {
-        if !searchText.isEmpty && hasMatches { return true }
+        if !filterQuery.isEmpty && hasMatches { return true }
         return expanded[kind]
     }
 
@@ -435,5 +443,25 @@ final class SidebarViewModel {
         cachedFilteredByKindFingerprint = nil
         cachedFilteredRoutines = [:]
         cachedFilteredRoutinesFingerprint = nil
+    }
+
+    private func scheduleFilterQueryUpdate(oldValue: String) {
+        if searchText.isEmpty || oldValue.isEmpty {
+            filterDebounceTask?.cancel()
+            filterDebounceTask = nil
+            filterQuery = searchText
+            return
+        }
+        filterDebounceTask?.cancel()
+        filterDebounceTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: Self.searchDebounceNanoseconds)
+            guard !Task.isCancelled else { return }
+            guard let self else { return }
+            self.filterQuery = self.searchText
+        }
+    }
+
+    deinit {
+        filterDebounceTask?.cancel()
     }
 }

--- a/TablePro/Views/Sidebar/SidebarTreeView.swift
+++ b/TablePro/Views/Sidebar/SidebarTreeView.swift
@@ -23,7 +23,7 @@ struct SidebarTreeView: View {
     }
 
     private var searchText: String {
-        viewModel.searchText
+        viewModel.filterQuery
     }
 
     private var visibleSchemas: [String] {

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -275,7 +275,7 @@ struct SidebarView: View {
             loadingState
         case .failed(let message):
             errorState(message: message)
-        case .loaded where !viewModel.searchText.isEmpty && !hasAnyMatch:
+        case .loaded where !viewModel.filterQuery.isEmpty && !hasAnyMatch:
             noMatchState
         case .loaded(let allTables) where allTables.isEmpty && routines.isEmpty:
             emptyState
@@ -361,7 +361,7 @@ struct SidebarView: View {
             if viewModel.databaseType == .redis, let keyTreeVM = sidebarState.redisKeyTreeViewModel {
                 Section(isExpanded: $viewModel.isRedisKeysExpanded) {
                     RedisKeyTreeView(
-                        nodes: keyTreeVM.displayNodes(searchText: viewModel.searchText),
+                        nodes: keyTreeVM.displayNodes(searchText: viewModel.filterQuery),
                         isLoading: keyTreeVM.isLoading,
                         isTruncated: keyTreeVM.isTruncated,
                         onSelectNamespace: { prefix in

--- a/TableProTests/ViewModels/SidebarViewModelTests.swift
+++ b/TableProTests/ViewModels/SidebarViewModelTests.swift
@@ -523,7 +523,6 @@ struct SidebarViewModelMultiSectionTests {
 
 @Suite("SidebarViewModel search debounce")
 struct SidebarViewModelSearchDebounceTests {
-
     @Test("filterQuery updates immediately on first non-empty input")
     @MainActor
     func filterQueryUpdatesImmediatelyOnFirstInput() {
@@ -598,8 +597,9 @@ struct SidebarViewModelSearchDebounceTests {
     func filteredTablesHonorsFilterQueryNotSearchText() async {
         let vm = makeViewModel()
         let users = TestFixtures.makeTableInfo(name: "users", type: .table)
+        let userLog = TestFixtures.makeTableInfo(name: "user_log", type: .table)
         let orders = TestFixtures.makeTableInfo(name: "orders", type: .table)
-        let mixed = [users, orders]
+        let mixed = [users, userLog, orders]
 
         vm.searchText = "user"
         vm.searchText = "users"
@@ -607,6 +607,6 @@ struct SidebarViewModelSearchDebounceTests {
 
         let matches = vm.filteredTables(of: .table, from: mixed)
 
-        #expect(matches.map(\.name) == ["users"])
+        #expect(matches.map(\.name) == ["users", "user_log"])
     }
 }

--- a/TableProTests/ViewModels/SidebarViewModelTests.swift
+++ b/TableProTests/ViewModels/SidebarViewModelTests.swift
@@ -520,3 +520,93 @@ struct SidebarViewModelMultiSectionTests {
         UserDefaults.standard.removeObject(forKey: SidebarPersistenceKey.legacyTablesExpanded)
     }
 }
+
+@Suite("SidebarViewModel search debounce")
+struct SidebarViewModelSearchDebounceTests {
+
+    @Test("filterQuery updates immediately on first non-empty input")
+    @MainActor
+    func filterQueryUpdatesImmediatelyOnFirstInput() {
+        let vm = makeViewModel()
+
+        vm.searchText = "user"
+
+        #expect(vm.filterQuery == "user")
+    }
+
+    @Test("filterQuery clears immediately when search becomes empty")
+    @MainActor
+    func filterQueryClearsImmediatelyOnEmpty() async {
+        let vm = makeViewModel()
+        vm.searchText = "user"
+        vm.searchText = "users"
+        await Task.yield()
+
+        vm.searchText = ""
+
+        #expect(vm.filterQuery == "")
+    }
+
+    @Test("filterQuery stays at previous value during debounce window")
+    @MainActor
+    func filterQueryHoldsPreviousValueDuringDebounce() async {
+        let vm = makeViewModel()
+        vm.searchText = "user"
+        #expect(vm.filterQuery == "user")
+
+        vm.searchText = "users"
+        await Task.yield()
+
+        #expect(vm.filterQuery == "user")
+    }
+
+    @Test("filterQuery catches up after debounce window elapses")
+    @MainActor
+    func filterQueryCatchesUpAfterDebounce() async {
+        let vm = makeViewModel()
+        vm.searchText = "user"
+
+        vm.searchText = "users"
+
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        await Task.yield()
+
+        #expect(vm.filterQuery == "users")
+    }
+
+    @Test("rapid consecutive keystrokes collapse to the final value")
+    @MainActor
+    func rapidKeystrokesCollapseToFinalValue() async {
+        let vm = makeViewModel()
+        vm.searchText = "u"
+
+        vm.searchText = "us"
+        vm.searchText = "use"
+        vm.searchText = "user"
+        await Task.yield()
+
+        #expect(vm.filterQuery == "u")
+
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        await Task.yield()
+
+        #expect(vm.filterQuery == "user")
+    }
+
+    @Test("filter caches still serve filteredTables using filterQuery, not searchText")
+    @MainActor
+    func filteredTablesHonorsFilterQueryNotSearchText() async {
+        let vm = makeViewModel()
+        let users = TestFixtures.makeTableInfo(name: "users", type: .table)
+        let orders = TestFixtures.makeTableInfo(name: "orders", type: .table)
+        let mixed = [users, orders]
+
+        vm.searchText = "user"
+        vm.searchText = "users"
+        await Task.yield()
+
+        let matches = vm.filteredTables(of: .table, from: mixed)
+
+        #expect(matches.map(\.name) == ["users"])
+    }
+}


### PR DESCRIPTION
## 问题
侧边栏表搜索框每敲一个字符就对全部表、视图、外键表跑全量模糊匹配。表上千张时打字明显卡顿。

## 方案
引入 debounce 后的 `filterQuery` 作为过滤输入(150ms)，`searchText` 只负责即时显示。过滤缓存的指纹含 query，所以必须 debounce 查询本身，不能只 debounce 缓存失效。清空搜索与首次输入立即响应，连打时保留旧结果不闪烁。

## 验证
- BUILD SUCCEEDED (Xcode 27 beta, `CODE_SIGNING_ALLOWED=NO`)
- `SidebarViewModelSearchDebounceTests` 覆盖：首次输入立即更新、清空立即、debounce 窗口内保持旧值、debounce 后追上、缓存用 filterQuery 而非 searchText
