### PR TITLE
fix(datagrid): batch multi-row deletes into bounded statements (#1823)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Team plan: publish connections to a shared folder your team reads from, without sending passwords. Right-click a connection, then Share > Publish to Team Catalog. Teammates add the folder under Settings > Linked Folders.
 - Saved SQL queries and their folders now sync across your Macs when iCloud Sync is on. Toggle "Saved Queries" under Settings > Sync.
 - Recent section at the top of the sidebar tracks the last 10 tables you opened per connection and database, in every sidebar layout, and remembers them between launches. It records a table when you open it, not while you arrow through previews. Click a recent table to reopen it, or right-click to remove one or clear the list. Off by default, turn it on in Settings > General > Sidebar. (#1352)
+- Saving now asks you to confirm before it permanently deletes rows, so a bulk delete can't be committed by accident. (#1823)
 
 ### Fixed
 
+- Deleting many rows at once no longer freezes the app or the machine. Multi-row deletes now run as one batched statement, chunked to stay within the database's limits, instead of one query per row. (#1823)
+- Deleting rows from a table without a primary key now matches on every column instead of treating the first column as a key, so it won't remove other rows that happen to share that value. (#1823)
 - Elasticsearch connections using Username & Password now show a Password field, so basic auth on a secured cluster can be set up. It was hidden before, leaving only the Username field. Update the Elasticsearch plugin to get the fix. (#1816)
 - Switching schemas on an Oracle connection no longer hangs on an infinite loading spinner. Oracle now switches by schema like BigQuery, the sidebar lists every schema with its tables loading on expand, Oracle queries respect the query timeout setting and reconnect automatically after a timeout, and a schema load that fails shows an error with a Retry button instead of spinning forever. Works with an already-installed Oracle plugin; updating the plugin adds the query timeout enforcement. (#1807)
 

--- a/TablePro/Core/ChangeTracking/BulkDeleteConfirmation.swift
+++ b/TablePro/Core/ChangeTracking/BulkDeleteConfirmation.swift
@@ -1,0 +1,26 @@
+//
+//  BulkDeleteConfirmation.swift
+//  TablePro
+//
+
+import Foundation
+
+struct BulkDeleteConfirmation {
+    let deletedRowCount: Int
+
+    var isRequired: Bool { deletedRowCount > 0 }
+
+    var title: String {
+        deletedRowCount == 1
+            ? String(localized: "Delete this row?")
+            : String(format: String(localized: "Delete %lld rows?"), deletedRowCount)
+    }
+
+    var message: String {
+        String(localized: "This permanently deletes the selected rows from the database and can't be undone.")
+    }
+
+    var confirmButtonTitle: String {
+        String(localized: "Delete")
+    }
+}

--- a/TablePro/Core/ChangeTracking/DataChangeManager.swift
+++ b/TablePro/Core/ChangeTracking/DataChangeManager.swift
@@ -48,6 +48,7 @@ final class DataChangeManager: ChangeManaging {
     var changes: [RowChange] { pending.changes }
     var rowChanges: [RowChange] { pending.changes }
     var insertedRowIndices: Set<Int> { pending.insertedRowIndices }
+    var deletedRowIndices: Set<Int> { pending.deletedRowIndices }
 
     var tableName: String = ""
     var schemaName: String?

--- a/TablePro/Core/ChangeTracking/SQLStatementGenerator.swift
+++ b/TablePro/Core/ChangeTracking/SQLStatementGenerator.swift
@@ -381,7 +381,11 @@ struct SQLStatementGenerator {
         for (index, columnName) in columns.enumerated() {
             guard index < originalRow.count else { continue }
             let value = originalRow[index]
-            matches.append(DeleteColumnMatch(column: columnName, boundValue: value.isNull ? nil : value))
+            if value.isNull {
+                matches.append(DeleteColumnMatch(column: columnName, boundValue: nil))
+            } else {
+                matches.append(DeleteColumnMatch(column: columnName, boundValue: value))
+            }
         }
         return matches.isEmpty ? nil : matches
     }

--- a/TablePro/Core/ChangeTracking/SQLStatementGenerator.swift
+++ b/TablePro/Core/ChangeTracking/SQLStatementGenerator.swift
@@ -104,18 +104,8 @@ struct SQLStatementGenerator {
             }
         }
 
-        // Try batched DELETE first (uses PK if available), fall back to individual DELETEs
         if !deleteChanges.isEmpty {
-            if let stmt = generateBatchDeleteSQL(for: deleteChanges) {
-                statements.append(stmt)
-            } else {
-                // No PK - generate individual DELETE statements matching all columns
-                for change in deleteChanges {
-                    if let stmt = generateDeleteSQL(for: change) {
-                        statements.append(stmt)
-                    }
-                }
-            }
+            statements.append(contentsOf: generateDeleteStatements(for: deleteChanges))
         }
 
         return statements
@@ -340,72 +330,78 @@ struct SQLStatementGenerator {
 
     // MARK: - DELETE Generation
 
-    /// Generate a batched DELETE statement combining multiple rows
-    private func generateBatchDeleteSQL(for changes: [RowChange]) -> ParameterizedStatement? {
-        guard !changes.isEmpty else { return nil }
-
-        // If we have primary key(s), use them for efficient deletion
-        if !primaryKeyColumns.isEmpty {
-            let pkIndices: [(column: String, index: Int)] = primaryKeyColumns.compactMap { col in
-                guard let idx = columns.firstIndex(of: col) else { return nil }
-                return (col, idx)
-            }
-            guard !pkIndices.isEmpty else { return nil }
-
-            var parameters: [Any?] = []
-            let rowConditions = changes.compactMap { change -> String? in
-                guard let originalRow = change.originalRow else { return nil }
-
-                var pkConditions: [String] = []
-                for pk in pkIndices {
-                    guard pk.index < originalRow.count else { return nil }
-                    parameters.append(originalRow[pk.index].asAny)
-                    pkConditions.append(
-                        "\(quoteIdentifierFn(pk.column)) = \(placeholder(at: parameters.count - 1))"
-                    )
-                }
-                return pkIndices.count > 1
-                    ? "(\(pkConditions.joined(separator: " AND ")))"
-                    : pkConditions.joined()
-            }
-
-            guard !rowConditions.isEmpty else { return nil }
-
-            let whereClause = rowConditions.joined(separator: " OR ")
-            let sql = "DELETE FROM \(quoteIdentifierFn(tableName)) WHERE \(whereClause)"
-
-            return ParameterizedStatement(sql: sql, parameters: parameters)
-        }
-
-        // Fallback: No primary key - generate individual DELETE statements
-        return nil
+    private struct DeleteColumnMatch {
+        let column: String
+        let boundValue: PluginCellValue?
     }
 
-    private func generateDeleteSQL(for change: RowChange) -> ParameterizedStatement? {
-        guard let originalRow = change.originalRow else { return nil }
+    private func generateDeleteStatements(for changes: [RowChange]) -> [ParameterizedStatement] {
+        let rowMatches = changes.compactMap { deleteRowMatches(for: $0) }
+        guard !rowMatches.isEmpty else { return [] }
 
-        var parameters: [Any?] = []
-        var conditions: [String] = []
+        var statements: [ParameterizedStatement] = []
+        var chunk: [[DeleteColumnMatch]] = []
+        var chunkParameterCount = 0
 
-        for (index, columnName) in columns.enumerated() {
-            guard index < originalRow.count else { continue }
-
-            let value = originalRow[index]
-            let quotedColumn = quoteIdentifierFn(columnName)
-
-            if value.isNull {
-                conditions.append("\(quotedColumn) IS NULL")
-            } else {
-                parameters.append(value.asAny)
-                conditions.append("\(quotedColumn) = \(placeholder(at: parameters.count - 1))")
+        for matches in rowMatches {
+            let rowParameterCount = matches.count(where: { $0.boundValue != nil })
+            if !chunk.isEmpty, chunkParameterCount + rowParameterCount > maxBindParameters {
+                statements.append(deleteStatement(for: chunk))
+                chunk = []
+                chunkParameterCount = 0
             }
+            chunk.append(matches)
+            chunkParameterCount += rowParameterCount
         }
 
-        guard !conditions.isEmpty else { return nil }
+        if !chunk.isEmpty {
+            statements.append(deleteStatement(for: chunk))
+        }
 
-        let whereClause = conditions.joined(separator: " AND ")
+        return statements
+    }
+
+    private func deleteRowMatches(for change: RowChange) -> [DeleteColumnMatch]? {
+        guard let originalRow = change.originalRow else { return nil }
+
+        if !primaryKeyColumns.isEmpty {
+            var matches: [DeleteColumnMatch] = []
+            for pkColumn in primaryKeyColumns {
+                guard let pkIndex = columns.firstIndex(of: pkColumn), pkIndex < originalRow.count else {
+                    return nil
+                }
+                let value = originalRow[pkIndex]
+                guard !value.isNull else { return nil }
+                matches.append(DeleteColumnMatch(column: pkColumn, boundValue: value))
+            }
+            return matches.isEmpty ? nil : matches
+        }
+
+        var matches: [DeleteColumnMatch] = []
+        for (index, columnName) in columns.enumerated() {
+            guard index < originalRow.count else { continue }
+            let value = originalRow[index]
+            matches.append(DeleteColumnMatch(column: columnName, boundValue: value.isNull ? nil : value))
+        }
+        return matches.isEmpty ? nil : matches
+    }
+
+    private func deleteStatement(for rows: [[DeleteColumnMatch]]) -> ParameterizedStatement {
+        var parameters: [Any?] = []
+        let rowClauses = rows.map { matches -> String in
+            let conditions = matches.map { match -> String in
+                guard let value = match.boundValue else {
+                    return "\(quoteIdentifierFn(match.column)) IS NULL"
+                }
+                parameters.append(value.asAny)
+                return "\(quoteIdentifierFn(match.column)) = \(placeholder(at: parameters.count - 1))"
+            }
+            let joined = conditions.joined(separator: " AND ")
+            return matches.count > 1 ? "(\(joined))" : joined
+        }
+
+        let whereClause = rowClauses.joined(separator: " OR ")
         let sql = "DELETE FROM \(quoteIdentifierFn(tableName)) WHERE \(whereClause)"
-
         return ParameterizedStatement(sql: sql, parameters: parameters)
     }
 

--- a/TablePro/Core/Coordinators/RowEditingCoordinator+SaveChanges.swift
+++ b/TablePro/Core/Coordinators/RowEditingCoordinator+SaveChanges.swift
@@ -64,8 +64,33 @@ extension RowEditingCoordinator {
         }
         let connId = parent.connection.id
         let kind: OperationKind = hasPendingTableOps ? .destructiveQuery : .writeQuery
+        let deleteConfirmation = BulkDeleteConfirmation(deletedRowCount: parent.changeManager.deletedRowIndices.count)
         Task { [weak self, parent] in
             guard let self else { return }
+
+            if deleteConfirmation.isRequired {
+                let confirmed = await AlertHelper.confirmDestructive(
+                    title: deleteConfirmation.title,
+                    message: deleteConfirmation.message,
+                    confirmButton: deleteConfirmation.confirmButtonTitle,
+                    window: parent.contentWindow
+                )
+                guard confirmed else {
+                    if hasPendingTableOps {
+                        DatabaseManager.shared.updateSession(connId) { session in
+                            session.pendingTruncates = snapshotTruncates
+                            session.pendingDeletes = snapshotDeletes
+                            for (table, opts) in snapshotOptions {
+                                session.tableOperationOptions[table] = opts
+                            }
+                        }
+                    }
+                    parent.saveCompletionContinuation?.resume(returning: false)
+                    parent.saveCompletionContinuation = nil
+                    return
+                }
+            }
+
             let decision = await ExecutionGateProvider.shared.authorize(
                 OperationRequest(
                     connectionId: connId,

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
@@ -80,9 +80,7 @@ extension MainContentCoordinator {
                     tableName: newTab.tableContext.tableName ?? "",
                     schemaName: newTab.tableContext.schemaName,
                     columns: newRows.columns,
-                    primaryKeyColumns: newTab.tableContext.primaryKeyColumns.isEmpty
-                        ? newRows.columns.prefix(1).map { $0 }
-                        : newTab.tableContext.primaryKeyColumns,
+                    primaryKeyColumns: newTab.tableContext.primaryKeyColumns,
                     databaseType: connection.type,
                     triggerReload: false
                 )

--- a/TableProTests/Core/ChangeTracking/BulkDeleteConfirmationTests.swift
+++ b/TableProTests/Core/ChangeTracking/BulkDeleteConfirmationTests.swift
@@ -1,0 +1,38 @@
+//
+//  BulkDeleteConfirmationTests.swift
+//  TableProTests
+//
+
+@testable import TablePro
+import Testing
+
+@Suite("Bulk Delete Confirmation")
+struct BulkDeleteConfirmationTests {
+    @Test("No confirmation when nothing is being deleted")
+    func testNotRequiredWithoutDeletes() {
+        #expect(BulkDeleteConfirmation(deletedRowCount: 0).isRequired == false)
+    }
+
+    @Test("Confirmation required once a row is marked for deletion")
+    func testRequiredWithDeletes() {
+        #expect(BulkDeleteConfirmation(deletedRowCount: 1).isRequired == true)
+        #expect(BulkDeleteConfirmation(deletedRowCount: 42).isRequired == true)
+    }
+
+    @Test("Title reports the row count for a bulk delete")
+    func testTitleIncludesCount() {
+        #expect(BulkDeleteConfirmation(deletedRowCount: 12).title.contains("12"))
+    }
+
+    @Test("Single-row title differs from the bulk title")
+    func testSingleRowTitleDiffersFromBulk() {
+        let single = BulkDeleteConfirmation(deletedRowCount: 1).title
+        let bulk = BulkDeleteConfirmation(deletedRowCount: 2).title
+        #expect(single != bulk)
+    }
+
+    @Test("Confirm button is a specific, non-empty action title")
+    func testConfirmButtonTitle() {
+        #expect(BulkDeleteConfirmation(deletedRowCount: 3).confirmButtonTitle.isEmpty == false)
+    }
+}

--- a/TableProTests/Core/ChangeTracking/SQLStatementGeneratorBatchDeleteScaleTests.swift
+++ b/TableProTests/Core/ChangeTracking/SQLStatementGeneratorBatchDeleteScaleTests.swift
@@ -1,0 +1,140 @@
+//
+//  SQLStatementGeneratorBatchDeleteScaleTests.swift
+//  TableProTests
+//
+//  Guards that multi-row DELETE generation stays bounded: N deleted rows collapse
+//  into a small, fixed number of statements (one scan per chunk) instead of N
+//  separate statements, and no statement exceeds the driver's bind-parameter cap.
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("SQL Statement Generator: Batch Delete Scale")
+struct SQLStatementGeneratorBatchDeleteScaleTests {
+    private func makeGenerator(
+        columns: [String],
+        primaryKeyColumns: [String],
+        databaseType: DatabaseType
+    ) throws -> SQLStatementGenerator {
+        try SQLStatementGenerator(
+            tableName: "events",
+            columns: columns,
+            primaryKeyColumns: primaryKeyColumns,
+            databaseType: databaseType,
+            dialect: nil
+        )
+    }
+
+    private func deleteChanges(count: Int, columns: [String]) -> [RowChange] {
+        (0..<count).map { index in
+            RowChange(
+                rowIndex: index,
+                type: .delete,
+                cellChanges: [],
+                originalRow: columns.indices.map { .text("\(index)-\($0)") }
+            )
+        }
+    }
+
+    @Test("Large primary-key selection stays a single statement")
+    func testLargePKSelectionSingleStatement() throws {
+        let generator = try makeGenerator(
+            columns: ["id", "name"], primaryKeyColumns: ["id"], databaseType: .mysql
+        )
+        let changes = deleteChanges(count: 5_000, columns: ["id", "name"])
+
+        let statements = generator.generateStatements(
+            from: changes,
+            insertedRowData: [:],
+            deletedRowIndices: Set(0..<5_000),
+            insertedRowIndices: []
+        )
+
+        #expect(statements.count == 1)
+        #expect(statements[0].parameters.count == 5_000)
+    }
+
+    @Test("Primary-key selection chunks at the bind-parameter cap")
+    func testPKSelectionChunksAtBindParameterCap() throws {
+        let generator = try makeGenerator(
+            columns: ["id", "name"], primaryKeyColumns: ["id"], databaseType: .mssql
+        )
+        let cap = generator.maxBindParameters
+        let changes = deleteChanges(count: cap + 1, columns: ["id", "name"])
+
+        let statements = generator.generateStatements(
+            from: changes,
+            insertedRowData: [:],
+            deletedRowIndices: Set(0..<(cap + 1)),
+            insertedRowIndices: []
+        )
+
+        #expect(statements.count == 2)
+        #expect(statements.allSatisfy { $0.parameters.count <= cap })
+        #expect(statements.reduce(0) { $0 + $1.parameters.count } == cap + 1)
+    }
+
+    @Test("Primary-key selection exactly at the cap stays one statement")
+    func testPKSelectionExactlyAtCapSingleStatement() throws {
+        let generator = try makeGenerator(
+            columns: ["id"], primaryKeyColumns: ["id"], databaseType: .mssql
+        )
+        let cap = generator.maxBindParameters
+        let changes = deleteChanges(count: cap, columns: ["id"])
+
+        let statements = generator.generateStatements(
+            from: changes,
+            insertedRowData: [:],
+            deletedRowIndices: Set(0..<cap),
+            insertedRowIndices: []
+        )
+
+        #expect(statements.count == 1)
+        #expect(statements[0].parameters.count == cap)
+    }
+
+    @Test("No-PK selection collapses into one OR'd statement, not one per row")
+    func testNoPKSelectionSingleStatement() throws {
+        let generator = try makeGenerator(
+            columns: ["a", "b", "c"], primaryKeyColumns: [], databaseType: .mysql
+        )
+        let changes = deleteChanges(count: 1_000, columns: ["a", "b", "c"])
+
+        let statements = generator.generateStatements(
+            from: changes,
+            insertedRowData: [:],
+            deletedRowIndices: Set(0..<1_000),
+            insertedRowIndices: []
+        )
+
+        #expect(statements.count == 1)
+        #expect(statements[0].parameters.count == 3_000)
+        #expect(statements[0].sql.contains(") OR ("))
+    }
+
+    @Test("No-PK selection chunks when full-column parameters exceed the cap")
+    func testNoPKSelectionChunksAtBindParameterCap() throws {
+        let columns = ["a", "b", "c"]
+        let generator = try makeGenerator(
+            columns: columns, primaryKeyColumns: [], databaseType: .mssql
+        )
+        let cap = generator.maxBindParameters
+        let rowsPerChunk = cap / columns.count
+        let rowCount = rowsPerChunk + 1
+        let changes = deleteChanges(count: rowCount, columns: columns)
+
+        let statements = generator.generateStatements(
+            from: changes,
+            insertedRowData: [:],
+            deletedRowIndices: Set(0..<rowCount),
+            insertedRowIndices: []
+        )
+
+        #expect(statements.count == 2)
+        #expect(statements.allSatisfy { $0.parameters.count <= cap })
+        #expect(statements.reduce(0) { $0 + $1.parameters.count } == rowCount * columns.count)
+    }
+}

--- a/TableProTests/Core/ChangeTracking/SQLStatementGeneratorCompositePKTests.swift
+++ b/TableProTests/Core/ChangeTracking/SQLStatementGeneratorCompositePKTests.swift
@@ -380,7 +380,7 @@ struct SQLStatementGeneratorCompositePKTests {
         #expect(sql.contains("`level` = ?"))
     }
 
-    @Test("No PK DELETE uses individual per-row statements with all columns")
+    @Test("No PK DELETE batches rows into one OR'd all-column statement")
     func noPKDeleteFallback() throws {
         let gen = try makeGenerator(
             tableName: "logs",
@@ -396,11 +396,13 @@ struct SQLStatementGeneratorCompositePKTests {
             deletedRowIndices: [0, 1]
         )
 
-        // No PK batch delete returns nil → individual deletes
-        #expect(stmts.count == 2)
-        #expect(stmts[0].sql.contains("`ts` = ?"))
-        #expect(stmts[0].sql.contains("`message` = ?"))
-        #expect(stmts[0].sql.contains("`level` = ?"))
+        #expect(stmts.count == 1)
+        let sql = stmts[0].sql
+        #expect(sql.contains("`ts` = ?"))
+        #expect(sql.contains("`message` = ?"))
+        #expect(sql.contains("`level` = ?"))
+        #expect(sql.contains(") OR ("))
+        #expect(stmts[0].parameters.count == 6)
     }
 
     @Test("No PK fallback handles NULL values with IS NULL")

--- a/TableProTests/Core/ChangeTracking/SQLStatementGeneratorNoPKTests.swift
+++ b/TableProTests/Core/ChangeTracking/SQLStatementGeneratorNoPKTests.swift
@@ -6,9 +6,9 @@
 //
 
 import Foundation
+@testable import TablePro
 import TableProPluginKit
 import Testing
-@testable import TablePro
 
 @Suite("SQL Statement Generator — No Primary Key")
 struct SQLStatementGeneratorNoPKTests {
@@ -145,7 +145,7 @@ struct SQLStatementGeneratorNoPKTests {
 
     // MARK: - DELETE without PK
 
-    @Test("Delete without PK — multiple rows generate individual DELETEs")
+    @Test("Delete without PK: multiple rows batch into one OR'd full-column DELETE")
     func testDeleteNoPKMultipleRows() throws {
         let generator = try makeGenerator()
         let changes: [RowChange] = [
@@ -160,11 +160,14 @@ struct SQLStatementGeneratorNoPKTests {
             insertedRowIndices: []
         )
 
-        #expect(statements.count == 2)
-        #expect(statements[0].sql.contains("DELETE"))
-        #expect(statements[1].sql.contains("DELETE"))
-        #expect(statements[0].parameters[0] as? String == "1")
-        #expect(statements[1].parameters[0] as? String == "2")
+        #expect(statements.count == 1)
+        let stmt = statements[0]
+        #expect(stmt.sql.contains("DELETE FROM `users` WHERE "))
+        #expect(stmt.sql.contains("(`id` = ? AND `name` = ? AND `email` = ?)"))
+        #expect(stmt.sql.contains(") OR ("))
+        #expect(stmt.parameters.count == 6)
+        #expect(stmt.parameters[0] as? String == "1")
+        #expect(stmt.parameters[3] as? String == "2")
     }
 
     @Test("Delete without PK — all NULL originalRow uses IS NULL")

--- a/docs/features/change-tracking.mdx
+++ b/docs/features/change-tracking.mdx
@@ -78,7 +78,7 @@ Edits to cells in a new row are folded into the insertion, not tracked as separa
 
 ### Deleting Rows
 
-Select rows and press `Delete`. Deleted rows show a strikethrough indicator and stay visible until commit or discard.
+Select rows and press `Delete`. Deleted rows show a strikethrough indicator and stay visible until commit or discard. When you commit, TablePro asks you to confirm before it permanently deletes the rows.
 
 {/* Screenshot: Deleted row with deletion indicator */}
 <Frame caption="Deleted row">
@@ -97,6 +97,10 @@ Select rows and press `Delete`. Deleted rows show a strikethrough indicator and 
 <Warning>
 Batch deletion of multiple rows is tracked as a single undo action. Undoing a batch deletion restores all rows at once.
 </Warning>
+
+<Note>
+Deleting many rows commits as one batched statement, not one query per row, so a large selection stays fast. Very large selections are split into a few statements to stay within the database's parameter limits.
+</Note>
 
 ## Commit & Discard
 


### PR DESCRIPTION
## Summary

Fixes #1823. Selecting multiple rows and deleting them could exhaust system resources badly enough to restart the machine.

## Root cause

Deleting rows only marks them; the database work runs on Save. In `SQLStatementGenerator`, a table **without a primary key** generated one full-column-match `DELETE` per selected row, each an unindexed sequential scan. Committing N of these back to back in a single transaction is O(N × table size). Against a local Postgres that saturates the same machine, which matches the report: fine for one row, but a handful can lock up the box. The primary-key path also never chunked, so a large selection could exceed Postgres's 65,535 bind-parameter limit.

The in-process mark path (selection, change tracking, grid refresh) was traced end to end and is bounded, so the cost was entirely in the generated SQL at commit time.

## Changes

- **Batched, chunked DELETE generation.** N deleted rows now collapse into a single OR'd statement (one scan per chunk) for both the primary-key and no-primary-key cases, chunked so no statement exceeds the driver's bind-parameter cap. Rows with a NULL primary key are skipped, matching the existing UPDATE behavior.
- **No-primary-key data-loss fix.** Removed the tab-restore fallback that treated the first column as a synthetic primary key. A delete keyed on a non-unique first column could remove unintended rows; no-PK tables now match on every column.
- **Bulk-delete confirmation.** Committing pending row deletions now asks for confirmation first. Cancel leaves the changes staged.

## Tests

- New `SQLStatementGeneratorBatchDeleteScaleTests`: statement count stays bounded at N = 5,000; chunk boundaries land at the cap for both PK and no-PK selections.
- New `BulkDeleteConfirmationTests`: confirmation copy and gating.
- Updated the two tests that pinned the old one-statement-per-row behavior; the previously inconsistent composite-PK null test now passes via the NULL-PK skip.

## Notes

- No PluginKit ABI change.
- `swiftlint lint --strict` passes on the changed files. Local `xcodebuild` is not available in my environment, so please confirm the build and the test run.
