### PR TITLE
feat(ai-providers): add Claude Agent provider backed by the Claude Code CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Claude Agent** provider, which runs AI chat through the Claude Code command line tool so you can use a Claude subscription instead of a metered API key. It answers from your schema when the MCP server is on.
 - **Count exactly** next to an estimated row total, to replace the estimate with a real count when you want it.
 - Reorder filter rows by dragging the grip on the left of each row, or with **Move Up** and **Move Down** in the row's right-click menu.
 

--- a/TablePro/Core/AI/CLI/AgentCLIDiscovery.swift
+++ b/TablePro/Core/AI/CLI/AgentCLIDiscovery.swift
@@ -1,0 +1,110 @@
+//
+//  AgentCLIDiscovery.swift
+//  TablePro
+//
+
+import Foundation
+
+struct AgentCLIDiscovery: Sendable {
+    let candidatePaths: [String]
+    let preferredPathDirectories: [String]
+
+    private let fileManager: @Sendable (String) -> Bool
+
+    init(
+        candidatePaths: [String],
+        preferredPathDirectories: [String] = AgentCLIDiscovery.defaultPathDirectories,
+        isExecutable: @escaping @Sendable (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) }
+    ) {
+        self.candidatePaths = candidatePaths
+        self.preferredPathDirectories = preferredPathDirectories
+        self.fileManager = isExecutable
+    }
+
+    func resolveExecutable(override: String?) -> URL? {
+        if let override, !override.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let expanded = (override as NSString).expandingTildeInPath
+            return fileManager(expanded) ? URL(fileURLWithPath: expanded) : nil
+        }
+        guard let match = candidatePaths.first(where: fileManager) else { return nil }
+        return URL(fileURLWithPath: match)
+    }
+
+    func makeEnvironment(
+        base: [String: String] = ProcessInfo.processInfo.environment,
+        removingKeys: Set<String> = [],
+        adding overrides: [String: String] = [:]
+    ) -> [String: String] {
+        var environment = base
+        for key in removingKeys {
+            environment.removeValue(forKey: key)
+        }
+        environment["PATH"] = Self.composePath(
+            preferred: preferredPathDirectories,
+            existing: environment["PATH"] ?? ""
+        )
+        for (key, value) in overrides {
+            environment[key] = value
+        }
+        return environment
+    }
+
+    static func composePath(preferred: [String], existing: String) -> String {
+        let current = existing.split(separator: ":").map(String.init)
+        var seen = Set<String>()
+        return (preferred + current)
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+            .joined(separator: ":")
+    }
+
+    static var defaultPathDirectories: [String] {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return [
+            "\(home)/.local/bin",
+            "\(home)/.claude/local",
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "\(home)/.npm-global/bin",
+            "\(home)/.bun/bin",
+            "\(home)/.volta/bin",
+            "/usr/bin",
+            "/bin",
+            "/usr/sbin",
+            "/sbin"
+        ] + nodeVersionManagerDirectories(home: home)
+    }
+
+    static func nodeVersionManagerDirectories(
+        home: String,
+        contentsOfDirectory: (String) -> [String] = { path in
+            (try? FileManager.default.contentsOfDirectory(atPath: path)) ?? []
+        }
+    ) -> [String] {
+        let nvmVersions = "\(home)/.nvm/versions/node"
+        let newest = contentsOfDirectory(nvmVersions)
+            .filter { $0.hasPrefix("v") }
+            .max { compareVersions($0, $1) == .orderedAscending }
+        guard let newest else { return [] }
+        return ["\(nvmVersions)/\(newest)/bin"]
+    }
+
+    static func compareVersions(_ lhs: String, _ rhs: String) -> ComparisonResult {
+        let left = versionComponents(lhs)
+        let right = versionComponents(rhs)
+        for index in 0 ..< max(left.count, right.count) {
+            let leftValue = index < left.count ? left[index] : 0
+            let rightValue = index < right.count ? right[index] : 0
+            if leftValue != rightValue {
+                return leftValue < rightValue ? .orderedAscending : .orderedDescending
+            }
+        }
+        return .orderedSame
+    }
+
+    private static func versionComponents(_ value: String) -> [Int] {
+        value
+            .trimmingCharacters(in: CharacterSet(charactersIn: "v"))
+            .split(separator: ".")
+            .map { Int($0) ?? 0 }
+    }
+}

--- a/TablePro/Core/AI/CLI/AgentCLIProcess.swift
+++ b/TablePro/Core/AI/CLI/AgentCLIProcess.swift
@@ -1,0 +1,138 @@
+//
+//  AgentCLIProcess.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+enum AgentCLIError: Error, LocalizedError {
+    case notInstalled(String)
+    case launchFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notInstalled(let tool):
+            return String(format: String(localized: "The %@ command line tool is not installed."), tool)
+        case .launchFailed(let detail):
+            return String(format: String(localized: "Command line tool failed: %@"), detail)
+        }
+    }
+}
+
+struct AgentCLILaunch: Sendable {
+    let executable: URL
+    let arguments: [String]
+    let environment: [String: String]
+    let currentDirectory: URL?
+
+    init(
+        executable: URL,
+        arguments: [String],
+        environment: [String: String],
+        currentDirectory: URL? = nil
+    ) {
+        self.executable = executable
+        self.arguments = arguments
+        self.environment = environment
+        self.currentDirectory = currentDirectory
+    }
+}
+
+struct AgentCLIProcess: Sendable {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "AgentCLIProcess")
+    private static let terminationGracePeriod: Duration = .milliseconds(750)
+
+    let label: String
+
+    func run(_ launch: AgentCLILaunch) async throws -> (code: Int32, output: String) {
+        let process = Self.makeProcess(launch)
+        let combined = Pipe()
+        process.standardOutput = combined
+        process.standardError = combined
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                process.terminationHandler = { finished in
+                    let data = (try? combined.fileHandleForReading.readToEnd() ?? Data()) ?? Data()
+                    continuation.resume(
+                        returning: (finished.terminationStatus, String(data: data, encoding: .utf8) ?? "")
+                    )
+                }
+                do {
+                    try process.run()
+                } catch {
+                    process.terminationHandler = nil
+                    continuation.resume(throwing: AgentCLIError.launchFailed(error.localizedDescription))
+                }
+            }
+        } onCancel: {
+            Self.terminate(process, label: label)
+        }
+    }
+
+    func streamLines(_ launch: AgentCLILaunch) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            let process = Self.makeProcess(launch)
+            let stdout = Pipe()
+            let stderr = Pipe()
+            process.standardOutput = stdout
+            process.standardError = stderr
+
+            let label = self.label
+            let stderrDrain = Task {
+                for try await line in stderr.fileHandleForReading.bytes.lines where !line.isEmpty {
+                    Self.logger.error("\(label, privacy: .public) stderr: \(line, privacy: .public)")
+                }
+            }
+
+            do {
+                try process.run()
+            } catch {
+                stderrDrain.cancel()
+                continuation.finish(throwing: AgentCLIError.launchFailed(error.localizedDescription))
+                return
+            }
+
+            let reader = Task {
+                do {
+                    for try await line in stdout.fileHandleForReading.bytes.lines {
+                        if Task.isCancelled { break }
+                        continuation.yield(line)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { _ in
+                reader.cancel()
+                stderrDrain.cancel()
+                Self.terminate(process, label: label)
+            }
+        }
+    }
+
+    private static func makeProcess(_ launch: AgentCLILaunch) -> Process {
+        let process = Process()
+        process.executableURL = launch.executable
+        process.arguments = launch.arguments
+        process.environment = launch.environment
+        process.currentDirectoryURL = launch.currentDirectory
+        process.standardInput = FileHandle.nullDevice
+        return process
+    }
+
+    private static func terminate(_ process: Process, label: String) {
+        guard process.isRunning else { return }
+        let identifier = process.processIdentifier
+        process.terminate()
+        Task.detached(priority: .utility) {
+            try? await Task.sleep(for: terminationGracePeriod)
+            guard process.isRunning else { return }
+            logger.warning("\(label, privacy: .public) ignored SIGTERM, sending SIGKILL")
+            kill(identifier, SIGKILL)
+        }
+    }
+}

