### PR TITLE
feat(inspector): choose the CSV escape character (doubled quote or backslash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In the CSV editor, split a column into several by a delimiter or regular expression, and merge a column with the one next to it using a separator. Both are single undo steps. (#1469)
 - In the CSV editor, switch the first row between header and data with `Cmd+Shift+H` when auto-detection guesses wrong. Files without a header are no longer saved with a generated header row. (#1469)
 - In the CSV editor, set the delimiter, quote character, encoding, and line ending by hand from Edit > Set CSV Properties…, then Reload to re-read the file with those settings. (#1469)
+- In the CSV editor, choose the escape character (a doubled quote or a backslash) in Set CSV Properties…, so files that escape quotes with a backslash read and save correctly. (#1469)
 - Add llama.cpp and MLX as local AI providers. Each preset points at the server's default local endpoint and needs no API key, alongside the existing Ollama and custom OpenAI-compatible options. (#1777)
 
 ### Fixed

--- a/Plugins/CSVInspectorPlugin/CSVWriter.swift
+++ b/Plugins/CSVInspectorPlugin/CSVWriter.swift
@@ -72,9 +72,8 @@ struct CSVWriter {
     func encodeRow(_ cells: [String]) -> String {
         let delimiterScalar = UnicodeScalar(dialect.delimiter)
         let quoteScalar = UnicodeScalar(dialect.quoteChar)
+        let escapeScalar = UnicodeScalar(dialect.escapeChar)
         let delimiter = String(delimiterScalar)
-        let quote = String(quoteScalar)
-        let doubledQuote = quote + quote
 
         var line = ""
         for (index, field) in cells.enumerated() {
@@ -85,8 +84,7 @@ struct CSVWriter {
                 field,
                 delimiterScalar: delimiterScalar,
                 quoteScalar: quoteScalar,
-                quote: quote,
-                doubledQuote: doubledQuote
+                escapeScalar: escapeScalar
             )
         }
         return line
@@ -108,13 +106,19 @@ struct CSVWriter {
         _ field: String,
         delimiterScalar: UnicodeScalar,
         quoteScalar: UnicodeScalar,
-        quote: String,
-        doubledQuote: String
+        escapeScalar: UnicodeScalar
     ) -> String {
         let needsQuoting = field.unicodeScalars.contains { scalar in
             scalar == delimiterScalar || scalar == quoteScalar || scalar == "\n" || scalar == "\r"
         }
         guard needsQuoting else { return field }
-        return quote + field.replacingOccurrences(of: quote, with: doubledQuote) + quote
+        let quote = String(quoteScalar)
+        if escapeScalar == quoteScalar {
+            return quote + field.replacingOccurrences(of: quote, with: quote + quote) + quote
+        }
+        let escape = String(escapeScalar)
+        var body = field.replacingOccurrences(of: escape, with: escape + escape)
+        body = body.replacingOccurrences(of: quote, with: escape + quote)
+        return quote + body + quote
     }
 }

--- a/Plugins/TableProPluginKit/CSVDialect.swift
+++ b/Plugins/TableProPluginKit/CSVDialect.swift
@@ -17,6 +17,7 @@ public struct CSVDialect: Equatable, Sendable {
 
     public var delimiter: UInt8
     public var quoteChar: UInt8
+    public var escapeChar: UInt8 = 0x22
     public var encoding: String.Encoding
     public var lineEnding: LineEnding
     public var hasBom: Bool

--- a/Plugins/TableProPluginKit/CSVDialect.swift
+++ b/Plugins/TableProPluginKit/CSVDialect.swift
@@ -17,7 +17,7 @@ public struct CSVDialect: Equatable, Sendable {
 
     public var delimiter: UInt8
     public var quoteChar: UInt8
-    public var escapeChar: UInt8 = 0x22
+    public var escapeChar: UInt8
     public var encoding: String.Encoding
     public var lineEnding: LineEnding
     public var hasBom: Bool
@@ -31,6 +31,7 @@ public struct CSVDialect: Equatable, Sendable {
     ) {
         self.delimiter = delimiter
         self.quoteChar = quoteChar
+        self.escapeChar = quoteChar
         self.encoding = encoding
         self.lineEnding = lineEnding
         self.hasBom = hasBom

--- a/Plugins/TableProPluginKit/CSVStreamingParser.swift
+++ b/Plugins/TableProPluginKit/CSVStreamingParser.swift
@@ -10,6 +10,7 @@ public struct CSVStreamingParser: Sendable {
     public func indexRows(_ bytes: UnsafeBufferPointer<UInt8>) -> [Range<Int>] {
         var ranges: [Range<Int>] = []
         let quote = dialect.quoteChar
+        let escape = dialect.escapeChar
         let delimiter = dialect.delimiter
         let count = bytes.count
         var i = bomSkip(in: bytes)
@@ -20,8 +21,12 @@ public struct CSVStreamingParser: Sendable {
         while i < count {
             let byte = bytes[i]
             if insideQuotes {
+                if escape != quote, byte == escape, i + 1 < count {
+                    i += 2
+                    continue
+                }
                 if byte == quote {
-                    if i + 1 < count, bytes[i + 1] == quote {
+                    if escape == quote, i + 1 < count, bytes[i + 1] == quote {
                         i += 2
                         continue
                     }
@@ -69,6 +74,7 @@ public struct CSVStreamingParser: Sendable {
         var fields: [String] = []
         var field: [UInt8] = []
         let quote = dialect.quoteChar
+        let escape = dialect.escapeChar
         let delimiter = dialect.delimiter
         var insideQuotes = false
         var i = range.lowerBound
@@ -77,8 +83,13 @@ public struct CSVStreamingParser: Sendable {
         while i < end {
             let byte = bytes[i]
             if insideQuotes {
+                if escape != quote, byte == escape, i + 1 < end {
+                    field.append(bytes[i + 1])
+                    i += 2
+                    continue
+                }
                 if byte == quote {
-                    if i + 1 < end, bytes[i + 1] == quote {
+                    if escape == quote, i + 1 < end, bytes[i + 1] == quote {
                         field.append(quote)
                         i += 2
                         continue
@@ -115,6 +126,7 @@ public struct CSVStreamingParser: Sendable {
     public func field(_ bytes: UnsafeBufferPointer<UInt8>, range: Range<Int>, column: Int) -> String {
         guard column >= 0 else { return "" }
         let quote = dialect.quoteChar
+        let escape = dialect.escapeChar
         let delimiter = dialect.delimiter
         var insideQuotes = false
         var i = range.lowerBound
@@ -126,8 +138,13 @@ public struct CSVStreamingParser: Sendable {
         while i < end {
             let byte = bytes[i]
             if insideQuotes {
+                if escape != quote, byte == escape, i + 1 < end {
+                    if currentColumn == column { field.append(bytes[i + 1]) }
+                    i += 2
+                    continue
+                }
                 if byte == quote {
-                    if i + 1 < end, bytes[i + 1] == quote {
+                    if escape == quote, i + 1 < end, bytes[i + 1] == quote {
                         if currentColumn == column { field.append(quote) }
                         i += 2
                         continue

--- a/TablePro/Views/Inspector/CSVPropertiesSheet.swift
+++ b/TablePro/Views/Inspector/CSVPropertiesSheet.swift
@@ -13,6 +13,7 @@ struct CSVPropertiesSheet: View {
 
     @State private var delimiterIndex: Int
     @State private var quoteIndex: Int
+    @State private var escapeIndex: Int
     @State private var encodingIndex: Int
     @State private var lineEndingIndex: Int
 
@@ -26,6 +27,7 @@ struct CSVPropertiesSheet: View {
         self.onCancel = onCancel
         _delimiterIndex = State(initialValue: CSVPropertyOptions.delimiterIndex(for: dialect.delimiter))
         _quoteIndex = State(initialValue: CSVPropertyOptions.quoteIndex(for: dialect.quoteChar))
+        _escapeIndex = State(initialValue: CSVPropertyOptions.escapeIndex(for: dialect.escapeChar))
         _encodingIndex = State(initialValue: CSVPropertyOptions.encodingIndex(for: dialect.encoding))
         _lineEndingIndex = State(initialValue: CSVPropertyOptions.lineEndingIndex(for: dialect.lineEnding))
     }
@@ -46,6 +48,11 @@ struct CSVPropertiesSheet: View {
                 Picker("Quote character", selection: $quoteIndex) {
                     ForEach(CSVPropertyOptions.quotes.indices, id: \.self) { index in
                         Text(CSVPropertyOptions.quotes[index].label).tag(index)
+                    }
+                }
+                Picker("Escape character", selection: $escapeIndex) {
+                    ForEach(CSVPropertyOptions.escapes.indices, id: \.self) { index in
+                        Text(CSVPropertyOptions.escapes[index].label).tag(index)
                     }
                 }
                 Picker("Encoding", selection: $encodingIndex) {
@@ -77,6 +84,7 @@ struct CSVPropertiesSheet: View {
             base: baseDialect,
             delimiterIndex: delimiterIndex,
             quoteIndex: quoteIndex,
+            escapeIndex: escapeIndex,
             encodingIndex: encodingIndex,
             lineEndingIndex: lineEndingIndex
         )

--- a/TablePro/Views/Inspector/CSVPropertyOptions.swift
+++ b/TablePro/Views/Inspector/CSVPropertyOptions.swift
@@ -21,6 +21,11 @@ enum CSVPropertyOptions {
         (String(localized: "Single Quote  '"), 0x27),
     ]
 
+    static let escapes: [(label: String, byte: UInt8)] = [
+        (String(localized: "Doubled Quote"), 0x22),
+        (String(localized: "Backslash  \\"), 0x5C),
+    ]
+
     static let encodings: [(label: String, encoding: String.Encoding)] = [
         ("UTF-8", .utf8),
         ("UTF-16 LE", .utf16LittleEndian),
@@ -43,6 +48,10 @@ enum CSVPropertyOptions {
         quotes.firstIndex { $0.byte == byte } ?? 0
     }
 
+    static func escapeIndex(for byte: UInt8) -> Int {
+        escapes.firstIndex { $0.byte == byte } ?? 0
+    }
+
     static func encodingIndex(for encoding: String.Encoding) -> Int {
         encodings.firstIndex { $0.encoding == encoding } ?? 0
     }
@@ -55,15 +64,18 @@ enum CSVPropertyOptions {
         base: CSVDialect,
         delimiterIndex: Int,
         quoteIndex: Int,
+        escapeIndex: Int,
         encodingIndex: Int,
         lineEndingIndex: Int
     ) -> CSVDialect {
-        CSVDialect(
+        var dialect = CSVDialect(
             delimiter: delimiters.indices.contains(delimiterIndex) ? delimiters[delimiterIndex].byte : base.delimiter,
             quoteChar: quotes.indices.contains(quoteIndex) ? quotes[quoteIndex].byte : base.quoteChar,
             encoding: encodings.indices.contains(encodingIndex) ? encodings[encodingIndex].encoding : base.encoding,
             lineEnding: lineEndings.indices.contains(lineEndingIndex) ? lineEndings[lineEndingIndex].value : base.lineEnding,
             hasBom: base.hasBom
         )
+        dialect.escapeChar = escapes.indices.contains(escapeIndex) ? escapes[escapeIndex].byte : base.escapeChar
+        return dialect
     }
 }

--- a/TablePro/Views/Inspector/CSVPropertyOptions.swift
+++ b/TablePro/Views/Inspector/CSVPropertyOptions.swift
@@ -26,6 +26,8 @@ enum CSVPropertyOptions {
         (String(localized: "Backslash  \\"), 0x5C),
     ]
 
+    static let backslashEscapeIndex = 1
+
     static let encodings: [(label: String, encoding: String.Encoding)] = [
         ("UTF-8", .utf8),
         ("UTF-16 LE", .utf16LittleEndian),
@@ -49,7 +51,7 @@ enum CSVPropertyOptions {
     }
 
     static func escapeIndex(for byte: UInt8) -> Int {
-        escapes.firstIndex { $0.byte == byte } ?? 0
+        byte == escapes[backslashEscapeIndex].byte ? backslashEscapeIndex : 0
     }
 
     static func encodingIndex(for encoding: String.Encoding) -> Int {
@@ -75,7 +77,9 @@ enum CSVPropertyOptions {
             lineEnding: lineEndings.indices.contains(lineEndingIndex) ? lineEndings[lineEndingIndex].value : base.lineEnding,
             hasBom: base.hasBom
         )
-        dialect.escapeChar = escapes.indices.contains(escapeIndex) ? escapes[escapeIndex].byte : base.escapeChar
+        dialect.escapeChar = escapeIndex == backslashEscapeIndex
+            ? escapes[backslashEscapeIndex].byte
+            : dialect.quoteChar
         return dialect
     }
 }

--- a/TableProTests/Plugins/CSVInspectorTests.swift
+++ b/TableProTests/Plugins/CSVInspectorTests.swift
@@ -77,6 +77,13 @@ struct CSVDialectDetectionTests {
         let dialect = CSVDialect.detect(from: data)
         #expect(dialect.encoding == .windowsCP1252)
     }
+
+    @Test("Default escape character is the quote character")
+    func defaultEscapeChar() {
+        #expect(CSVDialect.csv.escapeChar == 0x22)
+        let detected = CSVDialect.detect(from: "a,b\n1,2\n".data(using: .utf8)!)
+        #expect(detected.escapeChar == 0x22)
+    }
 }
 
 @Suite("CSVStreamingParser")
@@ -131,6 +138,25 @@ struct CSVStreamingParserTests {
         let (data, ranges, parser) = parse(#"a,"say ""hi""",c"# + "\n")
         let fields = row(data, parser, ranges[0])
         #expect(fields == ["a", #"say "hi""#, "c"])
+    }
+
+    @Test("Backslash escape decodes an escaped quote to a single quote")
+    func backslashEscapesQuote() {
+        var dialect = CSVDialect.csv
+        dialect.escapeChar = 0x5C
+        let (data, ranges, parser) = parse(#""a\"b",c"# + "\n", dialect: dialect)
+        #expect(ranges.count == 1)
+        let fields = row(data, parser, ranges[0])
+        #expect(fields == [#"a"b"#, "c"])
+    }
+
+    @Test("Backslash escape decodes a doubled backslash to a single backslash")
+    func backslashEscapesBackslash() {
+        var dialect = CSVDialect.csv
+        dialect.escapeChar = 0x5C
+        let (data, ranges, parser) = parse(#""a\\b""# + "\n", dialect: dialect)
+        let fields = row(data, parser, ranges[0])
+        #expect(fields == [#"a\b"#])
     }
 
     @Test("Empty fields preserved")
@@ -471,6 +497,20 @@ struct CSVWriterRoundTripTests {
 
         let written = try Data(contentsOf: outURL)
         #expect(written.prefix(3) == Data([0xEF, 0xBB, 0xBF]))
+    }
+
+    @Test("Writer doubles an embedded quote by default")
+    func writerDefaultDoublesQuote() {
+        let writer = CSVWriter(dialect: .csv)
+        #expect(writer.encodeRow([#"a"b"#, "c"]) == #""a""b",c"#)
+    }
+
+    @Test("Writer escapes an embedded quote with the escape character")
+    func writerBackslashEscapesQuote() {
+        var dialect = CSVDialect.csv
+        dialect.escapeChar = 0x5C
+        let writer = CSVWriter(dialect: dialect)
+        #expect(writer.encodeRow([#"a"b"#, "c"]) == #""a\"b",c"#)
     }
 
     @Test("A headerless file is written without a synthetic header row")

--- a/TableProTests/Plugins/CSVInspectorTests.swift
+++ b/TableProTests/Plugins/CSVInspectorTests.swift
@@ -84,6 +84,11 @@ struct CSVDialectDetectionTests {
         let detected = CSVDialect.detect(from: "a,b\n1,2\n".data(using: .utf8)!)
         #expect(detected.escapeChar == 0x22)
     }
+
+    @Test("Escape character follows a non-default quote character")
+    func escapeFollowsQuote() {
+        #expect(CSVDialect(delimiter: 0x2C, quoteChar: 0x27).escapeChar == 0x27)
+    }
 }
 
 @Suite("CSVStreamingParser")
@@ -157,6 +162,18 @@ struct CSVStreamingParserTests {
         let (data, ranges, parser) = parse(#""a\\b""# + "\n", dialect: dialect)
         let fields = row(data, parser, ranges[0])
         #expect(fields == [#"a\b"#])
+    }
+
+    @Test("field(at:column:) honors the backslash escape inside a quoted field")
+    func fieldBackslashEscape() {
+        var dialect = CSVDialect.csv
+        dialect.escapeChar = 0x5C
+        let (data, ranges, parser) = parse(#""a\"b",c"# + "\n", dialect: dialect)
+        let first = data.withUnsafeBytes { raw -> String in
+            guard let base = raw.bindMemory(to: UInt8.self).baseAddress else { return "" }
+            return parser.field(UnsafeBufferPointer(start: base, count: raw.count), range: ranges[0], column: 0)
+        }
+        #expect(first == #"a"b"#)
     }
 
     @Test("Empty fields preserved")

--- a/TableProTests/Views/CSVPropertyOptionsTests.swift
+++ b/TableProTests/Views/CSVPropertyOptionsTests.swift
@@ -22,18 +22,20 @@ struct CSVPropertyOptionsTests {
         #expect(CSVPropertyOptions.delimiterIndex(for: 0x5E) == 0)
     }
 
-    @Test("Building a dialect from indices sets the four properties and keeps the BOM")
+    @Test("Building a dialect from indices sets every property and keeps the BOM")
     func dialectRoundTrip() {
         let base = CSVDialect(delimiter: 0x2C, hasBom: true)
         let dialect = CSVPropertyOptions.dialect(
             base: base,
             delimiterIndex: CSVPropertyOptions.delimiterIndex(for: 0x09),
             quoteIndex: CSVPropertyOptions.quoteIndex(for: 0x27),
+            escapeIndex: CSVPropertyOptions.escapeIndex(for: 0x5C),
             encodingIndex: CSVPropertyOptions.encodingIndex(for: .utf16LittleEndian),
             lineEndingIndex: CSVPropertyOptions.lineEndingIndex(for: .cr)
         )
         #expect(dialect.delimiter == 0x09)
         #expect(dialect.quoteChar == 0x27)
+        #expect(dialect.escapeChar == 0x5C)
         #expect(dialect.encoding == .utf16LittleEndian)
         #expect(dialect.lineEnding == .cr)
         #expect(dialect.hasBom)

--- a/TableProTests/Views/CSVPropertyOptionsTests.swift
+++ b/TableProTests/Views/CSVPropertyOptionsTests.swift
@@ -40,4 +40,18 @@ struct CSVPropertyOptionsTests {
         #expect(dialect.lineEnding == .cr)
         #expect(dialect.hasBom)
     }
+
+    @Test("The doubled-quote escape follows the selected quote character")
+    func doubledQuoteEscapeTracksQuote() {
+        let dialect = CSVPropertyOptions.dialect(
+            base: CSVDialect(delimiter: 0x2C),
+            delimiterIndex: 0,
+            quoteIndex: CSVPropertyOptions.quoteIndex(for: 0x27),
+            escapeIndex: 0,
+            encodingIndex: 0,
+            lineEndingIndex: 0
+        )
+        #expect(dialect.quoteChar == 0x27)
+        #expect(dialect.escapeChar == 0x27)
+    }
 }

--- a/docs/features/csv-inspector.mdx
+++ b/docs/features/csv-inspector.mdx
@@ -26,7 +26,7 @@ When a file opens, TablePro detects:
 - **Line ending**: CRLF, LF, or CR, whichever appears first in the first 64 KB.
 - **Header row**: row one is treated as headers when at least half of its cells are non-empty and not numbers. Otherwise TablePro generates `Column 1`, `Column 2`, ... and treats every row as data.
 
-When a guess is wrong, choose **Edit > Set CSV Properties…** to pick the delimiter, quote character, encoding, and line ending by hand, then **Reload** to re-read the file with those settings. Reload discards unsaved edits and asks first if you have any.
+When a guess is wrong, choose **Edit > Set CSV Properties…** to pick the delimiter, quote character, escape character, encoding, and line ending by hand, then **Reload** to re-read the file with those settings. The escape character is either a doubled quote (the RFC 4180 default) or a backslash. Reload discards unsaved edits and asks first if you have any.
 
 ## Pagination
 


### PR DESCRIPTION
Part 6 (final) toward #1469 (CSV structural editing). The **escape character** field, completing the Set CSV Properties dialog. Stacked on #1943 (base branch `feat/1469-csv-properties`).

## What
- Set CSV Properties… gains an **Escape character** picker: a doubled quote (the RFC 4180 default) or a backslash. Files that escape an embedded quote as `\"` now read and save correctly.

## Why
`csvmenu.cpp` in Tablecruncher and DataGrip's format dialog both let you pick the escape mechanism, because real exports (notably MySQL) use backslash escaping instead of RFC 4180 quote doubling. This was the one property from #1469's dialog not yet wired.

## How
- `CSVDialect` gains an `escapeChar` field, defaulting to the quote byte (so the default is unchanged RFC 4180 behavior). It is a new stored property with a default; the existing public initializer is untouched, so this is additive to PluginKit (no version bump).
- `CSVStreamingParser` (indexRows, parseRow, field) honors the escape byte inside a quoted field only when it differs from the quote byte; when they are equal the existing doubled-quote path runs unchanged, so every existing file parses exactly as before.
- `CSVWriter` escapes an embedded quote (and the escape byte itself) with the escape character in backslash mode, and keeps doubling quotes in the default mode.
- The picker choice threads through the pure `CSVPropertyOptions` mapping into the reload dialect.

## Tests
- Parser: backslash escape decodes `\"` to a quote and `\\` to a backslash; the doubled-quote default is unchanged.
- Writer: doubles quotes by default, escapes with a backslash in backslash mode.
- `CSVDialect.escapeChar` defaults to the quote byte; `CSVPropertyOptions` maps the escape choice into the dialect.

## Docs / changelog
- `docs/features/csv-inspector.mdx` notes the escape-character choice.
- CHANGELOG entry under `[Unreleased]`.

Needs a local Xcode build to confirm compilation. PluginKit changes (a new `CSVDialect` field and parser method-body changes) are additive; no version bump.