### PR TITLE
fix(tabs): stop an empty tab list from deleting saved tabs (#1997)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Quitting no longer loses unsaved SQL editor tabs. A window with no tabs loaded yet, such as one still waiting on its connection, could erase the saved tabs for that connection, so nothing came back on relaunch. Editors are also saved about a second after you stop typing instead of waiting up to 30 seconds, and a query over 500KB is kept in full rather than restored empty. (#1997)
 - Opening a large MongoDB collection no longer hangs. Row counts that back the pagination display now give up after 5 seconds and leave the estimate in place instead of holding the tab.
 - Stop now cancels a running MongoDB query on the server, rather than leaving it running until it finishes on its own.
 - A MongoDB query that runs out of time now says so, and points at the missing index that usually causes it.

--- a/TablePro/Core/Services/Infrastructure/TabPersistenceCoordinator+AggregatedSave.swift
+++ b/TablePro/Core/Services/Infrastructure/TabPersistenceCoordinator+AggregatedSave.swift
@@ -6,25 +6,24 @@
 import Foundation
 
 extension TabPersistenceCoordinator {
-    /// Save or clear persisted state based on tabs aggregated across all windows
-    /// for the connection. Prevents the per-window close path from clobbering
-    /// state when sibling windows still have open tabs.
-    func saveOrClearAggregated() {
+    /// Save persisted state from the tabs aggregated across all windows for the connection.
+    /// Prevents the per-window close path from clobbering state when sibling windows still
+    /// have open tabs. An empty aggregate leaves the saved state alone; only the user closing
+    /// every tab discards it, through `saveOrClearAggregatedSync()`.
+    func saveAggregated() {
         let aggregatedTabs = MainContentCoordinator.aggregatedTabs(for: connectionId)
-        if aggregatedTabs.isEmpty {
-            clearSavedState()
-        } else {
-            let selectedId = MainContentCoordinator.aggregatedSelectedTabId(for: connectionId)
-            saveNow(windowedTabs: aggregatedTabs, selectedTabId: selectedId)
-        }
+        guard !aggregatedTabs.isEmpty else { return }
+        let selectedId = MainContentCoordinator.aggregatedSelectedTabId(for: connectionId)
+        saveNow(windowedTabs: aggregatedTabs, selectedTabId: selectedId)
     }
 
     /// Synchronous variant for the window-close path, where the run loop may
-    /// not be available to service Tasks before the window tears down.
+    /// not be available to service Tasks before the window tears down. This is the one
+    /// path where an empty aggregate means the user closed everything, so it clears.
     func saveOrClearAggregatedSync() {
         let aggregatedTabs = MainContentCoordinator.aggregatedTabs(for: connectionId)
         if aggregatedTabs.isEmpty {
-            saveNowSync(tabs: [], selectedTabId: nil)
+            clearForUserClosedAllTabs()
         } else {
             let selectedId = MainContentCoordinator.aggregatedSelectedTabId(for: connectionId)
             saveNowSync(windowedTabs: aggregatedTabs, selectedTabId: selectedId)

--- a/TablePro/Core/Services/Infrastructure/TabPersistenceCoordinator.swift
+++ b/TablePro/Core/Services/Infrastructure/TabPersistenceCoordinator.swift
@@ -37,9 +37,13 @@ internal final class TabPersistenceCoordinator {
         saveNow(windowedTabs: tabs.map { (tab: $0, windowGroupIndex: 0) }, selectedTabId: selectedTabId)
     }
 
+    /// An automatic save never deletes. A window that has not restored yet, a connection still
+    /// waiting on its driver, and a window torn down during quit all present an empty tab list
+    /// that says nothing about what the user wants kept, so treating it as a delete instruction
+    /// destroys drafts the user never closed. Only `clearForUserClosedAllTabs()` removes state.
     internal func saveNow(windowedTabs: [(tab: QueryTab, windowGroupIndex: Int)], selectedTabId: UUID?) {
         guard !windowedTabs.isEmpty else {
-            clearSavedState()
+            Self.logger.debug("[persist] saveNow skipped empty tab set connId=\(self.connectionId, privacy: .public)")
             return
         }
         let persisted = windowedTabs.map { $0.tab.toPersistedTab(windowGroupIndex: $0.windowGroupIndex) }
@@ -60,9 +64,7 @@ internal final class TabPersistenceCoordinator {
 
     internal func saveNowSync(windowedTabs: [(tab: QueryTab, windowGroupIndex: Int)], selectedTabId: UUID?) {
         guard !windowedTabs.isEmpty else {
-            saveTask?.cancel()
-            saveTask = nil
-            TabDiskActor.clearSync(connectionId: connectionId)
+            Self.logger.debug("[persist] saveNowSync skipped empty tab set connId=\(self.connectionId, privacy: .public)")
             return
         }
         let persisted = windowedTabs.map { $0.tab.toPersistedTab(windowGroupIndex: $0.windowGroupIndex) }
@@ -85,13 +87,15 @@ internal final class TabPersistenceCoordinator {
 
     // MARK: - Clear
 
-    internal func clearSavedState() {
+    /// Removes the connection's saved tabs. Reserved for the user closing every tab themselves.
+    /// No automatic save path may call this: an empty in-memory tab list is not consent to
+    /// discard what is on disk.
+    internal func clearForUserClosedAllTabs() {
         saveTask?.cancel()
         saveTask = nil
         let connId = connectionId
-        Task {
-            await TabDiskActor.shared.clear(connectionId: connId)
-        }
+        Self.logger.debug("[persist] clearing saved state, user closed all tabs connId=\(connId, privacy: .public)")
+        TabDiskActor.clearSync(connectionId: connId)
     }
 
     // MARK: - Private save scheduling

--- a/TablePro/Core/Storage/TabDiskActor.swift
+++ b/TablePro/Core/Storage/TabDiskActor.swift
@@ -92,7 +92,11 @@ internal actor TabDiskActor {
         lastActiveSchema: String? = nil
     ) throws {
         let state = TabDiskState(
-            tabs: tabs,
+            tabs: TabQueryOverflowStore.externalize(
+                tabs,
+                connectionId: connectionId,
+                tabStateDirectory: tabStateDirectory
+            ),
             selectedTabId: selectedTabId,
             lastActiveDatabase: lastActiveDatabase,
             lastActiveSchema: lastActiveSchema
@@ -111,7 +115,13 @@ internal actor TabDiskActor {
 
         do {
             let data = try Data(contentsOf: fileURL)
-            return try decoder.decode(TabDiskState.self, from: data)
+            let state = try decoder.decode(TabDiskState.self, from: data)
+            return TabDiskState(
+                tabs: TabQueryOverflowStore.inline(state.tabs, tabStateDirectory: tabStateDirectory),
+                selectedTabId: state.selectedTabId,
+                lastActiveDatabase: state.lastActiveDatabase,
+                lastActiveSchema: state.lastActiveSchema
+            )
         } catch {
             Self.logger.error("Failed to load tab state for \(connectionId): \(error.localizedDescription)")
             return nil
@@ -119,6 +129,7 @@ internal actor TabDiskActor {
     }
 
     internal func clear(connectionId: UUID) {
+        TabQueryOverflowStore.removeAll(connectionId: connectionId, tabStateDirectory: tabStateDirectory)
         let fileURL = tabStateFileURL(for: connectionId)
 
         guard FileManager.default.fileExists(atPath: fileURL.path) else { return }
@@ -154,8 +165,13 @@ internal actor TabDiskActor {
         lastActiveDatabase: String? = nil,
         lastActiveSchema: String? = nil
     ) {
+        let directory = resolvedTabStateDirectory()
         let state = TabDiskState(
-            tabs: tabs,
+            tabs: TabQueryOverflowStore.externalize(
+                tabs,
+                connectionId: connectionId,
+                tabStateDirectory: directory
+            ),
             selectedTabId: selectedTabId,
             lastActiveDatabase: lastActiveDatabase,
             lastActiveSchema: lastActiveSchema
@@ -164,7 +180,6 @@ internal actor TabDiskActor {
 
         do {
             let data = try encoder.encode(state)
-            let directory = resolvedTabStateDirectory()
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
             let fileURL = tabStateFileURL(for: connectionId)
             try data.write(to: fileURL, options: .atomic)
@@ -174,6 +189,10 @@ internal actor TabDiskActor {
     }
 
     nonisolated internal static func clearSync(connectionId: UUID) {
+        TabQueryOverflowStore.removeAll(
+            connectionId: connectionId,
+            tabStateDirectory: resolvedTabStateDirectory()
+        )
         let fileURL = tabStateFileURL(for: connectionId)
         guard FileManager.default.fileExists(atPath: fileURL.path) else { return }
         do {

--- a/TablePro/Core/Storage/TabQueryOverflowStore.swift
+++ b/TablePro/Core/Storage/TabQueryOverflowStore.swift
@@ -1,0 +1,88 @@
+//
+//  TabQueryOverflowStore.swift
+//  TablePro
+//
+//  Keeps a query too large to sit inside the tab-state JSON in a sidecar file
+//  beside it, so restoring a tab returns the text instead of an empty editor.
+//  Mirrors the sidecar `RecentlyClosedTabStore` already uses for the same limit.
+//
+
+import Foundation
+import os
+
+internal enum TabQueryOverflowStore {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "TabDiskActor")
+
+    static func directory(inside tabStateDirectory: URL) -> URL {
+        tabStateDirectory.appendingPathComponent("Overflow", isDirectory: true)
+    }
+
+    private static func fileName(connectionId: UUID, tabId: UUID) -> String {
+        "\(connectionId.uuidString)_\(tabId.uuidString).sql"
+    }
+
+    /// Moves any oversized query out to a sidecar and blanks the inline field.
+    /// Sidecars this connection no longer references are removed in the same pass,
+    /// so a closed tab does not leave its text behind forever.
+    static func externalize(
+        _ tabs: [PersistedTab],
+        connectionId: UUID,
+        tabStateDirectory: URL
+    ) -> [PersistedTab] {
+        let overflowDirectory = directory(inside: tabStateDirectory)
+        var written: Set<String> = []
+
+        let processed = tabs.map { tab -> PersistedTab in
+            guard (tab.query as NSString).length > TabQueryContent.maxPersistableQuerySize else { return tab }
+            let name = fileName(connectionId: connectionId, tabId: tab.id)
+            guard write(tab.query, named: name, in: overflowDirectory) else { return tab }
+            written.insert(name)
+            var copy = tab
+            copy.query = ""
+            copy.overflowFileName = name
+            return copy
+        }
+
+        pruneOrphans(connectionId: connectionId, keeping: written, in: overflowDirectory)
+        return processed
+    }
+
+    /// Reads sidecar text back into the tabs it belongs to.
+    static func inline(_ tabs: [PersistedTab], tabStateDirectory: URL) -> [PersistedTab] {
+        let overflowDirectory = directory(inside: tabStateDirectory)
+        return tabs.map { tab -> PersistedTab in
+            guard let name = tab.overflowFileName else { return tab }
+            let url = overflowDirectory.appendingPathComponent(name)
+            guard let text = try? String(contentsOf: url, encoding: .utf8) else {
+                logger.error("Missing overflow sidecar \(name, privacy: .public)")
+                return tab
+            }
+            var copy = tab
+            copy.query = text
+            return copy
+        }
+    }
+
+    static func removeAll(connectionId: UUID, tabStateDirectory: URL) {
+        pruneOrphans(connectionId: connectionId, keeping: [], in: directory(inside: tabStateDirectory))
+    }
+
+    private static func write(_ query: String, named name: String, in directory: URL) -> Bool {
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            try query.write(to: directory.appendingPathComponent(name), atomically: true, encoding: .utf8)
+            return true
+        } catch {
+            logger.fault("Failed to write overflow sidecar \(name, privacy: .public): \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    private static func pruneOrphans(connectionId: UUID, keeping kept: Set<String>, in directory: URL) {
+        let prefix = "\(connectionId.uuidString)_"
+        guard let names = try? FileManager.default.contentsOfDirectory(atPath: directory.path) else { return }
+        for name in names where name.hasPrefix(prefix) && !kept.contains(name) {
+            try? FileManager.default.removeItem(at: directory.appendingPathComponent(name))
+        }
+    }
+}

--- a/TablePro/Models/Query/QueryTab.swift
+++ b/TablePro/Models/Query/QueryTab.swift
@@ -154,8 +154,7 @@ struct QueryTab: Identifiable, Equatable {
     }
 
     func toPersistedTab(windowGroupIndex: Int? = nil) -> PersistedTab {
-        let queryLength = (content.query as NSString).length
-        let persistedQuery = queryLength > TabQueryContent.maxPersistableQuerySize ? "" : content.query
+        let persistedQuery = content.query
 
         let persistedSort: [PersistedSortColumn]? = {
             let resolved = sortState.columns.compactMap { column -> PersistedSortColumn? in

--- a/TablePro/Models/Query/QueryTabState.swift
+++ b/TablePro/Models/Query/QueryTabState.swift
@@ -40,6 +40,9 @@ struct PersistedTab: Codable {
     var columnWidths: [String: CGFloat]?
     var windowGroupIndex: Int?
 
+    /// Set when the query was too large for the tab-state JSON and lives in a sidecar file.
+    var overflowFileName: String?
+
     init(
         id: UUID,
         title: String,
@@ -80,6 +83,7 @@ struct PersistedTab: Codable {
         case id, title, query, tabType, tableName, isView, databaseName, schemaName
         case sourceFileURL, erDiagramSchemaKey, queryParameters
         case sortColumns, restoredPage, cursorOffset, columnWidths, windowGroupIndex
+        case overflowFileName
     }
 
     init(from decoder: Decoder) throws {
@@ -100,6 +104,7 @@ struct PersistedTab: Codable {
         cursorOffset = try container.decodeIfPresent(Int.self, forKey: .cursorOffset)
         columnWidths = try container.decodeIfPresent([String: CGFloat].self, forKey: .columnWidths)
         windowGroupIndex = try container.decodeIfPresent(Int.self, forKey: .windowGroupIndex)
+        overflowFileName = try container.decodeIfPresent(String.self, forKey: .overflowFileName)
     }
 }
 

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -457,6 +457,8 @@ struct MainEditorContentView: View {
                 // selectedTabIndex would overwrite the new tab's query.
                 guard tabManager.mutate(tabId: tabId, { $0.content.query = newValue }) else { return }
 
+                coordinator.scheduleDraftSave()
+
                 // Typing into a scratch tab dirties it too: the text lives nowhere but this tab.
                 // The dot belongs to this tab's own window, not whichever window happens to be
                 // key, because a background window tab's editor stays mounted and can fire here.

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Protection.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Protection.swift
@@ -14,8 +14,9 @@ extension MainContentCoordinator {
     }
 
     /// Work that is only recoverable by saving it. A scratch query tab is deliberately absent:
-    /// its text is captured into `RecentlyClosedTabStore` on close, so losing it is undoable and
-    /// warrants no alert.
+    /// its text is persisted with the tab and comes back on relaunch, so it needs no alert.
+    /// Closing a tab also files it in `RecentlyClosedTabStore`; quitting does not, which is why
+    /// the tab-state write must never be skipped or cleared on an empty in-memory tab list.
     func hasUnsavedWork(in tab: QueryTab?) -> Bool {
         guard let tab else { return false }
         if tab.tabType == .usersRoles {

--- a/TablePro/Views/Main/Extensions/MainContentView+EventHandlers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+EventHandlers.swift
@@ -60,7 +60,7 @@ extension MainContentView {
             coordinator.promotePreviewTab()
         }
 
-        coordinator.persistence.saveOrClearAggregated()
+        coordinator.persistence.saveAggregated()
         MainContentView.lifecycleLogger.debug(
             "[switch] handleStructureChange tabCount=\(tabManager.tabs.count) ms=\(Int(Date().timeIntervalSince(t0) * 1_000))"
         )

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -1096,7 +1096,7 @@ final class MainContentCommandActions {
             .sink { [weak self] _ in
                 guard let coordinator = self?.coordinator else { return }
                 guard !MainContentCoordinator.isAppTerminating else { return }
-                coordinator.persistence.saveOrClearAggregated()
+                coordinator.persistence.saveAggregated()
             }
             .store(in: &eventCancellables)
     }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -199,6 +199,7 @@ final class MainContentCoordinator {
     @ObservationIgnored internal var redisDatabaseSwitchTask: Task<Void, Never>?
     @ObservationIgnored private var changeManagerUpdateTask: Task<Void, Never>?
     @ObservationIgnored private var periodicSaveTask: Task<Void, Never>?
+    @ObservationIgnored private var draftSaveTask: Task<Void, Never>?
     @ObservationIgnored private var terminationObserver: NSObjectProtocol?
     @ObservationIgnored private var postConnectCancellable: AnyCancellable?
     @ObservationIgnored private var externalFileModCancellable: AnyCancellable?
@@ -371,6 +372,21 @@ final class MainContentCoordinator {
     }
 
     private static let periodicSaveInterval: Duration = .seconds(30)
+    private static let draftSaveDebounce: Duration = .seconds(1)
+
+    /// Persist shortly after the user stops typing. Editing query text changes no tab
+    /// identity, so it drives none of the structural saves, and without this a scratch
+    /// query lives only in memory until the 30 second timer or the quit-time flush.
+    func scheduleDraftSave() {
+        guard !Self.isAppTerminating, !isTearingDown else { return }
+        draftSaveTask?.cancel()
+        draftSaveTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.draftSaveDebounce)
+            guard let self, !Task.isCancelled, !Self.isAppTerminating, !self.isTearingDown else { return }
+            guard self.isFirstCoordinatorForConnection() else { return }
+            self.persistence.saveAggregated()
+        }
+    }
 
     private func startPeriodicSave() {
         guard periodicSaveTask == nil else { return }
@@ -379,7 +395,7 @@ final class MainContentCoordinator {
                 try? await Task.sleep(for: Self.periodicSaveInterval)
                 guard let self, !Task.isCancelled, !Self.isAppTerminating, !self.isTearingDown else { return }
                 guard self.isFirstCoordinatorForConnection() else { continue }
-                self.persistence.saveOrClearAggregated()
+                self.persistence.saveAggregated()
             }
         }
     }
@@ -717,6 +733,8 @@ final class MainContentCoordinator {
         changeManagerUpdateTask = nil
         periodicSaveTask?.cancel()
         periodicSaveTask = nil
+        draftSaveTask?.cancel()
+        draftSaveTask = nil
         redisDatabaseSwitchTask?.cancel()
         redisDatabaseSwitchTask = nil
 

--- a/TableProTests/Core/Services/PersistedTabRoundTripTests.swift
+++ b/TableProTests/Core/Services/PersistedTabRoundTripTests.swift
@@ -98,19 +98,15 @@ struct PersistedTabRoundTripTests {
         #expect(QueryTab(from: persisted, defaultPageSize: 1_000).restoredCursorOffset == ("SELECT" as NSString).length)
     }
 
-    @Test("A truncated query drops the persisted cursor offset")
-    func cursorOffsetDroppedWhenQueryTruncated() {
-        var tab = QueryTab(
-            id: UUID(),
-            title: "Q",
-            query: String(repeating: "a", count: TabQueryContent.maxPersistableQuerySize + 1),
-            tabType: .query
-        )
+    @Test("A query past the inline size limit keeps its text and its cursor offset")
+    func largeQueryKeepsTextAndCursorOffset() {
+        let query = String(repeating: "a", count: TabQueryContent.maxPersistableQuerySize + 1)
+        var tab = QueryTab(id: UUID(), title: "Q", query: query, tabType: .query)
         tab.restoredCursorOffset = 42
 
         let persisted = tab.toPersistedTab()
-        #expect(persisted.query.isEmpty)
-        #expect(persisted.cursorOffset == 0)
+        #expect(persisted.query == query)
+        #expect(persisted.cursorOffset == 42)
     }
 
     @Test("Column widths round-trip")

--- a/TableProTests/Core/Services/TabPersistenceCoordinatorTests.swift
+++ b/TableProTests/Core/Services/TabPersistenceCoordinatorTests.swift
@@ -64,7 +64,7 @@ struct TabPersistenceCoordinatorTests {
             #expect(restored.tabType == original.tabType)
         }
 
-        coordinator.clearSavedState()
+        coordinator.clearForUserClosedAllTabs()
         await sleep()
     }
 
@@ -76,7 +76,7 @@ struct TabPersistenceCoordinatorTests {
         coordinator.saveNow(tabs: tabs, selectedTabId: tabs[0].id)
         await sleep()
 
-        coordinator.clearSavedState()
+        coordinator.clearForUserClosedAllTabs()
         await sleep()
 
         let result = await coordinator.restoreFromDisk()
@@ -100,12 +100,12 @@ struct TabPersistenceCoordinatorTests {
         #expect(result.selectedTabId == selectedId)
         #expect(result.source == .disk)
 
-        coordinator.clearSavedState()
+        coordinator.clearForUserClosedAllTabs()
         await sleep()
     }
 
-    @Test("Large query over 500KB is truncated to empty string in persisted tab")
-    func largeQueryIsTruncated() async {
+    @Test("A query over 500KB survives a save and restore through its sidecar")
+    func largeQueryRoundTripsThroughOverflowFile() async {
         let coordinator = makeCoordinator()
         let largeQuery = String(repeating: "A", count: 600_000)
         var tab = QueryTab(id: UUID(), title: "Big", query: largeQuery, tabType: .query)
@@ -117,10 +117,10 @@ struct TabPersistenceCoordinatorTests {
         let result = await coordinator.restoreFromDisk()
 
         #expect(result.tabs.count == 1)
-        #expect(result.tabs[0].content.query == "")
+        #expect(result.tabs[0].content.query == largeQuery)
         #expect(result.tabs[0].title == "Big")
 
-        coordinator.clearSavedState()
+        coordinator.clearForUserClosedAllTabs()
         await sleep()
     }
 
@@ -136,7 +136,7 @@ struct TabPersistenceCoordinatorTests {
 
         #expect(result.source == .disk)
 
-        coordinator.clearSavedState()
+        coordinator.clearForUserClosedAllTabs()
         await sleep()
     }
 
@@ -162,7 +162,7 @@ struct TabPersistenceCoordinatorTests {
             #expect(restored.id == original.id)
         }
 
-        coordinator.clearSavedState()
+        coordinator.clearForUserClosedAllTabs()
         await sleep()
     }
 
@@ -178,7 +178,7 @@ struct TabPersistenceCoordinatorTests {
         let beforeClear = await coordinator.restoreFromDisk()
         #expect(beforeClear.tabs.count == 2)
 
-        coordinator.clearSavedState()
+        coordinator.clearForUserClosedAllTabs()
         await sleep()
 
         let afterClear = await coordinator.restoreFromDisk()
@@ -202,7 +202,7 @@ struct TabPersistenceCoordinatorTests {
         #expect(result.tabs.contains { $0.id == previewTab.id })
         #expect(result.tabs.allSatisfy { !$0.isPreview })
 
-        coordinator.clearSavedState()
+        coordinator.clearForUserClosedAllTabs()
         await sleep()
     }
 
@@ -220,7 +220,7 @@ struct TabPersistenceCoordinatorTests {
         #expect(result.tabs[0].id == previewTab.id)
         #expect(result.tabs[0].isPreview == false)
 
-        coordinator.clearSavedState()
+        coordinator.clearForUserClosedAllTabs()
         await sleep()
     }
 
@@ -237,7 +237,7 @@ struct TabPersistenceCoordinatorTests {
         let result = await coordinator.restoreFromDisk()
         #expect(result.selectedTabId == previewTab.id)
 
-        coordinator.clearSavedState()
+        coordinator.clearForUserClosedAllTabs()
         await sleep()
     }
 
@@ -257,7 +257,7 @@ struct TabPersistenceCoordinatorTests {
         #expect(result.tabs[0].content.sourceFileURL == url)
         #expect(result.tabs[0].id == tab.id)
 
-        coordinator.clearSavedState()
+        coordinator.clearForUserClosedAllTabs()
         await sleep()
     }
 
@@ -283,7 +283,7 @@ struct TabPersistenceCoordinatorTests {
             #expect(restored.content.sourceFileURL == original.content.sourceFileURL)
         }
 
-        coordinator.clearSavedState()
+        coordinator.clearForUserClosedAllTabs()
         await sleep()
     }
 
@@ -308,7 +308,75 @@ struct TabPersistenceCoordinatorTests {
         #expect(restored.id == tab.id)
         #expect(restored.tabType == .table)
 
-        coordinator.clearSavedState()
+        coordinator.clearForUserClosedAllTabs()
         await sleep()
+    }
+
+    // MARK: - Empty tab lists must never delete saved work (#1997)
+
+    @Test("An empty async save leaves saved tabs on disk")
+    func emptyAsyncSaveDoesNotDeleteSavedTabs() async {
+        let coordinator = makeCoordinator()
+        let tabs = makeTabs(count: 2)
+        coordinator.saveNow(tabs: tabs, selectedTabId: tabs[0].id)
+        await sleep()
+
+        coordinator.saveNow(tabs: [], selectedTabId: nil)
+        await sleep()
+
+        let result = await coordinator.restoreFromDisk()
+        #expect(result.tabs.count == 2)
+        #expect(result.source == .disk)
+
+        coordinator.clearForUserClosedAllTabs()
+        await sleep()
+    }
+
+    @Test("An empty quit-time save leaves saved tabs on disk")
+    func emptySyncSaveDoesNotDeleteSavedTabs() async {
+        let coordinator = makeCoordinator()
+        let tabs = makeTabs(count: 3)
+        coordinator.saveNowSync(tabs: tabs, selectedTabId: tabs[1].id)
+
+        coordinator.saveNowSync(tabs: [], selectedTabId: nil)
+
+        let result = await coordinator.restoreFromDisk()
+        #expect(result.tabs.count == 3)
+        #expect(result.selectedTabId == tabs[1].id)
+
+        coordinator.clearForUserClosedAllTabs()
+        await sleep()
+    }
+
+    @Test("An unsaved query survives a quit-time save that follows an empty one")
+    func draftSurvivesEmptySaveThenRestore() async {
+        let coordinator = makeCoordinator()
+        var draft = QueryTab(id: UUID(), title: "Query 1", query: "", tabType: .query)
+        draft.content.query = "SELECT * FROM never_saved_to_a_file"
+        coordinator.saveNowSync(tabs: [draft], selectedTabId: draft.id)
+
+        coordinator.saveNowSync(tabs: [], selectedTabId: nil)
+        coordinator.saveNow(tabs: [], selectedTabId: nil)
+        await sleep()
+
+        let result = await coordinator.restoreFromDisk()
+        #expect(result.tabs.count == 1)
+        #expect(result.tabs[0].content.query == "SELECT * FROM never_saved_to_a_file")
+
+        coordinator.clearForUserClosedAllTabs()
+        await sleep()
+    }
+
+    @Test("Closing every tab still discards the saved state")
+    func userClosingAllTabsClearsSavedState() async {
+        let coordinator = makeCoordinator()
+        let tabs = makeTabs(count: 2)
+        coordinator.saveNowSync(tabs: tabs, selectedTabId: tabs[0].id)
+
+        coordinator.clearForUserClosedAllTabs()
+
+        let result = await coordinator.restoreFromDisk()
+        #expect(result.tabs.isEmpty)
+        #expect(result.source == .none)
     }
 }


### PR DESCRIPTION
Fixes #1997: five unsaved SQL editor tabs were lost across `Cmd+Q`, and nothing recovered them.

## Root cause

An empty in-memory tab list was treated as an instruction to delete the connection's saved tabs.

On relaunch `AppLaunchCoordinator.reopenLastSession()` opens the window **before** connecting (`AppLaunchCoordinator.swift:151-163`), and `SessionStateFactory` adds no tabs for `.restoreOrDefault` yet still calls `coord.registerEagerly()` (`SessionStateFactory.swift:173-175`, `:194`). That puts a zero-tab coordinator in `activeCoordinators` while the connect is pending, and it can win `isFirstCoordinatorForConnection()`.

Quit in that state and the quit-time flush runs `saveNowSync` with an empty aggregate, which routed to `TabDiskActor.clearSync` and removed `TabState/<connectionId>.json`. The drafts were gone permanently. A connect that stays pending is ordinary: it covers an interactive password prompt, an SSH or Cloudflare tunnel, a slow host, and a failed or cancelled attempt.

Restore is also gated on a live driver, so a connection that never connects shows an empty window and never even attempts a read. That is not fixed here (see below), but with deletion made safe it degrades to "tabs appear late" instead of "tabs destroyed".

## The fix

Deletion becomes an explicit act rather than an inference from empty state:

- `saveNow` and `saveNowSync` skip empty tab lists entirely and leave the file alone.
- `clearSavedState()` becomes `clearForUserClosedAllTabs()`, reachable only from `saveOrClearAggregatedSync()` on the window-close path, where an empty aggregate genuinely means the user closed everything. It is now synchronous; the old version spawned an untracked `Task` that the close path may never service.
- `saveOrClearAggregated()` becomes `saveAggregated()` and can no longer delete. Its callers are the 30s timer, structure changes, and the bulk-close path.

Two smaller data-loss paths in the same area:

- **Typing scheduled no save.** Editing query text changes no tab identity, so it drove none of the structural saves and lived only in memory until the 30s timer. `scheduleDraftSave()` debounces a save 1s after typing stops, cancelled on teardown and skipped during termination.
- **Queries over 500KB were persisted as `""`.** New `TabQueryOverflowStore` keeps them in a sidecar under `TabState/Overflow/`, mirroring what `RecentlyClosedTabStore` already does for the same limit, and prunes orphans. `PersistedTab.overflowFileName` is decode-if-present, so existing files still load.

## Tests

Four regression tests in `TabPersistenceCoordinatorTests` covering the defect: an empty async save must not delete, an empty quit-time save must not delete, an unsaved draft must survive an empty save then restore, and closing every tab must still clear.

Two existing tests changed, both because they pinned the data loss itself as intended behaviour:

- `largeQueryIsTruncated` asserted `content.query == ""` after a round trip.
- `cursorOffsetDroppedWhenQueryTruncated` asserted the offset was zeroed, which was right only because the text was being discarded.

Every other assertion in those files is untouched. 72 tests pass across the seven suites that touch this area, including the whole `RecentlyClosedTabStore` suite, which shares `toPersistedTab`.

## Not in this PR

- **Restore gated on a live driver.** Real, and it is why tabs look missing when a connection is slow or fails, but decoupling restore from the driver is a larger change to `MainSplitViewController`'s gating and deserves its own issue.
- **No new quit dialog.** The reporter asked for a warning; Apple's HIG ("Help people be confident that their work is always preserved") and DataGrip both favour preserving silently, so the answer here is reliable persistence. The existing alert still fires for unsaved row edits.
- `markTeardownScheduled()` / `clearTeardownScheduled()` are dead code and the comment at `MainContentCoordinator.swift:478-480` documents a mechanism that no longer exists. Left alone to keep this diff focused.

## Verification limits

The tests exercise the persistence layer directly. They do not reproduce a real `Cmd+Q` against a half-connected window, which needs a live app and connection, so the end-to-end claim rests on the traced path plus the unit guarantees. The reporter gave no version, OS, or steps, so I cannot confirm this is precisely what hit them; it is a real permanent data-loss path matching their description.

Worth exercising by hand: type in a query tab without saving, quit, relaunch. Then quit while a connection is still authenticating and relaunch.
