### PR TITLE
refactor(connection-form): hide the built-in password via a plugin metadata flag

### DIFF
--- a/TablePro/Core/Plugins/ConnectionField+PasswordHiding.swift
+++ b/TablePro/Core/Plugins/ConnectionField+PasswordHiding.swift
@@ -16,15 +16,26 @@ extension Sequence where Element == ConnectionField {
                 let value = values[field.id] ?? field.defaultValue
                 return value != field.defaultValue
             default:
-                return true
+                return isVisible(field, forValues: values)
             }
         }
+    }
+
+    func isVisible(_ field: ConnectionField, forValues values: [String: String]) -> Bool {
+        guard let rule = field.visibleWhen else { return true }
+        let defaultValue = first { $0.id == rule.fieldId }?.defaultValue ?? ""
+        let currentValue = values[rule.fieldId] ?? defaultValue
+        return rule.values.contains(currentValue)
     }
 }
 
 extension PluginManager {
     func hidesPassword(for connection: DatabaseConnection) -> Bool {
-        additionalConnectionFields(for: connection.type)
+        if PluginMetadataRegistry.shared.snapshot(forTypeId: connection.type.pluginTypeId)?
+            .connection.hidesBuiltInPassword == true {
+            return true
+        }
+        return additionalConnectionFields(for: connection.type)
             .hidesPassword(forValues: connection.additionalFields)
     }
 }

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+CloudDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+CloudDefaults.swift
@@ -149,7 +149,8 @@ extension PluginMetadataRegistry {
                         ),
                     ],
                     category: .cloud,
-                    tagline: String(localized: "AWS managed key-value/document store")
+                    tagline: String(localized: "AWS managed key-value/document store"),
+                    hidesBuiltInPassword: true
                 )
             )),
             ("BigQuery", PluginMetadataSnapshot(
@@ -339,7 +340,8 @@ extension PluginMetadataRegistry {
                         )
                     ],
                     category: .analytical,
-                    tagline: String(localized: "Google Cloud serverless data warehouse")
+                    tagline: String(localized: "Google Cloud serverless data warehouse"),
+                    hidesBuiltInPassword: true
                 )
             )),
             ("Snowflake", PluginMetadataSnapshot(
@@ -549,7 +551,8 @@ extension PluginMetadataRegistry {
                 connection: PluginMetadataSnapshot.ConnectionConfig(
                     additionalConnectionFields: snowflakeConnectionFields(),
                     category: .analytical,
-                    tagline: String(localized: "Cloud data warehouse")
+                    tagline: String(localized: "Cloud data warehouse"),
+                    hidesBuiltInPassword: true
                 )
             ))
         ]

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
@@ -285,8 +285,6 @@ extension PluginMetadataRegistry {
             "Enum": ["ENUM"]
         ]
 
-        let duckdbConnectionFields = Self.duckdbConnectionFields
-
         let cassandraDialect = SQLDialectDescriptor(
             identifierQuote: "\"",
             keywords: [
@@ -859,9 +857,10 @@ extension PluginMetadataRegistry {
                     columnTypesByCategory: duckdbColumnTypes
                 ),
                 connection: PluginMetadataSnapshot.ConnectionConfig(
-                    additionalConnectionFields: duckdbConnectionFields,
+                    additionalConnectionFields: Self.duckdbConnectionFields,
                     category: .analytical,
-                    tagline: String(localized: "Embedded and remote analytical SQL")
+                    tagline: String(localized: "Embedded and remote analytical SQL"),
+                    hidesBuiltInPassword: true
                 )
             )),
             ("Cassandra", PluginMetadataSnapshot(

--- a/TablePro/Core/Plugins/PluginMetadataRegistry.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry.swift
@@ -139,15 +139,18 @@ struct PluginMetadataSnapshot: Sendable {
         let additionalConnectionFields: [ConnectionField]
         let category: DatabaseCategory
         let tagline: String
+        let hidesBuiltInPassword: Bool
 
         init(
             additionalConnectionFields: [ConnectionField] = [],
             category: DatabaseCategory = .other,
-            tagline: String = ""
+            tagline: String = "",
+            hidesBuiltInPassword: Bool = false
         ) {
             self.additionalConnectionFields = additionalConnectionFields
             self.category = category
             self.tagline = tagline
+            self.hidesBuiltInPassword = hidesBuiltInPassword
         }
 
         static let defaults = ConnectionConfig()
@@ -986,7 +989,8 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                 category: existingSnapshot?.connection.category
                     ?? Self.fallbackCategory(forTypeId: driverType.databaseTypeId),
                 tagline: existingSnapshot?.connection.tagline
-                    ?? Self.fallbackTagline(forTypeId: driverType.databaseTypeId)
+                    ?? Self.fallbackTagline(forTypeId: driverType.databaseTypeId),
+                hidesBuiltInPassword: existingSnapshot?.connection.hidesBuiltInPassword ?? false
             )
         )
     }

