### PR TITLE
fix(plugin-oracle): make channel-fatal classification testable to unbreak test target

### DIFF
--- a/Plugins/OracleDriverPlugin/OracleConnection.swift
+++ b/Plugins/OracleDriverPlugin/OracleConnection.swift
@@ -286,16 +286,7 @@ final class OracleConnectionWrapper: @unchecked Sendable {
     }
 
     private static func isChannelFatal(_ error: OracleSQLError) -> Bool {
-        isChannelFatalCode(error.code.description)
-    }
-
-    static func isChannelFatalCode(_ codeDescription: String) -> Bool {
-        switch codeDescription {
-        case "connectionError", "messageDecodingFailure", "unexpectedBackendMessage":
-            return true
-        default:
-            return false
-        }
+        OracleChannelFatalCode.isChannelFatal(error.code.description)
     }
 
     func disconnect() {

--- a/Plugins/TableProPluginKit/OracleChannelFatalCode.swift
+++ b/Plugins/TableProPluginKit/OracleChannelFatalCode.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public enum OracleChannelFatalCode {
+    public static func isChannelFatal(_ codeDescription: String) -> Bool {
+        switch codeDescription {
+        case "connectionError", "messageDecodingFailure", "unexpectedBackendMessage":
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/TableProTests/Plugins/OracleConnectionErrorTests.swift
+++ b/TableProTests/Plugins/OracleConnectionErrorTests.swift
@@ -1,21 +1,19 @@
-import Foundation
 import Testing
-
-@testable import TablePro
+import TableProPluginKit
 
 @Suite("Oracle channel-fatal error classification")
 struct OracleConnectionErrorTests {
     @Test("Decode and connection failures are treated as channel-fatal")
     func channelFatalCodes() {
-        #expect(OracleConnectionWrapper.isChannelFatalCode("connectionError"))
-        #expect(OracleConnectionWrapper.isChannelFatalCode("messageDecodingFailure"))
-        #expect(OracleConnectionWrapper.isChannelFatalCode("unexpectedBackendMessage"))
+        #expect(OracleChannelFatalCode.isChannelFatal("connectionError"))
+        #expect(OracleChannelFatalCode.isChannelFatal("messageDecodingFailure"))
+        #expect(OracleChannelFatalCode.isChannelFatal("unexpectedBackendMessage"))
     }
 
     @Test("Server-side SQL errors keep the connection alive")
     func nonFatalCodes() {
-        #expect(!OracleConnectionWrapper.isChannelFatalCode("server"))
-        #expect(!OracleConnectionWrapper.isChannelFatalCode("statementCancelled"))
-        #expect(!OracleConnectionWrapper.isChannelFatalCode("malformedStatement"))
+        #expect(!OracleChannelFatalCode.isChannelFatal("server"))
+        #expect(!OracleChannelFatalCode.isChannelFatal("statementCancelled"))
+        #expect(!OracleChannelFatalCode.isChannelFatal("malformedStatement"))
     }
 }


### PR DESCRIPTION
## 问题
main HEAD 的 `TableProTests/Plugins/OracleConnectionErrorTests.swift`(PR #1723 引入)引用 `OracleConnectionWrapper.isChannelFatalCode`,但 `OracleConnectionWrapper` 是 OracleDriverPlugin 的 plugin 内部类型,app/test target 通过 `@testable import TablePro` 看不到它,导致整个 TableProTests target 编译失败(exit 65),macOS App Tests 全部无法运行,并阻塞其他 PR 的 CI。

## 修复
把 `isChannelFatalCode` 的纯字符串分类逻辑提到 TableProPluginKit 的 public `OracleChannelFatalCode`(TableProPluginKit 已有 PluginDriverError / SSLHandshakeError / AWSAuthError 等 driver 特定 error 类型作为先例)。`OracleConnectionWrapper` 转调,行为不变。测试改为 `import TableProPluginKit` 测可见类型。

PluginKit 改动为新增一个 public enum,纯 additive,无 ABI bump,无需 version bump。

## 验证
- App target BUILD SUCCEEDED
- TableProTests target 编译通过(`cannot find 'OracleConnectionWrapper'` 消除)
- OracleConnectionErrorTests 6 断言全绿
- PluginKit diff 纯 additive(新增 public enum,无现有 public symbol 改动)
