### PR TITLE
fix(plugin-trino): page results with OFFSET before LIMIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - SSH tunnels using the None auth method now work on iPhone and iPad, not just the Mac. A connection synced from the Mac with None auth no longer fails to connect. (#1912)
+- Browsing a Trino table no longer fails with a syntax error. Trino requires `OFFSET` before `LIMIT`, so paging now uses `OFFSET` and `FETCH FIRST`. (#1936)
 
 ## [0.59.0] - 2026-07-21
 

--- a/Plugins/TrinoDriverPlugin/TrinoPlugin.swift
+++ b/Plugins/TrinoDriverPlugin/TrinoPlugin.swift
@@ -133,7 +133,8 @@ final class TrinoPlugin: NSObject, TableProPlugin, DriverPlugin {
         regexSyntax: .regexpLike,
         booleanLiteralStyle: .truefalse,
         likeEscapeStyle: .explicit,
-        paginationStyle: .limit
+        paginationStyle: .offsetFetch,
+        offsetFetchOrderBy: ""
     )
 
     static let explainVariants: [ExplainVariant] = [

--- a/TablePro/Core/Database/FilterSQLGenerator.swift
+++ b/TablePro/Core/Database/FilterSQLGenerator.swift
@@ -330,7 +330,8 @@ extension FilterSQLGenerator {
 
         if dialect.paginationStyle == .offsetFetch {
             let orderBy = dialect.offsetFetchOrderBy
-            sql += "\n\(orderBy) OFFSET 0 ROWS FETCH NEXT \(limit) ROWS ONLY"
+            let orderByPrefix = orderBy.isEmpty ? "" : "\(orderBy) "
+            sql += "\n\(orderByPrefix)OFFSET 0 ROWS FETCH NEXT \(limit) ROWS ONLY"
         } else {
             sql += "\nLIMIT \(limit)"
         }

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
@@ -390,7 +390,8 @@ extension PluginMetadataRegistry {
                         regexSyntax: .regexpLike,
                         booleanLiteralStyle: .truefalse,
                         likeEscapeStyle: .explicit,
-                        paginationStyle: .limit
+                        paginationStyle: .offsetFetch,
+                        offsetFetchOrderBy: ""
                     ),
                     statementCompletions: [],
                     columnTypesByCategory: [

--- a/TablePro/Core/Services/Query/TableQueryBuilder.swift
+++ b/TablePro/Core/Services/Query/TableQueryBuilder.swift
@@ -215,7 +215,8 @@ struct TableQueryBuilder {
             return orderBy
         }
         guard dialect?.paginationStyle == .offsetFetch else { return nil }
-        return dialect?.offsetFetchOrderBy ?? "ORDER BY (SELECT NULL)"
+        let defaultOrderBy = dialect?.offsetFetchOrderBy ?? "ORDER BY (SELECT NULL)"
+        return defaultOrderBy.isEmpty ? nil : defaultOrderBy
     }
 
     private func buildOrderByClause(sortState: SortState?, columns: [String]) -> String? {

--- a/TableProTests/Core/Database/FilterSQLGeneratorTests.swift
+++ b/TableProTests/Core/Database/FilterSQLGeneratorTests.swift
@@ -50,6 +50,13 @@ struct FilterSQLGeneratorTests {
         offsetFetchOrderBy: "ORDER BY 1"
     )
 
+    private static let trinoDialect = SQLDialectDescriptor(
+        identifierQuote: "\"", keywords: [], functions: [], dataTypes: [],
+        regexSyntax: .regexpLike, booleanLiteralStyle: .truefalse,
+        likeEscapeStyle: .explicit, paginationStyle: .offsetFetch,
+        offsetFetchOrderBy: ""
+    )
+
     // MARK: - Per-Operator Tests (MySQL)
 
     @Test("Equal operator generates correct condition")
@@ -824,6 +831,25 @@ struct FilterSQLGeneratorTests {
             tableName: "users", schemaName: "", filters: [], limit: 1_000
         )
         #expect(result.contains("SELECT * FROM `users`"))
+    }
+
+    @Test("Trino paging emits OFFSET before FETCH FIRST with no synthetic ORDER BY")
+    func testPreviewSQLTrinoOffsetFetch() {
+        let generator = FilterSQLGenerator(dialect: Self.trinoDialect)
+        let result = generator.generatePreviewSQL(
+            tableName: "pseudo_columns", schemaName: "jdbc", filters: [], limit: 1_000
+        )
+        #expect(result.contains("OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY"))
+        #expect(!result.contains("LIMIT"))
+        #expect(!result.contains("ORDER BY"))
+    }
+
+    @Test("Oracle paging keeps its default ORDER BY before OFFSET and FETCH FIRST")
+    func testPreviewSQLOracleOffsetFetch() {
+        let generator = FilterSQLGenerator(dialect: Self.oracleDialect)
+        let result = generator.generatePreviewSQL(tableName: "users", filters: [], limit: 1_000)
+        #expect(result.contains("ORDER BY 1 OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY"))
+        #expect(!result.contains("LIMIT"))
     }
 
     // MARK: - Edge Cases

--- a/TableProTests/Core/Services/TableQueryBuilderFilterTests.swift
+++ b/TableProTests/Core/Services/TableQueryBuilderFilterTests.swift
@@ -134,6 +134,75 @@ struct TableQueryBuilderFilteredCountTests {
     }
 }
 
+@Suite("Table Query Builder - Pagination Clause")
+struct TableQueryBuilderPaginationTests {
+    private static let trinoDialect = SQLDialectDescriptor(
+        identifierQuote: "\"", keywords: [], functions: [], dataTypes: [],
+        regexSyntax: .regexpLike, booleanLiteralStyle: .truefalse,
+        likeEscapeStyle: .explicit, paginationStyle: .offsetFetch, offsetFetchOrderBy: ""
+    )
+
+    private static let mssqlDialect = SQLDialectDescriptor(
+        identifierQuote: "[", keywords: [], functions: [], dataTypes: [],
+        regexSyntax: .unsupported, booleanLiteralStyle: .numeric,
+        likeEscapeStyle: .explicit, paginationStyle: .offsetFetch
+    )
+
+    private static let mysqlDialect = SQLDialectDescriptor(
+        identifierQuote: "`", keywords: [], functions: [], dataTypes: [],
+        regexSyntax: .regexp, booleanLiteralStyle: .numeric,
+        likeEscapeStyle: .implicit, paginationStyle: .limit
+    )
+
+    private func builder(_ dialect: SQLDialectDescriptor) -> TableQueryBuilder {
+        TableQueryBuilder(databaseType: .postgresql, dialect: dialect)
+    }
+
+    private func enabledFilter(_ column: String, _ value: String) -> TableFilter {
+        var filter = TableFilter()
+        filter.columnName = column
+        filter.filterOperator = .equal
+        filter.value = value
+        filter.isEnabled = true
+        return filter
+    }
+
+    @Test("Trino base query pages with OFFSET before FETCH FIRST and no ORDER BY")
+    func trinoBaseQueryOffsetFetch() {
+        let query = builder(Self.trinoDialect).buildBaseQuery(
+            tableName: "pseudo_columns", schemaName: "jdbc", limit: 1_000, offset: 0
+        )
+        #expect(query.contains("\"jdbc\".\"pseudo_columns\""))
+        #expect(query.contains("OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY"))
+        #expect(!query.contains("LIMIT"))
+        #expect(!query.contains("ORDER BY"))
+    }
+
+    @Test("Trino filtered query keeps the WHERE and pages with OFFSET/FETCH FIRST")
+    func trinoFilteredQueryOffsetFetch() {
+        let query = builder(Self.trinoDialect).buildFilteredQuery(
+            tableName: "orders", filters: [enabledFilter("status", "open")], limit: 500, offset: 500
+        )
+        #expect(query.contains("WHERE"))
+        #expect(query.contains("OFFSET 500 ROWS FETCH NEXT 500 ROWS ONLY"))
+        #expect(!query.contains("LIMIT"))
+    }
+
+    @Test("MSSQL base query injects its default ORDER BY before OFFSET/FETCH FIRST")
+    func mssqlBaseQueryKeepsDefaultOrderBy() {
+        let query = builder(Self.mssqlDialect).buildBaseQuery(tableName: "users", limit: 100, offset: 0)
+        #expect(query.contains("ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT 100 ROWS ONLY"))
+        #expect(!query.contains("LIMIT"))
+    }
+
+    @Test("LIMIT-style dialect pages with LIMIT then OFFSET")
+    func limitStyleBaseQuery() {
+        let query = builder(Self.mysqlDialect).buildBaseQuery(tableName: "users", limit: 200, offset: 0)
+        #expect(query.contains("LIMIT 200 OFFSET 0"))
+        #expect(!query.contains("FETCH NEXT"))
+    }
+}
+
 @Suite("Table Query Builder - NoSQL Nil Dialect Fallback")
 struct TableQueryBuilderNoSQLTests {
     // MongoDB has no SQL dialect — should produce bare SELECT without WHERE

--- a/docs/databases/trino.mdx
+++ b/docs/databases/trino.mdx
@@ -32,7 +32,7 @@ Trino requires TLS for any authentication. If you pick Password or JWT, set an S
 
 A Trino connection is scoped to a catalog and schema, but every query can name objects in full as `catalog.schema.table`. TablePro shows catalogs from `SHOW CATALOGS`, schemas from `SHOW SCHEMAS`, and tables and columns from each catalog's `information_schema`. Materialized views appear alongside tables and views. Expand a catalog to see its schemas, then a schema to see its tables. Table row counts come from `SHOW STATS`, and table and column comments come from `information_schema` and the `system.metadata` tables.
 
-Identifiers are quoted with double quotes. Results page with standard `LIMIT` and `OFFSET`.
+Identifiers are quoted with double quotes. Results page with `OFFSET` and `FETCH FIRST`, the order Trino's grammar requires.
 
 ## Types
 


### PR DESCRIPTION
## Problem

Clicking a Trino table failed with:

```
SELECT * FROM "jdbc"."pseudo_columns" LIMIT 1000 OFFSET 0
SYNTAX_ERROR: line 1:50: mismatched input 'OFFSET'. Expecting: <EOF>
```

Trino's grammar requires `OFFSET` before `LIMIT`/`FETCH`, but TablePro classified Trino's dialect as `paginationStyle: .limit`, so it emitted the MySQL/Postgres order `LIMIT 1000 OFFSET 0`. This broke every Trino table browse.

## Fix

Reclassify Trino as `paginationStyle: .offsetFetch` with an empty `offsetFetchOrderBy`. The `.offsetFetch` path already emits `OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY`, which Trino accepts and which needs no `ORDER BY`. The empty `offsetFetchOrderBy` is a sentinel telling the two ORDER-BY-injection sites to skip the MSSQL-only synthetic `ORDER BY (SELECT NULL)`.

Reusing `.offsetFetch` keeps this ABI-free. `PaginationStyle` is `@frozen`, so a new `OFFSET n LIMIT n` case would force a PluginKit version bump and a re-release of every registry plugin. No other plugins are touched.

## Changes

- `TrinoPlugin.swift` and `PluginMetadataRegistry+RegistryDefaults.swift`: Trino dialect now `.offsetFetch` with an empty `offsetFetchOrderBy`.
- `TableQueryBuilder.swift` and `FilterSQLGenerator.swift`: treat an empty `offsetFetchOrderBy` as "no synthetic ORDER BY".
- Tests: Trino pages with `OFFSET ... FETCH NEXT ... ROWS ONLY` and no `LIMIT`/`ORDER BY`; MSSQL still injects its default ORDER BY; `.limit` dialects still emit `LIMIT n OFFSET m`.
- Docs and CHANGELOG updated.

## Delivery

The dialect in the plugin binary is authoritative at browse time, so users get the fix once the Trino plugin is re-published (`plugin-trino-v*`, a normal release, no ABI bump). The app-side changes ride the next app release.

## Grammar check

Confirmed against the Trino docs: `LIMIT n OFFSET m` is a syntax error; both `OFFSET m LIMIT n` and `OFFSET m ROWS FETCH NEXT n ROWS ONLY` are valid, and neither requires `ORDER BY` (only `FETCH ... WITH TIES` does).

https://claude.ai/code/session_01FYwKEwKydeMG6WAHucMdY9