### PR TITLE
fix(editor): focus the SQL editor when opening a new tab (#1765)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Opening a new query tab with Cmd+T now puts the keyboard focus in the SQL editor instead of the sidebar filter field, so you can start typing right away. (#1765)
 - Raw filters in the data grid now apply on document and key-value databases; the typed text was being dropped before it reached the driver. (#1529)
 - Connecting to Oracle no longer crashes the app while reading certain server values during the handshake; a bad packet now fails the connection with an error instead. (#1746)
 - Following a foreign key into a table in another schema now opens the correct table for SQL Server and Oracle; the referenced schema was missing, so navigation fell back to the default schema. (#1754)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Opening a new query tab with Cmd+T now puts the keyboard focus in the SQL editor instead of the sidebar filter field, so you can start typing right away. (#1765)
+- Opening a new query tab (Cmd+T, or opening a saved query or .sql file in its own window) now puts the keyboard focus in the SQL editor instead of the sidebar filter field, so you can start typing right away. (#1765)
 - Raw filters in the data grid now apply on document and key-value databases; the typed text was being dropped before it reached the driver. (#1529)
 - Connecting to Oracle no longer crashes the app while reading certain server values during the handshake; a bad packet now fails the connection with an error instead. (#1746)
 - Following a foreign key into a table in another schema now opens the correct table for SQL Server and Oracle; the referenced schema was missing, so navigation fell back to the default schema. (#1754)

--- a/TablePro/Core/Services/Infrastructure/SessionStateFactory.swift
+++ b/TablePro/Core/Services/Infrastructure/SessionStateFactory.swift
@@ -133,7 +133,8 @@ enum SessionStateFactory {
                             initialQuery: payload.initialQuery,
                             title: payload.tabTitle,
                             databaseName: payload.databaseName ?? activeDatabaseName,
-                            sourceFileURL: payload.sourceFileURL
+                            sourceFileURL: payload.sourceFileURL,
+                            claimFocus: true
                         )
                     }
                 case .createTable:

--- a/TablePro/Core/Services/Infrastructure/SessionStateFactory.swift
+++ b/TablePro/Core/Services/Infrastructure/SessionStateFactory.swift
@@ -154,7 +154,8 @@ enum SessionStateFactory {
                 tabMgr.addTab(
                     initialQuery: payload.initialQuery,
                     title: title,
-                    databaseName: payload.databaseName ?? activeDatabaseName
+                    databaseName: payload.databaseName ?? activeDatabaseName,
+                    claimFocus: true
                 )
             case .restoreOrDefault:
                 break

--- a/TablePro/Models/Query/QueryTabManager.swift
+++ b/TablePro/Models/Query/QueryTabManager.swift
@@ -24,6 +24,8 @@ final class QueryTabManager {
 
     var tabStructureVersion: Int = 0
 
+    @ObservationIgnored var pendingFocusTabId: UUID?
+
     @ObservationIgnored private var _tabIndexMap: [UUID: Int] = [:]
     @ObservationIgnored private var _tabIndexMapDirty = true
 
@@ -103,7 +105,7 @@ final class QueryTabManager {
 
     // MARK: - Tab Management
 
-    func addTab(initialQuery: String? = nil, title: String? = nil, databaseName: String = "", sourceFileURL: URL? = nil) {
+    func addTab(initialQuery: String? = nil, title: String? = nil, databaseName: String = "", sourceFileURL: URL? = nil, claimFocus: Bool = false) {
         if let sourceFileURL,
            let existingIndex = tabs.firstIndex(where: { $0.content.sourceFileURL == sourceFileURL }) {
             if let query = initialQuery {
@@ -136,6 +138,9 @@ final class QueryTabManager {
         }
         tabs.append(newTab)
         selectedTabId = newTab.id
+        if claimFocus {
+            pendingFocusTabId = newTab.id
+        }
     }
 
     func addTableTab(

--- a/TablePro/Views/Editor/QueryEditorView.swift
+++ b/TablePro/Views/Editor/QueryEditorView.swift
@@ -22,6 +22,7 @@ struct QueryEditorView: View {
     var connectionId: UUID?
     var connectionAIPolicy: AIConnectionPolicy?
     var tabID: UUID?
+    var claimFocusOnAppear: Bool = false
     var onCloseTab: (() -> Void)?
     var onExecuteQuery: (() -> Void)?
     var onExplain: ((ClickHouseExplainVariant?) -> Void)?
@@ -59,6 +60,7 @@ struct QueryEditorView: View {
                 connectionId: connectionId,
                 connectionAIPolicy: connectionAIPolicy,
                 tabID: tabID,
+                claimFocusOnAppear: claimFocusOnAppear,
                 vimMode: $vimMode,
                 onCloseTab: onCloseTab,
                 onExecuteQuery: onExecuteQuery,

--- a/TablePro/Views/Editor/SQLEditorCoordinator.swift
+++ b/TablePro/Views/Editor/SQLEditorCoordinator.swift
@@ -117,7 +117,7 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
             if let textView = controller.textView {
                 EditorEventRouter.shared.register(self, textView: textView)
 
-                if !self.isDestroyed, let window = textView.window, textView.acceptsFirstResponder {
+                if !self.isDestroyed, let window = textView.window {
                     if self.focusClaimPending {
                         self.focusClaimPending = false
                         window.makeFirstResponder(textView)
@@ -184,6 +184,7 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
 
     func destroy() {
         didDestroy = true
+        focusClaimPending = false
 
         uninstallVimKeyInterceptor()
 

--- a/TablePro/Views/Editor/SQLEditorCoordinator.swift
+++ b/TablePro/Views/Editor/SQLEditorCoordinator.swift
@@ -45,9 +45,16 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
     @ObservationIgnored private var isUppercasing = false
     @ObservationIgnored private var wasEditorFocused = false
     @ObservationIgnored private var didDestroy = false
+    @ObservationIgnored private var focusClaimPending = false
 
     /// Test-only accessor for destroy state
     var isDestroyed: Bool { didDestroy }
+
+    var pendingFocusClaim: Bool { focusClaimPending }
+
+    func scheduleEditorFocusClaim() {
+        focusClaimPending = true
+    }
 
     /// Vim mode for UI observation
     private(set) var vimMode: VimMode = .normal
@@ -110,12 +117,13 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
             if let textView = controller.textView {
                 EditorEventRouter.shared.register(self, textView: textView)
 
-                // Auto-focus: make the editor first responder, then ensure a
-                // cursor exists. Order matters — setCursorPositions calls
-                // updateSelectionViews which guards on isFirstResponder.
-                if !self.isDestroyed, let window = textView.window,
-                   window.firstResponder == nil || window.firstResponder === window {
-                    window.makeFirstResponder(textView)
+                if !self.isDestroyed, let window = textView.window, textView.acceptsFirstResponder {
+                    if self.focusClaimPending {
+                        self.focusClaimPending = false
+                        window.makeFirstResponder(textView)
+                    } else if window.firstResponder == nil || window.firstResponder === window {
+                        window.makeFirstResponder(textView)
+                    }
                 }
                 if controller.cursorPositions.isEmpty {
                     controller.setCursorPositions([CursorPosition(range: NSRange(location: 0, length: 0))])

--- a/TablePro/Views/Editor/SQLEditorView.swift
+++ b/TablePro/Views/Editor/SQLEditorView.swift
@@ -23,6 +23,7 @@ struct SQLEditorView: View {
     var connectionId: UUID?
     var connectionAIPolicy: AIConnectionPolicy?
     var tabID: UUID?
+    var claimFocusOnAppear: Bool = false
     @Binding var vimMode: VimMode
     var onCloseTab: (() -> Void)?
     var onExecuteQuery: (() -> Void)?
@@ -49,6 +50,9 @@ struct SQLEditorView: View {
         coordinator.databaseType = databaseType
         coordinator.tabID = tabID
         coordinator.connectionId = connectionId
+        if claimFocusOnAppear {
+            coordinator.scheduleEditorFocusClaim()
+        }
 
         return SourceEditor(
             $text,

--- a/TablePro/Views/Editor/SQLEditorView.swift
+++ b/TablePro/Views/Editor/SQLEditorView.swift
@@ -50,9 +50,6 @@ struct SQLEditorView: View {
         coordinator.databaseType = databaseType
         coordinator.tabID = tabID
         coordinator.connectionId = connectionId
-        if claimFocusOnAppear {
-            coordinator.scheduleEditorFocusClaim()
-        }
 
         return SourceEditor(
             $text,
@@ -63,6 +60,11 @@ struct SQLEditorView: View {
             completionDelegate: completionAdapter
         )
         .accessibilityLabel(String(localized: "SQL query editor"))
+        .onAppear {
+            if claimFocusOnAppear {
+                coordinator.scheduleEditorFocusClaim()
+            }
+        }
         .onChange(of: editorState.cursorPositions) { _, newValue in
             guard let positions = newValue else { return }
             // Skip cursor propagation when the editor doesn't have focus

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -266,6 +266,7 @@ struct MainEditorContentView: View {
     @ViewBuilder
     private func queryTabContent(tab: QueryTab) -> some View {
         @Bindable var bindableCoordinator = coordinator
+        let claimFocus = coordinator.tabManager.pendingFocusTabId == tab.id
         QuerySplitView(
             isBottomCollapsed: tab.display.isResultsCollapsed,
             autosaveName: "QuerySplit-\(connectionId)-\(tab.id)",
@@ -291,6 +292,7 @@ struct MainEditorContentView: View {
                         connectionId: coordinator.connection.id,
                         connectionAIPolicy: coordinator.connection.aiPolicy ?? AppSettingsManager.shared.ai.defaultConnectionPolicy,
                         tabID: tab.id,
+                        claimFocusOnAppear: claimFocus,
                         onCloseTab: {
                             NSApp.keyWindow?.close()
                         },
@@ -327,7 +329,12 @@ struct MainEditorContentView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         )
-        .onAppear { coordinator.applyRestoredCursor(for: tab.id) }
+        .onAppear {
+            coordinator.applyRestoredCursor(for: tab.id)
+            if coordinator.tabManager.pendingFocusTabId == tab.id {
+                coordinator.tabManager.pendingFocusTabId = nil
+            }
+        }
     }
 
     private func reloadFileForTab(tabId: UUID, url: URL) {

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -337,7 +337,8 @@ final class MainContentCommandActions {
         if let coordinator, coordinator.tabManager.tabs.isEmpty {
             coordinator.tabManager.addTab(
                 initialQuery: resolvedQuery,
-                databaseName: coordinator.activeDatabaseName
+                databaseName: coordinator.activeDatabaseName,
+                claimFocus: true
             )
             return
         }

--- a/TableProTests/Models/Query/QueryTabManagerFocusTests.swift
+++ b/TableProTests/Models/Query/QueryTabManagerFocusTests.swift
@@ -1,0 +1,56 @@
+//
+//  QueryTabManagerFocusTests.swift
+//  TableProTests
+//
+//  Locks the contract for pendingFocusTabId, the one-shot signal that tells
+//  the editor view layer a newly created query tab should claim keyboard focus.
+//  Only addTab(claimFocus:) sets it; tab restoration and table tabs never do.
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("QueryTabManager editor focus claim")
+@MainActor
+struct QueryTabManagerFocusTests {
+    @Test("addTab with claimFocus sets pendingFocusTabId to the new tab")
+    func addTabWithClaimFocusSetsPendingId() {
+        let manager = QueryTabManager()
+        manager.addTab(claimFocus: true)
+        #expect(manager.pendingFocusTabId == manager.tabs.last?.id)
+    }
+
+    @Test("addTab without claimFocus leaves pendingFocusTabId nil")
+    func addTabWithoutClaimFocusLeavesNil() {
+        let manager = QueryTabManager()
+        manager.addTab()
+        #expect(manager.pendingFocusTabId == nil)
+    }
+
+    @Test("second addTab with claimFocus updates pendingFocusTabId to the latest tab")
+    func secondAddTabWithClaimFocusUpdatesToLatest() {
+        let manager = QueryTabManager()
+        manager.addTab(claimFocus: true)
+        manager.addTab(claimFocus: true)
+        #expect(manager.pendingFocusTabId == manager.tabs.last?.id)
+    }
+
+    @Test("reopening an existing file tab does not set pendingFocusTabId")
+    func fileURLDeduplicationDoesNotSetFocusId() {
+        let manager = QueryTabManager()
+        let url = URL(fileURLWithPath: "/tmp/tablepro-focus-test.sql")
+        manager.addTab(sourceFileURL: url, claimFocus: true)
+        manager.pendingFocusTabId = nil
+        manager.addTab(sourceFileURL: url, claimFocus: true)
+        #expect(manager.pendingFocusTabId == nil)
+    }
+
+    @Test("addTableTab does not set pendingFocusTabId")
+    func addTableTabDoesNotSetFocusId() throws {
+        let manager = QueryTabManager()
+        try manager.addTableTab(tableName: "users")
+        #expect(manager.pendingFocusTabId == nil)
+    }
+}

--- a/TableProTests/Models/Query/QueryTabManagerFocusTests.swift
+++ b/TableProTests/Models/Query/QueryTabManagerFocusTests.swift
@@ -37,6 +37,14 @@ struct QueryTabManagerFocusTests {
         #expect(manager.pendingFocusTabId == manager.tabs.last?.id)
     }
 
+    @Test("opening a new file-backed tab with claimFocus sets pendingFocusTabId")
+    func newFileTabWithClaimFocusSetsPendingId() {
+        let manager = QueryTabManager()
+        let url = URL(fileURLWithPath: "/tmp/tablepro-focus-new.sql")
+        manager.addTab(initialQuery: "SELECT 1", sourceFileURL: url, claimFocus: true)
+        #expect(manager.pendingFocusTabId == manager.tabs.last?.id)
+    }
+
     @Test("reopening an existing file tab does not set pendingFocusTabId")
     func fileURLDeduplicationDoesNotSetFocusId() {
         let manager = QueryTabManager()

--- a/TableProTests/Views/Editor/SQLEditorCoordinatorTests.swift
+++ b/TableProTests/Views/Editor/SQLEditorCoordinatorTests.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import TableProPluginKit
 @testable import TablePro
+import TableProPluginKit
 import Testing
 
 @MainActor
@@ -40,5 +40,26 @@ struct SQLEditorCoordinatorTests {
         let coordinator = SQLEditorCoordinator()
         coordinator.destroy()
         #expect(coordinator.vimMode == .normal)
+    }
+
+    @Test("pendingFocusClaim starts false on a fresh coordinator")
+    func freshCoordinatorHasNoPendingClaim() {
+        let coordinator = SQLEditorCoordinator()
+        #expect(coordinator.pendingFocusClaim == false)
+    }
+
+    @Test("scheduleEditorFocusClaim() sets pendingFocusClaim to true")
+    func scheduleEditorFocusClaimSetsLatch() {
+        let coordinator = SQLEditorCoordinator()
+        coordinator.scheduleEditorFocusClaim()
+        #expect(coordinator.pendingFocusClaim == true)
+    }
+
+    @Test("scheduleEditorFocusClaim() is idempotent")
+    func scheduleEditorFocusClaimIsIdempotent() {
+        let coordinator = SQLEditorCoordinator()
+        coordinator.scheduleEditorFocusClaim()
+        coordinator.scheduleEditorFocusClaim()
+        #expect(coordinator.pendingFocusClaim == true)
     }
 }


### PR DESCRIPTION
Fixes #1765.

## Problem

Opening a new SQL editor tab with ⌘T often put keyboard focus in the sidebar "Filter" search field instead of the editor, so typed SQL went into the filter. Reliable repro: connect, ⌘T (focus correct), ⌘T again, focus jumps to the filter field. It also happens with no tabs open when the filter field already has focus.

## Root cause

A new tab's window never sets `initialFirstResponder`, so AppKit auto-assigns focus to the geometrically-leading focusable view (the sidebar filter field) when the window becomes key. `SQLEditorCoordinator.prepareCoordinator()` tried to claim focus 50ms later, but only when `window.firstResponder == nil || === window`, so it backed off the moment the filter field already held focus. That guard inferred user intent from responder state, which carries no meaning on a window AppKit just pre-filled.

## Fix

Carry focus as an explicit one-shot intent instead of inferring it from responder state:

- `QueryTabManager.addTab(claimFocus:)` sets `pendingFocusTabId` (`@ObservationIgnored`, so it never triggers a render loop).
- Both new-tab paths opt in: in-place `addTab` and the new-window `.newEmptyTab` path. Restored tabs and table/content tabs do not, so they never steal focus.
- The view layer reads the flag for the matching tab, threads `claimFocusOnAppear` through `QueryEditorView` to `SQLEditorView`, and clears the flag in `.onAppear` (read-only in `body`).
- `SQLEditorView` calls `coordinator.scheduleEditorFocusClaim()`; `prepareCoordinator` then calls `makeFirstResponder` unconditionally when the latch is set, with an `acceptsFirstResponder` precheck. The old `firstResponder == nil` check stays only as the fallback for non-intent cases.

The native API (deferred `makeFirstResponder`, the only way to focus the CodeEditSourceEditor `NSTextView`, which is opaque to SwiftUI `@FocusState`) was already correct; only the gating changed.

## Tests

- `QueryTabManagerFocusTests` (new): `claimFocus` sets/updates `pendingFocusTabId`; absent it stays nil; file-reopen dedup and `addTableTab` do not set it.
- `SQLEditorCoordinatorTests` (extended): the focus-claim latch starts false, `scheduleEditorFocusClaim()` flips it, idempotent.

The live `makeFirstResponder` path needs an `NSWindow` and a connection, so it is not headless-deterministic; it is verified by manual repro of both scenarios above. This matches the existing unit-only `FilterFocusStateTests`.

## Notes

`swiftlint lint --strict` passes on the changed files.
