### PR TITLE
docs: Team plan, Team Catalog, and secret-manager password sources

### DIFF
--- a/docs/customization/settings.mdx
+++ b/docs/customization/settings.mdx
@@ -170,7 +170,7 @@ Only install plugins from sources you trust. Code-signature checks do not guaran
 
 ## License & Account
 
-Activate, deactivate, or view your license under **Settings** > **Account**. Validation is local (cryptographic signature) and re-checks every 7 days. iCloud sync, linked folders, and account info live on the same tab. See [iCloud Sync](/features/icloud-sync).
+Activate, deactivate, or view your license under **Settings** > **Account**. Validation is local (cryptographic signature) and re-checks every 7 days. On a Team plan, paste an invite code in the same activation field to join a team instead of entering a license key. See the [Team plan](/features/team). iCloud sync, linked folders, and account info live on the same tab. See [iCloud Sync](/features/icloud-sync).
 
 ## Data Grid
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -146,6 +146,10 @@
                 ]
               },
               {
+                "group": "Team",
+                "pages": ["features/team"]
+              },
+              {
                 "group": "Extensibility",
                 "pages": ["features/plugins"]
               }

--- a/docs/features/connection-sharing.mdx
+++ b/docs/features/connection-sharing.mdx
@@ -168,6 +168,18 @@ Works with Git repos, Dropbox, network drives.
   />
 </Frame>
 
