### PR TITLE
docs: remove stale built-in terminal references

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ Built-in drivers ship with the app. Plugin drivers install on demand from the [p
 - Query history with full-text search
 - iCloud sync for connections, groups, tags, settings, and SSH profiles
 - AI chat, inline suggestions, and Explain/Optimize
-- Built-in terminal with mysql, psql, redis-cli, mongosh (SSH and Docker aware)
 - MCP server and URL scheme for Raycast, Cursor, Claude Desktop
 - Plugin system, write your own database driver in Swift
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -100,7 +100,6 @@ Driver tích hợp sẵn đi kèm app. Driver dạng plugin cài thêm khi cần
 - Lịch sử query tìm kiếm full-text
 - iCloud sync cho connection, group, tag, cài đặt, SSH profile
 - AI chat, gợi ý inline, Explain/Optimize
-- Terminal tích hợp: mysql, psql, redis-cli, mongosh (hỗ trợ SSH và Docker)
 - MCP server và URL scheme cho Raycast, Cursor, Claude Desktop
 - Hệ thống plugin, tự viết driver database bằng Swift
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -100,7 +100,6 @@ TablePro 补上缺失的第四类:原生、多数据库、开源。
 - 查询历史全文搜索
 - iCloud 同步:连接、分组、标签、设置、SSH 配置
 - AI 聊天、行内建议、Explain/Optimize
-- 内置终端:mysql、psql、redis-cli、mongosh(支持 SSH 和 Docker)
 - MCP 服务器和 URL scheme:Raycast、Cursor、Claude Desktop
 - 插件系统:用 Swift 自己写数据库驱动
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -48,7 +48,6 @@ Native macOS client for every database. Built on SwiftUI and AppKit. Ships under
 **CSV Inspector**: Open `.csv` and `.tsv` files natively. Edit cells, insert and delete rows and columns, undo/redo, save preserving the original dialect.
 **Import & Export**: CSV, JSON, SQL, XLSX, MQL. Streaming export for large datasets.
 **AI Assistant**: Chat, inline suggestions, and Explain/Optimize via GitHub Copilot, Claude, OpenAI, or Ollama.
-**Terminal**: Built-in database CLI (mysql, psql, redis-cli, mongosh, etc.) with SSH and Docker support.
 **MCP Server**: Expose your connections to AI tools via the Model Context Protocol.
 **External API**: Drive TablePro from Raycast, Cursor, Claude Desktop, and other MCP clients. URL scheme, MCP, and one-click pairing.
 **Plugin System**: 5 bundled drivers (covering 7 databases) plus 10 more from the plugin registry. Third-party plugins supported.


### PR DESCRIPTION
## Summary

Removes the stale "built-in terminal" feature claim from the in-repo documentation:

- README.md: "Built-in terminal with mysql, psql, redis-cli, mongosh (SSH and Docker aware)" bullet
- README.zh.md: the same bullet (Chinese)
- README.vi.md: the same bullet (Vietnamese)
- docs/index.mdx: "**Terminal**: Built-in database CLI ..." line

## Why this matters

The embedded terminal/CLI was removed from TablePro, and docs/changelog.mdx already records it ("Embedded Terminal: The built-in database CLI terminal has been removed"). The README and docs still advertised the feature, which is what led the reporter to look for a terminal that no longer exists. This brings the in-repo docs in line with the changelog. The changelog removal note is left untouched.

## Testing

Docs-only change. Verified that no feature advertisement for the built-in terminal remains in the READMEs or docs/, and that the changelog removal note is still present.

Fixes #1729
