### PR TITLE
docs: name the SOCKS5 remote-DNS behavior socks5h

### DIFF
--- a/docs/databases/socks-proxy.mdx
+++ b/docs/databases/socks-proxy.mdx
@@ -1,6 +1,6 @@
 ---
 title: SOCKS Proxy
-description: Route a database connection through a SOCKS5 proxy
+description: Route a database connection through a SOCKS5 proxy, with remote DNS (socks5h) so the proxy resolves the database hostname
 ---
 
 # SOCKS Proxy
@@ -29,7 +29,7 @@ flowchart LR
 
 TablePro opens a loopback listener on a free port and relays every connection through the proxy to the database, then points the driver at the local port. Unlike Cloudflare Tunnel and Cloud SQL Auth Proxy, there is no external binary to install: TablePro's own networking stack (Network.framework) speaks SOCKS5 directly.
 
-The database hostname is sent to the proxy and resolved there, not on your Mac. Hostnames that only resolve inside the private network behind the proxy work, and no DNS query for the database host leaves your machine.
+The database hostname is sent to the proxy and resolved there, not on your Mac. This is remote DNS (what a `socks5h://` URL selects in other clients), and TablePro always does it, so there is no separate `socks5` mode that resolves locally. Hostnames that only resolve inside the private network behind the proxy work, and no DNS query for the database host leaves your machine.
 
 ## Setting up
 


### PR DESCRIPTION
Issue #1933 asks for socks5h (remote DNS through the SOCKS5 proxy). TablePro already does this: the SOCKS5 transport (v0.58.0, #1882) passes the database hostname to the proxy unresolved, so the proxy resolves it. The behavior was documented, just not by the name people search for.

This adds the term "socks5h" to the SOCKS Proxy docs page (frontmatter description and the how-it-works section) so the behavior is findable, and notes there is no separate local-resolution mode.

Docs-only, no code change.

https://claude.ai/code/session_017Z4znQFPkXHLS6CyVdShx4