### PR TITLE
build(plugins): include elasticsearch in registry plugin list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ TablePro is a native macOS database client (SwiftUI + AppKit) — a fast, lightw
 - **Source**: `TablePro/` — `Core/` (business logic, services), `Views/` (UI), `Models/` (data structures), `ViewModels/`, `Extensions/`, `Theme/`
 - **Plugins**: `Plugins/` — `.tableplugin` bundles + `TableProPluginKit` shared framework.
     - **Bundled in app**: MySQL, PostgreSQL, SQLite, ClickHouse, Redis, CSV, JSON, SQL export, XLSX export, MQL export, SQL import. Shipped only inside the app bundle. **Never publish bundled plugins to the registry.** Updates ride with the next app release.
-    - **Registry-only**: MongoDB, Oracle, DuckDB, MSSQL, Cassandra, Etcd, CloudflareD1, DynamoDB, BigQuery, LibSQL. Distributed via [TableProApp/plugins](https://github.com/TableProApp/plugins) `plugins.json`, installed into the user plugins directory.
+    - **Registry-only**: MongoDB, Oracle, DuckDB, MSSQL, Cassandra, Etcd, CloudflareD1, DynamoDB, BigQuery, LibSQL, Snowflake, Elasticsearch. Distributed via [TableProApp/plugins](https://github.com/TableProApp/plugins) `plugins.json`, installed into the user plugins directory.
 - **C bridges**: Each plugin contains its own C bridge module (e.g., `Plugins/MySQLDriverPlugin/CMariaDB/`, `Plugins/PostgreSQLDriverPlugin/CLibPQ/`)
 - **Static libs**: `Libs/` — pre-built `.a` files. `Libs/ios/` — xcframeworks for iOS. Both downloaded via `scripts/download-libs.sh` (not in git)
 - **SPM deps**: CodeEditSourceEditor (`main` branch, tree-sitter editor), Sparkle (2.8.1, auto-update), OracleNIO. Managed via Xcode, no `Package.swift`.

--- a/scripts/release-all-plugins.sh
+++ b/scripts/release-all-plugins.sh
@@ -38,6 +38,7 @@ PLUGINS=(
     bigquery
     snowflake
     libsql
+    elasticsearch
 )
 
 BUNDLED_PLUGINS=(


### PR DESCRIPTION
Elasticsearch support was announced in 0.53.0 and the app prompts to install the plugin, but the binary was never published to the registry, so install and Browse failed with "Plugin not found" (#1787).

The plugin is now published to the registry (`plugin-elasticsearch-v1.0.0`). This commit closes the two gaps that let it ship unpublished:

- Add `elasticsearch` to `PLUGINS` in `release-all-plugins.sh` so ABI re-releases include it (it was omitted, which would make this recur).
- Add Elasticsearch and Snowflake to the registry-only plugin list in CLAUDE.md.

Fixes #1787