### PR TITLE
style(app): apply rustfmt to satisfy CI format check (#1954)

### DIFF
--- a/linux/crates/app/src/ui/app/mod.rs
+++ b/linux/crates/app/src/ui/app/mod.rs
@@ -188,7 +188,6 @@ pub struct StructureTabSlot {
     pub mode: crate::ui::structure_tab::StructureMode,
 }
 
-
 /// One workspace tab pinned to a single `(schema, table)` entity in
 /// Data (Browse) mode. The Structure (DDL) view is no longer fused
 /// into the same tab — `WorkspaceTab::Structure` is its own

--- a/linux/crates/app/src/ui/browse_tab.rs
+++ b/linux/crates/app/src/ui/browse_tab.rs
@@ -486,10 +486,7 @@ impl BrowseTab {
         // shows the active rule count next to the word when ≥1 rule
         // applies; hidden otherwise.
         let filter_label = gtk::Label::new(Some(&crate::tr!("Filter")));
-        let filter_badge = gtk::Label::builder()
-            .label("")
-            .visible(false)
-            .build();
+        let filter_badge = gtk::Label::builder().label("").visible(false).build();
         filter_badge.add_css_class("numeric");
         filter_badge.add_css_class("caption-heading");
         filter_badge.add_css_class("dim-label");
@@ -1255,7 +1252,6 @@ impl BrowseTab {
             .build();
         self.replace_status_child("error", &page);
     }
-
 }
 
 impl SimpleComponent for BrowseTab {
@@ -1374,9 +1370,8 @@ impl SimpleComponent for BrowseTab {
             let no_pk_for_sync = no_pk_banner.clone();
             let filter_for_sync = filter_strip.widget.clone();
             std::rc::Rc::new(move || {
-                let any_revealed = read_only_for_sync.is_revealed()
-                    || no_pk_for_sync.is_revealed()
-                    || filter_for_sync.reveals_child();
+                let any_revealed =
+                    read_only_for_sync.is_revealed() || no_pk_for_sync.is_revealed() || filter_for_sync.reveals_child();
                 root_for_sync.set_reveal_top_bars(any_revealed);
             })
         };
@@ -2500,9 +2495,7 @@ fn update_selection_chrome(label: &gtk::Label, n: u32) {
         return;
     }
     let count = n.to_string();
-    label.set_label(
-        &crate::tr!("{n} selected · press Delete to remove").replace("{n}", &count),
-    );
+    label.set_label(&crate::tr!("{n} selected · press Delete to remove").replace("{n}", &count));
     label.set_visible(true);
 }
 


### PR DESCRIPTION
## Summary

- The `linux` branch fails `cargo fmt --all -- --check` under the pinned 1.93 toolchain (rustfmt 1.8.0), turning the **Fast checks** CI job red before build / clippy / tests run.
- This runs `cargo fmt --all` over the two drifted files (`crates/app/src/ui/app/mod.rs`, `crates/app/src/ui/browse_tab.rs`): a stray blank line and a few builder chains collapsed to fit `max_width = 120`.
- Formatting only, no behavior change (2 files, +4 / -12). Fixes #1954.

## Test plan

- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo build --workspace` (exit 0)
- [x] `cargo test --workspace --lib` (148 passed, 1 ignored)

No UI/visual change (formatting only), so no before/after screenshots apply.
