### PR TITLE
fix(plugin-elasticsearch): show the password field for username & password auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Elasticsearch connections using Username & Password now show a Password field, so basic auth on a secured cluster can be set up. It was hidden before, leaving only the Username field. Update the Elasticsearch plugin to get the fix. (#1816)
 - Switching schemas on an Oracle connection no longer hangs on an infinite loading spinner. Oracle now switches by schema like BigQuery, the sidebar lists every schema with its tables loading on expand, Oracle queries respect the query timeout setting and reconnect automatically after a timeout, and a schema load that fails shows an error with a Retry button instead of spinning forever. Works with an already-installed Oracle plugin; updating the plugin adds the query timeout enforcement. (#1807)
 
 ## [0.55.0] - 2026-07-04

--- a/Plugins/ElasticsearchDriverPlugin/ElasticsearchPlugin.swift
+++ b/Plugins/ElasticsearchDriverPlugin/ElasticsearchPlugin.swift
@@ -17,7 +17,7 @@ final class ElasticsearchPlugin: NSObject, TableProPlugin, DriverPlugin {
     static let databaseTypeId = "Elasticsearch"
     static let databaseDisplayName = "Elasticsearch"
     static let iconName = "elasticsearch-icon"
-    static let defaultPort = 9200
+    static let defaultPort = 9_200
     static let isDownloadable = true
 
     static let navigationModel: NavigationModel = .standard
@@ -70,7 +70,8 @@ final class ElasticsearchPlugin: NSObject, TableProPlugin, DriverPlugin {
                 .init(value: "apiKey", label: "API Key"),
                 .init(value: "none", label: "None"),
             ]),
-            section: .authentication
+            section: .authentication,
+            hidesPassword: true
         ),
         ConnectionField(
             id: "esApiKey",
@@ -78,7 +79,6 @@ final class ElasticsearchPlugin: NSObject, TableProPlugin, DriverPlugin {
             placeholder: "Base64-encoded API key",
             fieldType: .secure,
             section: .authentication,
-            hidesPassword: true,
             visibleWhen: FieldVisibilityRule(fieldId: "esAuthMethod", values: ["apiKey"])
         ),
         ConnectionField(

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+ElasticsearchDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+ElasticsearchDefaults.swift
@@ -99,7 +99,8 @@ func elasticsearchConnectionFields() -> [ConnectionField] {
                 .init(value: "apiKey", label: "API Key"),
                 .init(value: "none", label: "None"),
             ]),
-            section: .authentication
+            section: .authentication,
+            hidesPassword: true
         ),
         ConnectionField(
             id: "esApiKey",
@@ -107,7 +108,6 @@ func elasticsearchConnectionFields() -> [ConnectionField] {
             placeholder: "Base64-encoded API key",
             fieldType: .secure,
             section: .authentication,
-            hidesPassword: true,
             visibleWhen: FieldVisibilityRule(fieldId: "esAuthMethod", values: ["apiKey"])
         ),
         ConnectionField(

--- a/TableProTests/Plugins/ElasticsearchConnectionFieldsTests.swift
+++ b/TableProTests/Plugins/ElasticsearchConnectionFieldsTests.swift
@@ -1,0 +1,73 @@
+//
+//  ElasticsearchConnectionFieldsTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("Elasticsearch connection fields")
+struct ElasticsearchConnectionFieldsTests {
+    private func elasticsearchFields() throws -> [ConnectionField] {
+        let defaults = PluginMetadataRegistry.shared.registryPluginDefaults()
+        let entry = try #require(defaults.first { $0.typeId == "Elasticsearch" })
+        return entry.snapshot.connection.additionalConnectionFields
+    }
+
+    @Test("Registry declares auth method, API key, and TLS fields")
+    func registryDeclaresAllFields() throws {
+        let fields = try elasticsearchFields()
+        #expect(fields.map(\.id) == ["esAuthMethod", "esApiKey", "esSkipTLSVerify"])
+    }
+
+    @Test("Auth method dropdown defaults to basic and offers API key and none")
+    func authMethodDropdownDefaultsToBasic() throws {
+        let fields = try elasticsearchFields()
+        let method = try #require(fields.first { $0.id == "esAuthMethod" })
+        #expect(method.defaultValue == "basic")
+        guard case .dropdown(let options) = method.fieldType else {
+            Issue.record("Expected a dropdown field type")
+            return
+        }
+        #expect(options.map(\.value) == ["basic", "apiKey", "none"])
+    }
+
+    @Test("Auth method dropdown drives password hiding, API key field does not")
+    func authMethodDropdownControlsPasswordHiding() throws {
+        let fields = try elasticsearchFields()
+        let method = try #require(fields.first { $0.id == "esAuthMethod" })
+        let apiKey = try #require(fields.first { $0.id == "esApiKey" })
+        #expect(method.hidesPassword)
+        #expect(!apiKey.hidesPassword)
+    }
+
+    @Test("API key is a secure field gated to API key mode")
+    func apiKeyIsSecureAndModeGated() throws {
+        let fields = try elasticsearchFields()
+        let apiKey = try #require(fields.first { $0.id == "esApiKey" })
+        #expect(apiKey.isSecure)
+        #expect(apiKey.visibleWhen == FieldVisibilityRule(fieldId: "esAuthMethod", values: ["apiKey"]))
+    }
+
+    @Test("Password row shows for Username & Password and hides for API key and None")
+    func passwordShowsOnlyForBasicAuth() throws {
+        let fields = try elasticsearchFields()
+        #expect(!fields.hidesPassword(forValues: [:]))
+        #expect(!fields.hidesPassword(forValues: ["esAuthMethod": "basic"]))
+        #expect(fields.hidesPassword(forValues: ["esAuthMethod": "apiKey"]))
+        #expect(fields.hidesPassword(forValues: ["esAuthMethod": "none"]))
+    }
+
+    @Test("API key field visibility swaps with the auth method")
+    @MainActor
+    func apiKeyVisibilitySwapsByAuthMethod() throws {
+        let type = DatabaseType(rawValue: "Elasticsearch")
+        let fields = try elasticsearchFields()
+        let apiKey = try #require(fields.first { $0.id == "esApiKey" })
+        #expect(!PluginFieldRendering.isFieldVisible(apiKey, type: type, values: ["esAuthMethod": "basic"]))
+        #expect(PluginFieldRendering.isFieldVisible(apiKey, type: type, values: ["esAuthMethod": "apiKey"]))
+        #expect(!PluginFieldRendering.isFieldVisible(apiKey, type: type, values: ["esAuthMethod": "none"]))
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1816. In the New Elasticsearch Connection form, selecting "Username & Password" showed only the Username field, with no Password field, so basic auth on a secured cluster could not be set up.

## Root cause

The form hides the built-in Password field via `hidesPassword(forValues:)`, which is value-aware only for `.dropdown` and `.toggle` fields. Every other field type returns `true` unconditionally, ignoring its own `visibleWhen` rule. Elasticsearch put `hidesPassword: true` on `esApiKey`, a `.secure` field gated to API Key mode, so it hid the Password field in every auth mode, including "Username & Password". The Username field stayed visible because it is gated separately (on `connectionMode == .network`), which matches the report.

## Fix

Move `hidesPassword: true` from `esApiKey` onto the `esAuthMethod` dropdown (default `basic`), matching the pattern MySQL, PostgreSQL, LibSQL, and AWS already use. The password now shows for Username & Password and hides for API Key and None. The driver already reads the standard username/password for HTTP Basic, so no driver change was needed.

| Auth Method | Password field | API Key field |
| --- | --- | --- |
| Username & Password (default) | shown | hidden |
| API Key | hidden | shown |
| None | hidden | hidden |

Applied to both definition sites (the plugin bundle and the app-side snapshot) so they stay in sync.

## Why not fix the shared switch

Making `hidesPassword(forValues:)` respect `visibleWhen` would regress DuckDB, DynamoDB, and BigQuery, which use a `.secure` + `hidesPassword` field to hide the built-in password entirely (they never use the built-in password). DuckDB's `passwordAlwaysHidden` test locks that in. Elasticsearch is the only plugin that uses the built-in username/password and wants the password shown conditionally, so the fix belongs in the Elasticsearch field declaration.

## Tests

New `ElasticsearchConnectionFieldsTests`: the password row shows in basic mode, hides in apiKey and none, the auth-method dropdown carries `hidesPassword` while the API Key field no longer does, and the API Key field visibility swaps with the auth method.

## Follow-up

Elasticsearch is a registry-only plugin, and the installed bundle's metadata overrides the app snapshot once loaded. Users who already installed the driver get the fix only after the plugin is re-released (`plugin-elasticsearch-v1.0.1`, data-only, no PluginKit bump). The app-snapshot change covers the pre-install state and ships with the next app release.
