### PR TITLE
feat(sidebar): add New Query to Favorites plus menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The Favorites sidebar **+** menu now includes **New Query**, which opens an empty SQL query tab.
+
 ## [0.56.0] - 2026-07-09
 
 ### Added

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -49282,6 +49282,62 @@
         }
       }
     },
+    "New Query" : {
+      "localizations" : {
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yeni Sorgu"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Truy vấn mới"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新建查询"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增查詢"
+          }
+        }
+      }
+    },
+    "New Query, favorite, or folder" : {
+      "localizations" : {
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yeni sorgu, sık kullanılan veya klasör"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Truy vấn mới, mục yêu thích hoặc thư mục"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新建查询、收藏或文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增查詢、我的最愛或資料夾"
+          }
+        }
+      }
+    },
     "New query tab" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/TablePro/Views/Sidebar/FavoritesTabView.swift
+++ b/TablePro/Views/Sidebar/FavoritesTabView.swift
@@ -577,6 +577,10 @@ internal struct FavoritesTabView: View {
     private var bottomToolbar: some View {
         HStack(spacing: 8) {
             Menu {
+                Button(String(localized: "New Query")) {
+                    coordinator?.commandActions?.newTab()
+                }
+                Divider()
                 Button(String(localized: "New Favorite")) {
                     viewModel.createFavorite()
                 }
@@ -599,7 +603,7 @@ internal struct FavoritesTabView: View {
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
             .fixedSize()
-            .help(String(localized: "Add"))
+            .help(String(localized: "New Query, favorite, or folder"))
 
             Spacer()
         }

--- a/docs/features/favorites.mdx
+++ b/docs/features/favorites.mdx
@@ -26,6 +26,10 @@ Turn on **Show recent tables** in Settings > General > Sidebar to add a **Recent
 
 Save queries you run often. Organize them in folders, assign keyword shortcuts, and expand them inline via autocomplete.
 
+## New Query from the Favorites Sidebar
+
+In the Favorites tab, click **+** and choose **New Query** to open an empty SQL query tab (same as `Cmd+T`). The other items in that menu create a saved favorite, a folder, or a linked SQL folder.
+
 ## Creating an SQL Favorite
 
 Ways to save a favorite:
@@ -33,7 +37,7 @@ Ways to save a favorite:
 - **From the editor toolbar**: Click the star button above the editor, or press `Cmd+D`
 - **From the editor**: Right-click selected SQL > **Save as Favorite**
 - **From query history**: Right-click an entry > **Save as Favorite**
-- **From the sidebar**: Click **+ New Favorite** in the Favorites tab
+- **From the sidebar**: Click **+** in the Favorites tab, then **New Favorite**
 
 Enter a name, the SQL text, and optionally a keyword and scope.
 

--- a/docs/features/tabs.mdx
+++ b/docs/features/tabs.mdx
@@ -71,8 +71,7 @@ Disable preview tabs in **Settings** > **Tabs** if you prefer every click to ope
 
 | Action | How |
 |--------|-----|
-| New query tab | `Cmd+T` or click **+** in the tab bar |
-| New query tab (toolbar) | Click the **SQL** button |
+| New query tab | `Cmd+T`, click **+** in the tab bar, or Favorites sidebar **+** > **New Query** |
 | New table tab | Double-click a table in the sidebar (single-click reuses the preview tab) |
 
 ### Closing Tabs


### PR DESCRIPTION
## Summary
- Add **New Query** as the first item in the Favorites sidebar **+** menu; it opens an empty SQL query tab via the existing `newTab()` path (same as `Cmd+T`).
- Update docs (`favorites.mdx`, `tabs.mdx`) and CHANGELOG.
- Add localization strings for the new menu label and tooltip.

Autocomplete (table/column suggestions), execute shortcuts (`Cmd+Enter`), and optional auto-uppercase keywords are unchanged; this PR only adds a clearer entry point for creating a new query from the Favorites sidebar.

## Test plan
- [ ] Connect to a database, switch to the Favorites sidebar tab.
- [ ] Click **+** > **New Query** and confirm an empty query tab opens with editor focus.
- [ ] Confirm **New Favorite**, **New Folder**, and linked-folder actions still work.
- [ ] Confirm `Cmd+T` still opens a new query tab.
- [ ] Confirm `Cmd+Enter` still executes a query.
- [ ] Confirm Settings > Editor still shows **Auto-uppercase keywords** (default off).


Made with [Cursor](https://cursor.com)