### PR TITLE
fix(datagrid): resolve header comments from the header view to stop a sort crash (#1869)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a crash when clicking a column header on a table whose columns have comments. Sorting such a table quit the app immediately. (#1869)
+
 ## [0.57.0] - 2026-07-14
 
 ### Added

--- a/TablePro/Views/Results/DataGridColumnPool.swift
+++ b/TablePro/Views/Results/DataGridColumnPool.swift
@@ -41,7 +41,8 @@ final class DataGridColumnPool {
 
         let willRestoreWidths = !(savedLayout?.columnWidths.isEmpty ?? true)
         let hiddenFromLayout = savedLayout?.hiddenColumns ?? []
-        var commentsChanged = false
+        var comments: [NSUserInterfaceItemIdentifier: String] = [:]
+        var showsComments = false
 
         for slot in 0..<pooledColumns.count {
             let column = pooledColumns[slot]
@@ -50,28 +51,30 @@ final class DataGridColumnPool {
                 let resolvedWidth = willRestoreWidths
                     ? (savedLayout?.columnWidths[columnName] ?? widthCalculator(columnName, slot))
                     : widthCalculator(columnName, slot)
-                if configureColumn(
+                let comment = displayableComment(columnComments[columnName])
+                configureColumn(
                     column,
                     name: columnName,
                     columnType: slot < columnTypes.count ? columnTypes[slot] : nil,
-                    comment: columnComments[columnName],
+                    comment: comment,
                     width: resolvedWidth,
                     isEditable: isEditable
-                ) {
-                    commentsChanged = true
-                }
+                )
                 let hidden = hiddenFromLayout.contains(columnName) || hiddenColumnNames.contains(columnName)
                 if column.isHidden != hidden {
                     column.isHidden = hidden
+                }
+                if let comment {
+                    comments[column.identifier] = comment
+                    if !hidden {
+                        showsComments = true
+                    }
                 }
             } else if !column.isHidden {
                 column.isHidden = true
             }
         }
-        updateHeaderHeight(in: tableView, showsComments: hasVisibleComments(visibleCount: visibleCount))
-        if commentsChanged {
-            tableView.headerView?.needsDisplay = true
-        }
+        applyComments(comments, showsComments: showsComments, in: tableView)
 
         let targetOrder = computeTargetOrder(
             visibleCount: visibleCount,
@@ -190,17 +193,12 @@ final class DataGridColumnPool {
         comment: String?,
         width: CGFloat,
         isEditable: Bool
-    ) -> Bool {
+    ) {
         if !(column.headerCell is SortableHeaderCell) || column.headerCell.stringValue != name {
             let cell = SortableHeaderCell(textCell: name)
             cell.font = column.headerCell.font
             cell.alignment = column.headerCell.alignment
             column.headerCell = cell
-        }
-        var commentChanged = false
-        if let headerCell = column.headerCell as? SortableHeaderCell, headerCell.headerComment != comment {
-            headerCell.headerComment = comment
-            commentChanged = true
         }
 
         var tooltip: String
@@ -209,14 +207,14 @@ final class DataGridColumnPool {
         } else {
             tooltip = name
         }
-        if let comment, !comment.isEmpty {
+        if let comment {
             tooltip += "\n\(comment)"
         }
         if column.headerToolTip != tooltip {
             column.headerToolTip = tooltip
         }
 
-        let label = String(format: String(localized: "Column: %@"), name)
+        let label = accessibilityLabel(name: name, comment: comment)
         if column.headerCell.accessibilityLabel() != label {
             column.headerCell.setAccessibilityLabel(label)
         }
@@ -230,23 +228,27 @@ final class DataGridColumnPool {
         if column.sortDescriptorPrototype?.key != name {
             column.sortDescriptorPrototype = NSSortDescriptor(key: name, ascending: true)
         }
-
-        return commentChanged
     }
 
-    private func hasVisibleComments(visibleCount: Int) -> Bool {
-        pooledColumns.enumerated().contains { slot, column in
-            guard slot < visibleCount,
-                  !column.isHidden,
-                  let cell = column.headerCell as? SortableHeaderCell,
-                  let comment = cell.headerComment else {
-                return false
-            }
-            return !comment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        }
+    private func accessibilityLabel(name: String, comment: String?) -> String {
+        let label = String(format: String(localized: "Column: %@"), name)
+        guard let comment else { return label }
+        return "\(label), \(comment)"
     }
 
-    private func updateHeaderHeight(in tableView: NSTableView, showsComments: Bool) {
-        (tableView.headerView as? SortableHeaderView)?.showsComments = showsComments
+    private func displayableComment(_ comment: String?) -> String? {
+        guard let comment else { return nil }
+        let trimmed = comment.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func applyComments(
+        _ comments: [NSUserInterfaceItemIdentifier: String],
+        showsComments: Bool,
+        in tableView: NSTableView
+    ) {
+        guard let headerView = tableView.headerView as? SortableHeaderView else { return }
+        headerView.showsComments = showsComments
+        headerView.updateComments(comments)
     }
 }

--- a/TablePro/Views/Results/SortableHeaderCell.swift
+++ b/TablePro/Views/Results/SortableHeaderCell.swift
@@ -13,7 +13,6 @@ final class SortableHeaderCell: NSTableHeaderCell {
     var isValueFiltered: Bool = false
     var isFunnelVisible: Bool = false
     var supportsValueFilter: Bool = true
-    var headerComment: String?
 
     private static let indicatorPadding: CGFloat = 4
     private static let indicatorSpacing: CGFloat = 2
@@ -59,7 +58,7 @@ final class SortableHeaderCell: NSTableHeaderCell {
             in: titleRect(forBounds: cellFrame),
             font: titleFont(isSorted: sortDirection != nil),
             color: foreground,
-            comment: visibleComment,
+            comment: visibleComment(in: controlView),
             commentColor: commentColor(emphasized: isColumnSelected)
         )
 
@@ -167,10 +166,9 @@ final class SortableHeaderCell: NSTableHeaderCell {
         return NSFontManager.shared.convert(baseFont, toHaveTrait: .boldFontMask)
     }
 
-    private var visibleComment: String? {
-        guard let headerComment else { return nil }
-        let trimmed = headerComment.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
+    private func visibleComment(in controlView: NSView?) -> String? {
+        guard let headerView = controlView as? SortableHeaderView else { return nil }
+        return headerView.comment(for: self)
     }
 
     private func foregroundColor(emphasized: Bool) -> NSColor {
@@ -260,9 +258,6 @@ final class SortableHeaderCell: NSTableHeaderCell {
         }
         if isValueFiltered {
             components.append(String(localized: "Filtered"))
-        }
-        if let visibleComment {
-            components.append(visibleComment)
         }
         return components.joined(separator: ", ")
     }

--- a/TablePro/Views/Results/SortableHeaderView.swift
+++ b/TablePro/Views/Results/SortableHeaderView.swift
@@ -73,6 +73,7 @@ final class SortableHeaderView: NSTableHeaderView {
     private var hoveredColumnIndex: Int?
 
     private let naturalHeight: CGFloat
+    private var commentsByColumn: [NSUserInterfaceItemIdentifier: String] = [:]
 
     var commentHeaderHeight: CGFloat {
         naturalHeight + SortableHeaderCell.commentLineHeight
@@ -83,6 +84,20 @@ final class SortableHeaderView: NSTableHeaderView {
             guard showsComments != oldValue else { return }
             applyHeaderHeight()
         }
+    }
+
+    func updateComments(_ comments: [NSUserInterfaceItemIdentifier: String]) {
+        guard commentsByColumn != comments else { return }
+        commentsByColumn = comments
+        needsDisplay = true
+    }
+
+    func comment(for cell: NSCell) -> String? {
+        guard let tableView,
+              let column = tableView.tableColumns.first(where: { $0.headerCell === cell }) else {
+            return nil
+        }
+        return commentsByColumn[column.identifier]
     }
 
     override init(frame frameRect: NSRect) {

--- a/TableProTests/Views/Results/DataGridColumnPoolTests.swift
+++ b/TableProTests/Views/Results/DataGridColumnPoolTests.swift
@@ -371,10 +371,12 @@ struct DataGridColumnPoolTests {
         }
     }
 
-    @Test("reconcile assigns column comments to sortable header cells")
-    func reconcile_assignsColumnCommentsToHeaderCells() throws {
+    @Test("reconcile publishes column comments to the header view")
+    func reconcile_publishesColumnCommentsToHeaderView() throws {
         let pool = DataGridColumnPool()
         let tableView = makeTableView()
+        let headerView = SortableHeaderView(frame: NSRect(x: 0, y: 0, width: 200, height: 28))
+        tableView.headerView = headerView
         let schema = ColumnIdentitySchema(columns: ["id", "email"])
 
         pool.reconcile(
@@ -390,8 +392,9 @@ struct DataGridColumnPoolTests {
 
         let emailColumn = try #require(dataColumns(in: tableView).first { $0.headerCell.stringValue == "email" })
         let headerCell = try #require(emailColumn.headerCell as? SortableHeaderCell)
-        #expect(headerCell.headerComment == "Primary contact address")
+        #expect(headerView.comment(for: headerCell) == "Primary contact address")
         #expect(emailColumn.headerToolTip == "email (Text)\nPrimary contact address")
+        #expect(headerCell.accessibilityLabel() == "Column: email, Primary contact address")
 
         pool.reconcile(
             tableView: tableView,
@@ -404,8 +407,9 @@ struct DataGridColumnPoolTests {
             widthCalculator: defaultWidthCalculator
         )
 
-        #expect(headerCell.headerComment == nil)
+        #expect(headerView.comment(for: headerCell) == nil)
         #expect(emailColumn.headerToolTip == "email (Text)")
+        #expect(headerCell.accessibilityLabel() == "Column: email")
     }
 
     @Test("reconcile expands and restores header height based on visible comments")
@@ -485,7 +489,7 @@ struct DataGridColumnPoolTests {
 
         let emailColumn = try #require(dataColumns(in: tableView).first { $0.headerCell.stringValue == "email" })
         let headerCell = try #require(emailColumn.headerCell as? SortableHeaderCell)
-        #expect(headerCell.headerComment == "Primary contact address")
+        #expect(headerView.comment(for: headerCell) == "Primary contact address")
         #expect(headerView.frame.height == headerView.commentHeaderHeight)
     }
 
@@ -523,7 +527,7 @@ struct DataGridColumnPoolTests {
 
         let emailColumn = try #require(dataColumns(in: tableView).first { $0.headerCell.stringValue == "email" })
         let headerCell = try #require(emailColumn.headerCell as? SortableHeaderCell)
-        #expect(headerCell.headerComment == "Work address")
+        #expect(headerView.comment(for: headerCell) == "Work address")
         #expect(emailColumn.headerToolTip == "email (Text)\nWork address")
         #expect(headerView.frame.height == heightAfterFirstReconcile)
     }

--- a/TableProTests/Views/Results/SortableHeaderCellTests.swift
+++ b/TableProTests/Views/Results/SortableHeaderCellTests.swift
@@ -59,13 +59,62 @@ struct SortableHeaderCellTests {
         #expect(prioritizedWidth < sortedWidth)
     }
 
-    @Test("Accessibility label includes the visible header comment")
-    func accessibilityLabelIncludesHeaderComment() {
+    @Test("Accessibility label appends the sort and filter state to the column label")
+    func accessibilityLabelAppendsSortAndFilterState() {
         let cell = SortableHeaderCell(textCell: "email")
-        cell.headerComment = "Primary contact address"
-        cell.setAccessibilityLabel("Column: email")
+        cell.setAccessibilityLabel("Column: email, Primary contact address")
+        cell.sortDirection = .ascending
+        cell.isValueFiltered = true
 
-        #expect(cell.accessibilityLabel() == "Column: email, Primary contact address")
+        #expect(cell.accessibilityLabel() == "Column: email, Primary contact address, Sorted ascending, Filtered")
+    }
+
+    @Test("Header comment is resolved from the header view, not stored on the cell")
+    func headerCommentIsResolvedFromHeaderView() {
+        let comment = heapAllocatedComment()
+        let header = makeHeader(comment: comment)
+
+        #expect(header.view.comment(for: header.cell) == comment)
+    }
+
+    @Test("A copied header cell resolves no comment, so the overflow filler draws none")
+    func copiedHeaderCellResolvesNoComment() throws {
+        let header = makeHeader(comment: heapAllocatedComment())
+        let copy = try #require(header.cell.copy() as? SortableHeaderCell)
+
+        #expect(header.view.comment(for: copy) == nil)
+    }
+
+    @Test("Header cell survives the shallow copies AppKit makes while drawing the header")
+    func headerCellSurvivesShallowCopies() {
+        let comment = heapAllocatedComment()
+        let header = makeHeader(comment: comment)
+
+        for _ in 0..<3 {
+            autoreleasepool {
+                _ = header.cell.copy()
+            }
+        }
+
+        #expect(header.view.comment(for: header.cell) == comment)
+    }
+
+    private func heapAllocatedComment() -> String {
+        String(repeating: "Primary contact address", count: 1)
+    }
+
+    private func makeHeader(comment: String) -> (view: SortableHeaderView, cell: SortableHeaderCell) {
+        let tableView = NSTableView()
+        let cell = SortableHeaderCell(textCell: "email")
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("email"))
+        column.headerCell = cell
+        tableView.addTableColumn(column)
+
+        let headerView = SortableHeaderView(frame: NSRect(x: 0, y: 0, width: 200, height: 28))
+        tableView.headerView = headerView
+        headerView.updateComments([column.identifier: comment])
+
+        return (headerView, cell)
     }
 }
 


### PR DESCRIPTION
Fixes #1869.

Clicking a column header crashes the app with `EXC_BAD_ACCESS` (SIGSEGV) at a garbage address, inside `-[NSTextFieldCell dealloc]` during `NSDisplayCycleFlush`. It reproduces on any table whose last column has a comment longer than 15 UTF-8 bytes.

## Root cause

`SortableHeaderCell` is the repo's only `NSCell` subclass. In 0.56.2 (#1842) it gained `headerComment: String?`, its first reference-counted stored property.

`NSCell.copyWithZone:` is a legacy `NSCopyObject` shallow copy: it bit-copies subclass ivars and re-retains only the ones the Objective-C runtime can see. `class_getIvarLayout` returns NULL for Swift classes, so the Swift ivar is pointer-copied with **no retain**, while the copy's ARC `.cxx_destruct` still releases it on dealloc.

AppKit copies the header cell while drawing (`NSTableHeaderView._preparedHeaderFillerCell`, reached from `drawRect:` and from vibrancy updates). A header click dirties the header, the copy is made and autoreleased, and it dies at `objc_autoreleasePoolPop` inside the display cycle, releasing a string it never retained. The real cell is then left pointing at freed memory.

Comments shorter than 16 UTF-8 bytes live inline in the `String` with no heap object, which is why this only fires on tables with real column comments. Apple's `NSTableColumn` docs require a custom `headerCell` to "properly implement `-copyWithZone:`"; we never did.

This is live in 0.57.0 as well, and #1863 makes comments populate earlier, so it fires more readily there than in 0.56.2.

## The fix

Rather than compensating for the broken copy with a retain, the comment moves off the cell entirely, so the bug class is gone:

- `SortableHeaderCell` now holds only trivial state (a raw-value enum, `Int?`, `Bool`s). With nothing reference-counted, `NSCopyObject` has nothing to get wrong no matter how often AppKit copies it.
- `SortableHeaderView` (an `NSView`, not subject to `NSCopyObject`) owns the comments keyed by column identifier. The cell resolves its comment from `controlView` at draw time.
- `DataGridColumnPool` publishes comments to the header view, and now bakes the comment into the header's accessibility label (it already built the tooltip from the same value), so moving the comment off the cell costs no accessibility.

A copied cell belongs to no column, so it resolves no comment and the overflow filler cell cannot draw a stray one.

## Tests

The existing tests could not have caught this: they assigned comments from **string literals**, which are immortal and never reference-counted. The new tests build the comment at runtime so a real heap object is exercised, then copy the cell the way AppKit does.

- header comment resolves from the header view, not the cell
- a copied cell resolves no comment (overflow filler draws none)
- the cell survives the shallow copies AppKit makes while drawing

All 26 tests across `SortableHeaderCellTests` and `DataGridColumnPoolTests` pass; `swiftlint lint --strict` is clean on the changed files.

## Verification note

Tests cover comment resolution and copy safety, but not drawing. Worth one manual pass on a table with commented columns to confirm the comment still renders in the header and the header still grows to fit it.

https://claude.ai/code/session_01P7qP2VjoTKfq4Nh19roxtu