### PR TITLE
fix(coordinator): reload the schema once per connection instead of once per window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SSH tunnels using the None auth method now work on iPhone and iPad, not just the Mac. A connection synced from the Mac with None auth no longer fails to connect. (#1912)
 - Browsing a Trino table no longer fails with a syntax error. Trino requires `OFFSET` before `LIMIT`, so paging now uses `OFFSET` and `FETCH FIRST`. (#1936)
 - The Authentication method selector no longer changes position in the connection form when you switch between methods that show or hide the username and password (for example SQL Server's SQL vs Windows Authentication, or PostgreSQL's password vs AWS IAM). (#1947)
+- Switching schemas no longer makes the sidebar flash its loading spinner once per open tab. The table list now reloads once for the connection instead of once per window, which also cuts the metadata queries a schema switch sends. (#1946)
 
 ## [0.59.0] - 2026-07-21
 

--- a/TablePro/Core/Database/DatabaseManager+Metadata.swift
+++ b/TablePro/Core/Database/DatabaseManager+Metadata.swift
@@ -5,6 +5,17 @@
 
 import Foundation
 
+@MainActor
+protocol MetadataDriverProviding: AnyObject {
+    func withMetadataDriver<T: Sendable>(
+        connectionId: UUID,
+        workload: MetadataConnectionPool.Workload,
+        _ body: @Sendable @escaping (DatabaseDriver) async throws -> T
+    ) async throws -> T
+}
+
+extension DatabaseManager: MetadataDriverProviding {}
+
 extension DatabaseManager {
     func withMetadataDriver<T: Sendable>(
         connectionId: UUID,

--- a/TablePro/Core/Services/AppServices.swift
+++ b/TablePro/Core/Services/AppServices.swift
@@ -14,6 +14,7 @@ struct AppServices {
     let databaseManager: DatabaseManager
     let pluginManager: PluginManager
     let schemaService: SchemaService
+    let schemaRefreshService: SchemaRefreshService
     let schemaProviderRegistry: SchemaProviderRegistry
     let sqlFavoriteManager: SQLFavoriteManager
     let favoriteTablesStorage: FavoriteTablesStorage
@@ -42,6 +43,7 @@ struct AppServices {
         databaseManager: .shared,
         pluginManager: .shared,
         schemaService: .shared,
+        schemaRefreshService: .shared,
         schemaProviderRegistry: .shared,
         sqlFavoriteManager: .shared,
         favoriteTablesStorage: .shared,

--- a/TablePro/Core/Services/Query/SchemaRefreshService.swift
+++ b/TablePro/Core/Services/Query/SchemaRefreshService.swift
@@ -1,0 +1,125 @@
+//
+//  SchemaRefreshService.swift
+//  TablePro
+//
+
+import Combine
+import Foundation
+import os
+import TableProPluginKit
+
+/// Owns the connection-scoped schema refresh so every window of a connection shares
+/// one load instead of running its own. Requests for the same connection and database
+/// scope join the in-flight refresh.
+@MainActor
+final class SchemaRefreshService {
+    static let shared = SchemaRefreshService()
+
+    private struct RefreshKey: Hashable {
+        let connectionId: UUID
+        let database: String?
+    }
+
+    private static let logger = Logger(subsystem: "com.TablePro", category: "SchemaRefreshService")
+
+    private let schemaService: SchemaService
+    private let treeMetadataService: DatabaseTreeMetadataService
+    private let providerRegistry: SchemaProviderRegistry
+    private let pluginManager: PluginManager
+    private let metadataDriverProvider: any MetadataDriverProviding
+    private let databaseManager: DatabaseManager?
+
+    private var inFlight: [RefreshKey: Task<Void, Never>] = [:]
+    private var schemaChangeCancellable: AnyCancellable?
+
+    init(
+        schemaService: SchemaService = .shared,
+        treeMetadataService: DatabaseTreeMetadataService = .shared,
+        providerRegistry: SchemaProviderRegistry = .shared,
+        pluginManager: PluginManager = .shared,
+        metadataDriverProvider: any MetadataDriverProviding = DatabaseManager.shared,
+        databaseManager: DatabaseManager? = .shared
+    ) {
+        self.schemaService = schemaService
+        self.treeMetadataService = treeMetadataService
+        self.providerRegistry = providerRegistry
+        self.pluginManager = pluginManager
+        self.metadataDriverProvider = metadataDriverProvider
+        self.databaseManager = databaseManager
+        schemaChangeCancellable = AppEvents.shared.currentSchemaChanged
+            .sink { [weak self] connectionId in
+                Task { @MainActor [weak self] in
+                    await self?.refreshForSchemaSwitch(connectionId: connectionId)
+                }
+            }
+    }
+
+    func refresh(connection: DatabaseConnection, database: String? = nil) async {
+        let key = RefreshKey(connectionId: connection.id, database: database)
+        if let existing = inFlight[key] {
+            await existing.value
+            return
+        }
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.performRefresh(connection: connection, database: database)
+        }
+        inFlight[key] = task
+        await task.value
+        inFlight.removeValue(forKey: key)
+    }
+
+    /// Push the loaded table list into the autocomplete provider. Called after every
+    /// refresh and after the initial per-window schema load.
+    func syncAutocompleteProvider(connectionId: UUID) async {
+        guard case .loaded = schemaService.state(for: connectionId),
+              let driver = databaseManager?.driver(for: connectionId),
+              let provider = providerRegistry.provider(for: connectionId) else { return }
+        let currentDatabase = databaseManager?.session(for: connectionId)?.activeDatabase
+        await provider.resetForDatabase(
+            currentDatabase,
+            tables: schemaService.allLoadedTables(for: connectionId),
+            driver: driver
+        )
+        await provider.setNamespaces(
+            schemas: schemaService.schemas(for: connectionId),
+            databases: currentDatabase.map { [$0] } ?? []
+        )
+    }
+
+    private func refreshForSchemaSwitch(connectionId: UUID) async {
+        guard let connection = databaseManager?.session(for: connectionId)?.connection else { return }
+        await refresh(connection: connection)
+    }
+
+    private func performRefresh(connection: DatabaseConnection, database: String?) async {
+        let connectionId = connection.id
+
+        if pluginManager.databaseGroupingStrategy(for: connection.type) == .hierarchicalSchema {
+            await schemaService.invalidate(connectionId: connectionId)
+        }
+
+        do {
+            try await metadataDriverProvider.withMetadataDriver(
+                connectionId: connectionId,
+                workload: .bulk
+            ) { [schemaService] driver in
+                await schemaService.reload(
+                    connectionId: connectionId,
+                    driver: driver,
+                    connection: connection
+                )
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            Self.logger.warning(
+                "[schema] refresh failed connId=\(connectionId, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+            )
+            schemaService.markLoadFailed(connectionId: connectionId, message: error.localizedDescription)
+        }
+
+        await treeMetadataService.refreshLoadedTables(connectionId: connectionId, database: database)
+        await syncAutocompleteProvider(connectionId: connectionId)
+    }
+}

--- a/TablePro/Core/Services/Query/SchemaService.swift
+++ b/TablePro/Core/Services/Query/SchemaService.swift
@@ -3,7 +3,6 @@
 //  TablePro
 //
 
-import Combine
 import Foundation
 import os
 import TableProPluginKit
@@ -38,19 +37,9 @@ final class SchemaService {
         let connectionId: UUID
         let schema: String
     }
-    @ObservationIgnored private var schemaChangeCancellable: AnyCancellable?
     @ObservationIgnored private var loadGenerations: [UUID: Int] = [:]
     @ObservationIgnored private var nextLoadGeneration = 0
     @ObservationIgnored private static let logger = Logger(subsystem: "com.TablePro", category: "SchemaService")
-
-    init() {
-        schemaChangeCancellable = AppEvents.shared.currentSchemaChanged
-            .sink { [weak self] connectionId in
-                Task { @MainActor [weak self] in
-                    await self?.handleSchemaSwitch(connectionId: connectionId)
-                }
-            }
-    }
 
     func state(for connectionId: UUID) -> SchemaState {
         states[connectionId] ?? .idle
@@ -418,61 +407,6 @@ final class SchemaService {
                 "[schema] \(kind.rawValue, privacy: .public) load failed connId=\(connectionId, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
             )
             return []
-        }
-    }
-
-    private func handleSchemaSwitch(connectionId: UUID) async {
-        guard let session = DatabaseManager.shared.activeSessions[connectionId],
-              let driver = session.driver else { return }
-        let connection = session.connection
-        if PluginManager.shared.databaseGroupingStrategy(for: connection.type) == .hierarchicalSchema {
-            await invalidate(connectionId: connectionId)
-            await reload(connectionId: connectionId, driver: driver, connection: connection)
-            return
-        }
-        await reloadCurrentSchemaContent(connectionId: connectionId, driver: driver)
-    }
-
-    private func reloadCurrentSchemaContent(connectionId: UUID, driver: DatabaseDriver) async {
-        await loadDedup.cancel(key: connectionId)
-        await procedureDedup.cancel(key: connectionId)
-        await functionDedup.cancel(key: connectionId)
-
-        states[connectionId] = .loading
-        bumpGeneration(connectionId)
-
-        async let proceduresTask: [RoutineInfo] = Self.fetchRoutinesSafely(
-            connectionId: connectionId,
-            kind: .procedure,
-            dedup: procedureDedup,
-            fetch: { try await driver.fetchProcedures(schema: nil) }
-        )
-        async let functionsTask: [RoutineInfo] = Self.fetchRoutinesSafely(
-            connectionId: connectionId,
-            kind: .function,
-            dedup: functionDedup,
-            fetch: { try await driver.fetchFunctions(schema: nil) }
-        )
-
-        let loadedProcedures = await proceduresTask
-        let loadedFunctions = await functionsTask
-
-        do {
-            let tables = try await loadDedup.execute(key: connectionId) {
-                try await driver.fetchTables()
-            }
-            states[connectionId] = .loaded(tables)
-            procedures[connectionId] = loadedProcedures
-            functions[connectionId] = loadedFunctions
-            bumpGeneration(connectionId)
-        } catch is CancellationError {
-            return
-        } catch {
-            Self.logger.warning(
-                "[schema] current-schema reload failed connId=\(connectionId, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
-            )
-            states[connectionId] = .failed(error.localizedDescription)
-            bumpGeneration(connectionId)
         }
     }
 }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -232,7 +232,6 @@ final class MainContentCoordinator {
 
     @ObservationIgnored var refreshCoalesceTask: Task<Void, Never>?
     @ObservationIgnored var refreshPendingTrailing = false
-    @ObservationIgnored private var schemaReloadTask: Task<Void, Never>?
 
     /// True once the coordinator's view has appeared (onAppear fired).
     /// Coordinators that SwiftUI creates during body re-evaluation but never
@@ -492,7 +491,6 @@ final class MainContentCoordinator {
             }
 
         schemaSwitchCancellable = services.appEvents.currentSchemaChanged
-            .receive(on: RunLoop.main)
             .sink { [weak self] changedConnectionId in
                 guard let self, changedConnectionId == self.connectionId else { return }
                 Task { @MainActor in
@@ -595,45 +593,15 @@ final class MainContentCoordinator {
         _teardownScheduled.withLock { $0 = false }
     }
 
+    /// Requests the connection-scoped refresh, which every window of this connection
+    /// shares, then applies the window-local follow-up.
     func refreshTables(currentDatabaseOnly: Bool = false) async {
-        if let existing = schemaReloadTask {
-            await existing.value
-            return
-        }
-        let task = Task { [weak self] in
-            guard let self else { return }
-            await self.reloadSchema(currentDatabaseOnly: currentDatabaseOnly)
-        }
-        schemaReloadTask = task
-        await task.value
-        schemaReloadTask = nil
-    }
-
-    private func reloadSchema(currentDatabaseOnly: Bool = false) async {
         schemaColumns.removeAll()
-        let schemaService = services.schemaService
-        let connectionId = connectionId
-        let connection = connection
-        do {
-            try await services.databaseManager.withMetadataDriver(
-                connectionId: connectionId,
-                workload: .bulk
-            ) { driver in
-                await schemaService.reload(
-                    connectionId: connectionId,
-                    driver: driver,
-                    connection: connection
-                )
-            }
-        } catch is CancellationError {
-            return
-        } catch {
-            Self.logger.warning("Schema refresh failed: \(error.localizedDescription, privacy: .public)")
-            schemaService.markLoadFailed(connectionId: connectionId, message: error.localizedDescription)
-        }
-        let database = currentDatabaseOnly ? activeDatabaseName : nil
-        await DatabaseTreeMetadataService.shared.refreshLoadedTables(connectionId: connectionId, database: database)
-        await reconcilePostSchemaLoad()
+        await services.schemaRefreshService.refresh(
+            connection: connection,
+            database: currentDatabaseOnly ? activeDatabaseName : nil
+        )
+        pruneStaleSidebarState()
     }
 
     func refreshProcedures() async {
@@ -683,21 +651,11 @@ final class MainContentCoordinator {
         }
     }
 
-    /// Push the SchemaService table list into the autocomplete provider and prune sidebar
-    /// state for tables that no longer exist.
-    private func reconcilePostSchemaLoad() async {
+    /// Drop sidebar state for tables that no longer exist. The selection lives in this
+    /// window's sidebar, so it is pruned per window.
+    private func pruneStaleSidebarState() {
         guard case .loaded = services.schemaService.state(for: connectionId) else { return }
         let tables = services.schemaService.allLoadedTables(for: connectionId)
-        if let driver = services.databaseManager.driver(for: connectionId),
-           let provider = services.schemaProviderRegistry.provider(for: connectionId) {
-            let currentDb = services.databaseManager.session(for: connectionId)?.activeDatabase
-            await provider.resetForDatabase(currentDb, tables: tables, driver: driver)
-            await provider.setNamespaces(
-                schemas: services.schemaService.schemas(for: connectionId),
-                databases: currentDb.map { [$0] } ?? []
-            )
-        }
-
         guard let vm = sidebarViewModel else { return }
         let validNames = Set(tables.map(\.name))
         let staleSelections = vm.selectedTables.filter { !validNames.contains($0.name) }
@@ -744,8 +702,6 @@ final class MainContentCoordinator {
         currentQueryTask = nil
         refreshCoalesceTask?.cancel()
         refreshCoalesceTask = nil
-        schemaReloadTask?.cancel()
-        schemaReloadTask = nil
         for entry in tableLoadTasks.values { entry.task.cancel() }
         tableLoadTasks.removeAll()
         changeManagerUpdateTask?.cancel()
@@ -863,7 +819,8 @@ final class MainContentCoordinator {
             connectionId: connectionId,
             databaseType: connection.type
         )
-        await reconcilePostSchemaLoad()
+        await services.schemaRefreshService.syncAutocompleteProvider(connectionId: connectionId)
+        pruneStaleSidebarState()
     }
 
     func loadTableMetadata(tableName: String) async {

--- a/TableProTests/Core/Autocomplete/SQLSchemaProviderTests.swift
+++ b/TableProTests/Core/Autocomplete/SQLSchemaProviderTests.swift
@@ -24,6 +24,7 @@ final class MockDatabaseDriver: DatabaseDriver, SchemaSwitchable, @unchecked Sen
     var tablesToReturn: [TableInfo] = []
     var schemaTablesToReturn: [String: [TableInfo]] = [:]
     var columnsToReturn: [String: [ColumnInfo]] = [:]
+    var fetchTablesCallCount = 0
     var fetchColumnsCallCount = 0
     var fetchColumnsCalls: [String] = []
     var fetchSchemaTablesCalls: [String] = []
@@ -80,7 +81,8 @@ final class MockDatabaseDriver: DatabaseDriver, SchemaSwitchable, @unchecked Sen
     }
 
     func fetchTables() async throws -> [TableInfo] {
-        tablesToReturn
+        fetchTablesCallCount += 1
+        return tablesToReturn
     }
 
     func fetchTables(schema: String?) async throws -> [TableInfo] {

--- a/TableProTests/Core/Services/Query/SchemaRefreshServiceTests.swift
+++ b/TableProTests/Core/Services/Query/SchemaRefreshServiceTests.swift
@@ -1,0 +1,116 @@
+//
+//  SchemaRefreshServiceTests.swift
+//  TableProTests
+//
+//  Tests that a connection's schema refresh runs once no matter how many
+//  windows request it (#1946).
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@MainActor
+private final class FakeMetadataDriverProvider: MetadataDriverProviding {
+    let driver: MockDatabaseDriver
+    var acquisitionCount = 0
+    var errorToThrow: Error?
+
+    init(driver: MockDatabaseDriver) {
+        self.driver = driver
+    }
+
+    func withMetadataDriver<T: Sendable>(
+        connectionId: UUID,
+        workload: MetadataConnectionPool.Workload,
+        _ body: @Sendable @escaping (DatabaseDriver) async throws -> T
+    ) async throws -> T {
+        acquisitionCount += 1
+        if let errorToThrow {
+            throw errorToThrow
+        }
+        return try await body(driver)
+    }
+}
+
+@Suite("SchemaRefreshService")
+@MainActor
+struct SchemaRefreshServiceTests {
+    private func makeService(
+        schemaService: SchemaService,
+        provider: FakeMetadataDriverProvider
+    ) -> SchemaRefreshService {
+        SchemaRefreshService(
+            schemaService: schemaService,
+            metadataDriverProvider: provider,
+            databaseManager: nil
+        )
+    }
+
+    @Test("concurrent refreshes for one connection run a single schema load")
+    func concurrentRefreshesRunOneLoad() async {
+        let driver = MockDatabaseDriver()
+        driver.tablesToReturn = [TableInfo(name: "orders", type: .table, rowCount: 0, schema: nil)]
+        let provider = FakeMetadataDriverProvider(driver: driver)
+        let schemaService = SchemaService()
+        let service = makeService(schemaService: schemaService, provider: provider)
+        let connection = TestFixtures.makeConnection()
+
+        async let first: Void = service.refresh(connection: connection)
+        async let second: Void = service.refresh(connection: connection)
+        async let third: Void = service.refresh(connection: connection)
+        _ = await (first, second, third)
+
+        #expect(driver.fetchTablesCallCount == 1)
+        #expect(provider.acquisitionCount == 1)
+        #expect(schemaService.state(for: connection.id) == .loaded(driver.tablesToReturn))
+    }
+
+    @Test("a refresh requested after the previous one finished loads again")
+    func sequentialRefreshesReload() async {
+        let driver = MockDatabaseDriver()
+        let provider = FakeMetadataDriverProvider(driver: driver)
+        let schemaService = SchemaService()
+        let service = makeService(schemaService: schemaService, provider: provider)
+        let connection = TestFixtures.makeConnection()
+
+        await service.refresh(connection: connection)
+        await service.refresh(connection: connection)
+
+        #expect(driver.fetchTablesCallCount == 2)
+    }
+
+    @Test("refreshes scoped to different databases do not join each other")
+    func differentDatabaseScopesDoNotJoin() async {
+        let driver = MockDatabaseDriver()
+        let provider = FakeMetadataDriverProvider(driver: driver)
+        let schemaService = SchemaService()
+        let service = makeService(schemaService: schemaService, provider: provider)
+        let connection = TestFixtures.makeConnection()
+
+        async let scoped: Void = service.refresh(connection: connection, database: "shop")
+        async let unscoped: Void = service.refresh(connection: connection, database: nil)
+        _ = await (scoped, unscoped)
+
+        #expect(provider.acquisitionCount == 2)
+    }
+
+    @Test("a metadata connection failure surfaces a failed schema state")
+    func metadataFailureSurfacesFailedState() async {
+        let driver = MockDatabaseDriver()
+        let provider = FakeMetadataDriverProvider(driver: driver)
+        provider.errorToThrow = DatabaseError.connectionFailed("pool exhausted")
+        let schemaService = SchemaService()
+        let service = makeService(schemaService: schemaService, provider: provider)
+        let connection = TestFixtures.makeConnection()
+
+        await service.refresh(connection: connection)
+
+        var isFailed = false
+        if case .failed = schemaService.state(for: connection.id) {
+            isFailed = true
+        }
+        #expect(isFailed)
+    }
+}

--- a/TableProTests/ViewModels/WelcomeViewModelTests.swift
+++ b/TableProTests/ViewModels/WelcomeViewModelTests.swift
@@ -76,6 +76,7 @@ final class WelcomeViewModelTests: XCTestCase {
             databaseManager: live.databaseManager,
             pluginManager: live.pluginManager,
             schemaService: live.schemaService,
+            schemaRefreshService: live.schemaRefreshService,
             schemaProviderRegistry: live.schemaProviderRegistry,
             sqlFavoriteManager: live.sqlFavoriteManager,
             favoriteTablesStorage: live.favoriteTablesStorage,


### PR DESCRIPTION
Fixes #1946.

## Problem

With N table tabs open, switching schemas flashes the sidebar's loading spinner N times.

`currentSchemaChanged` is a connection-scoped event that had window-scoped subscribers. Every native tab is its own window with its own `MainContentCoordinator`, and each one ran the full schema reload; `SchemaService` ran a second, overlapping one of its own (its subscription came from #1308, the coordinator's from #1547, which did not notice the overlap).

Those reloads cannot coalesce. `MetadataConnectionPool.Entry.runSerially` runs each window's block strictly after the previous one finished, so `OnceTask` never sees them overlap. Each pass sets `SchemaService.states[id] = .loading`, and `tables(for:)` returns `[]` unless `.loaded`, so `SidebarView` blanks the list and shows a `ProgressView` once per window.

The spinner is the visible part. Each pass also re-runs `DatabaseTreeMetadataService.refreshLoadedTables`, which cancels and refetches per loaded tree node, so N tabs meant N x M redundant `fetchTables` round trips per schema switch.

## Fix

Move the connection-scoped refresh out of the per-window coordinator.

- **`SchemaRefreshService`** (new): connection-scoped single-flight keyed by connection + database scope. Owns the metadata-driver load into `SchemaService`, the hierarchical invalidate that `handleSchemaSwitch` did, the tree-metadata refresh, and the autocomplete-provider reset. It subscribes to `currentSchemaChanged` so an MCP schema switch with no window open still refreshes the cache `MCPConnectionBridge.listTables` reads.
- **`SchemaService`**: drops its own subscription, `handleSchemaSwitch`, and `reloadCurrentSchemaContent`. It is the state store again, with one loader path instead of two that used different drivers.
- **`MainContentCoordinator`**: `refreshTables()` awaits the shared refresh and then does only window-local work (clear `schemaColumns`, prune stale sidebar selection). Removes `reloadSchema`, `schemaReloadTask`, and its teardown cancel, which could kill a load other windows were waiting on. Drops `.receive(on: RunLoop.main)` from the schema sink so every window lands in the same MainActor turn and joins the in-flight task instead of starting a second one.
- **`DatabaseManager+Metadata`**: adds `MetadataDriverProviding` so the refresh service is testable without a live session.
- **`AppServices`**: gains `schemaRefreshService`.

One schema switch is now one load, one spinner, and one tree-metadata pass regardless of tab count.

The sidebar still blanks during that single reload. The old list belongs to the old schema, so keeping it visible would let you click tables that are not there.

## Tests

New `SchemaRefreshServiceTests`: concurrent refreshes for one connection run a single load; a refresh after the previous one finished reloads; refreshes scoped to different databases do not join; a metadata connection failure surfaces a failed schema state.

```
xcodebuild test -only-testing:TableProTests/SchemaRefreshServiceTests \
  -only-testing:TableProTests/SchemaServiceTests \
  -only-testing:TableProTests/SQLSchemaProviderTests
** TEST SUCCEEDED **
```

`swiftlint lint --strict` clean on every changed file.

No UI automation: the flicker is a timing artifact of window count and metadata round trips, which XCUITest cannot assert deterministically.

https://claude.ai/code/session_017Bnfw7hmEH1snigyc5hXHm
