### PR TITLE
fix(sidebar): remove blank space at top of sidebar when switching tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Switching between sidebar tables no longer leaves extra blank space above the table tree. (#1675)
+- Switching between sidebar tables no longer leaves extra blank space above the list. (#1675)
 - SSH tunnels no longer pin a CPU core after the connection drops. A dropped tunnel is now detected and torn down instead of spinning in its relay loop. (#1769)
 
 ## [0.53.0] - 2026-06-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Switching between sidebar tables no longer leaves extra blank space above the table tree. (#1675)
 - SSH tunnels no longer pin a CPU core after the connection drops. A dropped tunnel is now detected and torn down instead of spinning in its relay loop. (#1769)
 
 ## [0.53.0] - 2026-06-25

--- a/TablePro/Views/Sidebar/FavoritesTabView.swift
+++ b/TablePro/Views/Sidebar/FavoritesTabView.swift
@@ -183,8 +183,7 @@ internal struct FavoritesTabView: View {
                 }
             }
         }
-        .listStyle(.sidebar)
-        .scrollContentBackground(.hidden)
+        .sidebarListLayout()
         .onDeleteCommand {
             deleteSelectedNode()
         }

--- a/TablePro/Views/Sidebar/SidebarListLayout.swift
+++ b/TablePro/Views/Sidebar/SidebarListLayout.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+private struct SidebarListLayout: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .listStyle(.sidebar)
+            .scrollContentBackground(.hidden)
+            .safeAreaPadding(.top, 0)
+            .environment(\.defaultMinListHeaderHeight, 0)
+    }
+}
+
+extension View {
+    func sidebarListLayout() -> some View {
+        modifier(SidebarListLayout())
+    }
+}

--- a/TablePro/Views/Sidebar/SidebarTreeView.swift
+++ b/TablePro/Views/Sidebar/SidebarTreeView.swift
@@ -63,10 +63,7 @@ struct SidebarTreeView: View {
                 }
             }
         }
-        .listStyle(.sidebar)
-        .scrollContentBackground(.hidden)
-        .safeAreaPadding(.top, 0)
-        .environment(\.defaultMinListHeaderHeight, 0)
+        .sidebarListLayout()
         .contextMenu(forSelectionType: TableInfo.self) { _ in
             EmptyView()
         } primaryAction: { selection in

--- a/TablePro/Views/Sidebar/SidebarTreeView.swift
+++ b/TablePro/Views/Sidebar/SidebarTreeView.swift
@@ -65,6 +65,8 @@ struct SidebarTreeView: View {
         }
         .listStyle(.sidebar)
         .scrollContentBackground(.hidden)
+        .safeAreaPadding(.top, 0)
+        .environment(\.defaultMinListHeaderHeight, 0)
         .contextMenu(forSelectionType: TableInfo.self) { _ in
             EmptyView()
         } primaryAction: { selection in

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -376,10 +376,7 @@ struct SidebarView: View {
                 }
             }
         }
-        .listStyle(.sidebar)
-        .scrollContentBackground(.hidden)
-        .safeAreaPadding(.top, 0)
-        .environment(\.defaultMinListHeaderHeight, 0)
+        .sidebarListLayout()
         .contextMenu(forSelectionType: TableInfo.self) { selection in
             SidebarContextMenu(
                 clickedTable: selection.first,

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -378,6 +378,8 @@ struct SidebarView: View {
         }
         .listStyle(.sidebar)
         .scrollContentBackground(.hidden)
+        .safeAreaPadding(.top, 0)
+        .environment(\.defaultMinListHeaderHeight, 0)
         .contextMenu(forSelectionType: TableInfo.self) { selection in
             SidebarContextMenu(
                 clickedTable: selection.first,


### PR DESCRIPTION
## Summary

Switching between tables in the sidebar no longer leaves a blank band at the top of the table tree. The first row now stays flush to the top across repeated selections.

## Why this matters

Reported in #1675 (screen recording attached there): with a database open, clicking from one table to another inserts an empty gap above the first row that grows and persists on each switch. Both sidebar lists render `List(selection:)` with pinned `Section { } header: { }` headers, so when the selection changes the List re-applies its default top content/safe-area inset and the pinned header height, which shows up as leading whitespace.

The fix normalizes that inset and header height at the two list call sites so a re-layout on selection does not add space:
- `TablePro/Views/Sidebar/SidebarTreeView.swift` (the `treeList` list)
- `TablePro/Views/Sidebar/SidebarView.swift` (the `tableList` list)

Each gets `.safeAreaPadding(.top, 0)` and `.environment(\.defaultMinListHeaderHeight, 0)`.

## Testing

The two modifiers typecheck against the macOS 14 SDK (`swiftc -typecheck -target arm64-apple-macosx14.0`). `swiftlint lint --strict` reports 0 violations on both changed files. The change is presentation-only and does not touch selection or navigation logic, so the existing `SidebarNavigationResultTests` decision-logic suite is unaffected. The visual gap is a layout glitch that is not deterministically unit-testable, so no flaky UI assertion was added; please verify by clicking through several tables in the sidebar.

Fixes #1675
