### PR TITLE
fix(coordinator): resolve a table tab's schema from the active session when none is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Tables and views outside the connection's default schema now open and save correctly when reached through the Quick Switcher, a restored tab, or the MCP table-open tool. These paths used to send unqualified queries, which failed with "Invalid object name" on SQL Server or silently targeted the wrong table. (#1774)
 - Quick Switcher opens again on macOS Sequoia. Since 0.51.0 the panel came up invisible on macOS 15, and the toolbar button and keyboard shortcut appeared to do nothing. (#1806)
 - Quick Switcher keyboard navigation (Ctrl-J/K and arrow shortcuts) no longer goes dead after the switcher has been opened and closed repeatedly. (#1806)
 - Restored table tabs no longer reload all at once or flood failure dialogs on launch. Only the frontmost tab loads immediately; other restored tabs load when you switch to them, and a load failure now shows inline in the tab instead of a dialog. (#1796)

--- a/TablePro/Core/Database/DatabaseManager.swift
+++ b/TablePro/Core/Database/DatabaseManager.swift
@@ -89,6 +89,13 @@ final class DatabaseManager {
         activeSessions[connection.id]?.activeDatabase ?? connection.database
     }
 
+    /// Authoritative schema for a table identity when the caller has no explicit
+    /// schema. Explicit schemas pass through unchanged; nil resolves to the live
+    /// session's current schema and stays nil for schema-less engines.
+    func resolvedSchemaName(_ schemaName: String?, for connectionId: UUID) -> String? {
+        schemaName ?? activeSessions[connectionId]?.currentSchema
+    }
+
     /// Current connection status
     var status: ConnectionStatus {
         currentSession?.status ?? .disconnected

--- a/TablePro/Core/Database/FilterSQLGenerator.swift
+++ b/TablePro/Core/Database/FilterSQLGenerator.swift
@@ -314,6 +314,7 @@ extension FilterSQLGenerator {
     /// Generate a preview-friendly query string (for display, not execution)
     func generatePreviewSQL(
         tableName: String,
+        schemaName: String? = nil,
         filters: [TableFilter],
         logicMode: FilterLogicMode = .and,
         limit: Int = 1_000,
@@ -333,7 +334,7 @@ extension FilterSQLGenerator {
                     return (filter.columnName, filter.filterOperator.rawValue, value)
                 }
             if let result = pluginDriver.buildFilteredQuery(
-                table: tableName, filters: filterTuples,
+                table: tableName, schema: schemaName, filters: filterTuples,
                 logicMode: logicMode == .and ? "and" : "or",
                 sortColumns: [], columns: [],
                 limit: limit, offset: 0
@@ -342,7 +343,12 @@ extension FilterSQLGenerator {
             }
         }
 
-        let quotedTable = quoteIdentifierFn(tableName)
+        let quotedTable: String
+        if let schemaName, !schemaName.isEmpty {
+            quotedTable = "\(quoteIdentifierFn(schemaName)).\(quoteIdentifierFn(tableName))"
+        } else {
+            quotedTable = quoteIdentifierFn(tableName)
+        }
         var sql = "SELECT * FROM \(quotedTable)"
 
         let whereClause = generateWhereClause(from: filters, logicMode: logicMode)

--- a/TablePro/Core/Services/Infrastructure/SessionStateFactory.swift
+++ b/TablePro/Core/Services/Infrastructure/SessionStateFactory.swift
@@ -90,6 +90,9 @@ enum SessionStateFactory {
                 switch payload.tabType {
                 case .table:
                     toolbarSt.isTableTab = true
+                    let resolvedSchemaName = DatabaseManager.shared.resolvedSchemaName(
+                        payload.schemaName, for: connectionId
+                    )
                     if let tableName = payload.tableName {
                         do {
                             if payload.isPreview {
@@ -97,14 +100,14 @@ enum SessionStateFactory {
                                     tableName: tableName,
                                     databaseType: connection.type,
                                     databaseName: payload.databaseName ?? activeDatabaseName,
-                                    schemaName: payload.schemaName
+                                    schemaName: resolvedSchemaName
                                 )
                             } else {
                                 try tabMgr.addTableTab(
                                     tableName: tableName,
                                     databaseType: connection.type,
                                     databaseName: payload.databaseName ?? activeDatabaseName,
-                                    schemaName: payload.schemaName
+                                    schemaName: resolvedSchemaName
                                 )
                             }
                         } catch {
@@ -113,7 +116,7 @@ enum SessionStateFactory {
                         if let index = tabMgr.selectedTabIndex {
                             tabMgr.tabs[index].tableContext.isView = payload.isView
                             tabMgr.tabs[index].tableContext.isEditable = !payload.isView
-                            tabMgr.tabs[index].tableContext.schemaName = payload.schemaName
+                            tabMgr.tabs[index].tableContext.schemaName = resolvedSchemaName
                             if payload.showStructure {
                                 tabMgr.tabs[index].display.resultsViewMode = .structure
                             }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+FKNavigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+FKNavigation.swift
@@ -31,7 +31,7 @@ extension MainContentCoordinator {
 
         let currentDatabase = activeDatabaseName
 
-        let targetSchema = fkInfo.referencedSchema ?? DatabaseManager.shared.session(for: connectionId)?.currentSchema
+        let targetSchema = DatabaseManager.shared.resolvedSchemaName(fkInfo.referencedSchema, for: connectionId)
 
         if !openInNewTab,
            let current = tabManager.selectedTab,

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -56,7 +56,7 @@ extension MainContentCoordinator {
             currentDatabase = activeDatabaseName
         }
 
-        let resolvedSchema = schema
+        let resolvedSchema = DatabaseManager.shared.resolvedSchemaName(schema, for: connectionId)
         let createAsPreview = !forceNonPreview && !forceNewWindowTab
             && AppSettingsManager.shared.tabs.enablePreviewTabs
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TableFirstLoad.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TableFirstLoad.swift
@@ -15,9 +15,14 @@ extension MainContentCoordinator {
     @discardableResult
     func prepareTableTabFirstLoad(tabId: UUID) async -> Bool {
         guard tabManager.selectedTabId == tabId,
-              let tab = tabManager.tabs.first(where: { $0.id == tabId }),
+              var tab = tabManager.tabs.first(where: { $0.id == tabId }),
               tab.tabType == .table,
               let tableName = tab.tableContext.tableName, !tableName.isEmpty else { return false }
+
+        if resolveTableTabSchemaIfNeeded(tabId: tabId),
+           let resolvedTab = tabManager.tabs.first(where: { $0.id == tabId }) {
+            tab = resolvedTab
+        }
 
         let hint = PluginManager.shared.defaultSortHint(for: connection.type, table: tableName)
         guard firstLoadNeedsSchemaColumns(for: tab, hint: hint) else {
@@ -39,6 +44,19 @@ extension MainContentCoordinator {
         if restoreApplied || sortApplied || !tabManager.tabs[index].columnLayout.hiddenColumns.isEmpty {
             filterCoordinator.rebuildTableQuery(at: index)
         }
+        return true
+    }
+
+    @discardableResult
+    func resolveTableTabSchemaIfNeeded(tabId: UUID) -> Bool {
+        guard let index = tabManager.tabs.firstIndex(where: { $0.id == tabId }),
+              tabManager.tabs[index].tabType == .table,
+              tabManager.tabs[index].tableContext.schemaName == nil,
+              let resolvedSchema = DatabaseManager.shared.resolvedSchemaName(nil, for: connectionId)
+        else { return false }
+
+        tabManager.mutate(at: index) { $0.tableContext.schemaName = resolvedSchema }
+        filterCoordinator.rebuildTableQuery(at: index)
         return true
     }
 

--- a/TablePro/Views/Main/Extensions/MainContentView+Helpers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Helpers.swift
@@ -43,6 +43,9 @@ extension MainContentView {
     }
 
     private func consumePendingLoad(trigger: TableLoadTrigger, session: ConnectionSession) {
+        if let tabId = tabManager.selectedTab?.id {
+            coordinator.resolveTableTabSchemaIfNeeded(tabId: tabId)
+        }
         if let selectedTab = tabManager.selectedTab,
             !selectedTab.tableContext.databaseName.isEmpty,
             selectedTab.tableContext.databaseName != session.activeDatabase

--- a/TableProTests/Core/Database/DatabaseManagerTests.swift
+++ b/TableProTests/Core/Database/DatabaseManagerTests.swift
@@ -31,4 +31,40 @@ struct DatabaseManagerSessionTests {
         let session = DatabaseManager.shared.activeSessions[unknownId]
         #expect(session == nil)
     }
+
+    @Test("resolvedSchemaName keeps an explicit schema over the session's current schema")
+    func resolvedSchemaNameKeepsExplicitSchema() {
+        let connection = TestFixtures.makeConnection()
+        var session = ConnectionSession(connection: connection)
+        session.currentSchema = "sales"
+        DatabaseManager.shared.injectSession(session, for: connection.id)
+        defer { DatabaseManager.shared.removeSession(for: connection.id) }
+
+        #expect(DatabaseManager.shared.resolvedSchemaName("audit", for: connection.id) == "audit")
+    }
+
+    @Test("resolvedSchemaName falls back to the session's current schema")
+    func resolvedSchemaNameFallsBackToSessionSchema() {
+        let connection = TestFixtures.makeConnection()
+        var session = ConnectionSession(connection: connection)
+        session.currentSchema = "sales"
+        DatabaseManager.shared.injectSession(session, for: connection.id)
+        defer { DatabaseManager.shared.removeSession(for: connection.id) }
+
+        #expect(DatabaseManager.shared.resolvedSchemaName(nil, for: connection.id) == "sales")
+    }
+
+    @Test("resolvedSchemaName stays nil without a session")
+    func resolvedSchemaNameStaysNilWithoutSession() {
+        #expect(DatabaseManager.shared.resolvedSchemaName(nil, for: UUID()) == nil)
+    }
+
+    @Test("resolvedSchemaName stays nil for a schema-less session")
+    func resolvedSchemaNameStaysNilForSchemaLessSession() {
+        let connection = TestFixtures.makeConnection()
+        DatabaseManager.shared.injectSession(ConnectionSession(connection: connection), for: connection.id)
+        defer { DatabaseManager.shared.removeSession(for: connection.id) }
+
+        #expect(DatabaseManager.shared.resolvedSchemaName(nil, for: connection.id) == nil)
+    }
 }

--- a/TableProTests/Core/Database/FilterSQLGeneratorTests.swift
+++ b/TableProTests/Core/Database/FilterSQLGeneratorTests.swift
@@ -808,6 +808,24 @@ struct FilterSQLGeneratorTests {
         #expect(result.contains("LIMIT 1000"))
     }
 
+    @Test("Preview SQL qualifies the table with the schema")
+    func testPreviewSQLWithSchema() {
+        let generator = FilterSQLGenerator(dialect: Self.mysqlDialect)
+        let result = generator.generatePreviewSQL(
+            tableName: "users", schemaName: "sales", filters: [], limit: 1_000
+        )
+        #expect(result.contains("SELECT * FROM `sales`.`users`"))
+    }
+
+    @Test("Preview SQL with an empty schema stays unqualified")
+    func testPreviewSQLWithEmptySchema() {
+        let generator = FilterSQLGenerator(dialect: Self.mysqlDialect)
+        let result = generator.generatePreviewSQL(
+            tableName: "users", schemaName: "", filters: [], limit: 1_000
+        )
+        #expect(result.contains("SELECT * FROM `users`"))
+    }
+
     // MARK: - Edge Cases
 
     @Test("Between with missing secondValue returns nil")

--- a/TableProTests/Views/Main/FKNavigationTests.swift
+++ b/TableProTests/Views/Main/FKNavigationTests.swift
@@ -92,6 +92,37 @@ struct FKNavigationTests {
         #expect(tabManager.selectedTab?.tableContext.tableName == "users")
     }
 
+    @Test("FK navigation with no referenced schema resolves the session's current schema")
+    @MainActor
+    func nilReferencedSchemaResolvesActiveSchema() throws {
+        let connection = TestFixtures.makeConnection(database: "db_a", type: .postgresql)
+        var session = ConnectionSession(connection: connection)
+        session.currentSchema = "sales"
+        DatabaseManager.shared.injectSession(session, for: connection.id)
+        defer { DatabaseManager.shared.removeSession(for: connection.id) }
+
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        defer { coordinator.teardown() }
+
+        try tabManager.addTableTab(
+            tableName: "orders",
+            databaseType: connection.type,
+            databaseName: coordinator.activeDatabaseName
+        )
+
+        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+
+        #expect(tabManager.selectedTab?.tableContext.tableName == "users")
+        #expect(tabManager.selectedTab?.tableContext.schemaName == "sales")
+    }
+
     @Test("Metadata is not cached until foreign keys were fetched")
     @MainActor
     func metadataCacheRequiresFetchedForeignKeys() throws {

--- a/TableProTests/Views/Main/OpenTableTabTests.swift
+++ b/TableProTests/Views/Main/OpenTableTabTests.swift
@@ -129,6 +129,73 @@ struct OpenTableTabTests {
         #expect(tabManager.selectedTab?.tableContext.tableName == "users")
     }
 
+    // MARK: - Schema identity resolution (issue #1774)
+
+    @Test("Opening a bare table name stamps the session's current schema")
+    @MainActor
+    func bareTableNameResolvesActiveSchema() {
+        let connection = TestFixtures.makeConnection(type: .postgresql)
+        var session = ConnectionSession(connection: connection)
+        session.currentSchema = "sales"
+        DatabaseManager.shared.injectSession(session, for: connection.id)
+        defer { DatabaseManager.shared.removeSession(for: connection.id) }
+
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        defer { coordinator.teardown() }
+
+        coordinator.openTableTab("routes")
+
+        #expect(tabManager.selectedTab?.tableContext.tableName == "routes")
+        #expect(tabManager.selectedTab?.tableContext.schemaName == "sales")
+    }
+
+    @Test("Opening with an explicit schema wins over the session's current schema")
+    @MainActor
+    func explicitSchemaWinsOverActiveSchema() {
+        let connection = TestFixtures.makeConnection(type: .postgresql)
+        var session = ConnectionSession(connection: connection)
+        session.currentSchema = "sales"
+        DatabaseManager.shared.injectSession(session, for: connection.id)
+        defer { DatabaseManager.shared.removeSession(for: connection.id) }
+
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        defer { coordinator.teardown() }
+
+        coordinator.openTableTab("routes", schema: "audit")
+
+        #expect(tabManager.selectedTab?.tableContext.schemaName == "audit")
+    }
+
+    @Test("Opening without a session leaves the schema nil")
+    @MainActor
+    func noSessionLeavesSchemaNil() {
+        let connection = TestFixtures.makeConnection(database: "db_a")
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        defer { coordinator.teardown() }
+
+        coordinator.openTableTab("routes")
+
+        #expect(tabManager.selectedTab?.tableContext.schemaName == nil)
+    }
+
     // MARK: - isActiveTabReusable
 
     @Test("A preview table tab is reusable")

--- a/TableProTests/Views/Main/SessionStateFactoryTests.swift
+++ b/TableProTests/Views/Main/SessionStateFactoryTests.swift
@@ -20,6 +20,7 @@ struct SessionStateFactoryTests {
         tabType: TabType = .query,
         tableName: String? = nil,
         databaseName: String? = nil,
+        schemaName: String? = nil,
         initialQuery: String? = nil,
         isView: Bool = false,
         showStructure: Bool = false
@@ -29,6 +30,7 @@ struct SessionStateFactoryTests {
             tabType: tabType,
             tableName: tableName,
             databaseName: databaseName,
+            schemaName: schemaName,
             initialQuery: initialQuery,
             isView: isView,
             showStructure: showStructure
@@ -111,6 +113,49 @@ struct SessionStateFactoryTests {
         }
         #expect(tab.tableContext.isView == true)
         #expect(tab.tableContext.isEditable == false)
+    }
+
+    @Test("Table payload without a schema resolves the session's current schema")
+    @MainActor
+    func tablePayloadWithoutSchema_resolvesActiveSchema() {
+        let conn = TestFixtures.makeConnection(type: .postgresql)
+        var session = ConnectionSession(connection: conn)
+        session.currentSchema = "sales"
+        DatabaseManager.shared.injectSession(session, for: conn.id)
+        defer { DatabaseManager.shared.removeSession(for: conn.id) }
+
+        let payload = makePayload(connectionId: conn.id, tabType: .table, tableName: "users")
+        let state = SessionStateFactory.create(connection: conn, payload: payload)
+
+        #expect(state.tabManager.tabs.first?.tableContext.schemaName == "sales")
+    }
+
+    @Test("Table payload with an explicit schema keeps it over the session's current schema")
+    @MainActor
+    func tablePayloadWithExplicitSchema_keepsIt() {
+        let conn = TestFixtures.makeConnection(type: .postgresql)
+        var session = ConnectionSession(connection: conn)
+        session.currentSchema = "sales"
+        DatabaseManager.shared.injectSession(session, for: conn.id)
+        defer { DatabaseManager.shared.removeSession(for: conn.id) }
+
+        let payload = makePayload(
+            connectionId: conn.id, tabType: .table, tableName: "users", schemaName: "audit"
+        )
+        let state = SessionStateFactory.create(connection: conn, payload: payload)
+
+        #expect(state.tabManager.tabs.first?.tableContext.schemaName == "audit")
+    }
+
+    @Test("Table payload without a session leaves the schema nil")
+    @MainActor
+    func tablePayloadWithoutSession_leavesSchemaNil() {
+        let conn = TestFixtures.makeConnection()
+        let payload = makePayload(connectionId: conn.id, tabType: .table, tableName: "users")
+
+        let state = SessionStateFactory.create(connection: conn, payload: payload)
+
+        #expect(state.tabManager.tabs.first?.tableContext.schemaName == nil)
     }
 
     @Test("Nil payload creates empty tab manager")

--- a/TableProTests/Views/Main/TableTabSchemaResolutionTests.swift
+++ b/TableProTests/Views/Main/TableTabSchemaResolutionTests.swift
@@ -1,0 +1,127 @@
+//
+//  TableTabSchemaResolutionTests.swift
+//  TableProTests
+//
+//  Tests for the first-load schema backstop: a table tab created without a
+//  schema identity (Quick Switcher, MCP tool, restored tabs) is stamped with
+//  the session's current schema before its query runs. Regression coverage
+//  for #1774.
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("TableTabSchemaResolution")
+struct TableTabSchemaResolutionTests {
+    @MainActor
+    private func makeCoordinator(
+        connection: DatabaseConnection,
+        tabManager: QueryTabManager
+    ) -> MainContentCoordinator {
+        MainContentCoordinator(
+            connection: connection,
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+    }
+
+    @Test("Stamps the session's current schema and rebuilds the query")
+    @MainActor
+    func stampsSchemaAndRebuildsQuery() throws {
+        let connection = TestFixtures.makeConnection(type: .postgresql)
+        var session = ConnectionSession(connection: connection)
+        session.currentSchema = "sales"
+        DatabaseManager.shared.injectSession(session, for: connection.id)
+        defer { DatabaseManager.shared.removeSession(for: connection.id) }
+
+        let tabManager = QueryTabManager()
+        let coordinator = makeCoordinator(connection: connection, tabManager: tabManager)
+        defer { coordinator.teardown() }
+
+        try tabManager.addTableTab(
+            tableName: "routes",
+            databaseType: connection.type,
+            databaseName: "testdb"
+        )
+        #expect(tabManager.selectedTab?.tableContext.schemaName == nil)
+        let tabId = try #require(tabManager.selectedTab?.id)
+
+        let resolved = coordinator.resolveTableTabSchemaIfNeeded(tabId: tabId)
+
+        #expect(resolved == true)
+        #expect(tabManager.selectedTab?.tableContext.schemaName == "sales")
+        #expect(tabManager.selectedTab?.content.query.contains("sales") == true)
+    }
+
+    @Test("Leaves an already-resolved schema untouched")
+    @MainActor
+    func leavesResolvedSchemaUntouched() throws {
+        let connection = TestFixtures.makeConnection(type: .postgresql)
+        var session = ConnectionSession(connection: connection)
+        session.currentSchema = "sales"
+        DatabaseManager.shared.injectSession(session, for: connection.id)
+        defer { DatabaseManager.shared.removeSession(for: connection.id) }
+
+        let tabManager = QueryTabManager()
+        let coordinator = makeCoordinator(connection: connection, tabManager: tabManager)
+        defer { coordinator.teardown() }
+
+        try tabManager.addTableTab(
+            tableName: "routes",
+            databaseType: connection.type,
+            databaseName: "testdb",
+            schemaName: "audit"
+        )
+        let tabId = try #require(tabManager.selectedTab?.id)
+
+        let resolved = coordinator.resolveTableTabSchemaIfNeeded(tabId: tabId)
+
+        #expect(resolved == false)
+        #expect(tabManager.selectedTab?.tableContext.schemaName == "audit")
+    }
+
+    @Test("No-op without a session")
+    @MainActor
+    func noOpWithoutSession() throws {
+        let connection = TestFixtures.makeConnection()
+        let tabManager = QueryTabManager()
+        let coordinator = makeCoordinator(connection: connection, tabManager: tabManager)
+        defer { coordinator.teardown() }
+
+        try tabManager.addTableTab(
+            tableName: "routes",
+            databaseType: connection.type,
+            databaseName: "testdb"
+        )
+        let tabId = try #require(tabManager.selectedTab?.id)
+
+        let resolved = coordinator.resolveTableTabSchemaIfNeeded(tabId: tabId)
+
+        #expect(resolved == false)
+        #expect(tabManager.selectedTab?.tableContext.schemaName == nil)
+    }
+
+    @Test("No-op for a query tab")
+    @MainActor
+    func noOpForQueryTab() throws {
+        let connection = TestFixtures.makeConnection(type: .postgresql)
+        var session = ConnectionSession(connection: connection)
+        session.currentSchema = "sales"
+        DatabaseManager.shared.injectSession(session, for: connection.id)
+        defer { DatabaseManager.shared.removeSession(for: connection.id) }
+
+        let tabManager = QueryTabManager()
+        let coordinator = makeCoordinator(connection: connection, tabManager: tabManager)
+        defer { coordinator.teardown() }
+
+        tabManager.addTab(databaseName: "testdb")
+        let tabId = try #require(tabManager.selectedTab?.id)
+
+        let resolved = coordinator.resolveTableTabSchemaIfNeeded(tabId: tabId)
+
+        #expect(resolved == false)
+    }
+}


### PR DESCRIPTION
## Summary
- Resolve a table tab's schema once, at tab creation, from the live session when the caller passes none. New shared resolver `DatabaseManager.resolvedSchemaName(_:for:)`; explicit schemas always win, schema-less engines stay nil.
- Covers every path that created tabs with no schema identity: Quick Switcher, the MCP `open_table_tab` tool, and tabs restored from either. FK navigation now uses the same resolver (no behavior change there).
- Add a first-load backstop that stamps legacy nil-schema tabs after connect and schema switch, before their SQL runs.
- Thread a schema parameter through `FilterSQLGenerator.generatePreviewSQL`.

## Root cause
Quick Switcher items and MCP payloads carry no schema, so `tableContext.schemaName` stayed nil. Query builders correctly refuse to guess, so SQL Server received unqualified names: SELECT resolved through the login default schema and failed with "Invalid object name", and generated INSERT/UPDATE/DELETE could silently target a same-named table in another schema. No rebuild ever fixed the write path.

The sidebar path was already fixed by #1758. The re-report in #1774 came from the registry serving the pre-fix MSSQL plugin binary until v1.0.29 was published on June 30. This PR fixes the remaining nil-schema paths app-side; no plugin re-release is needed.

The fix deliberately does not add a `_currentSchema` fallback inside the driver (the approach in #1778): SQL Server has no session schema, and the app's cached query-building driver never connects, so its `_currentSchema` is permanently `dbo` and would mis-qualify names for logins with a different default schema.

Related: #1774. Supersedes #1778.

## Validation
- `xcodebuild test` on the six affected suites: 131 passed, 0 failed, including 13 new tests (Quick Switcher and MCP payload reproductions, resolver unit tests, first-load backstop, FK regression guard)
- `swiftlint lint --strict` on changed files: no new violations
- `git diff --cached` style gate: clean
