### PR TITLE
fix(connections): drain password-source command output without a reader race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reading a connection password from a command, 1Password, Vault, or AWS Secrets Manager no longer occasionally returns corrupted output from a race while reading the command's output. (#1841)
 - The Structure tab filter and column sort now update the grid instead of leaving stale rows on screen.
 - The row details inspector now shows the selected row's values, including JSON, when a column value filter is active, and a JSON or serialized value you open now follows the selected row as you move between rows. (#1837)
 - Copying, duplicating, and deleting rows now act on the rows you selected when a column value filter is active, instead of the rows sitting at those positions in the unfiltered result. (#1837)

--- a/TablePro/Core/Utilities/Connection/PasswordSourceResolver.swift
+++ b/TablePro/Core/Utilities/Connection/PasswordSourceResolver.swift
@@ -156,20 +156,26 @@ enum PasswordSourceResolver {
 
             let stdoutCollector = PipeDataCollector(maxBytes: maxOutputBytes)
             let stderrCollector = PipeDataCollector(maxBytes: maxOutputBytes)
-            stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
-                let chunk = handle.availableData
-                guard !chunk.isEmpty else { return }
-                stdoutCollector.append(chunk)
-                if stdoutCollector.overflowed, process.isRunning {
+            try process.run()
+
+            let drainGroup = DispatchGroup()
+            let drainQueue = DispatchQueue(label: "com.TablePro.PasswordSourceResolver.pipe-drain", attributes: .concurrent)
+            drainPipe(
+                stdoutPipe.fileHandleForReading,
+                into: stdoutCollector,
+                using: drainGroup,
+                queue: drainQueue
+            ) {
+                if process.isRunning {
                     process.terminate()
                 }
             }
-            stderrPipe.fileHandleForReading.readabilityHandler = { handle in
-                let chunk = handle.availableData
-                if !chunk.isEmpty { stderrCollector.append(chunk) }
-            }
-
-            try process.run()
+            drainPipe(
+                stderrPipe.fileHandleForReading,
+                into: stderrCollector,
+                using: drainGroup,
+                queue: drainQueue
+            )
 
             let didTimeout = AtomicFlag()
             let timeoutTask = Task.detached {
@@ -182,14 +188,7 @@ enum PasswordSourceResolver {
 
             process.waitUntilExit()
             timeoutTask.cancel()
-
-            stdoutPipe.fileHandleForReading.readabilityHandler = nil
-            stderrPipe.fileHandleForReading.readabilityHandler = nil
-
-            let remainingStdout = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-            if !remainingStdout.isEmpty { stdoutCollector.append(remainingStdout) }
-            let remainingStderr = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-            if !remainingStderr.isEmpty { stderrCollector.append(remainingStderr) }
+            drainGroup.wait()
 
             if stdoutCollector.overflowed {
                 throw ResolutionError.outputTooLarge
@@ -210,6 +209,27 @@ enum PasswordSourceResolver {
             throw ResolutionError.emptyPassword
         }
         return try nonEmpty(output.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    private static func drainPipe(
+        _ handle: FileHandle,
+        into collector: PipeDataCollector,
+        using group: DispatchGroup,
+        queue: DispatchQueue,
+        onOverflow: (() -> Void)? = nil
+    ) {
+        group.enter()
+        queue.async {
+            defer { group.leave() }
+            while true {
+                let chunk = handle.readData(ofLength: 8_192)
+                guard !chunk.isEmpty else { return }
+                collector.append(chunk)
+                if collector.overflowed {
+                    onOverflow?()
+                }
+            }
+        }
     }
 
     private static func augmentedEnvironment() -> [String: String] {

--- a/TableProTests/Core/Utilities/Connection/PasswordSourceResolverTests.swift
+++ b/TableProTests/Core/Utilities/Connection/PasswordSourceResolverTests.swift
@@ -1,0 +1,82 @@
+//
+//  PasswordSourceResolverTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("PasswordSourceResolver command output")
+struct PasswordSourceResolverTests {
+    @Test("Command stdout is returned trimmed")
+    func returnsTrimmedStdout() async throws {
+        let output = try await PasswordSourceResolver.resolveCommand(
+            shell: "printf '  hunter2\\n'",
+            timeoutSeconds: 5
+        )
+        #expect(output == "hunter2")
+    }
+
+    @Test("Large stdout drains in full and in order while stderr is also draining")
+    func drainsLargeStdoutWithoutTruncation() async throws {
+        let shell = """
+        head -c 300000 /dev/zero | tr '\\0' 'a'
+        head -c 300000 /dev/zero | tr '\\0' 'b' >&2
+        """
+        let output = try await PasswordSourceResolver.resolveCommand(shell: shell, timeoutSeconds: 30)
+        #expect(output.count == 300_000)
+        #expect(output.allSatisfy { $0 == "a" })
+    }
+
+    @Test("A failing command surfaces the exit code and stderr")
+    func failingCommandSurfacesStderr() async throws {
+        do {
+            _ = try await PasswordSourceResolver.resolveCommand(
+                shell: "printf boom >&2; exit 7",
+                timeoutSeconds: 5
+            )
+            Issue.record("Expected resolveCommand to throw")
+        } catch let PasswordSourceResolver.ResolutionError.commandFailed(exitCode, stderr) {
+            #expect(exitCode == 7)
+            #expect(stderr.contains("boom"))
+        }
+    }
+
+    @Test("Output over the size cap fails as too large")
+    func overflowFailsAsTooLarge() async throws {
+        do {
+            _ = try await PasswordSourceResolver.resolveCommand(
+                shell: "yes | head -c 1200000",
+                timeoutSeconds: 30
+            )
+            Issue.record("Expected outputTooLarge")
+        } catch PasswordSourceResolver.ResolutionError.outputTooLarge {
+        }
+    }
+
+    @Test("A command that exceeds the timeout is terminated")
+    func timeoutTerminatesCommand() async throws {
+        do {
+            _ = try await PasswordSourceResolver.resolveCommand(
+                shell: "sleep 30",
+                timeoutSeconds: 1
+            )
+            Issue.record("Expected commandTimedOut")
+        } catch PasswordSourceResolver.ResolutionError.commandTimedOut {
+        }
+    }
+
+    @Test("Empty output fails as an empty password")
+    func emptyOutputFailsAsEmpty() async throws {
+        do {
+            _ = try await PasswordSourceResolver.resolveCommand(
+                shell: "true",
+                timeoutSeconds: 5
+            )
+            Issue.record("Expected emptyPassword")
+        } catch PasswordSourceResolver.ResolutionError.emptyPassword {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Splits the `PasswordSourceResolver` change out of #1813 (a MongoDB numeric-literal fix), where it was bundled without a description, test, or CHANGELOG entry.

`resolveCommand` runs a shell command to fetch a connection password (used by command, 1Password, Vault, and AWS Secrets Manager sources) and reads its stdout/stderr. The old code drained the pipes with `readabilityHandler`, then set the handlers to `nil` and called `readDataToEndOfFile()` after the process exited. Setting a `readabilityHandler` to `nil` does not wait for an in-flight handler block, so a handler could append a chunk after `readDataToEndOfFile()` had already appended the tail. The collector is lock-guarded, so bytes are not corrupted individually, but they can land out of order, which garbles the resolved password.

## Change

- Drain stdout and stderr with one blocking read loop per stream on a concurrent `DispatchQueue`, joined with a `DispatchGroup`. Each stream has a single reader, so appends stay in order, and the two streams drain in parallel so neither can block the other by filling its pipe buffer.
- Behavior is otherwise unchanged: the 1 MB output cap still throws `outputTooLarge` (and terminates the process), the 30s timeout still throws `commandTimedOut`, and a non-zero exit still throws `commandFailed` with stderr.

## Tests

New `PasswordSourceResolverTests`:
- stdout is returned trimmed
- a large stdout (300 KB) drains in full and in order while stderr is also draining
- a failing command surfaces its exit code and stderr
- output over the 1 MB cap fails as `outputTooLarge`
- a command past the timeout is terminated and fails as `commandTimedOut`
- empty output fails as `emptyPassword`

## Notes

- `AppKit`/subprocess: these tests spawn `/bin/bash`, which is what the resolver does in production (TablePro ships non-sandboxed with the hardened runtime).
- The MongoDB fix stays in #1813, now scoped to just that change.