--- a/TablePro/Core/AI/CLI/AgentPromptRenderer.swift
+++ b/TablePro/Core/AI/CLI/AgentPromptRenderer.swift
@@ -1,0 +1,46 @@
+//
+//  AgentPromptRenderer.swift
+//  TablePro
+//
+
+import Foundation
+
+enum AgentPromptRenderer {
+    static func renderPrompt(turns: [ChatTurnWire], includingSystemPrompt systemPrompt: String?) -> String {
+        var sections: [String] = []
+        if let systemPrompt, !systemPrompt.isEmpty {
+            sections.append(systemPrompt)
+        }
+        for turn in turns {
+            let text = turnText(turn)
+            guard !text.isEmpty else { continue }
+            switch turn.role {
+            case .user:
+                sections.append("User: \(text)")
+            case .assistant:
+                sections.append("Assistant: \(text)")
+            case .system:
+                sections.append(text)
+            }
+        }
+        return sections.joined(separator: "\n\n")
+    }
+
+    static func turnText(_ turn: ChatTurnWire) -> String {
+        var parts: [String] = []
+        for block in turn.blocks {
+            switch block.kind {
+            case .text(let text):
+                if !text.isEmpty { parts.append(text) }
+            case .sqlWalkthrough(let walkthrough):
+                let text = walkthrough.transcriptText
+                if !text.isEmpty { parts.append(text) }
+            case .toolResult(let result):
+                if !result.content.isEmpty { parts.append("Result: \(result.content)") }
+            case .toolUse, .attachment, .reasoning, .image:
+                continue
+            }
+        }
+        return parts.joined(separator: "\n")
+    }
+}

--- a/TablePro/Core/AI/ClaudeAgent/ClaudeAgent.swift
+++ b/TablePro/Core/AI/ClaudeAgent/ClaudeAgent.swift
@@ -1,0 +1,23 @@
+//
+//  ClaudeAgent.swift
+//  TablePro
+//
+
+import Foundation
+
+enum ClaudeAgent {
+    static let mcpServerName = "tablepro"
+
+    static let curatedModels: [CuratedModel] = [
+        CuratedModel(id: "opus", displayName: "Claude Opus"),
+        CuratedModel(id: "sonnet", displayName: "Claude Sonnet"),
+        CuratedModel(id: "haiku", displayName: "Claude Haiku")
+    ]
+
+    static let systemPrompt = """
+    You are a SQL assistant embedded in TablePro, a macOS database client. \
+    Answer questions about the user's databases and help them write, explain, and fix SQL. \
+    Keep responses focused and concise. When database tools are available, use them to \
+    ground your answers in the user's actual schema rather than guessing.
+    """
+}

--- a/TablePro/Core/AI/ClaudeAgent/ClaudeAgentCLI.swift
+++ b/TablePro/Core/AI/ClaudeAgent/ClaudeAgentCLI.swift
@@ -1,0 +1,142 @@
+//
+//  ClaudeAgentCLI.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+struct ClaudeAgentAuthStatus: Decodable, Equatable, Sendable {
+    let loggedIn: Bool
+    let authMethod: String?
+    let email: String?
+    let subscriptionType: String?
+
+    static let signedOut = ClaudeAgentAuthStatus(
+        loggedIn: false,
+        authMethod: nil,
+        email: nil,
+        subscriptionType: nil
+    )
+
+    var accountDescription: String? {
+        guard loggedIn else { return nil }
+        if let email, !email.isEmpty { return email }
+        return authMethod
+    }
+
+    var planDescription: String? {
+        guard let subscriptionType, !subscriptionType.isEmpty else { return nil }
+        return subscriptionType.capitalized
+    }
+}
+
+struct ClaudeAgentCLI: Sendable {
+    static let toolName = "claude"
+    static let installCommand = "npm install -g @anthropic-ai/claude-code"
+    static let minimumVersion = "2.1.205"
+
+    private static let logger = Logger(subsystem: "com.TablePro", category: "ClaudeAgentCLI")
+    private static let subscriptionOverridingKeys: Set<String> = [
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN"
+    ]
+
+    private let discovery: AgentCLIDiscovery
+    private let process: AgentCLIProcess
+    private let executableOverride: String?
+
+    init(executableOverride: String? = nil, discovery: AgentCLIDiscovery = ClaudeAgentCLI.defaultDiscovery) {
+        self.executableOverride = executableOverride
+        self.discovery = discovery
+        self.process = AgentCLIProcess(label: Self.toolName)
+    }
+
+    static var defaultDiscovery: AgentCLIDiscovery {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return AgentCLIDiscovery(candidatePaths: [
+            "\(home)/.local/bin/claude",
+            "\(home)/.claude/local/claude",
+            "\(home)/.claude/bin/claude",
+            "/opt/homebrew/bin/claude",
+            "/usr/local/bin/claude",
+            "\(home)/.npm-global/bin/claude",
+            "/usr/bin/claude"
+        ])
+    }
+
+    func executableURL() -> URL? {
+        discovery.resolveExecutable(override: executableOverride)
+    }
+
+    var isInstalled: Bool { executableURL() != nil }
+
+    func environment(additional: [String: String] = [:]) -> [String: String] {
+        discovery.makeEnvironment(
+            removingKeys: Self.subscriptionOverridingKeys,
+            adding: additional
+        )
+    }
+
+    func launch(
+        arguments: [String],
+        additionalEnvironment: [String: String] = [:],
+        currentDirectory: URL? = nil
+    ) throws -> AgentCLILaunch {
+        guard let executable = executableURL() else {
+            throw AgentCLIError.notInstalled(Self.toolName)
+        }
+        return AgentCLILaunch(
+            executable: executable,
+            arguments: arguments,
+            environment: environment(additional: additionalEnvironment),
+            currentDirectory: currentDirectory
+        )
+    }
+
+    func streamLines(
+        arguments: [String],
+        additionalEnvironment: [String: String] = [:],
+        currentDirectory: URL? = nil
+    ) throws -> AsyncThrowingStream<String, Error> {
+        let launch = try launch(
+            arguments: arguments,
+            additionalEnvironment: additionalEnvironment,
+            currentDirectory: currentDirectory
+        )
+        return process.streamLines(launch)
+    }
+
+    func authStatus() async throws -> ClaudeAgentAuthStatus {
+        let result = try await process.run(try launch(arguments: ["auth", "status", "--json"]))
+        guard result.code == 0 else { return .signedOut }
+        return Self.decodeAuthStatus(result.output) ?? .signedOut
+    }
+
+    func version() async throws -> String? {
+        let result = try await process.run(try launch(arguments: ["--version"]))
+        guard result.code == 0 else { return nil }
+        return Self.parseVersion(result.output)
+    }
+
+    static func decodeAuthStatus(_ output: String) -> ClaudeAgentAuthStatus? {
+        guard let start = output.firstIndex(of: "{"), let end = output.lastIndex(of: "}"), start < end else {
+            return nil
+        }
+        let json = String(output[start ... end])
+        guard let data = json.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(ClaudeAgentAuthStatus.self, from: data)
+    }
+
+    static func parseVersion(_ output: String) -> String? {
+        let scalars = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = scalars.split(separator: " ").first else { return nil }
+        let candidate = String(first)
+        return candidate.first?.isNumber == true ? candidate : nil
+    }
+
+    static func meetsMinimumVersion(_ version: String?) -> Bool {
+        guard let version else { return false }
+        return AgentCLIDiscovery.compareVersions(version, minimumVersion) != .orderedAscending
+    }
+}

