### PR TITLE
fix(plugin-mssql): set TEXTSIZE 2147483647 on connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switching between sidebar tables no longer leaves extra blank space above the list. (#1675)
 - SSH tunnels no longer pin a CPU core after the connection drops. A dropped tunnel is now detected and torn down instead of spinning in its relay loop. (#1769)
 - Restored table tabs now load with the current page size instead of the page size from the previous session.
+- MSSQL: large `nvarchar(max)` and `text` values no longer truncate to 2048 bytes when copied or viewed. TEXTSIZE is raised at connect time. (#1783)
 
 ## [0.53.0] - 2026-06-25
 

--- a/Plugins/MSSQLDriverPlugin/FreeTDSConnection.swift
+++ b/Plugins/MSSQLDriverPlugin/FreeTDSConnection.swift
@@ -179,6 +179,11 @@ nonisolated final class FreeTDSConnection: @unchecked Sendable {
         lock.lock()
         _isConnected = true
         lock.unlock()
+
+        // FreeTDS default TEXTSIZE is 2048. Set to 2 GB so nvarchar(max)/text columns return in full.
+        _ = dbcmd(proc, "SET TEXTSIZE 2147483647")
+        _ = dbsqlexec(proc)
+        _ = dbresults(proc)
     }
 
     func switchDatabase(_ database: String) async throws {

--- a/Plugins/MSSQLDriverPlugin/FreeTDSConnection.swift
+++ b/Plugins/MSSQLDriverPlugin/FreeTDSConnection.swift
@@ -180,10 +180,20 @@ nonisolated final class FreeTDSConnection: @unchecked Sendable {
         _isConnected = true
         lock.unlock()
 
-        // FreeTDS default TEXTSIZE is 2048. Set to 2 GB so nvarchar(max)/text columns return in full.
-        _ = dbcmd(proc, "SET TEXTSIZE 2147483647")
-        _ = dbsqlexec(proc)
-        _ = dbresults(proc)
+        applyMaxTextSize(proc)
+    }
+
+    private func applyMaxTextSize(_ proc: UnsafeMutablePointer<DBPROCESS>) {
+        guard dbcmd(proc, "SET TEXTSIZE \(Int32.max)") != FAIL, dbsqlexec(proc) != FAIL else {
+            freetdsLogger.error("Failed to raise TEXTSIZE; large text columns may be truncated to the 2048-byte default")
+            return
+        }
+        while true {
+            let resCode = dbresults(proc)
+            if resCode == FAIL || resCode == Int32(NO_MORE_RESULTS) {
+                break
+            }
+        }
     }
 
     func switchDatabase(_ database: String) async throws {


### PR DESCRIPTION
FreeTDS inherits TDS protocol default of 2048 bytes for nvarchar(max)/text columns, silently truncating large cell values on copy. SET TEXTSIZE at connect time fixes both the batch and streaming query paths.

Close #1783