### PR TITLE
fix(plugin-mysql): make socket read timeout follow the query timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Windows Authentication (Kerberos) to SQL Server now works on macOS. The bundled SQL Server driver was built without Kerberos support, so every Windows-auth connect failed as if the credentials were wrong. (#1918)
+- MySQL and MariaDB queries no longer fail after about a minute when a longer query timeout is set. The client read timeout now follows the configured query timeout, so a long query or stored procedure runs for the full time you allow. (#1921)
+- A dropped MySQL or MariaDB connection no longer silently re-runs a statement that changes data, so a lost connection can no longer run an insert, update, or stored procedure twice. (#1921)
 - The MongoDB, Oracle, Cassandra, and Elasticsearch plugins failed to install on 0.58 with "Bundle failed to load executable". (#1917)
 
 ## [0.58.0] - 2026-07-18

--- a/Plugins/MySQLDriverPlugin/MariaDBPluginConnection.swift
+++ b/Plugins/MySQLDriverPlugin/MariaDBPluginConnection.swift
@@ -159,6 +159,7 @@ final class MariaDBPluginConnection: @unchecked Sendable {
     private let database: String
     private let sslConfig: SSLConfiguration
     private let enableCleartextPlugin: Bool
+    private let queryTimeoutSeconds: Int
 
     private let stateLock = NSLock()
     private var _isConnected: Bool = false
@@ -192,7 +193,8 @@ final class MariaDBPluginConnection: @unchecked Sendable {
         password: String?,
         database: String,
         sslConfig: SSLConfiguration,
-        enableCleartextPlugin: Bool = false
+        enableCleartextPlugin: Bool = false,
+        queryTimeoutSeconds: Int = 0
     ) {
         self.host = host
         self.port = UInt32(port)
@@ -201,6 +203,7 @@ final class MariaDBPluginConnection: @unchecked Sendable {
         self.database = database
         self.sslConfig = sslConfig
         self.enableCleartextPlugin = enableCleartextPlugin
+        self.queryTimeoutSeconds = queryTimeoutSeconds
     }
 
     deinit {
@@ -261,10 +264,10 @@ final class MariaDBPluginConnection: @unchecked Sendable {
         var timeout: UInt32 = 10
         mysql_options(mysql, MYSQL_OPT_CONNECT_TIMEOUT, &timeout)
 
-        var readTimeout: UInt32 = 30
+        var readTimeout = mysqlSocketTimeoutSeconds(forQueryTimeout: queryTimeoutSeconds)
         mysql_options(mysql, MYSQL_OPT_READ_TIMEOUT, &readTimeout)
 
-        var writeTimeout: UInt32 = 30
+        var writeTimeout = mysqlSocketTimeoutSeconds(forQueryTimeout: queryTimeoutSeconds)
         mysql_options(mysql, MYSQL_OPT_WRITE_TIMEOUT, &writeTimeout)
 
         var protocol_tcp = UInt32(MYSQL_PROTOCOL_TCP.rawValue)

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
@@ -79,7 +79,8 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             password: config.password,
             database: _activeDatabase,
             sslConfig: sslConfig,
-            enableCleartextPlugin: config.additionalFields["enableCleartextPlugin"] == "true"
+            enableCleartextPlugin: config.additionalFields["enableCleartextPlugin"] == "true",
+            queryTimeoutSeconds: config.additionalFields["queryTimeoutSeconds"].flatMap { Int($0) } ?? 0
         )
 
         try await conn.connect()
@@ -193,7 +194,8 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 isTruncated: result.isTruncated,
                 columnMeta: result.columnMeta
             )
-        } catch let error as MariaDBPluginError where !isRetry && isConnectionLostError(error) {
+        } catch let error as MariaDBPluginError
+            where !isRetry && isConnectionLostError(error) && mysqlStatementIsReadOnly(query) {
             try await reconnect()
             return try await executeWithReconnect(query: query, isRetry: true, rowCap: rowCap)
         }

--- a/Plugins/MySQLDriverPlugin/MySQLSocketTimeout.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLSocketTimeout.swift
@@ -1,0 +1,13 @@
+//
+//  MySQLSocketTimeout.swift
+//  MySQLDriverPlugin
+//
+
+internal let mysqlSocketTimeoutGraceSeconds = 30
+
+internal func mysqlSocketTimeoutSeconds(forQueryTimeout queryTimeoutSeconds: Int) -> UInt32 {
+    guard queryTimeoutSeconds > 0 else { return 0 }
+    let ceiling = Int(UInt32.max) - mysqlSocketTimeoutGraceSeconds
+    let clamped = min(queryTimeoutSeconds, ceiling)
+    return UInt32(clamped + mysqlSocketTimeoutGraceSeconds)
+}

--- a/Plugins/MySQLDriverPlugin/MySQLStatementClassification.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLStatementClassification.swift
@@ -1,0 +1,17 @@
+//
+//  MySQLStatementClassification.swift
+//  MySQLDriverPlugin
+//
+
+internal func mysqlStatementIsReadOnly(_ query: String) -> Bool {
+    let keyword = query
+        .drop(while: { $0.isWhitespace })
+        .prefix(while: { $0.isLetter })
+        .uppercased()
+    switch keyword {
+    case "SELECT", "SHOW", "DESCRIBE", "DESC":
+        return true
+    default:
+        return false
+    }
+}

--- a/TablePro.xcodeproj/project.pbxproj
+++ b/TablePro.xcodeproj/project.pbxproj
@@ -532,6 +532,8 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				MySQLQueryTimeoutStatement.swift,
+				MySQLSocketTimeout.swift,
+				MySQLStatementClassification.swift,
 			);
 			target = 5ABCC5A62F43856700EAF3FC /* TableProTests */;
 		};

--- a/TablePro/Core/Database/DatabaseDriver.swift
+++ b/TablePro/Core/Database/DatabaseDriver.swift
@@ -473,6 +473,7 @@ enum DatabaseDriverFactory {
             }
             additionalFields["enableCleartextPlugin"] = "true"
         }
+        additionalFields["queryTimeoutSeconds"] = String(AppSettingsManager.shared.general.queryTimeoutSeconds)
         let config = DriverConnectionConfig(
             host: connection.host,
             port: connection.port,

--- a/TableProTests/Plugins/MySQLSocketTimeoutTests.swift
+++ b/TableProTests/Plugins/MySQLSocketTimeoutTests.swift
@@ -1,0 +1,35 @@
+//
+//  MySQLSocketTimeoutTests.swift
+//  TableProTests
+//
+
+import Testing
+
+@Suite("MySQL Socket Timeout")
+struct MySQLSocketTimeoutTests {
+    @Test("No limit maps to an infinite socket timeout")
+    func noLimitIsInfinite() {
+        #expect(mysqlSocketTimeoutSeconds(forQueryTimeout: 0) == 0)
+    }
+
+    @Test("A negative query timeout maps to an infinite socket timeout")
+    func negativeIsInfinite() {
+        #expect(mysqlSocketTimeoutSeconds(forQueryTimeout: -5) == 0)
+    }
+
+    @Test("A finite query timeout adds the grace period")
+    func finiteAddsGrace() {
+        #expect(mysqlSocketTimeoutSeconds(forQueryTimeout: 60) == 90)
+        #expect(mysqlSocketTimeoutSeconds(forQueryTimeout: 600) == 630)
+    }
+
+    @Test("The grace period is applied on top of the query timeout")
+    func graceMatchesConstant() {
+        #expect(mysqlSocketTimeoutSeconds(forQueryTimeout: 1) == UInt32(1 + mysqlSocketTimeoutGraceSeconds))
+    }
+
+    @Test("A very large query timeout clamps without overflowing")
+    func largeValueClamps() {
+        #expect(mysqlSocketTimeoutSeconds(forQueryTimeout: Int.max) == UInt32.max)
+    }
+}

--- a/TableProTests/Plugins/MySQLStatementClassificationTests.swift
+++ b/TableProTests/Plugins/MySQLStatementClassificationTests.swift
@@ -1,0 +1,48 @@
+//
+//  MySQLStatementClassificationTests.swift
+//  TableProTests
+//
+
+import Testing
+
+@Suite("MySQL Statement Classification")
+struct MySQLStatementClassificationTests {
+    @Test("SELECT is read-only")
+    func selectIsReadOnly() {
+        #expect(mysqlStatementIsReadOnly("SELECT * FROM users"))
+    }
+
+    @Test("Leading whitespace and lowercase are handled")
+    func whitespaceAndCase() {
+        #expect(mysqlStatementIsReadOnly("   \n select 1"))
+    }
+
+    @Test("SHOW, DESCRIBE, and DESC are read-only")
+    func showAndDescribe() {
+        #expect(mysqlStatementIsReadOnly("SHOW TABLES"))
+        #expect(mysqlStatementIsReadOnly("DESCRIBE users"))
+        #expect(mysqlStatementIsReadOnly("DESC users"))
+    }
+
+    @Test("Mutating statements are not read-only")
+    func mutatingStatements() {
+        #expect(!mysqlStatementIsReadOnly("INSERT INTO users VALUES (1)"))
+        #expect(!mysqlStatementIsReadOnly("UPDATE users SET name = 'a'"))
+        #expect(!mysqlStatementIsReadOnly("DELETE FROM users"))
+        #expect(!mysqlStatementIsReadOnly("CALL do_work()"))
+        #expect(!mysqlStatementIsReadOnly("REPLACE INTO users VALUES (1)"))
+        #expect(!mysqlStatementIsReadOnly("DROP TABLE users"))
+    }
+
+    @Test("A statement behind a leading comment is treated conservatively")
+    func leadingCommentIsConservative() {
+        #expect(!mysqlStatementIsReadOnly("/* note */ SELECT 1"))
+        #expect(!mysqlStatementIsReadOnly("-- note\nSELECT 1"))
+    }
+
+    @Test("An empty statement is not read-only")
+    func emptyIsNotReadOnly() {
+        #expect(!mysqlStatementIsReadOnly(""))
+        #expect(!mysqlStatementIsReadOnly("   "))
+    }
+}


### PR DESCRIPTION
Fixes #1921.

## Problem

With Settings > General > Query timeout set to 600s, a MySQL/MariaDB query or stored procedure that runs longer than about a minute without returning a packet fails with `[2026] TLS/SSL error: Operation timed out (60)`, while the statement keeps running on the server. That makes the result ambiguous and risks running a statement twice.

## Root cause

`MariaDBPluginConnection.attemptConnect` hardcoded `MYSQL_OPT_READ_TIMEOUT = 30`, with no relation to the configured query timeout. MariaDB Connector/C applies that as a per-read (inter-packet) timeout, set once at connect, so a query that emits no packet for ~30s is aborted client-side. The server-side timeout (`SET SESSION max_execution_time` / `max_statement_time`) is derived from the setting but never touches the socket timeout, and does not apply to stored procedures at all.

The connector does not multiply the read timeout (the "3x" wording is Oracle's libmysqlclient, a different library), and `mysql_options` on a live handle has no effect, so the derived value must be set at connect.

## Fix

- Derive the socket read/write timeout from the configured query timeout plus a 30s grace, so a long query runs for the full time allowed. A "No limit" (0) query timeout maps to no read-timeout cap, matching how native clients like Sequel Ace and DataGrip behave.
- The query timeout reaches the plugin through the existing `additionalFields` config seam, injected app-side at driver creation. No PluginKit ABI change, no version bump.
- Extract the derivation into a pure, unit-tested helper.

## Retry safety (related)

`executeWithReconnect` reconnects and re-runs on connection-lost errors. On a plaintext connection a read timeout surfaces as error 2013, which was in the retry set, so a dropped connection could silently re-run an insert, update, or stored procedure. The retry is now gated on the statement being read-only, so it can never re-run a statement that changes data, while metadata SELECTs keep their stale-connection recovery.

## Tests

- `MySQLSocketTimeoutTests`: 0 stays infinite, negative stays infinite, finite adds the grace, large values clamp without overflow.
- `MySQLStatementClassificationTests`: SELECT/SHOW/DESCRIBE/DESC read-only; INSERT/UPDATE/DELETE/CALL/REPLACE/DROP not; leading comments treated conservatively.

## Out of scope

The plugin's internal reconnect does not re-apply the server-side `SET SESSION` timeout, and a settings change does not reach live sessions ("Applied to new connections"). Both are pre-existing and tracked separately.
