### PR TITLE
fix(editor): focus new editor tab on cold start (#1765)

### DIFF
--- a/TablePro/Views/Editor/SQLEditorCoordinator.swift
+++ b/TablePro/Views/Editor/SQLEditorCoordinator.swift
@@ -54,6 +54,7 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
 
     func scheduleEditorFocusClaim() {
         focusClaimPending = true
+        Self.logger.debug("Editor focus claim armed")
     }
 
     /// Vim mode for UI observation
@@ -118,12 +119,18 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
                 EditorEventRouter.shared.register(self, textView: textView)
 
                 if !self.isDestroyed, let window = textView.window {
-                    if self.focusClaimPending {
+                    let claimPending = self.focusClaimPending
+                    let responderName = window.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
+                    var made = false
+                    if claimPending {
                         self.focusClaimPending = false
-                        window.makeFirstResponder(textView)
+                        made = window.makeFirstResponder(textView)
                     } else if window.firstResponder == nil || window.firstResponder === window {
-                        window.makeFirstResponder(textView)
+                        made = window.makeFirstResponder(textView)
                     }
+                    Self.logger.debug("Editor focus claim: pending=\(claimPending) isKey=\(window.isKeyWindow) responderBefore=\(responderName, privacy: .public) made=\(made)")
+                } else {
+                    Self.logger.debug("Editor focus claim skipped: hasWindow=\(textView.window != nil) destroyed=\(self.isDestroyed) pending=\(self.focusClaimPending)")
                 }
                 if controller.cursorPositions.isEmpty {
                     controller.setCursorPositions([CursorPosition(range: NSRange(location: 0, length: 0))])

--- a/TablePro/Views/Editor/SQLEditorCoordinator.swift
+++ b/TablePro/Views/Editor/SQLEditorCoordinator.swift
@@ -54,7 +54,6 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
 
     func scheduleEditorFocusClaim() {
         focusClaimPending = true
-        Self.logger.debug("Editor focus claim armed")
     }
 
     /// Vim mode for UI observation

--- a/TablePro/Views/Editor/SQLEditorView.swift
+++ b/TablePro/Views/Editor/SQLEditorView.swift
@@ -50,6 +50,9 @@ struct SQLEditorView: View {
         coordinator.databaseType = databaseType
         coordinator.tabID = tabID
         coordinator.connectionId = connectionId
+        if claimFocusOnAppear {
+            coordinator.scheduleEditorFocusClaim()
+        }
 
         return SourceEditor(
             $text,
@@ -60,11 +63,6 @@ struct SQLEditorView: View {
             completionDelegate: completionAdapter
         )
         .accessibilityLabel(String(localized: "SQL query editor"))
-        .onAppear {
-            if claimFocusOnAppear {
-                coordinator.scheduleEditorFocusClaim()
-            }
-        }
         .onChange(of: editorState.cursorPositions) { _, newValue in
             guard let positions = newValue else { return }
             // Skip cursor propagation when the editor doesn't have focus


### PR DESCRIPTION
Follow-up to #1766 (merged). On the first ⌘T after a cold app launch the new editor still didn't get keyboard focus (first line was highlighted but no caret); you had to click into the editor once, after which later new tabs focused correctly.

## Root cause

In #1766 the focus-claim latch was armed from `SQLEditorView`'s `.onAppear`. `prepareCoordinator` claims focus from a 50ms-deferred task that starts during `makeNSView`, which runs **before** `.onAppear`. On a warm app the view appears within 50ms so the latch is armed in time; on a cold first launch the view appears later than 50ms, so the deferred task runs first, sees no pending claim, falls through to the old `firstResponder == nil` branch, and the sidebar filter (auto-assigned first responder on a fresh window) keeps focus.

## Fix

Arm the latch in `body` again, which runs synchronously before `makeNSView` starts the deferred task, so `focusClaimPending` is always set before it's read, regardless of cold/warm timing. Arming via the one-shot `scheduleEditorFocusClaim()` (which only ever sets the flag true, cleared on consume or `destroy()`) means a body re-render can't clear it early.

Also added OSLog instrumentation under `com.TablePro / SQLEditorCoordinator` to confirm the path:
- `Editor focus claim: pending=… isKey=… responderBefore=… made=…`
- `Editor focus claim skipped: hasWindow=… destroyed=… pending=…`

## Notes

- `swiftlint lint --strict` clean on the changed files.
- The build is verified by the user; please reproduce the cold-start ⌘T and confirm the caret lands in the editor (Console will show the `Editor focus claim` lines).
