### PR TITLE
fix(ssh): bound the forwarding channel open so a stuck tunnel fails fast (#1883)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed SSH tunnels that could accept a database connection and then go quiet instead of forwarding it or failing, which showed up as MySQL and MariaDB connections timing out while reading the server greeting. A tunnel that cannot open its forwarding channel now gives up after 10 seconds, closes the connection, and logs the reason, instead of leaving the driver to wait out its own timeout with no explanation. (#1883)
+- Fixed connections being reset when a single database session opened several at once through one SSH tunnel, which could happen while browsing schemas. (#1883)
+
 ## [0.57.1] - 2026-07-15
 
 ### Added

--- a/TablePro/Core/SSH/LibSSH2ChannelIO.swift
+++ b/TablePro/Core/SSH/LibSSH2ChannelIO.swift
@@ -32,10 +32,15 @@ internal struct LibSSH2ChannelIO: SSHChannelIO {
     }
 
     func blockDirections() -> RelayDirections {
-        let directions = sessionQueue.sync { libssh2_session_block_directions(session) }
+        RelayDirections(libssh2BlockDirections: sessionQueue.sync { libssh2_session_block_directions(session) })
+    }
+}
+
+internal extension RelayDirections {
+    init(libssh2BlockDirections directions: Int32) {
         var result: RelayDirections = []
         if directions & LIBSSH2_SESSION_BLOCK_INBOUND != 0 { result.insert(.inbound) }
         if directions & LIBSSH2_SESSION_BLOCK_OUTBOUND != 0 { result.insert(.outbound) }
-        return result
+        self = result
     }
 }

--- a/TablePro/Core/SSH/LibSSH2ForwardChannel.swift
+++ b/TablePro/Core/SSH/LibSSH2ForwardChannel.swift
@@ -7,6 +7,47 @@ import Foundation
 
 import CLibSSH2
 
+/// Result of a single non-blocking attempt to open a forwarding channel.
+internal enum SSHForwardChannelAttempt {
+    case opened(OpaquePointer)
+    case wouldBlock(RelayDirections)
+    case failed(Int32)
+}
+
+/// One non-blocking attempt to open a forwarding channel. Implementations must return
+/// promptly: the caller drives retries and owns the deadline, so an implementation that
+/// blocks would stall every other channel sharing the session.
+internal protocol SSHForwardChannelOpening {
+    func attemptOpen() -> SSHForwardChannelAttempt
+}
+
+/// Bridges `SSHForwardChannelOpening` to libssh2. Each attempt takes the session queue
+/// only long enough to try the open and read back the error and block directions, so a
+/// slow open never holds the queue against relays or keep-alive.
+internal struct LibSSH2ForwardChannelOpener: SSHForwardChannelOpening {
+    let session: OpaquePointer
+    let destination: SSHForwardDestination
+    let originPort: Int
+    let sessionQueue: DispatchQueue
+
+    func attemptOpen() -> SSHForwardChannelAttempt {
+        sessionQueue.sync {
+            if let channel = LibSSH2ForwardChannel.open(
+                session: session,
+                destination: destination,
+                originPort: originPort
+            ) {
+                return .opened(channel)
+            }
+
+            let errorCode = libssh2_session_last_errno(session)
+            guard errorCode == LIBSSH2_ERROR_EAGAIN else { return .failed(errorCode) }
+
+            return .wouldBlock(RelayDirections(libssh2BlockDirections: libssh2_session_block_directions(session)))
+        }
+    }
+}
+
 /// Opens the channel that carries forwarded traffic to the destination. The two libssh2
 /// entry points behave identically to the caller: both return a channel that reads and
 /// writes the same way, and both signal "not ready yet" with `LIBSSH2_ERROR_EAGAIN`.

--- a/TablePro/Core/SSH/LibSSH2Tunnel.swift
+++ b/TablePro/Core/SSH/LibSSH2Tunnel.swift
@@ -28,7 +28,7 @@ internal final class LibSSH2Tunnel: @unchecked Sendable {
     private var forwardingTask: Task<Void, Never>?
     private var keepAliveTask: Task<Void, Never>?
     private let isAlive = OSAllocatedUnfairLock(initialState: true)
-    private let relayTasks = OSAllocatedUnfairLock(initialState: [Task<Void, Never>]())
+    private let clientTasks = OSAllocatedUnfairLock(initialState: [Task<Void, Never>]())
 
     /// Serial queue for all libssh2 calls on this tunnel's session.
     /// libssh2 is not thread-safe per session, so every call must be serialized.
@@ -52,6 +52,13 @@ internal final class LibSSH2Tunnel: @unchecked Sendable {
     }
 
     private static let relayBufferSize = 32_768 // 32KB
+
+    /// Bounds a forwarding channel open. libssh2 retries EAGAIN forever on its own, so
+    /// without this a stuck open outlives the database driver's connect timeout and the
+    /// client waits on a socket nothing will ever write to. Matches the driver's own
+    /// connect timeout so TablePro reports the cause before the driver gives up blind.
+    private static let channelOpenDeadlineSeconds: TimeInterval = 10
+    private static let channelOpenPollTimeoutMs: Int32 = 5_000
 
     init(connectionId: UUID, localPort: Int, session: OpaquePointer,
          socketFD: Int32, listenFD: Int32, jumpChain: [JumpHop] = []) {
@@ -109,20 +116,7 @@ internal final class LibSSH2Tunnel: @unchecked Sendable {
                             break
                         }
 
-                        // Open channel on sessionQueue (serialized libssh2 call),
-                        // then hand off relay to relayQueue (concurrent I/O).
-                        let channel: OpaquePointer? = self.sessionQueue.sync {
-                            self.openForwardChannel(destination: destination)
-                        }
-
-                        guard let channel else {
-                            Self.logger.error("Failed to open forwarding channel to \(target)")
-                            Darwin.close(clientFD)
-                            continue
-                        }
-
-                        Self.logger.debug("Client connected, relaying to \(target)")
-                        self.spawnRelay(clientFD: clientFD, channel: channel)
+                        self.spawnClient(clientFD: clientFD, destination: destination)
                     }
 
                     Self.logger.info("Forwarding loop ended for port \(self.localPort)")
@@ -172,7 +166,7 @@ internal final class LibSSH2Tunnel: @unchecked Sendable {
         // Cancel all tasks so relay loops see isCancelled
         forwardingTask?.cancel()
         keepAliveTask?.cancel()
-        let currentRelayTasks = relayTasks.withLock { tasks -> [Task<Void, Never>] in
+        let currentClientTasks = clientTasks.withLock { tasks -> [Task<Void, Never>] in
             let copy = tasks
             for task in tasks { task.cancel() }
             tasks.removeAll()
@@ -197,7 +191,7 @@ internal final class LibSSH2Tunnel: @unchecked Sendable {
             // Wait for all tasks to exit before touching the session.
             await forwardingTask?.value
             await keepAliveTask?.value
-            for task in currentRelayTasks {
+            for task in currentClientTasks {
                 await task.value
             }
 
@@ -235,7 +229,7 @@ internal final class LibSSH2Tunnel: @unchecked Sendable {
 
         forwardingTask?.cancel()
         keepAliveTask?.cancel()
-        relayTasks.withLock { tasks in
+        clientTasks.withLock { tasks in
             for task in tasks { task.cancel() }
             tasks.removeAll()
         }
@@ -285,36 +279,56 @@ internal final class LibSSH2Tunnel: @unchecked Sendable {
         return clientFD
     }
 
-    /// Open the forwarding channel to the destination, handling EAGAIN with select().
-    /// Must be called on `sessionQueue`.
-    private func openForwardChannel(destination: SSHForwardDestination) -> OpaquePointer? {
-        while isRunning {
-            let channel = LibSSH2ForwardChannel.open(
+    /// Open the channel and relay the client, off the accept loop so a slow open cannot
+    /// stall the next accept, and off `sessionQueue` between attempts so it cannot stall
+    /// the relays and keep-alive that share the session.
+    private func openAndRelay(clientFD: Int32, destination: SSHForwardDestination) {
+        let pump = SSHForwardChannelOpenPump(
+            opener: LibSSH2ForwardChannelOpener(
                 session: session,
                 destination: destination,
-                originPort: localPort
-            )
-
-            if let channel {
-                return channel
+                originPort: localPort,
+                sessionQueue: sessionQueue
+            ),
+            isActive: { [weak self] in self?.isRunning ?? false },
+            deadline: Date().addingTimeInterval(Self.channelOpenDeadlineSeconds),
+            pollForReadiness: { [weak self] directions in
+                guard let self else { return false }
+                return pollReady(
+                    fd: self.socketFD,
+                    directions: directions,
+                    timeoutMs: Self.channelOpenPollTimeoutMs
+                )
             }
+        )
 
-            let errno = libssh2_session_last_errno(session)
-            guard errno == LIBSSH2_ERROR_EAGAIN else {
-                return nil
-            }
-
-            if !waitForSocket(session: session, socketFD: socketFD, timeoutMs: 5_000) {
-                return nil
-            }
+        let outcome = pump.run()
+        logChannelOpenOutcome(outcome, destination: destination)
+        handleChannelOpenOutcome(outcome, clientFD: clientFD) { channel in
+            runRelay(clientFD: clientFD, channel: channel)
         }
-        return nil
     }
 
-    /// Bidirectional relay between a client socket and an SSH channel.
-    /// The relay loop runs on `relayQueue` (concurrent). Individual libssh2 calls
-    /// are dispatched to `sessionQueue` (serial) for thread safety.
-    private func spawnRelay(clientFD: Int32, channel: OpaquePointer) {
+    private func logChannelOpenOutcome(_ outcome: ChannelOpenOutcome, destination: SSHForwardDestination) {
+        let target = destination.logDescription
+        switch outcome {
+        case .opened:
+            Self.logger.debug("Client connected, relaying to \(target)")
+        case .failed(let errorCode):
+            Self.logger.error("Forwarding channel to \(target) failed to open, libssh2 error \(errorCode)")
+        case .timedOut:
+            Self.logger.error(
+                "Forwarding channel to \(target) did not open within \(Int(Self.channelOpenDeadlineSeconds))s, closing local socket"
+            )
+        case .cancelled:
+            break
+        }
+    }
+
+    /// Opens the channel and relays one accepted client, off the accept loop so a slow
+    /// open cannot delay the next accept. The loop runs on `relayQueue` (concurrent);
+    /// individual libssh2 calls are dispatched to `sessionQueue` (serial) for thread safety.
+    private func spawnClient(clientFD: Int32, destination: SSHForwardDestination) {
         let task = Task.detached { [weak self] in
             guard let self else {
                 Darwin.close(clientFD)
@@ -328,12 +342,12 @@ internal final class LibSSH2Tunnel: @unchecked Sendable {
                         Darwin.close(clientFD)
                         return
                     }
-                    self.runRelay(clientFD: clientFD, channel: channel)
+                    self.openAndRelay(clientFD: clientFD, destination: destination)
                 }
             }
         }
 
-        let shouldCancel = relayTasks.withLock { tasks -> Bool in
+        let shouldCancel = clientTasks.withLock { tasks -> Bool in
             tasks.removeAll { $0.isCancelled }
             tasks.append(task)
             return !isAlive.withLock { $0 }
@@ -367,30 +381,5 @@ internal final class LibSSH2Tunnel: @unchecked Sendable {
             Self.logger.info("SSH transport hung up, marking tunnel dead for \(self.connectionId)")
             markDead()
         }
-    }
-
-    /// Wait for the SSH socket to become ready, based on libssh2's block directions.
-    /// Must be called on `sessionQueue` (reads session state via `libssh2_session_block_directions`).
-    private func waitForSocket(session: OpaquePointer, socketFD: Int32, timeoutMs: Int32) -> Bool {
-        let directions = libssh2_session_block_directions(session)
-        return waitForSocketDirections(directions: directions, socketFD: socketFD, timeoutMs: timeoutMs)
-    }
-
-    /// Wait for the SSH socket to become ready with pre-fetched block directions.
-    /// Safe to call from any queue since it does not access the session.
-    private func waitForSocketDirections(directions: Int32, socketFD: Int32, timeoutMs: Int32) -> Bool {
-        var events: Int16 = 0
-        if directions & LIBSSH2_SESSION_BLOCK_INBOUND != 0 {
-            events |= Int16(POLLIN)
-        }
-        if directions & LIBSSH2_SESSION_BLOCK_OUTBOUND != 0 {
-            events |= Int16(POLLOUT)
-        }
-
-        guard events != 0 else { return true }
-
-        var pollFD = pollfd(fd: socketFD, events: events, revents: 0)
-        let rc = poll(&pollFD, 1, timeoutMs)
-        return rc > 0
     }
 }

--- a/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
+++ b/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
@@ -22,6 +22,11 @@ internal enum LibSSH2TunnelFactory {
 
     private static let connectionTimeout: Int32 = 10 // seconds
 
+    /// A single session opens more than one connection through the tunnel: the query
+    /// connection plus the metadata pool. A backlog that cannot hold them resets the
+    /// overflow before the accept loop reaches it.
+    private static let listenBacklogSize: Int32 = 16
+
     // MARK: - Global Init
 
     private static let initialized: Bool = {
@@ -816,7 +821,7 @@ internal enum LibSSH2TunnelFactory {
             throw SSHTunnelError.tunnelCreationFailed("Port \(port) already in use")
         }
 
-        guard listen(listenFD, 5) == 0 else {
+        guard listen(listenFD, Self.listenBacklogSize) == 0 else {
             Darwin.close(listenFD)
             throw SSHTunnelError.tunnelCreationFailed("Failed to listen on port \(port)")
         }

--- a/TablePro/Core/SSH/RelayPollState.swift
+++ b/TablePro/Core/SSH/RelayPollState.swift
@@ -18,3 +18,39 @@ internal func relayFDState(_ revents: Int16) -> RelayFDState {
     if revents & Int16(POLLIN) != 0 { return .readable }
     return .idle
 }
+
+/// Outcome of waiting for a specific direction on the SSH transport. Distinct from
+/// `RelayFDState`, which classifies a read-side poll where "no bits set" means idle.
+/// Here "no bits set" means the wait expired without the requested direction becoming
+/// ready, which must not be mistaken for readiness.
+internal enum TransportPollOutcome: Equatable {
+    case ready
+    case timedOut
+    case hangup
+}
+
+internal func transportPollOutcome(revents: Int16, requestedEvents: Int16) -> TransportPollOutcome {
+    if revents & Int16(POLLERR | POLLNVAL | POLLHUP) != 0 { return .hangup }
+    if revents & requestedEvents != 0 { return .ready }
+    return .timedOut
+}
+
+/// Waits for libssh2's requested block directions to become ready on the transport.
+/// When libssh2 reports no direction, there is nothing to wait on, so this yields
+/// briefly instead of returning immediately, which would let a caller retry in a
+/// zero-yield spin.
+internal func pollReady(fd: Int32, directions: RelayDirections, timeoutMs: Int32) -> Bool {
+    var events: Int16 = 0
+    if directions.contains(.inbound) { events |= Int16(POLLIN) }
+    if directions.contains(.outbound) { events |= Int16(POLLOUT) }
+
+    guard events != 0 else {
+        usleep(directionlessYieldMicroseconds)
+        return true
+    }
+
+    var pollFD = pollfd(fd: fd, events: events, revents: 0)
+    return poll(&pollFD, 1, timeoutMs) > 0
+}
+
+private let directionlessYieldMicroseconds: UInt32 = 1_000

--- a/TablePro/Core/SSH/SSHChannelRelay.swift
+++ b/TablePro/Core/SSH/SSHChannelRelay.swift
@@ -165,11 +165,13 @@ internal struct SSHChannelRelay {
                 if errno == EINTR { continue }
                 return .hangup
             }
-            switch relayFDState(pollFD.revents) {
-            case .stop, .drainThenStop:
+            switch transportPollOutcome(revents: pollFD.revents, requestedEvents: events) {
+            case .hangup:
                 return .hangup
-            case .readable, .idle:
+            case .ready:
                 return .ready
+            case .timedOut:
+                guard isActive() else { return .hangup }
             }
         }
     }

--- a/TablePro/Core/SSH/SSHForwardChannelOpenPump.swift
+++ b/TablePro/Core/SSH/SSHForwardChannelOpenPump.swift
@@ -1,0 +1,60 @@
+//
+//  SSHForwardChannelOpenPump.swift
+//  TablePro
+//
+
+import Foundation
+
+internal enum ChannelOpenOutcome: Equatable {
+    case opened(OpaquePointer)
+    case failed(Int32)
+    case timedOut
+    case cancelled
+}
+
+/// Drives a forwarding channel open to a decision within an app-owned deadline.
+///
+/// libssh2 signals "not ready yet" with `LIBSSH2_ERROR_EAGAIN` and never gives up on its
+/// own, so without a deadline an open can outlive the database driver's own timeout. The
+/// driver then sits on an accepted socket that is never written to and never closed, which
+/// surfaces as a greeting-read timeout with no indication of the cause. Bounding the open
+/// here lets the caller close the socket and name the reason instead.
+internal struct SSHForwardChannelOpenPump {
+    let opener: any SSHForwardChannelOpening
+    let isActive: () -> Bool
+    let deadline: Date
+    let pollForReadiness: (RelayDirections) -> Bool
+    var now: () -> Date = Date.init
+
+    func run() -> ChannelOpenOutcome {
+        while true {
+            guard isActive() else { return .cancelled }
+            guard now() < deadline else { return .timedOut }
+
+            switch opener.attemptOpen() {
+            case .opened(let channel):
+                return .opened(channel)
+            case .failed(let errorCode):
+                return .failed(errorCode)
+            case .wouldBlock(let directions):
+                guard pollForReadiness(directions) else { return .timedOut }
+            }
+        }
+    }
+}
+
+/// Hands an opened channel to the relay, and closes the local socket on every other
+/// outcome so the client fails fast instead of waiting out its own read timeout on a
+/// socket nothing will ever write to.
+internal func handleChannelOpenOutcome(
+    _ outcome: ChannelOpenOutcome,
+    clientFD: Int32,
+    onOpened: (OpaquePointer) -> Void
+) {
+    switch outcome {
+    case .opened(let channel):
+        onOpened(channel)
+    case .failed, .timedOut, .cancelled:
+        Darwin.close(clientFD)
+    }
+}

--- a/TableProTests/Core/SSH/RelayPollStateTests.swift
+++ b/TableProTests/Core/SSH/RelayPollStateTests.swift
@@ -52,3 +52,64 @@ struct RelayPollStateTests {
         #expect(relayFDState(Int16(POLLHUP) | Int16(POLLERR)) == .stop)
     }
 }
+
+@Suite("transportPollOutcome")
+struct TransportPollOutcomeTests {
+    @Test("An expired wait is not readiness")
+    func timeoutIsNotReady() {
+        #expect(transportPollOutcome(revents: 0, requestedEvents: Int16(POLLIN)) == .timedOut)
+    }
+
+    @Test("The requested direction becoming ready is readiness")
+    func requestedDirectionReady() {
+        #expect(transportPollOutcome(revents: Int16(POLLIN), requestedEvents: Int16(POLLIN)) == .ready)
+        #expect(transportPollOutcome(revents: Int16(POLLOUT), requestedEvents: Int16(POLLOUT)) == .ready)
+    }
+
+    @Test("Another direction becoming ready is not the requested one")
+    func otherDirectionIsNotReady() {
+        #expect(transportPollOutcome(revents: Int16(POLLIN), requestedEvents: Int16(POLLOUT)) == .timedOut)
+    }
+
+    @Test("Hangup and errors end the wait")
+    func hangupEndsWait() {
+        #expect(transportPollOutcome(revents: Int16(POLLHUP), requestedEvents: Int16(POLLOUT)) == .hangup)
+        #expect(transportPollOutcome(revents: Int16(POLLERR), requestedEvents: Int16(POLLOUT)) == .hangup)
+        #expect(transportPollOutcome(revents: Int16(POLLNVAL), requestedEvents: Int16(POLLOUT)) == .hangup)
+    }
+
+    @Test("Hangup wins over the requested direction")
+    func hangupWinsOverReady() {
+        #expect(transportPollOutcome(revents: Int16(POLLOUT) | Int16(POLLHUP), requestedEvents: Int16(POLLOUT)) == .hangup)
+    }
+}
+
+@Suite("pollReady")
+struct PollReadyTests {
+    @Test("A directionless wait yields and retries instead of spinning")
+    func directionlessYields() {
+        let pair = SocketPair()
+        defer { pair.close() }
+
+        #expect(pollReady(fd: pair.a, directions: [], timeoutMs: 5_000))
+    }
+
+    @Test("Readable data satisfies an inbound wait")
+    func inboundReady() {
+        let pair = SocketPair()
+        defer { pair.close() }
+
+        var byte: UInt8 = 1
+        _ = Darwin.send(pair.b, &byte, 1, 0)
+
+        #expect(pollReady(fd: pair.a, directions: .inbound, timeoutMs: 1_000))
+    }
+
+    @Test("An inbound wait with no data expires")
+    func inboundExpires() {
+        let pair = SocketPair()
+        defer { pair.close() }
+
+        #expect(pollReady(fd: pair.a, directions: .inbound, timeoutMs: 50) == false)
+    }
+}

--- a/TableProTests/Core/SSH/SSHChannelRelayTests.swift
+++ b/TableProTests/Core/SSH/SSHChannelRelayTests.swift
@@ -139,6 +139,50 @@ struct SSHChannelRelayTests {
         #expect(io.written == payload)
     }
 
+    @Test("Concurrent relays sharing one transport each receive their own channel data")
+    func concurrentRelaysShareTransport() {
+        let transport = SocketPair()
+        let first = SocketPair()
+        let second = SocketPair()
+        defer { transport.close(); first.close(); second.close() }
+
+        var dummy: UInt8 = 1
+        _ = Darwin.send(transport.b, &dummy, 1, 0)
+
+        let firstPayload = Data("first".utf8)
+        let secondPayload = Data("second".utf8)
+        let firstIO = FakeChannelIO(actions: [.data(firstPayload)], fallback: .closed)
+        let secondIO = FakeChannelIO(actions: [.data(secondPayload)], fallback: .closed)
+
+        let group = DispatchGroup()
+        let firstBox = ResultBox()
+        let secondBox = ResultBox()
+
+        for (localFD, io, box) in [(first.a, firstIO, firstBox), (second.a, secondIO, secondBox)] {
+            group.enter()
+            runRelayOnDedicatedThread(
+                localFD: localFD,
+                transportFD: transport.a,
+                io: io,
+                isActive: { true },
+                box: box
+            ) { group.leave() }
+        }
+
+        #expect(group.wait(timeout: .now() + 5) == .success)
+        #expect(firstBox.value == .channelClosed)
+        #expect(secondBox.value == .channelClosed)
+        #expect(readPayload(from: first.b, count: firstPayload.count) == firstPayload)
+        #expect(readPayload(from: second.b, count: secondPayload.count) == secondPayload)
+    }
+
+    private func readPayload(from fd: Int32, count: Int) -> Data {
+        var buffer = [UInt8](repeating: 0, count: count)
+        let received = recv(fd, &buffer, count, 0)
+        guard received > 0 else { return Data() }
+        return Data(buffer.prefix(received))
+    }
+
     private func runRelay(
         localFD: Int32,
         transportFD: Int32,
@@ -148,43 +192,47 @@ struct SSHChannelRelayTests {
     ) -> RelayTermination? {
         let box = ResultBox()
         let semaphore = DispatchSemaphore(value: 0)
-        DispatchQueue.global().async {
-            let relay = SSHChannelRelay(
-                localFD: localFD,
-                transportFD: transportFD,
-                channelIO: io,
-                bufferSize: 32_768,
-                isActive: isActive
-            )
-            box.value = relay.run()
-            semaphore.signal()
-        }
+        runRelayOnDedicatedThread(
+            localFD: localFD,
+            transportFD: transportFD,
+            io: io,
+            isActive: isActive,
+            box: box
+        ) { semaphore.signal() }
         _ = semaphore.wait(timeout: .now() + timeout)
         return box.value
     }
 }
 
-private final class ResultBox: @unchecked Sendable {
-    var value: RelayTermination?
+/// Runs a relay on a thread of its own rather than borrowing from the shared global
+/// queue. The relay loop blocks its thread for as long as it runs, and the test suite
+/// runs in parallel, so relays sharing the global queue's bounded pool can starve each
+/// other and time out on machines under load.
+internal func runRelayOnDedicatedThread(
+    localFD: Int32,
+    transportFD: Int32,
+    io: any SSHChannelIO,
+    isActive: @escaping @Sendable () -> Bool,
+    box: ResultBox,
+    onFinish: @escaping @Sendable () -> Void
+) {
+    let thread = Thread {
+        let relay = SSHChannelRelay(
+            localFD: localFD,
+            transportFD: transportFD,
+            channelIO: io,
+            bufferSize: 32_768,
+            isActive: isActive
+        )
+        box.value = relay.run()
+        onFinish()
+    }
+    thread.stackSize = 512 * 1_024
+    thread.start()
 }
 
-private final class SocketPair {
-    let a: Int32
-    let b: Int32
-
-    init() {
-        var fds: [Int32] = [0, 0]
-        _ = socketpair(AF_UNIX, SOCK_STREAM, 0, &fds)
-        a = fds[0]
-        b = fds[1]
-    }
-
-    func closeB() { Darwin.close(b) }
-
-    func close() {
-        Darwin.close(a)
-        Darwin.close(b)
-    }
+internal final class ResultBox: @unchecked Sendable {
+    var value: RelayTermination?
 }
 
 private final class FakeChannelIO: SSHChannelIO, @unchecked Sendable {

--- a/TableProTests/Core/SSH/SSHForwardChannelOpenPumpTests.swift
+++ b/TableProTests/Core/SSH/SSHForwardChannelOpenPumpTests.swift
@@ -1,0 +1,236 @@
+//
+//  SSHForwardChannelOpenPumpTests.swift
+//  TableProTests
+//
+//  Tests the deadline that bounds a forwarding channel open. Without it a stuck open
+//  outlives the database driver's connect timeout, leaving an accepted socket that is
+//  never written to and never closed, which the driver reports as a greeting-read
+//  timeout with no stated cause (#1883).
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("SSHForwardChannelOpenPump")
+struct SSHForwardChannelOpenPumpTests {
+    @Test("An immediately available channel opens without polling")
+    func opensWithoutPolling() {
+        let opener = FakeChannelOpener(attempts: [.opened(Self.fakeChannel)])
+        let polls = CountBox()
+
+        let outcome = makePump(opener: opener, polls: polls).run()
+
+        #expect(outcome == .opened(Self.fakeChannel))
+        #expect(opener.attemptCount == 1)
+        #expect(polls.value == 0)
+    }
+
+    @Test("A non-EAGAIN failure returns immediately without polling")
+    func failsFastWithoutPolling() {
+        let opener = FakeChannelOpener(attempts: [.failed(42)])
+        let polls = CountBox()
+
+        let outcome = makePump(opener: opener, polls: polls).run()
+
+        #expect(outcome == .failed(42))
+        #expect(opener.attemptCount == 1)
+        #expect(polls.value == 0)
+    }
+
+    @Test("Retries through wouldBlock until the channel opens")
+    func retriesUntilOpened() {
+        let opener = FakeChannelOpener(attempts: [
+            .wouldBlock(.inbound),
+            .wouldBlock(.outbound),
+            .opened(Self.fakeChannel),
+        ])
+        let polls = CountBox()
+
+        let outcome = makePump(opener: opener, polls: polls).run()
+
+        #expect(outcome == .opened(Self.fakeChannel))
+        #expect(opener.attemptCount == 3)
+        #expect(polls.value == 2)
+    }
+
+    @Test("A never-ready open gives up at the deadline instead of retrying forever")
+    func timesOutAtDeadline() {
+        let opener = FakeChannelOpener(fallback: .wouldBlock(.inbound))
+        let clock = SteppingClock(step: 1)
+
+        let pump = SSHForwardChannelOpenPump(
+            opener: opener,
+            isActive: { true },
+            deadline: clock.start.addingTimeInterval(5),
+            pollForReadiness: { _ in true },
+            now: clock.now
+        )
+
+        #expect(pump.run() == .timedOut)
+        #expect(opener.attemptCount <= 6)
+    }
+
+    @Test("A directionless open cannot spin past the deadline")
+    func directionlessOpenTimesOut() {
+        let opener = FakeChannelOpener(fallback: .wouldBlock([]))
+        let clock = SteppingClock(step: 1)
+
+        let pump = SSHForwardChannelOpenPump(
+            opener: opener,
+            isActive: { true },
+            deadline: clock.start.addingTimeInterval(3),
+            pollForReadiness: { _ in true },
+            now: clock.now
+        )
+
+        #expect(pump.run() == .timedOut)
+    }
+
+    @Test("A failed readiness wait gives up instead of retrying")
+    func unreadyTransportTimesOut() {
+        let opener = FakeChannelOpener(fallback: .wouldBlock(.inbound))
+
+        let pump = SSHForwardChannelOpenPump(
+            opener: opener,
+            isActive: { true },
+            deadline: Date().addingTimeInterval(60),
+            pollForReadiness: { _ in false }
+        )
+
+        #expect(pump.run() == .timedOut)
+        #expect(opener.attemptCount == 1)
+    }
+
+    @Test("Teardown during a retry cancels the open")
+    func cancelsOnTeardown() {
+        let opener = FakeChannelOpener(fallback: .wouldBlock(.inbound))
+        let active = FlagBox(value: true)
+
+        let pump = SSHForwardChannelOpenPump(
+            opener: opener,
+            isActive: { active.value },
+            deadline: Date().addingTimeInterval(60),
+            pollForReadiness: { _ in
+                active.value = false
+                return true
+            }
+        )
+
+        #expect(pump.run() == .cancelled)
+    }
+
+    private func makePump(opener: FakeChannelOpener, polls: CountBox) -> SSHForwardChannelOpenPump {
+        SSHForwardChannelOpenPump(
+            opener: opener,
+            isActive: { true },
+            deadline: Date().addingTimeInterval(60),
+            pollForReadiness: { _ in
+                polls.value += 1
+                return true
+            }
+        )
+    }
+
+    private static let fakeChannel = OpaquePointer(bitPattern: 0xDEAD_BEEF)!
+}
+
+@Suite("handleChannelOpenOutcome")
+struct HandleChannelOpenOutcomeTests {
+    @Test("An opened channel is relayed and the local socket stays open")
+    func openedKeepsSocket() {
+        let pair = SocketPair()
+        defer { pair.close() }
+
+        let channel = OpaquePointer(bitPattern: 0xFEED)!
+        var relayed: OpaquePointer?
+        handleChannelOpenOutcome(.opened(channel), clientFD: pair.a) { relayed = $0 }
+
+        #expect(relayed == channel)
+
+        var byte: UInt8 = 7
+        #expect(Darwin.send(pair.b, &byte, 1, 0) == 1)
+    }
+
+    @Test("A libssh2 failure closes the local socket so the client fails fast")
+    func failedClosesSocket() {
+        expectLocalSocketClosed(for: .failed(42))
+    }
+
+    @Test("A channel open that hits the deadline closes the local socket")
+    func timedOutClosesSocket() {
+        expectLocalSocketClosed(for: .timedOut)
+    }
+
+    @Test("A cancelled channel open closes the local socket")
+    func cancelledClosesSocket() {
+        expectLocalSocketClosed(for: .cancelled)
+    }
+
+    private func expectLocalSocketClosed(for outcome: ChannelOpenOutcome) {
+        let pair = SocketPair()
+        defer { Darwin.close(pair.b) }
+
+        var relayed = false
+        handleChannelOpenOutcome(outcome, clientFD: pair.a) { _ in relayed = true }
+
+        #expect(relayed == false)
+
+        var byte: UInt8 = 0
+        #expect(recv(pair.b, &byte, 1, 0) == 0)
+    }
+}
+
+private final class CountBox: @unchecked Sendable {
+    var value = 0
+}
+
+private final class FlagBox: @unchecked Sendable {
+    var value: Bool
+
+    init(value: Bool) {
+        self.value = value
+    }
+}
+
+/// Returns timestamps that advance by a fixed step on every read, so a deadline is
+/// reached deterministically without sleeping.
+private final class SteppingClock: @unchecked Sendable {
+    let start = Date(timeIntervalSince1970: 0)
+    private let step: TimeInterval
+    private var reads = 0
+
+    init(step: TimeInterval) {
+        self.step = step
+    }
+
+    func now() -> Date {
+        defer { reads += 1 }
+        return start.addingTimeInterval(step * Double(reads))
+    }
+}
+
+private final class FakeChannelOpener: SSHForwardChannelOpening, @unchecked Sendable {
+    private let lock = NSLock()
+    private var attempts: [SSHForwardChannelAttempt]
+    private let fallback: SSHForwardChannelAttempt
+    private var madeAttempts = 0
+
+    init(attempts: [SSHForwardChannelAttempt] = [], fallback: SSHForwardChannelAttempt = .wouldBlock(.inbound)) {
+        self.attempts = attempts
+        self.fallback = fallback
+    }
+
+    var attemptCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return madeAttempts
+    }
+
+    func attemptOpen() -> SSHForwardChannelAttempt {
+        lock.lock()
+        defer { lock.unlock() }
+        madeAttempts += 1
+        return attempts.isEmpty ? fallback : attempts.removeFirst()
+    }
+}

--- a/TableProTests/Core/SSH/TestSupport/SocketPair.swift
+++ b/TableProTests/Core/SSH/TestSupport/SocketPair.swift
@@ -1,0 +1,28 @@
+//
+//  SocketPair.swift
+//  TableProTests
+//
+
+import Foundation
+
+/// A connected pair of local socket fds, used to drive relay and channel-open tests over
+/// real sockets rather than fakes, so closing behaviour is observed the way a database
+/// client would observe it.
+internal final class SocketPair {
+    let a: Int32
+    let b: Int32
+
+    init() {
+        var fds: [Int32] = [0, 0]
+        _ = socketpair(AF_UNIX, SOCK_STREAM, 0, &fds)
+        a = fds[0]
+        b = fds[1]
+    }
+
+    func closeB() { Darwin.close(b) }
+
+    func close() {
+        Darwin.close(a)
+        Darwin.close(b)
+    }
+}

--- a/docs/databases/ssh-tunneling.mdx
+++ b/docs/databases/ssh-tunneling.mdx
@@ -125,6 +125,8 @@ Paste a `scheme+ssh://` URL to create a connection with SSH pre-filled. The `+ss
 
 **Tunnel connects but the database fails**: the database host is resolved from the SSH server, not your Mac. Verify it from the server: `ssh user@server "nc -z db-host 5432"`. Also check that the database credentials differ from the SSH ones where they should.
 
+**Tunnel connects but the database times out reading the server greeting**: the tunnel could not open its forwarding channel to the database. TablePro gives up after 10 seconds and closes the connection. Open Console.app and filter on `com.TablePro` to see the `LibSSH2Tunnel` message naming the destination and the reason. Check that the SSH server allows TCP forwarding (`AllowTcpForwarding yes`) and that it can reach the database host itself.
+
 **Tunnel drops on idle networks**: TablePro already sends a libssh2 keep-alive every 30 seconds plus OS-level TCP keep-alives. If tunnels still drop, check the server's `ClientAliveInterval` and idle timeouts on firewalls or load balancers in between.
 
 **Firewall prompt on connect**: TablePro listens on a local port between 60000 and 65000 for the tunnel. Allow it.


### PR DESCRIPTION
Fixes #1883.

## The error code is the diagnosis

`system error: 60` is `ETIMEDOUT`: the client's read of the MySQL greeting expired. I measured what each tunnel behaviour actually reports, using the connector TablePro ships (`Libs/libmariadb.a`) with the same options as `MariaDBPluginConnection`, against a real OpenSSH server and a real `mysql:8.4` container:

| Tunnel behaviour | MariaDB error | Elapsed |
| --- | --- | --- |
| Healthy | connects | ~5ms |
| Destination refused | `system error: 35` | ~0ms |
| Destination blackholed, remote `connect()` hangs | `system error: 35` | 5001ms |
| **Accepted, then silent** | **`system error: 60`** | 10001ms |
| **`listen()` up but `accept()` never called** | **`system error: 60`** | 10001ms |

So error 60 is a positive fingerprint: the tunnel accepted the socket (or left it completed in the listen backlog), never wrote to it, and never closed it. Every path where TablePro *detects* a failure closes the fd and yields error 35 instead. That rules out a wrong or unreachable destination, and explains why `127.0.0.1`, `localhost`, and the docker service name all failed identically for the reporter: the destination never mattered, because nothing got that far.

It also pins the budget: the greeting read during `mysql_real_connect` is governed by `MYSQL_OPT_CONNECT_TIMEOUT` (10s), not `MYSQL_OPT_READ_TIMEOUT` (30s).

## Root cause

Stated honestly: Render's SSH gateway is a custom, undocumented proxy that I cannot replicate locally, so I cannot point at one line and say "this fired for this user". What is provable is that `LibSSH2Tunnel` had several structural paths that produce exactly that silence, and none of them logged a cause:

- **`openForwardChannel` had no wall-clock deadline.** It retried libssh2's `EAGAIN` for as long as libssh2 kept asking, bounded only by a per-iteration 5s poll, with no cap on iterations. libssh2 never gives up on its own.
- **It ran inside `sessionQueue.sync` on the accept thread.** So one slow open blocked the next `accept()` and queued every live relay's channel read and write behind it, on a queue every connection shares. `MetadataConnectionPool` opens up to 6 more connections through the same tunnel.
- **`waitForSocketDirections` returned `true` immediately when libssh2 reported no block direction**, which turns the retry into a zero-yield spin holding that queue.
- **`listen(fd, 5)`** could not hold the connections one session opens.
- **`waitForTransport` treated a poll timeout as "ready"**, manufacturing readiness from no event (write path only, but the same class of bug).

## The fix

Channel-open becomes a non-blocking state machine driven off the accept loop, bounded by a 10s app-owned deadline. This mirrors the precedent already in this codebase for PostgreSQL's `PQconnectStart`/`PQconnectPoll`, and the CLAUDE.md invariant it came from. Each attempt takes `sessionQueue` only long enough to try the open and read back errno and block-directions atomically; the waiting happens off the queue. On failure or deadline the local socket is closed and an OSLog line names the destination and reason, so a repeat is diagnosable instead of silent.

**Deliberately not a rewrite.** DBeaver and DataGrip (JSch, sshj) use a single transport-reader thread, which tempts one. But `SSHChannelRelay`'s unconditional 500ms pump is already the mechanism that makes server-speaks-first MySQL work, and it is verified working here (1/2/4 concurrent clients, 0 to 300ms latency). It also bounds libssh2's [acknowledged, unfixed-since-2014 multi-channel lost-wakeup defect](https://libssh2.org/mail/libssh2-devel-archive-2014-06/0028.shtml) to ~500ms; a run measured a greeting arriving at 503ms, which is that fallback doing its job. Rebuilding demuxing that libssh2 already does internally would be a large regression risk for no proven gain.

Worth recording: `libssh2_keepalive_send` is send-only (`src/keepalive.c` never calls `_libssh2_transport_read`), so keepalive can never rescue a stalled channel. And Sequel Ace, contrary to a common assumption, does not use libssh2 at all: it shells out to `/usr/bin/ssh`.

## Verification

Compiled TablePro's real SSH sources into a standalone harness against the shipped `libssh2.a` and drove them against real containers.

- **No regression on the healthy path**: 1/2/4 concurrent clients all receive the greeting at 0ms, 100ms, and 300ms injected latency (netem). Real `ssh -L` was used as ground truth.
- **Backlog fix measured**: backlog 5 gave 5/8 clients (three `ECONNRESET`); backlog 16 gives 8/8, and 12/12 at the metadata-pool worst case.

New tests, on the existing fake-`SSHChannelIO` seam:

- The channel-open deadline test (loops forever against the old code).
- `transportPollOutcome` timeout test (returns `.ready` against the old code).
- Three tests proving a failed, timed-out, or cancelled open actually closes the local fd, observed through a real socketpair.
- Two relays sharing one `transportFD`, the gap that had no coverage.

`swiftlint lint --strict` clean.

## Also in here

`SSHChannelRelayTests.forwardsChannelData` was **already flaky on `main`** before this branch. I confirmed it by stashing this work and running clean `main`: it failed run 1, passed run 2. The suite ran blocking relay loops on the shared GCD global pool, which starves under swift-testing's parallel execution, so `runRelay`'s 3s wait expired and the result stayed nil. Since the new concurrent-relay test adds two more relays to that pool, the suite now runs each relay on a dedicated thread. Three consecutive full runs: 0 failures.

## Honest limits

- **This may not make the reporter's connection succeed.** It guarantees a fast, closed, logged failure instead of a 10s silent hang. If Render's gateway genuinely needs more than 10 seconds to open a channel, they will now get a clear TablePro error naming the cause. Worth asking them for the `com.TablePro` Console output.
- `channelOpenDeadlineSeconds = 10` matches the existing `connectionTimeout` and the driver's own connect timeout; `listenBacklogSize = 16` is sized off the proven concurrency. Both are judgment calls.

## Follow-ups found, deliberately out of scope

- `LibSSH2TunnelFactory.openChannel` (jump-host chaining) has the same unbounded shape, but at tunnel setup time, where there is no accepted client socket to leave silent.
- TableProMobile has an independent SSH stack (no shared code, verified) with an analogous unbounded `openDirectTcpipChannel` loop on its actor's executor.

## Test plan

- [ ] Build and run; connect MySQL/MariaDB over an SSH tunnel and confirm normal connects still work.
- [ ] Browse schemas on a tunnelled connection (exercises the metadata pool and the backlog).
- [ ] Point a tunnel at an unreachable destination and confirm it fails quickly with a `LibSSH2Tunnel` log line rather than hanging.
