### PR TITLE
feat(datagrid): resizable JSON field in the row details inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The JSON field in the row details inspector can now be resized by dragging the handle below it. The height is remembered across rows and app restarts. (#1849)
+
 ### Changed
 
 - Data grid column comments now appear directly in column headers when object comments are enabled, instead of only being available from the header tooltip. (#1789)

--- a/TablePro/Views/RightSidebar/FieldEditors/JsonEditorView.swift
+++ b/TablePro/Views/RightSidebar/FieldEditors/JsonEditorView.swift
@@ -11,6 +11,7 @@ internal struct JsonEditorView: View {
     var onPopOut: ((String) -> Void)?
 
     @State private var displayText: String
+    @AppStorage("rightSidebar.jsonFieldHeight") private var fieldHeight = ResizableFieldMetrics.defaultJsonHeight
 
     init(context: FieldEditorContext, onExpand: (() -> Void)? = nil, onPopOut: ((String) -> Void)? = nil) {
         self.context = context
@@ -20,37 +21,40 @@ internal struct JsonEditorView: View {
     }
 
     var body: some View {
-        JSONCodeEditor(text: $displayText, isEditable: !context.isReadOnly)
-            .frame(minHeight: context.isReadOnly ? 60 : 80, maxHeight: 120)
-            .clipShape(RoundedRectangle(cornerRadius: 5))
-            .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Color(nsColor: .separatorColor)))
-            .overlay(alignment: .bottomTrailing) {
-                HStack(spacing: 2) {
-                    if let onPopOut {
-                        Button { onPopOut(displayText) } label: {
-                            Image(systemName: "arrow.up.forward.app")
-                                .font(.caption2)
-                                .padding(4)
-                                .themeMaterial(.inlineControl, .ultraThinMaterial, in: RoundedRectangle(cornerRadius: 4))
-                        }
-                        .buttonStyle(.borderless)
-                        .help(String(localized: "Open in Window"))
-                    }
-                    if let onExpand {
-                        Button(action: onExpand) {
-                            Image(systemName: "arrow.up.left.and.arrow.down.right")
-                                .font(.caption2)
-                                .padding(4)
-                                .themeMaterial(.inlineControl, .ultraThinMaterial, in: RoundedRectangle(cornerRadius: 4))
-                        }
-                        .buttonStyle(.borderless)
-                        .help(String(localized: "Expand in Sidebar"))
-                    }
+        ResizableEditorContainer(height: $fieldHeight, range: ResizableFieldMetrics.jsonHeightRange) {
+            JSONCodeEditor(text: $displayText, isEditable: !context.isReadOnly)
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+                .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Color(nsColor: .separatorColor)))
+                .overlay(alignment: .bottomTrailing) { actionButtons }
+        }
+        .onChange(of: displayText) { propagateEdit() }
+        .onChange(of: context.value.wrappedValue) { syncFromBinding() }
+    }
+
+    private var actionButtons: some View {
+        HStack(spacing: 2) {
+            if let onPopOut {
+                Button { onPopOut(displayText) } label: {
+                    Image(systemName: "arrow.up.forward.app")
+                        .font(.caption2)
+                        .padding(4)
+                        .themeMaterial(.inlineControl, .ultraThinMaterial, in: RoundedRectangle(cornerRadius: 4))
                 }
-                .padding(4)
+                .buttonStyle(.borderless)
+                .help(String(localized: "Open in Window"))
             }
-            .onChange(of: displayText) { propagateEdit() }
-            .onChange(of: context.value.wrappedValue) { syncFromBinding() }
+            if let onExpand {
+                Button(action: onExpand) {
+                    Image(systemName: "arrow.up.left.and.arrow.down.right")
+                        .font(.caption2)
+                        .padding(4)
+                        .themeMaterial(.inlineControl, .ultraThinMaterial, in: RoundedRectangle(cornerRadius: 4))
+                }
+                .buttonStyle(.borderless)
+                .help(String(localized: "Expand in Sidebar"))
+            }
+        }
+        .padding(4)
     }
 
     private func propagateEdit() {

--- a/TablePro/Views/RightSidebar/FieldEditors/ResizableEditorContainer.swift
+++ b/TablePro/Views/RightSidebar/FieldEditors/ResizableEditorContainer.swift
@@ -1,0 +1,66 @@
+//
+//  ResizableEditorContainer.swift
+//  TablePro
+//
+
+import AppKit
+import SwiftUI
+
+internal struct ResizableEditorContainer<Content: View>: View {
+    @Binding var height: Double
+    let range: ClosedRange<Double>
+    @ViewBuilder let content: () -> Content
+
+    @GestureState private var liveDelta: Double = 0
+    @State private var isHandleHovered = false
+
+    private var resolvedHeight: Double {
+        ResizableFieldMetrics.resolve(base: height, delta: liveDelta, range: range)
+    }
+
+    var body: some View {
+        VStack(spacing: 2) {
+            content()
+                .frame(height: resolvedHeight)
+            resizeHandle
+        }
+    }
+
+    private var resizeHandle: some View {
+        Capsule()
+            .fill(Color(nsColor: .tertiaryLabelColor))
+            .frame(width: 26, height: 4)
+            .opacity(isHandleHovered ? 1 : 0.5)
+            .frame(maxWidth: .infinity, minHeight: 11)
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 1)
+                    .updating($liveDelta) { value, state, _ in
+                        state = value.translation.height
+                    }
+                    .onEnded { value in
+                        height = ResizableFieldMetrics.resolve(
+                            base: height,
+                            delta: value.translation.height,
+                            range: range
+                        )
+                    }
+            )
+            .onHover { hovering in
+                guard hovering != isHandleHovered else { return }
+                isHandleHovered = hovering
+                if hovering {
+                    NSCursor.resizeUpDown.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
+            .onDisappear {
+                if isHandleHovered {
+                    NSCursor.pop()
+                    isHandleHovered = false
+                }
+            }
+            .accessibilityHidden(true)
+    }
+}

--- a/TablePro/Views/RightSidebar/FieldEditors/ResizableEditorContainer.swift
+++ b/TablePro/Views/RightSidebar/FieldEditors/ResizableEditorContainer.swift
@@ -34,7 +34,7 @@ internal struct ResizableEditorContainer<Content: View>: View {
             .frame(maxWidth: .infinity, minHeight: 11)
             .contentShape(Rectangle())
             .gesture(
-                DragGesture(minimumDistance: 1)
+                DragGesture(minimumDistance: 1, coordinateSpace: .global)
                     .updating($liveDelta) { value, state, _ in
                         state = value.translation.height
                     }

--- a/TablePro/Views/RightSidebar/FieldEditors/ResizableFieldMetrics.swift
+++ b/TablePro/Views/RightSidebar/FieldEditors/ResizableFieldMetrics.swift
@@ -1,0 +1,15 @@
+//
+//  ResizableFieldMetrics.swift
+//  TablePro
+//
+
+import Foundation
+
+internal enum ResizableFieldMetrics {
+    static let jsonHeightRange: ClosedRange<Double> = 80...600
+    static let defaultJsonHeight: Double = 120
+
+    static func resolve(base: Double, delta: Double, range: ClosedRange<Double>) -> Double {
+        min(max(base + delta, range.lowerBound), range.upperBound)
+    }
+}

--- a/TableProTests/Views/RightSidebar/ResizableFieldMetricsTests.swift
+++ b/TableProTests/Views/RightSidebar/ResizableFieldMetricsTests.swift
@@ -1,0 +1,37 @@
+//
+//  ResizableFieldMetricsTests.swift
+//  TableProTests
+//
+
+import XCTest
+
+@testable import TablePro
+
+final class ResizableFieldMetricsTests: XCTestCase {
+    private let range: ClosedRange<Double> = 80...600
+
+    func testResolveAddsDeltaWithinRange() {
+        XCTAssertEqual(ResizableFieldMetrics.resolve(base: 120, delta: 40, range: range), 160)
+    }
+
+    func testResolveClampsToLowerBound() {
+        XCTAssertEqual(ResizableFieldMetrics.resolve(base: 100, delta: -200, range: range), 80)
+    }
+
+    func testResolveClampsToUpperBound() {
+        XCTAssertEqual(ResizableFieldMetrics.resolve(base: 500, delta: 400, range: range), 600)
+    }
+
+    func testResolveNegativeDeltaStaysWithinRange() {
+        XCTAssertEqual(ResizableFieldMetrics.resolve(base: 300, delta: -100, range: range), 200)
+    }
+
+    func testResolveHonoursExactBounds() {
+        XCTAssertEqual(ResizableFieldMetrics.resolve(base: 80, delta: 0, range: range), 80)
+        XCTAssertEqual(ResizableFieldMetrics.resolve(base: 600, delta: 0, range: range), 600)
+    }
+
+    func testDefaultJsonHeightIsWithinJsonRange() {
+        XCTAssertTrue(ResizableFieldMetrics.jsonHeightRange.contains(ResizableFieldMetrics.defaultJsonHeight))
+    }
+}

--- a/docs/features/data-grid.mdx
+++ b/docs/features/data-grid.mdx
@@ -113,6 +113,8 @@ See [Change Tracking](/features/change-tracking) for details.
 
 Toggle the inspector with `Cmd+Shift+B`. With a row selected, it lists every column value with a full editor for long text and JSON. With no row selected, it shows table metadata: row count, size, engine, charset, and collation.
 
+Drag the handle below a JSON field to make it taller and see more content without leaving the inspector. The height is remembered across rows and app restarts. For very large values, use **Expand in Sidebar** or **Open in Window**.
+
 <Frame caption="Cell Inspector">
   <img className="block dark:hidden" src="/images/cell-inspector.png" alt="Cell Inspector" />
   <img className="hidden dark:block" src="/images/cell-inspector-dark.png" alt="Cell Inspector" />


### PR DESCRIPTION
Closes #1849.

## Problem

The row details inspector showed JSON values in a fixed field capped at about 3 lines (`JsonEditorView` pinned `.frame(minHeight: 80, maxHeight: 120)`, and the code editor is greedy so it always sat at the 120px cap). To read more you had to click Expand or Open in Window. There was no way to make the field taller inline, and nothing was remembered.

## Change

The JSON field in the inspector is now resizable. Drag the handle below it to make it taller, up to a sensible cap. The height is stored in `@AppStorage` and applies to every JSON field, so it survives moving between rows and app restarts.

- `ResizableFieldMetrics` (new): pure, unit-tested clamp helper plus the JSON height range (80 to 600) and default (120, matching the current look).
- `ResizableEditorContainer` (new): reusable view that renders content at a bound height with a thin bottom drag handle. Uses `DragGesture` with `@GestureState` for the live delta, commits the clamped height on end, and shows `NSCursor.resizeUpDown` on hover (the same cursor pattern used in `ERDiagramView`).
- `JsonEditorView`: wraps the editor in the container and stores the height in `@AppStorage("rightSidebar.jsonFieldHeight")`. The editor's `SourceEditorState`/`SourceEditorConfiguration` are untouched on resize, so marked text (IME), the undo stack, and focus are preserved. The existing Expand and Open in Window buttons stay as the keyboard/VoiceOver path and the very-large-value escape hatch.

## Why `@AppStorage`

The inspector's `List`/`ForEach` re-creates `JsonEditorView` for each selected row, so a plain `@State` height would reset every time you change rows, which is the reset the issue calls out. `@AppStorage` re-reads the stored value on each re-creation, so the height persists across rows and launches. One shared value means multiple JSON columns resize together, matching the single resizable value area in DataGrip and DBeaver.

## Native basis

There is no per-view resize affordance to reuse: `.resizable()` is Image-only, `.pointerStyle(.frameResize:)` is macOS 15+ and we target 14, and `NSSplitView` is the wrong granularity for one row in a scrolling list. This follows Apple's split-view divider idiom (thin handle, min and max clamps) with a `DragGesture` scoped to a thin bottom strip so it does not fight the list's scroll or the text view's own mouse handling.

## Tests

`ResizableFieldMetricsTests` covers the clamp: within range, at both bounds, and default-in-range. Verified locally with a standalone `swiftc` run (6/6 pass). The full `xcodebuild test` was not run here; please confirm on CI.

## Docs / CHANGELOG

- `docs/features/data-grid.mdx`: the Cell Inspector section notes the resizable, persisted JSON field.
- `CHANGELOG.md`: Added entry under `[Unreleased]`.
