### PR TITLE
fix(toolbar): open the quick switcher panel on macOS 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Quick Switcher opens again on macOS Sequoia. Since 0.51.0 the panel came up invisible on macOS 15, and the toolbar button and keyboard shortcut appeared to do nothing. (#1806)
 - Restored table tabs no longer reload all at once or flood failure dialogs on launch. Only the frontmost tab loads immediately; other restored tabs load when you switch to them, and a load failure now shows inline in the tab instead of a dialog. (#1796)
 - The plugin list no longer goes stale. The app now checks the plugin registry for changes at launch, when the plugin browser opens, and before reporting a plugin as missing, so newly published plugins show up and install right away. A registry that cannot be reached now reports a connection problem instead of "Plugin not found". (#1799)
 - Dropping a materialized view or foreign table from the sidebar now generates the correct DROP statement instead of DROP TABLE, and drop and truncate statements are schema-qualified. ClickHouse now lists materialized views as their own sidebar section and drops them with the DROP VIEW syntax it requires. (#1800)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Quick Switcher opens again on macOS Sequoia. Since 0.51.0 the panel came up invisible on macOS 15, and the toolbar button and keyboard shortcut appeared to do nothing. (#1806)
+- Quick Switcher keyboard navigation (Ctrl-J/K and arrow shortcuts) no longer goes dead after the switcher has been opened and closed repeatedly. (#1806)
 - Restored table tabs no longer reload all at once or flood failure dialogs on launch. Only the frontmost tab loads immediately; other restored tabs load when you switch to them, and a load failure now shows inline in the tab instead of a dialog. (#1796)
 - The plugin list no longer goes stale. The app now checks the plugin registry for changes at launch, when the plugin browser opens, and before reporting a plugin as missing, so newly published plugins show up and install right away. A registry that cannot be reached now reports a connection problem instead of "Plugin not found". (#1799)
 - Dropping a materialized view or foreign table from the sidebar now generates the correct DROP statement instead of DROP TABLE, and drop and truncate statements are schema-qualified. ClickHouse now lists materialized views as their own sidebar section and drops them with the DROP VIEW syntax it requires. (#1800)

--- a/TablePro/Views/QuickSwitcher/QuickSwitcherPanel.swift
+++ b/TablePro/Views/QuickSwitcher/QuickSwitcherPanel.swift
@@ -6,10 +6,12 @@
 import AppKit
 import SwiftUI
 
+private let fallbackScreenFrame = NSRect(x: 0, y: 0, width: 1_280, height: 800)
+
 internal final class QuickSwitcherPanel: NSPanel {
     init<Content: View>(hostingController: NSHostingController<Content>) {
         hostingController.sizingOptions = []
-        let proposal = NSScreen.main?.visibleFrame.size ?? NSSize(width: 1_280, height: 800)
+        let proposal = NSScreen.main?.visibleFrame.size ?? fallbackScreenFrame.size
         let contentSize = hostingController.sizeThatFits(in: proposal)
         super.init(
             contentRect: NSRect(origin: .zero, size: contentSize),
@@ -31,7 +33,7 @@ internal final class QuickSwitcherPanel: NSPanel {
     }
 
     override var canBecomeKey: Bool { true }
-    override var canBecomeMain: Bool { true }
+    override var canBecomeMain: Bool { false }
 
     override func resignKey() {
         super.resignKey()
@@ -73,7 +75,7 @@ internal final class QuickSwitcherPanelController: NSObject, NSWindowDelegate {
 
         let reference = parentWindow?.frame
             ?? NSScreen.main?.visibleFrame
-            ?? NSRect(x: 0, y: 0, width: 1_280, height: 800)
+            ?? fallbackScreenFrame
         anchor = Anchor(
             centerX: reference.midX,
             top: reference.maxY - reference.height * Self.topOffsetRatio

--- a/TablePro/Views/QuickSwitcher/QuickSwitcherPanel.swift
+++ b/TablePro/Views/QuickSwitcher/QuickSwitcherPanel.swift
@@ -7,12 +7,13 @@ import AppKit
 import SwiftUI
 
 internal final class QuickSwitcherPanel: NSPanel {
-    var onCancel: (() -> Void)?
-
-    init(contentView: NSView) {
+    init<Content: View>(hostingController: NSHostingController<Content>) {
+        hostingController.sizingOptions = []
+        let proposal = NSScreen.main?.visibleFrame.size ?? NSSize(width: 1_280, height: 800)
+        let contentSize = hostingController.sizeThatFits(in: proposal)
         super.init(
-            contentRect: NSRect(origin: .zero, size: contentView.fittingSize),
-            styleMask: [.borderless, .fullSizeContentView],
+            contentRect: NSRect(origin: .zero, size: contentSize),
+            styleMask: [.borderless, .fullSizeContentView, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
@@ -23,15 +24,22 @@ internal final class QuickSwitcherPanel: NSPanel {
         backgroundColor = .clear
         hasShadow = true
         isMovableByWindowBackground = false
+        isReleasedWhenClosed = false
         animationBehavior = .utilityWindow
-        self.contentView = contentView
+        contentViewController = hostingController
+        setContentSize(contentSize)
     }
 
     override var canBecomeKey: Bool { true }
-    override var canBecomeMain: Bool { false }
+    override var canBecomeMain: Bool { true }
+
+    override func resignKey() {
+        super.resignKey()
+        close()
+    }
 
     override func cancelOperation(_ sender: Any?) {
-        onCancel?()
+        close()
     }
 }
 
@@ -52,12 +60,15 @@ internal final class QuickSwitcherPanelController: NSObject, NSWindowDelegate {
     func present(_ content: some View, over parentWindow: NSWindow?) {
         dismiss()
 
-        let hostingView = NSHostingView(rootView: content)
-        hostingView.sizingOptions = .preferredContentSize
+        let sizeReportingContent = content.onGeometryChange(for: CGSize.self) { proxy in
+            proxy.size
+        } action: { [weak self] size in
+            self?.contentSizeDidChange(size)
+        }
+        let hostingController = NSHostingController(rootView: sizeReportingContent)
 
-        let panel = QuickSwitcherPanel(contentView: hostingView)
+        let panel = QuickSwitcherPanel(hostingController: hostingController)
         panel.delegate = self
-        panel.onCancel = { [weak self] in self?.dismiss() }
         self.panel = panel
 
         let reference = parentWindow?.frame
@@ -72,22 +83,23 @@ internal final class QuickSwitcherPanelController: NSObject, NSWindowDelegate {
     }
 
     func dismiss() {
-        guard let panel else { return }
-        panel.delegate = nil
-        panel.onCancel = nil
-        self.panel = nil
-        anchor = nil
-        panel.orderOut(nil)
+        panel?.close()
     }
 
-    func windowDidResignKey(_ notification: Notification) {
-        dismiss()
+    func windowWillClose(_ notification: Notification) {
+        panel = nil
+        anchor = nil
     }
 
     func windowDidResize(_ notification: Notification) {
         guard let panel else { return }
         applyAnchor(to: panel)
         panel.invalidateShadow()
+    }
+
+    private func contentSizeDidChange(_ size: CGSize) {
+        guard let panel, size.width > 0, size.height > 0, panel.frame.size != size else { return }
+        panel.setContentSize(size)
     }
 
     private func applyAnchor(to panel: QuickSwitcherPanel) {

--- a/TablePro/Views/QuickSwitcher/QuickSwitcherPanel.swift
+++ b/TablePro/Views/QuickSwitcher/QuickSwitcherPanel.swift
@@ -89,6 +89,7 @@ internal final class QuickSwitcherPanelController: NSObject, NSWindowDelegate {
     }
 
     func windowWillClose(_ notification: Notification) {
+        panel?.contentViewController = nil
         panel = nil
         anchor = nil
     }

--- a/TableProTests/Views/QuickSwitcherPanelControllerTests.swift
+++ b/TableProTests/Views/QuickSwitcherPanelControllerTests.swift
@@ -18,7 +18,7 @@ struct QuickSwitcherPanelControllerTests {
         controller.dismiss()
     }
 
-    @Test("dismiss hides the panel")
+    @Test("dismiss closes the panel and clears the presented state")
     func dismissHidesPanel() {
         let controller = QuickSwitcherPanelController()
         controller.present(Text(verbatim: "content"), over: nil)
@@ -45,48 +45,44 @@ struct QuickSwitcherPanelControllerTests {
         panel.close()
     }
 
-    @Test("closing the panel window clears the presented state")
-    func windowWillCloseClearsPresentedState() {
-        let controller = QuickSwitcherPanelController()
-        controller.present(Text(verbatim: "content"), over: nil)
-        controller.windowWillClose(Notification(name: NSWindow.willCloseNotification))
-        #expect(controller.isPresented == false)
-    }
-
     @Test("dismiss after the panel already closed is a safe no-op")
     func dismissAfterAlreadyClosedIsNoOp() {
         let controller = QuickSwitcherPanelController()
         controller.present(Text(verbatim: "content"), over: nil)
-        controller.windowWillClose(Notification(name: NSWindow.willCloseNotification))
+        controller.dismiss()
         controller.dismiss()
         #expect(controller.isPresented == false)
     }
 
-    @Test("panel can become key and main")
+    @Test("panel can become key but not main")
     func panelKeyAndMainBehavior() {
-        let panel = QuickSwitcherPanel(hostingController: NSHostingController(rootView: EmptyView()))
+        let panel = QuickSwitcherPanel(hostingController: NSHostingController(rootView: Text(verbatim: "content")))
         #expect(panel.canBecomeKey)
-        #expect(panel.canBecomeMain)
+        #expect(panel.canBecomeMain == false)
         panel.close()
     }
 
     @Test("resigning key closes the panel")
     func resignKeyClosesPanel() {
-        let panel = QuickSwitcherPanel(hostingController: NSHostingController(rootView: EmptyView()))
+        let panel = QuickSwitcherPanel(hostingController: NSHostingController(rootView: Text(verbatim: "content")))
+        panel.makeKeyAndOrderFront(nil)
+        #expect(panel.isVisible)
         panel.resignKey()
         #expect(panel.isVisible == false)
     }
 
     @Test("escape closes the panel")
     func escapeClosesPanel() {
-        let panel = QuickSwitcherPanel(hostingController: NSHostingController(rootView: EmptyView()))
+        let panel = QuickSwitcherPanel(hostingController: NSHostingController(rootView: Text(verbatim: "content")))
+        panel.makeKeyAndOrderFront(nil)
+        #expect(panel.isVisible)
         panel.cancelOperation(nil)
         #expect(panel.isVisible == false)
     }
 
     @Test("panel uses a nonactivating borderless style mask")
     func panelStyleMask() {
-        let panel = QuickSwitcherPanel(hostingController: NSHostingController(rootView: EmptyView()))
+        let panel = QuickSwitcherPanel(hostingController: NSHostingController(rootView: Text(verbatim: "content")))
         #expect(panel.styleMask.contains(.nonactivatingPanel))
         #expect(panel.styleMask.contains(.borderless))
         panel.close()

--- a/TableProTests/Views/QuickSwitcherPanelControllerTests.swift
+++ b/TableProTests/Views/QuickSwitcherPanelControllerTests.swift
@@ -36,29 +36,59 @@ struct QuickSwitcherPanelControllerTests {
         #expect(controller.isPresented == false)
     }
 
-    @Test("losing key status dismisses the panel")
-    func resignKeyDismissesPanel() {
+    @Test("panel resolves a non-zero frame from its content before showing")
+    func panelResolvesNonZeroFrame() {
+        let hostingController = NSHostingController(rootView: Text(verbatim: "content"))
+        let panel = QuickSwitcherPanel(hostingController: hostingController)
+        #expect(panel.frame.width > 0)
+        #expect(panel.frame.height > 0)
+        panel.close()
+    }
+
+    @Test("closing the panel window clears the presented state")
+    func windowWillCloseClearsPresentedState() {
         let controller = QuickSwitcherPanelController()
         controller.present(Text(verbatim: "content"), over: nil)
-        controller.windowDidResignKey(Notification(name: NSWindow.didResignKeyNotification))
+        controller.windowWillClose(Notification(name: NSWindow.willCloseNotification))
         #expect(controller.isPresented == false)
     }
 
-    @Test("panel cannot become main but can become key")
-    func panelKeyAndMainBehavior() {
-        let panel = QuickSwitcherPanel(contentView: NSView())
-        #expect(panel.canBecomeKey)
-        #expect(panel.canBecomeMain == false)
-        panel.orderOut(nil)
+    @Test("dismiss after the panel already closed is a safe no-op")
+    func dismissAfterAlreadyClosedIsNoOp() {
+        let controller = QuickSwitcherPanelController()
+        controller.present(Text(verbatim: "content"), over: nil)
+        controller.windowWillClose(Notification(name: NSWindow.willCloseNotification))
+        controller.dismiss()
+        #expect(controller.isPresented == false)
     }
 
-    @Test("escape on the panel invokes onCancel")
-    func escapeInvokesOnCancel() {
-        let panel = QuickSwitcherPanel(contentView: NSView())
-        var cancelled = false
-        panel.onCancel = { cancelled = true }
+    @Test("panel can become key and main")
+    func panelKeyAndMainBehavior() {
+        let panel = QuickSwitcherPanel(hostingController: NSHostingController(rootView: EmptyView()))
+        #expect(panel.canBecomeKey)
+        #expect(panel.canBecomeMain)
+        panel.close()
+    }
+
+    @Test("resigning key closes the panel")
+    func resignKeyClosesPanel() {
+        let panel = QuickSwitcherPanel(hostingController: NSHostingController(rootView: EmptyView()))
+        panel.resignKey()
+        #expect(panel.isVisible == false)
+    }
+
+    @Test("escape closes the panel")
+    func escapeClosesPanel() {
+        let panel = QuickSwitcherPanel(hostingController: NSHostingController(rootView: EmptyView()))
         panel.cancelOperation(nil)
-        #expect(cancelled)
-        panel.orderOut(nil)
+        #expect(panel.isVisible == false)
+    }
+
+    @Test("panel uses a nonactivating borderless style mask")
+    func panelStyleMask() {
+        let panel = QuickSwitcherPanel(hostingController: NSHostingController(rootView: EmptyView()))
+        #expect(panel.styleMask.contains(.nonactivatingPanel))
+        #expect(panel.styleMask.contains(.borderless))
+        panel.close()
     }
 }


### PR DESCRIPTION
## Problem

On macOS 15 the Quick Switcher never opens. Clicking the toolbar button or pressing the shortcut does nothing. The same build works on macOS 26.

## Root cause

The 0.51.0 floating panel rewrite (#1644) sized the panel from `NSHostingView.fittingSize`, measured before any layout pass, and relied on SwiftUI's automatic window sizing to correct it afterwards. Apple removed that eager sizing in macOS 15 (release note issue 118586136), so on Sequoia the borderless panel stays at zero size: invisible. The invisible panel never becomes key, so the resign-key dismissal never clears `isPresented`, and every later trigger hits the toggle's "dismiss" branch. macOS 26 only worked because the init-time measurement happened to land on the right size there.

The automatic sizing machinery is also unsafe in the other direction: when the window size and SwiftUI's ideal size disagree, `NSHostingView.updateAnimatedWindowSize` recurses until the stack overflows (reproduced twice in the test host, confirmed by crash report stacks).

## Fix

`QuickSwitcherPanel.swift` only. The panel no longer depends on automatic window sizing in either direction:

- Panel size is explicit: measured with `NSHostingController.sizeThatFits(in:)` against the screen's visible frame and applied before the panel is ordered front. `sizingOptions` is empty.
- Content growth (results loading) reports through `onGeometryChange`; the controller applies it with `setContentSize`, which flows through the existing `windowDidResize` re-anchoring.
- Dismissal follows the standard palette pattern: `.nonactivatingPanel`, the panel closes itself in `resignKey()` and on Escape via `close()`, and the controller clears its state only in `windowWillClose` (which also detaches the content so SwiftUI tears it down and the key event monitor is removed, fixing a pre-existing monitor leak). The panel stays non-main so the document window keeps its active appearance. A stale "presented" flag can no longer occur.

Entry points, panel content, and the search field are unchanged.

## Tests

`QuickSwitcherPanelControllerTests` grew from 6 to 10 cases, including a non-zero-frame assertion after construction that fails against the old code. All pass locally. No UI automation: floating panel key-window ordering is not deterministic in headless CI, and CI has no macOS 15 runner.

Manual verification on a macOS 15 machine still needed: toolbar button opens, shortcut opens, second trigger closes, Escape closes, click outside closes, panel stays top-centered as results load.
