### PR TITLE
feat(datagrid): reorder filter rows by drag or the row menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Count exactly** next to an estimated row total, to replace the estimate with a real count when you want it.
+- Reorder filter rows by dragging the grip on the left of each row, or with **Move Up** and **Move Down** in the row's right-click menu.
 
 ### Fixed
 

--- a/TablePro/Core/Coordinators/FilterCoordinator.swift
+++ b/TablePro/Core/Coordinators/FilterCoordinator.swift
@@ -340,6 +340,71 @@ final class FilterCoordinator {
         }
     }
 
+    enum FilterMoveDirection {
+        case up
+        case down
+    }
+
+    struct FilterMove: Equatable {
+        let source: IndexSet
+        let destination: Int
+    }
+
+    static func filterMove(
+        in filters: [TableFilter],
+        moving draggedID: UUID,
+        onto targetID: UUID
+    ) -> FilterMove? {
+        guard draggedID != targetID,
+              let from = filters.firstIndex(where: { $0.id == draggedID }),
+              let target = filters.firstIndex(where: { $0.id == targetID }) else { return nil }
+        return FilterMove(source: IndexSet(integer: from), destination: from < target ? target + 1 : target)
+    }
+
+    static func filterMove(
+        in filters: [TableFilter],
+        moving filterID: UUID,
+        direction: FilterMoveDirection
+    ) -> FilterMove? {
+        guard let from = filters.firstIndex(where: { $0.id == filterID }) else { return nil }
+        switch direction {
+        case .up:
+            guard from > 0 else { return nil }
+            return FilterMove(source: IndexSet(integer: from), destination: from - 1)
+        case .down:
+            guard from < filters.count - 1 else { return nil }
+            return FilterMove(source: IndexSet(integer: from), destination: from + 2)
+        }
+    }
+
+    func moveFilter(_ draggedID: UUID, onto targetID: UUID) {
+        guard let move = Self.filterMove(
+            in: selectedTabFilterState.filters,
+            moving: draggedID,
+            onto: targetID
+        ) else { return }
+        applyFilterMove(move)
+    }
+
+    func moveFilter(_ filterID: UUID, direction: FilterMoveDirection) {
+        guard let move = Self.filterMove(
+            in: selectedTabFilterState.filters,
+            moving: filterID,
+            direction: direction
+        ) else { return }
+        applyFilterMove(move)
+    }
+
+    func canMoveFilter(_ filterID: UUID, direction: FilterMoveDirection) -> Bool {
+        Self.filterMove(in: selectedTabFilterState.filters, moving: filterID, direction: direction) != nil
+    }
+
+    private func applyFilterMove(_ move: FilterMove) {
+        mutateSelectedTabFilterState { state in
+            state.filters.move(fromOffsets: move.source, toOffset: move.destination)
+        }
+    }
+
     func filterBinding(for filter: TableFilter) -> Binding<TableFilter> {
         Binding(
             get: { [weak self] in

--- a/TablePro/Info.plist
+++ b/TablePro/Info.plist
@@ -227,6 +227,16 @@
 	<array>
 		<dict>
 			<key>UTTypeIdentifier</key>
+			<string>com.tablepro.filter-row</string>
+			<key>UTTypeDescription</key>
+			<string>TablePro Filter Row</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+		</dict>
+		<dict>
+			<key>UTTypeIdentifier</key>
 			<string>com.tablepro.beancount</string>
 			<key>UTTypeDescription</key>
 			<string>Beancount Ledger</string>

--- a/TablePro/Models/Database/FilterRowTransfer.swift
+++ b/TablePro/Models/Database/FilterRowTransfer.swift
@@ -1,0 +1,20 @@
+//
+//  FilterRowTransfer.swift
+//  TablePro
+//
+
+import CoreTransferable
+import Foundation
+import UniformTypeIdentifiers
+
+internal extension UTType {
+    static let tableProFilterRow = UTType(exportedAs: "com.tablepro.filter-row")
+}
+
+internal struct FilterRowTransfer: Codable, Transferable {
+    let filterID: UUID
+
+    static var transferRepresentation: some TransferRepresentation {
+        CodableRepresentation(contentType: .tableProFilterRow)
+    }
+}

--- a/TablePro/Views/Filter/FilterPanelView.swift
+++ b/TablePro/Views/Filter/FilterPanelView.swift
@@ -245,6 +245,14 @@ struct FilterPanelView: View {
                     onApply: { applySoloFilter(filter) },
                     onSubmit: { applyAllValidFilters() },
                     onCancel: { closePanelAndFocusGrid() },
+                    isReorderEnabled: filterState.filters.count > 1,
+                    canMoveUp: coordinator.canMoveFilter(filter.id, direction: .up),
+                    canMoveDown: coordinator.canMoveFilter(filter.id, direction: .down),
+                    onMoveUp: { coordinator.moveFilter(filter.id, direction: .up) },
+                    onMoveDown: { coordinator.moveFilter(filter.id, direction: .down) },
+                    onDropFilter: { draggedID in
+                        coordinator.moveFilter(draggedID, onto: filter.id)
+                    },
                     focusedFilterId: $focusedFilterId
                 )
             }

--- a/TablePro/Views/Filter/FilterRowDragHandle.swift
+++ b/TablePro/Views/Filter/FilterRowDragHandle.swift
@@ -1,0 +1,33 @@
+//
+//  FilterRowDragHandle.swift
+//  TablePro
+//
+
+import SwiftUI
+
+struct FilterRowDragHandle: View {
+    static let gutterWidth: CGFloat = 10
+
+    private let dotSize: CGFloat = 2.5
+    private let dotSpacing: CGFloat = 2.5
+    private let rowCount = 3
+    private let columnCount = 2
+
+    var body: some View {
+        VStack(spacing: dotSpacing) {
+            ForEach(0 ..< rowCount, id: \.self) { _ in
+                HStack(spacing: dotSpacing) {
+                    ForEach(0 ..< columnCount, id: \.self) { _ in
+                        Circle()
+                            .frame(width: dotSize, height: dotSize)
+                    }
+                }
+            }
+        }
+        .foregroundStyle(.tertiary)
+        .frame(width: Self.gutterWidth)
+        .contentShape(Rectangle())
+        .accessibilityHidden(true)
+        .help(String(localized: "Drag to reorder this filter"))
+    }
+}

--- a/TablePro/Views/Filter/FilterRowView.swift
+++ b/TablePro/Views/Filter/FilterRowView.swift
@@ -17,7 +17,15 @@ struct FilterRowView: View {
     let onApply: () -> Void
     let onSubmit: () -> Void
     let onCancel: () -> Void
+    let isReorderEnabled: Bool
+    let canMoveUp: Bool
+    let canMoveDown: Bool
+    let onMoveUp: () -> Void
+    let onMoveDown: () -> Void
+    let onDropFilter: (UUID) -> Void
     @Binding var focusedFilterId: UUID?
+
+    @State private var isDropTargeted = false
 
     private let rowButtonGlyphSize: CGFloat = 14
 
@@ -41,6 +49,8 @@ struct FilterRowView: View {
 
     var body: some View {
         HStack(spacing: 4) {
+            dragHandle
+
             enabledToggle
 
             Group {
@@ -58,7 +68,71 @@ struct FilterRowView: View {
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 8)
+        .background(dropHighlight)
+        .dropDestination(for: FilterRowTransfer.self) { items, _ in
+            guard let dragged = items.first else { return false }
+            onDropFilter(dragged.filterID)
+            return true
+        } isTargeted: { targeted in
+            isDropTargeted = targeted
+        }
         .contextMenu { rowContextMenu }
+        .accessibilityElement(children: .contain)
+        .accessibilityActions {
+            if canMoveUp {
+                Button(String(localized: "Move Filter Up"), action: onMoveUp)
+            }
+            if canMoveDown {
+                Button(String(localized: "Move Filter Down"), action: onMoveDown)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var dragHandle: some View {
+        if isReorderEnabled {
+            FilterRowDragHandle()
+                .draggable(FilterRowTransfer(filterID: filter.id)) {
+                    dragPreview
+                }
+        } else {
+            Color.clear
+                .frame(width: FilterRowDragHandle.gutterWidth, height: 1)
+        }
+    }
+
+    private var dragPreview: some View {
+        HStack(spacing: 4) {
+            Text(filter.isRawSQL ? String(localized: "Raw SQL") : filter.columnName)
+
+            if !filter.isRawSQL {
+                Text(filter.filterOperator.symbol.isEmpty
+                    ? filter.filterOperator.displayName
+                    : filter.filterOperator.symbol)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(previewValue)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .font(.callout)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    private var previewValue: String {
+        if filter.isRawSQL {
+            return filter.rawSQL ?? ""
+        }
+        guard filter.filterOperator.requiresValue else { return "" }
+        return filter.value
+    }
+
+    private var dropHighlight: some View {
+        RoundedRectangle(cornerRadius: 4)
+            .fill(Color.accentColor.opacity(isDropTargeted ? 0.18 : 0))
     }
 
     private var enabledToggle: some View {
@@ -203,6 +277,22 @@ struct FilterRowView: View {
         } label: {
             Label(String(localized: "Duplicate Filter"), systemImage: "doc.on.doc")
         }
+
+        Divider()
+
+        Button {
+            onMoveUp()
+        } label: {
+            Label(String(localized: "Move Up"), systemImage: "arrow.up")
+        }
+        .disabled(!canMoveUp)
+
+        Button {
+            onMoveDown()
+        } label: {
+            Label(String(localized: "Move Down"), systemImage: "arrow.down")
+        }
+        .disabled(!canMoveDown)
 
         Divider()
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+FilterState.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+FilterState.swift
@@ -44,6 +44,18 @@ extension MainContentCoordinator {
         filterCoordinator.updateFilter(filter)
     }
 
+    func moveFilter(_ draggedID: UUID, onto targetID: UUID) {
+        filterCoordinator.moveFilter(draggedID, onto: targetID)
+    }
+
+    func moveFilter(_ filterID: UUID, direction: FilterCoordinator.FilterMoveDirection) {
+        filterCoordinator.moveFilter(filterID, direction: direction)
+    }
+
+    func canMoveFilter(_ filterID: UUID, direction: FilterCoordinator.FilterMoveDirection) -> Bool {
+        filterCoordinator.canMoveFilter(filterID, direction: direction)
+    }
+
     func filterBinding(for filter: TableFilter) -> Binding<TableFilter> {
         filterCoordinator.filterBinding(for: filter)
     }

--- a/TableProTests/Core/Coordinators/FilterMoveTests.swift
+++ b/TableProTests/Core/Coordinators/FilterMoveTests.swift
@@ -1,0 +1,169 @@
+//
+//  FilterMoveTests.swift
+//  TableProTests
+//
+
+import Foundation
+import SwiftUI
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("Filter Move")
+@MainActor
+struct FilterMoveTests {
+    private static let mysqlDialect = SQLDialectDescriptor(
+        identifierQuote: "`", keywords: [], functions: [], dataTypes: [],
+        regexSyntax: .regexp, booleanLiteralStyle: .numeric,
+        likeEscapeStyle: .implicit, paginationStyle: .limit
+    )
+
+    private func makeFilters() -> [TableFilter] {
+        [
+            TestFixtures.makeTableFilter(column: "name", op: .contains, value: "ana"),
+            TestFixtures.makeTableFilter(column: "age", op: .greaterThan, value: "18"),
+            TestFixtures.makeTableFilter(column: "id", op: .equal, value: "42"),
+        ]
+    }
+
+    private func applying(_ move: FilterCoordinator.FilterMove, to filters: [TableFilter]) -> [TableFilter] {
+        var moved = filters
+        moved.move(fromOffsets: move.source, toOffset: move.destination)
+        return moved
+    }
+
+    @Test("Dropping a row onto an earlier row takes that row's position")
+    func dropOntoEarlierRowTakesItsPosition() throws {
+        let filters = makeFilters()
+
+        let move = try #require(
+            FilterCoordinator.filterMove(in: filters, moving: filters[2].id, onto: filters[0].id)
+        )
+        let result = applying(move, to: filters)
+
+        #expect(result.map(\.columnName) == ["id", "name", "age"])
+    }
+
+    @Test("Dropping a row onto a later row takes that row's position")
+    func dropOntoLaterRowTakesItsPosition() throws {
+        let filters = makeFilters()
+
+        let move = try #require(
+            FilterCoordinator.filterMove(in: filters, moving: filters[0].id, onto: filters[2].id)
+        )
+        let result = applying(move, to: filters)
+
+        #expect(result.map(\.columnName) == ["age", "id", "name"])
+    }
+
+    @Test("Dropping a row onto itself is a no-op")
+    func dropOntoSelfIsNoOp() {
+        let filters = makeFilters()
+
+        #expect(FilterCoordinator.filterMove(in: filters, moving: filters[1].id, onto: filters[1].id) == nil)
+    }
+
+    @Test("A dragged row that is not in the current filter set is a no-op")
+    func unknownDraggedFilterIsNoOp() {
+        let filters = makeFilters()
+
+        #expect(FilterCoordinator.filterMove(in: filters, moving: UUID(), onto: filters[0].id) == nil)
+        #expect(FilterCoordinator.filterMove(in: filters, moving: filters[0].id, onto: UUID()) == nil)
+    }
+
+    @Test("Move up swaps a row with the one above it")
+    func moveUpSwapsWithRowAbove() throws {
+        let filters = makeFilters()
+
+        let move = try #require(FilterCoordinator.filterMove(in: filters, moving: filters[1].id, direction: .up))
+        let result = applying(move, to: filters)
+
+        #expect(result.map(\.columnName) == ["age", "name", "id"])
+    }
+
+    @Test("Move down swaps a row with the one below it")
+    func moveDownSwapsWithRowBelow() throws {
+        let filters = makeFilters()
+
+        let move = try #require(FilterCoordinator.filterMove(in: filters, moving: filters[1].id, direction: .down))
+        let result = applying(move, to: filters)
+
+        #expect(result.map(\.columnName) == ["name", "id", "age"])
+    }
+
+    @Test("Move up on the first row and move down on the last row are no-ops")
+    func moveBeyondBoundsIsNoOp() {
+        let filters = makeFilters()
+
+        #expect(FilterCoordinator.filterMove(in: filters, moving: filters[0].id, direction: .up) == nil)
+        #expect(FilterCoordinator.filterMove(in: filters, moving: filters[2].id, direction: .down) == nil)
+    }
+
+    @Test("Move up and move down on an unknown filter are no-ops")
+    func moveUnknownFilterIsNoOp() {
+        let filters = makeFilters()
+
+        #expect(FilterCoordinator.filterMove(in: filters, moving: UUID(), direction: .up) == nil)
+        #expect(FilterCoordinator.filterMove(in: filters, moving: UUID(), direction: .down) == nil)
+    }
+
+    @Test("Moving a row carries every field of the condition unchanged")
+    func moveCarriesWholeConditionUnchanged() throws {
+        let filters = [
+            TestFixtures.makeTableFilter(column: "created_at", op: .between, value: "2024", secondValue: "2025"),
+            TestFixtures.makeTableFilter(column: "status", op: .equal, value: "active", isEnabled: false),
+            TestFixtures.makeTableFilter(
+                column: TableFilter.rawSQLColumn,
+                op: .equal,
+                value: "",
+                rawSQL: "price * quantity > 1000"
+            ),
+        ]
+
+        let move = try #require(
+            FilterCoordinator.filterMove(in: filters, moving: filters[2].id, onto: filters[0].id)
+        )
+        let result = applying(move, to: filters)
+
+        #expect(result[0] == filters[2])
+        #expect(result[1] == filters[0])
+        #expect(result[2] == filters[1])
+    }
+
+    @Test("Reordering rows does not change which filters are applied")
+    func reorderPreservesAppliedFilterSet() throws {
+        let filters = makeFilters()
+        var state = TabFilterState()
+        state.filters = filters
+        state.commit = .all
+
+        let move = try #require(
+            FilterCoordinator.filterMove(in: filters, moving: filters[2].id, onto: filters[0].id)
+        )
+        var reordered = state
+        reordered.filters = applying(move, to: filters)
+
+        #expect(Set(reordered.appliedFilters) == Set(state.appliedFilters))
+    }
+
+    @Test("Reordering rows produces an equivalent WHERE clause under a single logic mode")
+    func reorderProducesEquivalentWhereClause() throws {
+        let filters = makeFilters()
+        let generator = FilterSQLGenerator(dialect: Self.mysqlDialect)
+
+        let move = try #require(
+            FilterCoordinator.filterMove(in: filters, moving: filters[2].id, onto: filters[0].id)
+        )
+        let reordered = applying(move, to: filters)
+
+        for mode in [FilterLogicMode.and, .or] {
+            let separator = mode == .and ? " AND " : " OR "
+            let original = generator.generateConditions(from: filters, logicMode: mode)
+            let moved = generator.generateConditions(from: reordered, logicMode: mode)
+
+            #expect(original != moved)
+            #expect(Set(original.components(separatedBy: separator))
+                == Set(moved.components(separatedBy: separator)))
+        }
+    }
+}

--- a/TableProTests/Core/Storage/FilterSettingsStorageTests.swift
+++ b/TableProTests/Core/Storage/FilterSettingsStorageTests.swift
@@ -34,6 +34,29 @@ struct FilterSettingsStorageTests {
         )
     }
 
+    @Test("Saving then loading preserves the order of several filters")
+    func roundTripsFilterOrder() {
+        let (storage, directory) = makeStorage()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let connectionId = UUID()
+        let filters = [
+            TestFixtures.makeTableFilter(column: "id", value: "42"),
+            TestFixtures.makeTableFilter(column: "name", op: .contains, value: "ana"),
+            TestFixtures.makeTableFilter(column: "age", op: .greaterThan, value: "18"),
+        ]
+
+        storage.saveLastFilters(filters, for: "users", connectionId: connectionId, databaseName: "db", schemaName: nil)
+
+        let loaded = storage.loadLastFilters(
+            for: "users",
+            connectionId: connectionId,
+            databaseName: "db",
+            schemaName: nil
+        )
+        #expect(loaded == filters)
+        #expect(loaded.map(\.columnName) == ["id", "name", "age"])
+    }
+
     @Test("Loading an unsaved table returns no filters")
     func loadReturnsEmptyForMissing() {
         let (storage, directory) = makeStorage()

--- a/docs/features/filtering.mdx
+++ b/docs/features/filtering.mdx
@@ -10,7 +10,7 @@ Press `Cmd+F` while viewing a table to open the filter panel. Type a raw SQL WHE
   <img className="hidden dark:block" src="/images/filter-panel-dark.png" alt="Filter panel above the data grid" />
 </Frame>
 
-Each row has a checkbox, a column picker, operator, value field, and **+**/**−** buttons. The **Match all** / **Match any** picker in the header combines rows with AND or OR. You can also right-click a column header in the data grid and choose **Filter with column** to pre-fill a filter row for that column.
+Each row has a drag grip, a checkbox, a column picker, operator, value field, and **+**/**−** buttons. The **Match all** / **Match any** picker in the header combines rows with AND or OR. You can also right-click a column header in the data grid and choose **Filter with column** to pre-fill a filter row for that column.
 
 | Control | What it does |
 |---------|--------------|
@@ -18,6 +18,10 @@ Each row has a checkbox, a column picker, operator, value field, and **+**/**−
 | Row checkbox | Turns that filter off without deleting it; unchecked rows stay dimmed. Toggling does not re-run the query, press **Apply** when ready |
 | Row **Apply** | Filters by just that row, leaving all checkboxes as they are, so you can test one condition and return to the checked set with the header **Apply** |
 | **Clear** | Removes the applied filter without deleting the filter rows |
+| Row grip (left edge) | Drag it onto another row to move the filter into that row's position. The whole condition moves, so the column, operator, and value stay as they were. The grip appears once there are two or more rows |
+| Right-click > **Move Up** / **Move Down** | Reorders a row without dragging |
+
+Row order is for organizing the list. Every row is joined by the same **Match all** or **Match any** setting, so moving a row never changes which rows the query returns.
 
 When you reopen a table, TablePro restores the filters you last applied to it, including the ones you left unchecked, after you quit and relaunch. Filters are saved per connection, database, schema, and table, so two tables on the same connection keep independent filters. If you cleared the filter with **Clear** or removed its rows with **−**, the table reopens unfiltered. Tables with active filters open in a new tab when you click another table.
 


### PR DESCRIPTION
Filter rows could only be ordered by the order they were created. Moving a condition meant deleting and recreating it, which risks changing an operator or value by accident.

Rows can now be reordered three ways, all going through one model API:

- Drag the grip at the left of a row onto another row. It takes that row's position, carrying the whole condition (column, operator, value, enabled flag) unchanged.
- Right-click a row and pick **Move Up** or **Move Down**.
- VoiceOver rotor actions "Move Filter Up" and "Move Filter Down".

The grip appears once there are two or more rows. Its gutter is always reserved, so rows do not shift when the second one is added.

## Why not `List` + `.onMove`

`.onMove` only works inside a `List`, and the API that lifts that restriction (`.reorderable()` / `reorderContainer`) is macOS 27. This app targets macOS 14.

Moving the panel into a `List` would have meant putting `FilterValueTextField`, a 587-line `NSViewRepresentable` with its own focus-claim state machine and an attached autocomplete panel, inside a control with [documented macOS List/TextField editing friction](https://developer.apple.com/forums/thread/784010) (click, then wait, before the field takes text). It would also have invalidated the panel's height measurement and conditional scroll view. Rewriting onto `NSTableView` would re-host that same focus machinery for a bigger cost.

So the panel keeps its `VStack`, and reordering is additive: `Transferable` payload, `.draggable(_:preview:)` on the grip, `.dropDestination` per row. Because it is a real system drag session, VoiceOver's own drag and drop works against it, which a hand-rolled `DragGesture` would have broken silently.

## Notes

- Order is organizational only. Every row is joined by the same **Match all** / **Match any** setting, so a move can never change which rows the query returns. No AND/OR rebalancing exists to get wrong, and a test pins that.
- No persistence or query changes. A reorder mutates state like editing a value does, and rides the existing save paths (Apply, tab switch, navigate away).
- The drop target only accepts `com.tablepro.filter-row`, so text drags still pass through to the value field.
- A drag whose payload is not in the current filter set is a no-op, which is what makes a drag between windows safe.
- No undo stack. The panel has none today (removing a filter is not undoable either), and Move Up / Move Down makes a mistake trivially reversible.

## Tests

30 passing across `FilterMoveTests` (new, 11 cases) and `FilterSettingsStorageTests` (added a 3-filter order round-trip; every existing fixture used a single filter). Covers both drop directions, both menu directions, every no-op path, whole-condition preservation, and WHERE-clause equivalence after a move.

No UI automation for the drag gesture: AppKit/SwiftUI drag sessions do not run deterministically under XCUITest, so the pure move logic carries the coverage.

## Design note

The grip is a judgement call, not an Apple convention. The HIG has no macOS drag-handle concept (`showsReorderControl` is iOS-only), and whole-row dragging is the stated convention. But whole-row dragging is not available here: a mousedown in the value field starts text selection and the pickers consume clicks, so most of each row cannot begin a drag. A narrow dedicated gutter resolves that. No SF Symbol matches a 2x3 dot grid, so it is drawn as six circles. The pointer stays an arrow, since the HIG assigns hand cursors to content panning.

Requested in TablePlus/TablePlus#3890.