--- a/TablePro/Core/AI/ClaudeAgent/ClaudeAgentMCPBridge.swift
+++ b/TablePro/Core/AI/ClaudeAgent/ClaudeAgentMCPBridge.swift
@@ -1,0 +1,103 @@
+//
+//  ClaudeAgentMCPBridge.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+struct ClaudeAgentToolGrant: Sendable, Equatable {
+    let configPath: String
+    let tokenId: UUID
+}
+
+protocol ClaudeAgentMCPBridging: Sendable {
+    func makeGrant() async -> ClaudeAgentToolGrant?
+    func release(_ grant: ClaudeAgentToolGrant?) async
+}
+
+struct ClaudeAgentMCPBridge: ClaudeAgentMCPBridging {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "ClaudeAgentMCPBridge")
+    private static let tokenName = "__claude_agent__"
+    private static let tokenLifetime: TimeInterval = 15 * 60
+
+    private let permissions: TokenPermissions
+    private let connectionAccess: ConnectionAccess
+
+    init(permissions: TokenPermissions = .readOnly, connectionAccess: ConnectionAccess = .all) {
+        self.permissions = permissions
+        self.connectionAccess = connectionAccess
+    }
+
+    func makeGrant() async -> ClaudeAgentToolGrant? {
+        guard let endpoint = await Self.resolveEndpoint() else { return nil }
+        guard let tokenStore = await MCPServerManager.shared.tokenStore else { return nil }
+
+        let generated = await tokenStore.generate(
+            name: Self.tokenName,
+            permissions: permissions,
+            connectionAccess: connectionAccess,
+            expiresAt: Date.now.addingTimeInterval(Self.tokenLifetime)
+        )
+
+        guard let configPath = Self.writeConfig(endpoint: endpoint, token: generated.plaintext) else {
+            await tokenStore.delete(tokenId: generated.token.id)
+            return nil
+        }
+
+        Self.logger.debug("Issued Claude Agent MCP grant")
+        return ClaudeAgentToolGrant(configPath: configPath, tokenId: generated.token.id)
+    }
+
+    func release(_ grant: ClaudeAgentToolGrant?) async {
+        guard let grant else { return }
+        try? FileManager.default.removeItem(atPath: grant.configPath)
+        guard let tokenStore = await MCPServerManager.shared.tokenStore else { return }
+        await tokenStore.delete(tokenId: grant.tokenId)
+        Self.logger.debug("Released Claude Agent MCP grant")
+    }
+
+    @MainActor
+    private static func resolveEndpoint() -> URL? {
+        guard case .running(let port) = MCPServerManager.shared.state else {
+            logger.info("MCP server is not running; Claude Agent runs without database tools")
+            return nil
+        }
+        guard !AppSettingsManager.shared.mcp.allowRemoteConnections else {
+            logger.info("MCP server uses TLS for remote access; Claude Agent runs without database tools")
+            return nil
+        }
+        return URL(string: "http://127.0.0.1:\(port)/mcp")
+    }
+
+    static func configPayload(endpoint: URL, token: String) -> String? {
+        let payload: [String: Any] = [
+            "mcpServers": [
+                ClaudeAgent.mcpServerName: [
+                    "type": "http",
+                    "url": endpoint.absoluteString,
+                    "headers": ["Authorization": "Bearer \(token)"]
+                ]
+            ]
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: payload) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func writeConfig(endpoint: URL, token: String) -> String? {
+        guard let payload = configPayload(endpoint: endpoint, token: token) else { return nil }
+        let url = FileManager.default.temporaryDirectory
+            .appending(path: "tablepro-claude-mcp-\(UUID().uuidString).json")
+        do {
+            try payload.write(to: url, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: url.path
+            )
+            return url.path
+        } catch {
+            logger.error("Failed to write MCP config: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+}

--- a/TablePro/Core/AI/ClaudeAgent/ClaudeAgentProvider.swift
+++ b/TablePro/Core/AI/ClaudeAgent/ClaudeAgentProvider.swift
@@ -1,0 +1,169 @@
+//
+//  ClaudeAgentProvider.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+final class ClaudeAgentProvider: ChatTransport {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "ClaudeAgentProvider")
+
+    private let model: String
+    private let cli: ClaudeAgentCLI
+    private let toolBridge: ClaudeAgentMCPBridging
+
+    init(
+        model: String,
+        cli: ClaudeAgentCLI = ClaudeAgentCLI(),
+        toolBridge: ClaudeAgentMCPBridging = ClaudeAgentMCPBridge()
+    ) {
+        self.model = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.cli = cli
+        self.toolBridge = toolBridge
+    }
+
+    func streamChat(
+        turns: [ChatTurnWire],
+        options: ChatTransportOptions
+    ) -> AsyncThrowingStream<ChatStreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                var grant: ClaudeAgentToolGrant?
+                do {
+                    grant = await toolBridge.makeGrant()
+                    let prompt = AgentPromptRenderer.renderPrompt(turns: turns, includingSystemPrompt: nil)
+                    let lines = try cli.streamLines(
+                        arguments: Self.inferenceArguments(
+                            prompt: prompt,
+                            model: model,
+                            systemPrompt: options.systemPrompt ?? ClaudeAgent.systemPrompt,
+                            mcpConfigPath: grant?.configPath
+                        ),
+                        currentDirectory: FileManager.default.temporaryDirectory
+                    )
+
+                    for try await line in lines {
+                        if Task.isCancelled { break }
+                        guard let event = Self.decodeEvent(line) else { continue }
+                        switch event {
+                        case .text(let text):
+                            continuation.yield(.textDelta(text))
+                        case .usage(let usage):
+                            continuation.yield(.usage(usage))
+                        case .failure(let message):
+                            await toolBridge.release(grant)
+                            grant = nil
+                            continuation.finish(throwing: AIProviderError.authenticationFailed(message))
+                            return
+                        }
+                    }
+                    await toolBridge.release(grant)
+                    grant = nil
+                    continuation.finish()
+                } catch {
+                    await toolBridge.release(grant)
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    func fetchAvailableModels() async throws -> [String] {
+        ClaudeAgent.curatedModels.map(\.id)
+    }
+
+    func testConnection() async throws -> Bool {
+        let status = try await cli.authStatus()
+        guard status.loggedIn else {
+            throw AIProviderError.authenticationFailed(
+                String(localized: "Not signed in to Claude. Run \"claude /login\" in Terminal, then try again.")
+            )
+        }
+        return true
+    }
+
+    enum DecodedEvent: Equatable {
+        case text(String)
+        case usage(AITokenUsage)
+        case failure(String)
+    }
+
+    static func inferenceArguments(
+        prompt: String,
+        model: String,
+        systemPrompt: String?,
+        mcpConfigPath: String?
+    ) -> [String] {
+        var arguments = [
+            "-p",
+            "--output-format", "stream-json",
+            "--verbose",
+            "--include-partial-messages",
+            "--no-session-persistence",
+            "--disable-slash-commands",
+            "--setting-sources", "",
+            "--tools", ""
+        ]
+
+        if let mcpConfigPath {
+            arguments += ["--mcp-config", mcpConfigPath, "--allowedTools", "mcp__\(ClaudeAgent.mcpServerName)__*"]
+        }
+        arguments.append("--strict-mcp-config")
+
+        if let systemPrompt, !systemPrompt.isEmpty {
+            arguments += ["--system-prompt", systemPrompt]
+        }
+        if !model.isEmpty {
+            arguments += ["--model", model]
+        }
+        arguments += ["--", prompt]
+        return arguments
+    }
+
+    static func decodeEvent(_ line: String) -> DecodedEvent? {
+        guard let json = decodeJSON(line), let type = json["type"] as? String else { return nil }
+        switch type {
+        case "stream_event":
+            guard let text = partialText(json) else { return nil }
+            return .text(text)
+        case "result":
+            return resultEvent(json)
+        default:
+            return nil
+        }
+    }
+
+    static func partialText(_ json: [String: Any]) -> String? {
+        guard let event = json["event"] as? [String: Any],
+              let delta = event["delta"] as? [String: Any],
+              delta["type"] as? String == "text_delta",
+              let text = delta["text"] as? String,
+              !text.isEmpty else {
+            return nil
+        }
+        return text
+    }
+
+    static func resultEvent(_ json: [String: Any]) -> DecodedEvent? {
+        if json["is_error"] as? Bool == true {
+            let message = (json["result"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+                ?? String(localized: "Claude Code reported an error.")
+            return .failure(message)
+        }
+        guard let usage = json["usage"] as? [String: Any] else { return nil }
+        let input = usage["input_tokens"] as? Int ?? 0
+        let output = usage["output_tokens"] as? Int ?? 0
+        guard input > 0 || output > 0 else { return nil }
+        return .usage(AITokenUsage(inputTokens: input, outputTokens: output))
+    }
+
+    private static func decodeJSON(_ line: String) -> [String: Any]? {
+        guard let data = line.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+}

--- a/TablePro/Core/AI/ClaudeAgent/ClaudeAgentService.swift
+++ b/TablePro/Core/AI/ClaudeAgent/ClaudeAgentService.swift
@@ -1,0 +1,101 @@
+//
+//  ClaudeAgentService.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+@MainActor @Observable
+final class ClaudeAgentService {
+    enum InstallState: Equatable {
+        case unknown
+        case notInstalled
+        case outdated(version: String)
+        case signedOut
+        case signedIn(account: String?, plan: String?)
+
+        var isUsable: Bool {
+            if case .signedIn = self { return true }
+            return false
+        }
+    }
+
+    static let shared = ClaudeAgentService()
+
+    private static let logger = Logger(subsystem: "com.TablePro", category: "ClaudeAgentService")
+
+    private(set) var state: InstallState = .unknown
+    private(set) var isRefreshing = false
+
+    private var refreshTask: Task<Void, Never>?
+
+    func refreshStatus() {
+        refreshTask?.cancel()
+        refreshTask = Task { await performRefresh() }
+    }
+
+    func performRefresh() async {
+        isRefreshing = true
+        defer { isRefreshing = false }
+
+        let cli = ClaudeAgentCLI()
+        guard cli.isInstalled else {
+            state = .notInstalled
+            return
+        }
+
+        do {
+            let version = try await cli.version()
+            guard ClaudeAgentCLI.meetsMinimumVersion(version) else {
+                state = .outdated(version: version ?? String(localized: "unknown"))
+                return
+            }
+            let status = try await cli.authStatus()
+            guard status.loggedIn else {
+                state = .signedOut
+                return
+            }
+            state = .signedIn(account: status.accountDescription, plan: status.planDescription)
+        } catch {
+            Self.logger.error("Claude Agent status check failed: \(error.localizedDescription, privacy: .public)")
+            state = .notInstalled
+        }
+    }
+
+    var statusDescription: String {
+        switch state {
+        case .unknown:
+            return String(localized: "Checking for the Claude Code command line tool...")
+        case .notInstalled:
+            return String(localized: "Claude Code is not installed.")
+        case .outdated(let version):
+            return String(
+                format: String(localized: "Claude Code %@ is too old. Version %@ or newer is required."),
+                version,
+                ClaudeAgentCLI.minimumVersion
+            )
+        case .signedOut:
+            return String(localized: "Claude Code is installed but not signed in.")
+        case .signedIn(let account, let plan):
+            if let account, let plan {
+                return String(format: String(localized: "Signed in as %@ on the %@ plan."), account, plan)
+            }
+            if let account {
+                return String(format: String(localized: "Signed in as %@."), account)
+            }
+            return String(localized: "Signed in.")
+        }
+    }
+
+    var remedyCommand: String? {
+        switch state {
+        case .notInstalled, .outdated:
+            return ClaudeAgentCLI.installCommand
+        case .signedOut:
+            return "claude /login"
+        case .unknown, .signedIn:
+            return nil
+        }
+    }
+}

--- a/TablePro/Core/AI/Cursor/CursorAgentCLI.swift
+++ b/TablePro/Core/AI/Cursor/CursorAgentCLI.swift
@@ -4,7 +4,6 @@
 //
 
 import Foundation
-import os
 
 enum CursorAgentError: Error, LocalizedError {
     case notInstalled
@@ -23,117 +22,63 @@ enum CursorAgentError: Error, LocalizedError {
 struct CursorAgentCLI: Sendable {
     static let installCommand = "curl https://cursor.com/install -fsS | bash"
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "CursorAgentCLI")
+    private static let process = AgentCLIProcess(label: "agent")
+
+    static var discovery: AgentCLIDiscovery {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return AgentCLIDiscovery(
+            candidatePaths: [
+                "\(home)/.local/bin/agent",
+                "/usr/local/bin/agent",
+                "/opt/homebrew/bin/agent"
+            ],
+            preferredPathDirectories: [
+                "\(home)/.local/bin", "/opt/homebrew/bin", "/usr/local/bin",
+                "/usr/bin", "/bin", "/usr/sbin", "/sbin"
+            ]
+        )
+    }
 
     static func executableURL() -> URL? {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        let candidates = [
-            home.appending(path: ".local/bin/agent"),
-            URL(fileURLWithPath: "/usr/local/bin/agent"),
-            URL(fileURLWithPath: "/opt/homebrew/bin/agent")
-        ]
-        return candidates.first { FileManager.default.isExecutableFile(atPath: $0.path) }
+        discovery.resolveExecutable(override: nil)
     }
 
     var isInstalled: Bool { Self.executableURL() != nil }
 
     func run(_ arguments: [String]) async throws -> (code: Int32, output: String) {
-        guard let executable = Self.executableURL() else { throw CursorAgentError.notInstalled }
-        let process = Process()
-        Self.configure(process, executable: executable, arguments: arguments)
-        let stdout = Pipe()
-        process.standardOutput = stdout
-        process.standardError = stdout
-        Self.logger.debug("Running agent \(arguments.first ?? "", privacy: .public)")
-        return try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
-                process.terminationHandler = { proc in
-                    let data = (try? stdout.fileHandleForReading.readToEnd() ?? Data()) ?? Data()
-                    continuation.resume(returning: (proc.terminationStatus, String(data: data, encoding: .utf8) ?? ""))
-                }
-                do {
-                    try process.run()
-                } catch {
-                    process.terminationHandler = nil
-                    continuation.resume(throwing: CursorAgentError.launchFailed(error.localizedDescription))
-                }
-            }
-        } onCancel: {
-            if process.isRunning { process.terminate() }
+        do {
+            return try await Self.process.run(try Self.makeLaunch(arguments))
+        } catch {
+            throw Self.translate(error)
         }
     }
 
     func stream(_ arguments: [String]) -> AsyncThrowingStream<String, Error> {
-        AsyncThrowingStream { continuation in
-            guard let executable = Self.executableURL() else {
-                continuation.finish(throwing: CursorAgentError.notInstalled)
-                return
-            }
-            let process = Process()
-            Self.configure(process, executable: executable, arguments: arguments)
-            let stdout = Pipe()
-            let stderr = Pipe()
-            process.standardOutput = stdout
-            process.standardError = stderr
-
-            let stderrReader = Task {
-                do {
-                    for try await line in stderr.fileHandleForReading.bytes.lines where !line.isEmpty {
-                        Self.logger.error("agent stderr: \(line, privacy: .public)")
-                    }
-                } catch {}
-            }
-            process.terminationHandler = { proc in
-                Self.logger.debug("agent exited code=\(proc.terminationStatus)")
-            }
-
-            Self.logger.debug("Streaming agent (\(arguments.count) args)")
-            do {
-                try process.run()
-            } catch {
-                stderrReader.cancel()
-                continuation.finish(throwing: CursorAgentError.launchFailed(error.localizedDescription))
-                return
-            }
-
-            let reader = Task {
-                do {
-                    for try await line in stdout.fileHandleForReading.bytes.lines {
-                        if Task.isCancelled { break }
-                        continuation.yield(line)
-                    }
-                    continuation.finish()
-                } catch {
-                    continuation.finish(throwing: error)
-                }
-            }
-
-            continuation.onTermination = { _ in
-                reader.cancel()
-                stderrReader.cancel()
-                if process.isRunning { process.terminate() }
-            }
+        do {
+            return Self.process.streamLines(try Self.makeLaunch(arguments))
+        } catch {
+            let translated = Self.translate(error)
+            return AsyncThrowingStream { $0.finish(throwing: translated) }
         }
     }
 
-    private static func configure(_ process: Process, executable: URL, arguments: [String]) {
-        process.executableURL = executable
-        process.arguments = arguments
-        process.standardInput = FileHandle.nullDevice
-        process.environment = makeEnvironment()
+    private static func makeLaunch(_ arguments: [String]) throws -> AgentCLILaunch {
+        guard let executable = executableURL() else { throw CursorAgentError.notInstalled }
+        return AgentCLILaunch(
+            executable: executable,
+            arguments: arguments,
+            environment: discovery.makeEnvironment()
+        )
     }
 
-    private static func makeEnvironment() -> [String: String] {
-        var environment = ProcessInfo.processInfo.environment
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        let preferred = [
-            "\(home)/.local/bin", "/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"
-        ]
-        let current = (environment["PATH"] ?? "").split(separator: ":").map(String.init)
-        var seen = Set<String>()
-        environment["PATH"] = (preferred + current)
-            .filter { seen.insert($0).inserted }
-            .joined(separator: ":")
-        return environment
+    private static func translate(_ error: Error) -> Error {
+        switch error {
+        case AgentCLIError.notInstalled:
+            return CursorAgentError.notInstalled
+        case AgentCLIError.launchFailed(let detail):
+            return CursorAgentError.launchFailed(detail)
+        default:
+            return error
+        }
     }
 }

--- a/TablePro/Core/AI/Cursor/CursorProvider.swift
+++ b/TablePro/Core/AI/Cursor/CursorProvider.swift
@@ -140,23 +140,7 @@ final class CursorProvider: ChatTransport {
     }
 
     static func renderPrompt(turns: [ChatTurnWire], options: ChatTransportOptions) -> String {
-        var sections: [String] = []
-        if let systemPrompt = options.systemPrompt, !systemPrompt.isEmpty {
-            sections.append(systemPrompt)
-        }
-        for turn in turns {
-            let text = turnText(turn)
-            guard !text.isEmpty else { continue }
-            switch turn.role {
-            case .user:
-                sections.append("User: \(text)")
-            case .assistant:
-                sections.append("Assistant: \(text)")
-            case .system:
-                sections.append(text)
-            }
-        }
-        return sections.joined(separator: "\n\n")
+        AgentPromptRenderer.renderPrompt(turns: turns, includingSystemPrompt: options.systemPrompt)
     }
 
     static func launchBody(prompt: String, model: String) -> [String: Any] {
@@ -165,24 +149,6 @@ final class CursorProvider: ChatTransport {
             body["model"] = ["id": model]
         }
         return body
-    }
-
-    private static func turnText(_ turn: ChatTurnWire) -> String {
-        var parts: [String] = []
-        for block in turn.blocks {
-            switch block.kind {
-            case .text(let text):
-                if !text.isEmpty { parts.append(text) }
-            case .sqlWalkthrough(let walkthrough):
-                let text = walkthrough.transcriptText
-                if !text.isEmpty { parts.append(text) }
-            case .toolResult(let result):
-                if !result.content.isEmpty { parts.append("Result: \(result.content)") }
-            case .toolUse, .attachment, .reasoning, .image:
-                continue
-            }
-        }
-        return parts.joined(separator: "\n")
     }
 
     private static func url(_ path: String) throws -> URL {

--- a/TablePro/Core/AI/Registry/AIProviderRegistration.swift
+++ b/TablePro/Core/AI/Registry/AIProviderRegistration.swift
@@ -30,6 +30,18 @@ enum AIProviderRegistration {
         ))
 
         registry.register(AIProviderDescriptor(
+            typeID: AIProviderType.claudeAgent.rawValue,
+            displayName: AIProviderType.claudeAgent.displayName,
+            defaultEndpoint: "",
+            capabilities: [.chat, .models],
+            symbolName: AIProviderType.claudeAgent.symbolName,
+            curatedModels: ClaudeAgent.curatedModels,
+            makeProvider: { config, _ in
+                ClaudeAgentProvider(model: config.model)
+            }
+        ))
+
+        registry.register(AIProviderDescriptor(
             typeID: AIProviderType.gemini.rawValue,
             displayName: "Gemini",
             defaultEndpoint: "https://generativelanguage.googleapis.com",

--- a/TablePro/Models/AI/AIModels.swift
+++ b/TablePro/Models/AI/AIModels.swift
@@ -12,6 +12,7 @@ enum AIProviderType: String, Codable, CaseIterable, Identifiable, Sendable {
     case chatgptCodex
     case cursor
     case claude
+    case claudeAgent
     case openAI
     case openRouter
     case gemini
@@ -30,6 +31,7 @@ enum AIProviderType: String, Codable, CaseIterable, Identifiable, Sendable {
         case .chatgptCodex: return "ChatGPT"
         case .cursor:       return "Cursor"
         case .claude:       return "Claude"
+        case .claudeAgent:  return "Claude Agent"
         case .openAI:       return "OpenAI"
         case .openRouter:   return "OpenRouter"
         case .gemini:       return "Gemini"
@@ -48,6 +50,7 @@ enum AIProviderType: String, Codable, CaseIterable, Identifiable, Sendable {
         case .chatgptCodex: return ""
         case .cursor:       return ""
         case .claude:       return "https://api.anthropic.com"
+        case .claudeAgent:  return ""
         case .openAI:       return "https://api.openai.com"
         case .openRouter:   return "https://openrouter.ai/api"
         case .gemini:       return "https://generativelanguage.googleapis.com"
@@ -71,6 +74,7 @@ enum AIProviderType: String, Codable, CaseIterable, Identifiable, Sendable {
         case .copilot:      return .oauth
         case .chatgptCodex: return .oauth
         case .cursor:       return .optionalApiKey
+        case .claudeAgent:  return .none
         case .xai:          return .optionalApiKey
         case .ollama:       return .none
         case .llamaCpp:     return .none
@@ -86,6 +90,7 @@ enum AIProviderType: String, Codable, CaseIterable, Identifiable, Sendable {
         case .chatgptCodex: return "bubble.left.and.bubble.right"
         case .cursor:       return "cursorarrow"
         case .claude:       return "brain"
+        case .claudeAgent:  return "terminal"
         case .openAI:       return "cpu"
         case .openRouter:   return "globe"
         case .gemini:       return "wand.and.stars"

--- a/TablePro/Views/Settings/AIProviderDetailSheet.swift
+++ b/TablePro/Views/Settings/AIProviderDetailSheet.swift
@@ -31,6 +31,7 @@ struct AIProviderDetailSheet: View {
     @State private var chatGPTCodexService = ChatGPTCodexService.shared
 
     @State private var cursorAgentService = CursorAgentService.shared
+    @State private var claudeAgentService = ClaudeAgentService.shared
 
     @State private var xaiService = XAIService.shared
 
@@ -99,6 +100,9 @@ struct AIProviderDetailSheet: View {
                     }
                     if draft.type == .cursor {
                         Task { await cursorAgentService.refreshStatus() }
+                    }
+                    if draft.type == .claudeAgent {
+                        Task { await claudeAgentService.performRefresh() }
                     }
                     if draft.type == .xai {
                         Task { await xaiService.refreshAuthState() }
@@ -170,7 +174,47 @@ struct AIProviderDetailSheet: View {
                 EmptyView()
             }
         case .none:
-            EmptyView()
+            if draft.type == .claudeAgent {
+                claudeAgentAuthSection
+            } else {
+                EmptyView()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var claudeAgentAuthSection: some View {
+        Section {
+            HStack(spacing: 8) {
+                Image(systemName: claudeAgentService.state.isUsable
+                    ? "checkmark.circle.fill"
+                    : "exclamationmark.triangle.fill")
+                    .foregroundStyle(claudeAgentService.state.isUsable ? Color.green : Color.orange)
+                Text(claudeAgentService.statusDescription)
+                    .font(.callout)
+                Spacer()
+                Button(String(localized: "Recheck")) {
+                    claudeAgentService.refreshStatus()
+                }
+                .disabled(claudeAgentService.isRefreshing)
+            }
+            if let command = claudeAgentService.remedyCommand {
+                HStack {
+                    Text(command)
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                    Spacer()
+                    Button(String(localized: "Copy")) {
+                        copyToPasteboard(command)
+                    }
+                }
+            }
+        } header: {
+            Text("Claude Code")
+        } footer: {
+            Text("Runs the claude command line tool so chat bills against your Claude subscription. Database tools need the MCP server turned on in Settings > Integrations.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/TableProTests/Core/AI/ClaudeAgentProviderTests.swift
+++ b/TableProTests/Core/AI/ClaudeAgentProviderTests.swift
@@ -1,0 +1,241 @@
+//
+//  ClaudeAgentProviderTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("ClaudeAgentProvider")
+struct ClaudeAgentProviderTests {
+    @Test("Inference arguments constrain the CLI to a chat backend and end with the prompt")
+    func inferenceArgumentsConstrainTheAgent() {
+        let args = ClaudeAgentProvider.inferenceArguments(
+            prompt: "count the users",
+            model: "sonnet",
+            systemPrompt: "be terse",
+            mcpConfigPath: nil
+        )
+        #expect(args.contains("-p"))
+        #expect(args.contains("stream-json"))
+        #expect(args.contains("--no-session-persistence"))
+        #expect(args.contains("--strict-mcp-config"))
+        #expect(args.contains("--disable-slash-commands"))
+        #expect(args.contains("--model"))
+        #expect(args.contains("sonnet"))
+        #expect(args.contains("--system-prompt"))
+        #expect(args.contains("be terse"))
+        #expect(args.last == "count the users")
+        #expect(args[args.count - 2] == "--")
+    }
+
+    @Test("Built-in tools are disabled so the CLI cannot touch the filesystem")
+    func builtInToolsAreDisabled() {
+        let args = ClaudeAgentProvider.inferenceArguments(
+            prompt: "hi",
+            model: "",
+            systemPrompt: nil,
+            mcpConfigPath: nil
+        )
+        guard let index = args.firstIndex(of: "--tools") else {
+            Issue.record("--tools flag missing")
+            return
+        }
+        #expect(args[index + 1] == "")
+        #expect(!args.contains("--mcp-config"))
+        #expect(!args.contains("--allowedTools"))
+    }
+
+    @Test("A prompt that looks like a flag is not parsed as an option")
+    func promptThatLooksLikeFlagIsNotParsedAsOption() {
+        let args = ClaudeAgentProvider.inferenceArguments(
+            prompt: "--dangerously-skip-permissions",
+            model: "",
+            systemPrompt: nil,
+            mcpConfigPath: nil
+        )
+        #expect(args[args.count - 2] == "--")
+        #expect(args.last == "--dangerously-skip-permissions")
+    }
+
+    @Test("An MCP config path allows only TablePro's namespaced tools")
+    func mcpConfigAllowsOnlyTableProTools() {
+        let args = ClaudeAgentProvider.inferenceArguments(
+            prompt: "hi",
+            model: "",
+            systemPrompt: nil,
+            mcpConfigPath: "/tmp/config.json"
+        )
+        #expect(args.contains("--mcp-config"))
+        #expect(args.contains("/tmp/config.json"))
+        guard let index = args.firstIndex(of: "--allowedTools") else {
+            Issue.record("--allowedTools flag missing")
+            return
+        }
+        #expect(args[index + 1] == "mcp__tablepro__*")
+    }
+
+    @Test("Partial message deltas decode as incremental text")
+    func partialMessageDeltasDecodeAsText() {
+        let line = """
+        {"type":"stream_event","event":{"delta":{"type":"text_delta","text":"SELECT"}}}
+        """
+        #expect(ClaudeAgentProvider.decodeEvent(line) == .text("SELECT"))
+    }
+
+    @Test("Non-text deltas and unknown event types are ignored")
+    func unrelatedEventsAreIgnored() {
+        let thinking = """
+        {"type":"stream_event","event":{"delta":{"type":"thinking_delta","text":"hmm"}}}
+        """
+        #expect(ClaudeAgentProvider.decodeEvent(thinking) == nil)
+        #expect(ClaudeAgentProvider.decodeEvent(#"{"type":"system","subtype":"init"}"#) == nil)
+        #expect(ClaudeAgentProvider.decodeEvent("not json") == nil)
+    }
+
+    @Test("A failed result surfaces its message even when subtype claims success")
+    func failedResultSurfacesMessage() {
+        let line = """
+        {"subtype":"success","is_error":true,"result":"Not logged in · Please run /login","type":"result"}
+        """
+        #expect(ClaudeAgentProvider.decodeEvent(line) == .failure("Not logged in · Please run /login"))
+    }
+
+    @Test("A successful result reports token usage")
+    func successfulResultReportsUsage() {
+        let line = """
+        {"is_error":false,"type":"result","usage":{"input_tokens":120,"output_tokens":40}}
+        """
+        guard case .usage(let usage) = ClaudeAgentProvider.decodeEvent(line) else {
+            Issue.record("expected usage event")
+            return
+        }
+        #expect(usage.inputTokens == 120)
+        #expect(usage.outputTokens == 40)
+    }
+}
+
+@Suite("ClaudeAgentCLI")
+struct ClaudeAgentCLITests {
+    @Test("Auth status decodes a signed-in subscription account")
+    func authStatusDecodesSubscription() {
+        let output = """
+        {"loggedIn":true,"authMethod":"claude.ai","email":"a@b.com","subscriptionType":"max"}
+        """
+        let status = ClaudeAgentCLI.decodeAuthStatus(output)
+        #expect(status?.loggedIn == true)
+        #expect(status?.accountDescription == "a@b.com")
+        #expect(status?.planDescription == "Max")
+    }
+
+    @Test("Auth status tolerates leading banner noise from the shell")
+    func authStatusTolerantOfNoise() {
+        let output = "some banner\n{\"loggedIn\":false}\n"
+        #expect(ClaudeAgentCLI.decodeAuthStatus(output)?.loggedIn == false)
+        #expect(ClaudeAgentCLI.decodeAuthStatus("no json here") == nil)
+    }
+
+    @Test("Version parsing and the minimum version gate")
+    func versionGate() {
+        #expect(ClaudeAgentCLI.parseVersion("2.1.220 (Claude Code)") == "2.1.220")
+        #expect(ClaudeAgentCLI.parseVersion("garbage") == nil)
+        #expect(ClaudeAgentCLI.meetsMinimumVersion("2.1.220"))
+        #expect(ClaudeAgentCLI.meetsMinimumVersion("2.2.0"))
+        #expect(!ClaudeAgentCLI.meetsMinimumVersion("2.1.100"))
+        #expect(!ClaudeAgentCLI.meetsMinimumVersion(nil))
+    }
+
+    @Test("Subscription auth is not silently overridden by an inherited API key")
+    func subscriptionAuthIsNotOverriddenByInheritedKey() {
+        let cli = ClaudeAgentCLI()
+        let environment = cli.environment(
+            additional: [:]
+        )
+        #expect(environment["ANTHROPIC_API_KEY"] == nil)
+        #expect(environment["ANTHROPIC_AUTH_TOKEN"] == nil)
+    }
+}
+
+@Suite("AgentCLIDiscovery")
+struct AgentCLIDiscoveryTests {
+    @Test("The first executable candidate wins")
+    func firstExecutableCandidateWins() {
+        let discovery = AgentCLIDiscovery(
+            candidatePaths: ["/nope/claude", "/yes/claude", "/also/claude"],
+            isExecutable: { $0 == "/yes/claude" || $0 == "/also/claude" }
+        )
+        #expect(discovery.resolveExecutable(override: nil)?.path == "/yes/claude")
+    }
+
+    @Test("An override wins when executable and fails closed when not")
+    func overrideWinsWhenExecutable() {
+        let discovery = AgentCLIDiscovery(
+            candidatePaths: ["/yes/claude"],
+            isExecutable: { $0 == "/yes/claude" || $0 == "/custom/claude" }
+        )
+        #expect(discovery.resolveExecutable(override: "/custom/claude")?.path == "/custom/claude")
+        #expect(discovery.resolveExecutable(override: "/missing/claude") == nil)
+    }
+
+    @Test("PATH composition puts preferred directories first and removes duplicates")
+    func pathCompositionDeduplicates() {
+        let path = AgentCLIDiscovery.composePath(
+            preferred: ["/opt/homebrew/bin", "/usr/bin"],
+            existing: "/usr/bin:/bin"
+        )
+        #expect(path == "/opt/homebrew/bin:/usr/bin:/bin")
+    }
+
+    @Test("Node version directories sort numerically, not lexically")
+    func nodeVersionsSortNumerically() {
+        let directories = AgentCLIDiscovery.nodeVersionManagerDirectories(
+            home: "/home",
+            contentsOfDirectory: { _ in ["v9.0.0", "v20.11.1", "v18.0.0"] }
+        )
+        #expect(directories == ["/home/.nvm/versions/node/v20.11.1/bin"])
+    }
+}
+
+@Suite("ClaudeAgentMCPBridge")
+struct ClaudeAgentMCPBridgeTests {
+    @Test("The MCP config carries the bearer token and TablePro's server name")
+    func configCarriesScopedToken() throws {
+        let payload = try #require(
+            ClaudeAgentMCPBridge.configPayload(
+                endpoint: try #require(URL(string: "http://127.0.0.1:23508/mcp")),
+                token: "tp_secret"
+            )
+        )
+        let json = try JSONSerialization.jsonObject(with: try #require(payload.data(using: .utf8)))
+        let servers = try #require((json as? [String: Any])?["mcpServers"] as? [String: Any])
+        let server = try #require(servers["tablepro"] as? [String: Any])
+        #expect(server["type"] as? String == "http")
+        #expect(server["url"] as? String == "http://127.0.0.1:23508/mcp")
+        let headers = try #require(server["headers"] as? [String: String])
+        #expect(headers["Authorization"] == "Bearer tp_secret")
+    }
+}
+
+@Suite("ClaudeAgent registration")
+struct ClaudeAgentRegistrationTests {
+    @Test("Claude Agent needs no API key, so the settings sheet shows no key field")
+    func claudeAgentUsesNoAPIKey() {
+        #expect(AIProviderType.claudeAgent.authStyle == .none)
+        #expect(!AIProviderType.claudeAgent.authStyle.usesAPIKey)
+    }
+
+    @Test("Claude Agent is registered and builds the CLI-backed transport")
+    func claudeAgentIsRegistered() throws {
+        AIProviderRegistration.registerAll()
+        let descriptor = try #require(
+            AIProviderRegistry.shared.descriptor(for: AIProviderType.claudeAgent.rawValue)
+        )
+        #expect(descriptor.displayName == "Claude Agent")
+        #expect(!descriptor.allowsEndpointConfiguration)
+        #expect(descriptor.curatedModels.map(\.id) == ["opus", "sonnet", "haiku"])
+
+        let config = AIProviderConfig(type: .claudeAgent, model: "sonnet")
+        #expect(descriptor.makeProvider(config, nil) is ClaudeAgentProvider)
+    }
+}

--- a/docs/features/ai-assistant.mdx
+++ b/docs/features/ai-assistant.mdx
@@ -1,6 +1,6 @@
 ---
 title: AI Assistant
-description: "Built-in AI for SQL: chat with tool calling, inline suggestions, explain, optimize, and fix-error across 13 providers."
+description: "Built-in AI for SQL: chat with tool calling, inline suggestions, explain, optimize, and fix-error across 14 providers."
 ---
 
 Built-in AI for writing, explaining, optimizing, and fixing SQL. One active provider drives every AI feature: chat, inline suggestions, editor actions, and fix-error. Provider keys stay in the macOS Keychain.
@@ -14,7 +14,7 @@ Open **Settings > AI** (`Cmd+,`). The **Enable AI Features** toggle at the top g
   <img className="hidden dark:block" src="/images/ai-chat-settings-provider-dark.png" alt="AI settings" />
 </Frame>
 
-1. Click **Add Provider...** and pick a type: GitHub Copilot, ChatGPT, Cursor, Claude, OpenAI, OpenRouter, Gemini, xAI, Ollama, llama.cpp, MLX, or OpenCode Zen. **Add Custom Provider...** at the bottom of the menu takes any OpenAI-compatible endpoint.
+1. Click **Add Provider...** and pick a type: GitHub Copilot, ChatGPT, Cursor, Claude, Claude Agent, OpenAI, OpenRouter, Gemini, xAI, Ollama, llama.cpp, MLX, or OpenCode Zen. **Add Custom Provider...** at the bottom of the menu takes any OpenAI-compatible endpoint.
 2. Enter the API key, or sign in for Copilot, ChatGPT, Cursor, and xAI.
 3. Enter a model name, or pick one from the fetched list.
 4. Click **Test Connection**.
@@ -25,6 +25,7 @@ Provider notes:
 
 - **GitHub Copilot**: signs in with GitHub's device flow. Tool calls go through Copilot's tool bridge and the same approval flow as other providers.
 - **ChatGPT**: sign in with your ChatGPT account to use the Codex quota from Plus, Pro, Business, and Enterprise plans, no API key. **Import from Codex CLI** reuses an existing Codex login. Unofficial interface; may change.
+- **Claude Agent**: runs the `claude` command line tool that Claude Code installs, so AI chat bills against your Claude subscription instead of an API key. Install Claude Code and run `claude /login` in Terminal first; there is no API key field. Pick Opus, Sonnet, or Haiku from the model list. It answers from your schema when the MCP server is on in **Settings > Integrations**, and falls back to plain chat when it is off. Usage counts against your Claude subscription limits, not a per-token bill.
 - **Cursor**: paste an API key from the Cursor dashboard, or leave it blank and click **Sign in with Cursor** (needs the Cursor CLI installed). Cursor runs as an agent, not a chat-completions endpoint. It cannot call TablePro's database tools, so Edit and Agent modes do not run queries through it.
 - **xAI**: paste an API key, or click **Sign in with xAI** to use a SuperGrok or X Premium+ subscription. Sign-in opens a Grok Build consent screen; this path is unofficial and may change. Preset models: Grok 4.5 and Grok 4.3.
 - **Ollama, llama.cpp, MLX**: local providers, no API key. Each preset fills in its default endpoint (`http://localhost:11434` for Ollama, `http://localhost:8080` for `llama-server` and `mlx_lm.server`); edit it if you moved the host or port. Start the server first, then **Test Connection** and pick a model from the fetched list. llama.cpp and MLX speak the OpenAI-compatible API; for tool calling, start `llama-server` with `--jinja`. For any other OpenAI-compatible server, use the custom endpoint.
@@ -71,7 +72,7 @@ In Edit and Agent modes, each tool call appears as a card in the reply. Read-onl
 
 If the connection's safe-mode level is **Silent**, write tools auto-approve. If it is **Read-Only**, they auto-deny. Destructive operations are the exception: `confirm_destructive_operation` always requires a per-call click. Silent mode does not auto-approve it, and **Always for this connection** is refused for it. The tool also requires the model to pass the verbatim phrase `I understand this is irreversible`.
 
-Provider support for tool calling: every provider except Cursor. Ollama, llama.cpp, MLX, and custom endpoints depend on the model.
+Provider support for tool calling: every provider except Cursor. Claude Agent reaches the same tools through the MCP server, so it needs that server turned on. Ollama, llama.cpp, MLX, and custom endpoints depend on the model.
 
 #### Tool Call Limit
 


### PR DESCRIPTION
Adds a **Claude Agent** provider that drives the locally installed `claude` command line tool, so AI chat can run against a Claude subscription instead of a metered Anthropic API key.

Requested upstream as [TablePlus#3774](https://github.com/TablePlus/TablePlus/issues/3774), open and unanswered since 2026-02-10.

## Authentication note, please read before merging

Anthropic's published terms prohibit this by default. From [Claude Code legal and compliance](https://code.claude.com/docs/en/legal-and-compliance):

> Anthropic does not permit third-party developers to offer Claude.ai login or to route requests through Free, Pro, or Max plan credentials on behalf of their users.

and from the [Agent SDK overview](https://code.claude.com/docs/en/agent-sdk/overview):

> **Unless previously approved**, Anthropic does not allow third party developers to offer claude.ai login or rate limits for their products.

This PR proceeds on the basis that TablePro holds that prior approval. **The approval scope (contact, date, and which auth shape was blessed) still needs recording in `CLAUDE.md`** so a future contributor does not read the public docs, conclude this was a mistake, and rip it out. Two comparable projects were asked to remove equivalent features: Crush (PR #1783, "following a request from Anthropic") and opencode (PR #18186, "anthropic legal requests").

The provider is named **Claude Agent**, not "Claude Code": Anthropic's branding rules for SDK integrations list "Claude Code" and "Claude Code Agent" as not permitted. This also avoids colliding with `IntegrationClient.claudeCode`, which already means the *inbound* MCP client integration.

## How it works

Spawns the user's own `claude` binary. TablePro never reads the keychain, never offers a login UI, and never touches `CLAUDE_CODE_OAUTH_TOKEN`.

The CLI is constrained to a chat backend rather than a coding agent: `--tools ""` disables every built-in tool, `--system-prompt` replaces the default coding-agent prompt, `--no-session-persistence` keeps it from writing transcripts under `~/.claude/projects/`, and `--disable-slash-commands` stops a `/`-prefixed message from firing the user's skills. `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` are scrubbed from the child environment so a shell profile cannot silently redirect billing to a metered key.

### Database tools

Unlike the Cursor agent provider, which discards `options.tools` and therefore cannot run queries, this one reaches TablePro's real tools through the MCP server over loopback HTTP.

Tool access **requires the MCP server to already be enabled**. The bridge does not call `lazyStart()`, because turning on an AI provider should not silently open a listening socket the user may have deliberately turned off. With the server off, the provider degrades to plain chat.

The bundled `tablepro-mcp` stdio bridge was deliberately not used: it authenticates from `mcp-handshake.json`, which carries a full-access, all-connections, non-expiring token. Instead the bridge mints its own token per session, read-only and expiring in 15 minutes, and writes it to a `0600` temp config file rather than passing it inline on argv, since argv is world-readable via `ps`. The token is revoked and the file deleted when the stream ends.

## Refactor

`CursorAgentCLI` already contained generic CLI-agent plumbing. Rather than copy it, the first commit extracts `AgentCLIProcess`, `AgentCLIDiscovery`, and `AgentPromptRenderer` and migrates Cursor onto them. `CursorAgentCLI`'s public surface and `CursorAgentError` are unchanged, so no Cursor caller or existing test moves.

Behaviour differences fixed during migration:
- Cursor joined content blocks with `"\n"`; the shared renderer was aligned to that rather than the reverse.
- Process termination now escalates SIGTERM to SIGKILL after a grace period. `Task.cancel()` is cooperative and cannot interrupt a blocked child (see the "Cancelling a connect does not stop the driver" invariant).
- The child `PATH` now includes nvm/volta/bun directories. Finding `claude` is not sufficient: its shebang resolves `node` from `PATH`, and a Finder-launched app has launchd's minimal `PATH`.

## Tests

Pure-function coverage in the style of `CursorAgentProviderTests`, since `Process` is not exercisable in CI:

- argv-injection guard (a prompt of `--dangerously-skip-permissions` stays a prompt)
- built-in tools disabled; MCP access restricted to `mcp__tablepro__*`
- the CLI's real failure shape, where `is_error: true` ships alongside `subtype: "success"`
- banner-tolerant `claude auth status` parsing
- node version directories sorted numerically, not lexically
- `AIProviderType.claudeAgent.authStyle == .none`, guarding the trap that `authStyle`'s `default: return .apiKey` would otherwise swallow silently

## Not done

- **Not built.** `swiftlint --strict` is clean and the writing-style gate passes, but this has not been compiled. Several types were written against inferred APIs.
- Per-connection token scoping. The token is currently `ConnectionAccess.all` + `.readOnly`, because `ChatTransportOptions` carries no connection identity. Narrowing it to the chat's connection needs that plumbing added.
