### PR TITLE
fix(concurrency): resolve Swift concurrency warnings

### DIFF
--- a/TablePro/Core/Services/SQL/SQLFolderWatcher.swift
+++ b/TablePro/Core/Services/SQL/SQLFolderWatcher.swift
@@ -141,27 +141,17 @@ internal final class SQLFolderWatcher {
             return
         }
 
-        guard let enumerator = fileManager.enumerator(
-            at: folderURL,
-            includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey, .fileSizeKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            return
-        }
-
         var indexed: [LinkedSQLIndex.IndexedFile] = []
 
-        for case let url as URL in enumerator {
-            guard SQLFileService.supportedExtensions.contains(url.pathExtension.lowercased()) else { continue }
-
+        enumerateSQLFileURLs(in: folderURL, fileManager: fileManager) { url in
             let resourceValues = try? url.resourceValues(forKeys: [
                 .isRegularFileKey, .contentModificationDateKey, .fileSizeKey
             ])
-            guard resourceValues?.isRegularFile == true else { continue }
+            guard resourceValues?.isRegularFile == true else { return }
             let mtime = resourceValues?.contentModificationDate ?? Date()
             let fileSize = Int64(resourceValues?.fileSize ?? 0)
 
-            guard let relativePath = relativePathFor(url: url, base: folderURL) else { continue }
+            guard let relativePath = relativePathFor(url: url, base: folderURL) else { return }
             let header = FileTextLoader.loadHeader(url)
             let metadata = header.map { SQLFrontmatter.parse($0.content) } ?? SQLFrontmatter.Metadata()
             let encoding = header?.encoding ?? .utf8
@@ -182,6 +172,25 @@ internal final class SQLFolderWatcher {
         }
 
         await LinkedSQLIndex.shared.replaceAll(folderId: folder.id, files: indexed, folderURL: folderURL)
+    }
+
+    private static func enumerateSQLFileURLs(
+        in folderURL: URL,
+        fileManager: FileManager,
+        handle: (URL) -> Void
+    ) {
+        guard let enumerator = fileManager.enumerator(
+            at: folderURL,
+            includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey, .fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return
+        }
+
+        for case let url as URL in enumerator {
+            guard SQLFileService.supportedExtensions.contains(url.pathExtension.lowercased()) else { continue }
+            handle(url)
+        }
     }
 
     private static func pruneRemovedFolders(stillKnownIds: Set<UUID>) async {

--- a/TablePro/ViewModels/WelcomeViewModel.swift
+++ b/TablePro/ViewModels/WelcomeViewModel.swift
@@ -163,7 +163,11 @@ final class WelcomeViewModel {
 
     // MARK: - Initialization
 
-    init(services: AppServices = .live) {
+    convenience init() {
+        self.init(services: .live)
+    }
+
+    init(services: AppServices) {
         self.services = services
         self.showOnboarding = !services.appSettingsStorage.hasCompletedOnboarding()
     }

--- a/TablePro/Views/Components/SQLReviewSheet.swift
+++ b/TablePro/Views/Components/SQLReviewSheet.swift
@@ -87,7 +87,7 @@ struct SQLReviewSheet: View {
         return build(statements: statements, isJavaScript: isJavaScript)
     }
 
-    private nonisolated static func build(statements: [String], isJavaScript: Bool) -> Prepared {
+    nonisolated private static func build(statements: [String], isJavaScript: Bool) -> Prepared {
         var full = statements
             .map { $0.hasSuffix(";") ? $0 : $0 + ";" }
             .joined(separator: "\n\n")
@@ -95,16 +95,17 @@ struct SQLReviewSheet: View {
             full = convertExtendedJsonToShellSyntax(full)
         }
 
-        let fullCount = full.count
+        let nsFull = full as NSString
+        let fullCount = nsFull.length
         if fullCount > maxDisplayChars {
-            let head = full.prefix(maxDisplayChars)
+            let head = nsFull.substring(to: maxDisplayChars)
             let remaining = fullCount - maxDisplayChars
             let note = String(
                 format: String(localized: "-- … %d more characters not shown; use Copy All for the full output."),
                 remaining
             )
             return Prepared(
-                display: String(head) + "\n\n" + note,
+                display: head + "\n\n" + note,
                 full: full,
                 mode: .truncated
             )

--- a/TablePro/Views/Components/SQLReviewSheet.swift
+++ b/TablePro/Views/Components/SQLReviewSheet.swift
@@ -33,9 +33,9 @@ struct SQLReviewSheet: View {
     }
 
     /// Past this many characters the display is truncated; the full text stays available via Copy All.
-    static let maxDisplayChars = 20_000
+    nonisolated static let maxDisplayChars = 20_000
     /// Past this many characters tree-sitter is skipped in favour of a plain monospaced view.
-    static let treeSitterCutoff = 8_000
+    nonisolated static let treeSitterCutoff = 8_000
 
     var body: some View {
         VStack(spacing: 0) {
@@ -75,18 +75,23 @@ struct SQLReviewSheet: View {
 
     private func prepare() async {
         guard prepared == nil, !statements.isEmpty else { return }
-        let result = await Task.detached(priority: .userInitiated) { [statements, databaseType] in
-            Self.build(statements: statements, databaseType: databaseType)
+        let isJavaScript = PluginManager.shared.editorLanguage(for: databaseType) == .javascript
+        let result = await Task.detached(priority: .userInitiated) { [statements, isJavaScript] in
+            Self.build(statements: statements, isJavaScript: isJavaScript)
         }.value
         prepared = result
     }
 
     static func build(statements: [String], databaseType: DatabaseType) -> Prepared {
-        let isJS = PluginManager.shared.editorLanguage(for: databaseType) == .javascript
+        let isJavaScript = PluginManager.shared.editorLanguage(for: databaseType) == .javascript
+        return build(statements: statements, isJavaScript: isJavaScript)
+    }
+
+    private nonisolated static func build(statements: [String], isJavaScript: Bool) -> Prepared {
         var full = statements
             .map { $0.hasSuffix(";") ? $0 : $0 + ";" }
             .joined(separator: "\n\n")
-        if isJS {
+        if isJavaScript {
             full = convertExtendedJsonToShellSyntax(full)
         }
 
@@ -112,7 +117,7 @@ struct SQLReviewSheet: View {
         )
     }
 
-    static func convertExtendedJsonToShellSyntax(_ mql: String) -> String {
+    nonisolated static func convertExtendedJsonToShellSyntax(_ mql: String) -> String {
         let pattern = #"\{"\$oid":\s*"([0-9a-fA-F]{24})"\}"#
         guard let regex = try? NSRegularExpression(pattern: pattern) else { return mql }
         let nsString = mql as NSString

--- a/TablePro/Views/Connection/ImportFromApp/ImportFromAppSourcePicker.swift
+++ b/TablePro/Views/Connection/ImportFromApp/ImportFromAppSourcePicker.swift
@@ -164,11 +164,10 @@ struct ImportFromAppSourcePicker: View {
     private func loadStates() {
         Task.detached(priority: .userInitiated) {
             let importers = ForeignAppImporterRegistry.all
-            var states: [(importer: any ForeignAppImporter, available: Bool, count: Int)] = []
-            for importer in importers {
+            let states: [(importer: any ForeignAppImporter, available: Bool, count: Int)] = importers.map { importer in
                 let available = importer.isAvailable()
                 let count = available ? importer.connectionCount() : 0
-                states.append((importer: importer, available: available, count: count))
+                return (importer: importer, available: available, count: count)
             }
             await MainActor.run {
                 importerStates = states


### PR DESCRIPTION
## Summary
Swift concurrency checks no longer flag these app paths for detached-task capture, main-actor default arguments, or non-Sendable filesystem enumeration. SQL review preparation now resolves actor-isolated plugin metadata before leaving the main actor, while detached work only formats already-derived values.

The SQL folder watcher keeps synchronous filesystem enumeration out of async scanning, the import picker publishes an immutable importer-state snapshot back to the main actor, and `WelcomeViewModel` preserves its production initializer behavior without a main actor-isolated default parameter.

## Testing
- `env -u CPATH -u CPLUS_INCLUDE_PATH -u C_INCLUDE_PATH -u LIBRARY_PATH -u CPPFLAGS -u CFLAGS -u CXXFLAGS -u LDFLAGS xcodebuild -project TablePro.xcodeproj -scheme TablePro -configuration Debug -destination platform=macOS,arch=arm64 -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO build`
- `env -u CPATH -u CPLUS_INCLUDE_PATH -u C_INCLUDE_PATH -u LIBRARY_PATH -u CPPFLAGS -u CFLAGS -u CXXFLAGS -u LDFLAGS xcodebuild -project TablePro.xcodeproj -scheme TablePro -configuration Debug -destination platform=macOS,arch=arm64 -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO test -only-testing:TableProTests/SQLReviewSheetTests -only-testing:TableProTests/WelcomeViewModelTests`
- `git diff --check`

Not run: `swiftlint` and `swiftformat`, because neither tool is installed in this environment.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This is a compile-time Swift concurrency cleanup with no expected runtime behavior change; the macOS Debug build and targeted tests are the validation signal.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
