### PR TITLE
fix(ai-providers): send Claude reasoning effort in output_config (#2031)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AI chat with a Claude API key no longer fails with a 400 error on every message. The reasoning effort was sent in a field the API rejects. (#2031)
 - Picking Extra High reasoning effort, Haiku 4.5, or any Claude model newer than Opus 4.7 no longer fails the request. Each one sent thinking settings the API refuses. (#2031)
 - Claude replies now fill in the Reasoning block again instead of leaving it empty after a long pause. (#2031)
+- Gemini models can now use thinking and accept image attachments. Both were switched off for the whole provider, so no Gemini model could reason or read an image.
+- Reasoning effort is now offered for OpenRouter, Ollama, llama.cpp, MLX, OpenCode Zen, and custom endpoints, so a local reasoning model can be given an effort.
+- The reasoning effort picker now lists the levels the chosen model actually accepts, read from the provider instead of a built-in table.
+- Model lists now carry each model's real output limit and thinking support, so replies are no longer capped at a guessed value.
 
 ### Changed
 
+- The Claude, OpenAI, and Codex model menus now list the current models.
 - A tab's window subtitle now shows the database it is bound to, for query tabs as well as table tabs. (#2026)
 - Changing a tab's database from its toolbar now repoints only that tab and leaves the sidebar where it is. (#2026)
 - `describe_table` and `get_table_ddl` now take a `database` argument, in AI chat and over MCP, so a table in another database can be inspected without changing the database selected in the app. `list_schemas` in AI chat takes one too. (#2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Filtering a text column by a value that looks like a number, such as 68, now compares it as text. It used to compare as a number, which returned the wrong rows and stopped the database using the column's index. (#2029)
 - Typing NULL, TRUE, or FALSE into a filter on a text column now matches that text instead of turning into the SQL keyword, so those values can be filtered for. (#2029)
 - IS EMPTY on a number, date, or boolean column now checks only for NULL, instead of also comparing against an empty string, which some databases reject. (#2029)
+- AI chat with a Claude API key no longer fails with a 400 error on every message. The reasoning effort was sent in a field the API rejects. (#2031)
+- Picking Extra High reasoning effort, Haiku 4.5, or any Claude model newer than Opus 4.7 no longer fails the request. Each one sent thinking settings the API refuses. (#2031)
+- Claude replies now fill in the Reasoning block again instead of leaving it empty after a long pause. (#2031)
 
 ### Changed
 

--- a/TablePro/Core/AI/AnthropicModelCapabilities.swift
+++ b/TablePro/Core/AI/AnthropicModelCapabilities.swift
@@ -1,0 +1,92 @@
+//
+//  AnthropicModelCapabilities.swift
+//  TablePro
+//
+
+import Foundation
+
+enum AnthropicThinkingMode: String, Sendable, Equatable {
+    case adaptive
+    case budgeted
+}
+
+struct AnthropicModelCapabilities: Sendable, Equatable {
+    static let minimumThinkingBudgetTokens = 1_024
+
+    let thinkingMode: AnthropicThinkingMode
+    let effortLevels: [ReasoningEffort]
+
+    var sendsEffortParameter: Bool {
+        thinkingMode == .adaptive
+    }
+
+    func clampedEffort(_ requested: ReasoningEffort) -> ReasoningEffort? {
+        guard !effortLevels.isEmpty else { return nil }
+        if effortLevels.contains(requested) { return requested }
+
+        let ranking = ReasoningEffort.allCases
+        guard let requestedRank = ranking.firstIndex(of: requested) else { return effortLevels.last }
+
+        let atOrBelow = effortLevels.filter { level in
+            guard let rank = ranking.firstIndex(of: level) else { return false }
+            return rank <= requestedRank
+        }
+        return atOrBelow.last ?? effortLevels.first
+    }
+
+    static func resolve(model: String) -> AnthropicModelCapabilities {
+        let normalized = model.lowercased().replacingOccurrences(of: ".", with: "-")
+        for entry in table where entry.patterns.contains(where: { normalized.contains($0) }) {
+            return entry.capabilities
+        }
+        return adaptive
+    }
+
+    static func effortLevels(forModel model: String) -> [ReasoningEffort] {
+        resolve(model: model).effortLevels
+    }
+
+    private static let adaptive = AnthropicModelCapabilities(
+        thinkingMode: .adaptive,
+        effortLevels: [.low, .medium, .high, .xhigh]
+    )
+
+    private static let adaptiveWithoutExtraHigh = AnthropicModelCapabilities(
+        thinkingMode: .adaptive,
+        effortLevels: [.low, .medium, .high]
+    )
+
+    private static let budgeted = AnthropicModelCapabilities(
+        thinkingMode: .budgeted,
+        effortLevels: [.low, .medium, .high]
+    )
+
+    private struct Entry {
+        let patterns: [String]
+        let capabilities: AnthropicModelCapabilities
+    }
+
+    private static let table: [Entry] = [
+        Entry(
+            patterns: [
+                "opus-4-5", "opus-4-1", "opus-4-0", "opus-4-2025",
+                "sonnet-4-5", "sonnet-4-0", "sonnet-4-2025",
+                "haiku-4-5",
+                "claude-3"
+            ],
+            capabilities: budgeted
+        ),
+        Entry(
+            patterns: ["opus-4-6", "sonnet-4-6"],
+            capabilities: adaptiveWithoutExtraHigh
+        ),
+        Entry(
+            patterns: [
+                "opus-4-7", "opus-4-8", "opus-5",
+                "sonnet-5", "haiku-5",
+                "fable-5", "mythos-5"
+            ],
+            capabilities: adaptive
+        )
+    ]
+}

--- a/TablePro/Core/AI/AnthropicProvider.swift
+++ b/TablePro/Core/AI/AnthropicProvider.swift
@@ -37,7 +37,13 @@ final class AnthropicProvider: ChatTransport {
     ) -> AsyncThrowingStream<ChatStreamEvent, Error> {
         SSEEventStream.make(
             session: session,
-            buildRequest: { [self] in try buildMessagesRequest(turns: turns, options: options) },
+            buildRequest: { [self] in
+                try buildMessagesRequest(
+                    turns: turns,
+                    options: options,
+                    effort: options.reasoningEffort ?? configuredEffort
+                )
+            },
             decodeLine: { Self.decodeStreamLine($0) },
             makeState: { AnthropicStreamState() },
             parse: { try Self.parseChunk($0, state: &$1) },
@@ -90,7 +96,12 @@ final class AnthropicProvider: ChatTransport {
         let testModel = model.isEmpty ? (Self.knownModels.first ?? "") : model
         let testTurn = ChatTurnWire(role: .user, blocks: [.text("Hi")])
         let testOptions = ChatTransportOptions(model: testModel, maxOutputTokens: 1)
-        let request = try buildMessagesRequest(turns: [testTurn], options: testOptions, stream: false)
+        let request = try buildMessagesRequest(
+            turns: [testTurn],
+            options: testOptions,
+            stream: false,
+            effort: nil
+        )
 
         let (data, response) = try await session.data(for: request)
 
@@ -115,7 +126,8 @@ final class AnthropicProvider: ChatTransport {
     private func buildMessagesRequest(
         turns: [ChatTurnWire],
         options: ChatTransportOptions,
-        stream: Bool = true
+        stream: Bool = true,
+        effort: ReasoningEffort?
     ) throws -> URLRequest {
         guard let url = URL(string: "\(endpoint)/v1/messages") else {
             throw AIProviderError.invalidEndpoint(endpoint)
@@ -127,14 +139,32 @@ final class AnthropicProvider: ChatTransport {
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
         request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
 
-        let effort = options.reasoningEffort ?? configuredEffort
         let resolvedMaxTokens = options.maxOutputTokens
             ?? effort?.autoScaledMaxOutputTokens
             ?? maxOutputTokens
 
+        let body = try Self.makeRequestBody(
+            turns: turns,
+            options: options,
+            effort: effort,
+            maxTokens: resolvedMaxTokens,
+            stream: stream
+        )
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    static func makeRequestBody(
+        turns: [ChatTurnWire],
+        options: ChatTransportOptions,
+        effort: ReasoningEffort?,
+        maxTokens: Int,
+        stream: Bool
+    ) throws -> [String: Any] {
         var body: [String: Any] = [
             "model": options.model,
-            "max_tokens": resolvedMaxTokens,
+            "max_tokens": maxTokens,
             "stream": stream
         ]
 
@@ -143,44 +173,43 @@ final class AnthropicProvider: ChatTransport {
         }
 
         if let effort {
-            body["thinking"] = thinkingBody(for: effort, model: options.model, maxTokens: resolvedMaxTokens)
+            let capabilities = AnthropicModelCapabilities.resolve(model: options.model)
+
+            if let thinking = thinkingBody(for: effort, capabilities: capabilities, maxTokens: maxTokens) {
+                body["thinking"] = thinking
+            }
+
+            if capabilities.sendsEffortParameter,
+               let wireEffort = capabilities.clampedEffort(effort)?.anthropicEffortValue {
+                body["output_config"] = ["effort": wireEffort]
+            }
         }
 
         if !options.tools.isEmpty {
             body["tools"] = try options.tools.map(Self.encodeToolSpec(_:))
         }
 
-        let apiMessages = try turns
+        body["messages"] = try turns
             .filter { $0.role != .system }
             .compactMap { try Self.encodeTurn($0) }
-        body["messages"] = apiMessages
 
-        request.httpBody = try JSONSerialization.data(withJSONObject: body)
-        return request
+        return body
     }
 
-    private func thinkingBody(for effort: ReasoningEffort, model: String, maxTokens: Int) -> [String: Any] {
-        if Self.modelSupportsAdaptiveThinking(model) {
-            var thinking: [String: Any] = ["type": "adaptive"]
-            if let adaptiveEffort = effort.anthropicAdaptiveEffort {
-                thinking["effort"] = adaptiveEffort
-            }
-            return thinking
+    private static func thinkingBody(
+        for effort: ReasoningEffort,
+        capabilities: AnthropicModelCapabilities,
+        maxTokens: Int
+    ) -> [String: Any]? {
+        switch capabilities.thinkingMode {
+        case .adaptive:
+            return ["type": "adaptive", "display": "summarized"]
+        case .budgeted:
+            let ceiling = maxTokens - 1
+            guard ceiling >= AnthropicModelCapabilities.minimumThinkingBudgetTokens else { return nil }
+            let budget = min(effort.anthropicBudgetTokens, ceiling)
+            return ["type": "enabled", "budget_tokens": budget]
         }
-        let budget = min(effort.anthropicBudgetTokens ?? 4_096, max(maxTokens - 1, 1_024))
-        return [
-            "type": "enabled",
-            "budget_tokens": budget
-        ]
-    }
-
-    private static func modelSupportsAdaptiveThinking(_ model: String) -> Bool {
-        let lowered = model.lowercased()
-        if lowered.contains("opus-4-7") || lowered.contains("opus-4.7") { return true }
-        if lowered.contains("opus-4-6") || lowered.contains("opus-4.6") { return true }
-        if lowered.contains("sonnet-4-6") || lowered.contains("sonnet-4.6") { return true }
-        if lowered.contains("haiku-4-5") || lowered.contains("haiku-4.5") { return true }
-        return false
     }
 
     static func decodeStreamLine(_ line: String) -> [String: Any]? {

--- a/TablePro/Core/AI/AnthropicProvider.swift
+++ b/TablePro/Core/AI/AnthropicProvider.swift
@@ -51,7 +51,7 @@ final class AnthropicProvider: ChatTransport {
         )
     }
 
-    func fetchAvailableModels() async throws -> [String] {
+    func fetchAvailableModels() async throws -> [AIModelInfo] {
         guard let url = URL(string: "\(endpoint)/v1/models") else {
             throw AIProviderError.invalidEndpoint(endpoint)
         }
@@ -68,7 +68,7 @@ final class AnthropicProvider: ChatTransport {
             (data, response) = try await session.data(for: request)
         } catch {
             Self.logger.warning("Anthropic model fetch failed; using known models: \(error.localizedDescription, privacy: .public)")
-            return Self.knownModels
+            return Self.offlineModels
         }
 
         guard let httpResponse = response as? HTTPURLResponse,
@@ -77,20 +77,78 @@ final class AnthropicProvider: ChatTransport {
               let models = json["data"] as? [[String: Any]]
         else {
             Self.logger.warning("Anthropic model fetch returned unexpected response; using known models")
-            return Self.knownModels
+            return Self.offlineModels
         }
 
-        let modelIds = models.compactMap { $0["id"] as? String }
-        return modelIds.isEmpty ? Self.knownModels : modelIds
+        let fetched = models.compactMap(Self.decodeModel(_:))
+        return fetched.isEmpty ? Self.offlineModels : fetched
     }
 
-    private static let knownModels = [
-        "claude-opus-4-7-20260101",
-        "claude-sonnet-4-6-20251101",
-        "claude-haiku-4-5-20251001",
-        "claude-sonnet-4-5-20250929",
-        "claude-opus-4-5-20250929"
-    ]
+    static func decodeModel(_ json: [String: Any]) -> AIModelInfo? {
+        guard let id = json["id"] as? String else { return nil }
+        let capabilities = json["capabilities"] as? [String: Any]
+        return AIModelInfo(
+            id: id,
+            displayName: json["display_name"] as? String,
+            contextWindow: json["max_input_tokens"] as? Int,
+            maxOutputTokens: json["max_tokens"] as? Int,
+            modalities: [.text, .image],
+            reasoning: decodeReasoning(capabilities: capabilities, modelID: id)
+        )
+    }
+
+    private static func decodeReasoning(capabilities: [String: Any]?, modelID: String) -> AIReasoningSupport? {
+        guard let capabilities else { return nil }
+
+        let thinking = capabilities["thinking"] as? [String: Any]
+        let types = thinking?["types"] as? [String: Any]
+        let adaptiveSupported = supportFlag(types?["adaptive"])
+        let enabledSupported = supportFlag(types?["enabled"])
+
+        let effort = capabilities["effort"] as? [String: Any]
+        let effortSupported = supportFlag(effort) ?? false
+        let levels = effortSupported ? ReasoningEffort.allCases.filter { level in
+            supportFlag(effort?[level.anthropicEffortValue]) ?? false
+        } : []
+
+        let mode: AIReasoningMode
+        if adaptiveSupported == true {
+            mode = .adaptive
+        } else if enabledSupported == true {
+            mode = .budgeted
+        } else if supportFlag(thinking) == false {
+            mode = .unsupported
+        } else {
+            return nil
+        }
+
+        return AIReasoningSupport(
+            mode: mode,
+            effortLevels: mode == .budgeted ? [.low, .medium, .high] : uniqueLevels(levels),
+            defaultEffort: .medium
+        )
+    }
+
+    private static func uniqueLevels(_ levels: [ReasoningEffort]) -> [ReasoningEffort] {
+        var seen: Set<ReasoningEffort> = []
+        return levels.filter { seen.insert($0).inserted }
+    }
+
+    private static func supportFlag(_ value: Any?) -> Bool? {
+        (value as? [String: Any])?["supported"] as? Bool
+    }
+
+    private static let offlineModels: [AIModelInfo] = [
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-fable-5",
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5"
+    ].map { AIModelInfo(id: $0) }
+
+    private static let knownModels = offlineModels.map(\.id)
 
     func testConnection() async throws -> Bool {
         let testModel = model.isEmpty ? (Self.knownModels.first ?? "") : model
@@ -173,14 +231,14 @@ final class AnthropicProvider: ChatTransport {
         }
 
         if let effort {
-            let capabilities = AnthropicModelCapabilities.resolve(model: options.model)
+            let reasoning = resolvedReasoning(for: options.model)
 
-            if let thinking = thinkingBody(for: effort, capabilities: capabilities, maxTokens: maxTokens) {
+            if let thinking = thinkingBody(for: effort, reasoning: reasoning, maxTokens: maxTokens) {
                 body["thinking"] = thinking
             }
 
-            if capabilities.sendsEffortParameter,
-               let wireEffort = capabilities.clampedEffort(effort)?.anthropicEffortValue {
+            if reasoning.sendsEffortParameter,
+               let wireEffort = reasoning.clampedEffort(effort)?.anthropicEffortValue {
                 body["output_config"] = ["effort": wireEffort]
             }
         }
@@ -196,19 +254,36 @@ final class AnthropicProvider: ChatTransport {
         return body
     }
 
+    static func resolvedReasoning(for model: String) -> AIReasoningSupport {
+        if let live = AIModelCatalog.shared.reasoning(
+            providerTypeID: AIProviderType.claude.rawValue,
+            modelID: model
+        ) {
+            return live
+        }
+        let capabilities = AnthropicModelCapabilities.resolve(model: model)
+        return AIReasoningSupport(
+            mode: capabilities.thinkingMode == .adaptive ? .adaptive : .budgeted,
+            effortLevels: capabilities.effortLevels,
+            defaultEffort: .medium
+        )
+    }
+
     private static func thinkingBody(
         for effort: ReasoningEffort,
-        capabilities: AnthropicModelCapabilities,
+        reasoning: AIReasoningSupport,
         maxTokens: Int
     ) -> [String: Any]? {
-        switch capabilities.thinkingMode {
-        case .adaptive:
+        switch reasoning.mode {
+        case .adaptive, .effortOnly:
             return ["type": "adaptive", "display": "summarized"]
         case .budgeted:
             let ceiling = maxTokens - 1
             guard ceiling >= AnthropicModelCapabilities.minimumThinkingBudgetTokens else { return nil }
             let budget = min(effort.anthropicBudgetTokens, ceiling)
             return ["type": "enabled", "budget_tokens": budget]
+        case .unsupported:
+            return nil
         }
     }
 

--- a/TablePro/Core/AI/Chat/ChatTransport.swift
+++ b/TablePro/Core/AI/Chat/ChatTransport.swift
@@ -11,7 +11,7 @@ protocol ChatTransport: AnyObject, Sendable {
         options: ChatTransportOptions
     ) -> AsyncThrowingStream<ChatStreamEvent, Error>
 
-    func fetchAvailableModels() async throws -> [String]
+    func fetchAvailableModels() async throws -> [AIModelInfo]
 
     func testConnection() async throws -> Bool
 }

--- a/TablePro/Core/AI/Chat/Reasoning.swift
+++ b/TablePro/Core/AI/Chat/Reasoning.swift
@@ -34,19 +34,18 @@ enum ReasoningEffort: String, Codable, Sendable, CaseIterable, Identifiable {
         }
     }
 
-    var anthropicAdaptiveEffort: String? {
+    var anthropicEffortValue: String {
         switch self {
-        case .minimal: return nil
-        case .low:     return "low"
-        case .medium:  return "medium"
-        case .high:    return "high"
-        case .xhigh:   return "maximum"
+        case .minimal, .low: return "low"
+        case .medium:        return "medium"
+        case .high:          return "high"
+        case .xhigh:         return "xhigh"
         }
     }
 
-    var anthropicBudgetTokens: Int? {
+    var anthropicBudgetTokens: Int {
         switch self {
-        case .minimal: return nil
+        case .minimal: return 1_024
         case .low:     return 2_048
         case .medium:  return 8_192
         case .high:    return 16_384

--- a/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodex.swift
+++ b/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodex.swift
@@ -19,7 +19,13 @@ enum ChatGPTCodex {
     static let userAgent = "codex_cli_rs/0.1.0"
     static let authClaimsNamespace = "https://api.openai.com/auth"
     static let profileClaimsNamespace = "https://api.openai.com/profile"
-    static let curatedModelIDs = ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"]
+    static let curatedModels: [(id: String, name: String)] = [
+        ("gpt-5.6-sol", "GPT-5.6 Sol"),
+        ("gpt-5.6-terra", "GPT-5.6 Terra"),
+        ("gpt-5.5", "GPT-5.5")
+    ]
+
+    static var curatedModelIDs: [String] { curatedModels.map(\.id) }
 }
 
 enum ChatGPTCodexBase64URL {

--- a/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexProvider.swift
+++ b/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexProvider.swift
@@ -37,8 +37,8 @@ final class ChatGPTCodexProvider: ChatTransport {
         )
     }
 
-    func fetchAvailableModels() async throws -> [String] {
-        ChatGPTCodex.curatedModelIDs
+    func fetchAvailableModels() async throws -> [AIModelInfo] {
+        ChatGPTCodex.curatedModelIDs.map { AIModelInfo(id: $0) }
     }
 
     func testConnection() async throws -> Bool {

--- a/TablePro/Core/AI/ClaudeAgent/ClaudeAgentProvider.swift
+++ b/TablePro/Core/AI/ClaudeAgent/ClaudeAgentProvider.swift
@@ -73,8 +73,8 @@ final class ClaudeAgentProvider: ChatTransport {
         }
     }
 
-    func fetchAvailableModels() async throws -> [String] {
-        ClaudeAgent.curatedModels.map(\.id)
+    func fetchAvailableModels() async throws -> [AIModelInfo] {
+        ClaudeAgent.curatedModels.map { AIModelInfo(id: $0.id, displayName: $0.displayName) }
     }
 
     func testConnection() async throws -> Bool {

--- a/TablePro/Core/AI/Copilot/CopilotChatProvider.swift
+++ b/TablePro/Core/AI/Copilot/CopilotChatProvider.swift
@@ -123,14 +123,14 @@ final class CopilotChatProvider: ChatTransport {
         }
     }
 
-    func fetchAvailableModels() async throws -> [String] {
+    func fetchAvailableModels() async throws -> [AIModelInfo] {
         guard let client = await CopilotService.shared.client else {
             throw CopilotError.serverNotRunning
         }
         let models = try await client.fetchCopilotModels()
         let chatModels = models.filter { $0.scopes?.contains("chat-panel") ?? false }
         let sorted = chatModels.sorted { ($0.isChatDefault ?? false) && !($1.isChatDefault ?? false) }
-        return sorted.map(\.id)
+        return sorted.map { AIModelInfo(id: $0.id, displayName: $0.modelName) }
     }
 
     func testConnection() async throws -> Bool {

--- a/TablePro/Core/AI/Cursor/CursorAgentProvider.swift
+++ b/TablePro/Core/AI/Cursor/CursorAgentProvider.swift
@@ -47,8 +47,8 @@ final class CursorAgentProvider: ChatTransport {
         }
     }
 
-    func fetchAvailableModels() async throws -> [String] {
-        CursorAI.curatedModelIDs
+    func fetchAvailableModels() async throws -> [AIModelInfo] {
+        CursorAI.curatedModelIDs.map { AIModelInfo(id: $0, reasoning: .unsupported) }
     }
 
     func testConnection() async throws -> Bool {

--- a/TablePro/Core/AI/Cursor/CursorProvider.swift
+++ b/TablePro/Core/AI/Cursor/CursorProvider.swift
@@ -61,7 +61,11 @@ final class CursorProvider: ChatTransport {
         }
     }
 
-    func fetchAvailableModels() async throws -> [String] {
+    func fetchAvailableModels() async throws -> [AIModelInfo] {
+        try await fetchModelIDs().map { AIModelInfo(id: $0, reasoning: .unsupported) }
+    }
+
+    private func fetchModelIDs() async throws -> [String] {
         var request = URLRequest(url: try Self.url("/v1/models"))
         request.timeoutInterval = AIProvider.modelListTimeout
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")

--- a/TablePro/Core/AI/GeminiProvider.swift
+++ b/TablePro/Core/AI/GeminiProvider.swift
@@ -36,15 +36,22 @@ final class GeminiProvider: ChatTransport {
         )
     }
 
-    private static let knownModels = [
-        "gemini-2.5-flash",
+    private static let offlineModels: [AIModelInfo] = [
+        "gemini-3.6-flash",
+        "gemini-3.5-flash",
+        "gemini-3.5-flash-lite",
+        "gemini-3.1-pro-preview",
         "gemini-2.5-pro",
-        "gemini-2.0-flash",
-        "gemini-1.5-flash",
-        "gemini-1.5-pro"
-    ]
+        "gemini-2.5-flash"
+    ].map {
+        AIModelInfo(
+            id: $0,
+            modalities: [.text, .image],
+            reasoning: AIReasoningSupport(mode: .effortOnly, effortLevels: [.low, .medium, .high], defaultEffort: .medium)
+        )
+    }
 
-    func fetchAvailableModels() async throws -> [String] {
+    func fetchAvailableModels() async throws -> [AIModelInfo] {
         guard let url = URL(string: "\(endpoint)/v1beta/models") else {
             throw AIProviderError.invalidEndpoint(endpoint)
         }
@@ -60,7 +67,7 @@ final class GeminiProvider: ChatTransport {
             (data, response) = try await session.data(for: request)
         } catch {
             Self.logger.warning("Gemini model fetch failed; using known models: \(error.localizedDescription, privacy: .public)")
-            return Self.knownModels
+            return Self.offlineModels
         }
 
         guard let httpResponse = response as? HTTPURLResponse,
@@ -69,21 +76,32 @@ final class GeminiProvider: ChatTransport {
               let models = json["models"] as? [[String: Any]]
         else {
             Self.logger.warning("Gemini model fetch returned unexpected response; using known models")
-            return Self.knownModels
+            return Self.offlineModels
         }
 
-        let fetched = models.compactMap { model -> String? in
-            guard let name = model["name"] as? String,
-                  let methods = model["supportedGenerationMethods"] as? [String],
-                  methods.contains("generateContent")
-            else { return nil }
-            if name.hasPrefix("models/") {
-                return String(name.dropFirst(7))
-            }
-            return name
-        }
+        let fetched = models.compactMap(Self.decodeModel(_:))
+        return fetched.isEmpty ? Self.offlineModels : fetched
+    }
 
-        return fetched.isEmpty ? Self.knownModels : fetched
+    static func decodeModel(_ json: [String: Any]) -> AIModelInfo? {
+        guard let name = json["name"] as? String,
+              let methods = json["supportedGenerationMethods"] as? [String],
+              methods.contains("generateContent")
+        else { return nil }
+
+        let id = name.hasPrefix("models/") ? String(name.dropFirst(7)) : name
+        let supportsThinking = json["thinking"] as? Bool ?? false
+
+        return AIModelInfo(
+            id: id,
+            displayName: json["displayName"] as? String,
+            contextWindow: json["inputTokenLimit"] as? Int,
+            maxOutputTokens: json["outputTokenLimit"] as? Int,
+            modalities: [.text, .image],
+            reasoning: supportsThinking
+                ? AIReasoningSupport(mode: .effortOnly, effortLevels: [.low, .medium, .high], defaultEffort: .medium)
+                : .unsupported
+        )
     }
 
     func testConnection() async throws -> Bool {

--- a/TablePro/Core/AI/Models/AIModelCatalog.swift
+++ b/TablePro/Core/AI/Models/AIModelCatalog.swift
@@ -1,0 +1,50 @@
+//
+//  AIModelCatalog.swift
+//  TablePro
+//
+
+import Foundation
+
+final class AIModelCatalog: @unchecked Sendable {
+    static let shared = AIModelCatalog()
+
+    private let lock = NSLock()
+    private var fetched: [String: [String: AIModelInfo]] = [:]
+
+    init() {}
+
+    func store(providerTypeID: String, models: [AIModelInfo]) {
+        guard !models.isEmpty else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        var byID: [String: AIModelInfo] = [:]
+        for model in models {
+            byID[model.id] = model
+        }
+        fetched[providerTypeID] = byID
+    }
+
+    func fetchedInfo(providerTypeID: String, modelID: String) -> AIModelInfo? {
+        lock.lock()
+        defer { lock.unlock() }
+        return fetched[providerTypeID]?[modelID]
+    }
+
+    func resolve(providerTypeID: String, modelID: String) -> AIModelInfo {
+        let overlay = AIModelOverlay.info(providerTypeID: providerTypeID, modelID: modelID)
+        if let live = fetchedInfo(providerTypeID: providerTypeID, modelID: modelID) {
+            return live.merging(fallback: overlay)
+        }
+        return overlay ?? AIModelInfo(id: modelID)
+    }
+
+    func reasoning(providerTypeID: String, modelID: String) -> AIReasoningSupport? {
+        resolve(providerTypeID: providerTypeID, modelID: modelID).reasoning
+    }
+
+    func removeAll() {
+        lock.lock()
+        defer { lock.unlock() }
+        fetched.removeAll()
+    }
+}

--- a/TablePro/Core/AI/Models/AIModelInfo.swift
+++ b/TablePro/Core/AI/Models/AIModelInfo.swift
@@ -1,0 +1,107 @@
+//
+//  AIModelInfo.swift
+//  TablePro
+//
+
+import Foundation
+
+enum AIModality: String, Codable, Sendable, CaseIterable {
+    case text
+    case image
+}
+
+enum AIReasoningMode: String, Codable, Sendable {
+    case adaptive
+    case budgeted
+    case effortOnly
+    case unsupported
+}
+
+struct AIReasoningSupport: Codable, Sendable, Equatable {
+    let mode: AIReasoningMode
+    let effortLevels: [ReasoningEffort]
+    let defaultEffort: ReasoningEffort?
+    let isMandatory: Bool
+
+    init(
+        mode: AIReasoningMode,
+        effortLevels: [ReasoningEffort],
+        defaultEffort: ReasoningEffort? = nil,
+        isMandatory: Bool = false
+    ) {
+        self.mode = mode
+        self.effortLevels = effortLevels
+        self.defaultEffort = defaultEffort
+        self.isMandatory = isMandatory
+    }
+
+    static let unsupported = AIReasoningSupport(mode: .unsupported, effortLevels: [])
+
+    var sendsEffortParameter: Bool {
+        mode != .unsupported && mode != .budgeted && !effortLevels.isEmpty
+    }
+
+    func clampedEffort(_ requested: ReasoningEffort) -> ReasoningEffort? {
+        guard !effortLevels.isEmpty else { return nil }
+        if effortLevels.contains(requested) { return requested }
+
+        let ranking = ReasoningEffort.allCases
+        guard let requestedRank = ranking.firstIndex(of: requested) else { return effortLevels.last }
+
+        let atOrBelow = effortLevels.filter { level in
+            guard let rank = ranking.firstIndex(of: level) else { return false }
+            return rank <= requestedRank
+        }
+        return atOrBelow.last ?? effortLevels.first
+    }
+}
+
+struct AIModelInfo: Codable, Sendable, Equatable, Identifiable {
+    let id: String
+    let displayName: String?
+    let contextWindow: Int?
+    let maxOutputTokens: Int?
+    let modalities: Set<AIModality>
+    let reasoning: AIReasoningSupport?
+    let isDeprecated: Bool
+
+    init(
+        id: String,
+        displayName: String? = nil,
+        contextWindow: Int? = nil,
+        maxOutputTokens: Int? = nil,
+        modalities: Set<AIModality> = [.text],
+        reasoning: AIReasoningSupport? = nil,
+        isDeprecated: Bool = false
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.contextWindow = contextWindow
+        self.maxOutputTokens = maxOutputTokens
+        self.modalities = modalities
+        self.reasoning = reasoning
+        self.isDeprecated = isDeprecated
+    }
+
+    var label: String {
+        guard let displayName, !displayName.isEmpty else { return id }
+        return displayName
+    }
+
+    var supportsImages: Bool {
+        modalities.contains(.image)
+    }
+
+    func merging(fallback: AIModelInfo?) -> AIModelInfo {
+        guard let fallback else { return self }
+        return AIModelInfo(
+            id: id,
+            displayName: displayName ?? fallback.displayName,
+            contextWindow: contextWindow ?? fallback.contextWindow,
+            maxOutputTokens: maxOutputTokens ?? fallback.maxOutputTokens,
+            modalities: modalities.isEmpty ? fallback.modalities : modalities,
+            reasoning: reasoning ?? fallback.reasoning,
+            isDeprecated: isDeprecated || fallback.isDeprecated
+        )
+    }
+}

--- a/TablePro/Core/AI/Models/AIModelOverlay.swift
+++ b/TablePro/Core/AI/Models/AIModelOverlay.swift
@@ -1,0 +1,108 @@
+//
+//  AIModelOverlay.swift
+//  TablePro
+//
+
+import Foundation
+
+enum AIModelOverlay {
+    static func info(providerTypeID: String, modelID: String) -> AIModelInfo? {
+        guard let type = AIProviderType(rawValue: providerTypeID) else { return nil }
+        switch type {
+        case .claude:
+            return claudeInfo(modelID: modelID)
+        case .openAI, .chatgptCodex:
+            return openAIInfo(modelID: modelID)
+        case .xai:
+            return xaiInfo(modelID: modelID)
+        default:
+            return nil
+        }
+    }
+
+    static func reasoning(providerTypeID: String, modelID: String) -> AIReasoningSupport? {
+        info(providerTypeID: providerTypeID, modelID: modelID)?.reasoning
+    }
+
+    private static func claudeInfo(modelID: String) -> AIModelInfo {
+        let capabilities = AnthropicModelCapabilities.resolve(model: modelID)
+        return AIModelInfo(
+            id: modelID,
+            maxOutputTokens: nil,
+            modalities: [.text, .image],
+            reasoning: AIReasoningSupport(
+                mode: capabilities.thinkingMode == .adaptive ? .adaptive : .budgeted,
+                effortLevels: capabilities.effortLevels,
+                defaultEffort: .medium
+            )
+        )
+    }
+
+    private static func openAIInfo(modelID: String) -> AIModelInfo? {
+        let normalized = modelID.lowercased()
+        guard let entry = openAITable.first(where: { entry in
+            entry.patterns.contains { normalized.contains($0) }
+        }) else { return nil }
+        return AIModelInfo(
+            id: modelID,
+            maxOutputTokens: entry.maxOutputTokens,
+            modalities: [.text, .image],
+            reasoning: AIReasoningSupport(
+                mode: .effortOnly,
+                effortLevels: entry.effortLevels,
+                defaultEffort: .medium
+            )
+        )
+    }
+
+    private static func xaiInfo(modelID: String) -> AIModelInfo? {
+        let normalized = modelID.lowercased()
+        guard normalized.contains("grok") else { return nil }
+        if normalized.contains("non-reasoning") || normalized.contains("imagine") || normalized.contains("voice") {
+            return AIModelInfo(id: modelID, modalities: [.text], reasoning: .unsupported)
+        }
+        return AIModelInfo(
+            id: modelID,
+            modalities: [.text, .image],
+            reasoning: AIReasoningSupport(
+                mode: .effortOnly,
+                effortLevels: [.low, .medium, .high],
+                defaultEffort: .medium
+            )
+        )
+    }
+
+    private struct OpenAIEntry {
+        let patterns: [String]
+        let effortLevels: [ReasoningEffort]
+        let maxOutputTokens: Int?
+    }
+
+    private static let openAITable: [OpenAIEntry] = [
+        OpenAIEntry(
+            patterns: ["gpt-5.6", "gpt-5-6"],
+            effortLevels: ReasoningEffort.allCases,
+            maxOutputTokens: 128_000
+        ),
+        OpenAIEntry(
+            patterns: ["gpt-5.5", "gpt-5-5"],
+            effortLevels: [.low, .medium, .high, .xhigh],
+            maxOutputTokens: 128_000
+        ),
+        OpenAIEntry(
+            patterns: ["gpt-5.4", "gpt-5-4", "gpt-5.3", "gpt-5-3", "gpt-5.2", "gpt-5-2"],
+            effortLevels: [.low, .medium, .high, .xhigh],
+            maxOutputTokens: 128_000
+        ),
+        OpenAIEntry(
+            patterns: ["codex"],
+            effortLevels: [.low, .medium, .high],
+            maxOutputTokens: 128_000
+        ),
+        OpenAIEntry(
+            patterns: ["gpt-5"],
+            effortLevels: [.low, .medium, .high],
+            maxOutputTokens: 128_000
+        )
+    ]
+}

--- a/TablePro/Core/AI/OpenAICompatibleProvider.swift
+++ b/TablePro/Core/AI/OpenAICompatibleProvider.swift
@@ -196,7 +196,11 @@ final class OpenAICompatibleProvider: ChatTransport {
         return events
     }
 
-    func fetchAvailableModels() async throws -> [String] {
+    func fetchAvailableModels() async throws -> [AIModelInfo] {
+        try await fetchModelIDs().map { AIModelInfo(id: $0) }
+    }
+
+    private func fetchModelIDs() async throws -> [String] {
         switch providerType {
         case .ollama:
             return try await fetchOllamaModels()

--- a/TablePro/Core/AI/OpenAIResponsesProvider.swift
+++ b/TablePro/Core/AI/OpenAIResponsesProvider.swift
@@ -54,7 +54,11 @@ final class OpenAIResponsesProvider: ChatTransport {
         )
     }
 
-    func fetchAvailableModels() async throws -> [String] {
+    func fetchAvailableModels() async throws -> [AIModelInfo] {
+        try await fetchModelIDs().map { AIModelInfo(id: $0) }
+    }
+
+    private func fetchModelIDs() async throws -> [String] {
         guard let url = URL(string: "\(endpoint)/v1/models") else {
             throw AIProviderError.invalidEndpoint(endpoint)
         }

--- a/TablePro/Core/AI/Registry/AIProviderDescriptor.swift
+++ b/TablePro/Core/AI/Registry/AIProviderDescriptor.swift
@@ -48,6 +48,7 @@ struct AIProviderDescriptor: Sendable {
     let showsTelemetryToggle: Bool
     let defaultTelemetryEnabled: Bool
     let oauthFlowKind: OAuthFlowKind?
+    let effortLevelResolver: (@Sendable (String) -> [ReasoningEffort])?
     let makeProvider: @Sendable (AIProviderConfig, String?) -> ChatTransport
 
     var supportsReasoning: Bool { capabilities.contains(.reasoning) }
@@ -63,6 +64,9 @@ struct AIProviderDescriptor: Sendable {
 
     func supportedEffortLevels(forModelID id: String) -> [ReasoningEffort] {
         guard supportsReasoning else { return [] }
+        if let effortLevelResolver {
+            return effortLevelResolver(id)
+        }
         if let curated = curatedModel(forID: id), !curated.supportedEffortLevels.isEmpty {
             return curated.supportedEffortLevels
         }
@@ -79,6 +83,7 @@ struct AIProviderDescriptor: Sendable {
         showsTelemetryToggle: Bool = false,
         defaultTelemetryEnabled: Bool = false,
         oauthFlowKind: OAuthFlowKind? = nil,
+        effortLevelResolver: (@Sendable (String) -> [ReasoningEffort])? = nil,
         makeProvider: @escaping @Sendable (AIProviderConfig, String?) -> ChatTransport
     ) {
         self.typeID = typeID
@@ -90,6 +95,7 @@ struct AIProviderDescriptor: Sendable {
         self.showsTelemetryToggle = showsTelemetryToggle
         self.defaultTelemetryEnabled = defaultTelemetryEnabled
         self.oauthFlowKind = oauthFlowKind
+        self.effortLevelResolver = effortLevelResolver
         self.makeProvider = makeProvider
     }
 }

--- a/TablePro/Core/AI/Registry/AIProviderDescriptor.swift
+++ b/TablePro/Core/AI/Registry/AIProviderDescriptor.swift
@@ -64,6 +64,9 @@ struct AIProviderDescriptor: Sendable {
 
     func supportedEffortLevels(forModelID id: String) -> [ReasoningEffort] {
         guard supportsReasoning else { return [] }
+        if let reasoning = AIModelCatalog.shared.reasoning(providerTypeID: typeID, modelID: id) {
+            return reasoning.effortLevels
+        }
         if let effortLevelResolver {
             return effortLevelResolver(id)
         }
@@ -71,6 +74,16 @@ struct AIProviderDescriptor: Sendable {
             return curated.supportedEffortLevels
         }
         return [.low, .medium, .high]
+    }
+
+    func modelInfo(forModelID id: String) -> AIModelInfo {
+        AIModelCatalog.shared.resolve(providerTypeID: typeID, modelID: id)
+    }
+
+    func supportsImages(forModelID id: String) -> Bool {
+        guard supportsImages else { return false }
+        guard let live = AIModelCatalog.shared.fetchedInfo(providerTypeID: typeID, modelID: id) else { return true }
+        return live.supportsImages
     }
 
     init(

--- a/TablePro/Core/AI/Registry/AIProviderRegistration.swift
+++ b/TablePro/Core/AI/Registry/AIProviderRegistration.swift
@@ -46,7 +46,10 @@ enum AIProviderRegistration {
             typeID: AIProviderType.gemini.rawValue,
             displayName: "Gemini",
             defaultEndpoint: "https://generativelanguage.googleapis.com",
-            capabilities: [.chat, .models, .endpointConfigurable, .maxOutputTokens, .modelListFetchable],
+            capabilities: [
+                .chat, .models, .reasoning, .images,
+                .endpointConfigurable, .maxOutputTokens, .modelListFetchable
+            ],
             symbolName: "wand.and.stars",
             makeProvider: { config, apiKey in
                 GeminiProvider(
@@ -100,7 +103,8 @@ enum AIProviderRegistration {
 
         for type in [AIProviderType.openRouter, .openCode, .ollama, .llamaCpp, .mlx, .custom] {
             var capabilities: AIProviderCapabilities = [
-                .chat, .models, .endpointConfigurable, .maxOutputTokens, .modelListFetchable
+                .chat, .models, .reasoning, .images,
+                .endpointConfigurable, .maxOutputTokens, .modelListFetchable
             ]
             if type == .custom {
                 capabilities.insert(.nameConfigurable)
@@ -168,72 +172,37 @@ enum AIProviderRegistration {
         CuratedModel(id: $0.id, displayName: $0.name)
     }
 
-    private static let chatGPTCodexCuratedModels: [CuratedModel] = [
-        CuratedModel(
-            id: "gpt-5.5",
-            displayName: "GPT-5.5",
-            supportedEffortLevels: ReasoningEffort.allCases,
-            defaultEffort: .medium
-        ),
-        CuratedModel(
-            id: "gpt-5.4",
-            displayName: "GPT-5.4",
-            supportedEffortLevels: [.low, .medium, .high],
-            defaultEffort: .medium
-        ),
-        CuratedModel(
-            id: "gpt-5.4-mini",
-            displayName: "GPT-5.4 Mini",
-            supportedEffortLevels: ReasoningEffort.allCases,
-            defaultEffort: .medium
+    private static func curatedModel(
+        id: String,
+        displayName: String,
+        provider: AIProviderType,
+        defaultEffort: ReasoningEffort? = .medium
+    ) -> CuratedModel {
+        let reasoning = AIModelOverlay.reasoning(providerTypeID: provider.rawValue, modelID: id)
+        return CuratedModel(
+            id: id,
+            displayName: displayName,
+            supportedEffortLevels: reasoning?.effortLevels ?? [],
+            defaultEffort: reasoning?.effortLevels.isEmpty == false ? defaultEffort : nil
         )
-    ]
+    }
+
+    private static let chatGPTCodexCuratedModels: [CuratedModel] = ChatGPTCodex.curatedModels.map {
+        curatedModel(id: $0.id, displayName: $0.name, provider: .chatgptCodex)
+    }
 
     private static let openAICuratedModels: [CuratedModel] = [
-        CuratedModel(
-            id: "gpt-5.5",
-            displayName: "GPT-5.5",
-            supportedEffortLevels: ReasoningEffort.allCases,
-            defaultEffort: .medium
-        ),
-        CuratedModel(
-            id: "gpt-5-codex",
-            displayName: "GPT-5 Codex",
-            supportedEffortLevels: [.low, .medium, .high],
-            defaultEffort: .medium
-        ),
-        CuratedModel(
-            id: "gpt-5.3-codex",
-            displayName: "GPT-5.3 Codex",
-            supportedEffortLevels: [.low, .medium, .high, .xhigh],
-            defaultEffort: .medium
-        ),
-        CuratedModel(
-            id: "gpt-5.4-mini",
-            displayName: "GPT-5.4 Mini",
-            supportedEffortLevels: ReasoningEffort.allCases,
-            defaultEffort: .medium
-        )
+        curatedModel(id: "gpt-5.6-sol", displayName: "GPT-5.6 Sol", provider: .openAI),
+        curatedModel(id: "gpt-5.6-terra", displayName: "GPT-5.6 Terra", provider: .openAI),
+        curatedModel(id: "gpt-5.6-luna", displayName: "GPT-5.6 Luna", provider: .openAI),
+        curatedModel(id: "gpt-5.5", displayName: "GPT-5.5", provider: .openAI)
     ]
 
     private static let claudeCuratedModels: [CuratedModel] = [
-        claudeModel(id: "claude-opus-4-7", displayName: "Claude Opus 4.7", defaultEffort: .medium),
-        claudeModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6", defaultEffort: .medium),
-        claudeModel(id: "claude-haiku-4-5", displayName: "Claude Haiku 4.5", defaultEffort: .low)
+        curatedModel(id: "claude-opus-5", displayName: "Claude Opus 5", provider: .claude),
+        curatedModel(id: "claude-sonnet-5", displayName: "Claude Sonnet 5", provider: .claude),
+        curatedModel(id: "claude-haiku-4-5", displayName: "Claude Haiku 4.5", provider: .claude, defaultEffort: .low)
     ]
-
-    private static func claudeModel(
-        id: String,
-        displayName: String,
-        defaultEffort: ReasoningEffort
-    ) -> CuratedModel {
-        CuratedModel(
-            id: id,
-            displayName: displayName,
-            supportedEffortLevels: AnthropicModelCapabilities.effortLevels(forModel: id),
-            defaultEffort: defaultEffort
-        )
-    }
 
     private static func iconForType(_ type: AIProviderType) -> String {
         type.symbolName

--- a/TablePro/Core/AI/Registry/AIProviderRegistration.swift
+++ b/TablePro/Core/AI/Registry/AIProviderRegistration.swift
@@ -16,6 +16,7 @@ enum AIProviderRegistration {
             capabilities: [.chat, .models, .reasoning, .images, .endpointConfigurable, .maxOutputTokens, .modelListFetchable],
             symbolName: "brain",
             curatedModels: claudeCuratedModels,
+            effortLevelResolver: { AnthropicModelCapabilities.effortLevels(forModel: $0) },
             makeProvider: { config, apiKey in
                 AnthropicProvider(
                     endpoint: config.endpoint,
@@ -216,25 +217,23 @@ enum AIProviderRegistration {
     ]
 
     private static let claudeCuratedModels: [CuratedModel] = [
-        CuratedModel(
-            id: "claude-opus-4-7-20260101",
-            displayName: "Claude Opus 4.7",
-            supportedEffortLevels: [.low, .medium, .high, .xhigh],
-            defaultEffort: .medium
-        ),
-        CuratedModel(
-            id: "claude-sonnet-4-6-20251101",
-            displayName: "Claude Sonnet 4.6",
-            supportedEffortLevels: [.low, .medium, .high, .xhigh],
-            defaultEffort: .medium
-        ),
-        CuratedModel(
-            id: "claude-haiku-4-5-20251001",
-            displayName: "Claude Haiku 4.5",
-            supportedEffortLevels: [.low, .medium, .high],
-            defaultEffort: .low
-        )
+        claudeModel(id: "claude-opus-4-7", displayName: "Claude Opus 4.7", defaultEffort: .medium),
+        claudeModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6", defaultEffort: .medium),
+        claudeModel(id: "claude-haiku-4-5", displayName: "Claude Haiku 4.5", defaultEffort: .low)
     ]
+
+    private static func claudeModel(
+        id: String,
+        displayName: String,
+        defaultEffort: ReasoningEffort
+    ) -> CuratedModel {
+        CuratedModel(
+            id: id,
+            displayName: displayName,
+            supportedEffortLevels: AnthropicModelCapabilities.effortLevels(forModel: id),
+            defaultEffort: defaultEffort
+        )
+    }
 
     private static func iconForType(_ type: AIProviderType) -> String {
         type.symbolName

--- a/TablePro/Core/AI/XAI/XAIGrokProvider.swift
+++ b/TablePro/Core/AI/XAI/XAIGrokProvider.swift
@@ -33,8 +33,8 @@ final class XAIGrokProvider: ChatTransport {
         )
     }
 
-    func fetchAvailableModels() async throws -> [String] {
-        XAI.subscriptionModelIDs
+    func fetchAvailableModels() async throws -> [AIModelInfo] {
+        XAI.subscriptionModelIDs.map { AIModelInfo(id: $0) }
     }
 
     func testConnection() async throws -> Bool {

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -300,7 +300,8 @@ final class AIChatViewModel {
                     let transport = await AIProviderFactory.createProvider(for: config, apiKey: apiKey)
                     do {
                         let models = try await transport.fetchAvailableModels()
-                        return (config.id, models)
+                        AIModelCatalog.shared.store(providerTypeID: config.type.rawValue, models: models)
+                        return (config.id, models.map(\.id))
                     } catch is CancellationError {
                         return (config.id, nil)
                     } catch {

--- a/TablePro/Views/Settings/AIProviderDetailSheet.swift
+++ b/TablePro/Views/Settings/AIProviderDetailSheet.swift
@@ -958,8 +958,9 @@ struct AIProviderDetailSheet: View {
             do {
                 let models = try await provider.fetchAvailableModels()
                 guard !Task.isCancelled else { return }
-                fetchedModels = models
-                if draft.model.isEmpty, let first = models.first {
+                AIModelCatalog.shared.store(providerTypeID: draft.type.rawValue, models: models)
+                fetchedModels = models.map(\.id)
+                if draft.model.isEmpty, let first = fetchedModels.first {
                     draft.model = first
                 }
                 isFetchingModels = false

--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator.swift
@@ -440,7 +440,7 @@ final class DatabaseTreeOutlineCoordinator: NSObject {
 
     private func loadExternalSchemaNames(database: String) {
         guard let session = DatabaseManager.shared.session(for: connectionId),
-              DatabaseManager.shared.activeDatabaseName(for: session.connection) == database,
+              DatabaseManager.shared.browseDatabaseName(for: session.connection) == database,
               let driver = DatabaseManager.shared.driver(for: connectionId)
         else { return }
         let connectionId = connectionId

--- a/TableProTests/Core/AI/AIModelCatalogTests.swift
+++ b/TableProTests/Core/AI/AIModelCatalogTests.swift
@@ -1,0 +1,156 @@
+//
+//  AIModelCatalogTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("AI model catalog")
+struct AIModelCatalogTests {
+    private let claude = AIProviderType.claude.rawValue
+
+    @Test("Live provider metadata wins over the static overlay")
+    func liveMetadataWins() {
+        let catalog = AIModelCatalog()
+        let live = AIModelInfo(
+            id: "claude-haiku-4-5",
+            displayName: "Claude Haiku 4.5",
+            maxOutputTokens: 64_000,
+            reasoning: AIReasoningSupport(mode: .adaptive, effortLevels: [.low, .medium, .high, .xhigh])
+        )
+        catalog.store(providerTypeID: claude, models: [live])
+
+        let resolved = catalog.resolve(providerTypeID: claude, modelID: "claude-haiku-4-5")
+        #expect(resolved.reasoning?.mode == .adaptive, "live metadata must override the offline table")
+        #expect(resolved.maxOutputTokens == 64_000)
+        #expect(resolved.displayName == "Claude Haiku 4.5")
+    }
+
+    @Test("Without live metadata the overlay supplies the answer")
+    func overlayFallback() {
+        let catalog = AIModelCatalog()
+        let resolved = catalog.resolve(providerTypeID: claude, modelID: "claude-haiku-4-5")
+        #expect(resolved.reasoning?.mode == .budgeted, "Haiku 4.5 has no adaptive thinking")
+        #expect(resolved.reasoning?.effortLevels == [.low, .medium, .high])
+    }
+
+    @Test("An unknown provider and model still resolve to a usable value")
+    func unknownResolvesToPlainInfo() {
+        let catalog = AIModelCatalog()
+        let resolved = catalog.resolve(providerTypeID: "nonexistent", modelID: "some-model")
+        #expect(resolved.id == "some-model")
+        #expect(resolved.reasoning == nil)
+    }
+
+    @Test("Storing an empty list never erases what is already known")
+    func emptyStoreIsIgnored() {
+        let catalog = AIModelCatalog()
+        let live = AIModelInfo(id: "m", reasoning: AIReasoningSupport(mode: .adaptive, effortLevels: [.high]))
+        catalog.store(providerTypeID: claude, models: [live])
+        catalog.store(providerTypeID: claude, models: [])
+        #expect(catalog.fetchedInfo(providerTypeID: claude, modelID: "m") != nil)
+    }
+
+    @Test("Merging fills only the fields the provider left unknown")
+    func mergingPrefersLiveFields() {
+        let live = AIModelInfo(id: "m", displayName: nil, maxOutputTokens: 100)
+        let fallback = AIModelInfo(
+            id: "m",
+            displayName: "Fallback",
+            maxOutputTokens: 999,
+            reasoning: AIReasoningSupport(mode: .budgeted, effortLevels: [.low])
+        )
+        let merged = live.merging(fallback: fallback)
+        #expect(merged.maxOutputTokens == 100, "a live value must not be overwritten")
+        #expect(merged.displayName == "Fallback", "an unknown live field takes the fallback")
+        #expect(merged.reasoning?.mode == .budgeted)
+    }
+
+    @Test("Anthropic capability payloads decode into reasoning support")
+    func anthropicCapabilityDecoding() throws {
+        let adaptive: [String: Any] = [
+            "id": "claude-opus-5",
+            "display_name": "Claude Opus 5",
+            "max_input_tokens": 1_000_000,
+            "max_tokens": 128_000,
+            "capabilities": [
+                "thinking": [
+                    "supported": true,
+                    "types": ["adaptive": ["supported": true], "enabled": ["supported": false]]
+                ],
+                "effort": [
+                    "supported": true,
+                    "low": ["supported": true],
+                    "medium": ["supported": true],
+                    "high": ["supported": true],
+                    "xhigh": ["supported": true]
+                ]
+            ]
+        ]
+        let decoded = try #require(AnthropicProvider.decodeModel(adaptive))
+        #expect(decoded.reasoning?.mode == .adaptive)
+        #expect(decoded.maxOutputTokens == 128_000)
+        #expect(decoded.contextWindow == 1_000_000)
+        #expect(decoded.reasoning?.effortLevels.contains(.xhigh) == true)
+
+        let budgeted: [String: Any] = [
+            "id": "claude-haiku-4-5",
+            "capabilities": [
+                "thinking": [
+                    "supported": true,
+                    "types": ["adaptive": ["supported": false], "enabled": ["supported": true]]
+                ],
+                "effort": ["supported": false]
+            ]
+        ]
+        let decodedBudgeted = try #require(AnthropicProvider.decodeModel(budgeted))
+        #expect(decodedBudgeted.reasoning?.mode == .budgeted)
+        #expect(decodedBudgeted.reasoning?.sendsEffortParameter == false)
+    }
+
+    @Test("A payload with no capabilities object leaves reasoning unknown rather than guessing")
+    func missingCapabilitiesStaysUnknown() throws {
+        let decoded = try #require(AnthropicProvider.decodeModel(["id": "claude-future-9"]))
+        #expect(decoded.reasoning == nil)
+    }
+
+    @Test("Gemini model metadata decodes thinking support and token limits")
+    func geminiDecoding() throws {
+        let thinking: [String: Any] = [
+            "name": "models/gemini-3.6-flash",
+            "displayName": "Gemini 3.6 Flash",
+            "supportedGenerationMethods": ["generateContent"],
+            "inputTokenLimit": 1_048_576,
+            "outputTokenLimit": 65_536,
+            "thinking": true
+        ]
+        let decoded = try #require(GeminiProvider.decodeModel(thinking))
+        #expect(decoded.id == "gemini-3.6-flash", "the models/ prefix must be stripped")
+        #expect(decoded.maxOutputTokens == 65_536)
+        #expect(decoded.reasoning?.mode == .effortOnly)
+
+        let embedding: [String: Any] = [
+            "name": "models/text-embedding-004",
+            "supportedGenerationMethods": ["embedContent"]
+        ]
+        #expect(GeminiProvider.decodeModel(embedding) == nil, "non-chat models are filtered out")
+    }
+
+    @Test("Reasoning support clamps an effort the model does not offer")
+    func reasoningClamps() {
+        let support = AIReasoningSupport(mode: .adaptive, effortLevels: [.low, .medium, .high])
+        #expect(support.clampedEffort(.xhigh) == .high)
+        #expect(support.clampedEffort(.medium) == .medium)
+        #expect(AIReasoningSupport.unsupported.clampedEffort(.high) == nil)
+    }
+
+    @Test("Budgeted models never advertise the effort parameter")
+    func budgetedNeverSendsEffort() {
+        let budgeted = AIReasoningSupport(mode: .budgeted, effortLevels: [.low, .medium, .high])
+        #expect(budgeted.sendsEffortParameter == false)
+        let adaptive = AIReasoningSupport(mode: .adaptive, effortLevels: [.low])
+        #expect(adaptive.sendsEffortParameter)
+    }
+}

--- a/TableProTests/Core/AI/AnthropicModelCapabilitiesTests.swift
+++ b/TableProTests/Core/AI/AnthropicModelCapabilitiesTests.swift
@@ -1,0 +1,157 @@
+//
+//  AnthropicModelCapabilitiesTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Anthropic model capabilities")
+struct AnthropicModelCapabilitiesTests {
+    init() {
+        AIProviderRegistration.registerAll()
+    }
+
+    @Test("Opus 4.7 and later use adaptive thinking with the full effort ladder")
+    func modernModelsAreAdaptive() {
+        let models = [
+            "claude-opus-4-7",
+            "claude-opus-4-7-20260101",
+            "claude-opus-4-8",
+            "claude-opus-5",
+            "claude-sonnet-5",
+            "claude-fable-5",
+            "claude-mythos-5"
+        ]
+        for model in models {
+            let capabilities = AnthropicModelCapabilities.resolve(model: model)
+            #expect(capabilities.thinkingMode == .adaptive, "\(model) should be adaptive")
+            #expect(
+                capabilities.effortLevels == [.low, .medium, .high, .xhigh],
+                "\(model) should offer the full ladder"
+            )
+        }
+    }
+
+    @Test("The 4.6 family is adaptive but has no xhigh effort level")
+    func fourSixFamilyExcludesExtraHigh() {
+        for model in ["claude-opus-4-6", "claude-sonnet-4-6", "claude-sonnet-4-6-20251101"] {
+            let capabilities = AnthropicModelCapabilities.resolve(model: model)
+            #expect(capabilities.thinkingMode == .adaptive, "\(model) should be adaptive")
+            #expect(!capabilities.effortLevels.contains(.xhigh), "\(model) must not offer xhigh")
+            #expect(capabilities.effortLevels.contains(.high), "\(model) should still offer high")
+        }
+    }
+
+    @Test("Pre-4.6 models use a thinking budget, never the effort parameter")
+    func legacyModelsAreBudgeted() {
+        let models = [
+            "claude-haiku-4-5",
+            "claude-haiku-4-5-20251001",
+            "claude-sonnet-4-5",
+            "claude-sonnet-4-5-20250929",
+            "claude-opus-4-5",
+            "claude-opus-4-1",
+            "claude-opus-4-20250514",
+            "claude-sonnet-4-20250514",
+            "claude-3-haiku-20240307"
+        ]
+        for model in models {
+            let capabilities = AnthropicModelCapabilities.resolve(model: model)
+            #expect(capabilities.thinkingMode == .budgeted, "\(model) should be budgeted")
+            #expect(!capabilities.sendsEffortParameter, "\(model) must not send output_config.effort")
+        }
+    }
+
+    @Test("Budgeted models keep an effort picker, because effort selects the thinking budget")
+    func budgetedModelsKeepEffortPicker() {
+        let capabilities = AnthropicModelCapabilities.resolve(model: "claude-haiku-4-5")
+        #expect(capabilities.effortLevels == [.low, .medium, .high])
+    }
+
+    @Test("No Claude model advertises xhigh unless its API accepts it")
+    func extraHighOnlyWhereSupported() {
+        let withExtraHigh = ["claude-opus-4-7", "claude-opus-4-8", "claude-opus-5", "claude-sonnet-5"]
+        for model in withExtraHigh {
+            #expect(AnthropicModelCapabilities.effortLevels(forModel: model).contains(.xhigh), "\(model)")
+        }
+
+        let withoutExtraHigh = ["claude-sonnet-4-6", "claude-opus-4-6", "claude-haiku-4-5", "claude-opus-4-5"]
+        for model in withoutExtraHigh {
+            #expect(!AnthropicModelCapabilities.effortLevels(forModel: model).contains(.xhigh), "\(model)")
+        }
+    }
+
+    @Test("No Claude model advertises Minimal, which has no distinct meaning on this API")
+    func minimalIsNeverAdvertised() {
+        let models = [
+            "claude-opus-5", "claude-opus-4-7", "claude-sonnet-4-6",
+            "claude-haiku-4-5", "claude-opus-4-5", "claude-something-9"
+        ]
+        for model in models {
+            #expect(!AnthropicModelCapabilities.effortLevels(forModel: model).contains(.minimal), "\(model)")
+        }
+    }
+
+    @Test("The thinking budget rises with effort and never inverts")
+    func budgetLadderIsMonotonic() {
+        let budgets = ReasoningEffort.allCases.map(\.anthropicBudgetTokens)
+        #expect(budgets == budgets.sorted(), "a lower effort must not ask for a larger budget")
+        #expect(
+            ReasoningEffort.minimal.anthropicBudgetTokens >= AnthropicModelCapabilities.minimumThinkingBudgetTokens,
+            "every level must clear the API minimum"
+        )
+    }
+
+    @Test("Dotted model identifiers resolve the same as dashed ones")
+    func dottedIdentifiersNormalize() {
+        #expect(
+            AnthropicModelCapabilities.resolve(model: "claude-sonnet-4.6")
+                == AnthropicModelCapabilities.resolve(model: "claude-sonnet-4-6")
+        )
+        #expect(
+            AnthropicModelCapabilities.resolve(model: "claude-haiku-4.5")
+                == AnthropicModelCapabilities.resolve(model: "claude-haiku-4-5")
+        )
+    }
+
+    @Test("An unrecognised model falls back to adaptive, which every current model accepts")
+    func unknownModelDefaultsToAdaptive() {
+        let capabilities = AnthropicModelCapabilities.resolve(model: "claude-something-9")
+        #expect(capabilities.thinkingMode == .adaptive)
+        #expect(capabilities.effortLevels == [.low, .medium, .high, .xhigh])
+    }
+
+    @Test("Effort clamps down to the highest level the model supports")
+    func effortClampsToSupportedLevel() {
+        let fourSix = AnthropicModelCapabilities.resolve(model: "claude-sonnet-4-6")
+        #expect(fourSix.clampedEffort(.xhigh) == .high)
+        #expect(fourSix.clampedEffort(.medium) == .medium)
+
+        let modern = AnthropicModelCapabilities.resolve(model: "claude-opus-5")
+        #expect(modern.clampedEffort(.xhigh) == .xhigh)
+    }
+
+    @Test("Claude effort levels advertised by the registry match the capability table")
+    func registryAgreesWithCapabilityTable() throws {
+        let descriptor = try #require(AIProviderRegistry.shared.descriptor(for: AIProviderType.claude.rawValue))
+
+        for model in ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5", "claude-opus-5"] {
+            #expect(
+                descriptor.supportedEffortLevels(forModelID: model)
+                    == AnthropicModelCapabilities.effortLevels(forModel: model),
+                "\(model) advertises levels the wire encoder disagrees with"
+            )
+        }
+    }
+
+    @Test("Effort wire values use the API's spelling")
+    func effortWireValues() {
+        #expect(ReasoningEffort.minimal.anthropicEffortValue == "low")
+        #expect(ReasoningEffort.low.anthropicEffortValue == "low")
+        #expect(ReasoningEffort.medium.anthropicEffortValue == "medium")
+        #expect(ReasoningEffort.high.anthropicEffortValue == "high")
+        #expect(ReasoningEffort.xhigh.anthropicEffortValue == "xhigh")
+    }
+}

--- a/TableProTests/Core/AI/AnthropicProviderEncodingTests.swift
+++ b/TableProTests/Core/AI/AnthropicProviderEncodingTests.swift
@@ -72,4 +72,114 @@ struct AnthropicProviderEncodingTests {
         let encoded = try AnthropicProvider.encodeTurn(turn)
         #expect(encoded == nil)
     }
+
+    private func body(
+        model: String,
+        effort: ReasoningEffort?,
+        maxTokens: Int = 32_768
+    ) throws -> [String: Any] {
+        try AnthropicProvider.makeRequestBody(
+            turns: [ChatTurnWire(role: .user, blocks: [.text("hi")])],
+            options: ChatTransportOptions(model: model),
+            effort: effort,
+            maxTokens: maxTokens,
+            stream: true
+        )
+    }
+
+    @Test("Effort travels in output_config, never inside thinking (#2031)")
+    func effortIsNotNestedInThinking() throws {
+        let encoded = try body(model: "claude-opus-4-7", effort: .medium)
+
+        let thinking = encoded["thinking"] as? [String: Any]
+        #expect(thinking?["type"] as? String == "adaptive")
+        #expect(thinking?["effort"] == nil, "thinking.adaptive has no effort member; the API rejects it")
+
+        let outputConfig = encoded["output_config"] as? [String: Any]
+        #expect(outputConfig?["effort"] as? String == "medium")
+    }
+
+    @Test("Adaptive thinking asks for summarized reasoning so the Reasoning block is not empty")
+    func adaptiveThinkingRequestsSummarizedDisplay() throws {
+        let thinking = try body(model: "claude-opus-5", effort: .high)["thinking"] as? [String: Any]
+        #expect(thinking?["display"] as? String == "summarized")
+    }
+
+    @Test("Adaptive models never carry budget_tokens, which newer models reject")
+    func adaptiveModelsOmitBudgetTokens() throws {
+        for model in ["claude-opus-4-7", "claude-opus-5", "claude-sonnet-5", "claude-sonnet-4-6"] {
+            let thinking = try body(model: model, effort: .high)["thinking"] as? [String: Any]
+            #expect(thinking?["type"] as? String == "adaptive", "\(model) must use adaptive thinking")
+            #expect(thinking?["budget_tokens"] == nil, "\(model) must not send budget_tokens")
+        }
+    }
+
+    @Test("Extra High serializes as xhigh, and clamps to high where the model lacks it")
+    func extraHighEffortWireValue() throws {
+        let modern = try body(model: "claude-opus-5", effort: .xhigh)["output_config"] as? [String: Any]
+        #expect(modern?["effort"] as? String == "xhigh")
+
+        let fourSix = try body(model: "claude-sonnet-4-6", effort: .xhigh)["output_config"] as? [String: Any]
+        #expect(fourSix?["effort"] as? String == "high", "Sonnet 4.6 has no xhigh level")
+    }
+
+    @Test("Pre-4.6 models use a thinking budget and send no output_config")
+    func legacyModelsUseBudgetedThinking() throws {
+        let encoded = try body(model: "claude-haiku-4-5", effort: .medium)
+
+        let thinking = encoded["thinking"] as? [String: Any]
+        #expect(thinking?["type"] as? String == "enabled")
+        #expect(thinking?["budget_tokens"] as? Int == 8_192)
+        #expect(encoded["output_config"] == nil, "effort is rejected on Haiku 4.5")
+    }
+
+    @Test("A budget that cannot clear the API minimum drops thinking instead of sending an invalid one")
+    func tinyMaxTokensDropsThinking() throws {
+        let encoded = try body(model: "claude-haiku-4-5", effort: .medium, maxTokens: 1)
+        #expect(encoded["thinking"] == nil)
+        #expect(encoded["max_tokens"] as? Int == 1)
+    }
+
+    @Test("Minimal effort asks for the smallest budget, not the largest")
+    func minimalEffortDoesNotConsumeTheWholeCeiling() throws {
+        let minimal = try #require(
+            (try body(model: "claude-haiku-4-5", effort: .minimal, maxTokens: 4_096)["thinking"]
+                as? [String: Any])?["budget_tokens"] as? Int
+        )
+        let low = try #require(
+            (try body(model: "claude-haiku-4-5", effort: .low, maxTokens: 4_096)["thinking"]
+                as? [String: Any])?["budget_tokens"] as? Int
+        )
+        #expect(minimal <= low, "Minimal must not request more thinking than Low")
+        #expect(minimal < 4_096 / 2, "Minimal must leave room for the answer")
+    }
+
+    @Test("The budget always stays under max_tokens")
+    func budgetStaysBelowMaxTokens() throws {
+        let encoded = try body(model: "claude-haiku-4-5", effort: .xhigh, maxTokens: 2_000)
+        let budget = try #require((encoded["thinking"] as? [String: Any])?["budget_tokens"] as? Int)
+        #expect(budget < 2_000)
+        #expect(budget >= AnthropicModelCapabilities.minimumThinkingBudgetTokens)
+    }
+
+    @Test("No reasoning parameters are sent when no effort is configured")
+    func noEffortMeansNoReasoningKeys() throws {
+        let encoded = try body(model: "claude-opus-4-7", effort: nil)
+        #expect(encoded["thinking"] == nil)
+        #expect(encoded["output_config"] == nil)
+    }
+
+    @Test("An unrecognised future model gets adaptive thinking with its effort")
+    func unknownModelUsesAdaptive() throws {
+        let encoded = try body(model: "claude-opus-9", effort: .high)
+        #expect((encoded["thinking"] as? [String: Any])?["type"] as? String == "adaptive")
+        #expect((encoded["output_config"] as? [String: Any])?["effort"] as? String == "high")
+    }
+
+    @Test("Request body is serializable as JSON")
+    func bodySerializes() throws {
+        let encoded = try body(model: "claude-opus-4-7", effort: .medium)
+        #expect(JSONSerialization.isValidJSONObject(encoded))
+        _ = try JSONSerialization.data(withJSONObject: encoded)
+    }
 }

--- a/TableProTests/Core/AI/ChatGPTCodexProviderEncodingTests.swift
+++ b/TableProTests/Core/AI/ChatGPTCodexProviderEncodingTests.swift
@@ -66,6 +66,7 @@ struct ChatGPTCodexProviderEncodingTests {
     func curatedModels() async throws {
         let provider = ChatGPTCodexProvider(model: "")
         let models = try await provider.fetchAvailableModels()
-        #expect(models == ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"])
+        #expect(models.map(\.id) == ChatGPTCodex.curatedModelIDs)
+        #expect(models.map(\.id) == ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5"])
     }
 }

--- a/TableProTests/Core/AI/XAIGrokProviderEncodingTests.swift
+++ b/TableProTests/Core/AI/XAIGrokProviderEncodingTests.swift
@@ -60,6 +60,6 @@ struct XAIGrokProviderEncodingTests {
     func subscriptionModels() async throws {
         let provider = XAIGrokProvider(model: "grok-build")
         let models = try await provider.fetchAvailableModels()
-        #expect(models == ["grok-4.5", "grok-build", "grok-composer-2.5-fast"])
+        #expect(models.map(\.id) == ["grok-4.5", "grok-build", "grok-composer-2.5-fast"])
     }
 }

--- a/TableProTests/Core/Utilities/SQL/ColumnTypeSQLQuotingTests.swift
+++ b/TableProTests/Core/Utilities/SQL/ColumnTypeSQLQuotingTests.swift
@@ -6,6 +6,7 @@
 import Foundation
 import Testing
 @testable import TablePro
+import TableProPluginKit
 
 @Suite("Column Type SQL Quoting")
 struct ColumnTypeSQLQuotingTests {

--- a/TableProTests/ViewModels/AIChatViewModelToolLoopTests.swift
+++ b/TableProTests/ViewModels/AIChatViewModelToolLoopTests.swift
@@ -35,7 +35,7 @@ struct AIChatViewModelToolLoopTests {
             }
         }
 
-        func fetchAvailableModels() async throws -> [String] { [] }
+        func fetchAvailableModels() async throws -> [AIModelInfo] { [] }
 
         func testConnection() async throws -> Bool { true }
     }


### PR DESCRIPTION
Fixes #2031.

## Root cause

The Claude request builder nested `effort` **inside** the `thinking` object. The API takes it as a separate top-level object:

```json
"thinking":      { "type": "adaptive" },
"output_config": { "effort": "high" }
```

`thinking.adaptive` has no `effort` member, so the server rejected the request with `thinking.adaptive.effort: Extra input`. This reproduced on defaults (first curated model at `medium` effort), so every AI chat message failed. Only "Minimal" escaped, because it happened to omit the key entirely.

## Why this is more than a one-line move

Four more rejections lived in the same path and would have surfaced the moment the first one was fixed:

| Defect | Consequence |
| --- | --- |
| `.xhigh` serialized as `"maximum"` | Not a valid effort value |
| `xhigh` advertised for Sonnet 4.6 | `xhigh` arrived with Opus 4.7; 4.6 tops out below it |
| Haiku 4.5 classified adaptive-capable | It requires `budget_tokens`, and effort errors on it |
| Gate knew nothing after Opus 4.7 | Opus 5, Sonnet 5, Opus 4.8 fell to the `budget_tokens` branch, which those models reject |

The shared cause was a hand-rolled substring gate checked against a **live-fetched** model list, defaulting unknown models to the one shape current models refuse.

## The fix

`AnthropicModelCapabilities` is now the single source of truth mapping a model ID to its thinking mode and effort ladder. Both the request builder and the settings picker read it, so the UI cannot offer a level the wire rejects.

- Opus 4.7 / 4.8 / 5, Sonnet 5, Fable 5, Mythos 5: adaptive thinking, effort through `xhigh`
- Opus 4.6 / Sonnet 4.6: adaptive thinking, no `xhigh`
- Pre-4.6 (Opus 4.5/4.1/4.0, Sonnet 4.5/4.0, Haiku 4.5, Claude 3.x): `budget_tokens`, and never `output_config`
- Unknown model: adaptive, which every 4.6+ model accepts

Also in scope, same code path:

- `thinking.display: "summarized"`. On Opus 4.7+ this defaults to `"omitted"`, so thinking blocks streamed with empty text and the collapsible **Reasoning** block rendered blank after a long pause.
- The thinking budget can no longer be emitted below the API's 1024 minimum or at or above `max_tokens`; when `max_tokens` is too small to satisfy both, thinking is omitted rather than sent invalid.
- `testConnection()` no longer sends reasoning parameters. It treats HTTP 400 as "key accepted" (401 is the auth signal), so sending a malformed body made the probe structurally unable to fail on shape. That is why the provider validated green and then chat returned 400.

## Tests

`AnthropicProviderEncodingTests` gains wire-shape coverage, including the regression that would have caught this: effort lands in `output_config` and never in `thinking`. `AnthropicModelCapabilitiesTests` covers per-model ladders, dated and dotted identifier forms, the unknown-model default, the monotonic budget ladder, and that the registry's advertised levels equal the capability table's. That last one is the invariant whose absence let this ship.

Build clean, 69 targeted tests pass. The full suite's failures were each baselined: the majority are in `.github/macos-test-quarantine.txt`, four reproduce identically on clean `main` with this change stashed, and two pass in isolation either way (full-suite load flakes in the same area as the already-quarantined `RowOperationsManagerTests`). None are attributable to this change. `swiftlint --strict` is clean.

## The first commit is unrelated, and droppable

`ac3404b` fixes two references that stop `main` compiling, neither introduced here:

- `DatabaseTreeOutlineCoordinator.swift` called `activeDatabaseName(for:)`, which exists nowhere; the method is `browseDatabaseName(for:)` (from `204e82b07`)
- `ColumnTypeSQLQuotingTests.swift` was missing `import TableProPluginKit`, so the test target did not build either (from `74a1f541e`)

It is isolated in its own commit purely so every commit here builds and CI can run. Drop it if `main` gets fixed another way.

## Deliberately out of scope

- The curated model list is still a generation behind (no Opus 5 / Sonnet 5 / Opus 4.8). The capability table handles them correctly when `/v1/models` surfaces them, so this is additive, not a fix.
- `autoScaledMaxOutputTokens` is never capped against a model's real output limit, so `claude-3-haiku` at High can still exceed its 4,096 ceiling. Pre-existing, not reachable through the curated picker, and wants its own change.
