### PR TITLE
test(datagrid): isolate header title-rect padding test from the value-filter funnel

### DIFF
--- a/TableProTests/Views/Results/SortableHeaderCellTests.swift
+++ b/TableProTests/Views/Results/SortableHeaderCellTests.swift
@@ -9,6 +9,7 @@ struct SortableHeaderCellTests {
     @Test("Title rect uses data cell horizontal padding")
     func titleRectUsesDataCellHorizontalPadding() {
         let cell = SortableHeaderCell(textCell: "id")
+        cell.supportsValueFilter = false
         let titleRect = cell.titleRect(forBounds: NSRect(x: 10, y: 0, width: 100, height: 24))
 
         #expect(titleRect.minX == 14)


### PR DESCRIPTION
## Problem

`macOS App Tests` has been red on `main` since #1756, failing only `SortableHeaderCellTests`:

```
"Title rect uses data cell horizontal padding" — (titleRect.width → 69.0) == (92 → 92.0)
```

Every PR branched off `main` inherits the red job (e.g. #1758, #1760), even when its own changes are unrelated and its other test jobs pass.

## Root cause

#1756 added the per-column value filter, giving `SortableHeaderCell` a funnel and a default `supportsValueFilter = true`. `titleRect(forBounds:)` now subtracts `reservedTrailingWidth()`, which reserves the funnel width (13) + spacing (2) + padding (8) = 23pt when the filter is supported. So for a 100pt-wide bounds the title rect is `100 − 8 − 23 = 69`, not 92.

The test builds a default cell (funnel on) but still asserts the old no-funnel width of 92, so it fails deterministically. Real data columns keep `supportsValueFilter = true`; only the row-number column sets it false.

## Fix

The test's purpose is the horizontal padding (the left inset and the `minX == 14` / width assertions), not the funnel, so it now sets `supportsValueFilter = false` to isolate that. Width is `100 − 8 = 92` again. Funnel and indicator reservation are already covered by the sibling tests in the same suite.

Test-only change, no user-facing behavior, so no CHANGELOG entry.

https://claude.ai/code/session_0198faM6VCrViRU4XwRoS1DC