### PR TITLE
fix(sidebar): filter tables by substring and prefix instead of fuzzy (#1822)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Saved SQL queries and their folders now sync across your Macs when iCloud Sync is on. Toggle "Saved Queries" under Settings > Sync.
 - Recent section at the top of the sidebar tracks the last 10 tables you opened per connection and database, in every sidebar layout, and remembers them between launches. It records a table when you open it, not while you arrow through previews. Click a recent table to reopen it, or right-click to remove one or clear the list. Off by default, turn it on in Settings > General > Sidebar. (#1352)
 
+### Changed
+
+- The sidebar filter now matches table and view names by substring and prefix instead of fuzzy matching, so typing the start of a name narrows the list instead of keeping every loose match. Names that start with what you typed sort to the top. (#1822)
+
 ### Fixed
 
 - Elasticsearch connections using Username & Password now show a Password field, so basic auth on a secured cluster can be set up. It was hidden before, leaving only the Username field. Update the Elasticsearch plugin to get the fix. (#1816)

--- a/TablePro/Core/Utilities/UI/SidebarNameFilter.swift
+++ b/TablePro/Core/Utilities/UI/SidebarNameFilter.swift
@@ -1,0 +1,46 @@
+//
+//  SidebarNameFilter.swift
+//  TablePro
+//
+
+import Foundation
+
+internal enum SidebarNameMatchTier: Int, Comparable {
+    case exact
+    case prefix
+    case substring
+
+    static func < (lhs: SidebarNameMatchTier, rhs: SidebarNameMatchTier) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+internal enum SidebarNameFilter {
+    static func matches(query: String, candidate: String) -> Bool {
+        tier(query: query, candidate: candidate) != nil
+    }
+
+    static func tier(query: String, candidate: String) -> SidebarNameMatchTier? {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return .exact }
+        let candidateString = candidate as NSString
+        let range = candidateString.localizedStandardRange(of: trimmed)
+        guard range.location != NSNotFound else { return nil }
+        guard range.location == 0 else { return .substring }
+        return range.length == candidateString.length ? .exact : .prefix
+    }
+
+    static func ranked<Element>(_ items: [Element], query: String, name: (Element) -> String) -> [Element] {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return items }
+        let scored = items.enumerated().compactMap { index, element -> (element: Element, tier: SidebarNameMatchTier, index: Int)? in
+            guard let tier = tier(query: trimmed, candidate: name(element)) else { return nil }
+            return (element, tier, index)
+        }
+        return scored
+            .sorted { lhs, rhs in
+                lhs.tier != rhs.tier ? lhs.tier < rhs.tier : lhs.index < rhs.index
+            }
+            .map(\.element)
+    }
+}

--- a/TablePro/ViewModels/SidebarViewModel.swift
+++ b/TablePro/ViewModels/SidebarViewModel.swift
@@ -332,9 +332,6 @@ final class SidebarViewModel {
 
     // MARK: - Filtering
 
-    @ObservationIgnored private var cachedFilteredTables: [TableInfo]?
-    @ObservationIgnored private var cachedFilterInputs: (count: Int, generation: Int, query: String)?
-
     @ObservationIgnored private var cachedKindBuckets: [SidebarObjectKind: [TableInfo]] = [:]
     @ObservationIgnored private var cachedKindFingerprint: (count: Int, generation: Int)?
 
@@ -346,25 +343,6 @@ final class SidebarViewModel {
 
     private var schemaGeneration: Int {
         SchemaService.shared.generationToken(for: connectionId)
-    }
-
-    func filteredTables(from tables: [TableInfo]) -> [TableInfo] {
-        let query = filterQuery
-        let fingerprint = (count: tables.count, generation: schemaGeneration, query: query)
-        if let cache = cachedFilteredTables,
-           let inputs = cachedFilterInputs,
-           inputs == fingerprint {
-            return cache
-        }
-        let result: [TableInfo]
-        if query.isEmpty {
-            result = tables
-        } else {
-            result = tables.filter { FuzzyMatcher.matches(query: query, candidate: $0.name) }
-        }
-        cachedFilteredTables = result
-        cachedFilterInputs = fingerprint
-        return result
     }
 
     func tables(of kind: SidebarObjectKind, from tables: [TableInfo]) -> [TableInfo] {
@@ -398,7 +376,9 @@ final class SidebarViewModel {
     }
 
     func filteredRecentTables(_ tables: [TableInfo]) -> [TableInfo] {
-        applyQuery(filterQuery, to: tables)
+        let query = filterQuery
+        guard !query.isEmpty else { return tables }
+        return tables.filter { SidebarNameFilter.matches(query: query, candidate: $0.name) }
     }
 
     func filteredRoutines(of kind: SidebarObjectKind, from routines: [RoutineInfo]) -> [RoutineInfo] {
@@ -422,13 +402,11 @@ final class SidebarViewModel {
     }
 
     private func applyQuery(_ query: String, to tables: [TableInfo]) -> [TableInfo] {
-        guard !query.isEmpty else { return tables }
-        return tables.filter { FuzzyMatcher.matches(query: query, candidate: $0.name) }
+        SidebarNameFilter.ranked(tables, query: query, name: { $0.name })
     }
 
     private func applyRoutineQuery(_ query: String, to routines: [RoutineInfo]) -> [RoutineInfo] {
-        guard !query.isEmpty else { return routines }
-        return routines.filter { FuzzyMatcher.matches(query: query, candidate: $0.name) }
+        SidebarNameFilter.ranked(routines, query: query, name: { $0.name })
     }
 
     private func rebuildKindBuckets(from tables: [TableInfo]) {
@@ -453,8 +431,6 @@ final class SidebarViewModel {
     }
 
     private func invalidateFilterCaches() {
-        cachedFilteredTables = nil
-        cachedFilterInputs = nil
         cachedFilteredByKind = [:]
         cachedFilteredByKindFingerprint = nil
         cachedFilteredRoutines = [:]

--- a/TablePro/Views/Sidebar/DatabaseTreeFilter.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeFilter.swift
@@ -8,16 +8,16 @@ import TableProPluginKit
 
 enum DatabaseTreeFilter {
     static func matches(_ query: String, _ candidate: String) -> Bool {
-        FuzzyMatcher.matches(query: query, candidate: candidate)
+        SidebarNameFilter.matches(query: query, candidate: candidate)
     }
 
     static func filteredTables(_ tables: [TableInfo], searchText: String) -> [TableInfo] {
-        let matched = searchText.isEmpty ? tables : tables.filter { matches(searchText, $0.name) }
+        let matched = SidebarNameFilter.ranked(tables, query: searchText, name: { $0.name })
         return deduplicated(matched, by: \.id)
     }
 
     static func filteredRoutines(_ routines: [RoutineInfo], searchText: String) -> [RoutineInfo] {
-        let matched = searchText.isEmpty ? routines : routines.filter { matches(searchText, $0.name) }
+        let matched = SidebarNameFilter.ranked(routines, query: searchText, name: { $0.name })
         return deduplicated(matched, by: \.id)
     }
 

--- a/TablePro/Views/Sidebar/DatabaseTreeFilterPopover.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeFilterPopover.swift
@@ -22,7 +22,7 @@ struct DatabaseTreeFilterPopover: View {
 
     private var matchingDatabases: [DatabaseMetadata] {
         guard !searchText.isEmpty else { return selectableDatabases }
-        return selectableDatabases.filter { FuzzyMatcher.matches(query: searchText, candidate: $0.name) }
+        return selectableDatabases.filter { SidebarNameFilter.matches(query: searchText, candidate: $0.name) }
     }
 
     private var shownCount: Int {

--- a/TablePro/Views/Sidebar/SidebarTreeView.swift
+++ b/TablePro/Views/Sidebar/SidebarTreeView.swift
@@ -228,14 +228,14 @@ struct SidebarTreeView: View {
 
     private func tablesToShow(for schema: String) -> [TableInfo] {
         let tables = schemaService.tables(for: connectionId, schema: schema)
-        guard !searchText.isEmpty, !FuzzyMatcher.matches(query: searchText, candidate: schema) else {
+        guard !searchText.isEmpty, !SidebarNameFilter.matches(query: searchText, candidate: schema) else {
             return tables
         }
-        return tables.filter { FuzzyMatcher.matches(query: searchText, candidate: $0.name) }
+        return SidebarNameFilter.ranked(tables, query: searchText, name: { $0.name })
     }
 
     private func schemaIsVisibleDuringSearch(_ schema: String) -> Bool {
-        if FuzzyMatcher.matches(query: searchText, candidate: schema) { return true }
+        if SidebarNameFilter.matches(query: searchText, candidate: schema) { return true }
         switch schemaService.schemaState(for: connectionId, schema: schema) {
         case .loaded:
             return !tablesToShow(for: schema).isEmpty

--- a/TableProTests/Utilities/SidebarNameFilterTests.swift
+++ b/TableProTests/Utilities/SidebarNameFilterTests.swift
@@ -1,0 +1,98 @@
+//
+//  SidebarNameFilterTests.swift
+//  TableProTests
+//
+
+@testable import TablePro
+import Testing
+
+struct SidebarNameFilterTests {
+    // MARK: - Matching
+
+    @Test("Empty or whitespace query matches everything")
+    func emptyQueryMatches() {
+        #expect(SidebarNameFilter.matches(query: "", candidate: "users"))
+        #expect(SidebarNameFilter.matches(query: "   ", candidate: "users"))
+    }
+
+    @Test("Substring in the middle of the name matches")
+    func substringMatches() {
+        #expect(SidebarNameFilter.matches(query: "ser", candidate: "users"))
+        #expect(SidebarNameFilter.matches(query: "log", candidate: "audit_log"))
+    }
+
+    @Test("Scattered subsequence no longer matches")
+    func subsequenceDoesNotMatch() {
+        #expect(!SidebarNameFilter.matches(query: "usr", candidate: "users"))
+        #expect(!SidebarNameFilter.matches(query: "ur", candidate: "user"))
+        #expect(!SidebarNameFilter.matches(query: "upv", candidate: "user_profile_view"))
+        #expect(!SidebarNameFilter.matches(query: "user", candidate: "purchase_events_registry"))
+    }
+
+    @Test("Matching is case and diacritic insensitive")
+    func caseAndDiacriticInsensitive() {
+        #expect(SidebarNameFilter.matches(query: "USER", candidate: "users"))
+        #expect(SidebarNameFilter.matches(query: "user", candidate: "USERS"))
+        #expect(SidebarNameFilter.matches(query: "cafe", candidate: "café_orders"))
+    }
+
+    @Test("Leading and trailing whitespace is trimmed")
+    func whitespaceTrimmed() {
+        #expect(SidebarNameFilter.tier(query: "  user  ", candidate: "users") == .prefix)
+    }
+
+    // MARK: - Tiers
+
+    @Test("Exact match reports the exact tier")
+    func exactTier() {
+        #expect(SidebarNameFilter.tier(query: "users", candidate: "users") == .exact)
+        #expect(SidebarNameFilter.tier(query: "USERS", candidate: "users") == .exact)
+    }
+
+    @Test("Prefix match reports the prefix tier")
+    func prefixTier() {
+        #expect(SidebarNameFilter.tier(query: "user", candidate: "users") == .prefix)
+        #expect(SidebarNameFilter.tier(query: "user", candidate: "user_log") == .prefix)
+    }
+
+    @Test("Interior substring reports the substring tier")
+    func substringTier() {
+        #expect(SidebarNameFilter.tier(query: "ser", candidate: "users") == .substring)
+        #expect(SidebarNameFilter.tier(query: "log", candidate: "user_log") == .substring)
+    }
+
+    @Test("Non-match reports no tier")
+    func noTier() {
+        #expect(SidebarNameFilter.tier(query: "usr", candidate: "users") == nil)
+        #expect(SidebarNameFilter.tier(query: "zzz", candidate: "users") == nil)
+    }
+
+    // MARK: - Ranking
+
+    @Test("Empty query keeps the original order")
+    func rankedEmptyQueryPreservesOrder() {
+        let result = SidebarNameFilter.ranked(["orders", "users"], query: "", name: { $0 })
+        #expect(result == ["orders", "users"])
+    }
+
+    @Test("Prefix matches sort above interior-substring matches")
+    func rankedPrefixBeforeSubstring() {
+        let names = ["audit_user", "users", "user_log", "orders"]
+        let result = SidebarNameFilter.ranked(names, query: "user", name: { $0 })
+        #expect(result == ["users", "user_log", "audit_user"])
+    }
+
+    @Test("Exact match sorts above prefix matches")
+    func rankedExactBeforePrefix() {
+        let names = ["user_log", "user", "users"]
+        let result = SidebarNameFilter.ranked(names, query: "user", name: { $0 })
+        #expect(result == ["user", "user_log", "users"])
+    }
+
+    @Test("Within a tier the original order is stable")
+    func rankedStableWithinTier() {
+        let names = ["ab_x", "ab_a", "ab_m"]
+        let result = SidebarNameFilter.ranked(names, query: "ab", name: { $0 })
+        #expect(result == ["ab_x", "ab_a", "ab_m"])
+    }
+}

--- a/TableProTests/ViewModels/SidebarViewModelTests.swift
+++ b/TableProTests/ViewModels/SidebarViewModelTests.swift
@@ -354,9 +354,9 @@ struct SidebarViewModelMultiSectionTests {
         #expect(funcs.map(\.name) == ["calculate_age"])
     }
 
-    @Test("Sidebar filter matches fuzzy abbreviations like Xcode's navigator")
+    @Test("Sidebar filter uses substring matching, not fuzzy abbreviations")
     @MainActor
-    func sidebarFilterMatchesAbbreviation() {
+    func sidebarFilterUsesSubstringNotAbbreviation() {
         let vm = makeViewModel()
         let userProfileView = TestFixtures.makeTableInfo(name: "user_profile_view", type: .view)
         let orders = TestFixtures.makeTableInfo(name: "orders", type: .view)
@@ -364,7 +364,21 @@ struct SidebarViewModelMultiSectionTests {
 
         let matches = vm.filteredTables(of: .view, from: [userProfileView, orders])
 
-        #expect(matches.map(\.name) == ["user_profile_view"])
+        #expect(matches.isEmpty)
+    }
+
+    @Test("Sidebar filter ranks prefix matches above interior-substring matches")
+    @MainActor
+    func sidebarFilterRanksPrefixFirst() {
+        let vm = makeViewModel()
+        let auditUser = TestFixtures.makeTableInfo(name: "audit_user", type: .table)
+        let users = TestFixtures.makeTableInfo(name: "users", type: .table)
+        let userLog = TestFixtures.makeTableInfo(name: "user_log", type: .table)
+        vm.searchText = "user"
+
+        let matches = vm.filteredTables(of: .table, from: [auditUser, users, userLog])
+
+        #expect(matches.map(\.name) == ["users", "user_log", "audit_user"])
     }
 
     @Test("filteredRoutines search matches name case insensitively")

--- a/TableProTests/Views/Sidebar/DatabaseTreeFilterTests.swift
+++ b/TableProTests/Views/Sidebar/DatabaseTreeFilterTests.swift
@@ -20,14 +20,21 @@ struct DatabaseTreeFilterTests {
         #expect(result.map(\.name) == ["users", "orders"])
     }
 
-    @Test("filteredTables keeps only fuzzy matches when searching")
+    @Test("filteredTables keeps only substring matches when searching")
     func filteredTablesSearch() {
         let tables = [table("users"), table("orders"), table("invoices")]
         let result = DatabaseTreeFilter.filteredTables(tables, searchText: "ord")
         #expect(result.map(\.name) == ["orders"])
     }
 
-    @Test("filteredRoutines deduplicates and fuzzy matches")
+    @Test("filteredTables ranks prefix matches above interior-substring matches")
+    func filteredTablesRanksPrefixFirst() {
+        let tables = [table("audit_user"), table("users"), table("user_log")]
+        let result = DatabaseTreeFilter.filteredTables(tables, searchText: "user")
+        #expect(result.map(\.name) == ["users", "user_log", "audit_user"])
+    }
+
+    @Test("filteredRoutines deduplicates and substring matches")
     func filteredRoutinesSearch() {
         let routines = [routine("calc_total"), routine("audit_log"), routine("calc_total")]
         #expect(DatabaseTreeFilter.filteredRoutines(routines, searchText: "").count == 2)
@@ -58,9 +65,11 @@ struct DatabaseTreeFilterTests {
         #expect(result == ["sales"])
     }
 
-    @Test("matches is a fuzzy subsequence test")
-    func matchesFuzzy() {
-        #expect(DatabaseTreeFilter.matches("usr", "users"))
+    @Test("matches is a case-insensitive substring test, not a subsequence test")
+    func matchesSubstring() {
+        #expect(DatabaseTreeFilter.matches("ser", "users"))
+        #expect(DatabaseTreeFilter.matches("USER", "users"))
+        #expect(!DatabaseTreeFilter.matches("usr", "users"))
         #expect(!DatabaseTreeFilter.matches("zzz", "users"))
     }
 }


### PR DESCRIPTION
Closes #1822.

## Problem

The sidebar table filter used `FuzzyMatcher.matches()`, a scattered-subsequence test with no ranking. Typing `ord` kept every table with `o…r…d` anywhere in the name, so on a database with many tables the list never narrowed and you had to type most of the full name. Fuzzy matching is the wrong policy for a persistent filter field; it belongs in the Quick Switcher.

## Change

- New `SidebarNameFilter` (`Core/Utilities/UI/`): one `NSString.localizedStandardRange(of:)` call (case, diacritic, and width insensitive, locale-aware, the API Apple recommends for user-facing search) yields a match tier, `exact < prefix < substring`. `matches()` reports a hit; `ranked()` keeps matches and stable-sorts them prefix-first, so names starting with what you typed float to the top while alphabetical order holds within each tier.
- Routed the four sidebar object-filter surfaces through it: the flat list (`SidebarViewModel`), the hierarchical schema tree (`SidebarTreeView`), the database tree (`DatabaseTreeFilter`), and the database filter popover.
- The Recent section stays filter-only so its most-recent-first order is preserved during a search.
- `FuzzyMatcher` is unchanged. The Quick Switcher, database switcher, and connection switcher keep ranked fuzzy, which is the right fit for a jump-to surface.
- Removed a dead `filteredTables(from:)` method and its orphaned caches.

This brings the Tables filter in line with the sibling Favorites filter, which already matches by substring.

## Why substring

`DataGrip`, `Postico`, `Sequel Ace`, and `Navicat` all filter their table trees by substring. VS Code splits the two on purpose: its Explorer filter is substring by default, Quick Open is fuzzy. TablePlus shipped a fuzzy sidebar and got the same complaint we did (their issue #1608). Apple documents `localizedStandardContains` as the user-facing search norm and ships no fuzzy list-filter API.

## Tests

- New `SidebarNameFilterTests`: tiers, case and diacritic insensitivity, the regression that scattered subsequences no longer match (`upv` no longer matches `user_profile_view`), and prefix-first ranking.
- Updated the two tests that asserted the old fuzzy behavior (`SidebarViewModelTests`, `DatabaseTreeFilterTests`) and added ranking assertions.

The tier and ranking logic was validated end to end against real Foundation `localizedStandardRange` (24 cases pass). `swiftlint --strict` is clean on the changed lines.
