### PR TITLE
docs: add a guide for testing a custom driver plugin locally

### DIFF
--- a/docs/development/testing-plugins.mdx
+++ b/docs/development/testing-plugins.mdx
@@ -1,0 +1,37 @@
+---
+title: Testing a Custom Plugin
+description: Run and test a third-party driver plugin in a local debug build without a code signing error
+---
+
+# Testing a Custom Plugin
+
+When you write your own driver plugin, you can run it inside a local debug build of TablePro before publishing it to the registry. Packaging the plugin and installing it like a registry plugin fails with a code signing error ("Unable to install plug-in"), because the registry install path verifies the bundle's signature. A locally-built plugin is unsigned, so that path rejects it.
+
+The fix is to copy the plugin into the app at build time. A plugin bundled into the **Copy Plug-Ins** build phase runs under the debug build's own signature, so the signature check passes and the plugin loads.
+
+## Steps
+
+<Steps>
+  <Step title="Add the plugin to Copy Plug-Ins">
+    In Xcode, select the **TablePro** target, open the **Build Phases** tab, and add your `.tableplugin` bundle to the **Copy Plug-Ins** phase.
+  </Step>
+  <Step title="Run the app">
+    Press `Cmd+R` to build and run. See [Building](/development/building) for the `-skipPackagePluginValidation` requirement on command-line builds.
+  </Step>
+  <Step title="Test the plugin">
+    The plugin loads with the app. Create a connection for your database type and confirm the driver works.
+  </Step>
+  <Step title="Remove it after testing">
+    Once the plugin works, remove it from the **Copy Plug-Ins** phase so it does not ride into a release build.
+  </Step>
+</Steps>
+
+<Note>
+Keep the plugin in **Copy Plug-Ins** only while you are testing. Release builds distribute plugins through the [Plugin Registry](/development/plugin-registry), where every binary is signed.
+</Note>
+
+## Why the signing error happens
+
+Plugins installed from the registry are signed, and TablePro verifies that signature before loading them. A plugin you just built locally has no such signature, so the registry install path reports "Unable to install plug-in." Copying the plugin into the **Copy Plug-Ins** build phase sidesteps that path: the plugin ships inside the debug app bundle and runs under the build's signature, which is enough to load and test it.
+
+When the plugin is ready to ship, publish it through the registry so users receive a signed binary. See [Plugin Registry](/development/plugin-registry) for the manifest format and publishing flow.

--- a/docs/development/testing-plugins.mdx
+++ b/docs/development/testing-plugins.mdx
@@ -5,9 +5,9 @@ description: Run and test a third-party driver plugin in a local debug build wit
 
 # Testing a Custom Plugin
 
-When you write your own driver plugin, you can run it inside a local debug build of TablePro before publishing it to the registry. Packaging the plugin and installing it like a registry plugin fails with a code signing error ("Unable to install plug-in"), because the registry install path verifies the bundle's signature. A locally-built plugin is unsigned, so that path rejects it.
+When you write your own driver plugin, you can run it inside a local debug build of TablePro before publishing it to the registry. If you package the plugin and install it the way the app installs a registry plugin, it fails with "Unable to install plug-in." The install path only accepts plugins signed by TablePro's signing team, and a plugin you just built locally is not signed by it.
 
-The fix is to copy the plugin into the app at build time. A plugin bundled into the **Copy Plug-Ins** build phase runs under the debug build's own signature, so the signature check passes and the plugin loads.
+The way around this is to let the plugin ship inside the app bundle instead of installing it as a user plugin. Add it to the **Copy Plug-Ins** build phase, then run the app. Plugins that live inside the app bundle load as built-in plugins, which are not put through the signature check.
 
 ## Steps
 
@@ -32,6 +32,17 @@ Keep the plugin in **Copy Plug-Ins** only while you are testing. Release builds 
 
 ## Why the signing error happens
 
-Plugins installed from the registry are signed, and TablePro verifies that signature before loading them. A plugin you just built locally has no such signature, so the registry install path reports "Unable to install plug-in." Copying the plugin into the **Copy Plug-Ins** build phase sidesteps that path: the plugin ships inside the debug app bundle and runs under the build's signature, which is enough to load and test it.
+TablePro loads plugins from two locations, and treats them differently:
+
+- **Inside the app bundle** (`PlugIns/`): loaded as built-in plugins. No signature check runs.
+- **In the user plugins directory**: loaded as user-installed plugins. Each one must be signed by TablePro's signing team, or it is rejected.
+
+Installing a plugin from the registry, or packaging your own to install the same way, goes through the user-installed path. A plugin you built locally does not carry TablePro's signature, so that path rejects it with "Unable to install plug-in."
+
+Adding the plugin to **Copy Plug-Ins** avoids the check on two counts. The plugin lands in the app's `PlugIns/` directory, so it loads as a built-in plugin and the user-install signature check never runs. The phase also re-signs the plugin with the debug build's own signing identity (`CodeSignOnCopy`) as it copies it in.
+
+## Alternative: allow unsigned user plugins
+
+If you would rather keep developing the plugin from the user plugins directory, a debug build skips the signature check when the `TABLEPRO_ALLOW_UNSIGNED_PLUGINS` environment variable is set to `1`. Set it under **Product > Scheme > Edit Scheme > Run > Arguments**. This works in debug builds only. Release builds always verify the signature.
 
 When the plugin is ready to ship, publish it through the registry so users receive a signed binary. See [Plugin Registry](/development/plugin-registry) for the manifest format and publishing flow.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -187,7 +187,8 @@
               "development/architecture",
               "development/building",
               "development/code-style",
-              "development/plugin-registry"
+              "development/plugin-registry",
+              "development/testing-plugins"
             ]
           }
         ]


### PR DESCRIPTION
## What

Adds a Development docs page, `Testing a Custom Plugin`, covering how to run and test a third-party driver plugin in a local debug build.

## Why

In #1747 a plugin author wrote their own driver and hit a code signing error ("Unable to install plug-in") when trying to package and install it like a registry plugin. The maintainer answered with the workflow but it wasn't documented anywhere: the existing Development pages cover `building`, `architecture`, and `plugin-registry`, but none explain how to develop and locally test a brand-new plugin without hitting the signing wall.

## Changes

- New page `docs/development/testing-plugins.mdx`: add the plugin to the **Copy Plug-Ins** build phase of the TablePro target, `Cmd+R` to run and test, then remove it from Copy Plug-Ins for a clean release build. Includes a short explanation of why the signing error happens (registry plugins are signed and verified; a locally-built plugin runs under the debug build's signature). Links to the existing Building and Plugin Registry pages rather than duplicating their content.
- `docs/docs.json`: register the page in the Development group, right after `development/plugin-registry`.

Docs-only change. No code or CHANGELOG entry per the docs-only rule.

Fixes #1747
