### PR TITLE
fix(ios): support None as an SSH tunnel auth method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- SSH tunnels using the None auth method now work on iPhone and iPad, not just the Mac. A connection synced from the Mac with None auth no longer fails to connect. (#1912)
+
 ## [0.59.0] - 2026-07-21
 
 ### Added

--- a/Packages/TableProCore/Sources/TableProModels/SSHConfiguration.swift
+++ b/Packages/TableProCore/Sources/TableProModels/SSHConfiguration.swift
@@ -14,6 +14,7 @@ public struct SSHConfiguration: Codable, Hashable, Sendable {
         case privateKey
         case sshAgent
         case keyboardInteractive
+        case none
 
         public init(from decoder: Decoder) throws {
             let raw = try decoder.singleValueContainer().decode(String.self)
@@ -26,6 +27,8 @@ public struct SSHConfiguration: Codable, Hashable, Sendable {
                 self = .sshAgent
             case "keyboardInteractive", "Keyboard Interactive":
                 self = .keyboardInteractive
+            case "none", "None":
+                self = .none
             default:
                 self = .password
             }

--- a/Packages/TableProCore/Tests/TableProModelsTests/SSHConfigurationTests.swift
+++ b/Packages/TableProCore/Tests/TableProModelsTests/SSHConfigurationTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+
+@testable import TableProModels
+
+@Suite("iOS SSHConfiguration auth method decoding")
+struct SSHConfigurationTests {
+    private func decode(authMethod raw: String) throws -> SSHConfiguration {
+        let json = """
+        {"host":"ssh.example.com","port":22,"username":"tailscale","authMethod":"\(raw)","jumpHosts":[]}
+        """
+        return try JSONDecoder().decode(SSHConfiguration.self, from: Data(json.utf8))
+    }
+
+    @Test("decodes the macOS None raw value")
+    func decodesMacOSNone() throws {
+        #expect(try decode(authMethod: "None").authMethod == .none)
+    }
+
+    @Test("decodes the lowercase none raw value")
+    func decodesLowercaseNone() throws {
+        #expect(try decode(authMethod: "none").authMethod == .none)
+    }
+
+    @Test("None survives an encode and decode round trip")
+    func roundTripsNone() throws {
+        let config = SSHConfiguration(host: "ssh.example.com", username: "tailscale", authMethod: .none)
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(SSHConfiguration.self, from: data)
+        #expect(decoded.authMethod == .none)
+    }
+
+    @Test("an unrecognized auth method still falls back to password")
+    func unknownFallsBackToPassword() throws {
+        #expect(try decode(authMethod: "totp-only").authMethod == .password)
+    }
+}

--- a/TablePro/Models/Connection/SSHTypes.swift
+++ b/TablePro/Models/Connection/SSHTypes.swift
@@ -33,6 +33,10 @@ enum SSHAuthMethod: String, CaseIterable, Identifiable, Codable {
         case .none: return "key.slash"
         }
     }
+
+    var supportsTwoFactorAuthentication: Bool {
+        self != .none
+    }
 }
 
 enum SSHAgentSocketOption: String, CaseIterable, Identifiable {

--- a/TablePro/Views/Connection/ConnectionSSHTunnelView.swift
+++ b/TablePro/Views/Connection/ConnectionSSHTunnelView.swift
@@ -223,7 +223,7 @@ struct ConnectionSSHTunnelView: View {
                 }
             }
 
-            if sshState.authMethod != .none {
+            if sshState.authMethod.supportsTwoFactorAuthentication {
                 Section(String(localized: "Two-Factor Authentication")) {
                     Picker(String(localized: "TOTP"), selection: $sshState.totpMode) {
                         ForEach(TOTPMode.allCases) { mode in

--- a/TablePro/Views/Connection/SSHProfileEditorView.swift
+++ b/TablePro/Views/Connection/SSHProfileEditorView.swift
@@ -75,7 +75,7 @@ struct SSHProfileEditorView: View {
                 serverSection
                 authenticationSection
 
-                if authMethod != .none {
+                if authMethod.supportsTwoFactorAuthentication {
                     totpSection
                 }
 

--- a/TableProMobile/TableProMobile/SSH/SSHTunnel.swift
+++ b/TableProMobile/TableProMobile/SSH/SSHTunnel.swift
@@ -207,6 +207,23 @@ actor SSHTunnel {
         Self.logger.debug("In-memory key authentication successful for \(username)")
     }
 
+    func authenticateNone(username: String) throws {
+        guard let session else {
+            throw SSHTunnelError.authenticationFailed("No active session")
+        }
+
+        let authList = libssh2_userauth_list(session, username, UInt32(username.utf8.count))
+        guard authList == nil else {
+            throw SSHTunnelError.authenticationFailed("Server requires credentials; passwordless authentication is not permitted")
+        }
+
+        guard libssh2_userauth_authenticated(session) != 0 else {
+            throw SSHTunnelError.authenticationFailed("Passwordless authentication failed")
+        }
+
+        Self.logger.debug("Passwordless authentication successful for \(username)")
+    }
+
     // MARK: - Port Forwarding
 
     func startForwarding(remoteHost: String, remotePort: Int) throws {

--- a/TableProMobile/TableProMobile/SSH/SSHTunnelFactory.swift
+++ b/TableProMobile/TableProMobile/SSH/SSHTunnelFactory.swift
@@ -48,6 +48,9 @@ enum SSHTunnelFactory {
                 throw SSHTunnelError.authenticationFailed("No private key provided")
             }
 
+        case .none:
+            try await tunnel.authenticateNone(username: config.username)
+
         default:
             throw SSHTunnelError.authenticationFailed(
                 "Auth method \(config.authMethod.rawValue) not supported on iOS"

--- a/TableProMobile/TableProMobile/Services/IOSConnectionImportService.swift
+++ b/TableProMobile/TableProMobile/Services/IOSConnectionImportService.swift
@@ -214,6 +214,7 @@ enum IOSConnectionImportService {
         case "privatekey", "publickey", "private key": return .privateKey
         case "sshagent", "agent", "ssh agent": return .sshAgent
         case "keyboardinteractive", "keyboard interactive": return .keyboardInteractive
+        case "none": return .none
         default: return .password
         }
     }

--- a/TableProTests/Core/SSH/Auth/SSHAuthMethodTests.swift
+++ b/TableProTests/Core/SSH/Auth/SSHAuthMethodTests.swift
@@ -1,0 +1,21 @@
+//
+//  SSHAuthMethodTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("SSHAuthMethod form contract")
+struct SSHAuthMethodTests {
+    @Test("None is the only method without two-factor authentication")
+    func noneHidesTwoFactor() {
+        #expect(SSHAuthMethod.none.supportsTwoFactorAuthentication == false)
+
+        for method in SSHAuthMethod.allCases where method != .none {
+            #expect(method.supportsTwoFactorAuthentication, "\(method.rawValue) should support two-factor")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds iOS parity for the **None** SSH tunnel auth method.

The None method (for hosts like Tailscale SSH that handle authentication themselves) shipped on macOS in v0.59.0 (#1907, #1909). The iOS app models SSH config with a separate type that was never taught the case, so a macOS connection using None, once synced to iOS, silently decoded to Password and then failed to connect with a misleading "No SSH password provided."

## Changes

iOS now honors None SSH tunnels. iOS uses libssh2 too, so this is real support rather than a clean error:

- `SSHConfiguration` (TableProModels): add the `.none` case and decode `"none"` / `"None"`.
- iOS `SSHTunnel`: add `authenticateNone`, mirroring the macOS `NoneAuthenticator` sequence (`libssh2_userauth_list` then `libssh2_userauth_authenticated`).
- iOS `SSHTunnelFactory`: dispatch `.none`.
- `IOSConnectionImportService`: map `"none"` when importing a `.tablepro` file.

Tests:

- Extract the macOS None form gate into `SSHAuthMethod.supportsTwoFactorAuthentication` (same behavior, now testable) and cover it in `TableProTests`.
- iOS model decode tests for `.none`: the macOS and lowercase raw values, an encode/decode round trip, and the unknown-value fallback to Password.

## Testing

- `swift test --filter SSHConfigurationTests`: 4/4 pass.
- `swiftlint lint --strict`: clean on changed in-scope files.

## Notes

- The macOS feature already shipped, so issue #1912 has a reply pointing the reporter to v0.59.0, plus the Tailscale `check`-mode caveat (that mode rejects `none`).
- Out of scope: adding None to the iOS form's auth picker (it is curated to Password / Private Key), and the pre-existing iOS to macOS raw-value casing question.

Ref #1912
