### PR TITLE
fix(plugin-mssql): build FreeTDS with Kerberos so Windows Auth works (#1918)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SSH tunnels can authenticate with no password or key, for hosts that handle SSH auth themselves like Tailscale SSH. Pick **None** as the SSH auth method. (#1907)
 
+### Fixed
+
+- Windows Authentication (Kerberos) to SQL Server now works on macOS. The bundled SQL Server driver was built without Kerberos support, so every Windows-auth connect failed as if the credentials were wrong. (#1918)
+
 ## [0.58.0] - 2026-07-18
 
 ### Added

--- a/scripts/build-freetds.sh
+++ b/scripts/build-freetds.sh
@@ -122,11 +122,21 @@ cp "$LIBS_DIR/libcrypto_arm64.a" "$MACOS_OPENSSL_ARM64/lib/libcrypto.a"
 cp "$LIBS_DIR/libssl_x86_64.a"    "$MACOS_OPENSSL_X86_64/lib/libssl.a"
 cp "$LIBS_DIR/libcrypto_x86_64.a" "$MACOS_OPENSSL_X86_64/lib/libcrypto.a"
 
-# macOS slices enable Kerberos/GSS (Windows Authentication). --enable-krb5 links the system
-# Heimdal GSS via the SDK libgssapi_krb5 stub (Kerberos.framework); the plugin adds -framework GSS
-# at link time to resolve the symbols. iOS slices stay krb5-free (Windows auth is macOS only).
-build_slice "macos-arm64"  "macosx" "arm64"  "aarch64-apple-darwin" "-mmacosx-version-min=${MACOS_DEPLOYMENT_TARGET}" "$MACOS_OPENSSL_ARM64"  "--enable-krb5"
-build_slice "macos-x86_64" "macosx" "x86_64" "x86_64-apple-darwin"  "-mmacosx-version-min=${MACOS_DEPLOYMENT_TARGET}" "$MACOS_OPENSSL_X86_64" "--enable-krb5"
+# macOS slices enable Kerberos/GSS (Windows Authentication). The explicit --enable-krb5=gssapi_krb5
+# form makes FreeTDS define ENABLE_KRB5 unconditionally; plain --enable-krb5 only defines it when an
+# auto link probe succeeds and skips it silently otherwise, which shipped an empty gssapi.o once.
+# The symbols resolve against the SDK's libgssapi_krb5 stub (Kerberos.framework); the plugin adds
+# -framework GSS at link time. iOS slices stay krb5-free (Windows auth is macOS only).
+build_slice "macos-arm64"  "macosx" "arm64"  "aarch64-apple-darwin" "-mmacosx-version-min=${MACOS_DEPLOYMENT_TARGET}" "$MACOS_OPENSSL_ARM64"  "--enable-krb5=gssapi_krb5"
+build_slice "macos-x86_64" "macosx" "x86_64" "x86_64-apple-darwin"  "-mmacosx-version-min=${MACOS_DEPLOYMENT_TARGET}" "$MACOS_OPENSSL_X86_64" "--enable-krb5=gssapi_krb5"
+
+for slice in macos-arm64 macos-x86_64; do
+    if ! nm "$LIBS_DIR/libsybdb_${slice}.a" 2>/dev/null | grep -q 'T _tds_gss_get_auth'; then
+        echo "ERROR: libsybdb_${slice}.a has no tds_gss_get_auth; Kerberos/GSS was not compiled in." >&2
+        echo "       configure did not define ENABLE_KRB5. Check --enable-krb5=gssapi_krb5 and the SDK gssapi headers." >&2
+        exit 1
+    fi
+done
 
 # iOS slices link OpenSSL statically from the existing xcframeworks; reconstruct a unix-style prefix
 # for FreeTDS's --with-openssl which expects include/ and lib/ siblings.


### PR DESCRIPTION
Fixes #1918.

## Root cause

Windows Authentication (Kerberos) to SQL Server fails on macOS because the FreeTDS library that ships in the registry MSSQL plugin was compiled **without** Kerberos support. `nm Libs/libsybdb.a` shows `tds_gss_get_auth` is absent and `gssapi.o` is an empty stub (only NTLM, `tds_ntlm_get_auth`, is present). Every Windows-auth connect fails inside `dbopen()` because FreeTDS has no GSS code to run; it then falls back to an empty-username TDS login, which the server rejects, and the app surfaces it as a credentials error. Both reported flows (reuse an existing `kinit` ticket, and type principal + password) fail at that same call for the same reason.

The Windows Auth feature (#1890/#1892) added correct Swift plumbing and patched `build-freetds.sh` with `--enable-krb5`, but the libraries were never rebuilt or republished, and the plugin binary (`plugin-mssql-v1.0.30`) still links the old GSS-less `libsybdb.a` from `libs-v1`.

This is a build/release gap, not a driver-logic bug, so the fix is a library rebuild plus guard-rails, not a code refactor. The Swift driver, the `-framework GSS` link, and the docs were already correct.

## Why a naive rebuild could ship broken again

FreeTDS's `--enable-krb5` in *auto* mode defines `ENABLE_KRB5` only if the `AC_SEARCH_LIBS(gss_init_sec_context, ...)` link probe succeeds, and skips it with **no error or warning** on failure. That silent path produces exactly the empty `gssapi.o` we see. So this PR also makes the build deterministic.

## Changes in this PR

- `scripts/build-freetds.sh`: macOS slices build with `--enable-krb5=gssapi_krb5`. The explicit-library form defines `ENABLE_KRB5` unconditionally, removing the silent auto-detect fallback. No `CPPFLAGS`/`LDFLAGS` changes are needed: the macOS SDK sysroot already supplies `<gssapi/gssapi_krb5.h>` and `libgssapi_krb5.tbd`, and the plugin already links `-framework GSS`.
- `scripts/build-freetds.sh`: a post-build `nm` assertion fails the build if the macOS archives lack `tds_gss_get_auth`, so a GSS-less `libsybdb.a` can never ship silently again.
- `CHANGELOG.md`: one `Fixed` entry under `[Unreleased]`.

## Not changed (verified correct)

- Plugin link flags: `-force_load Libs/libsybdb.a` + `-framework GSS` (both Debug and Release).
- Swift driver: username/password blanking for Windows auth, `KRB5CCNAME` FILE-ccache handling, `gss_aapl_initial_cred` ticket acquisition, and the Kerberos classifier.
- Docs: `docs/databases/mssql.mdx` already documents the `kinit` single sign-on flow, the typed-principal flow, and troubleshooting.

## Follow-up steps required to release the fix (not automatable in this PR)

The code change alone does not fix users. After merge, someone with the build/publish environment must:

1. `bash scripts/build-freetds.sh` (needs `brew install autoconf automake libtool openssl@3`). The new assertion verifies GSS is compiled in.
2. Verify: `nm Libs/libsybdb.a | grep tds_gss_get_auth` prints `T _tds_gss_get_auth`.
3. `scripts/publish-libs.sh libsybdb_arm64.a libsybdb_x86_64.a libsybdb_universal.a libsybdb.a`, then re-pack and upload the iOS xcframework archive per CLAUDE.md.
4. Commit the updated `Libs/checksums.sha256`.
5. Re-release the registry plugin (tag `plugin-mssql-v1.0.31`, or `gh workflow run build-plugin.yml`) so its binary links the rebuilt lib. No PluginKit ABI bump: `currentPluginKitVersion` stays 18.
6. Verify end-to-end against a real Kerberos SQL Server, both flows.

## Testing

The library/GSS path can't be unit-tested in the Swift suite (the lib isn't rebuilt in CI, and the C-bridge tests run zero rows in that target). The build-script `nm` assertion is the automated verification, self-checking at build time. No Swift behavior changes, so the existing `MSSQLKerberosClassifierTests` and `MSSQLConnectionOptionsAuthMethodTests` still hold.
