### PR TITLE
fix(tabs): keep safe-mode confirmation on the active tab (#1781)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Safe mode no longer jumps to the first tab after you confirm a query. The confirmation now stays on the tab you ran the query from. (#1781)
 - Switching between sidebar tables no longer leaves extra blank space above the list. (#1675)
 - SSH tunnels no longer pin a CPU core after the connection drops. A dropped tunnel is now detected and torn down instead of spinning in its relay loop. (#1769)
 - Restored table tabs now load with the current page size instead of the page size from the previous session.

--- a/TablePro/Core/Services/Execution/Providers/OperationConfirming.swift
+++ b/TablePro/Core/Services/Execution/Providers/OperationConfirming.swift
@@ -14,7 +14,7 @@ internal struct AlertOperationConfirming: OperationConfirming {
     @MainActor
     func confirm(sql: String, operationDescription: String, connectionId: UUID, isDestructive: Bool) async -> Bool {
         NSApp.activate(ignoringOtherApps: true)
-        let window = WindowLifecycleMonitor.shared.findWindow(for: connectionId)
+        let window = WindowLifecycleMonitor.shared.activeWindow(for: connectionId, preferring: NSApp.keyWindow)
         let preview = Self.preview(of: sql)
 
         if isDestructive {

--- a/TablePro/Core/Services/Infrastructure/WindowLifecycleMonitor.swift
+++ b/TablePro/Core/Services/Infrastructure/WindowLifecycleMonitor.swift
@@ -115,6 +115,19 @@ internal final class WindowLifecycleMonitor {
             .first { $0.isVisible }
     }
 
+    /// The active window for a connection, preferring `candidate` (typically the
+    /// key window) when it belongs to this connection. Each editor tab is a
+    /// separate window in a native tab group, so `findWindow` returns an
+    /// arbitrary tab's window; anchoring a connection-scoped sheet there would
+    /// switch the selected tab. Preferring the key window keeps the user on the
+    /// tab they triggered the action from.
+    internal func activeWindow(for connectionId: UUID, preferring candidate: NSWindow?) -> NSWindow? {
+        if let candidate, self.connectionId(forWindow: candidate) == connectionId {
+            return candidate
+        }
+        return findWindow(for: connectionId)
+    }
+
     /// Look up the connectionId for a given windowId.
     internal func connectionId(for windowId: UUID) -> UUID? {
         purgeStaleEntries()

--- a/TableProTests/Core/Services/WindowLifecycleMonitorTests.swift
+++ b/TableProTests/Core/Services/WindowLifecycleMonitorTests.swift
@@ -167,6 +167,48 @@ struct WindowLifecycleMonitorTests {
         #expect(monitor.findWindow(for: UUID()) == nil)
     }
 
+    // MARK: - activeWindow
+
+    @Test("activeWindow prefers the candidate when it belongs to the connection")
+    func activeWindowPrefersCandidate() {
+        let windowId = UUID()
+        let connectionId = UUID()
+        let window = NSWindow()
+
+        monitor.register(window: window, connectionId: connectionId, windowId: windowId)
+        defer { cleanup(windowId) }
+
+        #expect(monitor.activeWindow(for: connectionId, preferring: window) === window)
+    }
+
+    @Test("activeWindow ignores a candidate from a different connection")
+    func activeWindowIgnoresForeignCandidate() {
+        let windowIdA = UUID()
+        let windowIdB = UUID()
+        let connectionA = UUID()
+        let connectionB = UUID()
+        let windowA = NSWindow()
+        let windowB = NSWindow()
+
+        monitor.register(window: windowA, connectionId: connectionA, windowId: windowIdA)
+        monitor.register(window: windowB, connectionId: connectionB, windowId: windowIdB)
+        defer { cleanup(windowIdA, windowIdB) }
+
+        #expect(monitor.activeWindow(for: connectionA, preferring: windowB) !== windowB)
+    }
+
+    @Test("activeWindow falls back to findWindow when the candidate is nil")
+    func activeWindowNilCandidateFallsBack() {
+        let windowId = UUID()
+        let connectionId = UUID()
+        let window = NSWindow()
+
+        monitor.register(window: window, connectionId: connectionId, windowId: windowId)
+        defer { cleanup(windowId) }
+
+        #expect(monitor.activeWindow(for: connectionId, preferring: nil) === monitor.findWindow(for: connectionId))
+    }
+
     // MARK: - windows(for:) empty for unknown
 
     @Test("windows(for:) returns empty array for unknown connectionId")


### PR DESCRIPTION
## Summary

Fixes #1781. With safe mode on, running a query on a tab that is not the first tab and confirming the dialog switched the active tab to the first tab. It now stays on the tab the query was run from.

## Root cause

Each editor tab is a separate `NSWindow` sharing one `connectionId` (native NSWindow tabbing). The safe-mode confirmation anchored its sheet to `WindowLifecycleMonitor.findWindow(for:)`, which returns the first visible window from an unordered dictionary. Background tabs in a native tab group all report `isVisible`, so it picked an arbitrary tab's window. `beginSheetModal(for:)` then brought that window's tab forward, and it stayed selected after confirmation. The query itself ran on the correct tab; only the visible tab was wrong.

## Fix

- `WindowLifecycleMonitor` gains `activeWindow(for:preferring:)`, which returns the supplied candidate (the key window) when it belongs to the connection, otherwise falls back to `findWindow`. `findWindow`'s "any visible window" behavior is left intact for its other caller (`TabRouter`).
- `AlertOperationConfirming.confirm` anchors the sheet to `activeWindow(for: connectionId, preferring: NSApp.keyWindow)`, captured before presenting, so the sheet appears on the originating tab and selection does not change.

Covers both plain and parameterized execution, which share the same confirm step. Matches the HIG modality rule that a confirmation returns the user to where they were.

## Tests

`WindowLifecycleMonitorTests`: prefers a matching candidate, ignores a candidate from another connection, falls back when the candidate is nil.

## Manual check

Open two tabs on one connection, enable safe mode, run a query on the second tab, confirm. The second tab stays active.