+## Team Catalog <sup>Team</sup>
+
+Publish connections to a shared folder in one step so your teammates pick them up as [Linked Folders](#linked-folders). Passwords, passphrases, TOTP secrets, and secure plugin fields are never written. Team Catalog is part of the [Team plan](/features/team).
+
+Right-click a connection > **Share** > **Publish to Team Catalog...**. Select several first to publish them together.
+
+The first time, TablePro asks for the shared folder. Point it at a Git repo, a Dropbox folder, or a network drive that your team already shares. TablePro remembers it for next time.
+
+Each connection is written as its own `.tablepro` file, named after the connection. Republishing a connection overwrites its file, so the catalog stays current as you rename hosts or add connections.
+
+Teammates add the same folder under **Settings** (`Cmd+,`) > **Account** > **Linked Folders**. Published connections show up read-only in their sidebar, and each person enters their own password.
+
 ## Environment Variables <sup>Pro</sup>
 
 Use `$VAR` and `${VAR}` in `.tablepro` files. Resolved at connection time.
@@ -198,6 +210,22 @@ Add a `passwordSource` object to the connection:
 - `command`: runs the command through `/bin/bash` and reads stdout. Works with `op`, `vault`, `pass`, and `sops`. A trailing newline is trimmed, a non-zero exit fails the connection, and the command has a 30 second timeout.
 
 When `passwordSource` is set it replaces the Keychain lookup for that connection. If resolution fails, the connection reports the error instead of falling back to the Keychain.
+
+### Secret managers
+
+For 1Password, HashiCorp Vault, and AWS Secrets Manager there are dedicated kinds. They build the CLI call for you and quote every argument, so a reference can never break out into the shell.
+
+```json
+{ "passwordSource": { "kind": "onePassword", "reference": "op://vault/feature-x/password" } }
+{ "passwordSource": { "kind": "vault", "path": "secret/data/staging/db", "field": "password" } }
+{ "passwordSource": { "kind": "awsSecretsManager", "secretId": "prod/db", "jsonKey": "password" } }
+```
+
+- `onePassword`: runs `op read` on the secret reference. Sign in to the 1Password CLI first (`op signin`).
+- `vault`: runs `vault kv get` for one field at a path. Set `VAULT_ADDR` and `VAULT_TOKEN` in TablePro's environment.
+- `awsSecretsManager`: runs `aws secretsmanager get-secret-value` for the secret. When the secret is a JSON blob, set `jsonKey` to pull one field out of it. Leave `jsonKey` off to use the whole value.
+
+The CLI tools must be on `PATH`. TablePro also looks in `/usr/local/bin` and `/opt/homebrew/bin`. Each call has the same 30 second timeout as `command`.
 
 ## File Format
 

--- a/docs/features/icloud-sync.mdx
+++ b/docs/features/icloud-sync.mdx
@@ -5,7 +5,7 @@ description: Sync connections, table favorites, settings, and SSH profiles acros
 
 # iCloud Sync
 
-TablePro syncs your connections, groups, table favorites, settings, and SSH profiles across all your Macs via CloudKit. iCloud Sync is a Pro feature that requires an active license.
+TablePro syncs your connections, groups, table favorites, saved queries, settings, and SSH profiles across all your Macs via CloudKit. iCloud Sync is a Pro feature that requires an active license.
 
 ## What syncs (and what doesn't)
 
@@ -15,7 +15,8 @@ TablePro syncs your connections, groups, table favorites, settings, and SSH prof
 | **Passwords** | Optional | Opt-in via iCloud Keychain (end-to-end encrypted) |
 | **Groups & Tags** | Yes | Full connection organization, including nested group hierarchy (parent-child relationships and sort order) |
 | **Table Favorites** | Yes | Favorited table names shown in the Favorites tab and pinned in table lists |
-| **App Settings** | Yes | All settings categories (General, Appearance, Editor, Keyboard, AI, Terminal) |
+| **Saved Queries** | Yes | Saved SQL queries and their folders. Has its own toggle. |
+| **App Settings** | Yes | All settings categories (General, Appearance, Editor, Keyboard, AI, Terminal), including your custom AI slash commands |
 | **Linked SQL Folders** | No | Folder paths are per-Mac. Link the same Git repo on each Mac after cloning. Cached file metadata (`linked_sql_index.db`) is also local. |
 
 <Note>
@@ -40,7 +41,7 @@ Open **Settings** (`Cmd+,`) > **Account**, toggle iCloud Sync on, choose which c
   />
 </Frame>
 
-Connections, Groups & Tags, SSH Profiles, and App Settings each have their own toggle. Table favorites sync when iCloud Sync is enabled.
+Connections, Groups & Tags, SSH Profiles, App Settings, Table Favorites, and Saved Queries each have their own toggle. Custom AI slash commands ride along with the App Settings toggle.
 
 ## Excluding individual connections
 

--- a/docs/features/overview.mdx
+++ b/docs/features/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Features Overview
-description: Index of TablePro features grouped by editor, AI, views, data management, workflow, security, sync, and extensibility.
+description: Index of TablePro features grouped by editor, AI, views, data management, workflow, security, sync, team, and extensibility.
 ---
 
 # Features
@@ -125,6 +125,14 @@ TablePro opens with a sidebar-style welcome window, in the style of the Xcode la
   </Card>
   <Card title="Handoff" icon="arrow-right-arrow-left" href="/features/handoff">
     Resume the active connection or table on another Mac.
+  </Card>
+</CardGroup>
+
+## Team
+
+<CardGroup cols={2}>
+  <Card title="Team Plan" icon="users" href="/features/team">
+    Share one license, manage seats on the web, join with an invite code.
   </Card>
 </CardGroup>
 

--- a/docs/features/team.mdx
+++ b/docs/features/team.mdx
@@ -1,0 +1,55 @@
+---
+title: Team Plan
+description: Share one license across your team, manage seats on the web, and join with an invite code
+---
+
+# Team Plan
+
+The Team plan is one license that covers several people. You buy a number of seats, manage who uses them from the web, and each person activates TablePro on their Mac with an invite code. Team management lives in your account on the web. The app is only for activation.
+
+## Seats
+
+A Team license has a fixed number of seats. Each activated Mac takes one seat. Members have a role:
+
+| Role | Meaning |
+|------|---------|
+| Owner | The person who bought the license. Manages members and billing. Cannot be removed. |
+| Admin | Invited with the Admin role. |
+| Member | A regular seat. |
+
+The role travels with each member's activation, so the app and the account portal always know who is who.
+
+## Manage your team on the web
+
+Sign in to your account at [tablepro.app/account](https://tablepro.app/account) with the email on your license. You get a one-time sign-in link by email, so there is no separate password to remember.
+
+From the team panel you can:
+
+- See seats used and seats total.
+- Invite a member by email and pick their role (Admin or Member).
+- Cancel an invite that has not been accepted yet.
+- Remove a member. Removing a member frees their seat.
+
+An invited member gets an email with an invite code.
+
+## Join a team
+
+You join from the invite email. You do not need a license key of your own.
+
+1. Install TablePro and open the **Activate License** window: **Settings** (`Cmd+,`) > **Account**, or the activation prompt on first launch.
+2. Paste the **invite code** from your email into the same field where a license key goes.
+3. Click **Activate**.
+
+TablePro detects that the code is an invite rather than a license key, takes a seat on the team, and activates. From then on your copy validates and renews like any other license.
+
+<Note>
+An invite code is single use. It seats the first Mac that redeems it. To add a second Mac, ask your team owner for another invite. To move your seat to a new Mac, deactivate the old one under **Settings** > **Account** and redeem a fresh invite.
+</Note>
+
+## Share connections with your team
+
+The Team Catalog publishes connection definitions, without passwords, to a shared folder your teammates watch. See [Team Catalog](/features/connection-sharing#team-catalog).
+
+## What a seat includes
+
+Every seat is a full Pro seat. Alongside the shared license you get iCloud sync of connections, saved queries, and settings, secret manager password sources, and every other feature in the app. See [iCloud Sync](/features/icloud-sync) and [Connection Sharing](/features/connection-sharing).


### PR DESCRIPTION
Documents the Team features that shipped in #1817 and the website team backend. Docs-only, so no CHANGELOG entry.

## New
- `features/team.mdx`: Team plan hub. Seats and roles (Owner/Admin/Member), managing the team from the account portal on the web (invite, cancel, remove, seat counts), and joining a team by pasting an invite code in the Activate License window. Registered as a new "Team" group in the docs nav.

## Updated
- `features/connection-sharing.mdx`: new Team Catalog section (right-click > Share > Publish to Team Catalog, secret-free `.tablepro` files, teammates read via Linked Folders). Extended Password Sources with the `onePassword`, `vault`, and `awsSecretsManager` kinds, including the CLI each runs and the AWS `jsonKey` field.
- `features/icloud-sync.mdx`: added Saved Queries to the sync table and noted custom AI slash commands ride with App Settings.
- `customization/settings.mdx`: License & Account now mentions invite-code activation.
- `features/overview.mdx`: added a Team card and group.

Anchors follow the existing `#slug` convention (Mintlify drops the `<sup>` tag). Writing-style scan is clean (no em dashes or filler).