### PR TITLE
fix(plugins): implement the missing driver requirements in the concurrency test stub

### DIFF
--- a/TableProTests/Core/Plugins/PluginDriverAdapterConcurrencyTests.swift
+++ b/TableProTests/Core/Plugins/PluginDriverAdapterConcurrencyTests.swift
@@ -145,5 +145,14 @@ private final class ConcurrentStubPluginDriver: PluginDatabaseDriver, @unchecked
     func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] { [] }
     func fetchTableDDL(table: String, schema: String?) async throws -> String { "" }
     func fetchViewDefinition(view: String, schema: String?) async throws -> String { "" }
+
+    func fetchTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata {
+        PluginTableMetadata(tableName: table)
+    }
+
     func fetchDatabases() async throws -> [String] { [] }
+
+    func fetchDatabaseMetadata(_ database: String) async throws -> PluginDatabaseMetadata {
+        PluginDatabaseMetadata(name: database)
+    }
 }


### PR DESCRIPTION
`main` is red. The `macOS App Tests` job fails to compile:

```
type 'ConcurrentStubPluginDriver' does not conform to protocol 'PluginDatabaseDriver'
TableProTests/Core/Plugins/PluginDriverAdapterConcurrencyTests.swift:103
```

Introduced by #1864 ([failing run](https://github.com/TableProApp/TablePro/actions/runs/29249403635/job/86814056433)).

### Cause

`PluginDatabaseDriver` has 12 requirements with no default implementation in its protocol extension, so every conformer has to implement all of them. `ConcurrentStubPluginDriver` implements 10 and omits two:

- `fetchTableMetadata(table:schema:)`
- `fetchDatabaseMetadata(_:)`

Every other driver stub in the test target already implements both, which is why this is the only stub that fails.

The build passes on Xcode 27 locally and fails on the toolchain CI uses, which is the same local-versus-CI conformance gap this repo has hit before. CI is the authority here: the two requirements really are unsatisfied.

### Fix

Implement the two missing requirements on the stub, matching what the sibling stubs already return (`PluginTableMetadata(tableName:)` and `PluginDatabaseMetadata(name:)`).

No production code changes, and no CHANGELOG entry: this is a test-only build fix with no user-facing behaviour.

### Verification

- `PluginDriverAdapterConcurrencyTests` compiles and its 3 tests pass.
- `swiftlint lint --strict` clean.
- Confirmed by diffing the protocol's requirement list against the extension's defaults that the stub now satisfies all 12 non-defaulted requirements.
