### PR TITLE
fix(plugin-oracle): stop infinite loading when switching schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Switching schemas on an Oracle connection no longer hangs on an infinite loading spinner. Oracle now switches by schema like BigQuery, the sidebar lists every schema with its tables loading on expand, Oracle queries respect the query timeout setting and can be cancelled, and a schema load that fails now shows an error with a Retry button instead of spinning forever. Requires the updated Oracle plugin for the full fix. (#1807)
+- Switching schemas on an Oracle connection no longer hangs on an infinite loading spinner. Oracle now switches by schema like BigQuery, the sidebar lists every schema with its tables loading on expand, Oracle queries respect the query timeout setting and reconnect automatically after a timeout, and a schema load that fails shows an error with a Retry button instead of spinning forever. Works with an already-installed Oracle plugin; updating the plugin adds the query timeout enforcement. (#1807)
 
 ## [0.55.0] - 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Switching schemas on an Oracle connection no longer hangs on an infinite loading spinner. Oracle now switches by schema like BigQuery, the sidebar lists every schema with its tables loading on expand, Oracle queries respect the query timeout setting and can be cancelled, and a schema load that fails now shows an error with a Retry button instead of spinning forever. Requires the updated Oracle plugin for the full fix. (#1807)
+
 ## [0.55.0] - 2026-07-04
 
 ### Added

--- a/Packages/TableProCore/Tests/TableProPluginKitTests/AsyncTimeoutTests.swift
+++ b/Packages/TableProCore/Tests/TableProPluginKitTests/AsyncTimeoutTests.swift
@@ -32,4 +32,42 @@ final class AsyncTimeoutTests: XCTestCase {
             XCTFail("Expected Boom, got \(error)")
         }
     }
+
+    func testOnTimeoutUnblocksCancellationDeafOperation() async {
+        final class Latch: @unchecked Sendable {
+            var continuation: CheckedContinuation<Void, Never>?
+        }
+        struct Closed: Error {}
+        let latch = Latch()
+
+        do {
+            _ = try await withTimeout(
+                seconds: 0.05,
+                onTimeout: {
+                    latch.continuation?.resume()
+                    latch.continuation = nil
+                }
+            ) { () -> Int in
+                await withCheckedContinuation { latch.continuation = $0 }
+                throw Closed()
+            }
+            XCTFail("Expected an error")
+        } catch {
+            // TimeoutError or Closed both prove onTimeout unblocked the operation.
+            // Without it this test hangs: the continuation ignores task
+            // cancellation and the group waits for the operation child.
+        }
+    }
+
+    func testOnTimeoutNotInvokedWhenOperationWins() async throws {
+        final class Flag: @unchecked Sendable {
+            var value = false
+        }
+        let flag = Flag()
+
+        let value = try await withTimeout(seconds: 5, onTimeout: { flag.value = true }) { 42 }
+
+        XCTAssertEqual(value, 42)
+        XCTAssertFalse(flag.value)
+    }
 }

--- a/Plugins/OracleDriverPlugin/OracleConnection.swift
+++ b/Plugins/OracleDriverPlugin/OracleConnection.swift
@@ -29,6 +29,7 @@ struct OracleError: Error {
         case authVersionNotSupported
         case authConnectionDropped(phase: String?)
         case loginTimedOut
+        case queryTimedOut
         case nativeEncryptionFailed
     }
 
@@ -127,6 +128,7 @@ final class OracleConnectionWrapper: @unchecked Sendable {
     private struct LockedState: Sendable {
         var isConnected = false
         var nioConnection: OracleNIO.OracleConnection?
+        var queryTimeoutSeconds = 0
     }
 
     private let state = OSAllocatedUnfairLock(initialState: LockedState())
@@ -297,12 +299,18 @@ final class OracleConnectionWrapper: @unchecked Sendable {
             return String(localized: "This account uses a password verifier the database driver does not support.")
         case .loginTimedOut:
             return loginTimeoutMessage
+        case .queryTimedOut:
+            return queryTimeoutMessage
         case .nativeEncryptionFailed:
             return nativeEncryptionFailureMessage
         case .generic, .notConnected, .connectionFailed, .queryFailed, .protocolError:
             return serverDetail
         }
     }
