### PR TITLE
test: fix FakePluginAuthError LocalizedError conformance on the CI toolchain

### DIFF
--- a/TableProTests/Core/Database/ReconnectCredentialRecoveryTests.swift
+++ b/TableProTests/Core/Database/ReconnectCredentialRecoveryTests.swift
@@ -114,4 +114,5 @@ private struct FakePluginAuthError: PluginDriverError {
     let pluginErrorMessage: String
     let pluginErrorCode: Int?
     let pluginSqlState: String?
+    var errorDescription: String? { pluginErrorMessage }
 }


### PR DESCRIPTION
## Problem

`main`'s macOS App Tests job has been failing to compile since #1846. The test helper does not build on CI's toolchain (Xcode 26.4.1):

```
error: type 'FakePluginAuthError' does not conform to protocol 'LocalizedError'
private struct FakePluginAuthError: PluginDriverError {
```

`PluginDriverError` refines `LocalizedError` and supplies a default `errorDescription` in an extension inside `TableProPluginKit`, which is built with Library Evolution (`BUILD_LIBRARY_FOR_DISTRIBUTION = YES`). On the Swift compiler in Xcode 26.4.1, that inherited-requirement default is not picked up as the witness for a type conforming in a different module (the test target), so `FakePluginAuthError` is treated as not conforming to `LocalizedError`. The same code builds on Xcode 27, which is why it was not caught locally.

## Fix

Give `FakePluginAuthError` an explicit `errorDescription`, so its `LocalizedError` conformance no longer depends on the cross-module default being witnessed. Test-only change, no `TableProPluginKit` ABI impact.

## Verification

The test target compiles again on Xcode 26.4.1. `TableProTests` is not in the SwiftLint `included` scope, so the file's existing lint state is unchanged. No CHANGELOG entry: internal test build fix, not user-facing.
