### PR TITLE
fix(sync): restore the push completion log to a single OSLog literal

### DIFF
--- a/TablePro/Core/Sync/SyncCoordinator.swift
+++ b/TablePro/Core/Sync/SyncCoordinator.swift
@@ -361,10 +361,10 @@ final class SyncCoordinator {
             metadataStorage.removeTombstone(type: parsed.type, id: parsed.id)
         }
 
-        Self.logger.info(
-            "Push completed: \(outcome.savedRecords.count) saved, "
-                + "\(outcome.deletedRecordIDs.count) deleted, \(outcome.failures.count) rejected"
-        )
+        let savedCount = outcome.savedRecords.count
+        let deletedCount = outcome.deletedRecordIDs.count
+        let rejectedCount = outcome.failures.count
+        Self.logger.info("Push completed: \(savedCount) saved, \(deletedCount) deleted, \(rejectedCount) rejected")
 
         guard outcome.hasFailures else { return }
 


### PR DESCRIPTION
Unbreaks the build on `main`.

## Problem

`macOS App Tests` fails at compile with exit 65:

```
cannot convert value of type 'String' to expected argument type 'OSLogMessage'
TablePro/Core/Sync/SyncCoordinator.swift:366
```

Introduced by 6276f1b17 (#1990). `TableProCore Package Tests` passed because that target does not include this file.

## Cause

`os.Logger.info(_:)` takes an `OSLogMessage`, which the compiler builds from a single string literal with interpolation. The push completion message was split across two literals joined with `+`, so Swift evaluated the concatenation first and passed a plain `String`.

## Fix

Pull the three counts into locals so the message fits one literal within the 120-char width. The logged text is unchanged.

Grepped the repo for the same shape (a `+ "..."` continuation inside any `logger.*` call); this was the only one.

No CHANGELOG entry: #1990 is itself still under `[Unreleased]`, and CLAUDE.md says to fold such fixes into the existing entry rather than add a "Fixed" line. No test: no behaviour change, and a compile error cannot be covered by one.