### PR TITLE
test: add the missing Foundation import that breaks the macOS test build

### DIFF
--- a/TableProTests/Views/CSVPropertyOptionsTests.swift
+++ b/TableProTests/Views/CSVPropertyOptionsTests.swift
@@ -3,6 +3,7 @@
 //  TableProTests
 //
 
+import Foundation
 @testable import TablePro
 import TableProPluginKit
 import Testing


### PR DESCRIPTION
`main` is red: the `macOS App Tests` gate fails to compile `TableProTests`.

```
Static property 'windowsCP1252' is not available due to missing import of defining module 'Foundation'
Static property 'utf16LittleEndian' is not available due to missing import of defining module 'Foundation'
Testing cancelled because the build failed.
```

`CSVPropertyOptionsTests.swift` (added in #1944) imports only `TablePro`, `TableProPluginKit`, and `Testing`. None of those re-export Foundation, so `MemberImportVisibility` rejects the `String.Encoding` statics the test uses. The sibling files added in the same batch import AppKit, which does re-export Foundation, so this is the only file affected.

Adds `import Foundation`.

## Testing

Ran the CI gate command locally (same skip list from `.github/macos-test-quarantine.txt`): 7163 tests in 856 suites, compile clean. The 4 `CSVPropertyOptionsTests` cases pass.

One unrelated failure showed up locally, `StatusBarSnapshotTests/rowInfoTruncatedQuery`. It asserts `text.contains("1,000")`, which only holds in a locale that groups with a comma; my machine is `en_VN` and formats it `1.000`. CI runners are `en_US`, so it is green there. Pre-existing and out of scope for this fix.