### PR TITLE
feat(inspector): insert rows and confirm data-bearing deletes in the CSV editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Connect to PGlite through its socket server (`pglite-server`), with schema browsing, SQL editing, and row editing like PostgreSQL. Defaults to a loopback host with no TLS, and treats the connection as single-use to match PGlite's one-connection limit. (#1911)
 - In the CSV editor, right-click a column header to rename, insert, delete, or change the type of that column. (#1913)
+- In the CSV editor, insert a row above or below any row from the row's right-click menu or the Edit menu. Deleting rows that contain data now asks you to confirm first. (#1469)
 - Add llama.cpp and MLX as local AI providers. Each preset points at the server's default local endpoint and needs no API key, alongside the existing Ollama and custom OpenAI-compatible options. (#1777)
 
 ### Fixed

--- a/Plugins/CSVInspectorPlugin/CSVDocument.swift
+++ b/Plugins/CSVInspectorPlugin/CSVDocument.swift
@@ -191,6 +191,7 @@ public final class CSVDocument: NSDocument, InspectorDocument {
         registerUndo { document in
             document.removeRow(at: index, suppressUndo: false)
         }
+        setUndoActionName(String(localized: "Add Row"))
         onChange?()
     }
 
@@ -199,11 +200,13 @@ public final class CSVDocument: NSDocument, InspectorDocument {
         registerUndo { document in
             document.removeRow(at: index, suppressUndo: false)
         }
+        setUndoActionName(String(localized: "Insert Row"))
         onChange?()
     }
 
     public func removeRow(at index: Int) {
         removeRow(at: index, suppressUndo: false)
+        setUndoActionName(String(localized: "Delete Row"))
     }
 
     private func removeRow(at index: Int, suppressUndo: Bool) {
@@ -230,6 +233,11 @@ public final class CSVDocument: NSDocument, InspectorDocument {
         registerUndo { document in
             document.reinsertRows(removed)
         }
+        setUndoActionName(
+            removed.count == 1
+                ? String(localized: "Delete Row")
+                : String(localized: "Delete Rows")
+        )
         onChange?()
     }
 
@@ -316,6 +324,10 @@ public final class CSVDocument: NSDocument, InspectorDocument {
 
     private func registerUndo(_ action: @escaping (CSVDocument) -> Void) {
         undoManager?.registerUndo(withTarget: self, handler: action)
+    }
+
+    private func setUndoActionName(_ name: String) {
+        undoManager?.setActionName(name)
     }
 
     private func shiftTypeOverrides(insertingAt index: Int) {

--- a/Plugins/CSVInspectorPlugin/CSVDocument.swift
+++ b/Plugins/CSVInspectorPlugin/CSVDocument.swift
@@ -187,61 +187,63 @@ public final class CSVDocument: NSDocument, InspectorDocument {
     }
 
     public func appendRow() {
+        let name = String(localized: "Add Row")
         let index = store.appendRow(values: [])
         registerUndo { document in
-            document.removeRow(at: index, suppressUndo: false)
+            document.removeRow(at: index, suppressUndo: false, actionName: name)
         }
-        setUndoActionName(String(localized: "Add Row"))
+        setUndoActionName(name)
         onChange?()
     }
 
     public func insertRow(at index: Int) {
+        let name = String(localized: "Insert Row")
         store.insertRow([], at: index)
         registerUndo { document in
-            document.removeRow(at: index, suppressUndo: false)
+            document.removeRow(at: index, suppressUndo: false, actionName: name)
         }
-        setUndoActionName(String(localized: "Insert Row"))
+        setUndoActionName(name)
         onChange?()
     }
 
     public func removeRow(at index: Int) {
-        removeRow(at: index, suppressUndo: false)
-        setUndoActionName(String(localized: "Delete Row"))
+        removeRow(at: index, suppressUndo: false, actionName: String(localized: "Delete Row"))
     }
 
-    private func removeRow(at index: Int, suppressUndo: Bool) {
+    private func removeRow(at index: Int, suppressUndo: Bool, actionName: String) {
         guard let removed = store.removeRow(at: index) else { return }
         if !suppressUndo {
             registerUndo { document in
-                document.reinsertRow(removed, at: index)
+                document.reinsertRow(removed, at: index, actionName: actionName)
             }
+            setUndoActionName(actionName)
         }
         onChange?()
     }
 
-    private func reinsertRow(_ values: [String], at index: Int) {
+    private func reinsertRow(_ values: [String], at index: Int, actionName: String) {
         store.insertRow(values, at: index)
         registerUndo { document in
-            document.removeRow(at: index, suppressUndo: false)
+            document.removeRow(at: index, suppressUndo: false, actionName: actionName)
         }
+        setUndoActionName(actionName)
         onChange?()
     }
 
     public func removeRows(at indices: IndexSet) {
         let removed = store.removeRows(at: indices)
         guard !removed.isEmpty else { return }
+        let name = removed.count == 1
+            ? String(localized: "Delete Row")
+            : String(localized: "Delete Rows")
         registerUndo { document in
-            document.reinsertRows(removed)
+            document.reinsertRows(removed, actionName: name)
         }
-        setUndoActionName(
-            removed.count == 1
-                ? String(localized: "Delete Row")
-                : String(localized: "Delete Rows")
-        )
+        setUndoActionName(name)
         onChange?()
     }
 
-    private func reinsertRows(_ rows: [(index: Int, cells: [String])]) {
+    private func reinsertRows(_ rows: [(index: Int, cells: [String])], actionName: String) {
         for entry in rows.sorted(by: { $0.index < $1.index }) {
             store.insertRow(entry.cells, at: entry.index)
         }
@@ -249,6 +251,7 @@ public final class CSVDocument: NSDocument, InspectorDocument {
         registerUndo { document in
             document.removeRows(at: originalIndices)
         }
+        setUndoActionName(actionName)
         onChange?()
     }
 

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -605,6 +605,23 @@ struct AppMenuCommands: Commands {
 
             Divider()
 
+            Button(String(localized: "Insert Row Above")) {
+                NSApp.sendAction(#selector(InspectorViewController.inspectorInsertRowAbove(_:)), to: nil, from: nil)
+            }
+            .disabled(!keyWindowIsInspector)
+
+            Button(String(localized: "Insert Row Below")) {
+                NSApp.sendAction(#selector(InspectorViewController.inspectorInsertRowBelow(_:)), to: nil, from: nil)
+            }
+            .disabled(!keyWindowIsInspector)
+
+            Button(String(localized: "Delete Rows")) {
+                NSApp.sendAction(#selector(InspectorViewController.inspectorDeleteSelectedRows(_:)), to: nil, from: nil)
+            }
+            .disabled(!keyWindowIsInspector)
+
+            Divider()
+
             // Table operations (work when tables selected in sidebar)
             Button("Truncate Table") {
                 actions?.truncateTables()

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -605,17 +605,17 @@ struct AppMenuCommands: Commands {
 
             Divider()
 
-            Button(String(localized: "Insert Row Above")) {
+            Button("Insert Row Above") {
                 NSApp.sendAction(#selector(InspectorViewController.inspectorInsertRowAbove(_:)), to: nil, from: nil)
             }
             .disabled(!keyWindowIsInspector)
 
-            Button(String(localized: "Insert Row Below")) {
+            Button("Insert Row Below") {
                 NSApp.sendAction(#selector(InspectorViewController.inspectorInsertRowBelow(_:)), to: nil, from: nil)
             }
             .disabled(!keyWindowIsInspector)
 
-            Button(String(localized: "Delete Rows")) {
+            Button("Delete Rows") {
                 NSApp.sendAction(#selector(InspectorViewController.inspectorDeleteSelectedRows(_:)), to: nil, from: nil)
             }
             .disabled(!keyWindowIsInspector)

--- a/TablePro/Views/Inspector/InspectorDeleteConfirmation.swift
+++ b/TablePro/Views/Inspector/InspectorDeleteConfirmation.swift
@@ -1,0 +1,52 @@
+//
+//  InspectorDeleteConfirmation.swift
+//  TablePro
+//
+
+import AppKit
+
+@MainActor
+enum InspectorDeleteConfirmation {
+    static func rowsContainData(_ rowsCells: [[String]]) -> Bool {
+        rowsCells.contains { cells in cells.contains { !$0.isEmpty } }
+    }
+
+    static func rowDeleteTitle(count: Int) -> String {
+        count == 1
+            ? String(localized: "Delete this row?")
+            : String(format: String(localized: "Delete %lld rows?"), count)
+    }
+
+    static func confirmDeleteRowsIfNeeded(
+        rowsCells: [[String]],
+        window: NSWindow?,
+        proceed: @escaping @MainActor () -> Void
+    ) {
+        guard rowsContainData(rowsCells) else {
+            proceed()
+            return
+        }
+        present(messageText: rowDeleteTitle(count: rowsCells.count), window: window, proceed: proceed)
+    }
+
+    private static func present(
+        messageText: String,
+        window: NSWindow?,
+        proceed: @escaping @MainActor () -> Void
+    ) {
+        guard let window else {
+            proceed()
+            return
+        }
+        let alert = NSAlert()
+        alert.messageText = messageText
+        alert.alertStyle = .warning
+        let deleteButton = alert.addButton(withTitle: String(localized: "Delete"))
+        deleteButton.hasDestructiveAction = true
+        alert.addButton(withTitle: String(localized: "Cancel"))
+        alert.beginSheetModal(for: window) { response in
+            guard response == .alertFirstButtonReturn else { return }
+            proceed()
+        }
+    }
+}

--- a/TablePro/Views/Inspector/InspectorRowInsertion.swift
+++ b/TablePro/Views/Inspector/InspectorRowInsertion.swift
@@ -1,0 +1,17 @@
+//
+//  InspectorRowInsertion.swift
+//  TablePro
+//
+
+import Foundation
+
+enum InspectorRowInsertion {
+    static func storeIndex(anchorDisplayRow: Int?, below: Bool, displayToStore: [Int], rowCount: Int) -> Int {
+        guard let displayRow = anchorDisplayRow,
+              displayRow >= 0, displayRow < displayToStore.count else {
+            return below ? rowCount : 0
+        }
+        let storeRow = displayToStore[displayRow]
+        return below ? storeRow + 1 : storeRow
+    }
+}

--- a/TablePro/Views/Inspector/InspectorRowMenuBuilder.swift
+++ b/TablePro/Views/Inspector/InspectorRowMenuBuilder.swift
@@ -1,0 +1,31 @@
+//
+//  InspectorRowMenuBuilder.swift
+//  TablePro
+//
+
+import AppKit
+
+@MainActor
+enum InspectorRowMenuBuilder {
+    static func structureItems(forRow displayRow: Int) -> [NSMenuItem] {
+        [
+            actionItem(
+                title: String(localized: "Insert Row Above"),
+                action: #selector(InspectorViewController.inspectorInsertRowAbove(_:)),
+                row: displayRow
+            ),
+            actionItem(
+                title: String(localized: "Insert Row Below"),
+                action: #selector(InspectorViewController.inspectorInsertRowBelow(_:)),
+                row: displayRow
+            ),
+        ]
+    }
+
+    private static func actionItem(title: String, action: Selector, row: Int) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        item.tag = row
+        item.target = nil
+        return item
+    }
+}

--- a/TablePro/Views/Inspector/InspectorViewController.swift
+++ b/TablePro/Views/Inspector/InspectorViewController.swift
@@ -162,8 +162,19 @@ final class InspectorViewController: NSViewController, NSUserInterfaceValidation
             return displayToStore[index]
         }
         guard !storeIndices.isEmpty else { return }
-        pendingPostRefresh = .selectClamped(displayRow: sortedDisplay.first ?? 0)
-        inspectorDocument.removeRows(at: IndexSet(storeIndices))
+        let columnCount = inspectorDocument.columnNames.count
+        let rowsCells = storeIndices.map { storeRow in
+            (0..<columnCount).map { inspectorDocument.value(row: storeRow, column: $0) }
+        }
+        let firstDisplayRow = sortedDisplay.first ?? 0
+        InspectorDeleteConfirmation.confirmDeleteRowsIfNeeded(
+            rowsCells: rowsCells,
+            window: view.window
+        ) { [weak self] in
+            guard let self else { return }
+            self.pendingPostRefresh = .selectClamped(displayRow: firstDisplayRow)
+            self.inspectorDocument?.removeRows(at: IndexSet(storeIndices))
+        }
     }
 
     fileprivate func handleSortChanged(_ newState: SortState) {
@@ -204,6 +215,38 @@ final class InspectorViewController: NSViewController, NSUserInterfaceValidation
     @objc func inspectorAddRow(_ sender: Any?) { handleAddRow() }
     @objc func inspectorDeleteSelectedRows(_ sender: Any?) {
         handleDeleteRows(state.selectedRowIndices)
+    }
+
+    @objc func inspectorInsertRowAbove(_ sender: Any?) {
+        performInsertRow(anchoredBy: sender, below: false)
+    }
+
+    @objc func inspectorInsertRowBelow(_ sender: Any?) {
+        performInsertRow(anchoredBy: sender, below: true)
+    }
+
+    private func performInsertRow(anchoredBy sender: Any?, below: Bool) {
+        guard let inspectorDocument else { return }
+        let storeIndex = insertStoreIndex(anchoredBy: sender, below: below)
+        pendingPostRefresh = .focusStoreIndex(storeIndex)
+        inspectorDocument.insertRow(at: storeIndex)
+    }
+
+    private func insertStoreIndex(anchoredBy sender: Any?, below: Bool) -> Int {
+        let rowCount = inspectorDocument?.rowCount ?? 0
+        let anchorDisplayRow: Int? = if let item = sender as? NSMenuItem {
+            item.tag
+        } else if below {
+            state.selectedRowIndices.max()
+        } else {
+            state.selectedRowIndices.min()
+        }
+        guard let displayRow = anchorDisplayRow,
+              displayRow >= 0, displayRow < displayToStore.count else {
+            return below ? rowCount : 0
+        }
+        let storeRow = displayToStore[displayRow]
+        return below ? storeRow + 1 : storeRow
     }
 
     @objc func inspectorAddColumn(_ sender: Any?) {
@@ -278,6 +321,11 @@ final class InspectorViewController: NSViewController, NSUserInterfaceValidation
         )
     }
 
+    fileprivate func rowStructureMenuItems(forRow displayRow: Int) -> [NSMenuItem] {
+        guard inspectorDocument != nil else { return [] }
+        return InspectorRowMenuBuilder.structureItems(forRow: displayRow)
+    }
+
     private func renameLayoutKey(from oldName: String, to newName: String) {
         if state.columnLayout.columnOrder != nil {
             state.columnLayout.columnOrder = state.columnLayout.columnOrder?.map { $0 == oldName ? newName : $0 }
@@ -350,7 +398,8 @@ final class InspectorViewController: NSViewController, NSUserInterfaceValidation
         case #selector(redo(_:)):
             return nsDocument?.undoManager?.canRedo ?? false
         case #selector(saveDocument(_:)), #selector(saveDocumentAs(_:)),
-             #selector(toggleInspectorFilter(_:)), #selector(inspectorAddRow(_:)):
+             #selector(toggleInspectorFilter(_:)), #selector(inspectorAddRow(_:)),
+             #selector(inspectorInsertRowAbove(_:)), #selector(inspectorInsertRowBelow(_:)):
             return nsDocument != nil
         case #selector(inspectorDeleteSelectedRows(_:)):
             return !state.selectedRowIndices.isEmpty
@@ -699,6 +748,10 @@ private final class InspectorGridDelegate: DataGridViewDelegate {
 
     func dataGridColumnStructureMenuItems(forColumn dataColumnIndex: Int) -> [NSMenuItem] {
         owner?.columnStructureMenuItems(forColumn: dataColumnIndex) ?? []
+    }
+
+    func dataGridRowStructureMenuItems(forRow displayRow: Int) -> [NSMenuItem] {
+        owner?.rowStructureMenuItems(forRow: displayRow) ?? []
     }
 
     func dataGridUndo() {

--- a/TablePro/Views/Inspector/InspectorViewController.swift
+++ b/TablePro/Views/Inspector/InspectorViewController.swift
@@ -143,7 +143,6 @@ final class InspectorViewController: NSViewController, NSUserInterfaceValidation
 
         let undoManager = nsDocument?.undoManager
         undoManager?.beginUndoGrouping()
-        undoManager?.setActionName(String(localized: "Paste"))
         for row in rows {
             let newRowIndex = inspectorDocument.rowCount
             inspectorDocument.appendRow()
@@ -151,6 +150,7 @@ final class InspectorViewController: NSViewController, NSUserInterfaceValidation
                 inspectorDocument.setCell(row: newRowIndex, column: column, to: value)
             }
         }
+        undoManager?.setActionName(String(localized: "Paste"))
         undoManager?.endUndoGrouping()
     }
 
@@ -233,7 +233,6 @@ final class InspectorViewController: NSViewController, NSUserInterfaceValidation
     }
 
     private func insertStoreIndex(anchoredBy sender: Any?, below: Bool) -> Int {
-        let rowCount = inspectorDocument?.rowCount ?? 0
         let anchorDisplayRow: Int? = if let item = sender as? NSMenuItem {
             item.tag
         } else if below {
@@ -241,12 +240,12 @@ final class InspectorViewController: NSViewController, NSUserInterfaceValidation
         } else {
             state.selectedRowIndices.min()
         }
-        guard let displayRow = anchorDisplayRow,
-              displayRow >= 0, displayRow < displayToStore.count else {
-            return below ? rowCount : 0
-        }
-        let storeRow = displayToStore[displayRow]
-        return below ? storeRow + 1 : storeRow
+        return InspectorRowInsertion.storeIndex(
+            anchorDisplayRow: anchorDisplayRow,
+            below: below,
+            displayToStore: displayToStore,
+            rowCount: inspectorDocument?.rowCount ?? 0
+        )
     }
 
     @objc func inspectorAddColumn(_ sender: Any?) {

--- a/TablePro/Views/Results/DataGridRowView.swift
+++ b/TablePro/Views/Results/DataGridRowView.swift
@@ -320,6 +320,14 @@ class DataGridRowView: NSTableRowView {
         }
 
         if coordinator.isEditable {
+            let rowStructureItems = coordinator.delegate?.dataGridRowStructureMenuItems(forRow: rowIndex) ?? []
+            if !rowStructureItems.isEmpty {
+                menu.addItem(NSMenuItem.separator())
+                for item in rowStructureItems {
+                    menu.addItem(item)
+                }
+            }
+
             let duplicateItem = NSMenuItem(
                 title: String(localized: "Duplicate"), action: #selector(duplicateRow), keyEquivalent: "")
             duplicateItem.target = self

--- a/TablePro/Views/Results/DataGridViewDelegate.swift
+++ b/TablePro/Views/Results/DataGridViewDelegate.swift
@@ -28,6 +28,7 @@ protocol DataGridViewDelegate: AnyObject {
     func dataGridHideColumn(_ columnName: String)
     func dataGridShowAllColumns()
     func dataGridColumnStructureMenuItems(forColumn dataColumnIndex: Int) -> [NSMenuItem]
+    func dataGridRowStructureMenuItems(forRow displayRow: Int) -> [NSMenuItem]
     func dataGridVisualState(forRow row: Int) -> RowVisualState?
     func dataGridRowView(for tableView: NSTableView, row: Int, coordinator: TableViewCoordinator) -> NSTableRowView?
     func dataGridEmptySpaceMenu() -> NSMenu?
@@ -57,6 +58,7 @@ extension DataGridViewDelegate {
     func dataGridHideColumn(_ columnName: String) {}
     func dataGridShowAllColumns() {}
     func dataGridColumnStructureMenuItems(forColumn dataColumnIndex: Int) -> [NSMenuItem] { [] }
+    func dataGridRowStructureMenuItems(forRow displayRow: Int) -> [NSMenuItem] { [] }
     func dataGridVisualState(forRow row: Int) -> RowVisualState? { nil }
     func dataGridRowView(for tableView: NSTableView, row: Int, coordinator: TableViewCoordinator) -> NSTableRowView? { nil }
     func dataGridEmptySpaceMenu() -> NSMenu? { nil }

--- a/TableProTests/PluginTestSources/CSVDocument.swift
+++ b/TableProTests/PluginTestSources/CSVDocument.swift
@@ -1,0 +1,1 @@
+../../Plugins/CSVInspectorPlugin/CSVDocument.swift

--- a/TableProTests/Plugins/CSVDocumentUndoTests.swift
+++ b/TableProTests/Plugins/CSVDocumentUndoTests.swift
@@ -1,0 +1,53 @@
+//
+//  CSVDocumentUndoTests.swift
+//  TableProTests
+//
+//  Tests CSVDocument (compiled via symlink from Plugins/CSVInspectorPlugin/).
+//
+
+import AppKit
+import Foundation
+import TableProPluginKit
+import Testing
+
+@MainActor
+@Suite("CSVDocument undo naming")
+struct CSVDocumentUndoTests {
+    private func makeDocument(_ contents: String) throws -> CSVDocument {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).csv")
+        try contents.data(using: .utf8)!.write(to: url)
+        let document = CSVDocument()
+        try document.read(from: url, ofType: "public.comma-separated-values-text")
+        try? FileManager.default.removeItem(at: url)
+        return document
+    }
+
+    @Test("Insert Row keeps its name through undo and redo")
+    func insertRowNaming() throws {
+        let document = try makeDocument("a,b\n1,2\n")
+        document.insertRow(at: 0)
+        #expect(document.undoManager?.undoActionName == "Insert Row")
+        document.undoManager?.undo()
+        #expect(document.undoManager?.redoActionName == "Insert Row")
+        document.undoManager?.redo()
+        #expect(document.undoManager?.undoActionName == "Insert Row")
+    }
+
+    @Test("Delete Rows keeps its name through undo")
+    func deleteRowsNaming() throws {
+        let document = try makeDocument("a,b\n1,2\n3,4\n5,6\n")
+        document.removeRows(at: IndexSet([0, 1]))
+        #expect(document.undoManager?.undoActionName == "Delete Rows")
+        document.undoManager?.undo()
+        #expect(document.undoManager?.redoActionName == "Delete Rows")
+    }
+
+    @Test("Add Row keeps its name through undo and redo")
+    func addRowNaming() throws {
+        let document = try makeDocument("a,b\n1,2\n")
+        document.appendRow()
+        #expect(document.undoManager?.undoActionName == "Add Row")
+        document.undoManager?.undo()
+        #expect(document.undoManager?.redoActionName == "Add Row")
+    }
+}

--- a/TableProTests/Plugins/CSVInspectorTests.swift
+++ b/TableProTests/Plugins/CSVInspectorTests.swift
@@ -265,6 +265,39 @@ struct CSVRowStoreTests {
         #expect(store.cells(forRow: 4) == ["5", "5"])
     }
 
+    @Test("insertRow places a row at the given index and shifts the rest down")
+    func insertRowAtIndex() {
+        let store = makeStore("a,b\n1,1\n3,3\n")
+        store.insertRow(["2", "2"], at: 1)
+        #expect(store.rowCount == 3)
+        #expect(store.cells(forRow: 0) == ["1", "1"])
+        #expect(store.cells(forRow: 1) == ["2", "2"])
+        #expect(store.cells(forRow: 2) == ["3", "3"])
+    }
+
+    @Test("insertRow at 0 inserts above the first row")
+    func insertRowAtTop() {
+        let store = makeStore("a,b\n1,1\n2,2\n")
+        store.insertRow(["0", "0"], at: 0)
+        #expect(store.cells(forRow: 0) == ["0", "0"])
+        #expect(store.cells(forRow: 1) == ["1", "1"])
+    }
+
+    @Test("insertRow past the end clamps to an append")
+    func insertRowClampsToEnd() {
+        let store = makeStore("a,b\n1,1\n")
+        store.insertRow(["9", "9"], at: 99)
+        #expect(store.rowCount == 2)
+        #expect(store.cells(forRow: 1) == ["9", "9"])
+    }
+
+    @Test("insertRow pads a short row to the column count")
+    func insertRowPadsShortRow() {
+        let store = makeStore("a,b,c\n1,2,3\n")
+        store.insertRow(["x"], at: 0)
+        #expect(store.cells(forRow: 0) == ["x", "", ""])
+    }
+
     @Test("renameColumn updates columnNames in place")
     func renameColumnInPlace() {
         let store = makeStore("a,b,c\n1,2,3\n")

--- a/TableProTests/Views/InspectorDeleteConfirmationTests.swift
+++ b/TableProTests/Views/InspectorDeleteConfirmationTests.swift
@@ -1,0 +1,33 @@
+//
+//  InspectorDeleteConfirmationTests.swift
+//  TableProTests
+//
+
+import AppKit
+@testable import TablePro
+import Testing
+
+@MainActor
+@Suite("InspectorDeleteConfirmation")
+struct InspectorDeleteConfirmationTests {
+    @Test("An all-empty selection contains no data")
+    func emptyRowsHaveNoData() {
+        #expect(InspectorDeleteConfirmation.rowsContainData([["", ""], ["", ""]]) == false)
+    }
+
+    @Test("An empty selection contains no data")
+    func noRowsHaveNoData() {
+        #expect(InspectorDeleteConfirmation.rowsContainData([]) == false)
+    }
+
+    @Test("A selection with any non-empty cell contains data")
+    func nonEmptyRowsHaveData() {
+        #expect(InspectorDeleteConfirmation.rowsContainData([["", ""], ["", "x"]]) == true)
+    }
+
+    @Test("Delete title reflects the row count")
+    func rowDeleteTitles() {
+        #expect(InspectorDeleteConfirmation.rowDeleteTitle(count: 1) == "Delete this row?")
+        #expect(InspectorDeleteConfirmation.rowDeleteTitle(count: 3).contains("3"))
+    }
+}

--- a/TableProTests/Views/InspectorRowInsertionTests.swift
+++ b/TableProTests/Views/InspectorRowInsertionTests.swift
@@ -1,0 +1,44 @@
+//
+//  InspectorRowInsertionTests.swift
+//  TableProTests
+//
+
+@testable import TablePro
+import Testing
+
+@Suite("InspectorRowInsertion")
+struct InspectorRowInsertionTests {
+    @Test("A clicked row maps through displayToStore for above and below")
+    func mapsClickedRow() {
+        let displayToStore = [10, 11, 12]
+        #expect(InspectorRowInsertion.storeIndex(
+            anchorDisplayRow: 1, below: false, displayToStore: displayToStore, rowCount: 3) == 11)
+        #expect(InspectorRowInsertion.storeIndex(
+            anchorDisplayRow: 1, below: true, displayToStore: displayToStore, rowCount: 3) == 12)
+    }
+
+    @Test("A non-identity displayToStore (filtered or sorted view) resolves the store row")
+    func nonIdentityMapping() {
+        let displayToStore = [4, 0, 9]
+        #expect(InspectorRowInsertion.storeIndex(
+            anchorDisplayRow: 0, below: false, displayToStore: displayToStore, rowCount: 10) == 4)
+        #expect(InspectorRowInsertion.storeIndex(
+            anchorDisplayRow: 2, below: true, displayToStore: displayToStore, rowCount: 10) == 10)
+    }
+
+    @Test("No anchor inserts at the top for above and appends for below")
+    func emptySelectionFallback() {
+        #expect(InspectorRowInsertion.storeIndex(
+            anchorDisplayRow: nil, below: false, displayToStore: [0, 1], rowCount: 2) == 0)
+        #expect(InspectorRowInsertion.storeIndex(
+            anchorDisplayRow: nil, below: true, displayToStore: [0, 1], rowCount: 2) == 2)
+    }
+
+    @Test("An out-of-range anchor falls back to top or append")
+    func outOfRangeFallback() {
+        #expect(InspectorRowInsertion.storeIndex(
+            anchorDisplayRow: 5, below: false, displayToStore: [0, 1], rowCount: 2) == 0)
+        #expect(InspectorRowInsertion.storeIndex(
+            anchorDisplayRow: -1, below: true, displayToStore: [0, 1], rowCount: 2) == 2)
+    }
+}

--- a/TableProTests/Views/InspectorRowMenuBuilderTests.swift
+++ b/TableProTests/Views/InspectorRowMenuBuilderTests.swift
@@ -1,0 +1,31 @@
+//
+//  InspectorRowMenuBuilderTests.swift
+//  TableProTests
+//
+
+import AppKit
+@testable import TablePro
+import Testing
+
+@MainActor
+@Suite("InspectorRowMenuBuilder")
+struct InspectorRowMenuBuilderTests {
+    @Test("Structure items are Insert Row Above then Insert Row Below")
+    func structureItemsOrder() {
+        let items = InspectorRowMenuBuilder.structureItems(forRow: 4)
+
+        #expect(items.count == 2)
+        #expect(items[0].action == #selector(InspectorViewController.inspectorInsertRowAbove(_:)))
+        #expect(items[1].action == #selector(InspectorViewController.inspectorInsertRowBelow(_:)))
+    }
+
+    @Test("Each item carries the clicked row and no explicit target")
+    func structureItemsWiring() {
+        let items = InspectorRowMenuBuilder.structureItems(forRow: 7)
+
+        for item in items {
+            #expect(item.tag == 7)
+            #expect(item.target == nil)
+        }
+    }
+}

--- a/docs/features/csv-inspector.mdx
+++ b/docs/features/csv-inspector.mdx
@@ -34,7 +34,7 @@ Rows load in pages. The page size comes from the Default page size setting in [S
 
 - Double-click a cell (or press Return on it) to edit. Return commits and closes the editor. Tab commits and moves to the next cell, wrapping to the next row.
 - The toolbar `Add Row` button appends a new row, scrolls to it, and selects it.
-- Right-click a row and choose **Insert Row Above** or **Insert Row Below** to add a blank row next to it. Both also appear in the Edit menu, where they act on the selected row.
+- Right-click a row and choose **Insert Row Above** or **Insert Row Below** to add a blank row next to it. Both also appear in the Edit menu, where they insert next to the selected row, or at the top or bottom when nothing is selected.
 - Select rows and press `Delete` (the toolbar `Delete` button, or right-click a row and choose Delete) to remove them. The next row takes selection so arrow keys keep working from where you were.
 - Deleting rows that hold data asks you to confirm first. Deleting blank rows skips the prompt.
 - Cmd+Z and Cmd+Shift+Z undo and redo every change. Each insert, a bulk delete, or a paste is a single undo step.

--- a/docs/features/csv-inspector.mdx
+++ b/docs/features/csv-inspector.mdx
@@ -34,8 +34,10 @@ Rows load in pages. The page size comes from the Default page size setting in [S
 
 - Double-click a cell (or press Return on it) to edit. Return commits and closes the editor. Tab commits and moves to the next cell, wrapping to the next row.
 - The toolbar `Add Row` button appends a new row, scrolls to it, and selects it.
+- Right-click a row and choose **Insert Row Above** or **Insert Row Below** to add a blank row next to it. Both also appear in the Edit menu, where they act on the selected row.
 - Select rows and press `Delete` (the toolbar `Delete` button, or right-click a row and choose Delete) to remove them. The next row takes selection so arrow keys keep working from where you were.
-- Cmd+Z and Cmd+Shift+Z undo and redo every change. A bulk delete or a paste is a single undo step.
+- Deleting rows that hold data asks you to confirm first. Deleting blank rows skips the prompt.
+- Cmd+Z and Cmd+Shift+Z undo and redo every change. Each insert, a bulk delete, or a paste is a single undo step.
 
 ## Column operations
 


### PR DESCRIPTION
Part 1 of 4 toward #1469 (CSV structural editing). Focused on **rows**.

## What
- **Insert Row Above / Insert Row Below** from a row's right-click menu, and mirrored in the Edit menu (where they act on the selected row). Both insert a blank row and scroll to it.
- **Delete confirmation**: deleting rows that contain any non-empty cell now asks first. Deleting blank rows still deletes without a prompt.
- Row insert and delete are each a single named undo step ("Undo Insert Row", "Undo Delete Rows").

## Why
The CSV inspector (from #1259, extended by #1913/#1932) can edit cells and add/remove columns, but the only way to add a row was the toolbar Add Row button, which always appends. There was no way to insert at a position, and deletes had no guard for data-bearing rows. This closes the row half of #1469.

## How (native / HIG)
- Row items ride the existing shared row menu through a new `dataGridRowStructureMenuItems(forRow:)` delegate seam, mirroring the column seam #1932 added. Only the CSV inspector implements it, so database grids are unaffected.
- Edit-menu items dispatch through the responder chain (`NSApp.sendAction(_:to:nil)`) to the focused inspector, gated on `keyWindowIsInspector`, matching the existing Undo/Redo/Find routing.
- Insert reuses `CSVDocument.insertRow(at:)` (already undoable); delete adds a confirm-when-non-empty gate. Per Apple's HIG, undoable deletes normally don't need a prompt, so the prompt is scoped to data-bearing rows and its copy does not claim the action is irreversible.
- Selection is mapped display-position → store index through the inspector's `displayToStore`, respecting the filtered/sorted-view invariant (a display row is not a store row).

## Tests
- `CSVRowStore.insertRow` at a middle index, at the top, clamped past the end, and padding a short row.
- `InspectorRowMenuBuilder` item order, action wiring, and row tagging.
- `InspectorDeleteConfirmation.rowsContainData` / `rowDeleteTitle` decision logic.

## Docs / changelog
- `docs/features/csv-inspector.mdx` Editing section updated.
- CHANGELOG entry under `[Unreleased]`.

Needs a local Xcode build to confirm compilation (CI lints `TablePro/` only, which passes `--strict`).