### PR TITLE
fix(plugin-oracle): make native network encryption opt-in, default off (#1746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The connection switcher and welcome list now show each connection's tags and group. (#1323)
 - The ER diagram marks relationship cardinality (one-to-one, one-to-many, and optional variants) with crow's foot notation, read from primary keys and unique indexes. Junction tables collapse into a single many-to-many link, with a toolbar toggle to expand them. (#1335)
 - Export the ER diagram to SQL. A toolbar button opens a query tab with CREATE TABLE and foreign key statements for the current schema. (#1335)
+- Oracle connections have a Native network encryption option, off by default, for servers that require encrypted traffic. (#1746)
 
 ### Changed
 
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opening a new query tab now puts keyboard focus in the SQL editor instead of the sidebar filter, so you can type right away. (#1765)
 - Raw filters in the data grid now work on document and key-value databases; the typed text was dropped before reaching the driver. (#1529)
 - Connecting to Oracle no longer crashes on certain server values during the handshake; a bad packet now fails the connection with an error. (#1746)
+- Connecting to Oracle no longer hangs when the server permits but does not require native network encryption; TablePro now connects in clear text by default, like Oracle's own clients. (#1746)
 - Following a foreign key into another schema now opens the correct table on SQL Server and Oracle, instead of falling back to the default schema. (#1754)
 - Browsing or editing a SQL Server or Oracle table outside the default schema no longer fails with "Invalid object name" or writes to the wrong table; queries now qualify the table with its schema. (#1754)
 

--- a/Plugins/OracleDriverPlugin/OracleConnection.swift
+++ b/Plugins/OracleDriverPlugin/OracleConnection.swift
@@ -120,6 +120,7 @@ final class OracleConnectionWrapper: @unchecked Sendable {
     private let serviceName: String
     private let useSID: Bool
     private let sslConfig: SSLConfiguration
+    private let nativeNetworkEncryption: Bool
 
     private struct LockedState: Sendable {
         var isConnected = false
@@ -143,7 +144,8 @@ final class OracleConnectionWrapper: @unchecked Sendable {
         database: String,
         serviceName: String = "",
         useSID: Bool = false,
-        sslConfig: SSLConfiguration = SSLConfiguration()
+        sslConfig: SSLConfiguration = SSLConfiguration(),
+        nativeNetworkEncryption: Bool = false
     ) {
         self.host = host
         self.port = port
@@ -153,6 +155,7 @@ final class OracleConnectionWrapper: @unchecked Sendable {
         self.serviceName = serviceName
         self.useSID = useSID
         self.sslConfig = sslConfig
+        self.nativeNetworkEncryption = nativeNetworkEncryption
     }
 
     // MARK: - Connection
@@ -161,7 +164,7 @@ final class OracleConnectionWrapper: @unchecked Sendable {
         let identifier = serviceName.isEmpty ? database : serviceName
         let service: OracleServiceMethod = useSID ? .sid(identifier) : .serviceName(identifier)
         let tls = try OracleSSLMapping.tls(for: sslConfig)
-        let config = OracleNIO.OracleConnection.Configuration(
+        var config = OracleNIO.OracleConnection.Configuration(
             host: host,
             port: port,
             service: service,
@@ -169,6 +172,7 @@ final class OracleConnectionWrapper: @unchecked Sendable {
             password: password,
             tls: tls
         )
+        config.nativeNetworkEncryption = nativeNetworkEncryption
 
         let connectionId = Self.connectionCounter.withLock { state -> Int in
             state += 1

--- a/Plugins/OracleDriverPlugin/OraclePlugin.swift
+++ b/Plugins/OracleDriverPlugin/OraclePlugin.swift
@@ -38,6 +38,12 @@ final class OraclePlugin: NSObject, TableProPlugin, DriverPlugin, PluginDiagnost
             label: "SID",
             placeholder: "XE",
             visibleWhen: FieldVisibilityRule(fieldId: "oracleConnectionType", values: ["sid"])
+        ),
+        ConnectionField(
+            id: "oracleNativeEncryption",
+            label: "Native network encryption",
+            defaultValue: "false",
+            fieldType: .toggle
         )
     ]
 
@@ -230,7 +236,8 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             database: config.database,
             serviceName: identifier,
             useSID: useSID,
-            sslConfig: config.ssl
+            sslConfig: config.ssl,
+            nativeNetworkEncryption: config.additionalFields["oracleNativeEncryption"] == "true"
         )
         try await conn.connect()
         self.oracleConn = conn

--- a/TablePro.xcodeproj/project.pbxproj
+++ b/TablePro.xcodeproj/project.pbxproj
@@ -4934,7 +4934,7 @@
 			repositoryURL = "https://github.com/TableProApp/oracle-nio";
 			requirement = {
 				kind = revision;
-				revision = f58c1aa2fe0c308aa99edfd18081ae9a98e3d3ed;
+				revision = 1140759e3bc339a8383b5d38f45fcb4ef61e602a;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/TableProApp/oracle-nio",
       "state" : {
-        "revision" : "f58c1aa2fe0c308aa99edfd18081ae9a98e3d3ed"
+        "revision" : "1140759e3bc339a8383b5d38f45fcb4ef61e602a"
       }
     },
     {

--- a/docs/databases/oracle.mdx
+++ b/docs/databases/oracle.mdx
@@ -40,6 +40,7 @@ The Oracle driver is available as a downloadable plugin. When you select Oracle 
 | **Port** | `1521` | Listener port |
 | **Service Name** | - | **Required**. Check `tnsnames.ora` if unclear. To connect by SID instead, set **Connection Type** to SID and enter the SID. |
 | **Username** | - | Requires username/password auth (no OS auth) |
+| **Native network encryption** | Off | Advanced. Turn on only if the server requires encrypted traffic (`SQLNET.ENCRYPTION_SERVER = REQUIRED`). Leave off for servers that merely accept encryption, which connect in clear text like Oracle's own clients. |
 
 ## Example Configurations
 
@@ -148,6 +149,6 @@ Columns with types not yet supported render as `<unsupported: type>` rather than
 
 **Instant Client not found**: Download Basic package, extract to `/usr/local/oracle/instantclient`, set `DYLD_LIBRARY_PATH`
 
-**Connection dropped during handshake**: The server closed the connection mid-login. The error dialog shows the handshake phase it stopped at (for example `dataTypeNegotiation` or `authentication`). Check for a firewall, VPN, or proxy that resets traffic, and confirm the host and port reach the listener directly. On Oracle 11g, open an issue and include the handshake phase.
+**Connection dropped during handshake**: The server closed the connection mid-login. The error dialog shows the handshake phase it stopped at (for example `advancedNegotiation`, `dataTypeNegotiation`, or `authentication`). Check for a firewall, VPN, or proxy that resets traffic, and confirm the host and port reach the listener directly. If the phase is around negotiation and the server requires native network encryption, turn on the **Native network encryption** option; if you turned it on for a server that only accepts encryption, turn it back off.
 
 **Limitations**: Username/password only, BFILE shows locator metadata only (content fetch via DBMS_LOB not supported), PL/SQL limited to anonymous blocks.


### PR DESCRIPTION
## Root cause (confirmed from a TablePro packet capture)

The #1746 reporter (Oracle 11.2.0.4, no `sqlnet.ora`, so the server defaults to `ENCRYPTION_SERVER = ACCEPTED`) couldn't connect: the login handshake stalled and the server closed the socket after its 60-second `INBOUND_CONNECT_TIMEOUT`.

Decoding the capture: TablePro and the server complete the SNS/ANO security negotiation, then every later TTC payload is encrypted (high-entropy, where SQLcl against the same server stays clear text). oracle-nio negotiates AES, activates the cipher, and the encrypted handshake never completes against this server, so the client hangs.

oracle-nio's ANO request always advertised the encryption and data-integrity services (`AdvancedNegotiation.encodeRequest`), with no opt-out. Against a server that merely *accepts* encryption, that forces it on. Oracle's own clients (SQLcl, JDBC thin, python-oracledb) default to `ENCRYPTION_CLIENT = ACCEPTED`, which means "encrypt only if the server requires it", so they stay in clear text here.

## Fix

**oracle-nio fork** (re-pinned to `1140759`): `Configuration.nativeNetworkEncryption` (default `false`). When off, the ANO request advertises only the supervisor and authentication services, so a server that accepts but doesn't require encryption negotiates none and the session stays in clear text. When on, behavior is unchanged, for servers configured `ENCRYPTION_SERVER = REQUIRED`.

**Plugin**: a "Native network encryption" toggle on the Oracle connection form (off by default), threaded into the driver configuration.

This matches Oracle's default client behavior and unblocks 11g (and any server that only accepts encryption) without betting on an untestable in-handshake crypto fix.

## Testing

- Fork unit test `AdvancedNegotiationTests.omitsSecurityServicesWhenDisabled`: with security services off the ANO advertises 2 services (supervisor + auth) and is smaller than the 4-service request. Existing ANO tests updated for the new signature. Full `swift test --filter AdvancedNegotiationTests` passes.
- Plugin side is configuration pass-through (the driver wrapper imports OracleNIO, so it can't run in the app test target); the behavior is covered by the fork test.
- `swiftlint --strict` clean on changed files.

## Notes

- Oracle is a registry-only plugin, so this ships via a `plugin-oracle-v*` release.
- Builds on #1763 (handshake-phase diagnostic), already merged. The reporter can confirm by retrying with the default (off).

https://claude.ai/code/session_01NVomHPErfCr8FWRVywmyVP