+
+    private static let queryTimeoutMessage = String(
+        localized: "The query did not finish within the configured timeout, so the connection was reset. Run the query again."
+    )
 
     private func mapQueryError(_ sqlError: OracleSQLError) -> OracleError {
         guard Self.isChannelFatal(sqlError) else {
@@ -340,71 +348,71 @@ final class OracleConnectionWrapper: @unchecked Sendable {
         }
     }
 
+    func applyQueryTimeout(_ seconds: Int) {
+        state.withLock { $0.queryTimeoutSeconds = max(0, seconds) }
+    }
+
+    func abortCurrentQuery() {
+        guard isConnected else { return }
+        osLogger.notice("Aborting Oracle query by closing the connection; the driver has no server-side cancel")
+        disconnect()
+    }
+
     // MARK: - Query Execution
 
-    func executeQuery(_ query: String) async throws -> OracleQueryResult {
-        let connection = try state.withLock { current -> OracleNIO.OracleConnection in
+    private func requireConnection() throws -> OracleNIO.OracleConnection {
+        try state.withLock { current in
             guard let conn = current.nioConnection, current.isConnected else {
                 throw OracleError.notConnected
             }
             return conn
         }
+    }
+
+    /// Races the operation against the configured query timeout. On timeout the
+    /// connection is closed first, which fails the in-flight OracleNIO call even
+    /// if it ignores task cancellation, so the group can always unwind.
+    private func withQueryDeadline<T: Sendable>(
+        _ operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        let timeoutSeconds = state.withLock { $0.queryTimeoutSeconds }
+        guard timeoutSeconds > 0 else { return try await operation() }
+
+        return try await withThrowingTaskGroup(of: T?.self) { group in
+            group.addTask { try await operation() }
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(timeoutSeconds) * 1_000_000_000)
+                return nil
+            }
+            defer { group.cancelAll() }
+            guard let first = try await group.next(), let result = first else {
+                disconnect()
+                throw TimeoutError(seconds: Double(timeoutSeconds))
+            }
+            return result
+        }
+    }
+
+    private func queryTimeoutError(_ timeout: TimeoutError) -> OracleError {
+        osLogger.error("Oracle query timed out after \(Int(timeout.seconds), privacy: .public)s; the connection was closed to recover")
+        return OracleError(message: Self.queryTimeoutMessage, category: .queryTimedOut)
+    }
+
+    func executeQuery(_ query: String) async throws -> OracleQueryResult {
+        let connection = try requireConnection()
 
         // OracleNIO does not support concurrent queries on a single connection.
         // Serialize all queries to prevent state-machine corruption.
         await queryGate.acquire()
 
         do {
-            let statement = OracleStatement(stringLiteral: query)
-            let stream = try await connection.execute(statement, logger: nioLogger)
-
-            // Read column metadata from stream (available even with 0 rows)
-            var columns: [String] = []
-            for col in stream.columns {
-                columns.append(col.name)
+            let result = try await withQueryDeadline { [self] in
+                try await collectRows(query, on: connection)
             }
-            osLogger.debug("Oracle columns: \(columns.count) — \(columns.joined(separator: ", "))")
-
-            var columnTypeNames: [String] = []
-            var allRows: [[PluginCellValue]] = []
-            var didReadTypes = false
-            var truncated = false
-
-            for try await row in stream {
-                var rowValues: [PluginCellValue] = []
-                for cell in row {
-                    if !didReadTypes {
-                        columnTypeNames.append(oracleTypeName(cell.dataType))
-                    }
-                    if cell.bytes == nil {
-                        rowValues.append(.null)
-                    } else if cell.dataType == .raw || cell.dataType == .longRAW || cell.dataType == .blob,
-                              let bytes = cell.bytes {
-                        rowValues.append(.bytes(Data(bytes.readableBytesView)))
-                    } else {
-                        rowValues.append(PluginCellValue.fromOptional(decodeCell(cell)))
-                    }
-                }
-                didReadTypes = true
-                allRows.append(rowValues)
-                if allRows.count >= PluginRowLimits.emergencyMax {
-                    truncated = true
-                    break
-                }
-            }
-
-            if !didReadTypes {
-                columnTypeNames = Array(repeating: "unknown", count: columns.count)
-            }
-
             await queryGate.release()
-            return OracleQueryResult(
-                columns: columns,
-                columnTypeNames: columnTypeNames,
-                rows: allRows,
-                affectedRows: allRows.count,
-                isTruncated: truncated
-            )
+            return result
+        } catch let timeout as TimeoutError {
+            throw queryTimeoutError(timeout)
         } catch let sqlError as OracleSQLError {
             await queryGate.release()
             throw mapQueryError(sqlError)
@@ -420,76 +428,79 @@ final class OracleConnectionWrapper: @unchecked Sendable {
         }
     }
 
+    private func collectRows(
+        _ query: String,
+        on connection: OracleNIO.OracleConnection
+    ) async throws -> OracleQueryResult {
+        let statement = OracleStatement(stringLiteral: query)
+        let stream = try await connection.execute(statement, logger: nioLogger)
+
+        // Read column metadata from stream (available even with 0 rows)
+        var columns: [String] = []
+        for col in stream.columns {
+            columns.append(col.name)
+        }
+        osLogger.debug("Oracle columns (\(columns.count)): \(columns.joined(separator: ", "))")
+
+        var columnTypeNames: [String] = []
+        var allRows: [[PluginCellValue]] = []
+        var didReadTypes = false
+        var truncated = false
+
+        for try await row in stream {
+            var rowValues: [PluginCellValue] = []
+            for cell in row {
+                if !didReadTypes {
+                    columnTypeNames.append(oracleTypeName(cell.dataType))
+                }
+                if cell.bytes == nil {
+                    rowValues.append(.null)
+                } else if cell.dataType == .raw || cell.dataType == .longRAW || cell.dataType == .blob,
+                          let bytes = cell.bytes {
+                    rowValues.append(.bytes(Data(bytes.readableBytesView)))
+                } else {
+                    rowValues.append(PluginCellValue.fromOptional(decodeCell(cell)))
+                }
+            }
+            didReadTypes = true
+            allRows.append(rowValues)
+            if allRows.count >= PluginRowLimits.emergencyMax {
+                truncated = true
+                break
+            }
+        }
+
+        if !didReadTypes {
+            columnTypeNames = Array(repeating: "unknown", count: columns.count)
+        }
+
+        return OracleQueryResult(
+            columns: columns,
+            columnTypeNames: columnTypeNames,
+            rows: allRows,
+            affectedRows: allRows.count,
+            isTruncated: truncated
+        )
+    }
+
     // MARK: - Streaming Query
 
     func streamQuery(
         _ query: String,
         continuation: AsyncThrowingStream<PluginStreamElement, Error>.Continuation
     ) async throws {
-        let connection = try state.withLock { current -> OracleNIO.OracleConnection in
-            guard let conn = current.nioConnection, current.isConnected else {
-                throw OracleError.notConnected
-            }
-            return conn
-        }
+        let connection = try requireConnection()
 
         await queryGate.acquire()
 
         do {
-            let statement = OracleStatement(stringLiteral: query)
-            let stream = try await connection.execute(statement, logger: nioLogger)
-
-            var columns: [String] = []
-            for col in stream.columns {
-                columns.append(col.name)
+            try await withQueryDeadline { [self] in
+                try await streamRows(query, on: connection, continuation: continuation)
             }
-
-            var columnTypeNames: [String] = []
-            var headerSent = false
-
-            for try await row in stream {
-                if Task.isCancelled {
-                    await queryGate.release()
-                    continuation.finish(throwing: CancellationError())
-                    return
-                }
-
-                var rowValues: [PluginCellValue] = []
-                for cell in row {
-                    if !headerSent {
-                        columnTypeNames.append(oracleTypeName(cell.dataType))
-                    }
-                    if cell.bytes == nil {
-                        rowValues.append(.null)
-                    } else if cell.dataType == .raw || cell.dataType == .longRAW || cell.dataType == .blob,
-                              let bytes = cell.bytes {
-                        rowValues.append(.bytes(Data(bytes.readableBytesView)))
-                    } else {
-                        rowValues.append(PluginCellValue.fromOptional(decodeCell(cell)))
-                    }
-                }
-
-                if !headerSent {
-                    continuation.yield(.header(PluginStreamHeader(
-                        columns: columns,
-                        columnTypeNames: columnTypeNames
-                    )))
-                    headerSent = true
-                }
-
-                continuation.yield(.rows([rowValues]))
-            }
-
-            if !headerSent {
-                columnTypeNames = Array(repeating: "unknown", count: columns.count)
-                continuation.yield(.header(PluginStreamHeader(
-                    columns: columns,
-                    columnTypeNames: columnTypeNames
-                )))
-            }
-
             await queryGate.release()
             continuation.finish()
+        } catch let timeout as TimeoutError {
+            throw queryTimeoutError(timeout)
         } catch let sqlError as OracleSQLError {
             await queryGate.release()
             throw mapQueryError(sqlError)
@@ -499,6 +510,60 @@ final class OracleConnectionWrapper: @unchecked Sendable {
         } catch {
             await queryGate.release()
             throw OracleError(message: "Query execution failed: \(String(describing: error))")
+        }
+    }
+
+    private func streamRows(
+        _ query: String,
+        on connection: OracleNIO.OracleConnection,
+        continuation: AsyncThrowingStream<PluginStreamElement, Error>.Continuation
+    ) async throws {
+        let statement = OracleStatement(stringLiteral: query)
+        let stream = try await connection.execute(statement, logger: nioLogger)
+
+        var columns: [String] = []
+        for col in stream.columns {
+            columns.append(col.name)
+        }
+
+        var columnTypeNames: [String] = []
+        var headerSent = false
+
+        for try await row in stream {
+            try Task.checkCancellation()
+
+            var rowValues: [PluginCellValue] = []
+            for cell in row {
+                if !headerSent {
+                    columnTypeNames.append(oracleTypeName(cell.dataType))
+                }
+                if cell.bytes == nil {
+                    rowValues.append(.null)
+                } else if cell.dataType == .raw || cell.dataType == .longRAW || cell.dataType == .blob,
+                          let bytes = cell.bytes {
+                    rowValues.append(.bytes(Data(bytes.readableBytesView)))
+                } else {
+                    rowValues.append(PluginCellValue.fromOptional(decodeCell(cell)))
+                }
+            }
+
+            if !headerSent {
+                continuation.yield(.header(PluginStreamHeader(
+                    columns: columns,
+                    columnTypeNames: columnTypeNames
+                )))
+                headerSent = true
+            }
+
+            continuation.yield(.rows([rowValues]))
+        }
+
+        if !headerSent {
+            columnTypeNames = Array(repeating: "unknown", count: columns.count)
+            continuation.yield(.header(PluginStreamHeader(
+                columns: columns,
+                columnTypeNames: columnTypeNames
+            )))
         }
     }
 

--- a/Plugins/OracleDriverPlugin/OracleConnection.swift
+++ b/Plugins/OracleDriverPlugin/OracleConnection.swift
@@ -127,8 +127,10 @@ final class OracleConnectionWrapper: @unchecked Sendable {
 
     private struct LockedState: Sendable {
         var isConnected = false
+        var hasEverConnected = false
         var nioConnection: OracleNIO.OracleConnection?
         var queryTimeoutSeconds = 0
+        var sessionSchema: String?
     }
 
     private let state = OSAllocatedUnfairLock(initialState: LockedState())
@@ -197,6 +199,7 @@ final class OracleConnectionWrapper: @unchecked Sendable {
             state.withLock { current in
                 current.nioConnection = connection
                 current.isConnected = true
+                current.hasEverConnected = true
             }
 
             let target = useSID ? "\(self.host):\(self.port):\(identifier)" : "\(self.host):\(self.port)/\(identifier)"
@@ -352,10 +355,8 @@ final class OracleConnectionWrapper: @unchecked Sendable {
         state.withLock { $0.queryTimeoutSeconds = max(0, seconds) }
     }
 
-    func abortCurrentQuery() {
-        guard isConnected else { return }
-        osLogger.notice("Aborting Oracle query by closing the connection; the driver has no server-side cancel")
-        disconnect()
+    func noteSessionSchema(_ schema: String) {
+        state.withLock { $0.sessionSchema = schema }
     }
 
     // MARK: - Query Execution
@@ -369,28 +370,47 @@ final class OracleConnectionWrapper: @unchecked Sendable {
         }
     }
 
+    /// Serialized behind the query gate, so at most one reconnect runs at a time.
+    /// Reconnecting restores the session schema, which ALTER SESSION state does
+    /// not survive across connections.
+    private func reconnectedConnection() async throws -> OracleNIO.OracleConnection {
+        if let connection = state.withLock({ $0.isConnected ? $0.nioConnection : nil }) {
+            return connection
+        }
+        guard state.withLock({ $0.hasEverConnected }) else {
+            throw OracleError.notConnected
+        }
+
+        osLogger.notice("Reconnecting to Oracle after the previous connection was closed")
+        try await connect()
+        let connection = try requireConnection()
+        if let schema = state.withLock({ $0.sessionSchema }) {
+            _ = try await withQueryDeadline { [self] in
+                try await collectRows(Self.currentSchemaStatement(schema), on: connection)
+            }
+        }
+        return connection
+    }
+
+    private static func currentSchemaStatement(_ schema: String) -> String {
+        let escaped = schema.replacingOccurrences(of: "\"", with: "\"\"")
+        return "ALTER SESSION SET CURRENT_SCHEMA = \"\(escaped)\""
+    }
+
     /// Races the operation against the configured query timeout. On timeout the
     /// connection is closed first, which fails the in-flight OracleNIO call even
-    /// if it ignores task cancellation, so the group can always unwind.
+    /// if it ignores task cancellation, so the race can always unwind.
     private func withQueryDeadline<T: Sendable>(
         _ operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
         let timeoutSeconds = state.withLock { $0.queryTimeoutSeconds }
         guard timeoutSeconds > 0 else { return try await operation() }
 
-        return try await withThrowingTaskGroup(of: T?.self) { group in
-            group.addTask { try await operation() }
-            group.addTask {
-                try await Task.sleep(nanoseconds: UInt64(timeoutSeconds) * 1_000_000_000)
-                return nil
-            }
-            defer { group.cancelAll() }
-            guard let first = try await group.next(), let result = first else {
-                disconnect()
-                throw TimeoutError(seconds: Double(timeoutSeconds))
-            }
-            return result
-        }
+        return try await withTimeout(
+            seconds: Double(timeoutSeconds),
+            onTimeout: { [self] in disconnect() },
+            operation: operation
+        )
     }
 
     private func queryTimeoutError(_ timeout: TimeoutError) -> OracleError {
@@ -398,33 +418,36 @@ final class OracleConnectionWrapper: @unchecked Sendable {
         return OracleError(message: Self.queryTimeoutMessage, category: .queryTimedOut)
     }
 
-    func executeQuery(_ query: String) async throws -> OracleQueryResult {
-        let connection = try requireConnection()
+    private func mapExecutionError(_ error: Error) -> Error {
+        switch error {
+        case let timeout as TimeoutError:
+            return queryTimeoutError(timeout)
+        case let sqlError as OracleSQLError:
+            return mapQueryError(sqlError)
+        case let oracleError as OracleError:
+            return oracleError
+        case is CancellationError:
+            return error
+        default:
+            return OracleError(message: "Query execution failed: \(String(describing: error))")
+        }
+    }
 
+    func executeQuery(_ query: String) async throws -> OracleQueryResult {
         // OracleNIO does not support concurrent queries on a single connection.
         // Serialize all queries to prevent state-machine corruption.
         await queryGate.acquire()
 
         do {
+            let connection = try await reconnectedConnection()
             let result = try await withQueryDeadline { [self] in
                 try await collectRows(query, on: connection)
             }
             await queryGate.release()
             return result
-        } catch let timeout as TimeoutError {
-            throw queryTimeoutError(timeout)
-        } catch let sqlError as OracleSQLError {
-            await queryGate.release()
-            throw mapQueryError(sqlError)
-        } catch let error as OracleError {
-            await queryGate.release()
-            throw error
-        } catch is CancellationError {
-            await queryGate.release()
-            throw CancellationError()
         } catch {
             await queryGate.release()
-            throw OracleError(message: "Query execution failed: \(String(describing: error))")
+            throw mapExecutionError(error)
         }
     }
 
@@ -489,27 +512,18 @@ final class OracleConnectionWrapper: @unchecked Sendable {
         _ query: String,
         continuation: AsyncThrowingStream<PluginStreamElement, Error>.Continuation
     ) async throws {
-        let connection = try requireConnection()
-
         await queryGate.acquire()
 
         do {
+            let connection = try await reconnectedConnection()
             try await withQueryDeadline { [self] in
                 try await streamRows(query, on: connection, continuation: continuation)
             }
             await queryGate.release()
             continuation.finish()
-        } catch let timeout as TimeoutError {
-            throw queryTimeoutError(timeout)
-        } catch let sqlError as OracleSQLError {
-            await queryGate.release()
-            throw mapQueryError(sqlError)
-        } catch is CancellationError {
-            await queryGate.release()
-            throw CancellationError()
         } catch {
             await queryGate.release()
-            throw OracleError(message: "Query execution failed: \(String(describing: error))")
+            throw mapExecutionError(error)
         }
     }
 

--- a/Plugins/OracleDriverPlugin/OraclePlugin.swift
+++ b/Plugins/OracleDriverPlugin/OraclePlugin.swift
@@ -239,7 +239,6 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             .transactions,
             .alterTableDDL,
             .multiSchema,
-            .cancelQuery,
         ]
     }
 
@@ -299,10 +298,6 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func ping() async throws {
         _ = try await execute(query: "SELECT 1 FROM DUAL")
-    }
-
-    func cancelQuery() throws {
-        oracleConn?.abortCurrentQuery()
     }
 
     func applyQueryTimeout(_ seconds: Int) async throws {
@@ -1149,6 +1144,7 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         let escaped = schema.replacingOccurrences(of: "\"", with: "\"\"")
         _ = try await execute(query: "ALTER SESSION SET CURRENT_SCHEMA = \"\(escaped)\"")
         _currentSchema = schema
+        oracleConn?.noteSessionSchema(schema)
     }
 
     /// Oracle has no real database concept; "switch database" is a schema switch.

--- a/Plugins/OracleDriverPlugin/OraclePlugin.swift
+++ b/Plugins/OracleDriverPlugin/OraclePlugin.swift
@@ -54,11 +54,14 @@ final class OraclePlugin: NSObject, TableProPlugin, DriverPlugin, PluginDiagnost
     static let supportsTriggerEditing = true
     static let pathFieldRole: PathFieldRole = .serviceName
     static let supportsForeignKeyDisable = false
+    static let supportsDatabaseSwitching = false
     static let supportsSchemaSwitching = true
+    static let defaultSchemaName = ""
+    static let containerEntityName = "Schema"
     static let postConnectActions: [PostConnectAction] = [.selectSchemaFromLastSession]
     static let brandColorHex = "#C3160B"
     static let systemDatabaseNames: [String] = ["SYS", "SYSTEM", "OUTLN", "DBSNMP", "APPQOSSYS", "WMSYS", "XDB"]
-    static let databaseGroupingStrategy: GroupingStrategy = .bySchema
+    static let databaseGroupingStrategy: GroupingStrategy = .hierarchicalSchema
     static let columnTypesByCategory: [String: [String]] = [
         "Integer": ["NUMBER", "INTEGER", "INT", "SMALLINT"],
         "Float": ["FLOAT", "BINARY_FLOAT", "BINARY_DOUBLE", "DECIMAL", "NUMERIC", "REAL", "DOUBLE PRECISION"],
@@ -201,6 +204,17 @@ final class OraclePlugin: NSObject, TableProPlugin, DriverPlugin, PluginDiagnost
                 ],
                 supportURL: issuesURL
             )
+        case .queryTimedOut:
+            return PluginDiagnostic(
+                title: String(localized: "Query Timed Out"),
+                message: oracleError.message,
+                suggestedActions: [
+                    String(localized: "Run the query again. TablePro reconnects to the server automatically."),
+                    String(localized: "If the query legitimately needs more time, raise the query timeout in Settings > General."),
+                    String(localized: "If a metadata query timed out, the schema may hold a very large number of objects; try again once the server is less busy.")
+                ],
+                supportURL: issuesURL
+            )
         case .generic, .notConnected, .connectionFailed, .queryFailed:
             return nil
         }
@@ -225,6 +239,7 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             .transactions,
             .alterTableDDL,
             .multiSchema,
+            .cancelQuery,
         ]
     }
 
@@ -284,6 +299,14 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func ping() async throws {
         _ = try await execute(query: "SELECT 1 FROM DUAL")
+    }
+
+    func cancelQuery() throws {
+        oracleConn?.abortCurrentQuery()
+    }
+
+    func applyQueryTimeout(_ seconds: Int) async throws {
+        oracleConn?.applyQueryTimeout(seconds)
     }
 
     // MARK: - Transaction Management

--- a/Plugins/TableProPluginKit/AsyncTimeout.swift
+++ b/Plugins/TableProPluginKit/AsyncTimeout.swift
@@ -12,10 +12,22 @@ public func withTimeout<T: Sendable>(
     seconds: Double,
     operation: @escaping @Sendable () async throws -> T
 ) async throws -> T {
+    try await withTimeout(seconds: seconds, onTimeout: {}, operation: operation)
+}
+
+/// The task group waits for the operation child even after the deadline fires,
+/// so `onTimeout` must force the operation to complete (close a connection,
+/// fail a promise) when the wrapped call does not respond to task cancellation.
+public func withTimeout<T: Sendable>(
+    seconds: Double,
+    onTimeout: @escaping @Sendable () -> Void,
+    operation: @escaping @Sendable () async throws -> T
+) async throws -> T {
     try await withThrowingTaskGroup(of: T.self) { group in
         group.addTask { try await operation() }
         group.addTask {
             try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            onTimeout()
             throw TimeoutError(seconds: seconds)
         }
         defer { group.cancelAll() }

--- a/TablePro/Core/Plugins/PluginManager+Registration.swift
+++ b/TablePro/Core/Plugins/PluginManager+Registration.swift
@@ -38,6 +38,9 @@ extension PluginManager {
                     from: driverType,
                     isDownloadable: driverType.isDownloadable
                 )
+                if snapshot.schema.databaseGroupingStrategy == .hierarchicalSchema, snapshot.supportsDatabaseSwitching {
+                    Self.logger.warning("Plugin '\(pluginId)' declares hierarchicalSchema grouping together with supportsDatabaseSwitching; schema-only engines must declare supportsDatabaseSwitching = false or the container switcher misroutes")
+                }
                 PluginMetadataRegistry.shared.register(snapshot: snapshot, forTypeId: typeId, preserveIcon: true)
                 for additionalId in driverType.additionalDatabaseTypeIds {
                     var additionalSnapshot = snapshot

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
@@ -710,7 +710,7 @@ extension PluginMetadataRegistry {
                 postConnectActions: [.selectSchemaFromLastSession],
                 brandColorHex: "#C3160B",
                 queryLanguageName: "SQL", editorLanguage: .sql,
-                connectionMode: .network, supportsDatabaseSwitching: true,
+                connectionMode: .network, supportsDatabaseSwitching: false,
                 supportsColumnReorder: false,
                 capabilities: PluginMetadataSnapshot.CapabilityFlags(
                     supportsSchemaSwitching: true,
@@ -728,10 +728,10 @@ extension PluginMetadataRegistry {
                     supportsOpportunisticTLS: false
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
-                    defaultSchemaName: "public",
+                    defaultSchemaName: "",
                     defaultGroupName: "main",
                     tableEntityName: "Tables",
-                    containerEntityName: "Database",
+                    containerEntityName: "Schema",
                     defaultPrimaryKeyColumn: nil,
                     immutableColumns: [],
                     systemDatabaseNames: [
@@ -739,7 +739,7 @@ extension PluginMetadataRegistry {
                     ],
                     systemSchemaNames: [],
                     fileExtensions: [],
-                    databaseGroupingStrategy: .bySchema,
+                    databaseGroupingStrategy: .hierarchicalSchema,
                     structureColumnFields: [.name, .type, .nullable, .defaultValue, .autoIncrement, .comment]
                 ),
                 editor: PluginMetadataSnapshot.EditorConfig(

--- a/TablePro/Core/Plugins/PluginMetadataRegistry.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import os
 import TableProPluginKit
 
 struct PluginMetadataSnapshot: Sendable {
@@ -217,6 +218,37 @@ struct PluginMetadataSnapshot: Sendable {
             supportsDatabaseSwitching: supportsDatabaseSwitching,
             supportsColumnReorder: supportsColumnReorder,
             capabilities: capabilities, schema: schema, editor: editor, connection: connection
+        )
+    }
+
+    func withSwitchRouting(from source: PluginMetadataSnapshot) -> PluginMetadataSnapshot {
+        PluginMetadataSnapshot(
+            displayName: displayName, iconName: iconName, defaultPort: defaultPort,
+            requiresAuthentication: requiresAuthentication, supportsForeignKeys: supportsForeignKeys,
+            supportsSchemaEditing: supportsSchemaEditing, isDownloadable: isDownloadable,
+            primaryUrlScheme: primaryUrlScheme, parameterStyle: parameterStyle,
+            navigationModel: navigationModel, explainVariants: explainVariants,
+            pathFieldRole: pathFieldRole, supportsHealthMonitor: supportsHealthMonitor,
+            urlSchemes: urlSchemes, postConnectActions: postConnectActions,
+            brandColorHex: brandColorHex, queryLanguageName: queryLanguageName,
+            editorLanguage: editorLanguage, connectionMode: connectionMode,
+            supportsDatabaseSwitching: source.supportsDatabaseSwitching,
+            supportsColumnReorder: supportsColumnReorder,
+            capabilities: capabilities,
+            schema: SchemaInfo(
+                defaultSchemaName: source.schema.defaultSchemaName,
+                defaultGroupName: schema.defaultGroupName,
+                tableEntityName: schema.tableEntityName,
+                containerEntityName: source.schema.containerEntityName,
+                defaultPrimaryKeyColumn: schema.defaultPrimaryKeyColumn,
+                immutableColumns: schema.immutableColumns,
+                systemDatabaseNames: schema.systemDatabaseNames,
+                systemSchemaNames: schema.systemSchemaNames,
+                fileExtensions: schema.fileExtensions,
+                databaseGroupingStrategy: source.schema.databaseGroupingStrategy,
+                structureColumnFields: schema.structureColumnFields
+            ),
+            editor: editor, connection: connection
         )
     }
 }
@@ -771,11 +803,31 @@ final class PluginMetadataRegistry: @unchecked Sendable {
         }
         if let registryDefault = defaultSnapshots[typeId] {
             resolved = resolved.withIsDownloadable(registryDefault.isDownloadable)
+            if Self.declaresLegacySchemaOnlyRouting(resolved, registryDefault: registryDefault) {
+                Logger(subsystem: "com.TablePro", category: "PluginMetadataRegistry").notice(
+                    "Plugin '\(typeId, privacy: .public)' declares legacy two-tier switching for a schema-only engine; applying the app's switch routing"
+                )
+                resolved = resolved.withSwitchRouting(from: registryDefault)
+            }
         }
         snapshots[typeId] = resolved
         for scheme in resolved.urlSchemes {
             schemeIndex[scheme.lowercased()] = typeId
         }
+    }
+
+    /// A plugin built before its engine moved to schema-only switching still
+    /// declares database switching with bySchema grouping. The app's registry
+    /// default is the ground truth for routing, so its switch fields win.
+    static func declaresLegacySchemaOnlyRouting(
+        _ snapshot: PluginMetadataSnapshot,
+        registryDefault: PluginMetadataSnapshot
+    ) -> Bool {
+        !registryDefault.supportsDatabaseSwitching
+            && registryDefault.capabilities.supportsSchemaSwitching
+            && snapshot.supportsDatabaseSwitching
+            && snapshot.capabilities.supportsSchemaSwitching
+            && snapshot.schema.databaseGroupingStrategy == .bySchema
     }
 
     func unregister(typeId: String) {

--- a/TablePro/Core/Services/Query/MetadataConnectionPool.swift
+++ b/TablePro/Core/Services/Query/MetadataConnectionPool.swift
@@ -157,8 +157,8 @@ final class MetadataConnectionPool {
             await DatabaseManager.shared.executeStartupCommands(
                 session.connection.startupCommands, on: driver, connectionName: session.connection.name
             )
-            if let schema = key.schema, let switchable = driver as? SchemaSwitchable {
-                try await Self.switchSchema(switchable, to: schema, timeoutSeconds: operationTimeoutSeconds)
+            if let schema = key.schema {
+                try await Self.switchSchema(driver, to: schema, timeoutSeconds: operationTimeoutSeconds)
             }
         } catch {
             driver.disconnect()
@@ -168,26 +168,42 @@ final class MetadataConnectionPool {
     }
 
     static func connect(_ driver: DatabaseDriver, database: String, timeoutSeconds: Double) async throws {
-        do {
-            try await withTimeout(seconds: timeoutSeconds) { try await driver.connect() }
-        } catch is TimeoutError {
-            throw DatabaseError.connectionFailed(
-                String(format: String(localized: "Connecting to '%@' timed out."), database)
-            )
+        try await bounded(
+            driver: driver,
+            timeoutSeconds: timeoutSeconds,
+            timeoutMessage: String(format: String(localized: "Connecting to '%@' timed out."), database)
+        ) {
+            try await driver.connect()
         }
     }
 
-    static func switchSchema(
-        _ switchable: SchemaSwitchable,
-        to schema: String,
-        timeoutSeconds: Double
+    static func switchSchema(_ driver: DatabaseDriver, to schema: String, timeoutSeconds: Double) async throws {
+        guard let switchable = driver as? SchemaSwitchable else { return }
+        try await bounded(
+            driver: driver,
+            timeoutSeconds: timeoutSeconds,
+            timeoutMessage: String(format: String(localized: "Switching to schema '%@' timed out."), schema)
+        ) {
+            try await switchable.switchSchema(to: schema)
+        }
+    }
+
+    /// Disconnects the driver when the deadline fires so a driver call that
+    /// ignores task cancellation still completes and the timeout can propagate.
+    private static func bounded(
+        driver: DatabaseDriver,
+        timeoutSeconds: Double,
+        timeoutMessage: String,
+        _ operation: @escaping @Sendable () async throws -> Void
     ) async throws {
         do {
-            try await withTimeout(seconds: timeoutSeconds) { try await switchable.switchSchema(to: schema) }
-        } catch is TimeoutError {
-            throw DatabaseError.connectionFailed(
-                String(format: String(localized: "Switching to schema '%@' timed out."), schema)
+            try await withTimeout(
+                seconds: timeoutSeconds,
+                onTimeout: { driver.disconnect() },
+                operation: operation
             )
+        } catch is TimeoutError {
+            throw DatabaseError.connectionFailed(timeoutMessage)
         }
     }
 

--- a/TablePro/Core/Services/Query/MetadataConnectionPool.swift
+++ b/TablePro/Core/Services/Query/MetadataConnectionPool.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import TableProPluginKit
 
 @MainActor
 final class MetadataConnectionPool {
@@ -53,7 +54,7 @@ final class MetadataConnectionPool {
     private var entries: [Key: Entry] = [:]
     private var pending: [Key: Task<Void, Error>] = [:]
     private let maxPerConnection = 6
-    private let connectTimeoutSeconds: UInt64 = 15
+    private let operationTimeoutSeconds: Double = 15
 
     private init() {}
 
@@ -151,13 +152,13 @@ final class MetadataConnectionPool {
             awaitPlugins: true
         )
         do {
-            try await connectWithTimeout(driver: driver, database: key.database)
+            try await Self.connect(driver, database: key.database, timeoutSeconds: operationTimeoutSeconds)
             try? await driver.applyQueryTimeout(AppSettingsManager.shared.general.queryTimeoutSeconds)
             await DatabaseManager.shared.executeStartupCommands(
                 session.connection.startupCommands, on: driver, connectionName: session.connection.name
             )
             if let schema = key.schema, let switchable = driver as? SchemaSwitchable {
-                try await switchable.switchSchema(to: schema)
+                try await Self.switchSchema(switchable, to: schema, timeoutSeconds: operationTimeoutSeconds)
             }
         } catch {
             driver.disconnect()
@@ -166,18 +167,27 @@ final class MetadataConnectionPool {
         return Entry(driver: driver)
     }
 
-    private func connectWithTimeout(driver: DatabaseDriver, database: String) async throws {
-        let timeoutNanos = connectTimeoutSeconds * 1_000_000_000
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask { try await driver.connect() }
-            group.addTask {
-                try await Task.sleep(nanoseconds: timeoutNanos)
-                throw DatabaseError.connectionFailed(
-                    String(format: String(localized: "Connecting to '%@' timed out."), database)
-                )
-            }
-            try await group.next()
-            group.cancelAll()
+    static func connect(_ driver: DatabaseDriver, database: String, timeoutSeconds: Double) async throws {
+        do {
+            try await withTimeout(seconds: timeoutSeconds) { try await driver.connect() }
+        } catch is TimeoutError {
+            throw DatabaseError.connectionFailed(
+                String(format: String(localized: "Connecting to '%@' timed out."), database)
+            )
+        }
+    }
+
+    static func switchSchema(
+        _ switchable: SchemaSwitchable,
+        to schema: String,
+        timeoutSeconds: Double
+    ) async throws {
+        do {
+            try await withTimeout(seconds: timeoutSeconds) { try await switchable.switchSchema(to: schema) }
+        } catch is TimeoutError {
+            throw DatabaseError.connectionFailed(
+                String(format: String(localized: "Switching to schema '%@' timed out."), schema)
+            )
         }
     }
 

--- a/TablePro/Core/Services/Query/SchemaService.swift
+++ b/TablePro/Core/Services/Query/SchemaService.swift
@@ -209,7 +209,13 @@ final class SchemaService {
 
     func refresh(connectionId: UUID) async {
         guard let session = DatabaseManager.shared.activeSessions[connectionId],
-              let driver = session.driver else { return }
+              let driver = session.driver else {
+            markLoadFailed(
+                connectionId: connectionId,
+                message: String(localized: "The connection is not available. Reconnect and try again.")
+            )
+            return
+        }
         await invalidate(connectionId: connectionId)
         await reload(connectionId: connectionId, driver: driver, connection: session.connection)
     }
@@ -322,18 +328,30 @@ final class SchemaService {
 
         let loadedProcedures = await proceduresTask
         let loadedFunctions = await functionsTask
-        let loadedSchemas = await Self.fetchSchemasSafely(
-            connectionId: connectionId,
-            dedup: schemasDedup,
-            fetch: { try await driver.fetchSchemas() }
-        )
+
+        let loadedSchemas: [String]
+        do {
+            loadedSchemas = try await schemasDedup.execute(key: connectionId) {
+                try await driver.fetchSchemas()
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            guard isCurrentLoadGeneration(generation, for: connectionId, phase: "hierarchical-failed") else {
+                return
+            }
+            Self.logger.warning(
+                "[schema] hierarchical schema list failed connId=\(connectionId, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+            )
+            states[connectionId] = .failed(error.localizedDescription)
+            bumpGeneration(connectionId)
+            return
+        }
 
         guard isCurrentLoadGeneration(generation, for: connectionId, phase: "hierarchical-loaded") else {
             return
         }
-        if let loadedSchemas {
-            schemasInOrder[connectionId] = loadedSchemas
-        }
+        schemasInOrder[connectionId] = loadedSchemas
         procedures[connectionId] = loadedProcedures
         functions[connectionId] = loadedFunctions
         states[connectionId] = .loaded([])

--- a/TablePro/Core/Services/Query/SchemaService.swift
+++ b/TablePro/Core/Services/Query/SchemaService.swift
@@ -214,6 +214,12 @@ final class SchemaService {
         await reload(connectionId: connectionId, driver: driver, connection: session.connection)
     }
 
+    func markLoadFailed(connectionId: UUID, message: String) {
+        if case .loaded = state(for: connectionId) { return }
+        states[connectionId] = .failed(message)
+        bumpGeneration(connectionId)
+    }
+
     private func runLoad(
         connectionId: UUID,
         driver: DatabaseDriver,

--- a/TablePro/Models/Connection/ConnectionToolbarState.swift
+++ b/TablePro/Models/Connection/ConnectionToolbarState.swift
@@ -187,9 +187,10 @@ final class ConnectionToolbarState {
     }
 
     /// Text shown in the toolbar's database/schema chip. For `.bySchema` engines
-    /// (SQL Server, PostgreSQL, Oracle, BigQuery), this is the active schema; for
-    /// `.byDatabase` and `.flat` engines, it is the active database. Falls back to
-    /// `currentDatabase` when a schema-grouped engine has not yet resolved its schema.
+    /// (SQL Server, PostgreSQL) and `.hierarchicalSchema` engines that switch by
+    /// schema (Oracle, BigQuery), this is the active schema; other engines show the
+    /// active database, which is also the fallback while a schema-grouped engine
+    /// has not yet resolved its schema.
     var chipText: String {
         switch databaseGroupingStrategy {
         case .bySchema:

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -613,6 +613,8 @@ final class MainContentCoordinator {
                     connection: connection
                 )
             }
+        } catch is CancellationError {
+            return
         } catch {
             Self.logger.warning("Schema refresh failed: \(error.localizedDescription, privacy: .public)")
             schemaService.markLoadFailed(connectionId: connectionId, message: error.localizedDescription)

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -615,6 +615,7 @@ final class MainContentCoordinator {
             }
         } catch {
             Self.logger.warning("Schema refresh failed: \(error.localizedDescription, privacy: .public)")
+            schemaService.markLoadFailed(connectionId: connectionId, message: error.localizedDescription)
         }
         let database = currentDatabaseOnly ? activeDatabaseName : nil
         await DatabaseTreeMetadataService.shared.refreshLoadedTables(connectionId: connectionId, database: database)

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -300,6 +300,10 @@ struct SidebarView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
+            Button("Retry") {
+                Task { await schemaService.refresh(connectionId: connectionId) }
+            }
+            .controlSize(.small)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding()

--- a/TableProTests/Core/Autocomplete/SQLSchemaProviderTests.swift
+++ b/TableProTests/Core/Autocomplete/SQLSchemaProviderTests.swift
@@ -29,12 +29,18 @@ final class MockDatabaseDriver: DatabaseDriver, SchemaSwitchable, @unchecked Sen
     var fetchSchemaTablesCalls: [String] = []
     var applyQueryTimeoutValues: [Int] = []
     var cancelQueryCallCount = 0
+    var connectDelaySeconds: Double = 0
+    var switchSchemaDelaySeconds: Double = 0
 
     init(connection: DatabaseConnection = TestFixtures.makeConnection()) {
         self.connection = connection
     }
 
-    func connect() async throws {}
+    func connect() async throws {
+        guard connectDelaySeconds > 0 else { return }
+        try await Task.sleep(nanoseconds: UInt64(connectDelaySeconds * 1_000_000_000))
+    }
+
     func disconnect() {}
 
     func testConnection() async throws -> Bool { true }
@@ -105,6 +111,9 @@ final class MockDatabaseDriver: DatabaseDriver, SchemaSwitchable, @unchecked Sen
     func rollbackTransaction() async throws {}
 
     func switchSchema(to schema: String) async throws {
+        if switchSchemaDelaySeconds > 0 {
+            try await Task.sleep(nanoseconds: UInt64(switchSchemaDelaySeconds * 1_000_000_000))
+        }
         switchSchemaCallCount += 1
         currentSchema = schema
     }

--- a/TableProTests/Core/Autocomplete/SQLSchemaProviderTests.swift
+++ b/TableProTests/Core/Autocomplete/SQLSchemaProviderTests.swift
@@ -31,17 +31,35 @@ final class MockDatabaseDriver: DatabaseDriver, SchemaSwitchable, @unchecked Sen
     var cancelQueryCallCount = 0
     var connectDelaySeconds: Double = 0
     var switchSchemaDelaySeconds: Double = 0
+    var hangsUntilDisconnect = false
+    var schemasToReturn: [String] = []
+    var fetchSchemasError: Error?
+    private var hangContinuation: CheckedContinuation<Void, Never>?
 
     init(connection: DatabaseConnection = TestFixtures.makeConnection()) {
         self.connection = connection
     }
 
     func connect() async throws {
+        if hangsUntilDisconnect {
+            await withCheckedContinuation { hangContinuation = $0 }
+            throw DatabaseError.notConnected
+        }
         guard connectDelaySeconds > 0 else { return }
         try await Task.sleep(nanoseconds: UInt64(connectDelaySeconds * 1_000_000_000))
     }
 
-    func disconnect() {}
+    func disconnect() {
+        hangContinuation?.resume()
+        hangContinuation = nil
+    }
+
+    func fetchSchemas() async throws -> [String] {
+        if let fetchSchemasError {
+            throw fetchSchemasError
+        }
+        return schemasToReturn
+    }
 
     func testConnection() async throws -> Bool { true }
 

--- a/TableProTests/Core/Database/DatabaseManagerTests.swift
+++ b/TableProTests/Core/Database/DatabaseManagerTests.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import TableProPluginKit
 @testable import TablePro
+import TableProPluginKit
 import Testing
 
 @Suite("DatabaseManager Session-Scoped Accessors")
@@ -66,5 +66,64 @@ struct DatabaseManagerSessionTests {
         defer { DatabaseManager.shared.removeSession(for: connection.id) }
 
         #expect(DatabaseManager.shared.resolvedSchemaName(nil, for: connection.id) == nil)
+    }
+}
+
+private class DatabaseSwitchBaseDriver {
+    var supportsSchemas: Bool { true }
+    var supportsTransactions: Bool { false }
+    var currentSchema: String? { nil }
+    var serverVersion: String? { nil }
+
+    func connect() async throws {}
+    func disconnect() {}
+
+    func execute(query: String) async throws -> PluginQueryResult {
+        PluginQueryResult(columns: [], columnTypeNames: [], rows: [], rowsAffected: 0, executionTime: 0)
+    }
+
+    func fetchTables(schema: String?) async throws -> [PluginTableInfo] { [] }
+    func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] { [] }
+    func fetchIndexes(table: String, schema: String?) async throws -> [PluginIndexInfo] { [] }
+    func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] { [] }
+    func fetchTableDDL(table: String, schema: String?) async throws -> String { "" }
+    func fetchViewDefinition(view: String, schema: String?) async throws -> String { "" }
+    func fetchTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata {
+        PluginTableMetadata(tableName: table)
+    }
+
+    func fetchDatabases() async throws -> [String] { [] }
+    func fetchDatabaseMetadata(_ database: String) async throws -> PluginDatabaseMetadata {
+        PluginDatabaseMetadata(name: database)
+    }
+}
+
+private final class DatabaseSwitchingDriver: DatabaseSwitchBaseDriver, PluginDatabaseDriver {
+    private(set) var switchedDatabases: [String] = []
+
+    func switchDatabase(to database: String) async throws {
+        switchedDatabases.append(database)
+    }
+}
+
+@Suite("DatabaseManager database switch")
+@MainActor
+struct DatabaseManagerDatabaseSwitchTests {
+    @Test("bySchema engines reset the session schema to the plugin default")
+    func bySchemaSwitchResetsSchemaToDefault() async throws {
+        let connection = TestFixtures.makeConnection(type: .mssql)
+        let pluginDriver = DatabaseSwitchingDriver()
+        let adapter = PluginDriverAdapter(connection: connection, pluginDriver: pluginDriver)
+        var session = ConnectionSession(connection: connection, driver: adapter)
+        session.currentSchema = "sales"
+        DatabaseManager.shared.injectSession(session, for: connection.id)
+        defer { DatabaseManager.shared.removeSession(for: connection.id) }
+
+        try await DatabaseManager.shared.switchDatabase(to: "other_db", for: connection.id, persist: false)
+
+        let updated = DatabaseManager.shared.session(for: connection.id)
+        #expect(pluginDriver.switchedDatabases == ["other_db"])
+        #expect(updated?.currentDatabase == "other_db")
+        #expect(updated?.currentSchema == "dbo")
     }
 }

--- a/TableProTests/Core/Plugins/ContainerEntityNameTests.swift
+++ b/TableProTests/Core/Plugins/ContainerEntityNameTests.swift
@@ -67,6 +67,21 @@ struct ContainerEntityNameTests {
         #expect(PluginManager.shared.containerSwitchTarget(for: .bigQuery) == .schema)
     }
 
+    @Test("Oracle switches schemas, not databases")
+    func oracleSwitchesSchemas() {
+        #expect(PluginManager.shared.containerSwitchTarget(for: .oracle) == .schema)
+        #expect(PluginManager.shared.supportsDatabaseSwitching(for: .oracle) == false)
+        #expect(PluginManager.shared.supportsSchemaSwitching(for: .oracle) == true)
+    }
+
+    @Test("Oracle container is Schema with hierarchical grouping")
+    func oracleContainerIsSchema() {
+        #expect(PluginManager.shared.containerEntityName(for: .oracle) == "Schema")
+        #expect(PluginManager.shared.databaseGroupingStrategy(for: .oracle) == .hierarchicalSchema)
+        #expect(PluginManager.shared.supportsDatabaseTree(for: .oracle) == false)
+        #expect(snapshot(forTypeId: "Oracle")?.schema.defaultSchemaName == "")
+    }
+
     @Test("Engines supporting both prefer databases")
     func dualModeEnginesPreferDatabases() {
         #expect(PluginManager.shared.containerSwitchTarget(for: .postgresql) == .database)

--- a/TableProTests/Core/Plugins/PluginMetadataSwitchRoutingTests.swift
+++ b/TableProTests/Core/Plugins/PluginMetadataSwitchRoutingTests.swift
@@ -1,0 +1,51 @@
+//
+//  PluginMetadataSwitchRoutingTests.swift
+//  TableProTests
+//
+//  A plugin built before its engine moved to schema-only switching still
+//  declares two-tier routing; the registry must detect that and apply the
+//  app's switch-routing fields instead.
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@MainActor
+@Suite("Plugin metadata switch-routing normalization")
+struct PluginMetadataSwitchRoutingTests {
+    private var oracleDefault: PluginMetadataSnapshot? {
+        PluginMetadataRegistry.shared.snapshot(forTypeId: DatabaseType.oracle.pluginTypeId)
+    }
+
+    private var legacyTwoTier: PluginMetadataSnapshot? {
+        PluginMetadataRegistry.shared.snapshot(forTypeId: DatabaseType.mssql.pluginTypeId)
+    }
+
+    @Test("legacy two-tier declarations on a schema-only engine are detected")
+    func legacyDeclarationIsDetected() throws {
+        let oracle = try #require(oracleDefault)
+        let legacy = try #require(legacyTwoTier)
+
+        #expect(PluginMetadataRegistry.declaresLegacySchemaOnlyRouting(legacy, registryDefault: oracle))
+        #expect(!PluginMetadataRegistry.declaresLegacySchemaOnlyRouting(oracle, registryDefault: oracle))
+        #expect(!PluginMetadataRegistry.declaresLegacySchemaOnlyRouting(legacy, registryDefault: legacy))
+    }
+
+    @Test("withSwitchRouting carries over only the routing fields")
+    func switchRoutingCarriesRoutingFields() throws {
+        let oracle = try #require(oracleDefault)
+        let legacy = try #require(legacyTwoTier)
+
+        let normalized = legacy.withSwitchRouting(from: oracle)
+
+        #expect(normalized.supportsDatabaseSwitching == false)
+        #expect(normalized.schema.databaseGroupingStrategy == .hierarchicalSchema)
+        #expect(normalized.schema.defaultSchemaName.isEmpty)
+        #expect(normalized.schema.containerEntityName == "Schema")
+        #expect(normalized.displayName == legacy.displayName)
+        #expect(normalized.schema.tableEntityName == legacy.schema.tableEntityName)
+        #expect(normalized.capabilities.supportsSchemaSwitching == legacy.capabilities.supportsSchemaSwitching)
+    }
+}

--- a/TableProTests/Core/Services/Query/MetadataConnectionPoolTests.swift
+++ b/TableProTests/Core/Services/Query/MetadataConnectionPoolTests.swift
@@ -1,0 +1,53 @@
+//
+//  MetadataConnectionPoolTests.swift
+//  TableProTests
+//
+//  Tests for the pool's bounded connect and schema-switch steps: a driver
+//  that hangs must fail within the deadline instead of stalling the pool
+//  entry forever (#1807).
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("MetadataConnectionPool timeouts")
+@MainActor
+struct MetadataConnectionPoolTests {
+    @Test("connect passes through when the driver responds in time")
+    func connectPassesThrough() async throws {
+        let driver = MockDatabaseDriver()
+
+        try await MetadataConnectionPool.connect(driver, database: "db", timeoutSeconds: 1)
+    }
+
+    @Test("connect fails with a connection error when the driver hangs")
+    func connectTimesOut() async {
+        let driver = MockDatabaseDriver()
+        driver.connectDelaySeconds = 5
+
+        await #expect(throws: DatabaseError.self) {
+            try await MetadataConnectionPool.connect(driver, database: "db", timeoutSeconds: 0.05)
+        }
+    }
+
+    @Test("schema switch passes through when the driver responds in time")
+    func switchSchemaPassesThrough() async throws {
+        let driver = MockDatabaseDriver()
+
+        try await MetadataConnectionPool.switchSchema(driver, to: "HR", timeoutSeconds: 1)
+
+        #expect(driver.currentSchema == "HR")
+    }
+
+    @Test("schema switch fails with a connection error when the driver hangs")
+    func switchSchemaTimesOut() async {
+        let driver = MockDatabaseDriver()
+        driver.switchSchemaDelaySeconds = 5
+
+        await #expect(throws: DatabaseError.self) {
+            try await MetadataConnectionPool.switchSchema(driver, to: "HR", timeoutSeconds: 0.05)
+        }
+        #expect(driver.currentSchema == nil)
+    }
+}

--- a/TableProTests/Core/Services/Query/MetadataConnectionPoolTests.swift
+++ b/TableProTests/Core/Services/Query/MetadataConnectionPoolTests.swift
@@ -2,9 +2,8 @@
 //  MetadataConnectionPoolTests.swift
 //  TableProTests
 //
-//  Tests for the pool's bounded connect and schema-switch steps: a driver
-//  that hangs must fail within the deadline instead of stalling the pool
-//  entry forever (#1807).
+//  Tests for the pool's bounded connect and schema-switch steps: a hanging
+//  driver must fail within the deadline instead of stalling the pool entry.
 //
 
 import Foundation
@@ -25,6 +24,16 @@ struct MetadataConnectionPoolTests {
     func connectTimesOut() async {
         let driver = MockDatabaseDriver()
         driver.connectDelaySeconds = 5
+
+        await #expect(throws: DatabaseError.self) {
+            try await MetadataConnectionPool.connect(driver, database: "db", timeoutSeconds: 0.05)
+        }
+    }
+
+    @Test("connect force-disconnects a driver that ignores cancellation")
+    func connectUnsticksCancellationDeafDriver() async {
+        let driver = MockDatabaseDriver()
+        driver.hangsUntilDisconnect = true
 
         await #expect(throws: DatabaseError.self) {
             try await MetadataConnectionPool.connect(driver, database: "db", timeoutSeconds: 0.05)

--- a/TableProTests/Core/Services/Query/SchemaServiceTests.swift
+++ b/TableProTests/Core/Services/Query/SchemaServiceTests.swift
@@ -85,4 +85,47 @@ struct SchemaServiceTests {
 
         #expect(service.state(for: connectionId) == .loaded(driver.tablesToReturn))
     }
+
+    @Test("hierarchical load lists schemas")
+    func hierarchicalLoadListsSchemas() async {
+        let driver = MockDatabaseDriver()
+        driver.schemasToReturn = ["HR", "SALES"]
+        let connection = TestFixtures.makeConnection(type: .oracle)
+        let service = SchemaService()
+
+        await service.reload(connectionId: connection.id, driver: driver, connection: connection)
+
+        #expect(service.state(for: connection.id) == .loaded([]))
+        #expect(service.schemas(for: connection.id) == ["HR", "SALES"])
+    }
+
+    @Test("hierarchical schema list failure surfaces a failed state")
+    func hierarchicalFailureSetsFailedState() async {
+        let driver = MockDatabaseDriver()
+        driver.fetchSchemasError = DatabaseError.connectionFailed("schema list failed")
+        let connection = TestFixtures.makeConnection(type: .oracle)
+        let service = SchemaService()
+
+        await service.reload(connectionId: connection.id, driver: driver, connection: connection)
+
+        var isFailed = false
+        if case .failed = service.state(for: connection.id) {
+            isFailed = true
+        }
+        #expect(isFailed)
+    }
+
+    @Test("refresh without a session surfaces a failed state")
+    func refreshWithoutSessionSetsFailedState() async {
+        let service = SchemaService()
+        let connectionId = UUID()
+
+        await service.refresh(connectionId: connectionId)
+
+        var isFailed = false
+        if case .failed = service.state(for: connectionId) {
+            isFailed = true
+        }
+        #expect(isFailed)
+    }
 }

--- a/TableProTests/Core/Services/Query/SchemaServiceTests.swift
+++ b/TableProTests/Core/Services/Query/SchemaServiceTests.swift
@@ -58,4 +58,31 @@ struct SchemaServiceTests {
         let service = SchemaService()
         #expect(service.allLoadedTables(for: UUID()).isEmpty)
     }
+
+    @Test("markLoadFailed surfaces a failed state for spinners to resolve")
+    func markLoadFailedSetsFailedState() {
+        let service = SchemaService()
+        let connectionId = UUID()
+
+        service.markLoadFailed(connectionId: connectionId, message: "connect timed out")
+
+        #expect(service.state(for: connectionId) == .failed("connect timed out"))
+    }
+
+    @Test("markLoadFailed keeps already-loaded tables instead of replacing them")
+    func markLoadFailedKeepsLoadedTables() async {
+        let connectionId = UUID()
+        let driver = MockDatabaseDriver()
+        driver.tablesToReturn = [TableInfo(name: "orders", type: .table, rowCount: 0, schema: nil)]
+        let service = SchemaService()
+        await service.reload(
+            connectionId: connectionId,
+            driver: driver,
+            connection: TestFixtures.makeConnection()
+        )
+
+        service.markLoadFailed(connectionId: connectionId, message: "refresh failed")
+
+        #expect(service.state(for: connectionId) == .loaded(driver.tablesToReturn))
+    }
 }

--- a/TableProTests/Views/SwitchContainerTests.swift
+++ b/TableProTests/Views/SwitchContainerTests.swift
@@ -1,0 +1,44 @@
+//
+//  SwitchContainerTests.swift
+//  TableProTests
+//
+//  Regression coverage for #1807: Oracle declares schema-only switching, so
+//  the container switcher must route through switchSchema. The old routing
+//  went through switchDatabase, whose bySchema branch overwrote the session
+//  schema with a nonexistent default and hung the schema load.
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("SwitchContainer")
+@MainActor
+struct SwitchContainerTests {
+    @Test("switchContainer routes Oracle to a schema switch")
+    func oracleRoutesToSchemaSwitch() async {
+        let connection = TestFixtures.makeConnection(type: .oracle)
+        let driver = MockDatabaseDriver(connection: connection)
+        DatabaseManager.shared.injectSession(
+            ConnectionSession(connection: connection, driver: driver),
+            for: connection.id
+        )
+        defer { DatabaseManager.shared.removeSession(for: connection.id) }
+
+        let coordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: QueryTabManager(),
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        defer { coordinator.teardown() }
+
+        await coordinator.switchContainer(to: "HR")
+
+        #expect(driver.switchSchemaCallCount == 1)
+        #expect(driver.currentSchema == "HR")
+        #expect(coordinator.toolbarState.currentSchema == "HR")
+        #expect(DatabaseManager.shared.session(for: connection.id)?.currentSchema == "HR")
+    }
+}

--- a/TableProTests/Views/SwitchContainerTests.swift
+++ b/TableProTests/Views/SwitchContainerTests.swift
@@ -3,9 +3,7 @@
 //  TableProTests
 //
 //  Regression coverage for #1807: Oracle declares schema-only switching, so
-//  the container switcher must route through switchSchema. The old routing
-//  went through switchDatabase, whose bySchema branch overwrote the session
-//  schema with a nonexistent default and hung the schema load.
+//  the container switcher must route through switchSchema.
 //
 
 import Foundation

--- a/docs/customization/settings.mdx
+++ b/docs/customization/settings.mdx
@@ -38,7 +38,7 @@ Reopened tabs restore their SQL, cursor position, applied sort, filters, page, a
 
 Maximum seconds a query runs before cancellation. Default 60, range 0-600 (0 means no limit).
 
-Enforced at the database level where supported: `statement_timeout` (PostgreSQL), `max_execution_time` (MySQL, ClickHouse), `max_statement_time` (MariaDB), `sqlite3_busy_timeout` (SQLite). HTTP-based drivers (ClickHouse, BigQuery, CloudflareD1, LibSQL, Etcd, DynamoDB) also bound the HTTP request timeout to the configured value plus a 30-second grace, so the server-side error fires first. Setting "No limit" raises the HTTP transport ceiling to 1 hour. Applies on new connections; change requires reconnect.
+Enforced at the database level where supported: `statement_timeout` (PostgreSQL), `max_execution_time` (MySQL, ClickHouse), `max_statement_time` (MariaDB), `sqlite3_busy_timeout` (SQLite). HTTP-based drivers (ClickHouse, BigQuery, CloudflareD1, LibSQL, Etcd, DynamoDB) also bound the HTTP request timeout to the configured value plus a 30-second grace, so the server-side error fires first. Setting "No limit" raises the HTTP transport ceiling to 1 hour. Oracle enforces the timeout client-side: a query that exceeds it is stopped by closing the connection, and the next query reconnects and restores the current schema automatically. Applies on new connections; change requires reconnect.
 
 ### Software Update
 

--- a/docs/databases/oracle.mdx
+++ b/docs/databases/oracle.mdx
@@ -64,7 +64,7 @@ See [Connection URL Reference](/databases/connection-urls) for all parameters.
 
 ## Features
 
-**Schema Selection**: Each user is a schema. Switch with **⌘K**. Shows available schemas and objects.
+**Schema Selection**: Each user is a schema. The sidebar lists every schema and loads a schema's tables when you expand it. Switch the active schema with **⌘K** or the toolbar schema chip.
 
 **Table Info**: Structure (columns, types, nullability, defaults), indexes (B-tree, bitmap), foreign keys, DDL via DBMS_METADATA.
 


### PR DESCRIPTION
Fixes #1807.

## Root cause

Three layered problems produced the infinite spinner:

1. **Oracle's plugin metadata described a two-tier engine.** `OraclePlugin` never overrode `supportsDatabaseSwitching` (protocol default `true`) or `defaultSchemaName` (default `"public"`). `containerSwitchTarget` therefore returned `.database`, so the switcher routed through `switchDatabase`, whose `.bySchema` branch reset `session.currentSchema` to `"public"`, a schema that does not exist on any Oracle server. Oracle has one tier: a schema is a user and is the only switchable container.
2. **Nothing could time out.** The corrupted schema became the `MetadataConnectionPool` key. The pool opened a fresh Oracle connection and ran the schema switch with no bound. Oracle was the only plugin implementing no query timeout, and its `QueryGate` serializes all queries, so one stuck statement blocked the connection forever.
3. **The spinner had no failure state.** `reloadSchema`'s catch block only logged, so `SchemaService` never left `.loading` when driver acquisition failed.

## Fix

Plugin side (`Plugins/OracleDriverPlugin/`, ships via the next `plugin-oracle-v*` release, no PluginKit ABI change):

- Declare the one-tier model BigQuery already uses: `supportsDatabaseSwitching = false`, `databaseGroupingStrategy = .hierarchicalSchema`, `defaultSchemaName = ""`, `containerEntityName = "Schema"`. The sidebar becomes the hierarchical schema tree (schemas with lazily loaded tables). The old two-level tree ran the same `ALL_USERS` query at both levels and showed the identical list twice.
- Implement `applyQueryTimeout`. Queries race the configured timeout (Settings > General, 60s default). On timeout the connection is closed first, which fails the in-flight OracleNIO call even if it ignores task cancellation, then the query gate is released so queued queries (including the health ping) fail fast instead of hanging.
- The next query on a closed connection reconnects automatically and re-applies the session schema, so "run the query again" works immediately after a timeout instead of waiting for the 30s health ping.
- New `queryTimedOut` error category with a diagnostic (retry, raise the timeout, busy-server hint).
- No `cancelQuery` implementation: the app cancels queries in supersede style (refresh, pagination, new run) and expects the connection to survive, which Oracle cannot honor without a server-side cancel. The timeout bounds stuck queries instead.

App side (ships with the next app release):

- Mirror the four metadata fields in the static registry fallback, and **normalize legacy plugin metadata at registration**: when the app's registry default declares an engine schema-only but the loaded plugin still reports the old two-tier declaration, the registry applies its own switch-routing fields. Existing users get correct schema switching without updating the plugin.
- `MetadataConnectionPool` bounds the post-connect schema switch (15s) for every plugin. The shared `withTimeout` helper gained an `onTimeout` hook (additive PluginKit overload) that force-disconnects the driver, so a driver that ignores task cancellation still unwinds; the pool and the Oracle wrapper share one race implementation.
- `SchemaService.markLoadFailed` surfaces `.failed` when driver acquisition fails (without clobbering already-loaded tables); a failed schema-list fetch on the hierarchical path stamps `.failed` instead of rendering an empty tree; the sidebar error state gained a Retry button, and Retry reports a clear failure when the session is unavailable instead of silently doing nothing.
- Load-time log warning when a plugin declares the contradictory `hierarchicalSchema` + `supportsDatabaseSwitching` pair.

Deliberately unchanged: `DatabaseManager.switchDatabase`'s `.bySchema` schema reset. MSSQL depends on it (its driver never updates its own schema on a database switch), and a new test locks that in.

## Version skew

- New app + old (already-installed) plugin: schema switching routes correctly via registration-time normalization; the pool bounds metadata loads; the plugin update adds query timeout enforcement and auto-reconnect.
- Old app + new plugin: metadata is read live from the loaded plugin, so routing is fixed; timeout support works because the app already calls `applyQueryTimeout` generically.

No `currentPluginKitVersion` bump: the `withTimeout(onTimeout:)` overload is a new symbol (additive), and every other touched API already exists with defaults.

## Tests

- `ContainerEntityNameTests`: Oracle targets `.schema`, no database switching, `Schema` container, hierarchical grouping, empty default schema.
- `PluginMetadataSwitchRoutingTests` (new): legacy two-tier declarations are detected against a schema-only registry default, and normalization carries over exactly the four routing fields.
- `SwitchContainerTests` (new): coordinator-level regression proving `switchContainer(to: "HR")` on an Oracle connection routes to `switchSchema` and updates toolbar and session state.
- `DatabaseManagerDatabaseSwitchTests` (new): MSSQL database switch still resets the session schema to `dbo`.
- `MetadataConnectionPoolTests` (new): hanging connect and schema switch fail within the deadline; a driver that ignores cancellation is force-disconnected and still fails in time; fast paths pass through.
- `AsyncTimeoutTests`: `onTimeout` unblocks a cancellation-deaf operation and is not invoked when the operation wins.
- `SchemaServiceTests`: `markLoadFailed` semantics, hierarchical schema list success and failure states, and Retry-without-session feedback.

No UI automation: the flow needs a live Oracle server, which the UI test runner does not have. The Oracle wrapper's timeout and reconnect internals need a manual pass against a real server (`gvenzl/oracle-xe:21-slim`).

## Docs

- `docs/customization/settings.mdx`: documents Oracle's client-side timeout enforcement (connection reset + auto-reconnect).
- `docs/databases/oracle.mdx`: describes the hierarchical schema sidebar.

## Manual verification checklist

- Open an Oracle connection, switch schemas from the toolbar chip or Cmd+K: the switch is immediate, the sidebar lists all schemas, tables load on expand.
- Kill network mid-load: the sidebar shows an error with Retry within 15s instead of spinning.
- Long query with a 60s timeout: fails with the query-timeout diagnostic; running it again reconnects immediately and keeps the selected schema.
- With the OLD Oracle plugin still installed: schema switching works (normalized routing); metadata loads are bounded.
