### PR TITLE
fix(editor): stop treating a trailing comment as a second SQL statement

### DIFF
--- a/.github/macos-test-quarantine.txt
+++ b/.github/macos-test-quarantine.txt
@@ -57,4 +57,3 @@ DataChangeManagerTests
 CoordinatorEditorLoadTests
 CommandActionsDispatchTests
 ChatToolSpecCopilotTests
-SQLStatementScannerLocatedTests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a query with a comment after the closing semicolon, such as `SELECT 1; -- note`, being run as two statements, with the trailing comment sent to the server as a failing second statement. Running a comment-only query or selection now does nothing instead of producing a server error, and AI and MCP clients are no longer told such a query is multi-statement. (#1895)
 - Fixed duplicating a connection dropping its Cloudflare Tunnel and Cloud SQL Auth Proxy settings and stored secrets.
 - Fixed the tunnel panes warning about only some of the other enabled connection methods. Each pane now lists every conflicting method with a button to turn it off.
 - Fixed Copy as, the context menu's Delete, and the Edit menu's copy and delete commands acting on only the active row instead of every row in a cell-range or column selection in the data grid. (#1898)

--- a/TablePro/Core/Utilities/SQL/SQLStatementScanner.swift
+++ b/TablePro/Core/Utilities/SQL/SQLStatementScanner.swift
@@ -15,7 +15,8 @@ enum SQLStatementScanner {
     /// Returns statements with trailing semicolons stripped, for driver execution.
     static func allStatements(in sql: String, dialect: SqlDialect = .generic) -> [String] {
         var results: [String] = []
-        scan(sql: sql, cursorPosition: nil, dialect: dialect) { rawSQL, _ in
+        scan(sql: sql, cursorPosition: nil, dialect: dialect) { rawSQL, _, hasStatementContent in
+            guard hasStatementContent else { return true }
             var trimmed = rawSQL.trimmingCharacters(in: .whitespacesAndNewlines)
             if trimmed.hasSuffix(";") {
                 trimmed = String(trimmed.dropLast())
@@ -32,7 +33,8 @@ enum SQLStatementScanner {
     /// Returns statements preserving trailing semicolons, for display/history/favorites.
     static func allStatementsPreservingSemicolons(in sql: String) -> [String] {
         var results: [String] = []
-        scan(sql: sql, cursorPosition: nil) { rawSQL, _ in
+        scan(sql: sql, cursorPosition: nil) { rawSQL, _, hasStatementContent in
+            guard hasStatementContent else { return true }
             let trimmed = rawSQL.trimmingCharacters(in: .whitespacesAndNewlines)
             let withoutSemicolon = trimmed.hasSuffix(";")
                 ? String(trimmed.dropLast()).trimmingCharacters(in: .whitespacesAndNewlines)
@@ -58,7 +60,7 @@ enum SQLStatementScanner {
 
     static func locatedStatementAtCursor(in sql: String, cursorPosition: Int, dialect: SqlDialect = .generic) -> LocatedStatement {
         var result = LocatedStatement(sql: "", offset: 0)
-        scan(sql: sql, cursorPosition: cursorPosition, dialect: dialect) { rawSQL, offset in
+        scan(sql: sql, cursorPosition: cursorPosition, dialect: dialect) { rawSQL, offset, _ in
             result = LocatedStatement(sql: rawSQL, offset: offset)
             return false
         }
@@ -77,21 +79,24 @@ enum SQLStatementScanner {
     private static let newline = UInt16(UnicodeScalar("\n").value)
     private static let backslash = UInt16(UnicodeScalar("\\").value)
     private static let dollar = UInt16(UnicodeScalar("$").value)
+    private static let exclamationMark = UInt16(UnicodeScalar("!").value)
+    private static let space = UInt16(UnicodeScalar(" ").value)
+    private static let tab = UInt16(UnicodeScalar("\t").value)
+    private static let carriageReturn = UInt16(UnicodeScalar("\r").value)
+
+    private static func isWhitespace(_ ch: UInt16) -> Bool {
+        ch == space || ch == tab || ch == newline || ch == carriageReturn
+    }
 
     private static func scan(
         sql: String,
         cursorPosition: Int?,
         dialect: SqlDialect = .generic,
-        onStatement: (_ rawSQL: String, _ offset: Int) -> Bool
+        onStatement: (_ rawSQL: String, _ offset: Int, _ hasStatementContent: Bool) -> Bool
     ) {
         let nsQuery = sql as NSString
         let length = nsQuery.length
         guard length > 0 else { return }
-
-        guard nsQuery.range(of: ";").location != NSNotFound else {
-            _ = onStatement(sql, 0)
-            return
-        }
 
         let safePosition = cursorPosition.map { min(max(0, $0), length) }
 
@@ -102,6 +107,7 @@ enum SQLStatementScanner {
         var inBlockComment = false
         var inDollarQuote = false
         var dollarTag = ""
+        var hasStatementContent = false
         let dollarQuotesEnabled = dialect.supportsDollarQuotes
         var i = 0
 
@@ -143,6 +149,9 @@ enum SQLStatementScanner {
             }
 
             if !inString && ch == slash && i + 1 < length && nsQuery.character(at: i + 1) == star {
+                if i + 2 < length && nsQuery.character(at: i + 2) == exclamationMark {
+                    hasStatementContent = true
+                }
                 inBlockComment = true
                 i += 2
                 continue
@@ -170,6 +179,7 @@ enum SQLStatementScanner {
                case .opener(let openerLength, let tag) = SqlDollarQuote.scanOpener(at: i, in: nsQuery, bufLen: length) {
                 inDollarQuote = true
                 dollarTag = tag
+                hasStatementContent = true
                 i += openerLength
                 continue
             }
@@ -180,15 +190,18 @@ enum SQLStatementScanner {
                 if let cursor = safePosition {
                     if cursor >= currentStart && cursor <= stmtEnd {
                         let stmtRange = NSRange(location: currentStart, length: stmtEnd - currentStart)
-                        _ = onStatement(nsQuery.substring(with: stmtRange), currentStart)
+                        _ = onStatement(nsQuery.substring(with: stmtRange), currentStart, hasStatementContent)
                         return
                     }
                 } else {
                     let stmtRange = NSRange(location: currentStart, length: stmtEnd - currentStart)
-                    if !onStatement(nsQuery.substring(with: stmtRange), currentStart) { return }
+                    if !onStatement(nsQuery.substring(with: stmtRange), currentStart, hasStatementContent) { return }
                 }
 
                 currentStart = stmtEnd
+                hasStatementContent = false
+            } else if !isWhitespace(ch) {
+                hasStatementContent = true
             }
 
             i += 1
@@ -196,7 +209,7 @@ enum SQLStatementScanner {
 
         if currentStart < length {
             let stmtRange = NSRange(location: currentStart, length: length - currentStart)
-            _ = onStatement(nsQuery.substring(with: stmtRange), currentStart)
+            _ = onStatement(nsQuery.substring(with: stmtRange), currentStart, hasStatementContent)
         }
     }
 }

--- a/TableProTests/Core/Services/Execution/ExecutionGateTests.swift
+++ b/TableProTests/Core/Services/Execution/ExecutionGateTests.swift
@@ -375,6 +375,19 @@ struct ExecutionGateTests {
         #expect(allowed.isAuthorized)
     }
 
+    @Test("A trailing comment after the semicolon is not denied as multi-statement")
+    func trailingCommentNotDeniedAsMultiStatement() async {
+        let confirm = StubConfirming(answer: true)
+        let auth = StubAuthenticating(answer: true)
+        let gate = makeGate(level: .silent, confirm: confirm, auth: auth)
+
+        let decision = await gate.authorize(
+            makeRequest(sql: "SELECT 1; -- note", kind: .readQuery, capabilities: [.mayWrite])
+        )
+
+        #expect(decision.isAuthorized)
+    }
+
     // MARK: - Pre-cleared and cannot-prompt
 
     @Test("Pre-cleared caller skips confirmation and auth")

--- a/TableProTests/Core/Utilities/SQL/QueryClassifierTests.swift
+++ b/TableProTests/Core/Utilities/SQL/QueryClassifierTests.swift
@@ -93,3 +93,22 @@ struct QueryClassifierKeywordBoundaryTests {
         #expect(QueryClassifier.classifyTier("UPDATE\nt SET x = 1", databaseType: .mysql) == .write)
     }
 }
+
+@Suite("QueryClassifier isMultiStatement")
+struct QueryClassifierMultiStatementTests {
+    @Test("A trailing comment after the terminating semicolon is not a second statement")
+    func trailingCommentIsNotMultiStatement() {
+        #expect(!QueryClassifier.isMultiStatement("SELECT 1; -- note", databaseType: .mysql))
+        #expect(!QueryClassifier.isMultiStatement("SELECT 1; /* note */", databaseType: .postgresql))
+    }
+
+    @Test("Two real statements are still multi-statement")
+    func twoRealStatementsAreMultiStatement() {
+        #expect(QueryClassifier.isMultiStatement("SELECT 1; SELECT 2", databaseType: .mysql))
+    }
+
+    @Test("A comment-only query is not multi-statement")
+    func commentOnlyQueryIsNotMultiStatement() {
+        #expect(!QueryClassifier.isMultiStatement("-- note", databaseType: .mysql))
+    }
+}

--- a/TableProTests/Core/Utilities/SQLStatementScannerLocatedTests.swift
+++ b/TableProTests/Core/Utilities/SQLStatementScannerLocatedTests.swift
@@ -143,7 +143,7 @@ struct SQLStatementScannerLocatedTests {
     @Test("Handles very large input without crashing")
     func largeInput() {
         var parts: [String] = []
-        for i in 0..<200 {
+        for i in 0..<300 {
             parts.append("SELECT \(i) FROM very_long_table_name_for_testing;")
         }
         let sql = parts.joined(separator: " ")

--- a/TableProTests/Core/Utilities/SQLStatementScannerLocatedTests.swift
+++ b/TableProTests/Core/Utilities/SQLStatementScannerLocatedTests.swift
@@ -180,4 +180,18 @@ struct SQLStatementScannerLocatedTests {
         #expect(first.sql == "SELECT 'it''s here';")
         #expect(first.offset == 0)
     }
+
+    @Test("Cursor inside a trailing comment still returns the raw comment text")
+    func cursorInsideTrailingCommentReturnsRawText() {
+        let sql = "SELECT 1; -- note"
+        let located = SQLStatementScanner.locatedStatementAtCursor(in: sql, cursorPosition: 15)
+        #expect(located.sql == " -- note")
+        #expect(located.offset == 9)
+    }
+
+    @Test("statementAtCursor returns comment text for a cursor sitting in a trailing comment")
+    func statementAtCursorReturnsCommentTextForCursorInComment() {
+        let result = SQLStatementScanner.statementAtCursor(in: "SELECT 1; -- note", cursorPosition: 15)
+        #expect(result == "-- note")
+    }
 }

--- a/TableProTests/Core/Utilities/SQLStatementScannerTests.swift
+++ b/TableProTests/Core/Utilities/SQLStatementScannerTests.swift
@@ -109,6 +109,91 @@ final class SQLStatementScannerTests: XCTestCase {
         )
     }
 
+    // MARK: - Comment-Only Segments
+
+    func testTrailingLineCommentAfterSemicolonIsDropped() {
+        XCTAssertEqual(
+            SQLStatementScanner.allStatements(in: "SELECT 1; -- note"),
+            ["SELECT 1"]
+        )
+    }
+
+    func testTrailingBlockCommentAfterSemicolonIsDropped() {
+        XCTAssertEqual(
+            SQLStatementScanner.allStatements(in: "SELECT 1; /* note */"),
+            ["SELECT 1"]
+        )
+    }
+
+    func testMiddleCommentOnlySegmentIsDropped() {
+        XCTAssertEqual(
+            SQLStatementScanner.allStatements(in: "SELECT 1; /* x */; SELECT 2"),
+            ["SELECT 1", "SELECT 2"]
+        )
+    }
+
+    func testCommentOnlyWholeInputReturnsNoStatements() {
+        XCTAssertEqual(SQLStatementScanner.allStatements(in: "-- note"), [])
+        XCTAssertEqual(SQLStatementScanner.allStatements(in: "/* note */"), [])
+    }
+
+    func testMixedCommentAndWhitespaceMultilineSegmentIsDropped() {
+        let sql = "SELECT 1;\n  -- first\n  /* second */  \n; SELECT 2"
+        XCTAssertEqual(
+            SQLStatementScanner.allStatements(in: sql),
+            ["SELECT 1", "SELECT 2"]
+        )
+    }
+
+    func testConsecutiveSemicolonsStillDropped() {
+        XCTAssertEqual(
+            SQLStatementScanner.allStatements(in: "SELECT 1;;"),
+            ["SELECT 1"]
+        )
+    }
+
+    func testUnclosedTrailingBlockCommentIsDropped() {
+        XCTAssertEqual(
+            SQLStatementScanner.allStatements(in: "SELECT 1; /* note"),
+            ["SELECT 1"]
+        )
+    }
+
+    func testLineCommentAtEndOfInputIsDropped() {
+        XCTAssertEqual(
+            SQLStatementScanner.allStatements(in: "SELECT 1; --"),
+            ["SELECT 1"]
+        )
+    }
+
+    func testMySQLVersionedCommentSegmentIsKept() {
+        XCTAssertEqual(
+            SQLStatementScanner.allStatements(in: "/*!40101 SET @OLD=1 */; SELECT 1", dialect: .mysql),
+            ["/*!40101 SET @OLD=1 */", "SELECT 1"]
+        )
+    }
+
+    func testVersionedCommentKeptRegardlessOfDialect() {
+        XCTAssertEqual(
+            SQLStatementScanner.allStatements(in: "/*!40101 SET @OLD=1 */;", dialect: .generic),
+            ["/*!40101 SET @OLD=1 */"]
+        )
+    }
+
+    func testInStatementCommentsArePreserved() {
+        XCTAssertEqual(
+            SQLStatementScanner.allStatements(in: "SELECT 1 -- hint\n; SELECT 2 /* keep */"),
+            ["SELECT 1 -- hint", "SELECT 2 /* keep */"]
+        )
+    }
+
+    func testPreservingSemicolonsDropsCommentOnlySegment() {
+        XCTAssertEqual(
+            SQLStatementScanner.allStatementsPreservingSemicolons(in: "SELECT 1; -- note"),
+            ["SELECT 1;"]
+        )
+    }
+
     // MARK: - Dollar Quoting (PostgreSQL)
 
     func testDollarQuotedDoBlockKeepsInternalSemicolons() {
@@ -238,7 +323,7 @@ final class SQLStatementScannerTests: XCTestCase {
         )
     }
 
-    func testNoSemicolonsFastPath() {
+    func testNoSemicolonsWholeInputIsOneStatement() {
         let sql = "SELECT * FROM users"
         XCTAssertEqual(
             SQLStatementScanner.statementAtCursor(in: sql, cursorPosition: 5),


### PR DESCRIPTION
Fixes #1895.

## Root cause

`SQLStatementScanner.allStatements` keeps every segment that is non-empty after a whitespace trim, and comment text trims to a non-empty string. The scanner tracks comments to find the right split points but never asks whether a segment contains an executable token. That misfires in three places, not just the trailing one the issue named:

- `SELECT 1; -- note` splits into two statements, the run takes the multi-statement path, and the comment is sent to the server, producing the spurious "Statement 2/2 failed" error.
- `SELECT 1; /* x */; SELECT 2` produces three statements.
- A buffer that is entirely one comment with no semicolon produces one statement via a fast path that bypassed the state machine entirely.

`QueryClassifier.isMultiStatement` counts the same way, so the execution gate and the AI chat and MCP tools rejected `SELECT 1; -- note` as "multi-statement" before it even ran.

Context: TablePlus fixed this exact bug in 2019 (TablePlus#485), DBeaver in 24.0.4 (dbeaver#26416), DataGrip never had it. ClickHouse is the one server that hard-errors on comment-only text (code 62), and its own `clickhouse-client` drops trailing comments client-side.

## Fix

The `SQLFileParser` approach (`hasStatementContent`) transplanted into the scanner's existing state machine: one boolean tracked in the same character loop, passed as a third closure parameter. `allStatements` and `allStatementsPreservingSemicolons` skip segments without content; the cursor APIs ignore the flag, so autocomplete still sees raw comment segments and keeps suppressing suggestions inside comments.

- `/*!` versioned comments count as content in every dialect, so MySQL dump statements like `/*!40101 SET ... */;` still execute.
- The no-semicolon fast path is removed so a comment-only buffer goes through the same loop; the trailing branch emits byte-identical text and offset for that case.
- The content marker is an `else` of the semicolon check, so a boundary semicolon never marks the segment it closes.
- In-statement comments are untouched. Only whole segments that are pure comment and whitespace are dropped.

Running a comment-only buffer, selection, or cursor-in-comment statement is now a no-op through the pre-existing `guard !statements.isEmpty` checks at every call site, matching DataGrip and DBeaver. No production file changes besides the scanner.

## CI enablement (second commit)

The new cursor-API regression tests live in `SQLStatementScannerLocatedTests`, which was on the CI quarantine list since the test gate landed (#1481). It was benched because of one broken precondition: `largeInput` generates 9,889 characters and asserts `> 10_000`, failing since March while quarantine hid it. The second commit bumps the generated input to 300 statements (about 14,800 characters) and removes the suite from the quarantine list. All 17 tests in the suite pass.

## Testing

- 12 new scanner cases (trailing line and block comments, middle comment-only segment, comment-only whole input, mixed multi-line, unclosed trailing block comment, bare trailing dashes, versioned comments kept per dialect, in-statement comments preserved, `;;` still dropped, semicolon-preserving variant).
- 2 cursor-API regression guards proving the raw comment segment still reaches autocomplete.
- New `QueryClassifier.isMultiStatement` suite and an `ExecutionGateTests` case proving the gate no longer denies trailing-comment SQL.
- Full runs of the four affected suites pass via `xcodebuild test`; `swiftlint lint --strict` reports nothing new on changed files.

Follow-ups deliberately not in this PR: the scanner does not recognize `#` or `//` line comments (a trailing `# note` on ClickHouse can still error, a pre-existing splitting gap), and `MCPConnectionBridge` passes a trailing comment through to single-exec drivers.