### PR TITLE
fix(plugin-oracle): connect to servers that require native network encryption (#483)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- The Oracle Native network encryption connection option. Encryption is now offered to every server and used only when the server requires it, so the option is no longer needed. (#483)
+
 ### Fixed
 
+- Oracle now connects to servers that require native network encryption (`SQLNET.ENCRYPTION_SERVER = REQUIRED`), negotiating AES with a SHA checksum automatically like SQL Developer and DBeaver. (#483)
 - The Structure tab filter and column sort now update the grid instead of leaving stale rows on screen.
 - The row details inspector now shows the selected row's values, including JSON, when a column value filter is active, and a JSON or serialized value you open now follows the selected row as you move between rows. (#1837)
 - Copying, duplicating, and deleting rows now act on the rows you selected when a column value filter is active, instead of the rows sitting at those positions in the unfiltered result. (#1837)

--- a/Packages/TableProCore/Tests/TableProPluginKitTests/OracleConnectErrorClassifierTests.swift
+++ b/Packages/TableProCore/Tests/TableProPluginKitTests/OracleConnectErrorClassifierTests.swift
@@ -5,11 +5,18 @@ final class OracleConnectErrorClassifierTests: XCTestCase {
     func testClassifyKnownCodes() {
         XCTAssertEqual(OracleConnectErrorClassifier.classify("uncleanShutdown"), .connectionDropped)
         XCTAssertEqual(OracleConnectErrorClassifier.classify("serverVersionNotSupported"), .versionNotSupported)
+        XCTAssertEqual(OracleConnectErrorClassifier.classify("advancedNegotiationFailed"), .advancedNegotiationFailed)
         XCTAssertEqual(OracleConnectErrorClassifier.classify("somethingElse"), .connectionFailed)
         XCTAssertEqual(
             OracleConnectErrorClassifier.classify("unsupportedVerifierType(0x12)"),
             .verifierUnsupported(flag: "unsupportedVerifierType(0x12)")
         )
+    }
+
+    func testAdvancedNegotiationFailureIsEncryptionFailure() {
+        XCTAssertTrue(OracleConnectErrorClassifier.isLikelyNativeEncryptionFailure(
+            failure: .advancedNegotiationFailed, nativeNetworkEncryptionEnabled: true, timedOut: false
+        ))
     }
 
     func testEncryptionFailureRequiresEncryptionEnabled() {
@@ -27,11 +34,15 @@ final class OracleConnectErrorClassifierTests: XCTestCase {
         ))
     }
 
-    func testHandshakeDropWithEncryptionIsEncryptionFailure() {
-        XCTAssertTrue(OracleConnectErrorClassifier.isLikelyNativeEncryptionFailure(
+    func testHandshakeDropWithoutTimeoutIsNotEncryptionFailure() {
+        // With encryption always offered at ACCEPTED, a plain handshake drop is
+        // ambiguous (firewall, required-encryption server that RSTs, etc.), so it is
+        // not auto-classified. Only a stalled (timed out) handshake or an explicit
+        // advancedNegotiationFailed counts.
+        XCTAssertFalse(OracleConnectErrorClassifier.isLikelyNativeEncryptionFailure(
             failure: .connectionDropped, nativeNetworkEncryptionEnabled: true, timedOut: false
         ))
-        XCTAssertTrue(OracleConnectErrorClassifier.isLikelyNativeEncryptionFailure(
+        XCTAssertFalse(OracleConnectErrorClassifier.isLikelyNativeEncryptionFailure(
             failure: .connectionFailed, nativeNetworkEncryptionEnabled: true, timedOut: false
         ))
     }

--- a/Plugins/OracleDriverPlugin/OracleConnection.swift
+++ b/Plugins/OracleDriverPlugin/OracleConnection.swift
@@ -123,7 +123,6 @@ final class OracleConnectionWrapper: @unchecked Sendable {
     private let serviceName: String
     private let useSID: Bool
     private let sslConfig: SSLConfiguration
-    private let nativeNetworkEncryption: Bool
 
     private struct LockedState: Sendable {
         var isConnected = false
@@ -150,8 +149,7 @@ final class OracleConnectionWrapper: @unchecked Sendable {
         database: String,
         serviceName: String = "",
         useSID: Bool = false,
-        sslConfig: SSLConfiguration = SSLConfiguration(),
-        nativeNetworkEncryption: Bool = false
+        sslConfig: SSLConfiguration = SSLConfiguration()
     ) {
         self.host = host
         self.port = port
@@ -161,7 +159,6 @@ final class OracleConnectionWrapper: @unchecked Sendable {
         self.serviceName = serviceName
         self.useSID = useSID
         self.sslConfig = sslConfig
-        self.nativeNetworkEncryption = nativeNetworkEncryption
     }
 
     // MARK: - Connection
@@ -178,7 +175,6 @@ final class OracleConnectionWrapper: @unchecked Sendable {
             password: password,
             tls: tls
         )
-        config.nativeNetworkEncryption = nativeNetworkEncryption
         let connectConfig = config
         let connectLogger = nioLogger
 
@@ -205,7 +201,7 @@ final class OracleConnectionWrapper: @unchecked Sendable {
             let target = useSID ? "\(self.host):\(self.port):\(identifier)" : "\(self.host):\(self.port)/\(identifier)"
             osLogger.debug("Connected to Oracle \(target)")
         } catch is TimeoutError {
-            osLogger.error("Oracle login handshake timed out after \(Self.loginTimeoutSeconds, privacy: .public)s (nativeEncryption=\(self.nativeNetworkEncryption, privacy: .public))")
+            osLogger.error("Oracle login handshake timed out after \(Self.loginTimeoutSeconds, privacy: .public)s")
             throw makeConnectError(failure: .connectionFailed, detail: "", timedOut: true, phase: nil)
         } catch let sqlError as OracleSQLError {
             let detail = Self.connectFailureDetail(sqlError)
@@ -238,15 +234,19 @@ final class OracleConnectionWrapper: @unchecked Sendable {
         timedOut: Bool,
         phase: String?
     ) -> OracleError {
-        if OracleConnectErrorClassifier.isLikelyNativeEncryptionFailure(
-            failure: failure,
-            nativeNetworkEncryptionEnabled: nativeNetworkEncryption,
-            timedOut: timedOut
-        ) {
-            return OracleError(message: Self.nativeEncryptionFailureMessage, category: .nativeEncryptionFailed)
-        }
         if timedOut {
             return OracleError(message: Self.loginTimeoutMessage, category: .loginTimedOut)
+        }
+        // Native network encryption is always offered at ACCEPTED, so a non-timeout
+        // advanced-negotiation failure is the one definitive encryption signal.
+        if OracleConnectErrorClassifier.isLikelyNativeEncryptionFailure(
+            failure: failure,
+            nativeNetworkEncryptionEnabled: true,
+            timedOut: false
+        ) {
+            let base = Self.nativeEncryptionFailureMessage
+            let message = detail.isEmpty ? base : "\(base) (\(detail))"
+            return OracleError(message: message, category: .nativeEncryptionFailed)
         }
         let category = Self.category(for: failure, phase: phase)
         return OracleError(
@@ -265,6 +265,8 @@ final class OracleConnectionWrapper: @unchecked Sendable {
             return .authConnectionDropped(phase: phase)
         case .connectionFailed:
             return .connectionFailed
+        case .advancedNegotiationFailed:
+            return .nativeEncryptionFailed
         @unknown default:
             return .connectionFailed
         }
@@ -276,9 +278,8 @@ final class OracleConnectionWrapper: @unchecked Sendable {
 
     private static let nativeEncryptionFailureMessage = String(
         localized: """
-        Could not finish logging in with native network encryption enabled. \
-        This Oracle server may not support it, which is common with Oracle 11g. \
-        Turn off the Native network encryption option in this connection's settings and try again.
+        Could not complete Oracle native network encryption with this server. It may \
+        require an encryption or checksum algorithm the driver does not support.
         """
     )
 
@@ -286,7 +287,13 @@ final class OracleConnectionWrapper: @unchecked Sendable {
         if let refused = error.underlying as? OracleListenerRefusedError {
             return OracleListenerRefusal.detail(code: refused.code)
         }
-        return error.serverInfo?.message ?? error.description
+        if let serverMessage = error.serverInfo?.message {
+            return serverMessage
+        }
+        if let underlying = error.underlying {
+            return String(describing: underlying)
+        }
+        return error.description
     }
 
     private static func connectErrorMessage(

--- a/Plugins/OracleDriverPlugin/OraclePlugin.swift
+++ b/Plugins/OracleDriverPlugin/OraclePlugin.swift
@@ -38,12 +38,6 @@ final class OraclePlugin: NSObject, TableProPlugin, DriverPlugin, PluginDiagnost
             label: "SID",
             placeholder: "XE",
             visibleWhen: FieldVisibilityRule(fieldId: "oracleConnectionType", values: ["sid"])
-        ),
-        ConnectionField(
-            id: "oracleNativeEncryption",
-            label: "Native network encryption",
-            defaultValue: "false",
-            fieldType: .toggle
         )
     ]
 
@@ -187,9 +181,9 @@ final class OraclePlugin: NSObject, TableProPlugin, DriverPlugin, PluginDiagnost
                 title: String(localized: "Native Network Encryption Not Completed"),
                 message: oracleError.message,
                 suggestedActions: [
-                    String(localized: "Turn off the Native network encryption option in this connection's settings, then connect again."),
-                    String(localized: "Some servers, including Oracle 11g, accept but never complete native network encryption. Plain connections to such servers still work."),
-                    String(localized: "If you need encryption in transit, use TLS instead by setting an SSL mode in the connection's SSL settings.")
+                    String(localized: "The server requires Oracle native network encryption, and negotiating it with this server did not complete."),
+                    String(localized: "Ask the DBA which encryption and checksum algorithms the server requires. The driver supports AES with a SHA-2 checksum."),
+                    String(localized: "File an issue with your Oracle version and the details below so the driver can add support.")
                 ],
                 supportURL: issuesURL
             )
@@ -199,8 +193,7 @@ final class OraclePlugin: NSObject, TableProPlugin, DriverPlugin, PluginDiagnost
                 message: oracleError.message,
                 suggestedActions: [
                     String(localized: "Check for a firewall, VPN, or proxy between you and the server that stalls connections after the TCP handshake."),
-                    String(localized: "Confirm the host and port reach the database listener directly."),
-                    String(localized: "If you enabled the Native network encryption option, turn it off; some servers stall instead of completing it.")
+                    String(localized: "Confirm the host and port reach the database listener directly.")
                 ],
                 supportURL: issuesURL
             )
@@ -272,8 +265,7 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             database: config.database,
             serviceName: identifier,
             useSID: useSID,
-            sslConfig: config.ssl,
-            nativeNetworkEncryption: config.additionalFields["oracleNativeEncryption"] == "true"
+            sslConfig: config.ssl
         )
         try await conn.connect()
         self.oracleConn = conn

--- a/Plugins/TableProPluginKit/OracleConnectErrorClassifier.swift
+++ b/Plugins/TableProPluginKit/OracleConnectErrorClassifier.swift
@@ -5,6 +5,7 @@ public enum OracleConnectFailure: Sendable, Equatable {
     case versionNotSupported
     case connectionDropped
     case connectionFailed
+    case advancedNegotiationFailed
 }
 
 public enum OracleConnectErrorClassifier {
@@ -17,6 +18,8 @@ public enum OracleConnectErrorClassifier {
             return .connectionDropped
         case "serverVersionNotSupported":
             return .versionNotSupported
+        case "advancedNegotiationFailed":
+            return .advancedNegotiationFailed
         default:
             return .connectionFailed
         }
@@ -28,10 +31,11 @@ public enum OracleConnectErrorClassifier {
         timedOut: Bool
     ) -> Bool {
         guard nativeNetworkEncryptionEnabled else { return false }
-        if timedOut { return true }
         switch failure {
-        case .connectionDropped, .connectionFailed:
+        case .advancedNegotiationFailed:
             return true
+        case .connectionDropped, .connectionFailed:
+            return timedOut
         case .verifierUnsupported, .versionNotSupported:
             return false
         }

--- a/TablePro.xcodeproj/project.pbxproj
+++ b/TablePro.xcodeproj/project.pbxproj
@@ -4944,7 +4944,7 @@
 			repositoryURL = "https://github.com/TableProApp/oracle-nio";
 			requirement = {
 				kind = revision;
-				revision = 1140759e3bc339a8383b5d38f45fcb4ef61e602a;
+				revision = 23c77812ed90259243a761d7fdea19db47d3ca41;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/TableProApp/oracle-nio",
       "state" : {
-        "revision" : "1140759e3bc339a8383b5d38f45fcb4ef61e602a"
+        "revision" : "23c77812ed90259243a761d7fdea19db47d3ca41"
       }
     },
     {

--- a/TableProTests/Plugins/OracleConnectionErrorTests.swift
+++ b/TableProTests/Plugins/OracleConnectionErrorTests.swift
@@ -38,6 +38,14 @@ struct OracleConnectErrorClassifierTests {
         )
     }
 
+    @Test("A failed advanced negotiation is a native encryption failure")
+    func advancedNegotiationIsEncryptionFailure() {
+        #expect(OracleConnectErrorClassifier.classify("advancedNegotiationFailed") == .advancedNegotiationFailed)
+        #expect(OracleConnectErrorClassifier.isLikelyNativeEncryptionFailure(
+            failure: .advancedNegotiationFailed, nativeNetworkEncryptionEnabled: true, timedOut: false
+        ))
+    }
+
     @Test("Any other code falls back to a generic connection failure")
     func unknownIsConnectionFailed() {
         #expect(OracleConnectErrorClassifier.classify("connectionError") == .connectionFailed)

--- a/docs/databases/oracle.mdx
+++ b/docs/databases/oracle.mdx
@@ -40,7 +40,6 @@ The Oracle driver is available as a downloadable plugin. When you select Oracle 
 | **Port** | `1521` | Listener port |
 | **Service Name** | - | **Required**. Check `tnsnames.ora` if unclear. To connect by SID instead, set **Connection Type** to SID and enter the SID. |
 | **Username** | - | Requires username/password auth (no OS auth) |
-| **Native network encryption** | Off | Advanced. Turn on only if the server requires encrypted traffic (`SQLNET.ENCRYPTION_SERVER = REQUIRED`). Leave off for servers that merely accept encryption, which connect in clear text like Oracle's own clients. Some servers, including Oracle 11g, accept but never complete native encryption; with this on, the connect times out after 30 seconds and tells you to turn it off. |
 
 ## Example Configurations
 
@@ -149,8 +148,10 @@ Columns with types not yet supported render as `<unsupported: type>` rather than
 
 **Instant Client not found**: Download Basic package, extract to `/usr/local/oracle/instantclient`, set `DYLD_LIBRARY_PATH`
 
-**Connection dropped during handshake**: The server closed the connection mid-login. The error dialog shows the handshake phase it stopped at (for example `advancedNegotiation`, `dataTypeNegotiation`, or `authentication`). Check for a firewall, VPN, or proxy that resets traffic, and confirm the host and port reach the listener directly. If the phase is around negotiation and the server requires native network encryption, turn on the **Native network encryption** option; if you turned it on for a server that only accepts encryption, turn it back off.
+**Connection dropped during handshake**: The server closed the connection mid-login. The error dialog shows the handshake phase it stopped at (for example `advancedNegotiation`, `dataTypeNegotiation`, or `authentication`). Check for a firewall, VPN, or proxy that resets traffic, and confirm the host and port reach the listener directly.
 
-**Login handshake timed out / native network encryption not completed**: The TCP connection is accepted but login never finishes. The connect now stops after 30 seconds instead of waiting for the server to reset. The common cause is the **Native network encryption** option turned on against a server that does not complete it, such as Oracle 11g; turn it off and connect again. Plain connections to those servers still work. For encryption in transit, use TLS by setting an SSL mode in the SSL settings.
+**Native network encryption not completed**: The server requires native network encryption and the negotiation did not finish. TablePro offers encryption to every server (AES with a SHA crypto-checksum) and turns it on only when the server asks, the same as SQL Developer and DBeaver, so no option is needed. If this still fails, the server likely requires an algorithm the driver does not support; the error dialog shows the reason. File an issue with your Oracle version and that reason. For encryption in transit you can also use TLS by setting an SSL mode in the SSL settings.
+
+**Login handshake timed out**: The TCP connection is accepted but login never finishes, so the connect stops after 30 seconds instead of waiting for the server to reset. Check for a firewall, VPN, or proxy that stalls traffic after the TCP handshake, and confirm the host and port reach the listener directly.
 
 **Limitations**: Username/password only, BFILE shows locator metadata only (content fetch via DBMS_LOB not supported), PL/SQL limited to anonymous blocks.


### PR DESCRIPTION
Continues #483.

## Problem

Oracle connections fail during the native network encryption (Advanced Networking Option) handshake. The latest reporter state, on Oracle 19 with driver 1.2.15, is `OracleSQLError(code: advancedNegotiationFailed)`; earlier states were `uncleanShutdown` and a decode crash (already fixed). The same servers connect fine from SQL Developer and DBeaver.

## Root cause

TablePro never offered the `ACCEPTED` encryption level that every real Oracle client defaults to. The `nativeNetworkEncryption` toggle was binary, and neither setting was `ACCEPTED`:

- **Off (default):** advertised only supervisor + auth services, which a server reads as `ENCRYPTION_CLIENT = REJECTED`. Against a `SQLNET.ENCRYPTION_SERVER = REQUIRED` server, Oracle's own matrix says `REJECTED` × `REQUIRED` fails. That is #483.
- **On:** offered AES with no "none" algorithm, which reads as `REQUIRED` and forced AES even on servers that only accept it (the Oracle 11g hang in #1746).

Oracle signals the client level by whether the "none" algorithm (ID 0) is offered and where it sits: first for ACCEPTED, last for REQUESTED, absent for REQUIRED, alone for REJECTED. JDBC thin and go-ora default to ACCEPTED (offer all four services with the null algorithm first), so they stay clear text against accepting servers and negotiate AES against requiring ones. Confirmed against Oracle's JDBC/dbseg docs and the go-ora source.

## Fix

**Fork (`TableProApp/oracle-nio`, re-pinned `1140759` → `23c7781`):**
- Replace the binary `includeSecurityServices` with a `NativeNetworkEncryptionLevel` (default `.accepted`).
- `AdvancedNegotiation.encodeRequest` now always advertises all four services; the level only decides the "none" algorithm's presence/position in the encryption and data-integrity lists (`offeredAlgorithms(_:for:)`).
- Preserve the decode reason: `advancedNegotiationFailed(underlying:)` instead of discarding it.
- Existing DH + AES-CBC + checksum path is unchanged; it now runs when a server actually selects AES.

**App / Oracle plugin (registry-only, additive PluginKit change, no version bump):**
- Removed the "Native network encryption" connection toggle. Encryption is always offered at ACCEPTED, matching SQL Developer and DBeaver.
- `OracleConnectErrorClassifier`: added `.advancedNegotiationFailed` (the ABI gate confirms this is the only interface change, additive).
- `advancedNegotiationFailed` now maps to a clear "Native network encryption not completed" diagnostic that surfaces the underlying reason; login timeouts stay generic.
- Updated `docs/databases/oracle.mdx` and CHANGELOG.

## Tests

- Fork `AdvancedNegotiationTests`: all four levels advertise four services; `offeredAlgorithms` places the null algorithm per level; a null-selection (accepting-server) response decodes to clear text; an AES + Diffie-Hellman response still decodes. All pass locally.
- `OracleConnectErrorClassifierTests` (app + package): `advancedNegotiationFailed` classifies and is treated as a native-encryption failure; a non-timeout handshake drop is not. All pass locally.

## Verification limit

I can't test the AES/Diffie-Hellman path against a real `REQUIRED`-encryption server here, so accepting servers (the majority) are covered by the clear-text decode test and stay clear text, while a required server now negotiates AES for the first time. The #483 reporters (Oracle 19 / 23ai) should verify once `plugin-oracle-v<next>` is released.

## Release

Oracle is registry-only. After merge, cut a `plugin-oracle-v<next>` release so the reporters get the fix. No PluginKit version bump (ABI additive).
