### PR TITLE
fix(editor): keep autocomplete delegate attached for the editor's lifetime (#1731)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- SQL autocomplete no longer stops appearing until the app is relaunched; the suggestion list stays available after switching query tabs and windows. (#1731)
 - Oracle connections no longer crash the app when the server sends a backend message the driver cannot decode; the query fails with a clear error and the connection reconnects. (#483)
 - MongoDB TLS handshake failures now report the actual cause instead of always blaming a cipher or protocol mismatch. (#1418)
 - The External Clients access level no longer reverts to Read Only after saving and reopening a connection, so MCP clients keep the write access you granted. (#1730)

--- a/TablePro/Views/Editor/SQLCompletionAdapter.swift
+++ b/TablePro/Views/Editor/SQLCompletionAdapter.swift
@@ -44,9 +44,9 @@ final class SQLCompletionAdapter: CodeSuggestionDelegate {
         self.completionEngine = Self.makeEngine(schemaProvider: schemaProvider, databaseType: databaseType)
     }
 
-    /// Update the schema provider (e.g. when connection changes)
-    func updateSchemaProvider(_ provider: SQLSchemaProvider, databaseType: DatabaseType? = nil) {
-        completionEngine = Self.makeEngine(schemaProvider: provider, databaseType: databaseType)
+    /// Rebuild the completion engine for the current connection (nil schema still yields keyword completion)
+    func configure(schemaProvider: SQLSchemaProvider?, databaseType: DatabaseType?) {
+        completionEngine = Self.makeEngine(schemaProvider: schemaProvider, databaseType: databaseType)
         completionEngine.updateFavoriteKeywords(favoriteKeywords)
     }
 

--- a/TablePro/Views/Editor/SQLEditorCoordinator.swift
+++ b/TablePro/Views/Editor/SQLEditorCoordinator.swift
@@ -220,6 +220,10 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
         if inlineSuggestionManager == nil, let controller {
             installInlineSuggestionManager(controller: controller)
         }
+        if let controller {
+            installEditorSettingsObserver(controller: controller)
+            installWindowKeyObserver(for: controller.textView?.window)
+        }
     }
 
     // MARK: - AI Context Menu

--- a/TablePro/Views/Editor/SQLEditorView.swift
+++ b/TablePro/Views/Editor/SQLEditorView.swift
@@ -31,9 +31,8 @@ struct SQLEditorView: View {
     var onSaveAsFavorite: ((String) -> Void)?
 
     @State private var editorState = SourceEditorState()
-    @State private var completionAdapter: SQLCompletionAdapter?
+    @State private var completionAdapter = SQLCompletionAdapter(schemaProvider: nil, databaseType: nil)
     @State private var coordinator = SQLEditorCoordinator()
-    @State private var editorReady = false
     @State private var editorConfiguration = makeConfiguration()
     @State private var favoritesCancellables: Set<AnyCancellable> = []
     @Environment(\.colorScheme) private var colorScheme
@@ -51,68 +50,55 @@ struct SQLEditorView: View {
         coordinator.tabID = tabID
         coordinator.connectionId = connectionId
 
-        return Group {
-            if editorReady {
-            SourceEditor(
-                $text,
-                language: PluginManager.shared.editorLanguage(for: databaseType ?? .mysql).treeSitterLanguage,
-                configuration: editorConfiguration,
-                state: $editorState,
-                coordinators: [coordinator],
-                completionDelegate: completionAdapter
-            )
-            .accessibilityLabel(String(localized: "SQL query editor"))
-            .onChange(of: editorState.cursorPositions) { _, newValue in
-                guard let positions = newValue else { return }
-                // Skip cursor propagation when the editor doesn't have focus
-                // (e.g., find panel match highlighting). Propagating triggers
-                // a SwiftUI re-render that disrupts the find panel's focus.
-                guard coordinator.isEditorFirstResponder else { return }
-                // Guard against stale propagation during tab switch (.id() recreation):
-                // verify the editor's text still matches the binding before propagating.
-                // Use O(1) length pre-check to avoid O(n) string comparison on large docs.
-                if let controller = coordinator.controller {
-                    let currentString = controller.textView.string as NSString
-                    let bindingString = text as NSString
-                    if currentString.length != bindingString.length {
-                        return
-                    }
-                }
-                cursorPositions = positions
-            }
-            .onChange(of: connectionId) { _, _ in
-                if let schemaProvider, let completionAdapter {
-                    completionAdapter.updateSchemaProvider(schemaProvider, databaseType: databaseType)
-                }
-                setupFavoritesObserver()
-            }
-            .onChange(of: colorScheme) {
-                editorConfiguration = Self.makeConfiguration()
-            }
-            .onChange(of: AppSettingsManager.shared.editor) {
-                editorConfiguration = Self.makeConfiguration()
-            }
-            .onReceive(AppEvents.shared.accessibilityTextSizeChanged) { _ in
-                editorConfiguration = Self.makeConfiguration()
-            }
-            .onReceive(AppEvents.shared.themeChanged) { _ in
-                editorConfiguration = Self.makeConfiguration()
-            }
-            .onAppear {
-                initializeEditor()
-            }
-        } else {
-            Color(nsColor: .textBackgroundColor)
-                .onAppear {
-                    initializeEditor()
-                    editorReady = true
+        return SourceEditor(
+            $text,
+            language: PluginManager.shared.editorLanguage(for: databaseType ?? .mysql).treeSitterLanguage,
+            configuration: editorConfiguration,
+            state: $editorState,
+            coordinators: [coordinator],
+            completionDelegate: completionAdapter
+        )
+        .accessibilityLabel(String(localized: "SQL query editor"))
+        .onChange(of: editorState.cursorPositions) { _, newValue in
+            guard let positions = newValue else { return }
+            // Skip cursor propagation when the editor doesn't have focus
+            // (e.g., find panel match highlighting). Propagating triggers
+            // a SwiftUI re-render that disrupts the find panel's focus.
+            guard coordinator.isEditorFirstResponder else { return }
+            // Guard against stale propagation during tab switch (.id() recreation):
+            // verify the editor's text still matches the binding before propagating.
+            // Use O(1) length pre-check to avoid O(n) string comparison on large docs.
+            if let controller = coordinator.controller {
+                let currentString = controller.textView.string as NSString
+                let bindingString = text as NSString
+                if currentString.length != bindingString.length {
+                    return
                 }
             }
+            cursorPositions = positions
+        }
+        .onChange(of: connectionId) { _, _ in
+            completionAdapter.configure(schemaProvider: schemaProvider, databaseType: databaseType)
+            setupFavoritesObserver()
+        }
+        .onChange(of: colorScheme) {
+            editorConfiguration = Self.makeConfiguration()
+        }
+        .onChange(of: AppSettingsManager.shared.editor) {
+            editorConfiguration = Self.makeConfiguration()
+        }
+        .onReceive(AppEvents.shared.accessibilityTextSizeChanged) { _ in
+            editorConfiguration = Self.makeConfiguration()
+        }
+        .onReceive(AppEvents.shared.themeChanged) { _ in
+            editorConfiguration = Self.makeConfiguration()
+        }
+        .onAppear {
+            initializeEditor()
         }
         .onDisappear {
             teardownFavoritesObserver()
             coordinator.destroy()
-            completionAdapter = nil
         }
         .onChange(of: coordinator.vimMode) { _, newMode in
             vimMode = newMode
@@ -125,9 +111,7 @@ struct SQLEditorView: View {
         if coordinator.isDestroyed {
             coordinator.revive()
         }
-        if completionAdapter == nil {
-            completionAdapter = SQLCompletionAdapter(schemaProvider: schemaProvider, databaseType: databaseType)
-        }
+        completionAdapter.configure(schemaProvider: schemaProvider, databaseType: databaseType)
         setupFavoritesObserver()
     }
 
@@ -141,7 +125,7 @@ struct SQLEditorView: View {
         let refresh: () -> Void = {
             Task { @MainActor in
                 let keywords = await SQLFavoriteManager.shared.fetchKeywordMap(connectionId: connId)
-                adapter?.updateFavoriteKeywords(keywords)
+                adapter.updateFavoriteKeywords(keywords)
             }
         }
         AppEvents.shared.sqlFavoritesDidUpdate
@@ -164,7 +148,7 @@ struct SQLEditorView: View {
         let connId = connectionId
         Task { @MainActor in
             let keywords = await SQLFavoriteManager.shared.fetchKeywordMap(connectionId: connId)
-            completionAdapter?.updateFavoriteKeywords(keywords)
+            completionAdapter.updateFavoriteKeywords(keywords)
         }
     }
 

--- a/TableProTests/Views/Editor/SQLCompletionAdapterLifecycleTests.swift
+++ b/TableProTests/Views/Editor/SQLCompletionAdapterLifecycleTests.swift
@@ -1,0 +1,46 @@
+//
+//  SQLCompletionAdapterLifecycleTests.swift
+//  TableProTests
+//
+//  Guards the invariants behind the autocomplete delegate-lifetime fix (#1731):
+//  the completion engine produces keyword suggestions before any schema is
+//  attached, and reconfiguring the adapter across nil/non-nil schema transitions
+//  keeps it functional. The SwiftUI onDisappear/onAppear delegate attachment that
+//  caused the original dropout is an AppKit lifecycle behaviour and is not
+//  deterministically unit-testable; these tests cover the logic the fix relies on.
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("SQL Completion Adapter Lifecycle")
+struct SQLCompletionAdapterLifecycleTests {
+    @Test("engine returns keyword completions with no schema provider")
+    func keywordsAvailableWithoutSchema() async {
+        let engine = CompletionEngine(schemaProvider: nil, databaseType: .postgresql)
+        let context = await engine.getCompletions(text: "SEL", cursorPosition: 3)
+        #expect(context?.items.contains { $0.label == "SELECT" } == true)
+    }
+
+    @Test("engine returns keyword completions with no schema and no database type")
+    func keywordsAvailableWithoutSchemaOrDatabaseType() async {
+        let engine = CompletionEngine(schemaProvider: nil, databaseType: nil)
+        let context = await engine.getCompletions(text: "SEL", cursorPosition: 3)
+        #expect(context?.items.contains { $0.label == "SELECT" } == true)
+    }
+
+    @MainActor
+    @Test("configure across nil and non-nil schema keeps the adapter functional")
+    func configureAcrossSchemaTransitionsKeepsAdapterUsable() {
+        let adapter = SQLCompletionAdapter(schemaProvider: nil, databaseType: nil)
+        #expect(!adapter.completionTriggerCharacters().isEmpty)
+
+        adapter.configure(schemaProvider: nil, databaseType: .postgresql)
+        adapter.configure(schemaProvider: SQLSchemaProvider(), databaseType: .postgresql)
+        adapter.configure(schemaProvider: nil, databaseType: .mysql)
+
+        #expect(!adapter.completionTriggerCharacters().isEmpty)
+    }
+}


### PR DESCRIPTION
Fixes #1731.

## Problem
SQL autocomplete intermittently stopped appearing for any category (keywords, tables, columns), even with the schema fully loaded. Auto-capitalization still worked. It was tied to app/editor lifecycle and only a relaunch fixed it.

## Root cause
`TextViewController.completionDelegate` is `weak`, and the only strong owner was an optional `@State completionAdapter` that `SQLEditorView.onDisappear` set to `nil`. macOS does not guarantee `onAppear` fires after every `onDisappear` for views in native window-tab groups. When it didn't, the adapter was never recreated, `controller.completionDelegate` stayed `nil`, and every keystroke hit the trigger guard `guard let completionDelegate ... else { return }`, killing all completions (including schema-independent keywords) until relaunch.

## Fix
The completion adapter now lives for the editor's whole lifetime.

- `SQLEditorView`: `completionAdapter` is non-optional, created eagerly with nil schema; removed the `editorReady` two-phase gate and flattened the body; `onDisappear` no longer nils the adapter. `SourceEditor.updateNSViewController` continuously re-asserts a live, non-nil delegate. Keywords work from frame one; tables/columns enrich once schema loads.
- `SQLCompletionAdapter`: replaced `updateSchemaProvider` with `configure(schemaProvider:databaseType:)` accepting optionals, so the eager adapter can attach before schema loads and reconfigure when it arrives.
- `SQLEditorCoordinator.revive()`: reinstalls the editor-settings and window-key observers that `destroy()` tears down, so editor-settings and Vim live updates survive the destroy/revive cycle that tab switching now routinely exercises.

The "schema race" an earlier analysis pass suspected was not real: `services.schemaProviderRegistry` is `.shared` and the coordinator's `init` already calls `getOrCreate`, so the reconcile lookup always succeeds. No change made there.

## Tests
New `SQLCompletionAdapterLifecycleTests` (3 tests, all passing): the engine returns keyword completions with a nil schema (with and without a database type), and the adapter survives nil <-> provider `configure` transitions. The SwiftUI `onDisappear`/`onAppear` delegate detachment itself is an AppKit lifecycle behavior that is not deterministically unit-testable; these tests guard the invariants the fix relies on.

## Verification
- `BUILD SUCCEEDED`
- `swiftlint lint --strict`: 0 violations on changed files
- New tests pass (3/3)

Needs manual confirmation in-app: type to get suggestions, switch between query tabs and connection windows and back, and confirm autocomplete keeps appearing without a relaunch.
