### PR TITLE
ci(ios): fall back to an existing simulator when the runtime download fails

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -44,9 +44,24 @@ jobs:
         run: brew list xcbeautify &>/dev/null || brew install xcbeautify
 
       # macos-26 lazy-loads simulator runtimes; -downloadPlatform pulls the runtime
-      # matching Xcode's SDK and is a no-op when it is already present.
+      # matching Xcode's SDK and is a no-op when it is already present. The download
+      # endpoint flakes on hosted runners, so a failure falls back to checking whether
+      # the test device already exists before failing the job.
       - name: Install iOS simulator runtime
-        run: sudo xcodebuild -downloadPlatform iOS
+        run: |
+          if sudo xcodebuild -downloadPlatform iOS; then
+            exit 0
+          fi
+
+          echo "::warning::xcodebuild -downloadPlatform iOS failed; checking for an existing simulator"
+          device_name="$(echo "$TEST_DESTINATION" | sed -n 's/.*name=\([^,]*\).*/\1/p')"
+          if xcrun simctl list devices available | grep -qF "$device_name ("; then
+            echo "$device_name simulator is already available; continuing."
+            exit 0
+          fi
+
+          echo "::error::$device_name simulator is not available and the runtime download failed."
+          exit 1
 
       # Secrets.xcconfig is gitignored. Tests do not need analytics keys, so the
       # checked-in example template is enough for the project to resolve.


### PR DESCRIPTION
## Summary
- `sudo xcodebuild -downloadPlatform iOS` can flake on hosted macos-26 runners even when the image already carries the runtime. On failure, the step now checks `xcrun simctl list devices available` for the test device and continues if it exists; otherwise it fails with a clear error.
- The device name is derived from `TEST_DESTINATION` so the check cannot drift when the CI device is bumped.

Extracted from the CI portion of #1778. Differences from that version:
- Uses `simctl` instead of `xcodebuild -showdestinations`, so the check does not depend on project state and a tooling failure cannot be misreported as a missing simulator.
- Matches the device name exactly (`grep -F "name ("`), so "iPhone 17 Pro Max" or an ineligible destination cannot satisfy a check for "iPhone 17 Pro".

## Validation
- Verified locally that the `sed` extraction yields `iPhone 17 Pro` from `TEST_DESTINATION` and that the grep matches `iPhone 17 Pro (…)` but not `iPhone 17 Pro Max (…)`.
- YAML parses; workflow runs on this PR since it touches `.github/workflows/ios-tests.yml`.
