### PR TITLE
fix(plugins): populate referenced schema for SQL Server and Oracle foreign keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Raw filters in the data grid now apply on document and key-value databases; the typed text was being dropped before it reached the driver. (#1529)
 - Connecting to Oracle no longer crashes the app while reading certain server values during the handshake; a bad packet now fails the connection with an error instead. (#1746)
+- Following a foreign key into a table in another schema now opens the correct table for SQL Server and Oracle; the referenced schema was missing, so navigation fell back to the default schema. (#1754)
 
 ## [0.52.1] - 2026-06-22
 

--- a/Packages/TableProCore/Sources/TableProMSSQLCore/MSSQLSchemaQueries.swift
+++ b/Packages/TableProCore/Sources/TableProMSSQLCore/MSSQLSchemaQueries.swift
@@ -98,7 +98,8 @@ public enum MSSQLSchemaQueries {
                 fk.name AS constraint_name,
                 cp.name AS column_name,
                 tr.name AS ref_table,
-                cr.name AS ref_column
+                cr.name AS ref_column,
+                sr.name AS ref_schema
             FROM sys.foreign_keys fk
             JOIN sys.foreign_key_columns fkc ON fk.object_id = fkc.constraint_object_id
             JOIN sys.tables tp ON fkc.parent_object_id = tp.object_id
@@ -106,6 +107,7 @@ public enum MSSQLSchemaQueries {
             JOIN sys.columns cp
                 ON fkc.parent_object_id = cp.object_id AND fkc.parent_column_id = cp.column_id
             JOIN sys.tables tr ON fkc.referenced_object_id = tr.object_id
+            JOIN sys.schemas sr ON tr.schema_id = sr.schema_id
             JOIN sys.columns cr
                 ON fkc.referenced_object_id = cr.object_id AND fkc.referenced_column_id = cr.column_id
             WHERE tp.name = '\(t)' AND s.name = '\(s)'
@@ -198,12 +200,20 @@ public struct MSSQLForeignKeyRow: Sendable, Equatable {
     public let columnName: String
     public let referencedTable: String
     public let referencedColumn: String
+    public let referencedSchema: String?
 
-    public init(constraintName: String, columnName: String, referencedTable: String, referencedColumn: String) {
+    public init(
+        constraintName: String,
+        columnName: String,
+        referencedTable: String,
+        referencedColumn: String,
+        referencedSchema: String? = nil
+    ) {
         self.constraintName = constraintName
         self.columnName = columnName
         self.referencedTable = referencedTable
         self.referencedColumn = referencedColumn
+        self.referencedSchema = referencedSchema
     }
 }
 
@@ -251,7 +261,8 @@ public extension MSSQLSchemaQueries {
             constraintName: name,
             columnName: column,
             referencedTable: refTable,
-            referencedColumn: refColumn
+            referencedColumn: refColumn,
+            referencedSchema: row[safe: 4] ?? nil
         )
     }
 }

--- a/Packages/TableProCore/Tests/TableProMSSQLCoreTests/MSSQLSchemaQueriesTests.swift
+++ b/Packages/TableProCore/Tests/TableProMSSQLCoreTests/MSSQLSchemaQueriesTests.swift
@@ -45,6 +45,12 @@ final class MSSQLSchemaQueriesTests: XCTestCase {
         XCTAssertTrue(sql.contains("'dbo'"))
     }
 
+    func testForeignKeysQuerySelectsReferencedSchema() {
+        let sql = MSSQLSchemaQueries.foreignKeys(schema: "dbo", table: "Orders")
+        XCTAssertTrue(sql.contains("sr.name AS ref_schema"))
+        XCTAssertTrue(sql.contains("JOIN sys.schemas sr ON tr.schema_id = sr.schema_id"))
+    }
+
     func testParseTableRowDetectsView() {
         let row: [String?] = ["v_active_users", "VIEW"]
         XCTAssertEqual(MSSQLSchemaQueries.parseTableRow(row), MSSQLTableRow(name: "v_active_users", isView: true))
@@ -103,11 +109,17 @@ final class MSSQLSchemaQueriesTests: XCTestCase {
     }
 
     func testParseForeignKeyRowExtractsAll() {
-        let row: [String?] = ["FK_orders_users", "user_id", "users", "id"]
+        let row: [String?] = ["FK_orders_users", "user_id", "users", "id", "sales"]
         let parsed = MSSQLSchemaQueries.parseForeignKeyRow(row)
         XCTAssertEqual(parsed?.constraintName, "FK_orders_users")
         XCTAssertEqual(parsed?.columnName, "user_id")
         XCTAssertEqual(parsed?.referencedTable, "users")
         XCTAssertEqual(parsed?.referencedColumn, "id")
+        XCTAssertEqual(parsed?.referencedSchema, "sales")
+    }
+
+    func testParseForeignKeyRowWithoutReferencedSchema() {
+        let row: [String?] = ["FK_orders_users", "user_id", "users", "id"]
+        XCTAssertNil(MSSQLSchemaQueries.parseForeignKeyRow(row)?.referencedSchema)
     }
 }

--- a/Plugins/MSSQLDriverPlugin/MSSQLPluginDriver+Schema.swift
+++ b/Plugins/MSSQLDriverPlugin/MSSQLPluginDriver+Schema.swift
@@ -166,37 +166,16 @@ extension MSSQLPluginDriver {
     }
 
     func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] {
-        let escapedTable = table.replacingOccurrences(of: "'", with: "''")
-        let esc = effectiveSchemaEscaped(schema)
-        let sql = """
-            SELECT
-                fk.name AS constraint_name,
-                cp.name AS column_name,
-                tr.name AS ref_table,
-                cr.name AS ref_column
-            FROM sys.foreign_keys fk
-            JOIN sys.foreign_key_columns fkc ON fk.object_id = fkc.constraint_object_id
-            JOIN sys.tables tp ON fkc.parent_object_id = tp.object_id
-            JOIN sys.schemas s ON tp.schema_id = s.schema_id
-            JOIN sys.columns cp
-                ON fkc.parent_object_id = cp.object_id AND fkc.parent_column_id = cp.column_id
-            JOIN sys.tables tr ON fkc.referenced_object_id = tr.object_id
-            JOIN sys.columns cr
-                ON fkc.referenced_object_id = cr.object_id AND fkc.referenced_column_id = cr.column_id
-            WHERE tp.name = '\(escapedTable)' AND s.name = '\(esc)'
-            ORDER BY fk.name
-            """
+        let sql = MSSQLSchemaQueries.foreignKeys(schema: schema ?? _currentSchema, table: table)
         let result = try await execute(query: sql)
         return result.rows.compactMap { row -> PluginForeignKeyInfo? in
-            guard let constraintName = row[safe: 0]?.asText,
-                  let columnName = row[safe: 1]?.asText,
-                  let refTable = row[safe: 2]?.asText,
-                  let refColumn = row[safe: 3]?.asText else { return nil }
+            guard let parsed = MSSQLSchemaQueries.parseForeignKeyRow(row.map { $0.asText }) else { return nil }
             return PluginForeignKeyInfo(
-                name: constraintName,
-                column: columnName,
-                referencedTable: refTable,
-                referencedColumn: refColumn
+                name: parsed.constraintName,
+                column: parsed.columnName,
+                referencedTable: parsed.referencedTable,
+                referencedColumn: parsed.referencedColumn,
+                referencedSchema: parsed.referencedSchema
             )
         }
     }
@@ -360,7 +339,8 @@ extension MSSQLPluginDriver {
                 fk.name AS constraint_name,
                 cp.name AS column_name,
                 tr.name AS ref_table,
-                cr.name AS ref_column
+                cr.name AS ref_column,
+                sr.name AS ref_schema
             FROM sys.foreign_keys fk
             JOIN sys.foreign_key_columns fkc ON fk.object_id = fkc.constraint_object_id
             JOIN sys.tables tp ON fkc.parent_object_id = tp.object_id
@@ -368,6 +348,7 @@ extension MSSQLPluginDriver {
             JOIN sys.columns cp
                 ON fkc.parent_object_id = cp.object_id AND fkc.parent_column_id = cp.column_id
             JOIN sys.tables tr ON fkc.referenced_object_id = tr.object_id
+            JOIN sys.schemas sr ON tr.schema_id = sr.schema_id
             JOIN sys.columns cr
                 ON fkc.referenced_object_id = cr.object_id AND fkc.referenced_column_id = cr.column_id
             WHERE s.name = '\(esc)'
@@ -385,7 +366,8 @@ extension MSSQLPluginDriver {
                 name: constraintName,
                 column: columnName,
                 referencedTable: refTable,
-                referencedColumn: refColumn
+                referencedColumn: refColumn,
+                referencedSchema: row[safe: 5]?.asText
             )
             fksByTable[tableName, default: []].append(fk)
         }

--- a/Plugins/OracleDriverPlugin/OraclePlugin.swift
+++ b/Plugins/OracleDriverPlugin/OraclePlugin.swift
@@ -448,7 +448,8 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 acc.COLUMN_NAME,
                 rc.TABLE_NAME AS REF_TABLE,
                 rcc.COLUMN_NAME AS REF_COLUMN,
-                ac.DELETE_RULE
+                ac.DELETE_RULE,
+                rc.OWNER AS REF_SCHEMA
             FROM ALL_CONSTRAINTS ac
             JOIN ALL_CONS_COLUMNS acc ON ac.CONSTRAINT_NAME = acc.CONSTRAINT_NAME
                 AND ac.OWNER = acc.OWNER
@@ -473,6 +474,7 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 column: columnName,
                 referencedTable: refTable,
                 referencedColumn: refColumn,
+                referencedSchema: row[safe: 5]?.asText,
                 onDelete: deleteRule,
                 onUpdate: "NO ACTION"
             )
@@ -600,7 +602,8 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 acc.COLUMN_NAME,
                 rc.TABLE_NAME AS REF_TABLE,
                 rcc.COLUMN_NAME AS REF_COLUMN,
-                ac.DELETE_RULE
+                ac.DELETE_RULE,
+                rc.OWNER AS REF_SCHEMA
             FROM ALL_CONSTRAINTS ac
             JOIN ALL_CONS_COLUMNS acc ON ac.CONSTRAINT_NAME = acc.CONSTRAINT_NAME
                 AND ac.OWNER = acc.OWNER
@@ -625,6 +628,7 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 column: columnName,
                 referencedTable: refTable,
                 referencedColumn: refColumn,
+                referencedSchema: row[safe: 6]?.asText,
                 onDelete: deleteRule,
                 onUpdate: "NO ACTION"
             )


### PR DESCRIPTION
## Problem

Following a foreign key (FK navigation in the data grid, FK preview) into a table that lives in a different schema opened the wrong table or failed, on SQL Server and Oracle. Found while reviewing #1754.

## Root cause

The app already plumbs a referenced schema end to end: `PluginForeignKeyInfo.referencedSchema` exists, and `PluginDriverAdapter` maps it into the app's `ForeignKeyInfo`, which FK navigation reads. But the MSSQL and Oracle FK introspection queries never selected the referenced table's owner/schema, so `referencedSchema` was always nil. FK navigation then fell back to the current schema and qualified against the wrong table.

## Fix

- MSSQL: the FK queries now select `sr.name AS ref_schema` (joining `sys.schemas` on the referenced table's `schema_id`). The single-table path was a duplicate of the unused, tested `MSSQLSchemaQueries.foreignKeys`, so it now calls that shared query and `parseForeignKeyRow` instead of inline SQL. `MSSQLForeignKeyRow` and `parseForeignKeyRow` carry `referencedSchema`.
- Oracle: the FK queries now select `rc.OWNER AS REF_SCHEMA` and map it into `referencedSchema`.

`PluginForeignKeyInfo.referencedSchema` already exists with a defaulted init parameter, so this is additive with no PluginKit ABI change.

## Tests

`TableProMSSQLCoreTests`: the FK query selects `ref_schema`, and `parseForeignKeyRow` extracts `referencedSchema` (and stays nil when the column is absent). 20 pass.

## Shipping

MSSQL and Oracle are registry-only plugins, so this reaches users after re-releasing both plugins.

## Not included: export

The export path (`ExportDataSourceAdapter`) also drops schema for non-default-schema tables, but the fix is a separate, larger change: `PluginExportTable` (a PluginKit transfer type) and the `PluginExportDataSource` protocol methods carry only `databaseName`, no per-table schema, and the adapter is already inconsistent (it uses `currentSchema` for column/FK fetch but `databaseName` for the data query). Threading a real schema through export touches the transfer-type ABI and every export plugin, so it deserves its own scoped change.

Relates to #1754

https://claude.ai/code/session_0198faM6VCrViRU4XwRoS1DC