### PR TITLE
fix(plugin-mongodb): pin the auth database and create databases that persist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- MongoDB no longer fails with an authentication error when you open a database your credentials do not belong to. TablePro authenticated against whichever database you were browsing instead of the one set on the connection, which left the connection broken until you deleted and recreated it. Creating a database hit this every time. (#1970)
+- Creating a MongoDB database now asks for its first collection and keeps it. The database was created and then removed again, because MongoDB drops a database as soon as its last collection goes. (#1970)
+- A MongoDB authentication error now names the user and the database it tried to authenticate against, instead of a bare driver code. (#1970)
 - Exporting a MongoDB collection works again. Every format failed with "Unsupported MongoDB method: getCollection" before any data was read. You can now also write `db.getCollection("name")` in the query editor, which is the only way to reach collections whose names contain dots or spaces, start with a digit, or match a database method such as `stats`. (#1971)
 - Exported MongoDB collections keep every field. TablePro took the column list from the first document alone, so a field that showed up later was dropped from JSON exports and pushed CSV rows out of line with their header. (#1971)
 - The `postgres` database shows in the database list again. It was marked as a system database, which hid it from the sidebar, Cmd+K, the database filter, and the Backup and Restore Dump pickers. PostgreSQL creates it for users and applications, so nothing about it is internal. CockroachDB's `defaultdb` and Redshift's `dev` were hidden the same way and now show too. (#1967)

--- a/Plugins/MongoDBDriverPlugin/MongoDBAuthSourceResolver.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBAuthSourceResolver.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum MongoDBAuthSourceResolver {
+    static let defaultAuthSource = "admin"
+
+    static func resolve(explicitAuthSource: String?, configuredDatabase: String, useSrv: Bool) -> String {
+        if let explicitAuthSource, !explicitAuthSource.isEmpty {
+            return explicitAuthSource
+        }
+        guard !useSrv, !configuredDatabase.isEmpty else {
+            return defaultAuthSource
+        }
+        return configuredDatabase
+    }
+}

--- a/Plugins/MongoDBDriverPlugin/MongoDBConnection.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBConnection.swift
@@ -60,7 +60,7 @@ final class MongoDBConnection: @unchecked Sendable {
     private let password: String?
     let database: String
     private let ssl: SSLConfiguration
-    private let authSource: String?
+    private let resolvedAuthSource: String
     private let readPreference: String?
     private let writeConcern: String?
     private let useSrv: Bool
@@ -114,6 +114,7 @@ final class MongoDBConnection: @unchecked Sendable {
         user: String,
         password: String?,
         database: String,
+        configuredDatabase: String,
         ssl: SSLConfiguration = SSLConfiguration(),
         authSource: String? = nil,
         readPreference: String? = nil,
@@ -129,7 +130,11 @@ final class MongoDBConnection: @unchecked Sendable {
         self.password = password
         self.database = database
         self.ssl = ssl
-        self.authSource = authSource
+        self.resolvedAuthSource = MongoDBAuthSourceResolver.resolve(
+            explicitAuthSource: authSource,
+            configuredDatabase: configuredDatabase,
+            useSrv: useSrv
+        )
         self.readPreference = readPreference
         self.writeConcern = writeConcern
         self.useSrv = useSrv
@@ -204,18 +209,8 @@ final class MongoDBConnection: @unchecked Sendable {
         let encodedDb = database.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? database
         uri += database.isEmpty ? "/" : "/\(encodedDb)"
 
-        let effectiveAuthSource: String
-        if let source = authSource, !source.isEmpty {
-            effectiveAuthSource = source
-        } else if useSrv {
-            effectiveAuthSource = "admin"
-        } else if !database.isEmpty {
-            effectiveAuthSource = database
-        } else {
-            effectiveAuthSource = "admin"
-        }
-        let encodedAuthSource = effectiveAuthSource
-            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? effectiveAuthSource
+        let encodedAuthSource = resolvedAuthSource
+            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? resolvedAuthSource
         var params: [String] = [
             "connectTimeoutMS=10000",
             "serverSelectionTimeoutMS=10000",
@@ -267,6 +262,19 @@ final class MongoDBConnection: @unchecked Sendable {
         return String(trimmed[..<colonIndex])
     }
 
+    private var authenticationFailureMessage: String {
+        String(
+            format: String(
+                localized: """
+                Authentication failed for user '%1$@' against database '%2$@'. \
+                Check the username, password, and Auth Database in the connection settings.
+                """
+            ),
+            user,
+            resolvedAuthSource
+        )
+    }
+
     // MARK: - Connection Management
 
     func connect() async throws {
@@ -298,12 +306,17 @@ final class MongoDBConnection: @unchecked Sendable {
 
             guard success else {
                 let errorMsg = bsonErrorMessage(&error)
+                let domain = error.domain
+                let code = error.code
                 mongoc_client_destroy(newClient)
-                logger.error("MongoDB ping failed: \(errorMsg)")
+                logger.error("MongoDB ping failed [\(domain)/\(code)]: \(errorMsg)")
                 if let sslError = MongoDBSSLClassifier.classifySSLError(errorMsg) {
                     throw sslError
                 }
-                throw MongoDBError(code: error.code, message: errorMsg)
+                if domain == MONGOC_ERROR_CLIENT.rawValue, code == MONGOC_ERROR_CLIENT_AUTHENTICATE.rawValue {
+                    throw MongoDBError(code: 0, message: self.authenticationFailureMessage)
+                }
+                throw MongoDBError(code: code, message: errorMsg)
             }
 
             self.client = newClient

--- a/Plugins/MongoDBDriverPlugin/MongoDBCreateDatabasePlan.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBCreateDatabasePlan.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum MongoDBCreateDatabasePlan {
+    static let firstCollectionFieldId = "mongoFirstCollection"
+
+    static func firstCollectionName(from values: [String: String], databaseName: String) -> String {
+        let requested = values[firstCollectionFieldId]?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return requested.isEmpty ? databaseName : requested
+    }
+}

--- a/Plugins/MongoDBDriverPlugin/MongoDBNameValidator.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBNameValidator.swift
@@ -1,0 +1,84 @@
+import Foundation
+import TableProPluginKit
+
+enum MongoDBNameValidationError: Error, Equatable {
+    case emptyDatabaseName
+    case databaseNameTooLong
+    case databaseNameInvalidCharacter(Character)
+    case emptyCollectionName
+    case collectionNameInvalidCharacter(Character)
+    case collectionNameReservedPrefix
+    case namespaceTooLong
+}
+
+extension MongoDBNameValidationError: PluginDriverError {
+    var pluginErrorMessage: String {
+        switch self {
+        case .emptyDatabaseName:
+            return String(localized: "Enter a database name.")
+        case .databaseNameTooLong:
+            return String(
+                format: String(localized: "A database name must be shorter than %ld bytes."),
+                MongoDBNameValidator.maxDatabaseNameBytes
+            )
+        case .databaseNameInvalidCharacter(let character):
+            return String(
+                format: String(localized: "A database name cannot contain %@."),
+                String(character)
+            )
+        case .emptyCollectionName:
+            return String(localized: "Enter a collection name.")
+        case .collectionNameInvalidCharacter(let character):
+            return String(
+                format: String(localized: "A collection name cannot contain %@."),
+                String(character)
+            )
+        case .collectionNameReservedPrefix:
+            return String(
+                format: String(localized: "A collection name cannot start with %@."),
+                MongoDBNameValidator.reservedCollectionPrefix
+            )
+        case .namespaceTooLong:
+            return String(
+                format: String(localized: "The database and collection names together must be %ld bytes or fewer."),
+                MongoDBNameValidator.maxNamespaceBytes
+            )
+        }
+    }
+}
+
+enum MongoDBNameValidator {
+    static let maxDatabaseNameBytes = 64
+    static let maxNamespaceBytes = 255
+    static let reservedCollectionPrefix = "system."
+
+    private static let forbiddenDatabaseCharacters: Set<Character> = ["/", "\\", ".", "\"", "$", "\0"]
+    private static let forbiddenCollectionCharacters: Set<Character> = ["$", "\0"]
+
+    static func validateDatabaseName(_ name: String) throws {
+        guard !name.isEmpty else {
+            throw MongoDBNameValidationError.emptyDatabaseName
+        }
+        if let offender = name.first(where: forbiddenDatabaseCharacters.contains) {
+            throw MongoDBNameValidationError.databaseNameInvalidCharacter(offender)
+        }
+        guard name.utf8.count < maxDatabaseNameBytes else {
+            throw MongoDBNameValidationError.databaseNameTooLong
+        }
+    }
+
+    static func validateCollectionName(_ name: String, inDatabase database: String) throws {
+        guard !name.isEmpty else {
+            throw MongoDBNameValidationError.emptyCollectionName
+        }
+        if let offender = name.first(where: forbiddenCollectionCharacters.contains) {
+            throw MongoDBNameValidationError.collectionNameInvalidCharacter(offender)
+        }
+        guard !name.hasPrefix(reservedCollectionPrefix) else {
+            throw MongoDBNameValidationError.collectionNameReservedPrefix
+        }
+        guard database.utf8.count + 1 + name.utf8.count <= maxNamespaceBytes else {
+            throw MongoDBNameValidationError.namespaceTooLong
+        }
+    }
+}

--- a/Plugins/MongoDBDriverPlugin/MongoDBPluginDriver.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBPluginDriver.swift
@@ -68,6 +68,7 @@ final class MongoDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             user: config.username,
             password: config.password,
             database: currentDb,
+            configuredDatabase: config.database,
             ssl: effectiveSSL,
             authSource: config.additionalFields["mongoAuthSource"],
             readPreference: config.additionalFields["mongoReadPreference"],
@@ -451,7 +452,18 @@ final class MongoDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func createDatabaseFormSpec() async throws -> PluginCreateDatabaseFormSpec? {
-        PluginCreateDatabaseFormSpec(fields: [], footnote: nil)
+        PluginCreateDatabaseFormSpec(
+            fields: [],
+            textInputs: [
+                PluginCreateDatabaseFormSpec.TextInput(
+                    id: MongoDBCreateDatabasePlan.firstCollectionFieldId,
+                    label: String(localized: "First Collection"),
+                    placeholder: String(localized: "Collection name"),
+                    isRequired: true
+                )
+            ],
+            footnote: String(localized: "MongoDB stores a database only once it holds a collection, so a new database needs its first one.")
+        )
     }
 
     func createDatabase(_ request: PluginCreateDatabaseRequest) async throws {
@@ -459,8 +471,17 @@ final class MongoDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             throw MongoDBPluginError.notConnected
         }
 
-        _ = try await conn.insertOne(database: request.name, collection: "__tablepro_init", document: "{\"_init\": true}")
-        _ = try await conn.runCommand("{\"drop\": \"__tablepro_init\"}", database: request.name)
+        try MongoDBNameValidator.validateDatabaseName(request.name)
+        let collection = MongoDBCreateDatabasePlan.firstCollectionName(
+            from: request.values,
+            databaseName: request.name
+        )
+        try MongoDBNameValidator.validateCollectionName(collection, inDatabase: request.name)
+
+        _ = try await conn.runCommand(
+            "{\"create\": \"\(escapeJsonString(collection))\"}",
+            database: request.name
+        )
     }
 
     func dropDatabase(name: String) async throws {

--- a/Plugins/TableProPluginKit/PluginCreateDatabaseFormSpec.swift
+++ b/Plugins/TableProPluginKit/PluginCreateDatabaseFormSpec.swift
@@ -53,12 +53,34 @@ public struct PluginCreateDatabaseFormSpec: Sendable {
         }
     }
 
+    public struct TextInput: Sendable {
+        public let id: String
+        public let label: String
+        public let placeholder: String?
+        public let isRequired: Bool
+
+        public init(id: String, label: String, placeholder: String? = nil, isRequired: Bool = false) {
+            self.id = id
+            self.label = label
+            self.placeholder = placeholder
+            self.isRequired = isRequired
+        }
+    }
+
     public let fields: [Field]
     public let footnote: String?
+    public let textInputs: [TextInput]
 
     public init(fields: [Field], footnote: String? = nil) {
         self.fields = fields
         self.footnote = footnote
+        self.textInputs = []
+    }
+
+    public init(fields: [Field], textInputs: [TextInput], footnote: String? = nil) {
+        self.fields = fields
+        self.footnote = footnote
+        self.textInputs = textInputs
     }
 }
 

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -695,7 +695,17 @@ private extension PluginDriverAdapter {
     func mapFormSpec(_ spec: PluginCreateDatabaseFormSpec) -> CreateDatabaseFormSpec {
         CreateDatabaseFormSpec(
             fields: spec.fields.map(mapFormField),
-            footnote: spec.footnote
+            footnote: spec.footnote,
+            textInputs: spec.textInputs.map(mapTextInput)
+        )
+    }
+
+    func mapTextInput(_ input: PluginCreateDatabaseFormSpec.TextInput) -> CreateDatabaseFormSpec.TextInput {
+        CreateDatabaseFormSpec.TextInput(
+            id: input.id,
+            label: input.label,
+            placeholder: input.placeholder,
+            isRequired: input.isRequired
         )
     }
 

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
@@ -39,7 +39,8 @@ extension PluginMetadataRegistry {
                     supportsQueryProgress: false,
                     requiresReconnectForDatabaseSwitch: false,
                     supportsDropDatabase: true,
-                    supportsOpportunisticTLS: false
+                    supportsOpportunisticTLS: false,
+                    authenticationIsDatabaseScoped: true
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
                     defaultSchemaName: "public",

--- a/TablePro/Core/Plugins/PluginMetadataRegistry.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry.swift
@@ -62,6 +62,7 @@ struct PluginMetadataSnapshot: Sendable {
         var supportsCloudflareTunnel: Bool = true
         var supportsClientKeyPassphrase: Bool = false
         var supportsConnectionPooling: Bool = true
+        var authenticationIsDatabaseScoped: Bool = false
 
         var supportsSOCKSProxy: Bool { supportsSSH }
 

--- a/TablePro/Core/Services/Query/MetadataConnectionPool.swift
+++ b/TablePro/Core/Services/Query/MetadataConnectionPool.swift
@@ -155,7 +155,12 @@ final class MetadataConnectionPool {
             throw DatabaseError.notConnected
         }
         var connection = session.effectiveConnection ?? session.connection
-        connection.database = key.database
+        let plan = Self.planConnection(
+            configuredDatabase: connection.database,
+            targetDatabase: key.database,
+            authenticationIsDatabaseScoped: connection.type.authenticationIsDatabaseScoped
+        )
+        connection.database = plan.connectDatabase
 
         let driver = try await DatabaseDriverFactory.createDriver(
             for: connection,
@@ -163,11 +168,14 @@ final class MetadataConnectionPool {
             awaitPlugins: true
         )
         do {
-            try await Self.connect(driver, database: key.database, timeoutSeconds: operationTimeoutSeconds)
+            try await Self.connect(driver, database: plan.connectDatabase, timeoutSeconds: operationTimeoutSeconds)
             try? await driver.applyQueryTimeout(AppSettingsManager.shared.general.queryTimeoutSeconds)
             await DatabaseManager.shared.executeStartupCommands(
                 session.connection.startupCommands, on: driver, connectionName: session.connection.name
             )
+            if let database = plan.switchDatabase {
+                try await Self.switchDatabase(driver, to: database, timeoutSeconds: operationTimeoutSeconds)
+            }
             if let schema = key.schema {
                 try await Self.switchSchema(driver, to: schema, timeoutSeconds: operationTimeoutSeconds)
             }
@@ -185,6 +193,35 @@ final class MetadataConnectionPool {
             timeoutMessage: String(format: String(localized: "Connecting to '%@' timed out."), database)
         ) {
             try await driver.connect()
+        }
+    }
+
+    struct ConnectionPlan: Sendable, Equatable {
+        let connectDatabase: String
+        let switchDatabase: String?
+    }
+
+    static func planConnection(
+        configuredDatabase: String,
+        targetDatabase: String,
+        authenticationIsDatabaseScoped: Bool
+    ) -> ConnectionPlan {
+        guard authenticationIsDatabaseScoped, targetDatabase != configuredDatabase else {
+            return ConnectionPlan(connectDatabase: targetDatabase, switchDatabase: nil)
+        }
+        return ConnectionPlan(connectDatabase: configuredDatabase, switchDatabase: targetDatabase)
+    }
+
+    static func switchDatabase(_ driver: DatabaseDriver, to database: String, timeoutSeconds: Double) async throws {
+        guard let adapter = driver as? PluginDriverAdapter else {
+            throw DatabaseError.unsupportedOperation
+        }
+        try await bounded(
+            driver: driver,
+            timeoutSeconds: timeoutSeconds,
+            timeoutMessage: String(format: String(localized: "Switching to database '%@' timed out."), database)
+        ) {
+            try await adapter.switchDatabase(to: database)
         }
     }
 

--- a/TablePro/Models/Connection/DatabaseConnection.swift
+++ b/TablePro/Models/Connection/DatabaseConnection.swift
@@ -122,6 +122,11 @@ extension DatabaseType {
         PluginMetadataRegistry.shared.snapshot(forTypeId: rawValue)?.capabilities.supportsConnectionPooling ?? true
     }
 
+    var authenticationIsDatabaseScoped: Bool {
+        PluginMetadataRegistry.shared.snapshot(forTypeId: rawValue)?
+            .capabilities.authenticationIsDatabaseScoped ?? false
+    }
+
     var defaultHost: String? {
         PluginMetadataRegistry.shared.snapshot(forTypeId: rawValue)?.connection.defaultHost
     }

--- a/TablePro/Models/Schema/CreateDatabaseFormSpec.swift
+++ b/TablePro/Models/Schema/CreateDatabaseFormSpec.swift
@@ -26,8 +26,16 @@ internal struct CreateDatabaseFormSpec: Sendable {
         internal let groupedBy: String?
     }
 
+    internal struct TextInput: Sendable, Identifiable {
+        internal let id: String
+        internal let label: String
+        internal let placeholder: String?
+        internal let isRequired: Bool
+    }
+
     internal let fields: [Field]
     internal let footnote: String?
+    internal let textInputs: [TextInput]
 }
 
 internal struct CreateDatabaseRequest: Sendable {

--- a/TablePro/Views/DatabaseSwitcher/CreateDatabaseSheet.swift
+++ b/TablePro/Views/DatabaseSwitcher/CreateDatabaseSheet.swift
@@ -74,6 +74,7 @@ struct CreateDatabaseSheet: View {
             case .loading:
                 loadingRow
             case .ready(let spec):
+                textInputsList(spec: spec)
                 fieldsList(spec: spec)
                 if let footnote = spec.footnote {
                     Text(footnote)
@@ -147,6 +148,24 @@ struct CreateDatabaseSheet: View {
     }
 
     @ViewBuilder
+    private func textInputsList(spec: CreateDatabaseFormSpec) -> some View {
+        ForEach(spec.textInputs) { input in
+            TextField(
+                input.label,
+                text: textInputBinding(for: input),
+                prompt: input.placeholder.map { Text($0) }
+            )
+        }
+    }
+
+    private func textInputBinding(for input: CreateDatabaseFormSpec.TextInput) -> Binding<String> {
+        Binding<String>(
+            get: { values[input.id] ?? "" },
+            set: { values[input.id] = $0 }
+        )
+    }
+
+    @ViewBuilder
     private func fieldsList(spec: CreateDatabaseFormSpec) -> some View {
         ForEach(visibleFields(in: spec)) { field in
             fieldRow(field: field, spec: spec)
@@ -178,8 +197,11 @@ struct CreateDatabaseSheet: View {
 
     private var canSubmit: Bool {
         guard !databaseName.isEmpty, !isCreating else { return false }
-        if case .ready = loadState { return true }
-        return false
+        guard case .ready(let spec) = loadState else { return false }
+        return spec.textInputs.allSatisfy { input in
+            guard input.isRequired else { return true }
+            return !(values[input.id] ?? "").trimmingCharacters(in: .whitespaces).isEmpty
+        }
     }
 
     private func visibleFields(in spec: CreateDatabaseFormSpec) -> [CreateDatabaseFormSpec.Field] {
@@ -189,6 +211,12 @@ struct CreateDatabaseSheet: View {
     private func isVisible(_ field: CreateDatabaseFormSpec.Field) -> Bool {
         guard let visibility = field.visibleWhen else { return true }
         return values[visibility.fieldId] == visibility.equals
+    }
+
+    private func shouldSubmit(_ fieldId: String, in spec: CreateDatabaseFormSpec) -> Bool {
+        if spec.textInputs.contains(where: { $0.id == fieldId }) { return true }
+        guard let field = spec.fields.first(where: { $0.id == fieldId }) else { return false }
+        return isVisible(field)
     }
 
     private func filteredOptions(for field: CreateDatabaseFormSpec.Field) -> [CreateDatabaseFormSpec.Option] {
@@ -272,10 +300,7 @@ struct CreateDatabaseSheet: View {
         errorMessage = nil
 
         let name = databaseName
-        let submissionValues = values.filter { entry in
-            spec.fields.first { $0.id == entry.key }
-                .map { isVisible($0) } ?? false
-        }
+        let submissionValues = values.filter { shouldSubmit($0.key, in: spec) }
 
         Task {
             do {

--- a/TableProTests/Core/SSH/TestSupport/SocketPair.swift
+++ b/TableProTests/Core/SSH/TestSupport/SocketPair.swift
@@ -2,6 +2,10 @@
 //  SocketPair.swift
 //  TableProTests
 //
+//  Closing is tracked per descriptor because the suite runs in parallel: closing an
+//  already-closed fd releases a number the kernel may have handed to a socket another
+//  test is still polling, which makes that test observe a hangup it never caused.
+//
 
 import Foundation
 
@@ -9,20 +13,30 @@ import Foundation
 /// real sockets rather than fakes, so closing behaviour is observed the way a database
 /// client would observe it.
 internal final class SocketPair {
-    let a: Int32
-    let b: Int32
+    private(set) var a: Int32
+    private(set) var b: Int32
 
     init() {
-        var fds: [Int32] = [0, 0]
-        _ = socketpair(AF_UNIX, SOCK_STREAM, 0, &fds)
+        var fds: [Int32] = [-1, -1]
+        guard socketpair(AF_UNIX, SOCK_STREAM, 0, &fds) == 0 else {
+            a = -1
+            b = -1
+            return
+        }
         a = fds[0]
         b = fds[1]
     }
 
-    func closeB() { Darwin.close(b) }
+    func closeB() { Self.close(&b) }
 
     func close() {
-        Darwin.close(a)
-        Darwin.close(b)
+        Self.close(&a)
+        Self.close(&b)
+    }
+
+    private static func close(_ fd: inout Int32) {
+        guard fd >= 0 else { return }
+        Darwin.close(fd)
+        fd = -1
     }
 }

--- a/TableProTests/Core/Services/Query/MetadataConnectionPoolTests.swift
+++ b/TableProTests/Core/Services/Query/MetadataConnectionPoolTests.swift
@@ -59,4 +59,65 @@ struct MetadataConnectionPoolTests {
         }
         #expect(driver.currentSchema == nil)
     }
+
+    @Test("database switch rejects a driver that cannot switch")
+    func switchDatabaseRejectsUnsupportedDriver() async {
+        let driver = MockDatabaseDriver()
+
+        await #expect(throws: DatabaseError.self) {
+            try await MetadataConnectionPool.switchDatabase(driver, to: "shop", timeoutSeconds: 1)
+        }
+    }
+}
+
+@Suite("MetadataConnectionPool connection plan")
+@MainActor
+struct MetadataConnectionPoolPlanTests {
+    @Test("A database-scoped engine keeps its configured database and switches after connecting")
+    func planPreservesConfiguredDatabase() {
+        let plan = MetadataConnectionPool.planConnection(
+            configuredDatabase: "admin",
+            targetDatabase: "newly_created",
+            authenticationIsDatabaseScoped: true
+        )
+
+        #expect(plan.connectDatabase == "admin")
+        #expect(plan.switchDatabase == "newly_created")
+    }
+
+    @Test("A database-scoped engine connects directly when it is already the target")
+    func planSkipsRedundantSwitch() {
+        let plan = MetadataConnectionPool.planConnection(
+            configuredDatabase: "shop",
+            targetDatabase: "shop",
+            authenticationIsDatabaseScoped: true
+        )
+
+        #expect(plan.connectDatabase == "shop")
+        #expect(plan.switchDatabase == nil)
+    }
+
+    @Test("A database-scoped engine with no configured database connects to the server default")
+    func planHandlesBlankConfiguredDatabase() {
+        let plan = MetadataConnectionPool.planConnection(
+            configuredDatabase: "",
+            targetDatabase: "shop",
+            authenticationIsDatabaseScoped: true
+        )
+
+        #expect(plan.connectDatabase == "")
+        #expect(plan.switchDatabase == "shop")
+    }
+
+    @Test("Every other engine still connects straight to the target database")
+    func planLeavesOtherEnginesUnchanged() {
+        let plan = MetadataConnectionPool.planConnection(
+            configuredDatabase: "shop",
+            targetDatabase: "reports",
+            authenticationIsDatabaseScoped: false
+        )
+
+        #expect(plan.connectDatabase == "reports")
+        #expect(plan.switchDatabase == nil)
+    }
 }

--- a/TableProTests/PluginTestSources/MongoDBAuthSourceResolver.swift
+++ b/TableProTests/PluginTestSources/MongoDBAuthSourceResolver.swift
@@ -1,0 +1,1 @@
+../../Plugins/MongoDBDriverPlugin/MongoDBAuthSourceResolver.swift

--- a/TableProTests/PluginTestSources/MongoDBCreateDatabasePlan.swift
+++ b/TableProTests/PluginTestSources/MongoDBCreateDatabasePlan.swift
@@ -1,0 +1,1 @@
+../../Plugins/MongoDBDriverPlugin/MongoDBCreateDatabasePlan.swift

--- a/TableProTests/PluginTestSources/MongoDBNameValidator.swift
+++ b/TableProTests/PluginTestSources/MongoDBNameValidator.swift
@@ -1,0 +1,1 @@
+../../Plugins/MongoDBDriverPlugin/MongoDBNameValidator.swift

--- a/TableProTests/Plugins/MongoDBAuthSourceResolverTests.swift
+++ b/TableProTests/Plugins/MongoDBAuthSourceResolverTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("MongoDBAuthSourceResolver")
+struct MongoDBAuthSourceResolverTests {
+    @Test("An explicit auth source wins over everything else")
+    func testExplicitWins() {
+        let resolved = MongoDBAuthSourceResolver.resolve(
+            explicitAuthSource: "accounts",
+            configuredDatabase: "shop",
+            useSrv: false
+        )
+        #expect(resolved == "accounts")
+    }
+
+    @Test("A blank explicit auth source falls through")
+    func testBlankExplicitFallsThrough() {
+        let resolved = MongoDBAuthSourceResolver.resolve(
+            explicitAuthSource: "",
+            configuredDatabase: "shop",
+            useSrv: false
+        )
+        #expect(resolved == "shop")
+    }
+
+    @Test("SRV connections authenticate against admin")
+    func testSrvUsesAdmin() {
+        let resolved = MongoDBAuthSourceResolver.resolve(
+            explicitAuthSource: nil,
+            configuredDatabase: "shop",
+            useSrv: true
+        )
+        #expect(resolved == "admin")
+    }
+
+    @Test("Without a configured database the fallback is admin")
+    func testEmptyConfiguredUsesAdmin() {
+        let resolved = MongoDBAuthSourceResolver.resolve(
+            explicitAuthSource: nil,
+            configuredDatabase: "",
+            useSrv: false
+        )
+        #expect(resolved == "admin")
+    }
+
+    @Test("A configured database is the fallback when no auth source is set")
+    func testConfiguredDatabaseIsFallback() {
+        let resolved = MongoDBAuthSourceResolver.resolve(
+            explicitAuthSource: nil,
+            configuredDatabase: "shop",
+            useSrv: false
+        )
+        #expect(resolved == "shop")
+    }
+}

--- a/TableProTests/Plugins/MongoDBCreateDatabasePlanTests.swift
+++ b/TableProTests/Plugins/MongoDBCreateDatabasePlanTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("MongoDBCreateDatabasePlan")
+struct MongoDBCreateDatabasePlanTests {
+    @Test("The typed collection name is used")
+    func testUsesTypedName() {
+        let name = MongoDBCreateDatabasePlan.firstCollectionName(
+            from: [MongoDBCreateDatabasePlan.firstCollectionFieldId: "orders"],
+            databaseName: "shop"
+        )
+        #expect(name == "orders")
+    }
+
+    @Test("Surrounding whitespace is trimmed")
+    func testTrimsWhitespace() {
+        let name = MongoDBCreateDatabasePlan.firstCollectionName(
+            from: [MongoDBCreateDatabasePlan.firstCollectionFieldId: "  orders\n"],
+            databaseName: "shop"
+        )
+        #expect(name == "orders")
+    }
+
+    @Test("A blank collection name falls back to the database name")
+    func testBlankFallsBack() {
+        let name = MongoDBCreateDatabasePlan.firstCollectionName(
+            from: [MongoDBCreateDatabasePlan.firstCollectionFieldId: "   "],
+            databaseName: "shop"
+        )
+        #expect(name == "shop")
+    }
+
+    @Test("An app that does not send the field still creates a collection")
+    func testMissingFieldFallsBack() {
+        let name = MongoDBCreateDatabasePlan.firstCollectionName(from: [:], databaseName: "shop")
+        #expect(name == "shop")
+    }
+
+    @Test("The legacy form spec initializer declares no text inputs")
+    func testLegacySpecHasNoTextInputs() {
+        let spec = PluginCreateDatabaseFormSpec(fields: [])
+        #expect(spec.textInputs.isEmpty)
+    }
+}

--- a/TableProTests/Plugins/MongoDBNameValidatorTests.swift
+++ b/TableProTests/Plugins/MongoDBNameValidatorTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("MongoDBNameValidator")
+struct MongoDBNameValidatorTests {
+    @Test("A plain database name passes")
+    func testValidDatabaseName() throws {
+        try MongoDBNameValidator.validateDatabaseName("shop")
+    }
+
+    @Test("An empty database name is rejected")
+    func testEmptyDatabaseName() {
+        #expect(throws: MongoDBNameValidationError.emptyDatabaseName) {
+            try MongoDBNameValidator.validateDatabaseName("")
+        }
+    }
+
+    @Test("Each character MongoDB forbids in a database name is rejected", arguments: ["/", "\\", ".", "\"", "$"])
+    func testForbiddenDatabaseCharacters(character: String) {
+        #expect(throws: MongoDBNameValidationError.databaseNameInvalidCharacter(Character(character))) {
+            try MongoDBNameValidator.validateDatabaseName("sh\(character)op")
+        }
+    }
+
+    @Test("A database name of 64 bytes or more is rejected")
+    func testDatabaseNameLength() throws {
+        try MongoDBNameValidator.validateDatabaseName(String(repeating: "a", count: 63))
+        #expect(throws: MongoDBNameValidationError.databaseNameTooLong) {
+            try MongoDBNameValidator.validateDatabaseName(String(repeating: "a", count: 64))
+        }
+    }
+
+    @Test("Database name length counts bytes, not characters")
+    func testDatabaseNameCountsBytes() {
+        #expect(throws: MongoDBNameValidationError.databaseNameTooLong) {
+            try MongoDBNameValidator.validateDatabaseName(String(repeating: "é", count: 32))
+        }
+    }
+
+    @Test("A plain collection name passes")
+    func testValidCollectionName() throws {
+        try MongoDBNameValidator.validateCollectionName("orders", inDatabase: "shop")
+    }
+
+    @Test("An empty collection name is rejected")
+    func testEmptyCollectionName() {
+        #expect(throws: MongoDBNameValidationError.emptyCollectionName) {
+            try MongoDBNameValidator.validateCollectionName("", inDatabase: "shop")
+        }
+    }
+
+    @Test("A collection name containing a dollar sign is rejected")
+    func testCollectionNameDollarSign() {
+        #expect(throws: MongoDBNameValidationError.collectionNameInvalidCharacter("$")) {
+            try MongoDBNameValidator.validateCollectionName("or$ders", inDatabase: "shop")
+        }
+    }
+
+    @Test("A collection name in the system namespace is rejected")
+    func testCollectionNameReservedPrefix() {
+        #expect(throws: MongoDBNameValidationError.collectionNameReservedPrefix) {
+            try MongoDBNameValidator.validateCollectionName("system.users", inDatabase: "shop")
+        }
+    }
+
+    @Test("A dot inside a collection name is allowed")
+    func testCollectionNameDotIsAllowed() throws {
+        try MongoDBNameValidator.validateCollectionName("orders.archive", inDatabase: "shop")
+    }
+
+    @Test("A namespace longer than 255 bytes is rejected")
+    func testNamespaceLength() throws {
+        let database = String(repeating: "a", count: 63)
+        try MongoDBNameValidator.validateCollectionName(String(repeating: "b", count: 191), inDatabase: database)
+        #expect(throws: MongoDBNameValidationError.namespaceTooLong) {
+            try MongoDBNameValidator.validateCollectionName(String(repeating: "b", count: 192), inDatabase: database)
+        }
+    }
+}

--- a/docs/databases/mongodb.mdx
+++ b/docs/databases/mongodb.mdx
@@ -31,6 +31,8 @@ The form has no Database field. On connect TablePro opens the first non-system d
 
 **Advanced**: **Auth Database** (usually `admin`), **Read Preference**, **Write Concern**, **Use SRV Record**, and **Replica Set** name.
 
+Leaving **Auth Database** empty authenticates against the database in the connection URL path, or `admin` when there is none. Switching databases in the app never changes it, so browsing a database your user has no account in does not break the connection.
+
 <Frame caption="MongoDB connection form">
   <img className="block dark:hidden" src="/images/mongodb-connection-form.png" alt="MongoDB connection form with the multi-host Hosts editor" />
   <img className="hidden dark:block" src="/images/mongodb-connection-form-dark.png" alt="MongoDB connection form with the multi-host Hosts editor" />
@@ -72,6 +74,8 @@ See [Connection URL Reference](/databases/connection-urls) for all parameters.
 ## Features
 
 **Collection Browsing**: Sidebar shows all collections. Click to view documents in the data grid. Top-level fields render as columns, nested objects and arrays as formatted JSON, ObjectIds as strings. The grid schema is inferred by sampling documents.
+
+**New Database**: The dialog asks for a database name and the name of its first collection. Both are required. MongoDB stores a database only once it holds a collection, so a name on its own would disappear as soon as the sidebar refreshed. The collection is created empty.
 
 **Views**: **New View** in the sidebar opens a query tab with a `db.createView("view_name", "source_collection", [pipeline])` template. Editing a view definition pre-fills a `db.runCommand({"collMod": ...})` command.
 
@@ -119,7 +123,7 @@ db.users.countDocuments({"role": "admin"})
 
 **Connection refused**: Check MongoDB is running (`brew services start mongodb-community`), verify host/port in `mongod.conf`, check `bindIp` setting.
 
-**Auth failed**: Verify username, password, auth database, and auth mechanism. The MQL editor does not parse `db.getUsers()` or `db.createUser()`; inspect users with `db.runCommand({"usersInfo": 1})` or manage them in mongosh.
+**Auth failed**: The error names the database TablePro authenticated against. If that is not where your user lives, set **Auth Database** in the Advanced section. Otherwise verify username, password, and auth mechanism. The MQL editor does not parse `db.getUsers()` or `db.createUser()`; inspect users with `db.runCommand({"usersInfo": 1})` or manage them in mongosh.
 
 **Timeout**: Verify host/port, check network and firewall, whitelist your IP in MongoDB Atlas.
 


### PR DESCRIPTION
Fixes #1970.

Creating a MongoDB database put the connection into an error state showing `[11] Authentication failed`, with no way back. Creating the database was the trigger, not the bug. There are two independent defects.

## 1. Browsing a MongoDB database re-authenticated against that database

`MetadataConnectionPool.openEntry` opens a separate driver per database. It copied the session's connection, set `connection.database = key.database`, and connected. MongoDB uses the default `supportsConnectionPooling: true`, so this ran on every sidebar refresh.

That fabricated connection reached `MongoDBConnection.buildUri()`, which set `authSource` to the target database whenever "Auth Database" was blank and the connection was not SRV. libmongoc sent the SCRAM handshake to a database the user does not exist in and returned `MONGOC_ERROR_CLIENT_AUTHENTICATE` (11).

Verified against a live MongoDB 7 server:

```
mongodb://u:p@host/newdb?authSource=newdb  -> Authentication failed
mongodb://u:p@host/newdb?authSource=admin  -> { ok: 1 }
```

Creating a database auto-switches to it, which triggers the refresh, which opens the poisoned connection. Any database switch broke the same way on an authenticated server with a blank Auth Database, not just a freshly created one.

**Fix.** The pool no longer rewrites the connection's database for engines where that changes who you authenticate as. A pure `planConnection` decides: connect with the configured database, then `switchDatabase` to the target, the same shape `DatabaseManager+Health.restoreSchemaAndDatabase` already uses on every reconnect. Every other engine keeps today's behaviour byte for byte.

This is gated by a new capability, `authenticationIsDatabaseScoped`, defaulting to `false` and set only on MongoDB. It names the reason rather than the mechanism: the credentials authenticate against the database given at connect time. I deliberately did not reuse `requiresReconnectForDatabaseSwitch`, which is also `false` for MySQL, MariaDB, SQL Server, ClickHouse, Cassandra, Trino, Snowflake and others. "Can switch without reconnecting" is a different property from "the connect-time database does not change your identity", and flipping the path for eleven other engines buys nothing here.

On the plugin side, `authSource` now resolves through `MongoDBAuthSourceResolver` (explicit value, then the configured database, then `admin`) and is computed once at construction, so a later `switchDatabase` can never influence it.

Because the app-side change restores what the plugin is handed, users get the fix from the app update alone, on whatever MongoDB plugin version they already have installed.

## 2. Create database deleted the database it created

`createDatabase` inserted into `__tablepro_init` and then dropped it. MongoDB removes a database when its last collection goes. Verified live: present after the insert, gone after the drop. So "New Database" produced nothing even before the auth failure.

```
after insert  -> ["admin","config","local","tp_created"]
after drop    -> ["admin","config","local"]
```

**Fix.** `createDatabase` runs `{"create": "<collection>"}` and leaves the collection in place. An empty collection is enough to keep the database in `listDatabases`, verified on 7.0.39, so no placeholder document is needed. The dialog now asks for a required **First Collection**, which is what MongoDB Compass does and for the same reason. `MongoDBNameValidator` checks MongoDB's documented name limits and the sheet's existing banner shows the message inline.

## 3. The error message

A MongoDB auth failure now reads:

> Authentication failed for user 'app' against database 'admin'. Check the username, password, and Auth Database in the connection settings.

instead of `[11] Authentication failed`, which is a raw libmongoc enum ordinal and the shape the HIG calls out by name ("Avoid writing a title that doesn't convey useful information, like 'Error 329347 occurred'"). The domain and code go to OSLog.

## PluginKit ABI: additive, no version bump

`PluginCreateDatabaseFormSpec.FieldKind` is `@frozen`, so a new case would be a breaking change forcing a bump and a re-release of every registry plugin. Instead the spec gains a nested `TextInput` type, a `textInputs` property, and a new init overload, with the existing init's signature untouched.

`scripts/check-pluginkit-abi.sh origin/main` reports additions only: the new `TextInput`, the new property, the new init. Nothing removed, no signature changed, `FieldKind` still has exactly its two cases. Needs the `abi-additive` label.

The plugin marks the field required while still defaulting the collection name to the database name when the value is absent, so an older app that does not render the field degrades quietly. The app and plugin releases need no ordering.

## Tests

- `MongoDBAuthSourceResolverTests`: the fallback chain, including that SRV always uses `admin`.
- `MongoDBNameValidatorTests`: every forbidden character, byte-counted length limits, the `system.` prefix, the 255-byte namespace boundary.
- `MongoDBCreateDatabasePlanTests`: collection-name resolution, trimming, and both fallback paths, plus that the legacy form-spec init declares no text inputs.
- `MetadataConnectionPoolPlanTests`: the plan for a database-scoped engine, the redundant-switch case, a blank configured database, and that every other engine is unchanged.
- `MetadataConnectionPoolTests`: a driver that cannot switch databases is rejected rather than silently serving the wrong one.

35 tests pass. `swiftlint lint --strict` reports 0 violations in 1210 files. The `MongoDBDriver` target builds.

## Release

The app-side changes ship with the next app release and fix the reported failure on their own. The plugin changes ship on the next `plugin-mongodb-v*` tag. No other plugin needs re-releasing.

## Out of scope

- Sidebar recovery affordances (retry, reconnect, edit connection on a failed node) and mapping driver errors onto `NSError`'s failure-reason and recovery-suggestion tiers. Right, but a separate feature across every engine.
- SurrealDB declares `requiresReconnectForDatabaseSwitch: false` and has database-scoped credentials, so it may have the same latent problem. Unverified, worth its own issue.

## Second commit: an unrelated flaky test this PR exposed

The first CI run failed on `SSHChannelRelay` / "Channel close terminates the relay", which this change does not touch. It is a pre-existing double-close in the test helper.

`SocketPair.close()` closes both descriptors, and `localHangup` and `transportHangup` each call `closeB()` first and then `close()` through their `defer`, so `b` is closed twice. The suite runs in parallel, so the second close releases a descriptor number the kernel may have already handed to a socket another test is polling. That test then sees a hangup it never caused, which is exactly the reported symptom: `channelClosed` expected `.channelClosed` and got `.localClosed`.

`SocketPair` now tracks each descriptor and closes it once, and a failed `socketpair()` no longer leaves the fds at 0, where closing them would have closed stdin.

Reproduced locally at 1 failure in 5 runs before the fix, and 0 in 10 after. Kept as its own commit so it can be split out.
