### PR TITLE
fix(datagrid): keep rows-per-page when sorting a table column (#1826)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Sorting a table column no longer discards your rows-per-page setting. Clicking a column header to sort, or clicking again to clear the sort, now keeps the page size and returns to page 1 instead of loading the whole table. (#1826)
 - Elasticsearch connections using Username & Password now show a Password field, so basic auth on a secured cluster can be set up. It was hidden before, leaving only the Username field. Update the Elasticsearch plugin to get the fix. (#1816)
 - Switching schemas on an Oracle connection no longer hangs on an infinite loading spinner. Oracle now switches by schema like BigQuery, the sidebar lists every schema with its tables loading on expand, Oracle queries respect the query timeout setting and reconnect automatically after a timeout, and a schema load that fails shows an error with a Retry button instead of spinning forever. Works with an already-installed Oracle plugin; updating the plugin adds the query timeout enforcement. (#1807)
 

--- a/TablePro/Core/Services/Query/TableQueryBuilder.swift
+++ b/TablePro/Core/Services/Query/TableQueryBuilder.swift
@@ -219,35 +219,6 @@ struct TableQueryBuilder {
         return query
     }
 
-    func buildMultiSortQuery(
-        baseQuery: String,
-        sortState: SortState,
-        columns: [String]
-    ) -> String {
-        var query = removeOrderBy(from: baseQuery)
-
-        if let orderBy = buildOrderByClause(sortState: sortState, columns: columns) {
-            if let limitRange = query.range(of: "LIMIT", options: .caseInsensitive) {
-                let beforeLimit = query[..<limitRange.lowerBound].trimmingCharacters(in: .whitespaces)
-                let limitClause = query[limitRange.lowerBound...]
-                query = "\(beforeLimit) \(orderBy) \(limitClause)"
-            } else if let offsetRange = query.range(of: "OFFSET", options: .caseInsensitive) {
-                let beforeOffset = query[..<offsetRange.lowerBound].trimmingCharacters(in: .whitespaces)
-                let offsetClause = query[offsetRange.lowerBound...]
-                query = "\(beforeOffset) \(orderBy) \(offsetClause)"
-            } else {
-                let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-                if trimmed.hasSuffix(";") {
-                    query = String(trimmed.dropLast()) + " \(orderBy);"
-                } else {
-                    query = "\(trimmed) \(orderBy)"
-                }
-            }
-        }
-
-        return query
-    }
-
     // MARK: - Private Helpers
 
     private func selectClause(_ selectColumns: [String]?) -> String {

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -1417,26 +1417,15 @@ final class MainContentCoordinator {
 
         let tabId = tab.id
         let capturedSort = newState
-        let capturedQuery = tab.content.query
-        let capturedColumns = tableRows.columns
         confirmDiscardChangesIfNeeded(action: .sort) { [weak self] confirmed in
             guard let self, confirmed else { return }
-            let newQuery: String
-            if capturedSort.columns.isEmpty {
-                newQuery = Self.stripTrailingOrderBy(from: capturedQuery)
-            } else {
-                newQuery = self.queryBuilder.buildMultiSortQuery(
-                    baseQuery: capturedQuery,
-                    sortState: capturedSort,
-                    columns: capturedColumns
-                )
-            }
             guard self.tabManager.mutate(tabId: tabId, { tab in
                 tab.sortState = capturedSort
                 tab.hasUserInteraction = true
                 tab.pagination.reset()
-                tab.content.query = newQuery
             }) else { return }
+            guard let tabIndex = self.tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
+            self.rebuildTableQuery(at: tabIndex)
             self.runQuery()
         }
     }

--- a/TableProTests/Views/Main/MainContentCoordinatorSortTests.swift
+++ b/TableProTests/Views/Main/MainContentCoordinatorSortTests.swift
@@ -206,4 +206,52 @@ struct MainContentCoordinatorSortTests {
         #expect(tabManager.tabs[idx].pagination.currentPage == 1)
         #expect(tabManager.tabs[idx].pagination.currentOffset == 0)
     }
+
+    private func makeTableCoordinator(pageSize: Int) -> (MainContentCoordinator, QueryTabManager, UUID) {
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: TestFixtures.makeConnection(),
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        var tab = QueryTab(title: "users", query: "SELECT * FROM users", tabType: .table)
+        tab.tableContext.tableName = "users"
+        tab.pagination = PaginationState(totalRowCount: 100, pageSize: pageSize, currentPage: 1)
+        tab.execution.lastExecutedAt = Date()
+        tabManager.tabs.append(tab)
+        tabManager.selectedTabId = tab.id
+
+        let columns = ["id", "name"]
+        let rows = (0..<pageSize).map { i in columns.map { "\($0)_\(i)" as String? } }
+        let columnTypes: [ColumnType] = Array(repeating: .text(rawType: nil), count: columns.count)
+        let tableRows = TableRows.from(
+            queryRows: rows.map { row in row.map(PluginCellValue.fromOptional) },
+            columns: columns,
+            columnTypes: columnTypes
+        )
+        coordinator.setActiveTableRows(tableRows, for: tab.id)
+        return (coordinator, tabManager, tab.id)
+    }
+
+    @Test("Table tab keeps the rows-per-page LIMIT through ascending, descending, and cleared sort")
+    func tableTabSortPreservesPageSize() {
+        let (coordinator, tabManager, tabId) = makeTableCoordinator(pageSize: 10)
+        func query() -> String { tabManager.tabs.first { $0.id == tabId }?.content.query ?? "" }
+        func pagination() -> PaginationState? { tabManager.tabs.first { $0.id == tabId }?.pagination }
+
+        coordinator.handleSortStateChanged(sortState([(0, .ascending)]))
+        #expect(query().contains("LIMIT 10 OFFSET 0"))
+        #expect(query().localizedCaseInsensitiveContains("ORDER BY"))
+
+        coordinator.handleSortStateChanged(sortState([(0, .descending)]))
+        #expect(query().contains("LIMIT 10 OFFSET 0"))
+        #expect(query().localizedCaseInsensitiveContains("ORDER BY"))
+
+        coordinator.handleSortStateChanged(SortState())
+        #expect(query().contains("LIMIT 10 OFFSET 0"))
+        #expect(!query().localizedCaseInsensitiveContains("ORDER BY"))
+        #expect(pagination()?.pageSize == 10)
+        #expect(pagination()?.currentOffset == 0)
+    }
 }


### PR DESCRIPTION
Closes #1826.

## Problem

Open a table, set rows-per-page to a small value (e.g. 10), then click a column's sort arrow a few times. The rows-per-page limit gets dropped and the whole table loads.

## Root cause

`MainContentCoordinator.handleSortStateChanged` rebuilt table-tab queries by regex string-surgery on the stored SQL instead of rebuilding from state. On the sort arrow's third click (ascending, descending, then off), the clear-sort branch called `QuerySqlParser.stripTrailingOrderBy`, whose regex matches from `ORDER BY` to the end of the string. It dragged the trailing `LIMIT 10 OFFSET 0` out along with the `ORDER BY`, leaving `SELECT * FROM "users"` with no limit. Table tabs get no row-cap fallback (`qualifiesForRowCap` gates on `.query` tabs), so the grid fetched the entire table.

The per-tab page size (`tab.pagination.pageSize`) was never touched; only the executed SQL text lost its limit. This is not a regression from #1815, which only touched column-layout persistence.

## Fix

The table-tab sort branch now routes through `FilterCoordinator.rebuildTableQuery(at:)`, the same authoritative builder that initial load, filters, browse search, and page navigation already use. It derives `ORDER BY` from `tab.sortState` and `LIMIT`/`OFFSET` from `tab.pagination`, so the page-size limit can no longer be lost regardless of sort state. The now-dead `buildMultiSortQuery` string-surgery method is removed.

Behavior now matches every mature grid: sorting keeps the page size, resets to page 1, and re-runs a server-side `ORDER BY` over the whole table.

## Tests

New `.table`-tab regression test in `MainContentCoordinatorSortTests` cycles a column through ascending, descending, and cleared sort with `pageSize` 10, asserting the query keeps `LIMIT 10 OFFSET 0` at every step, that `ORDER BY` appears when sorted and is gone when cleared, and that pagination resets to page 1 while keeping the page size. The existing suite only exercised `.query` tabs, so the table-tab branch used in this repro was untested.

## Out of scope

The `.query`-tab clear-sort path calls the same greedy `stripTrailingOrderBy` and can drop a user's explicit trailing `LIMIT` in hand-written SQL. That is the same bug class but a different feature with different semantics (row-cap layer, sort-execution override), so it belongs in its own change.

`swiftlint --strict` is clean on the changed files.