--- a/TablePro/Views/ConnectionForm/Support/PluginFieldRendering.swift
+++ b/TablePro/Views/ConnectionForm/Support/PluginFieldRendering.swift
@@ -23,11 +23,8 @@ enum PluginFieldRendering {
         type: DatabaseType,
         values: [String: String]
     ) -> Bool {
-        guard let rule = field.visibleWhen else { return true }
-        let registry = PluginManager.shared.additionalConnectionFields(for: type)
-        let defaultValue = registry.first { $0.id == rule.fieldId }?.defaultValue ?? ""
-        let currentValue = values[rule.fieldId] ?? defaultValue
-        return rule.values.contains(currentValue)
+        PluginManager.shared.additionalConnectionFields(for: type)
+            .isVisible(field, forValues: values)
     }
 
     static func defaultFieldValue(

--- a/TablePro/Views/ConnectionForm/ViewModels/AuthPaneViewModel.swift
+++ b/TablePro/Views/ConnectionForm/ViewModels/AuthPaneViewModel.swift
@@ -40,8 +40,19 @@ final class AuthPaneViewModel {
             .filter { $0.section == .authentication }
     }
 
+    var hidesBuiltInPassword: Bool {
+        guard let type = coordinator?.value?.network.type else { return false }
+        return PluginMetadataRegistry.shared.snapshot(forTypeId: type.pluginTypeId)?
+            .connection.hidesBuiltInPassword ?? false
+    }
+
     var hidesPassword: Bool {
-        authFields.hidesPassword(forValues: additionalFieldValues)
+        if hidesBuiltInPassword { return true }
+        guard let type = coordinator?.value?.network.type else {
+            return authFields.hidesPassword(forValues: additionalFieldValues)
+        }
+        return PluginManager.shared.additionalConnectionFields(for: type)
+            .hidesPassword(forValues: additionalFieldValues)
     }
 
     var effectivePromptForPassword: Bool {
@@ -66,12 +77,9 @@ final class AuthPaneViewModel {
     }
 
     func isFieldVisible(_ field: ConnectionField) -> Bool {
-        guard let rule = field.visibleWhen else { return true }
         let type = coordinator?.value?.network.type ?? .mysql
-        let registry = PluginManager.shared.additionalConnectionFields(for: type)
-        let defaultValue = registry.first { $0.id == rule.fieldId }?.defaultValue ?? ""
-        let currentValue = additionalFieldValues[rule.fieldId] ?? defaultValue
-        return rule.values.contains(currentValue)
+        return PluginManager.shared.additionalConnectionFields(for: type)
+            .isVisible(field, forValues: additionalFieldValues)
     }
 
     func resetForType(_ newType: DatabaseType) {

--- a/TableProTests/Core/Plugins/PasswordHidingTests.swift
+++ b/TableProTests/Core/Plugins/PasswordHidingTests.swift
@@ -43,6 +43,29 @@ struct PasswordHidingTests {
         hidesPassword: true
     )
 
+    private func gatedSecretFields() -> [ConnectionField] {
+        [
+            ConnectionField(
+                id: "authMode",
+                label: "Auth",
+                defaultValue: "password",
+                fieldType: .dropdown(options: [
+                    .init(value: "password", label: "password"),
+                    .init(value: "token", label: "token"),
+                ]),
+                section: .authentication
+            ),
+            ConnectionField(
+                id: "token",
+                label: "Token",
+                fieldType: .secure,
+                section: .authentication,
+                hidesPassword: true,
+                visibleWhen: FieldVisibilityRule(fieldId: "authMode", values: ["token"])
+            ),
+        ]
+    }
+
     @Test("A dropdown hides the password only when set off its default")
     func dropdownAwayFromDefault() {
         let fields = [dropdown(default: "off", ["off", "accessKey", "profile"])]
@@ -60,9 +83,17 @@ struct PasswordHidingTests {
         #expect(fields.hidesPassword(forValues: ["usePgpass": "true"]) == true)
     }
 
-    @Test("A secure field that always replaces the password hides it unconditionally")
+    @Test("A secure field with no visibility rule always hides the password")
     func secureFieldAlwaysHides() {
         #expect([secretField].hidesPassword(forValues: [:]) == true)
+    }
+
+    @Test("A secure field hidden by its visibility rule does not hide the password")
+    func hiddenSecureFieldDoesNotHide() {
+        let fields = gatedSecretFields()
+        #expect(fields.hidesPassword(forValues: [:]) == false)
+        #expect(fields.hidesPassword(forValues: ["authMode": "password"]) == false)
+        #expect(fields.hidesPassword(forValues: ["authMode": "token"]) == true)
     }
 
     @Test("Fields without the hidesPassword flag never hide the password")
@@ -95,6 +126,10 @@ struct PluginManagerPasswordHidingTests {
         return connection
     }
 
+    private func hides(_ typeId: String, _ fields: [String: String]) -> Bool {
+        PluginManager.shared.hidesPassword(for: connection(type: DatabaseType(rawValue: typeId), fields: fields))
+    }
+
     @Test("AWS IAM modes hide the password for relational types")
     func iamHidesPassword() {
         let manager = PluginManager.shared
@@ -107,5 +142,14 @@ struct PluginManagerPasswordHidingTests {
         let manager = PluginManager.shared
         #expect(!manager.hidesPassword(for: connection(type: .mysql, fields: ["awsAuth": "off"])))
         #expect(!manager.hidesPassword(for: connection(type: .mysql, fields: [:])))
+    }
+
+    @Test("Plugins that never use the built-in password hide it in every mode")
+    func cloudPluginsHideBuiltInPassword() {
+        #expect(hides("DuckDB", ["duckdbMode": "local"]))
+        #expect(hides("DuckDB", ["duckdbMode": "remote"]))
+        #expect(hides("DynamoDB", ["awsAuthMethod": "profile"]))
+        #expect(hides("BigQuery", ["bqAuthMethod": "adc"]))
+        #expect(hides("Snowflake", ["snowflakeAuthMethod": "externalBrowser"]))
     }
 }

--- a/TableProTests/Plugins/CloudPluginConnectionFieldsTests.swift
+++ b/TableProTests/Plugins/CloudPluginConnectionFieldsTests.swift
@@ -1,0 +1,26 @@
+//
+//  CloudPluginConnectionFieldsTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("Cloud plugin connection fields")
+struct CloudPluginConnectionFieldsTests {
+    private func registrySnapshot(forTypeId typeId: String) throws -> PluginMetadataSnapshot {
+        let defaults = PluginMetadataRegistry.shared.registryPluginDefaults()
+        let entry = try #require(defaults.first { $0.typeId == typeId })
+        return entry.snapshot
+    }
+
+    @Test("DynamoDB, BigQuery, and Snowflake never offer the built-in password")
+    func cloudPluginsHideBuiltInPassword() throws {
+        for typeId in ["DynamoDB", "BigQuery", "Snowflake"] {
+            let snapshot = try registrySnapshot(forTypeId: typeId)
+            #expect(snapshot.connection.hidesBuiltInPassword)
+        }
+    }
+}

--- a/TableProTests/Plugins/DuckDBConnectionFieldsTests.swift
+++ b/TableProTests/Plugins/DuckDBConnectionFieldsTests.swift
@@ -69,12 +69,11 @@ struct DuckDBConnectionFieldsTests {
         #expect(token.hidesPassword)
     }
 
-    @Test("Main password row stays hidden in both local and remote modes")
-    func passwordAlwaysHidden() throws {
-        let fields = try duckdbFields()
-        #expect(fields.hidesPassword(forValues: [:]))
-        #expect(fields.hidesPassword(forValues: ["duckdbMode": "local"]))
-        #expect(fields.hidesPassword(forValues: ["duckdbMode": "remote"]))
+    @Test("Registry marks DuckDB as never using the built-in password")
+    func hidesBuiltInPassword() throws {
+        let defaults = PluginMetadataRegistry.shared.registryPluginDefaults()
+        let entry = try #require(defaults.first { $0.typeId == "DuckDB" })
+        #expect(entry.snapshot.connection.hidesBuiltInPassword)
     }
 
     @Test("Port defaults to 9494")


### PR DESCRIPTION
## Summary

Reworks how the connection form decides to hide the built-in Password field. Follow-up to #1818, stacked on that branch (review after it merges, or set base to `main`).

`Sequence<ConnectionField>.hidesPassword(forValues:)` was value-aware for `.dropdown`/`.toggle` but returned `true` unconditionally for `.secure`/`.text`, ignoring the field's own `visibleWhen`. Four registry plugins (DuckDB, DynamoDB, BigQuery, Snowflake) relied on that: a mode-gated `.secure` field kept the Password field hidden in every mode only because the `default:` branch ignored visibility. Each also has a mode with no secret field visible (DuckDB `local`, DynamoDB `profile`/`sso`, BigQuery `adc`, Snowflake `externalBrowser`), so simply making the switch respect `visibleWhen` would expose a stray Password field there.

## The model

Two separated concepts:

1. Snapshot-level `ConnectionConfig.hidesBuiltInPassword` (default `false`) = "this plugin's form never offers the built-in password." Set `true` for the four cloud plugins, which authenticate through dedicated secret fields.
2. Field-level `hidesPassword` stays for conditional, mode-driven hiding: value-aware on `.dropdown`/`.toggle`, and now visibility-aware on `.secure`/`.text` (a hidden field never suppresses the password).

Effective hidden = snapshot flag OR field-level result.

## No plugin re-release, no ABI change

`buildMetadataSnapshot` already preserves `category`/`tagline`/`supportsColumnReorder` from the app-side `existingSnapshot` instead of reading them off the plugin binary. `hidesBuiltInPassword` rides that same path, so even when an old DuckDB/DynamoDB/BigQuery/Snowflake bundle loads and overrides the snapshot, the flag survives from the app's baked-in default. No `DriverPlugin` change, no PluginKit version bump, no coordinated registry re-release. The four plugins' bundle field declarations are left untouched.

## Changes

- `PluginMetadataRegistry.swift` - add `hidesBuiltInPassword` to `ConnectionConfig` (defaulted); thread it through `buildMetadataSnapshot` from `existingSnapshot`.
- `PluginMetadataRegistry+CloudDefaults.swift` / `+RegistryDefaults.swift` - set the flag for DynamoDB, BigQuery, Snowflake, DuckDB. Inlined a single-use `duckdbConnectionFields` local to keep the file under the length limit.
- `ConnectionField+PasswordHiding.swift` - visibility-aware `default:` branch via a shared `isVisible(_:forValues:)` helper; `PluginManager.hidesPassword(for:)` ORs the flag.
- `AuthPaneViewModel.swift` / `PluginFieldRendering.swift` - OR the flag into `hidesPassword`; both `isFieldVisible` copies now delegate to the shared helper (three copies down to one).

## Tests

- `PasswordHidingTests` - a secure field hidden by its rule no longer hides the password; end-to-end coverage of all four cloud plugins' no-secret-field modes.
- `DuckDBConnectionFieldsTests` - asserts the snapshot flag.
- New `CloudPluginConnectionFieldsTests` - covers DynamoDB, BigQuery, Snowflake (none existed).

No user-facing behavior change (every plugin keeps its current Password-field visibility), so no CHANGELOG entry.
