### PR TITLE
fix(connections): unwrap optional session.driver in the metadata pool

### DIFF
--- a/TablePro/Core/Services/Query/MetadataConnectionPool.swift
+++ b/TablePro/Core/Services/Query/MetadataConnectionPool.swift
@@ -111,8 +111,10 @@ final class MetadataConnectionPool {
     ) async throws -> Entry {
         if let session = DatabaseManager.shared.session(for: connectionId),
            session.connection.type.supportsConnectionPooling == false {
-            guard session.driver.status == .connected else { throw DatabaseError.notConnected }
-            return Entry(driver: session.driver, ownsDriver: false)
+            guard let driver = session.driver, driver.status == .connected else {
+                throw DatabaseError.notConnected
+            }
+            return Entry(driver: driver, ownsDriver: false)
         }
 
         let key = Key(connectionId: connectionId, database: database, schema: schema, workload: workload)


### PR DESCRIPTION
## Problem

`main` does not compile after the PGlite PR (#1934). `MetadataConnectionPool.acquireEntry` uses `session.driver` (an optional `DatabaseDriver?`) as if it were non-optional:

```swift
guard session.driver.status == .connected else { throw DatabaseError.notConnected }
return Entry(driver: session.driver, ownsDriver: false)
```

```
error: Value of optional type '(any DatabaseDriver)?' must be unwrapped to refer to member 'status'
error: Value of optional type '(any DatabaseDriver)?' must be unwrapped to a value of type 'any DatabaseDriver'
```

## Fix

Unwrap `session.driver` once with `guard let`, then use it for both the status check and the `Entry`. A session with no driver throws `notConnected`, matching the other paths in the pool.

Build fix only, no behavior change. #1934 is unreleased, so no CHANGELOG entry.

https://claude.ai/code/session_01FYwKEwKydeMG6WAHucMdY9