### PR TITLE
fix(editor): stop the rectForOffset crash and keep the autocomplete popup below the caret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Typing in the SQL editor no longer crashes the app, and the autocomplete popup appears again as you type. A hidden background view kept reading a character position past the end of the text during each edit, which raised an error that both quit the app and stopped the keystroke before autocomplete could open. (#1835)
 - Deleting many rows at once no longer freezes the app or the machine. Multi-row deletes now run as one batched statement, chunked to stay within the database's limits, instead of one query per row. (#1823)
 - Deleting rows from a table without a primary key now matches on every column instead of treating the first column as a key, so it won't remove other rows that happen to share that value. (#1823)
 - Sorting a table column no longer discards your rows-per-page setting. Clicking a column header to sort, or clicking again to clear the sort, now keeps the page size and returns to page 1 instead of loading the whole table. (#1826)
@@ -34,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hidden columns stay hidden. The columns you choose to show are remembered per table across sessions, and resizing a column no longer brings the hidden ones back. Column widths and order are remembered per table too, now kept separately for each connection, database, and schema so two tables with the same name no longer overwrite each other's layout. A Reset Columns button in the Columns popover puts widths, order, and visibility back to defaults. Existing saved column layouts (widths, order, and which columns are hidden) reset once as part of this change. (#1815)
 - Query and filter errors now appear in a banner you can read, select, and copy, with a Fix with AI button, instead of a small dialog that cut the message off. The banner sizes to the message, staying a single line for short errors and scrolling only when the message is long. (#1815)
 - The filter autocomplete no longer pops up on empty input, and pressing Escape to close it no longer also closes the filter bar. (#1815)
-- The editor autocomplete popup no longer draws over the status bar, the Columns and Add buttons, or the editor's sides as it grows. Clicking anywhere on the popup that isn't a suggestion now dismisses it, instead of doing nothing and leaving the editor mouse dead. (#1815, #1831)
+- The editor autocomplete popup drops below the line you're typing instead of covering it, no longer overlaps the Columns and Add buttons on the right, and dismisses when you click anywhere on it that isn't a suggestion. (#1815, #1831)
 
 ## [0.55.0] - 2026-07-04
 

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/CodeSuggestion/Window/SuggestionController+Window.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/CodeSuggestion/Window/SuggestionController+Window.swift
@@ -14,10 +14,11 @@ internal final class SuggestionPanel: NSPanel {
 }
 
 extension SuggestionController {
-    /// Anchors the window to `cursorRect` and constrains it within the visible screen and, when provided,
-    /// the editor's bounds. The anchor is retained and re-applied on every later resize (see
-    /// ``applyPlacement(windowSize:)``), so the panel never drifts past the editor edges as its content
-    /// grows or shrinks during the same session.
+    /// Anchors the window to `cursorRect`. The horizontal position is constrained to the editor's bounds when
+    /// provided (so the panel never covers the right-side toolbar); the vertical position is constrained to the
+    /// screen, so the panel drops below the caret and may overflow the editor into the results area rather than
+    /// flipping up and covering the current line. The anchor is retained and re-applied on every later resize (see
+    /// ``applyPlacement(windowSize:)``), so the panel re-derives its position as its content grows or shrinks.
     public func constrainWindowToScreenEdges(cursorRect: NSRect, font: NSFont, editorFrame: NSRect? = nil) {
         guard let window = self.window else { return }
         placementAnchor = SuggestionPlacementAnchor(cursorRect: cursorRect, font: font, editorFrame: editorFrame)

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/CodeSuggestion/Window/SuggestionWindowPlacement.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/CodeSuggestion/Window/SuggestionWindowPlacement.swift
@@ -42,8 +42,7 @@ internal enum SuggestionWindowPlacement {
         let (y, isAboveCursor) = clampedY(
             windowSize: windowSize,
             cursorRect: cursorRect,
-            screenFrame: screenFrame,
-            editorFrame: editorFrame
+            screenFrame: screenFrame
         )
         return Placement(origin: NSPoint(x: x, y: y), isAboveCursor: isAboveCursor)
     }
@@ -70,35 +69,25 @@ internal enum SuggestionWindowPlacement {
         return anchorX
     }
 
+    /// Minimum room below the caret before the panel flips above it, in screen points.
+    internal static let minRoomBelowCaret: CGFloat = 90
+
+    /// The panel is always anchored to the caret: dropping below it (top edge at the caret's baseline) so the current
+    /// line stays visible, or flipping above it (bottom edge at the caret's top) only when there is little room below
+    /// on the screen and more above. The panel is never pinned to a screen edge, so it stays next to the caret and may
+    /// overflow the editor into the results area; a tall panel simply clips at the screen edge it runs into. Clicks
+    /// over the overflow dismiss it.
     private static func clampedY(
         windowSize: NSSize,
         cursorRect: NSRect,
-        screenFrame: NSRect,
-        editorFrame: NSRect?
+        screenFrame: NSRect
     ) -> (y: CGFloat, isAboveCursor: Bool) {
-        let lowerLimit = max(screenFrame.minY, editorFrame?.minY ?? screenFrame.minY)
-        let upperLimit = min(screenFrame.maxY, editorFrame?.maxY ?? screenFrame.maxY)
+        let spaceBelow = cursorRect.origin.y - screenFrame.minY
+        let spaceAbove = screenFrame.maxY - (cursorRect.origin.y + cursorRect.height)
 
-        guard cursorRect.origin.y - windowSize.height < lowerLimit else {
-            var topLeftY = cursorRect.origin.y
-            let maxTopLeftY = upperLimit - edgePadding
-            if topLeftY > maxTopLeftY {
-                topLeftY = maxTopLeftY
-            }
-            return (topLeftY - windowSize.height, false)
+        if spaceBelow >= minRoomBelowCaret || spaceBelow >= spaceAbove {
+            return (cursorRect.origin.y - windowSize.height, false)
         }
-
-        var bottomLeftY: CGFloat
-        if cursorRect.origin.y < lowerLimit {
-            bottomLeftY = lowerLimit + edgePadding
-        } else {
-            bottomLeftY = cursorRect.origin.y + cursorRect.height
-        }
-
-        if bottomLeftY + windowSize.height > upperLimit {
-            bottomLeftY = max(lowerLimit, upperLimit - windowSize.height)
-        }
-
-        return (bottomLeftY, true)
+        return (cursorRect.origin.y + cursorRect.height, true)
     }
 }

--- a/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/CodeSuggestion/SuggestionWindowPlacementTests.swift
+++ b/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/CodeSuggestion/SuggestionWindowPlacementTests.swift
@@ -49,34 +49,50 @@ final class SuggestionWindowPlacementTests: XCTestCase {
         XCTAssertEqual(placement.origin.x, narrowEditorFrame.minX + SuggestionWindowPlacement.edgePadding)
     }
 
-    func test_compute_flipsAboveCursorWhenBelowSpaceIsInsufficient() {
-        let cursorRect = NSRect(x: 300, y: 200, width: 6, height: 16)
+    func test_compute_flipsAboveCursorWhenBelowScreenSpaceIsInsufficient() {
+        // Caret near the screen bottom: not enough room below on the screen, so the panel flips above.
+        let cursorRect = NSRect(x: 300, y: 40, width: 6, height: 16)
 
         let placement = SuggestionWindowPlacement.compute(
-            windowSize: NSSize(width: 280, height: 100), cursorRect: cursorRect, font: font,
+            windowSize: NSSize(width: 280, height: 200), cursorRect: cursorRect, font: font,
             screenFrame: screenFrame, editorFrame: editorFrame
         )
 
         XCTAssertTrue(placement.isAboveCursor)
-        XCTAssertGreaterThanOrEqual(placement.origin.y, editorFrame.minY)
+        XCTAssertGreaterThanOrEqual(placement.origin.y, screenFrame.minY)
     }
 
-    func test_compute_growingHeightAcrossResizesStaysWithinEditorMaxY() {
-        let cursorRect = NSRect(x: 300, y: 200, width: 6, height: 16)
+    func test_compute_tallPanelNearEditorTopStaysBelowCaretAndOverflowsEditor() {
+        // The reported bug: a tall panel with the caret near the top of a short editor must drop below the caret
+        // (overflowing the editor into the results area) instead of flipping up and covering the current line.
+        let shortEditor = NSRect(x: 100, y: 300, width: 900, height: 300)
+        let caretNearEditorTop = NSRect(x: 300, y: 560, width: 6, height: 16)
 
-        let mid = SuggestionWindowPlacement.compute(
-            windowSize: NSSize(width: 280, height: 400), cursorRect: cursorRect, font: font,
+        let placement = SuggestionWindowPlacement.compute(
+            windowSize: NSSize(width: 280, height: 500), cursorRect: caretNearEditorTop, font: font,
+            screenFrame: screenFrame, editorFrame: shortEditor
+        )
+
+        XCTAssertFalse(placement.isAboveCursor)
+        // The panel's top sits at the caret's baseline, so the current line stays visible above it.
+        XCTAssertLessThanOrEqual(placement.origin.y + 500, caretNearEditorTop.origin.y)
+        // And it is allowed to overflow the editor's bottom, constrained only by the screen.
+        XCTAssertLessThan(placement.origin.y, shortEditor.minY)
+    }
+
+    func test_compute_staysAnchoredBelowCaretEvenWithMoreRoomAbove() {
+        // Regression for the panel vanishing: with the caret lower on screen (more room above) but still enough
+        // room below, the panel must stay anchored to the caret, not get pinned to the screen top.
+        let cursorRect = NSRect(x: 300, y: 250, width: 6, height: 16)
+
+        let placement = SuggestionWindowPlacement.compute(
+            windowSize: NSSize(width: 280, height: 500), cursorRect: cursorRect, font: font,
             screenFrame: screenFrame, editorFrame: editorFrame
         )
-        let grown = SuggestionWindowPlacement.compute(
-            windowSize: NSSize(width: 280, height: 560), cursorRect: cursorRect, font: font,
-            screenFrame: screenFrame, editorFrame: editorFrame
-        )
 
-        XCTAssertTrue(mid.isAboveCursor)
-        XCTAssertTrue(grown.isAboveCursor)
-        XCTAssertLessThanOrEqual(mid.origin.y + 400, editorFrame.maxY)
-        XCTAssertEqual(grown.origin.y + 560, editorFrame.maxY, accuracy: 0.001)
+        XCTAssertFalse(placement.isAboveCursor)
+        // The panel's top sits exactly at the caret's baseline, next to the caret, not up at the screen edge.
+        XCTAssertEqual(placement.origin.y + 500, cursorRect.origin.y, accuracy: 0.001)
     }
 
     func test_compute_fallsBackToScreenFrameWhenEditorFrameIsNil() {

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Public.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Public.swift
@@ -180,10 +180,10 @@ extension TextLayoutManager {
         }
 
         // Get the *real* length of the character at the offset. If this is a surrogate pair it'll return the correct
-        // length of the character at the offset.
-        let realRange = if textStorage?.length == 0 {
-            NSRange(location: offset, length: 0)
-        } else if let string = textStorage?.string as? NSString {
+        // length of the character at the offset. Guard against an offset past the text storage's length: the line
+        // storage can be transiently longer than the string during an edit, and `rangeOfComposedCharacterSequence`
+        // raises `NSInvalidArgumentException` for an out-of-bounds index.
+        let realRange = if let string = textStorage?.string as? NSString, offset < string.length {
             string.rangeOfComposedCharacterSequence(at: offset)
         } else {
             NSRange(location: offset, length: 0)
@@ -222,6 +222,11 @@ extension TextLayoutManager {
     /// - Returns: Multiple bounding rects. Will return one rect for each line fragment that overlaps the given range.
     private func rectsFor(range: NSRange, in line: borrowing TextLineStorage<TextLine>.TextLinePosition) -> [CGRect] {
         guard let textStorage = (textStorage?.string as? NSString) else { return [] }
+
+        // Guard against a range past the text storage's length: the line storage can be transiently longer than the
+        // string during an edit, and `rangeOfComposedCharacterSequence` raises `NSInvalidArgumentException` for an
+        // out-of-bounds index.
+        guard range.length > 0, range.upperBound <= textStorage.length else { return [] }
 
         // Don't make rects in between characters
         let realRangeStart = textStorage.rangeOfComposedCharacterSequence(at: range.lowerBound)

--- a/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/LayoutManager/TextLayoutManagerTests.swift
+++ b/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/LayoutManager/TextLayoutManagerTests.swift
@@ -243,6 +243,36 @@ struct TextLayoutManagerTests {
     }
 
     @Test
+    func rectForOffsetDoesNotThrowWhenLineStorageIsLongerThanText() throws {
+        // Reproduces the minimap desync: a layout manager whose line storage is transiently longer than the shared
+        // text storage. An offset that is valid for the line storage but past the string end must not raise, or
+        // rectForOffset breaks its optional contract and crashes AppKit when it runs inside drawRect.
+        let storage = NSTextStorage(string: "SELECT")
+        let manager = TextLayoutManager(
+            textStorage: storage,
+            lineHeightMultiplier: 1.0,
+            wrapLines: false,
+            textView: NSView(),
+            delegate: nil
+        )
+        manager.layoutLines(in: NSRect(x: 0, y: 0, width: 1000, height: 1000))
+
+        // Shrink the text without notifying the standalone manager, leaving its line storage stale and longer.
+        storage.mutableString.setString("S")
+
+        #expect(manager.lineStorage.length > storage.length)
+        for offset in 0..<manager.lineStorage.length {
+            #expect(manager.rectForOffset(offset) != nil, "rectForOffset failed at offset \(offset)")
+        }
+
+        // The range-based path (selection fill/highlight rects) must be safe against the same desync.
+        for length in 1...manager.lineStorage.length {
+            _ = manager.rectsFor(range: NSRange(location: 0, length: length))
+            _ = manager.roundedPathForRange(NSRange(location: 0, length: length))
+        }
+    }
+
+    @Test
     func textOffsetForPointReturnsValuesEverywhere() throws {
         layoutManager.layoutLines(in: NSRect(x: 0, y: 0, width: 1000, height: 1000))
 


### PR DESCRIPTION
Two related editor fixes, both surfaced while testing autocomplete on macOS 26.

## 1. Crash while typing (and the autocomplete popup going missing)

Typing in the SQL editor could quit the app with `NSInvalidArgumentException: The index N is invalid`, and the autocomplete popup often failed to appear.

Root cause: `TextLayoutManager.rectForOffset(_:)` returns `CGRect?` (meant to be safe) but guarded only `offset < lineStorage.length`, then called `rangeOfComposedCharacterSequence(at: offset)` on the text storage with no guard against the string's length. The editor's minimap keeps its own layout manager whose line storage is transiently longer than the shared string during an edit, so an offset valid for the line storage but past the string end made that call raise. From the selection path it spammed the log; from the draw path (`TextView.draw` -> `drawSelections` -> `getFillRects` -> `rectForOffset`) it raised inside `drawRect` and AppKit aborted. The same exception, thrown from `SelectionManager.didReplaceCharacters` during a keystroke, unwound the edit before the `didReplaceContentsIn` delegate that opens the autocomplete popup could run, which is why the popup went missing.

Fix: guard the `rangeOfComposedCharacterSequence` calls in `rectForOffset` and the sibling `rectsFor(range:in:)` against the text length, so both honor their safe contracts for every caller. The edit then completes, so the popup trigger fires.

Regression test reproduces the desync deterministically (a standalone `TextLayoutManager` whose text storage is shrunk without notifying it), and the sibling range path is exercised too.

## 2. Autocomplete popup covering the current line / landing off in the corner

The completion popup was constrained vertically to the editor pane, so a tall popup with the caret near the top of a short editor flipped above the caret and covered the line you were typing. An intermediate attempt to constrain it to the screen made it worse: the flip-above clamp pinned it to the screen top, far from the caret.

Fix: the panel is always anchored to the caret. It drops below the caret (top edge at the caret's baseline) so the current line stays visible, flips above only when the caret is near the screen bottom, and is never pinned to a screen edge. A tall panel clips at the screen edge it runs into. The horizontal editor constraint is kept so the panel still doesn't cover the right-side toolbar. This matches how VS Code positions its completion widget; clicks over any overflow dismiss it (shipped in #1831).

Pure placement math with unit tests, including a regression test for the "caret low on screen, don't fling to the top" case.

## Notes

- All in the vendored `LocalPackages/CodeEditTextView` and `LocalPackages/CodeEditSourceEditor` packages (no PluginKit ABI impact).
- Verified with `swift test` on both packages: rectForOffset and placement suites pass. The app build is not run here; please build to confirm.
- The minimap's own "suspend work while hidden" behavior already lives on `main`, so this PR does not touch it.
