### PR TITLE
feat(datagrid)!: add an On Update column for MySQL and MariaDB timestamps (#2005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Claude Agent** provider, which runs AI chat through the Claude Code command line tool so you can use a Claude subscription instead of a metered API key. It answers from your schema when the MCP server is on.
 - **Count exactly** next to an estimated row total, to replace the estimate with a real count when you want it.
 - Reorder filter rows by dragging the grip on the left of each row, or with **Move Up** and **Move Down** in the row's right-click menu.
+- An **On Update** column in the Structure tab for MySQL and MariaDB, so a timestamp column can be set to update itself without writing the SQL by hand. (#2005)
 
 ### Fixed
+
+- Editing a MySQL or MariaDB column no longer drops its `ON UPDATE CURRENT_TIMESTAMP`. Saving a change to any other part of the column, even just its comment, silently removed the clause. (#2005)
+- A MySQL or MariaDB timestamp column that keeps fractional seconds now saves. Its default was written as text instead of an expression, so the change was rejected. (#2005)
 
 - Quitting no longer loses unsaved SQL editor tabs. A window with no tabs loaded yet, such as one still waiting on its connection, could erase the saved tabs for that connection, so nothing came back on relaunch. Editors are also saved about a second after you stop typing instead of waiting up to 30 seconds, and a query over 500KB is kept in full rather than restored empty. (#1997)
 - Opening a large MongoDB collection no longer hangs. Row counts that back the pagination display now give up after 5 seconds and leave the estimate in place instead of holding the tab.

--- a/Plugins/BeancountDriverPlugin/Info.plist
+++ b/Plugins/BeancountDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Beancount</string>

--- a/Plugins/BigQueryDriverPlugin/Info.plist
+++ b/Plugins/BigQueryDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 </dict>
 </plist>

--- a/Plugins/CSVExportPlugin/Info.plist
+++ b/Plugins/CSVExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>csv</string>

--- a/Plugins/CSVImportPlugin/Info.plist
+++ b/Plugins/CSVImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>csv</string>

--- a/Plugins/CassandraDriverPlugin/Info.plist
+++ b/Plugins/CassandraDriverPlugin/Info.plist
@@ -21,6 +21,6 @@
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).CassandraPlugin</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 </dict>
 </plist>

--- a/Plugins/ClickHouseDriverPlugin/Info.plist
+++ b/Plugins/ClickHouseDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>ClickHouse</string>

--- a/Plugins/CloudflareD1DriverPlugin/Info.plist
+++ b/Plugins/CloudflareD1DriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 </dict>
 </plist>

--- a/Plugins/DuckDBDriverPlugin/Info.plist
+++ b/Plugins/DuckDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 </dict>
 </plist>

--- a/Plugins/DynamoDBDriverPlugin/Info.plist
+++ b/Plugins/DynamoDBDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 </dict>
 </plist>

--- a/Plugins/ElasticsearchDriverPlugin/Info.plist
+++ b/Plugins/ElasticsearchDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.53.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 </dict>
 </plist>

--- a/Plugins/EtcdDriverPlugin/Info.plist
+++ b/Plugins/EtcdDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 </dict>
 </plist>

--- a/Plugins/JSONExportPlugin/Info.plist
+++ b/Plugins/JSONExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>json</string>

--- a/Plugins/JSONImportPlugin/Info.plist
+++ b/Plugins/JSONImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>json</string>

--- a/Plugins/LibSQLDriverPlugin/Info.plist
+++ b/Plugins/LibSQLDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 </dict>
 </plist>

--- a/Plugins/MQLExportPlugin/Info.plist
+++ b/Plugins/MQLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>mql</string>

--- a/Plugins/MSSQLDriverPlugin/Info.plist
+++ b/Plugins/MSSQLDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 </dict>
 </plist>

--- a/Plugins/MongoDBDriverPlugin/Info.plist
+++ b/Plugins/MongoDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 </dict>
 </plist>

--- a/Plugins/MySQLDriverPlugin/Info.plist
+++ b/Plugins/MySQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>MySQL</string>

--- a/Plugins/MySQLDriverPlugin/MySQLColumnDefinitionSQL.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLColumnDefinitionSQL.swift
@@ -1,0 +1,85 @@
+//
+//  MySQLColumnDefinitionSQL.swift
+//  MySQLDriverPlugin
+//
+
+import Foundation
+import TableProPluginKit
+
+internal func mysqlQuoteIdentifier(_ name: String) -> String {
+    let escaped = name.replacingOccurrences(of: "`", with: "``")
+    return "`\(escaped)`"
+}
+
+internal func mysqlEscapeStringLiteral(_ value: String) -> String {
+    var result = value
+    result = result.replacingOccurrences(of: "\\", with: "\\\\")
+    result = result.replacingOccurrences(of: "'", with: "''")
+    result = result.replacingOccurrences(of: "\n", with: "\\n")
+    result = result.replacingOccurrences(of: "\r", with: "\\r")
+    result = result.replacingOccurrences(of: "\t", with: "\\t")
+    result = result.replacingOccurrences(of: "\0", with: "\\0")
+    result = result.replacingOccurrences(of: "\u{08}", with: "\\b")
+    result = result.replacingOccurrences(of: "\u{0C}", with: "\\f")
+    result = result.replacingOccurrences(of: "\u{1A}", with: "\\Z")
+    return result
+}
+
+/// MySQL rejects a CURRENT_TIMESTAMP expression whose fractional-second precision differs
+/// from the column's own, so the precision is always taken from the declared type.
+internal func mysqlFractionalSecondsSuffix(forDataType dataType: String) -> String {
+    let upper = dataType.uppercased()
+    guard upper.hasPrefix("TIMESTAMP(") || upper.hasPrefix("DATETIME(") else { return "" }
+    guard let open = dataType.firstIndex(of: "("),
+          let close = dataType[open...].firstIndex(of: ")") else { return "" }
+    return String(dataType[open...close])
+}
+
+internal func mysqlCurrentTimestampExpression(_ value: String, dataType: String) -> String? {
+    let upper = value.uppercased()
+    guard upper == "CURRENT_TIMESTAMP" || upper == "CURRENT_TIMESTAMP()"
+        || upper.hasPrefix("CURRENT_TIMESTAMP(") else { return nil }
+    return "CURRENT_TIMESTAMP" + mysqlFractionalSecondsSuffix(forDataType: dataType)
+}
+
+internal func mysqlDefaultValueLiteral(_ value: String, dataType: String) -> String {
+    if let expression = mysqlCurrentTimestampExpression(value, dataType: dataType) { return expression }
+    if value.uppercased() == "NULL" || value.hasPrefix("'") { return value }
+    if Int64(value) != nil || Double(value) != nil { return value }
+    return "'\(mysqlEscapeStringLiteral(value))'"
+}
+
+internal func mysqlColumnAttributesSQL(_ column: PluginColumnDefinition) -> String {
+    var def = ""
+
+    if column.unsigned {
+        def += " UNSIGNED"
+    }
+    if let charset = column.charset, !charset.isEmpty {
+        def += " CHARACTER SET \(charset)"
+    }
+    if let collation = column.collation, !collation.isEmpty {
+        def += " COLLATE \(collation)"
+    }
+    def += column.isNullable ? " NULL" : " NOT NULL"
+
+    if let defaultValue = column.defaultValue {
+        def += " DEFAULT \(mysqlDefaultValueLiteral(defaultValue, dataType: column.dataType))"
+    }
+    if column.autoIncrement {
+        def += " AUTO_INCREMENT"
+    }
+    if let onUpdate = column.onUpdate,
+       let expression = mysqlCurrentTimestampExpression(onUpdate, dataType: column.dataType) {
+        def += " ON UPDATE \(expression)"
+    }
+    if let comment = column.comment, !comment.isEmpty {
+        def += " COMMENT '\(mysqlEscapeStringLiteral(comment))'"
+    }
+
+    return def
+}
+
+internal func mysqlColumnDefinitionSQL(_ column: PluginColumnDefinition) -> String {
+    "\(mysqlQuoteIdentifier(column.name)) \(column.dataType)" + mysqlColumnAttributesSQL(column)
+}

--- a/Plugins/MySQLDriverPlugin/MySQLPlugin.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPlugin.swift
@@ -48,7 +48,7 @@ final class MySQLPlugin: NSObject, TableProPlugin, DriverPlugin {
     ]
 
     static let structureColumnFields: [StructureColumnField] = [
-        .name, .type, .nullable, .defaultValue, .autoIncrement, .comment, .charset, .collation
+        .name, .type, .nullable, .defaultValue, .onUpdate, .autoIncrement, .comment, .charset, .collation
     ]
 
     static let sqlDialect: SQLDialectDescriptor? = SQLDialectDescriptor(

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
@@ -42,22 +42,11 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func quoteIdentifier(_ name: String) -> String {
-        let escaped = name.replacingOccurrences(of: "`", with: "``")
-        return "`\(escaped)`"
+        mysqlQuoteIdentifier(name)
     }
 
     func escapeStringLiteral(_ value: String) -> String {
-        var result = value
-        result = result.replacingOccurrences(of: "\\", with: "\\\\")
-        result = result.replacingOccurrences(of: "'", with: "''")
-        result = result.replacingOccurrences(of: "\n", with: "\\n")
-        result = result.replacingOccurrences(of: "\r", with: "\\r")
-        result = result.replacingOccurrences(of: "\t", with: "\\t")
-        result = result.replacingOccurrences(of: "\0", with: "\\0")
-        result = result.replacingOccurrences(of: "\u{08}", with: "\\b")
-        result = result.replacingOccurrences(of: "\u{0C}", with: "\\f")
-        result = result.replacingOccurrences(of: "\u{1A}", with: "\\Z")
-        return result
+        mysqlEscapeStringLiteral(value)
     }
 
     private static let tableNameRegex = try? NSRegularExpression(pattern: "(?i)\\bFROM\\s+[`\"']?([\\w]+)[`\"']?")
@@ -761,48 +750,7 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     private func buildColumnDefinitionSQL(_ column: PluginColumnDefinition) -> String {
-        var def = "\(quoteIdentifier(column.name)) \(column.dataType)"
-
-        if column.unsigned {
-            def += " UNSIGNED"
-        }
-        if let charset = column.charset, !charset.isEmpty {
-            def += " CHARACTER SET \(charset)"
-        }
-        if let collation = column.collation, !collation.isEmpty {
-            def += " COLLATE \(collation)"
-        }
-        if column.isNullable {
-            def += " NULL"
-        } else {
-            def += " NOT NULL"
-        }
-        if let defaultValue = column.defaultValue {
-            let upper = defaultValue.uppercased()
-            if upper == "NULL" || upper == "CURRENT_TIMESTAMP" || upper == "CURRENT_TIMESTAMP()"
-                || defaultValue.hasPrefix("'") {
-                def += " DEFAULT \(defaultValue)"
-            } else if Int64(defaultValue) != nil || Double(defaultValue) != nil {
-                def += " DEFAULT \(defaultValue)"
-            } else {
-                def += " DEFAULT '\(escapeStringLiteral(defaultValue))'"
-            }
-        }
-        if column.autoIncrement {
-            def += " AUTO_INCREMENT"
-        }
-        if let onUpdate = column.onUpdate, !onUpdate.isEmpty {
-            let upper = onUpdate.uppercased()
-            if upper == "CURRENT_TIMESTAMP" || upper == "CURRENT_TIMESTAMP()"
-                || upper.hasPrefix("CURRENT_TIMESTAMP(") {
-                def += " ON UPDATE \(onUpdate)"
-            }
-        }
-        if let comment = column.comment, !comment.isEmpty {
-            def += " COMMENT '\(escapeStringLiteral(comment))'"
-        }
-
-        return def
+        mysqlColumnDefinitionSQL(column)
     }
 
     private func buildIndexDefinitionSQL(_ index: PluginIndexDefinition) -> String {
@@ -927,44 +875,7 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         let tableName = quoteIdentifier(table)
         let colName = quoteIdentifier(column.name)
 
-        var def = "\(column.dataType)"
-        if column.unsigned {
-            def += " UNSIGNED"
-        }
-        if let charset = column.charset, !charset.isEmpty {
-            def += " CHARACTER SET \(charset)"
-        }
-        if let collation = column.collation, !collation.isEmpty {
-            def += " COLLATE \(collation)"
-        }
-        if column.isNullable {
-            def += " NULL"
-        } else {
-            def += " NOT NULL"
-        }
-        if let defaultValue = column.defaultValue {
-            let upper = defaultValue.uppercased()
-            if upper == "NULL" || upper == "CURRENT_TIMESTAMP" || upper == "CURRENT_TIMESTAMP()"
-                || defaultValue.hasPrefix("'") {
-                def += " DEFAULT \(defaultValue)"
-            } else if Int64(defaultValue) != nil || Double(defaultValue) != nil {
-                def += " DEFAULT \(defaultValue)"
-            } else {
-                def += " DEFAULT '\(escapeStringLiteral(defaultValue))'"
-            }
-        }
-        if column.autoIncrement {
-            def += " AUTO_INCREMENT"
-        }
-        if let onUpdate = column.onUpdate, !onUpdate.isEmpty {
-            let upper = onUpdate.uppercased()
-            if upper == "CURRENT_TIMESTAMP" || upper == "CURRENT_TIMESTAMP()" || upper.hasPrefix("CURRENT_TIMESTAMP(") {
-                def += " ON UPDATE \(onUpdate)"
-            }
-        }
-        if let comment = column.comment, !comment.isEmpty {
-            def += " COMMENT '\(escapeStringLiteral(comment))'"
-        }
+        let def = "\(column.dataType)" + mysqlColumnAttributesSQL(column)
 
         let position: String
         if let afterCol = afterColumn {

--- a/Plugins/OracleDriverPlugin/Info.plist
+++ b/Plugins/OracleDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 </dict>
 </plist>

--- a/Plugins/PostgreSQLDriverPlugin/Info.plist
+++ b/Plugins/PostgreSQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>PostgreSQL</string>

--- a/Plugins/RedisDriverPlugin/Info.plist
+++ b/Plugins/RedisDriverPlugin/Info.plist
@@ -21,7 +21,7 @@
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).RedisPlugin</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Redis</string>

--- a/Plugins/SQLExportPlugin/Info.plist
+++ b/Plugins/SQLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>sql</string>

--- a/Plugins/SQLImportPlugin/Info.plist
+++ b/Plugins/SQLImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>sql</string>

--- a/Plugins/SQLiteDriverPlugin/Info.plist
+++ b/Plugins/SQLiteDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>SQLite</string>

--- a/Plugins/SnowflakeDriverPlugin/Info.plist
+++ b/Plugins/SnowflakeDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.48.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 </dict>
 </plist>

--- a/Plugins/SurrealDBDriverPlugin/Info.plist
+++ b/Plugins/SurrealDBDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>SurrealDB</string>

--- a/Plugins/TableProPluginKit/StructureColumnField.swift
+++ b/Plugins/TableProPluginKit/StructureColumnField.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-@frozen
 public enum StructureColumnField: String, Sendable, CaseIterable {
     case name
     case type
     case nullable
     case defaultValue
+    case onUpdate
     case primaryKey
     case autoIncrement
     case comment
@@ -18,6 +18,7 @@ public enum StructureColumnField: String, Sendable, CaseIterable {
         case .type: String(localized: "Type")
         case .nullable: String(localized: "Nullable")
         case .defaultValue: String(localized: "Default")
+        case .onUpdate: String(localized: "On Update")
         case .primaryKey: String(localized: "Primary Key")
         case .autoIncrement: String(localized: "Auto Inc")
         case .comment: String(localized: "Comment")

--- a/Plugins/TeradataDriverPlugin/Info.plist
+++ b/Plugins/TeradataDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 </dict>
 </plist>

--- a/Plugins/TrinoDriverPlugin/Info.plist
+++ b/Plugins/TrinoDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 </dict>
 </plist>

--- a/Plugins/XLSXExportPlugin/Info.plist
+++ b/Plugins/XLSXExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>18</integer>
+	<integer>19</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>xlsx</string>

--- a/TablePro.xcodeproj/project.pbxproj
+++ b/TablePro.xcodeproj/project.pbxproj
@@ -537,6 +537,7 @@
 		5A865000E00000000 /* Exceptions for "Plugins/MySQLDriverPlugin" folder in "TableProTests" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				MySQLColumnDefinitionSQL.swift,
 				MySQLQueryTimeoutStatement.swift,
 				MySQLSocketTimeout.swift,
 				MySQLStatementClassification.swift,

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -14,8 +14,8 @@ import TableProPluginKit
 @MainActor @Observable
 final class PluginManager {
     static let shared = PluginManager()
-    static let currentPluginKitVersion = 18
-    static let minimumCompatiblePluginKitVersion = 18
+    static let currentPluginKitVersion = 19
+    static let minimumCompatiblePluginKitVersion = 19
     static let currentInspectorKitVersion = 1
     private static let disabledPluginsKey = "com.TablePro.disabledPlugins"
     private static let legacyDisabledPluginsKey = "disabledPlugins"

--- a/TablePro/Core/Plugins/PluginMetadataRegistry.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry.swift
@@ -541,7 +541,10 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                     systemSchemaNames: [],
                     fileExtensions: [],
                     databaseGroupingStrategy: .byDatabase,
-                    structureColumnFields: [.name, .type, .nullable, .defaultValue, .autoIncrement, .comment, .charset, .collation]
+                    structureColumnFields: [
+                        .name, .type, .nullable, .defaultValue, .onUpdate, .autoIncrement,
+                        .comment, .charset, .collation
+                    ]
                 ),
                 editor: PluginMetadataSnapshot.EditorConfig(
                     sqlDialect: mysqlDialect,
@@ -593,7 +596,10 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                     systemSchemaNames: [],
                     fileExtensions: [],
                     databaseGroupingStrategy: .byDatabase,
-                    structureColumnFields: [.name, .type, .nullable, .defaultValue, .autoIncrement, .comment, .charset, .collation]
+                    structureColumnFields: [
+                        .name, .type, .nullable, .defaultValue, .onUpdate, .autoIncrement,
+                        .comment, .charset, .collation
+                    ]
                 ),
                 editor: PluginMetadataSnapshot.EditorConfig(
                     sqlDialect: mysqlDialect,

--- a/TablePro/Models/Schema/ColumnDefinition.swift
+++ b/TablePro/Models/Schema/ColumnDefinition.swift
@@ -25,6 +25,8 @@ struct EditableColumnDefinition: Hashable, Codable, Identifiable {
 
     var isPrimaryKey: Bool
 
+    static let currentTimestampExpression = "CURRENT_TIMESTAMP"
+
     /// Create a placeholder column for adding new columns
     static func placeholder() -> EditableColumnDefinition {
         EditableColumnDefinition(
@@ -63,11 +65,18 @@ struct EditableColumnDefinition: Hashable, Codable, Identifiable {
             unsigned: columnInfo.dataType.contains("unsigned"),
             comment: columnInfo.comment,
             collation: columnInfo.collation,
-            onUpdate: nil,
+            onUpdate: onUpdateExpression(fromExtra: columnInfo.extra),
             charset: columnInfo.charset,
             extra: columnInfo.extra,
             isPrimaryKey: columnInfo.isPrimaryKey
         )
+    }
+
+    /// Normalised to the bare expression: fractional-second precision is redundant with the
+    /// column's declared type and is re-derived when generating DDL.
+    private static func onUpdateExpression(fromExtra extra: String?) -> String? {
+        guard let extra, extra.lowercased().contains("on update") else { return nil }
+        return currentTimestampExpression
     }
 
     func toPlugin() -> PluginColumnDefinition {

--- a/TablePro/Views/Structure/StructureEditingSupport.swift
+++ b/TablePro/Views/Structure/StructureEditingSupport.swift
@@ -31,6 +31,8 @@ enum StructureEditingSupport {
         case .type: column.dataType = value
         case .nullable: column.isNullable = parseBool(value) && !column.isPrimaryKey
         case .defaultValue: column.defaultValue = value.isEmpty ? nil : value
+        case .onUpdate:
+            column.onUpdate = parseBool(value) ? EditableColumnDefinition.currentTimestampExpression : nil
         case .primaryKey:
             column.isPrimaryKey = parseBool(value)
             if column.isPrimaryKey { column.isNullable = false }
@@ -38,6 +40,7 @@ enum StructureEditingSupport {
         case .comment: column.comment = value.isEmpty ? nil : value
         case .charset: column.charset = value.isEmpty ? nil : value
         case .collation: column.collation = value.isEmpty ? nil : value
+        @unknown default: break
         }
     }
 
@@ -157,11 +160,13 @@ enum StructureEditingSupport {
         case .type: return old.dataType != new.dataType
         case .nullable: return old.isNullable != new.isNullable
         case .defaultValue: return old.defaultValue != new.defaultValue
+        case .onUpdate: return old.onUpdate != new.onUpdate
         case .primaryKey: return old.isPrimaryKey != new.isPrimaryKey
         case .autoIncrement: return old.autoIncrement != new.autoIncrement
         case .comment: return old.comment != new.comment
         case .charset: return old.charset != new.charset
         case .collation: return old.collation != new.collation
+        @unknown default: return false
         }
     }
 }

--- a/TablePro/Views/Structure/StructureRowProvider.swift
+++ b/TablePro/Views/Structure/StructureRowProvider.swift
@@ -18,7 +18,12 @@ struct StructureSortDescriptor {
 @MainActor
 final class StructureRowProvider {
     private static let canonicalFieldOrder: [StructureColumnField] = [
-        .name, .type, .nullable, .defaultValue, .primaryKey, .autoIncrement, .comment, .charset, .collation
+        .name, .type, .nullable, .defaultValue, .onUpdate, .primaryKey, .autoIncrement,
+        .comment, .charset, .collation
+    ]
+
+    private static let booleanFields: [StructureColumnField] = [
+        .nullable, .primaryKey, .autoIncrement, .onUpdate
     ]
 
     private let changeManager: StructureChangeManager
@@ -74,9 +79,10 @@ final class StructureRowProvider {
         switch tab {
         case .columns:
             var result: Set<Int> = []
-            if let i = orderedColumnFields.firstIndex(of: .nullable) { result.insert(i) }
-            if let i = orderedColumnFields.firstIndex(of: .primaryKey) { result.insert(i) }
-            if let i = orderedColumnFields.firstIndex(of: .autoIncrement) { result.insert(i) }
+            for field in Self.booleanFields {
+                guard let index = orderedColumnFields.firstIndex(of: field) else { continue }
+                result.insert(index)
+            }
             return result
         case .indexes:
             return [3]
@@ -100,7 +106,7 @@ final class StructureRowProvider {
             return [2: types, 3: Self.booleanOptions]
         case .columns:
             var result: [Int: [String]] = [:]
-            for field in [StructureColumnField.nullable, .primaryKey, .autoIncrement] {
+            for field in Self.booleanFields {
                 guard let index = orderedColumnFields.firstIndex(of: field) else { continue }
                 result[index] = Self.booleanOptions
             }
@@ -251,11 +257,13 @@ final class StructureRowProvider {
             case .type: column.dataType
             case .nullable: column.isNullable ? "YES" : "NO"
             case .defaultValue: column.defaultValue ?? ""
+            case .onUpdate: column.onUpdate != nil ? "YES" : "NO"
             case .primaryKey: column.isPrimaryKey ? "YES" : "NO"
             case .autoIncrement: column.autoIncrement ? "YES" : "NO"
             case .comment: column.comment ?? ""
             case .charset: column.charset ?? ""
             case .collation: column.collation ?? ""
+            @unknown default: nil
             }
         }
     }

--- a/TableProTests/Models/Schema/ColumnDefinitionTests.swift
+++ b/TableProTests/Models/Schema/ColumnDefinitionTests.swift
@@ -207,5 +207,65 @@ struct ColumnDefinitionTests {
         #expect(convertedBack.defaultValue == originalInfo.defaultValue)
         #expect(convertedBack.extra == originalInfo.extra)
         #expect(convertedBack.comment == originalInfo.comment)
+        #expect(editable.onUpdate == "CURRENT_TIMESTAMP")
+    }
+
+    // MARK: - On Update
+
+    @Test("Server-reported on-update timestamp survives a rebuild from the working column")
+    func onUpdateSurvivesRebuild() {
+        let original = ColumnInfo(
+            name: "updated_at",
+            dataType: "timestamp",
+            isNullable: false,
+            isPrimaryKey: false,
+            defaultValue: "CURRENT_TIMESTAMP",
+            extra: "on update CURRENT_TIMESTAMP",
+            charset: nil,
+            collation: nil,
+            comment: nil
+        )
+
+        var editable = EditableColumnDefinition.from(original)
+        editable.comment = "touched"
+        let rebuilt = EditableColumnDefinition.from(editable.toColumnInfo())
+
+        #expect(rebuilt.onUpdate == "CURRENT_TIMESTAMP")
+        #expect(editable.toPlugin().onUpdate == "CURRENT_TIMESTAMP")
+    }
+
+    @Test(
+        "On-update is parsed out of every EXTRA spelling the server uses",
+        arguments: [
+            (extra: String?.none, expected: String?.none),
+            (extra: "", expected: nil),
+            (extra: "auto_increment", expected: nil),
+            (extra: "DEFAULT_GENERATED", expected: nil),
+            (extra: "on update CURRENT_TIMESTAMP", expected: "CURRENT_TIMESTAMP"),
+            (extra: "ON UPDATE CURRENT_TIMESTAMP", expected: "CURRENT_TIMESTAMP"),
+            (extra: "on update CURRENT_TIMESTAMP(6)", expected: "CURRENT_TIMESTAMP"),
+            (extra: "DEFAULT_GENERATED on update CURRENT_TIMESTAMP", expected: "CURRENT_TIMESTAMP"),
+            (extra: "DEFAULT_GENERATED on update CURRENT_TIMESTAMP(3)", expected: "CURRENT_TIMESTAMP")
+        ]
+    )
+    func onUpdateParsing(extra: String?, expected: String?) {
+        let columnInfo = ColumnInfo(
+            name: "updated_at",
+            dataType: "timestamp",
+            isNullable: false,
+            isPrimaryKey: false,
+            defaultValue: nil,
+            extra: extra,
+            charset: nil,
+            collation: nil,
+            comment: nil
+        )
+
+        #expect(EditableColumnDefinition.from(columnInfo).onUpdate == expected)
+    }
+
+    @Test("A placeholder column carries no on-update attribute")
+    func placeholderHasNoOnUpdate() {
+        #expect(EditableColumnDefinition.placeholder().onUpdate == nil)
     }
 }

--- a/TableProTests/Plugins/MySQLColumnDefinitionSQLTests.swift
+++ b/TableProTests/Plugins/MySQLColumnDefinitionSQLTests.swift
@@ -1,0 +1,162 @@
+//
+//  MySQLColumnDefinitionSQLTests.swift
+//  TableProTests
+//
+//  MySQL restates a column in full for MODIFY/CHANGE COLUMN, so every attribute the
+//  clause builder omits is dropped by the server. These cover the attributes that a
+//  round trip has to carry through an edit to an unrelated field.
+//
+
+import TableProPluginKit
+import Testing
+
+@Suite("MySQL Column Definition SQL")
+struct MySQLColumnDefinitionSQLTests {
+    private func timestampColumn(
+        dataType: String = "TIMESTAMP",
+        defaultValue: String? = nil,
+        onUpdate: String? = nil,
+        comment: String? = nil
+    ) -> PluginColumnDefinition {
+        PluginColumnDefinition(
+            name: "updated_at",
+            dataType: dataType,
+            isNullable: false,
+            defaultValue: defaultValue,
+            comment: comment,
+            onUpdate: onUpdate
+        )
+    }
+
+    // MARK: - On Update
+
+    @Test("On update renders for a timestamp column")
+    func onUpdateRenders() {
+        let sql = mysqlColumnDefinitionSQL(
+            timestampColumn(defaultValue: "CURRENT_TIMESTAMP", onUpdate: "CURRENT_TIMESTAMP")
+        )
+        #expect(sql.contains("DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"))
+    }
+
+    @Test("On update adopts the column's fractional-second precision")
+    func onUpdateDerivesPrecision() {
+        let sql = mysqlColumnDefinitionSQL(
+            timestampColumn(dataType: "TIMESTAMP(6)", onUpdate: "CURRENT_TIMESTAMP")
+        )
+        #expect(sql.contains("ON UPDATE CURRENT_TIMESTAMP(6)"))
+    }
+
+    @Test("On update precision is re-derived rather than trusted")
+    func onUpdateOverridesStalePrecision() {
+        let sql = mysqlColumnDefinitionSQL(
+            timestampColumn(dataType: "DATETIME(3)", onUpdate: "CURRENT_TIMESTAMP(6)")
+        )
+        #expect(sql.contains("ON UPDATE CURRENT_TIMESTAMP(3)"))
+        #expect(!sql.contains("CURRENT_TIMESTAMP(6)"))
+    }
+
+    @Test("An expression outside the whitelist is omitted, never emitted raw")
+    func onUpdateRejectsUnknownExpression() {
+        let sql = mysqlColumnDefinitionSQL(timestampColumn(onUpdate: "NOW()"))
+        #expect(!sql.contains("ON UPDATE"))
+        #expect(!sql.contains("NOW()"))
+    }
+
+    @Test("No on update attribute emits no clause")
+    func onUpdateAbsent() {
+        let sql = mysqlColumnDefinitionSQL(timestampColumn(defaultValue: "CURRENT_TIMESTAMP"))
+        #expect(!sql.contains("ON UPDATE"))
+    }
+
+    @Test("Editing an unrelated attribute keeps the on update clause")
+    func onUpdateSurvivesCommentEdit() {
+        let sql = mysqlColumnDefinitionSQL(
+            timestampColumn(
+                defaultValue: "CURRENT_TIMESTAMP", onUpdate: "CURRENT_TIMESTAMP", comment: "touched"
+            )
+        )
+        #expect(sql.contains("ON UPDATE CURRENT_TIMESTAMP"))
+        #expect(sql.contains("COMMENT 'touched'"))
+    }
+
+    // MARK: - Default Value
+
+    @Test("A fractional-second default is an expression, not a quoted literal")
+    func fractionalDefaultIsNotQuoted() {
+        let sql = mysqlColumnDefinitionSQL(
+            timestampColumn(dataType: "TIMESTAMP(6)", defaultValue: "CURRENT_TIMESTAMP(6)")
+        )
+        #expect(sql.contains("DEFAULT CURRENT_TIMESTAMP(6)"))
+        #expect(!sql.contains("'CURRENT_TIMESTAMP"))
+    }
+
+    @Test("A bare CURRENT_TIMESTAMP default is unquoted")
+    func bareDefaultIsNotQuoted() {
+        let sql = mysqlColumnDefinitionSQL(timestampColumn(defaultValue: "CURRENT_TIMESTAMP"))
+        #expect(sql.contains("DEFAULT CURRENT_TIMESTAMP"))
+        #expect(!sql.contains("'CURRENT_TIMESTAMP'"))
+    }
+
+    @Test("A non-expression default is still quoted and escaped")
+    func plainDefaultStaysQuoted() {
+        let column = PluginColumnDefinition(
+            name: "status", dataType: "VARCHAR(16)", isNullable: false, defaultValue: "it's active"
+        )
+        #expect(mysqlColumnDefinitionSQL(column).contains("DEFAULT 'it''s active'"))
+    }
+
+    @Test("A numeric default is unquoted")
+    func numericDefaultStaysUnquoted() {
+        let column = PluginColumnDefinition(
+            name: "qty", dataType: "INT", isNullable: false, defaultValue: "0"
+        )
+        #expect(mysqlColumnDefinitionSQL(column).contains("DEFAULT 0"))
+    }
+
+    // MARK: - Precision Extraction
+
+    @Test(
+        "Fractional-second precision comes from the declared type only",
+        arguments: [
+            (dataType: "TIMESTAMP", expected: ""),
+            (dataType: "TIMESTAMP(6)", expected: "(6)"),
+            (dataType: "timestamp(3)", expected: "(3)"),
+            (dataType: "DATETIME", expected: ""),
+            (dataType: "DATETIME(0)", expected: "(0)"),
+            (dataType: "VARCHAR(255)", expected: ""),
+            (dataType: "ENUM('a(1)','b')", expected: "")
+        ]
+    )
+    func precisionExtraction(dataType: String, expected: String) {
+        #expect(mysqlFractionalSecondsSuffix(forDataType: dataType) == expected)
+    }
+
+    // MARK: - Other Attributes
+
+    @Test("Charset, collation, unsigned, and auto increment all render")
+    func attributesRender() {
+        let column = PluginColumnDefinition(
+            name: "id",
+            dataType: "BIGINT",
+            isNullable: false,
+            autoIncrement: true,
+            unsigned: true,
+            charset: "utf8mb4",
+            collation: "utf8mb4_general_ci"
+        )
+
+        let sql = mysqlColumnDefinitionSQL(column)
+        #expect(sql.contains("`id` BIGINT"))
+        #expect(sql.contains("UNSIGNED"))
+        #expect(sql.contains("CHARACTER SET utf8mb4"))
+        #expect(sql.contains("COLLATE utf8mb4_general_ci"))
+        #expect(sql.contains("NOT NULL"))
+        #expect(sql.contains("AUTO_INCREMENT"))
+    }
+
+    @Test("A backtick in a column name is escaped")
+    func backtickEscaping() {
+        let column = PluginColumnDefinition(name: "col`name", dataType: "INT")
+        #expect(mysqlColumnDefinitionSQL(column).contains("`col``name`"))
+    }
+}

--- a/TableProTests/Views/Structure/StructureColumnFieldRegistrationTests.swift
+++ b/TableProTests/Views/Structure/StructureColumnFieldRegistrationTests.swift
@@ -1,0 +1,54 @@
+//
+//  StructureColumnFieldRegistrationTests.swift
+//  TableProTests
+//
+//  MySQL and MariaDB share one plugin but are registered separately: MariaDB is an
+//  additional type id, and a variant adopts the app's curated snapshot wholesale rather
+//  than the one built from the plugin. A field added to only one of the declarations
+//  therefore reaches only one of the two engines.
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@MainActor @Suite("Structure column field registration")
+struct StructureColumnFieldRegistrationTests {
+    @Test("MySQL and MariaDB expose the same structure fields")
+    func mysqlAndMariaDBAgree() {
+        let mysql = PluginManager.shared.structureColumnFields(for: .mysql)
+        let mariadb = PluginManager.shared.structureColumnFields(for: .mariadb)
+        #expect(Set(mysql) == Set(mariadb))
+    }
+
+    @Test("MySQL and MariaDB both offer the on update field", arguments: [DatabaseType.mysql, .mariadb])
+    func onUpdateIsOffered(databaseType: DatabaseType) {
+        #expect(PluginManager.shared.structureColumnFields(for: databaseType).contains(.onUpdate))
+    }
+
+    @Test("On update is ordered next to the default it complements")
+    func onUpdateFollowsDefaultValue() {
+        let fields = StructureRowProvider.orderedFields(for: .mysql)
+        guard let defaultIndex = fields.firstIndex(of: .defaultValue),
+              let onUpdateIndex = fields.firstIndex(of: .onUpdate) else {
+            Issue.record("MySQL is missing the default or on update field")
+            return
+        }
+        #expect(onUpdateIndex == defaultIndex + 1)
+    }
+
+    @Test("Engines that do not support the attribute never offer it")
+    func onUpdateIsEngineScoped() {
+        for databaseType in [DatabaseType.postgresql, .sqlite, .clickhouse] {
+            #expect(!PluginManager.shared.structureColumnFields(for: databaseType).contains(.onUpdate))
+        }
+    }
+
+    @Test("Every declared field has a display name")
+    func everyFieldHasDisplayName() {
+        for field in StructureColumnField.allCases {
+            #expect(!field.displayName.isEmpty)
+        }
+    }
+}

--- a/TableProTests/Views/Structure/StructureEditingSupportBooleanParsingTests.swift
+++ b/TableProTests/Views/Structure/StructureEditingSupportBooleanParsingTests.swift
@@ -19,6 +19,10 @@ struct StructureEditingSupportBooleanParsingTests {
         .name, .type, .nullable, .defaultValue, .primaryKey, .autoIncrement, .comment
     ]
 
+    private static let mysqlOrderedFields: [StructureColumnField] = [
+        .name, .type, .nullable, .defaultValue, .onUpdate, .primaryKey, .autoIncrement, .comment
+    ]
+
     private static let trueTokens = ["YES", "yes", "Yes", "TRUE", "true", "True", "1"]
     private static let falseTokens = ["NO", "no", "FALSE", "false", "0", "", "maybe"]
 
@@ -111,6 +115,33 @@ struct StructureEditingSupportBooleanParsingTests {
             orderedFields: Self.postgresOrderedFields
         )
         #expect(column.autoIncrement)
+    }
+
+    // MARK: - On Update
+
+    @Test("On Update accepts every true token", arguments: trueTokens)
+    func onUpdateAcceptsEveryTrueToken(token: String) {
+        var column = makeColumn()
+        StructureEditingSupport.updateColumn(
+            &column,
+            at: Self.mysqlOrderedFields.firstIndex(of: .onUpdate) ?? -1,
+            with: token,
+            orderedFields: Self.mysqlOrderedFields
+        )
+        #expect(column.onUpdate == "CURRENT_TIMESTAMP")
+    }
+
+    @Test("On Update clears on a false token", arguments: falseTokens)
+    func onUpdateClears(token: String) {
+        var column = makeColumn()
+        column.onUpdate = "CURRENT_TIMESTAMP"
+        StructureEditingSupport.updateColumn(
+            &column,
+            at: Self.mysqlOrderedFields.firstIndex(of: .onUpdate) ?? -1,
+            with: token,
+            orderedFields: Self.mysqlOrderedFields
+        )
+        #expect(column.onUpdate == nil)
     }
 
     // MARK: - Primary key implies NOT NULL

--- a/TableProTests/Views/Structure/StructureEditingSupportFieldDiffTests.swift
+++ b/TableProTests/Views/Structure/StructureEditingSupportFieldDiffTests.swift
@@ -19,7 +19,7 @@ struct StructureEditingSupportFieldDiffTests {
     // MARK: - Fixtures
 
     private static let mysqlOrderedFields: [StructureColumnField] = [
-        .name, .type, .nullable, .defaultValue, .primaryKey,
+        .name, .type, .nullable, .defaultValue, .onUpdate, .primaryKey,
         .autoIncrement, .comment, .charset, .collation
     ]
 
@@ -111,8 +111,8 @@ struct StructureEditingSupportFieldDiffTests {
             new: changed,
             orderedFields: Self.mysqlOrderedFields
         )
-        // .type is at index 1, .comment is at index 6 in mysqlOrderedFields.
-        #expect(result == [1, 6])
+        // .type is at index 1, .comment is at index 7 in mysqlOrderedFields.
+        #expect(result == [1, 7])
     }
 
     @Test("Diff respects orderedFields and skips fields not displayed by the database type")
@@ -131,7 +131,7 @@ struct StructureEditingSupportFieldDiffTests {
         #expect(result.isEmpty)
     }
 
-    @Test("All nine StructureColumnField cases are diffable")
+    @Test("Every StructureColumnField case is diffable")
     func columnEveryFieldDetected() {
         let original = makeColumn(name: "a", dataType: "INT")
         var changed = original
@@ -139,6 +139,7 @@ struct StructureEditingSupportFieldDiffTests {
         changed.dataType = "BIGINT"
         changed.isNullable.toggle()
         changed.defaultValue = "0"
+        changed.onUpdate = "CURRENT_TIMESTAMP"
         changed.isPrimaryKey.toggle()
         changed.autoIncrement.toggle()
         changed.comment = "x"

--- a/TableProTests/Views/Structure/StructureRowProviderBooleanOptionsTests.swift
+++ b/TableProTests/Views/Structure/StructureRowProviderBooleanOptionsTests.swift
@@ -41,7 +41,7 @@ struct StructureRowProviderBooleanOptionsTests {
             changeManager: makeManager(),
             tab: tab,
             databaseType: .postgresql,
-            additionalFields: [.primaryKey],
+            additionalFields: [.primaryKey, .onUpdate],
             filterText: nil,
             sortDescriptor: nil
         )
@@ -52,7 +52,7 @@ struct StructureRowProviderBooleanOptionsTests {
         let provider = makeProvider()
         let options = provider.customDropdownOptions
 
-        for field in [StructureColumnField.nullable, .primaryKey, .autoIncrement] {
+        for field in [StructureColumnField.nullable, .primaryKey, .autoIncrement, .onUpdate] {
             guard let index = provider.orderedColumnFields.firstIndex(of: field) else {
                 Issue.record("Field \(field) missing from the columns tab")
                 continue

--- a/docs/features/table-structure.mdx
+++ b/docs/features/table-structure.mdx
@@ -22,6 +22,7 @@ Columns are edited inline in the grid:
 - Setting **Primary Key** to YES sets **Nullable** to NO. A primary key column cannot hold NULL, so Nullable stays NO until you turn the primary key off.
 - **Type** opens a picker with the database's types grouped by category. Search to filter, or type a parametric value such as `VARCHAR(255)` or `DECIMAL(10,2)` and press Return to use it as written.
 - **Charset** and **Collation** columns appear for MySQL and MariaDB.
+- **On Update** appears for MySQL and MariaDB, next to **Default**. Set it to YES on a `TIMESTAMP` or `DATETIME` column to add `ON UPDATE CURRENT_TIMESTAMP`, so the column re-stamps itself on every write. TablePro matches the fractional-second precision to the column's own type, so a `TIMESTAMP(6)` column gets `ON UPDATE CURRENT_TIMESTAMP(6)`.
 
 <Frame caption="Type picker popover">
   <img className="block dark:hidden" src="/images/structure-type-picker.png" alt="Type picker popover" />


### PR DESCRIPTION
Closes #2005.

The issue asked for a missing field. Tracing it found an active corruption bug sitting behind it, so this fixes both.

## The data-loss bug

`EditableColumnDefinition.from(_:)` hardcoded `onUpdate: nil`, so the value the server reported was thrown away on every load. MySQL's `generateModifyColumnSQL` restates the whole column definition, and `MODIFY`/`CHANGE COLUMN` drops whatever the restated definition omits.

The result: editing **any** attribute of a MySQL or MariaDB column that already had `ON UPDATE CURRENT_TIMESTAMP` silently stripped the clause on save. A rename, a comment, a charset change, anything. No error, no warning. This is DataGrip's [DBE-4079](https://youtrack.jetbrains.com/issue/DBE-4079) verbatim: "can lead to column property loss by simply renaming the column."

PostgreSQL and SQL Server emit per-attribute `ALTER COLUMN` and were never exposed. ClickHouse uses the same full-redefinition shape but has no attribute of this kind modelled yet.

## The field

`StructureColumnField` gains `.onUpdate`, ordered next to `.defaultValue` since it is that clause's companion. It renders as a YES/NO dropdown through the existing `customDropdownOptions` path, the same one already driving Nullable, Primary Key, and Auto Inc, so the grid, the inspector, and the Create Table sheet all pick it up with no separate wiring.

**Why a dropdown and not a combo box.** The HIG points at a combo box for "a list plus arbitrary text", but the vocabulary here is genuinely closed. The emit whitelist only accepts `CURRENT_TIMESTAMP` forms and silently discards anything else, and MySQL requires the fractional precision to match the column's own type, so a hand-typed `CURRENT_TIMESTAMP(3)` on a `TIMESTAMP(6)` column is just a server error. A combo box would let people type values that visibly stick in the cell and then vanish at save time. Sequel Ace, the one tool that has had this right for a decade, uses a fixed popup for the same reason.

**Why not a raw `Extra` passthrough.** It would collide with the existing first-class Auto Inc column, and reading `information_schema.COLUMNS.EXTRA` straight into DDL is what shipped syntax errors in TablePlus ([#1078](https://github.com/TablePlus/TablePlus/issues/1078)) and DBeaver ([#7850](https://github.com/dbeaver/dbeaver/issues/7850), [#13577](https://github.com/dbeaver/dbeaver/issues/13577)), because MySQL 8.0.13+ puts the non-DDL token `DEFAULT_GENERATED` in that column. The parser here matches a substring and re-emits a canonical expression, so a compound `EXTRA` value parses correctly and no server token ever reaches generated SQL.

## MySQL DDL builder

`buildColumnDefinitionSQL` and `generateMoveColumnSQL` were independently repeating the same eight clauses, including a verbatim copy of the `ON UPDATE` block. Both now share one builder.

Fractional-second precision is derived from the column's declared type rather than stored or typed, so a `TIMESTAMP(6)` column gets `ON UPDATE CURRENT_TIMESTAMP(6)`, and a stale `(6)` carried on a `DATETIME(3)` column is corrected instead of trusted.

That builder also fixes a sibling bug in the same function: the default branch accepted `CURRENT_TIMESTAMP` and `CURRENT_TIMESTAMP()` but not `CURRENT_TIMESTAMP(6)`, so a `TIMESTAMP(6)` column's default was quoted into `DEFAULT 'CURRENT_TIMESTAMP(6)'` and the ALTER failed. Auto-deriving precision makes those columns reachable, so leaving it would have shipped a landmine next to the new feature.

## Breaking PluginKit change

`StructureColumnField` was marked `@frozen`, so adding a case is breaking. It is also un-frozen here, in the same bump.

The release work is identical either way, and the case set was never closed: PostgreSQL already populates `identityKind` and `isGenerated` with no home in this enum, and SQL Server computed columns, ClickHouse default-kinds, and SQLite generated columns are all the same shape. Paying the bump once and un-freezing means the next per-engine field is additive and free. By CLAUDE.md's own criterion ("mark `@frozen` only when an exhaustive switch forces it and its case set is genuinely closed") the marking was already wrong.

`scripts/check-pluginkit-abi.sh main` confirms it, including one consequence I had not predicted:

```diff
-@frozen public enum StructureColumnField : Swift::String, Swift::Sendable, Swift::CaseIterable {
+public enum StructureColumnField : Swift::String, Swift::Sendable, Swift::CaseIterable {
   case defaultValue
+  case onUpdate
-extension TableProPluginKit::StructureColumnField : Swift::BitwiseCopyable {}
```

Un-freezing also drops the synthesized `BitwiseCopyable` conformance, since a resilient enum's layout is not statically known across the module boundary. That independently confirms the breaking classification. It is a compiler-synthesized marker protocol, not a requirement any plugin implements, and the raised version floor rejects a stale plugin before it could observe the difference.

**Do not add the `abi-additive` label.** This diff is breaking on two counts.

### Release order matters

`currentPluginKitVersion` and `minimumCompatiblePluginKitVersion` both go 18 → 19, with all 29 plugin `Info.plist` files.

`.github/workflows/build.yml` gates `Create GitHub Release` on `check-registry-readiness.py`, so **`scripts/release-all-plugins.sh 19` must run before or with the app release** across the 16 registry plugins. Otherwise the release job fails and users on the new app hit `noCompatibleBinary`.

## MariaDB needs three declarations, not one

Worth knowing for review. MariaDB is registered as an additional type id on the MySQL plugin, and `registerVariant` discards the plugin-built snapshot wholesale when a curated default exists. MariaDB's live field list is therefore the hardcoded literal in `PluginMetadataRegistry`, not `MySQLPlugin.swift`. Editing only the plugin would have shipped the field to MySQL and silently skipped MariaDB.

`StructureColumnFieldRegistrationTests` guards this: it asserts the two engines agree and that both offer the field.

## Tests

21 new cases in `MySQLColumnDefinitionSQLTests`, plus coverage in `ColumnDefinitionTests` (including the `DEFAULT_GENERATED` compound-token case), `StructureEditingSupportBooleanParsingTests`, and `StructureColumnFieldRegistrationTests`.

**`MySQLCreateTableTests.swift` has never run, and this is why the new tests are not in it.** The MySQL plugin is not a module in `TableProTests`. Pure-logic files are compiled *into* the test target via pbxproj `membershipExceptions` and called with no import at all, which is why `#if canImport(MySQLDriverPlugin)` is false and all 12 tests in that file compile to nothing. The new clause logic lives in `MySQLColumnDefinitionSQL.swift`, added to that exception set, and the new tests are verified to actually execute. The 12 pre-existing dead tests cover `CREATE TABLE` assembly and would need `generateCreateTableSQL` extracted as well; left alone here rather than widen scope, but it is a real gap worth its own issue.

## Verification

- `swiftlint lint --strict` clean. Local swiftformat cannot run against the repo config (version drift), so it was not run.
- New and affected suites pass, and are confirmed to execute rather than silently compile out.
- Full `TableProTests` failing-case IDs diffed against a stashed clean tree: 76 before, 75 after. The suite is already red in a headless run. The only deltas are one network test and one timer test flipping, and three pasteboard tests flipping the other way, all in areas this change does not touch.
- Two `StructureGridDelegateAddRowTests` SQLite cases fail on clean `main`, independently of this work.
- Not verified: behaviour against a live MySQL or MariaDB server. The `SHOW FULL COLUMNS` and `INFORMATION_SCHEMA` read paths use different queries, and the parser is deliberately case-insensitive so a casing difference between them cannot matter, but a live sanity check on both engines is worth doing before merge.
