### PR TITLE
fix(sidebar): use grouped form layout in favorite edit dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The New/Edit Favorite and linked file metadata dialogs no longer open with a large empty area and fields crushed against the right edge. They now use the standard macOS grouped form layout: the query editor spans the full dialog width, the cursor marker hint sits under the editor, keyword validation shows under the keyword field, and the Global option is a checkbox that explains its scope. (#1809)
 - Quick Switcher opens again on macOS Sequoia. Since 0.51.0 the panel came up invisible on macOS 15, and the toolbar button and keyboard shortcut appeared to do nothing. (#1806)
 - Quick Switcher keyboard navigation (Ctrl-J/K and arrow shortcuts) no longer goes dead after the switcher has been opened and closed repeatedly. (#1806)
 - Restored table tabs no longer reload all at once or flood failure dialogs on launch. Only the frontmost tab loads immediately; other restored tabs load when you switch to them, and a load failure now shows inline in the tab instead of a dialog. (#1796)

--- a/TablePro/Core/Storage/SQLFavoriteEditValidation.swift
+++ b/TablePro/Core/Storage/SQLFavoriteEditValidation.swift
@@ -1,0 +1,112 @@
+//
+//  SQLFavoriteEditValidation.swift
+//  TablePro
+//
+
+import Foundation
+import Observation
+
+internal enum SQLFavoriteKeywordValidation: Equatable {
+    case valid
+    case error(String)
+    case warning(String)
+
+    var blocksSave: Bool {
+        if case .error = self { return true }
+        return false
+    }
+
+    var isWarning: Bool {
+        if case .warning = self { return true }
+        return false
+    }
+
+    var displayText: String? {
+        switch self {
+        case .valid:
+            return nil
+        case let .error(text), let .warning(text):
+            return text
+        }
+    }
+}
+
+internal enum SQLFavoriteKeywordValidator {
+    static let reservedSQLKeywords: Set<String> = [
+        "select", "from", "where", "insert", "update", "delete",
+        "create", "drop", "alter", "join", "on", "and", "or",
+        "not", "in", "like", "between", "order", "group", "having",
+        "limit", "set", "values", "into", "as", "is", "null",
+        "true", "false", "case", "when", "then", "else", "end"
+    ]
+
+    static func requiresAvailabilityCheck(_ trimmedKeyword: String) -> Bool {
+        !trimmedKeyword.isEmpty && !trimmedKeyword.contains(" ")
+    }
+
+    static func classify(trimmedKeyword: String, isAvailable: Bool) -> SQLFavoriteKeywordValidation {
+        guard !trimmedKeyword.isEmpty else { return .valid }
+        guard !trimmedKeyword.contains(" ") else {
+            return .error(String(localized: "Keyword cannot contain spaces"))
+        }
+        guard isAvailable else {
+            return .error(String(localized: "This keyword is already in use"))
+        }
+        guard !reservedSQLKeywords.contains(trimmedKeyword.lowercased()) else {
+            return .warning(String(
+                format: String(localized: "Shadows the SQL keyword '%@'"),
+                trimmedKeyword.uppercased()
+            ))
+        }
+        return .valid
+    }
+}
+
+@MainActor
+@Observable
+internal final class SQLFavoriteKeywordField {
+    var keyword = ""
+    private(set) var validation: SQLFavoriteKeywordValidation = .valid
+
+    private var validationId = 0
+    private let availabilityCheck: (String, UUID?, UUID?) async -> Bool
+
+    init(
+        availabilityCheck: @escaping (String, UUID?, UUID?) async -> Bool = { keyword, connectionId, excludingFavoriteId in
+            await SQLFavoriteManager.shared.isKeywordAvailable(
+                keyword,
+                connectionId: connectionId,
+                excludingFavoriteId: excludingFavoriteId
+            )
+        }
+    ) {
+        self.availabilityCheck = availabilityCheck
+    }
+
+    var trimmedKeyword: String {
+        keyword.trimmingCharacters(in: .whitespaces)
+    }
+
+    func validate(connectionId: UUID?, excludingFavoriteId: UUID?) async {
+        validationId += 1
+        let currentId = validationId
+        let trimmed = trimmedKeyword
+        guard SQLFavoriteKeywordValidator.requiresAvailabilityCheck(trimmed) else {
+            validation = SQLFavoriteKeywordValidator.classify(trimmedKeyword: trimmed, isAvailable: true)
+            return
+        }
+        let available = await availabilityCheck(trimmed, connectionId, excludingFavoriteId)
+        guard currentId == validationId else { return }
+        validation = SQLFavoriteKeywordValidator.classify(trimmedKeyword: trimmed, isAvailable: available)
+    }
+}
+
+internal enum SQLFavoriteEditValidation {
+    static func canSave(
+        isNameBlank: Bool,
+        isQueryBlank: Bool = false,
+        keywordValidation: SQLFavoriteKeywordValidation
+    ) -> Bool {
+        !isNameBlank && !isQueryBlank && !keywordValidation.blocksSave
+    }
+}

--- a/TablePro/Views/Sidebar/FavoriteEditDialog.swift
+++ b/TablePro/Views/Sidebar/FavoriteEditDialog.swift
@@ -23,13 +23,10 @@ internal struct FavoriteEditDialog: View {
 
     @State private var name: String = ""
     @State private var query: String = ""
-    @State private var keyword: String = ""
+    @State private var keywordField = SQLFavoriteKeywordField()
     @State private var isGlobal: Bool = false
     @State private var selectedFolderId: UUID?
-    @State private var keywordError: String?
-    @State private var isKeywordWarning = false
     @State private var isSaving = false
-    @State private var validationId = 0
     @State private var loadedFolders: [SQLFavoriteFolder]?
 
     enum FocusField { case name, keyword }
@@ -38,9 +35,11 @@ internal struct FavoriteEditDialog: View {
     private var isEditing: Bool { favorite != nil }
     private var effectiveFolders: [SQLFavoriteFolder] { loadedFolders ?? (folders.isEmpty ? nil : folders) ?? [] }
     private var isValid: Bool {
-        !name.trimmingCharacters(in: .whitespaces).isEmpty &&
-            !query.trimmingCharacters(in: .whitespaces).isEmpty &&
-            (keywordError == nil || isKeywordWarning)
+        SQLFavoriteEditValidation.canSave(
+            isNameBlank: !name.contains { !$0.isWhitespace },
+            isQueryBlank: !query.contains { !$0.isWhitespace },
+            keywordValidation: keywordField.validation
+        )
     }
 
     private static let maxQuerySize = 500_000
@@ -60,102 +59,25 @@ internal struct FavoriteEditDialog: View {
     }
 
     var body: some View {
-        VStack(spacing: 16) {
-            Text(isEditing ? String(localized: "Edit Favorite") : String(localized: "New Favorite"))
-                .font(.headline)
-                .frame(maxWidth: .infinity, alignment: .leading)
+        VStack(alignment: .leading, spacing: 0) {
+            titleRow
+
+            Divider()
 
             Form {
-                TextField("Name", text: $name)
-                    .focused($focusedField, equals: .name)
-
-                if !effectiveFolders.isEmpty {
-                    Picker("Folder", selection: $selectedFolderId) {
-                        Text(String(localized: "None")).tag(nil as UUID?)
-                        ForEach(effectiveFolders) { folder in
-                            Text(folder.name).tag(folder.id as UUID?)
-                        }
-                    }
-                }
-
-                LabeledContent("Query") {
-                    TextEditor(text: $query)
-                        .font(.system(.body, design: .monospaced))
-                        .accessibilityLabel(String(localized: "Query"))
-                        .frame(height: 160)
-                        .scrollContentBackground(.hidden)
-                        .padding(4)
-                        .background(Color(nsColor: .textBackgroundColor))
-                        .clipShape(RoundedRectangle(cornerRadius: 4))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 4)
-                                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
-                        )
-                }
-
-                LabeledContent {} label: {
-                    Text(String(
-                        format: String(localized: "Type %@ in the query to set where the cursor lands after keyword expansion."),
-                        SQLSnippetMarker.token
-                    ))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                }
-
-                TextField("Keyword", text: $keyword)
-                    .focused($focusedField, equals: .keyword)
-                    .onChange(of: keyword) { _, newValue in
-                        validateKeyword(newValue)
-                    }
-
-                if let error = keywordError {
-                    LabeledContent {} label: {
-                        Text(error)
-                            .foregroundStyle(isKeywordWarning ? .orange : .red)
-                            .font(.callout)
-                    }
-                }
-
-                Toggle("Global", isOn: $isGlobal)
-                    .help(String(localized: "When enabled, this favorite is visible in all connections"))
-                    .onChange(of: isGlobal) {
-                        validateKeyword(keyword)
-                    }
+                identitySection
+                querySection
+                optionsSection
             }
-            .formStyle(.columns)
+            .formStyle(.grouped)
 
-            HStack {
-                Spacer()
-                Button("Cancel") {
-                    dismiss()
-                }
-                .keyboardShortcut(.cancelAction)
+            Divider()
 
-                Button(isEditing ? "Save" : "Add") {
-                    save()
-                }
-                .keyboardShortcut(.defaultAction)
-                .disabled(!isValid || isSaving)
-            }
+            buttonBar
         }
-        .padding(20)
-        .frame(width: 480)
+        .frame(width: 560, height: 580)
         .onAppear {
-            if let fav = favorite {
-                name = fav.name
-                query = fav.query
-                keyword = fav.keyword ?? ""
-                isGlobal = fav.connectionId == nil
-                selectedFolderId = fav.folderId
-            } else {
-                selectedFolderId = folderId
-                if let q = initialQuery {
-                    query = q
-                }
-                if name.isEmpty && !query.isEmpty {
-                    name = SQLFavorite.autoName(from: query)
-                }
-            }
+            populateFields()
             focusedField = .name
             if folders.isEmpty {
                 Task {
@@ -165,51 +87,126 @@ internal struct FavoriteEditDialog: View {
         }
     }
 
-    // MARK: - Validation
+    private var titleRow: some View {
+        HStack {
+            Text(isEditing ? String(localized: "Edit Favorite") : String(localized: "New Favorite"))
+                .font(.headline)
+            Spacer()
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+    }
 
-    private func validateKeyword(_ value: String) {
-        let trimmed = value.trimmingCharacters(in: .whitespaces)
-        if trimmed.isEmpty {
-            keywordError = nil
-            return
-        }
-        if trimmed.contains(" ") {
-            isKeywordWarning = false
-            keywordError = String(localized: "Keyword cannot contain spaces")
-            return
-        }
-        validationId += 1
-        let currentId = validationId
-        Task { @MainActor in
-            let scopeConnectionId = isGlobal ? nil : connectionId
-            let available = await SQLFavoriteManager.shared.isKeywordAvailable(
-                trimmed,
-                connectionId: scopeConnectionId,
-                excludingFavoriteId: favorite?.id
-            )
-            guard currentId == validationId else { return }
-            if !available {
-                isKeywordWarning = false
-                keywordError = String(localized: "This keyword is already in use")
-            } else {
-                let sqlKeywords: Set<String> = [
-                    "select", "from", "where", "insert", "update", "delete",
-                    "create", "drop", "alter", "join", "on", "and", "or",
-                    "not", "in", "like", "between", "order", "group", "having",
-                    "limit", "set", "values", "into", "as", "is", "null",
-                    "true", "false", "case", "when", "then", "else", "end"
-                ]
-                if sqlKeywords.contains(trimmed.lowercased()) {
-                    isKeywordWarning = true
-                    keywordError = String(
-                        format: String(localized: "Shadows the SQL keyword '%@'"),
-                        trimmed.uppercased()
-                    )
-                } else {
-                    isKeywordWarning = false
-                    keywordError = nil
+    private var identitySection: some View {
+        Section {
+            TextField("Name", text: $name)
+                .focused($focusedField, equals: .name)
+
+            if !effectiveFolders.isEmpty {
+                Picker("Folder", selection: $selectedFolderId) {
+                    Text(String(localized: "None")).tag(nil as UUID?)
+                    ForEach(effectiveFolders) { folder in
+                        Text(folder.name).tag(folder.id as UUID?)
+                    }
                 }
             }
+        }
+    }
+
+    private var querySection: some View {
+        Section {
+            TextEditor(text: $query)
+                .font(.system(.body, design: .monospaced))
+                .frame(minHeight: 180)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(Color(nsColor: .separatorColor))
+                )
+                .accessibilityLabel(String(localized: "Query"))
+        } header: {
+            Text("Query")
+        } footer: {
+            Text(String(
+                format: String(localized: "Type %@ in the query to set where the cursor lands after keyword expansion."),
+                SQLSnippetMarker.token
+            ))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    private var optionsSection: some View {
+        Section {
+            TextField("Keyword", text: $keywordField.keyword)
+                .focused($focusedField, equals: .keyword)
+                .onChange(of: keywordField.keyword) {
+                    revalidateKeyword()
+                }
+
+            if let message = keywordField.validation.displayText {
+                Text(message)
+                    .font(.callout)
+                    .foregroundStyle(keywordField.validation.isWarning ? Color.orange : Color.red)
+            }
+
+            Toggle(isOn: $isGlobal) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Global")
+                    Text(String(localized: "Available in all connections"))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .toggleStyle(.checkbox)
+            .onChange(of: isGlobal) {
+                revalidateKeyword()
+            }
+        }
+    }
+
+    private var buttonBar: some View {
+        HStack {
+            Spacer()
+
+            Button(String(localized: "Cancel")) {
+                dismiss()
+            }
+            .keyboardShortcut(.cancelAction)
+
+            Button(isEditing ? String(localized: "Save") : String(localized: "Add")) {
+                save()
+            }
+            .keyboardShortcut(.defaultAction)
+            .disabled(!isValid || isSaving)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+    }
+
+    private func populateFields() {
+        if let fav = favorite {
+            name = fav.name
+            query = fav.query
+            keywordField.keyword = fav.keyword ?? ""
+            isGlobal = fav.connectionId == nil
+            selectedFolderId = fav.folderId
+        } else {
+            selectedFolderId = folderId
+            if let q = initialQuery {
+                query = q
+            }
+            if name.isEmpty && !query.isEmpty {
+                name = SQLFavorite.autoName(from: query)
+            }
+        }
+    }
+
+    private func revalidateKeyword() {
+        Task {
+            await keywordField.validate(
+                connectionId: isGlobal ? nil : connectionId,
+                excludingFavoriteId: favorite?.id
+            )
         }
     }
 
@@ -218,7 +215,7 @@ internal struct FavoriteEditDialog: View {
     private func save() {
         isSaving = true
         let trimmedName = name.trimmingCharacters(in: .whitespaces)
-        let trimmedKeyword = keyword.trimmingCharacters(in: .whitespaces)
+        let trimmedKeyword = keywordField.trimmedKeyword
         let trimmedQuery: String
         if (query as NSString).length > Self.maxQuerySize {
             trimmedQuery = String(query.prefix(Self.maxQuerySize))

--- a/TablePro/Views/Sidebar/LinkedFavoriteMetadataDialog.swift
+++ b/TablePro/Views/Sidebar/LinkedFavoriteMetadataDialog.swift
@@ -12,133 +12,132 @@ internal struct LinkedFavoriteMetadataDialog: View {
 
     @Environment(\.dismiss) private var dismiss
     @State private var name: String = ""
-    @State private var keyword: String = ""
+    @State private var keywordField = SQLFavoriteKeywordField()
     @State private var fileDescription: String = ""
-    @State private var keywordError: String?
-    @State private var isKeywordWarning = false
-    @State private var validationId = 0
     @State private var isSaving = false
     @State private var saveError: String?
 
     @FocusState private var nameFocused: Bool
 
-    private var trimmedKeyword: String {
-        keyword.trimmingCharacters(in: .whitespaces)
-    }
-
     private var isValid: Bool {
-        !name.trimmingCharacters(in: .whitespaces).isEmpty
-            && (keywordError == nil || isKeywordWarning)
+        SQLFavoriteEditValidation.canSave(
+            isNameBlank: !name.contains { !$0.isWhitespace },
+            keywordValidation: keywordField.validation
+        )
     }
 
     var body: some View {
-        VStack(spacing: 16) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(String(localized: "Edit Metadata"))
-                    .font(.headline)
-                Text(favorite.relativePath)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
+        VStack(alignment: .leading, spacing: 0) {
+            titleRow
+
+            Divider()
 
             Form {
-                TextField(String(localized: "Name"), text: $name)
-                    .focused($nameFocused)
-                TextField(String(localized: "Keyword"), text: $keyword)
-                    .onChange(of: keyword) { _, newValue in
-                        validateKeyword(newValue)
-                    }
-                if let error = keywordError {
-                    LabeledContent {} label: {
-                        Text(error)
-                            .foregroundStyle(isKeywordWarning ? .orange : .red)
-                            .font(.callout)
-                    }
-                }
-                TextField(String(localized: "Description"), text: $fileDescription, axis: .vertical)
-                    .lineLimit(2...4)
+                identitySection
+                keywordSection
             }
-            .formStyle(.columns)
+            .formStyle(.grouped)
 
             if let saveError {
-                Label(saveError, systemImage: "exclamationmark.triangle.fill")
-                    .font(.caption)
-                    .foregroundStyle(.red)
+                Divider()
+                errorBanner(saveError)
             }
 
-            HStack {
-                Spacer()
-                Button(String(localized: "Cancel")) {
-                    dismiss()
-                }
-                .keyboardShortcut(.cancelAction)
+            Divider()
 
-                Button(String(localized: "Save")) {
-                    save()
-                }
-                .keyboardShortcut(.defaultAction)
-                .buttonStyle(.borderedProminent)
-                .disabled(!isValid || isSaving)
-            }
+            buttonBar
         }
-        .padding(20)
-        .frame(width: 460)
+        .frame(width: 480, height: 400)
         .onAppear {
             name = favorite.name
-            keyword = favorite.keyword ?? ""
+            keywordField.keyword = favorite.keyword ?? ""
             fileDescription = favorite.fileDescription ?? ""
             nameFocused = true
         }
     }
 
-    private func validateKeyword(_ value: String) {
-        let trimmed = value.trimmingCharacters(in: .whitespaces)
-        if trimmed.isEmpty {
-            keywordError = nil
-            return
+    private var titleRow: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(String(localized: "Edit Metadata"))
+                .font(.headline)
+            Text(favorite.relativePath)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
         }
-        if trimmed.contains(" ") {
-            isKeywordWarning = false
-            keywordError = String(localized: "Keyword cannot contain spaces")
-            return
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+    }
+
+    private var identitySection: some View {
+        Section {
+            TextField(String(localized: "Name"), text: $name)
+                .focused($nameFocused)
+            TextField(String(localized: "Description"), text: $fileDescription, axis: .vertical)
+                .lineLimit(2...4)
         }
-        validationId += 1
-        let currentId = validationId
-        Task { @MainActor in
-            let available = await SQLFavoriteManager.shared.isKeywordAvailable(
-                trimmed,
-                connectionId: connectionId,
-                excludingFavoriteId: nil
-            )
-            guard currentId == validationId else { return }
-            if !available {
-                isKeywordWarning = false
-                keywordError = String(localized: "This keyword is already in use")
-                return
+    }
+
+    private var keywordSection: some View {
+        Section {
+            TextField(String(localized: "Keyword"), text: $keywordField.keyword)
+                .onChange(of: keywordField.keyword) {
+                    revalidateKeyword()
+                }
+
+            if let message = keywordField.validation.displayText {
+                Text(message)
+                    .font(.callout)
+                    .foregroundStyle(keywordField.validation.isWarning ? Color.orange : Color.red)
             }
-            let sqlKeywords: Set<String> = [
-                "select", "from", "where", "insert", "update", "delete",
-                "create", "drop", "alter", "join", "on", "and", "or",
-                "not", "in", "like", "between", "order", "group", "having",
-                "limit", "set", "values", "into", "as", "is", "null",
-                "true", "false", "case", "when", "then", "else", "end"
-            ]
-            if sqlKeywords.contains(trimmed.lowercased()) {
-                isKeywordWarning = true
-                keywordError = String(format: String(localized: "Shadows the SQL keyword '%@'"), trimmed.uppercased())
-            } else {
-                isKeywordWarning = false
-                keywordError = nil
+        }
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.primary)
+                .lineLimit(2)
+            Spacer()
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 10)
+    }
+
+    private var buttonBar: some View {
+        HStack {
+            Spacer()
+
+            Button(String(localized: "Cancel")) {
+                dismiss()
             }
+            .keyboardShortcut(.cancelAction)
+
+            Button(String(localized: "Save")) {
+                save()
+            }
+            .keyboardShortcut(.defaultAction)
+            .disabled(!isValid || isSaving)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+    }
+
+    private func revalidateKeyword() {
+        Task {
+            await keywordField.validate(connectionId: connectionId, excludingFavoriteId: nil)
         }
     }
 
     private func save() {
         isSaving = true
         let trimmedName = name.trimmingCharacters(in: .whitespaces)
+        let trimmedKeyword = keywordField.trimmedKeyword
         let trimmedDescription = fileDescription.trimmingCharacters(in: .whitespaces)
 
         let metadata = SQLFrontmatter.Metadata(

--- a/TableProTests/Core/Storage/SQLFavoriteEditValidationTests.swift
+++ b/TableProTests/Core/Storage/SQLFavoriteEditValidationTests.swift
@@ -1,0 +1,160 @@
+//
+//  SQLFavoriteEditValidationTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("SQLFavoriteKeywordValidator")
+struct SQLFavoriteKeywordValidatorTests {
+    @Test("Empty keyword is valid regardless of availability")
+    func emptyKeywordIsValid() {
+        #expect(SQLFavoriteKeywordValidator.classify(trimmedKeyword: "", isAvailable: true) == .valid)
+        #expect(SQLFavoriteKeywordValidator.classify(trimmedKeyword: "", isAvailable: false) == .valid)
+    }
+
+    @Test("Keyword containing a space is an error regardless of availability")
+    func spaceIsError() {
+        let available = SQLFavoriteKeywordValidator.classify(trimmedKeyword: "my keyword", isAvailable: true)
+        let unavailable = SQLFavoriteKeywordValidator.classify(trimmedKeyword: "my keyword", isAvailable: false)
+        #expect(available.blocksSave)
+        #expect(unavailable.blocksSave)
+        #expect(!available.isWarning)
+        #expect(available.displayText != nil)
+    }
+
+    @Test("Unavailable keyword is an error")
+    func unavailableIsError() {
+        let result = SQLFavoriteKeywordValidator.classify(trimmedKeyword: "sel1", isAvailable: false)
+        #expect(result.blocksSave)
+        #expect(!result.isWarning)
+        #expect(result.displayText != nil)
+    }
+
+    @Test("Reserved SQL keyword warns without blocking", arguments: ["select", "SELECT", "Select", "limit"])
+    func reservedKeywordWarns(keyword: String) {
+        let result = SQLFavoriteKeywordValidator.classify(trimmedKeyword: keyword, isAvailable: true)
+        #expect(result.isWarning)
+        #expect(!result.blocksSave)
+        #expect(result.displayText?.contains(keyword.uppercased()) == true)
+    }
+
+    @Test("Available non-reserved keyword is valid")
+    func availableKeywordIsValid() {
+        #expect(SQLFavoriteKeywordValidator.classify(trimmedKeyword: "selusers", isAvailable: true) == .valid)
+    }
+
+    @Test("Availability check is required only for well-formed keywords")
+    func requiresAvailabilityCheck() {
+        #expect(!SQLFavoriteKeywordValidator.requiresAvailabilityCheck(""))
+        #expect(!SQLFavoriteKeywordValidator.requiresAvailabilityCheck("my keyword"))
+        #expect(SQLFavoriteKeywordValidator.requiresAvailabilityCheck("sel1"))
+    }
+}
+
+@Suite("SQLFavoriteEditValidation")
+struct SQLFavoriteEditValidationTests {
+    @Test("Blank name blocks save")
+    func blankNameBlocks() {
+        #expect(!SQLFavoriteEditValidation.canSave(isNameBlank: true, isQueryBlank: false, keywordValidation: .valid))
+    }
+
+    @Test("Blank query blocks save")
+    func blankQueryBlocks() {
+        #expect(!SQLFavoriteEditValidation.canSave(isNameBlank: false, isQueryBlank: true, keywordValidation: .valid))
+    }
+
+    @Test("Keyword error blocks save")
+    func keywordErrorBlocks() {
+        #expect(!SQLFavoriteEditValidation.canSave(
+            isNameBlank: false,
+            isQueryBlank: false,
+            keywordValidation: .error("taken")
+        ))
+    }
+
+    @Test("Keyword warning does not block save")
+    func keywordWarningAllows() {
+        #expect(SQLFavoriteEditValidation.canSave(
+            isNameBlank: false,
+            isQueryBlank: false,
+            keywordValidation: .warning("shadows")
+        ))
+    }
+
+    @Test("Valid fields allow save")
+    func validFieldsAllow() {
+        #expect(SQLFavoriteEditValidation.canSave(isNameBlank: false, isQueryBlank: false, keywordValidation: .valid))
+        #expect(SQLFavoriteEditValidation.canSave(isNameBlank: false, keywordValidation: .valid))
+    }
+}
+
+@MainActor
+@Suite("SQLFavoriteKeywordField")
+struct SQLFavoriteKeywordFieldTests {
+    @Test("Validation reflects the availability check result")
+    func reflectsAvailability() async {
+        let field = SQLFavoriteKeywordField { _, _, _ in false }
+        field.keyword = "sel1"
+        await field.validate(connectionId: nil, excludingFavoriteId: nil)
+        #expect(field.validation.blocksSave)
+
+        let availableField = SQLFavoriteKeywordField { _, _, _ in true }
+        availableField.keyword = "sel1"
+        await availableField.validate(connectionId: nil, excludingFavoriteId: nil)
+        #expect(availableField.validation == .valid)
+    }
+
+    @Test("Malformed keywords skip the availability check")
+    func malformedSkipsAvailabilityCheck() async {
+        let field = SQLFavoriteKeywordField { _, _, _ in
+            Issue.record("availability check should not run")
+            return true
+        }
+        field.keyword = "my keyword"
+        await field.validate(connectionId: nil, excludingFavoriteId: nil)
+        #expect(field.validation.blocksSave)
+
+        field.keyword = "   "
+        await field.validate(connectionId: nil, excludingFavoriteId: nil)
+        #expect(field.validation == .valid)
+    }
+
+    @Test("Keyword is trimmed before validation")
+    func trimsKeyword() async {
+        let field = SQLFavoriteKeywordField { keyword, _, _ in keyword == "sel1" }
+        field.keyword = "  sel1  "
+        await field.validate(connectionId: nil, excludingFavoriteId: nil)
+        #expect(field.validation == .valid)
+    }
+
+    @Test("Stale availability responses are discarded")
+    func staleResponseDiscarded() async {
+        let (enteredStream, enteredContinuation) = AsyncStream.makeStream(of: Void.self)
+        let (releaseStream, releaseContinuation) = AsyncStream.makeStream(of: Bool.self)
+
+        let field = SQLFavoriteKeywordField { keyword, _, _ in
+            guard keyword == "slowkw" else { return true }
+            enteredContinuation.yield()
+            var iterator = releaseStream.makeAsyncIterator()
+            return await iterator.next() ?? true
+        }
+
+        field.keyword = "slowkw"
+        let slowValidation = Task {
+            await field.validate(connectionId: nil, excludingFavoriteId: nil)
+        }
+        var enteredIterator = enteredStream.makeAsyncIterator()
+        await enteredIterator.next()
+
+        field.keyword = "fastkw"
+        await field.validate(connectionId: nil, excludingFavoriteId: nil)
+        #expect(field.validation == .valid)
+
+        releaseContinuation.yield(false)
+        await slowValidation.value
+        #expect(field.validation == .valid)
+    }
+}


### PR DESCRIPTION
## Problem

The New Favorite / Edit Favorite sheet rendered with a large empty region on the left, labels pushed to mid-dialog, and fields crushed against the right edge.

## Root cause

The form used `.formStyle(.columns)`, which lays out one shared trailing-aligned label column for the whole form. The dialog put the ~90-character ";;" hint sentence (and the keyword error text) into the label slot of an empty `LabeledContent`. That single row inflated the shared label column, which right-aligned every short label toward the center and squeezed the value column into a narrow strip. The same anti-pattern was copy-pasted into `LinkedFavoriteMetadataDialog`.

## Changes

- Rebuilt both dialogs on the repo-standard sheet shape (title row, `Divider`, `Form` with `.formStyle(.grouped)`, `Divider`, bottom-right Cancel/primary row). This matches the 24 existing `.grouped` form sites, Apple's grouped-form guidance (WWDC22 10052, Food Truck sample), and HIG rules for sheets, text fields, and toggles.
- The Query editor is now a full-width `TextEditor` in its own section (minHeight 180, monospaced), with the ";;" hint as a real section footer.
- Keyword validation shows inline directly under the Keyword field. Global is a checkbox (HIG: do not replace a checkbox with a switch) with a visible "Available in all connections" caption instead of a hover tooltip.
- Extracted the duplicated keyword validation from both view structs into `SQLFavoriteEditValidation.swift` (`SQLFavoriteKeywordValidator` pure classifier plus `SQLFavoriteKeywordField` with an injectable availability check). This also fixes a latent race: an in-flight availability check could overwrite the result of a newer synchronous validation. Every `validate` call now invalidates stale checks.
- Removed a latent perf issue: `isValid` trimmed the full query string (up to 500KB) on every body evaluation. It now uses a short-circuiting blank check. The 500KB save cap is unchanged.
- `CreateDatabaseSheet` keeps `.formStyle(.columns)` on purpose: all its labels are short and it is not affected.

## Tests

- New `SQLFavoriteEditValidationTests`: classifier table (empty, space, unavailable, reserved-keyword shadow), warning-allows-save vs error-blocks-save semantics, keyword trimming, and a deterministic stale-response race test using gated `AsyncStream`s.
- No UI automation added: `TableProUITests` has no harness for driving a `.sheet(item:)` dialog and no storage-injection seam, so the keyword-validation flow cannot run deterministically against the live SQLite-backed store. The extracted logic carries the coverage instead.
- `swiftlint lint --strict` clean on all changed files.

## Follow-up

The screenshots in `docs/features/favorites.mdx` (`sql-favorite-create.png`, `sql-favorite-create-dark.png`) show the old layout and need recapturing. The page text stays accurate.