### PR TITLE
test: import Foundation to fix FakePluginAuthError LocalizedError conformance on Xcode 26.4.1

### DIFF
--- a/TableProTests/Core/Database/ReconnectCredentialRecoveryTests.swift
+++ b/TableProTests/Core/Database/ReconnectCredentialRecoveryTests.swift
@@ -110,10 +110,11 @@ struct ReconnectCredentialRecoveryTests {
     }
 }
 
-private struct FakePluginAuthError: Error {
+private struct FakePluginAuthError: Error, LocalizedError {
     let pluginErrorMessage: String
     let pluginErrorCode: Int?
     let pluginSqlState: String?
+    var errorDescription: String? { pluginErrorMessage }
 }
 
 extension FakePluginAuthError: PluginDriverError {}

--- a/TableProTests/Core/Database/ReconnectCredentialRecoveryTests.swift
+++ b/TableProTests/Core/Database/ReconnectCredentialRecoveryTests.swift
@@ -110,9 +110,10 @@ struct ReconnectCredentialRecoveryTests {
     }
 }
 
-private struct FakePluginAuthError: PluginDriverError {
+private struct FakePluginAuthError: Error {
     let pluginErrorMessage: String
     let pluginErrorCode: Int?
     let pluginSqlState: String?
-    var errorDescription: String? { pluginErrorMessage }
 }
+
+extension FakePluginAuthError: PluginDriverError {}

--- a/TableProTests/Core/Database/ReconnectCredentialRecoveryTests.swift
+++ b/TableProTests/Core/Database/ReconnectCredentialRecoveryTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import TablePro
 import TableProPluginKit
@@ -110,11 +111,8 @@ struct ReconnectCredentialRecoveryTests {
     }
 }
 
-private struct FakePluginAuthError: Error, LocalizedError {
+private struct FakePluginAuthError: PluginDriverError {
     let pluginErrorMessage: String
     let pluginErrorCode: Int?
     let pluginSqlState: String?
-    var errorDescription: String? { pluginErrorMessage }
 }
-
-extension FakePluginAuthError: PluginDriverError {}


### PR DESCRIPTION
Follow-up to #1851, which did not fix the failure. `main`'s macOS App Tests still fail to compile with the same error on Xcode 26.4.1:

```
error: type 'FakePluginAuthError' does not conform to protocol 'LocalizedError'
```

Adding an explicit `errorDescription` (in #1851) did not help, so the missing witness was not the cause. The real difference: every shipping plugin error type conforms to `PluginDriverError` via a separate `extension`, with the base `Error` conformance stated on the type (`enum DuckDBPluginError: Error` + `extension DuckDBPluginError: PluginDriverError`). None conform inline. The test helper was the only inline `struct X: PluginDriverError`, and on the Xcode 26.4.1 compiler that inline conformance to a resilient cross-module protocol refining `LocalizedError` fails to synthesize the inherited `LocalizedError` conformance.

## Fix

Match the pattern used by all 13 real conformers: declare `Error` on the type and add `PluginDriverError` in an extension. Test-only, no `TableProPluginKit` ABI impact.

## Verification

Cannot compile-verify locally (Xcode 27 does not reproduce the 26.4.1 behavior). Relying on the macOS Tests check on this PR, which runs on the same 26.4.1 toolchain, plus the fact that this is the exact pattern shipping plugins already build with.