### PR TITLE
feat(sidebar): let object icons be hidden from a View Options menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Sidebar object icons can be turned off for a plain list of names. Right-click anywhere in the sidebar and use View Options, or toggle Show Object Icons from the View menu or Settings > General. Tables staged for truncate or delete keep their marker.
 - Redshift external schemas now list their tables. Spectrum, federated query, cross-database, and datashare schemas showed up empty because their tables are not in the standard catalog.
 - External schemas are marked in the sidebar, and their tables show an external icon. External tables open read-only, because Redshift rejects `UPDATE` and `DELETE` on them.
 

--- a/TablePro/Models/Settings/GeneralSettings.swift
+++ b/TablePro/Models/Settings/GeneralSettings.swift
@@ -69,6 +69,9 @@ struct GeneralSettings: Codable, Equatable {
     /// Whether to show database object comments in the sidebar and data grid headers
     var showObjectComments: Bool
 
+    /// Whether sidebar rows show a type icon before the object name
+    var showObjectIcons: Bool
+
     static let `default` = GeneralSettings(
         startupBehavior: .reopenLast,
         language: .system,
@@ -76,7 +79,8 @@ struct GeneralSettings: Codable, Equatable {
         queryTimeoutSeconds: 60,
         shareAnalytics: true,
         showRecentTables: false,
-        showObjectComments: true
+        showObjectComments: true,
+        showObjectIcons: true
     )
 
     init(
@@ -86,7 +90,8 @@ struct GeneralSettings: Codable, Equatable {
         queryTimeoutSeconds: Int = 60,
         shareAnalytics: Bool = true,
         showRecentTables: Bool = false,
-        showObjectComments: Bool = true
+        showObjectComments: Bool = true,
+        showObjectIcons: Bool = true
     ) {
         self.startupBehavior = startupBehavior
         self.language = language
@@ -95,6 +100,7 @@ struct GeneralSettings: Codable, Equatable {
         self.shareAnalytics = shareAnalytics
         self.showRecentTables = showRecentTables
         self.showObjectComments = showObjectComments
+        self.showObjectIcons = showObjectIcons
     }
 
     init(from decoder: Decoder) throws {
@@ -106,5 +112,6 @@ struct GeneralSettings: Codable, Equatable {
         shareAnalytics = try container.decodeIfPresent(Bool.self, forKey: .shareAnalytics) ?? true
         showRecentTables = try container.decodeIfPresent(Bool.self, forKey: .showRecentTables) ?? false
         showObjectComments = try container.decodeIfPresent(Bool.self, forKey: .showObjectComments) ?? true
+        showObjectIcons = try container.decodeIfPresent(Bool.self, forKey: .showObjectIcons) ?? true
     }
 }

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -163,6 +163,13 @@ struct AppMenuCommands: Commands {
         )
     }
 
+    private var showObjectIconsBinding: Binding<Bool> {
+        Binding(
+            get: { settingsManager.general.showObjectIcons },
+            set: { settingsManager.general.showObjectIcons = $0 }
+        )
+    }
+
     private func shortcut(for action: ShortcutAction) -> KeyboardShortcut? {
         settingsManager.keyboard.keyboardShortcut(for: action)
     }
@@ -716,6 +723,8 @@ struct AppMenuCommands: Commands {
             }
             .pickerStyle(.inline)
             .disabled(!(actions?.canSwitchSidebarLayout ?? false))
+
+            Toggle(String(localized: "Show Object Icons"), isOn: showObjectIconsBinding)
 
             Toggle(String(localized: "Show Object Comments"), isOn: showObjectCommentsBinding)
 

--- a/TablePro/Views/Settings/GeneralSettingsView.swift
+++ b/TablePro/Views/Settings/GeneralSettingsView.swift
@@ -58,6 +58,9 @@ struct GeneralSettingsView: View {
                 Toggle("Show recent tables", isOn: $settings.showRecentTables)
                     .help("Adds a Recent section at the top of the Tables sidebar with the last tables you opened per connection and database.")
 
+                Toggle("Show object icons", isOn: $settings.showObjectIcons)
+                    .help("Shows a type icon before each object name in the sidebar. Turn it off for a plain list of names.")
+
                 Toggle("Show object comments", isOn: $settings.showObjectComments)
                     .help("Shows database object comments next to tables in the sidebar and in grid column headers.")
 

--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator.swift
@@ -440,7 +440,7 @@ final class DatabaseTreeOutlineCoordinator: NSObject {
 
     private func loadExternalSchemaNames(database: String) {
         guard let session = DatabaseManager.shared.session(for: connectionId),
-              DatabaseManager.shared.activeDatabaseName(for: session.connection) == database,
+              DatabaseManager.shared.browseDatabaseName(for: session.connection) == database,
               let driver = DatabaseManager.shared.driver(for: connectionId)
         else { return }
         let connectionId = connectionId

--- a/TablePro/Views/Sidebar/DatabaseTreeRowView.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeRowView.swift
@@ -48,7 +48,11 @@ struct DatabaseTreeRowView: View {
 
     var body: some View {
         if hasContextMenu {
-            row.contextMenu { menuItems }
+            row.contextMenu {
+                menuItems
+                Divider()
+                SidebarViewOptionsMenu()
+            }
         } else {
             row
         }
@@ -127,6 +131,7 @@ struct DatabaseTreeRowView: View {
         } icon: {
             Image(systemName: systemImage)
         }
+        .sidebarRowIcon(visible: AppSettingsManager.shared.general.showObjectIcons)
         .lineLimit(1)
         .foregroundStyle(foreground(isActive: isActive, isSystem: isSystem))
     }

--- a/TablePro/Views/Sidebar/FavoritesTabView.swift
+++ b/TablePro/Views/Sidebar/FavoritesTabView.swift
@@ -276,7 +276,7 @@ internal struct FavoritesTabView: View {
             deleteSelectedNode()
         }
         .contextMenu(forSelectionType: FavoriteSelection.self) { selection in
-            if let selected = selection.first {
+            if let selected = selection.first, hasContextMenuItems(for: selected) {
                 contextMenu(for: selected)
                 Divider()
             }
@@ -323,6 +323,21 @@ internal struct FavoritesTabView: View {
     private func favoriteTable(database: String?, schema: String?, name: String) -> TableInfo? {
         guard database == activeDatabase else { return nil }
         return availableFavoriteTables.first { $0.name == name && $0.schema == schema }
+    }
+
+    private func hasContextMenuItems(for selection: FavoriteSelection) -> Bool {
+        switch selection {
+        case .table(let database, let schema, let name):
+            return favoriteTable(database: database, schema: schema, name: name) != nil
+        case .node(let id):
+            guard let node = viewModel.node(forId: id) else { return false }
+            switch node.content {
+            case .favorite, .linkedFavorite, .folder, .linkedFolder:
+                return true
+            case .linkedSubfolder:
+                return false
+            }
+        }
     }
 
     @ViewBuilder

--- a/TablePro/Views/Sidebar/FavoritesTabView.swift
+++ b/TablePro/Views/Sidebar/FavoritesTabView.swift
@@ -278,7 +278,9 @@ internal struct FavoritesTabView: View {
         .contextMenu(forSelectionType: FavoriteSelection.self) { selection in
             if let selected = selection.first {
                 contextMenu(for: selected)
+                Divider()
             }
+            SidebarViewOptionsMenu()
         } primaryAction: { selection in
             guard let selected = selection.first else { return }
             handlePrimaryAction(selected)
@@ -292,6 +294,7 @@ internal struct FavoritesTabView: View {
             Image(systemName: TableRowLogic.iconName(for: table.type))
                 .sidebarTint(Color.accentColor)
         }
+        .sidebarRowIcon(visible: AppSettingsManager.shared.general.showObjectIcons)
         .tag(FavoriteSelection.table(database: activeDatabase, schema: table.schema, name: table.name))
         .accessibilityLabel(
             TableRowLogic.accessibilityLabel(table: table, isPendingDelete: false, isPendingTruncate: false)

--- a/TablePro/Views/Sidebar/RedisKeyTreeView.swift
+++ b/TablePro/Views/Sidebar/RedisKeyTreeView.swift
@@ -49,6 +49,7 @@ internal struct RedisKeyTreeView: View {
             } label: {
                 HStack {
                     Label(name, systemImage: "folder")
+                        .sidebarRowIcon(visible: AppSettingsManager.shared.general.showObjectIcons)
                         .foregroundStyle(.primary)
                     Spacer()
                     Text("\(keyCount)")
@@ -66,6 +67,7 @@ internal struct RedisKeyTreeView: View {
             } label: {
                 HStack {
                     Label(name, systemImage: keyTypeIcon(keyType))
+                        .sidebarRowIcon(visible: AppSettingsManager.shared.general.showObjectIcons)
                         .foregroundStyle(.primary)
                     Spacer()
                     Text(keyType)

--- a/TablePro/Views/Sidebar/RoutineRowView.swift
+++ b/TablePro/Views/Sidebar/RoutineRowView.swift
@@ -43,6 +43,7 @@ struct RoutineRowView: View {
                 .sidebarTint(Color.accentColor)
                 .frame(width: 16)
         }
+        .sidebarRowIcon(visible: AppSettingsManager.shared.general.showObjectIcons)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(RoutineRowLogic.accessibilityLabel(for: routine))
         .help(RoutineRowLogic.tooltip(for: routine) ?? routine.name)

--- a/TablePro/Views/Sidebar/SidebarRowIcon.swift
+++ b/TablePro/Views/Sidebar/SidebarRowIcon.swift
@@ -1,0 +1,24 @@
+//
+//  SidebarRowIcon.swift
+//  TablePro
+//
+
+import SwiftUI
+
+private struct SidebarRowIcon: ViewModifier {
+    let isVisible: Bool
+
+    func body(content: Content) -> some View {
+        if isVisible {
+            content.labelStyle(.titleAndIcon)
+        } else {
+            content.labelStyle(.titleOnly)
+        }
+    }
+}
+
+extension View {
+    func sidebarRowIcon(visible: Bool) -> some View {
+        modifier(SidebarRowIcon(isVisible: visible))
+    }
+}

--- a/TablePro/Views/Sidebar/SidebarTreeView.swift
+++ b/TablePro/Views/Sidebar/SidebarTreeView.swift
@@ -131,6 +131,8 @@ struct SidebarTreeView: View {
         .tag(table)
         .contextMenu {
             tableContextMenu(table)
+            Divider()
+            SidebarViewOptionsMenu()
         }
     }
 
@@ -174,6 +176,8 @@ struct SidebarTreeView: View {
                         Button(String(localized: "Clear Recent Tables")) {
                             sidebarState.clearRecentTables(inDatabase: activeDatabase)
                         }
+                        Divider()
+                        SidebarViewOptionsMenu()
                     }
                 }
             } header: {
@@ -195,6 +199,8 @@ struct SidebarTreeView: View {
                 Button(String(localized: "Refresh")) {
                     reloadTables(for: schema)
                 }
+                Divider()
+                SidebarViewOptionsMenu()
             }
     }
 

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -408,6 +408,8 @@ struct SidebarView: View {
                         Button(String(localized: "Clear Recent Tables")) {
                             sidebarState.clearRecentTables(inDatabase: activeDatabase)
                         }
+                        Divider()
+                        SidebarViewOptionsMenu()
                     }
                 }
             } header: {
@@ -452,6 +454,8 @@ struct SidebarView: View {
                 onBatchToggleDelete: { viewModel.batchToggleDelete(tableNames: $0) },
                 coordinator: coordinator
             )
+            Divider()
+            SidebarViewOptionsMenu()
         } primaryAction: { selection in
             guard let table = selection.first else { return }
             onDoubleClick?(table)
@@ -502,6 +506,8 @@ struct SidebarView: View {
                         RoutineContextMenu(routine: routine) { selected in
                             coordinator?.showRoutineDDL(selected)
                         }
+                        Divider()
+                        SidebarViewOptionsMenu()
                     }
             }
         } else {
@@ -528,6 +534,8 @@ struct SidebarView: View {
             .help(helpLabel)
             .contextMenu {
                 sectionHeaderMenu(for: kind, title: title)
+                Divider()
+                SidebarViewOptionsMenu()
             }
     }
 

--- a/TablePro/Views/Sidebar/SidebarViewOptionsMenu.swift
+++ b/TablePro/Views/Sidebar/SidebarViewOptionsMenu.swift
@@ -1,0 +1,17 @@
+//
+//  SidebarViewOptionsMenu.swift
+//  TablePro
+//
+
+import SwiftUI
+
+struct SidebarViewOptionsMenu: View {
+    @State private var settingsManager = AppSettingsManager.shared
+
+    var body: some View {
+        Menu(String(localized: "View Options")) {
+            Toggle("Icons", isOn: $settingsManager.general.showObjectIcons)
+            Toggle("Comments", isOn: $settingsManager.general.showObjectComments)
+        }
+    }
+}

--- a/TablePro/Views/Sidebar/TableRowView.swift
+++ b/TablePro/Views/Sidebar/TableRowView.swift
@@ -30,6 +30,10 @@ enum TableRowLogic {
         }
     }
 
+    static func showsLeadingIcon(showObjectIcons: Bool, isPendingTruncate: Bool, isPendingDelete: Bool) -> Bool {
+        showObjectIcons || isPendingTruncate || isPendingDelete
+    }
+
     static func accessibilityLabel(table: TableInfo, isPendingDelete: Bool, isPendingTruncate: Bool, isFavorite: Bool = false) -> String {
         let kind = accessibilityKindLabel(for: table.type)
         var label = String(format: String(localized: "%@: %@"), kind, table.name)
@@ -58,6 +62,18 @@ struct TableRow: View {
               let comment = table.comment, !comment.isEmpty
         else { return nil }
         return comment
+    }
+
+    private var showsObjectIcon: Bool {
+        AppSettingsManager.shared.general.showObjectIcons
+    }
+
+    private var showsLeadingIcon: Bool {
+        TableRowLogic.showsLeadingIcon(
+            showObjectIcons: showsObjectIcon,
+            isPendingTruncate: isPendingTruncate,
+            isPendingDelete: isPendingDelete
+        )
     }
 
     @ViewBuilder
@@ -90,13 +106,19 @@ struct TableRow: View {
                     }
                 }
             } icon: {
-                Image(systemName: TableRowLogic.iconName(for: table.type))
-                    .sidebarTint(Color.accentColor)
-                    .frame(width: 16)
-                    .overlay(alignment: .bottomTrailing) {
-                        pendingStateBadge
-                    }
+                if showsObjectIcon {
+                    Image(systemName: TableRowLogic.iconName(for: table.type))
+                        .sidebarTint(Color.accentColor)
+                        .frame(width: 16)
+                        .overlay(alignment: .bottomTrailing) {
+                            pendingStateBadge
+                        }
+                } else {
+                    pendingStateBadge
+                        .frame(width: 16)
+                }
             }
+            .sidebarRowIcon(visible: showsLeadingIcon)
 
             Spacer(minLength: 4)
 

--- a/TableProTests/Core/Utilities/SQL/ColumnTypeSQLQuotingTests.swift
+++ b/TableProTests/Core/Utilities/SQL/ColumnTypeSQLQuotingTests.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import TableProPluginKit
 import Testing
 @testable import TablePro
 

--- a/TableProTests/Models/GeneralSettingsTests.swift
+++ b/TableProTests/Models/GeneralSettingsTests.swift
@@ -26,3 +26,38 @@ struct GeneralSettingsTests {
         #expect(decoded.showRecentTables == true)
     }
 }
+
+@Suite("GeneralSettings.showObjectIcons")
+struct GeneralSettingsObjectIconsTests {
+    @Test("Defaults to on")
+    func defaultsOn() {
+        #expect(GeneralSettings.default.showObjectIcons == true)
+        #expect(GeneralSettings().showObjectIcons == true)
+    }
+
+    @Test("Decoding settings saved before the key existed keeps icons on")
+    func decodesMissingKeyAsOn() throws {
+        let json = Data(#"{"startupBehavior":"showWelcome"}"#.utf8)
+        let decoded = try JSONDecoder().decode(GeneralSettings.self, from: json)
+        #expect(decoded.showObjectIcons == true)
+    }
+
+    @Test("Round-trips when disabled")
+    func roundTripsDisabled() throws {
+        var settings = GeneralSettings()
+        settings.showObjectIcons = false
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(GeneralSettings.self, from: data)
+        #expect(decoded.showObjectIcons == false)
+    }
+
+    @Test("Icons and comments are independent")
+    func independentFromComments() throws {
+        var settings = GeneralSettings()
+        settings.showObjectIcons = false
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(GeneralSettings.self, from: data)
+        #expect(decoded.showObjectIcons == false)
+        #expect(decoded.showObjectComments == true)
+    }
+}

--- a/TableProTests/Views/TableRowLogicTests.swift
+++ b/TableProTests/Views/TableRowLogicTests.swift
@@ -108,4 +108,33 @@ struct TableRowLogicTests {
     func externalTableIconIsDistinct() {
         #expect(TableRowLogic.iconName(for: .externalTable) != TableRowLogic.iconName(for: .table))
     }
+
+    // MARK: - Leading Icon Visibility
+
+    @Test("Leading icon shows when object icons are enabled")
+    func leadingIconShownWhenEnabled() {
+        #expect(TableRowLogic.showsLeadingIcon(showObjectIcons: true, isPendingTruncate: false, isPendingDelete: false))
+    }
+
+    @Test("Leading icon hides when object icons are disabled")
+    func leadingIconHiddenWhenDisabled() {
+        #expect(!TableRowLogic.showsLeadingIcon(showObjectIcons: false, isPendingTruncate: false, isPendingDelete: false))
+    }
+
+    @Test("Pending delete keeps the leading slot when object icons are disabled")
+    func leadingIconSurvivesPendingDelete() {
+        #expect(TableRowLogic.showsLeadingIcon(showObjectIcons: false, isPendingTruncate: false, isPendingDelete: true))
+    }
+
+    @Test("Pending truncate keeps the leading slot when object icons are disabled")
+    func leadingIconSurvivesPendingTruncate() {
+        #expect(TableRowLogic.showsLeadingIcon(showObjectIcons: false, isPendingTruncate: true, isPendingDelete: false))
+    }
+
+    @Test("Hiding icons leaves the accessibility label naming the object kind")
+    func accessibilityLabelIndependentOfIconVisibility() {
+        let view = TestFixtures.makeTableInfo(name: "active_users", type: .view)
+        #expect(TableRowLogic.accessibilityLabel(table: view, isPendingDelete: false, isPendingTruncate: false) == "View: active_users")
+        #expect(!TableRowLogic.showsLeadingIcon(showObjectIcons: false, isPendingTruncate: false, isPendingDelete: false))
+    }
 }

--- a/docs/customization/settings.mdx
+++ b/docs/customization/settings.mdx
@@ -49,6 +49,7 @@ Reopened tabs restore their SQL, cursor position, sort, filters, page, and colum
 | Setting | Default | Description |
 |---------|---------|-------------|
 | **Show recent tables** | Off | Adds a Recent section at the top of the sidebar with the last 10 tables opened per connection and database |
+| **Show object icons** | On | Shows a type icon before each object name in the sidebar. Turn it off for a plain list of names. Also on the **View** menu, and under **View Options** in the sidebar right-click menu |
 | **Show object comments** | On | Shows database object comments next to tables in the sidebar and in grid column headers |
 | **Default layout for new connections** | List | List or Tree, for servers that support a database tree. Switch the current connection from the **View** menu |
 


### PR DESCRIPTION
The sidebar always drew a type icon before every object name, with no way to turn it off. Some people want a plain list of names.

This branch also carries the two compile fixes that were blocking `main` (see the last section); #2037 was merged in here, so everything ships together.

## What it looks like

```
WITH ICONS                 WITHOUT ICONS

- cylinder shop_prod       - shop_prod
  - folder public            - public
      table  orders              orders
      table  users               users
      eye    active_users        active_users
      fn     calc_total          calc_total
```

## Where the setting lives

Three entry points, one global preference:

| Where | Item |
|---|---|
| Right-click anywhere in the sidebar | **View Options** > **Icons** / **Comments** |
| View menu | **Show Object Icons**, beside Show Object Comments |
| Settings > General > Sidebar | **Show object icons** |

The View menu item is not optional decoration. Apple's guidance on context menus is that "in macOS, an app's menu bar menus list all the app's commands, including those in various context menus", so a command reachable only by right-click is wrong. The menu bar item is the real home; the context menu is the shortcut.

It is a submenu rather than a loose `Show Icons` checkbox because a display toggle is not an action on the clicked table, and the group will grow. Every database client that puts appearance in a context menu uses a submenu for it (DBeaver's Customize view); the ones with flat menus keep appearance out entirely and put it behind a dedicated options button.

## Scope, and why global

The preference is app-wide, on `GeneralSettings` next to `showObjectComments`, not per connection.

DBeaver is the cautionary tale here: its equivalent is scoped to "the currently selected database", and its global default applies only to newly created connections, so an existing user flips the global switch and nothing happens. This is a personal visual preference, not a property of a database. Mail, Safari, VS Code, and macOS's own Sidebar icon size all treat it as global.

Hiding covers tables, views, routines, the database/schema/Recent headers, and Redis namespaces and keys, across the outline tree, both list sidebars, and the Favorites tab. A list that drops table icons but keeps folder icons looks arbitrary, and on Redis the Keys section sits directly under the Tables section in the same list, so leaving it out rendered one list half converted.

Deliberately untouched: the favorite star, the pending truncate and delete badges, the error triangle, and the Favorites tab's own folder and link icons. Those are state and organisation affordances, not database object type icons.

## How it renders

`.labelStyle(.titleOnly)`, through a small `sidebarRowIcon(visible:)` modifier that sits next to the existing `sidebarTint`. `TitleOnlyLabelStyle` removes the icon from layout rather than hiding it, so names align to the disclosure triangle with no leftover gutter. That gutter is the classic defect in this feature (DBeaver #9735 is exactly it). Indentation per level is independent of the icon, so tree alignment is untouched.

## The trap this nearly shipped with

The pending truncate/delete badge is an `.overlay` on the icon image:

```swift
Image(systemName: TableRowLogic.iconName(for: table.type))
    .overlay(alignment: .bottomTrailing) { pendingStateBadge }
```

Applying `.titleOnly` naively deletes the icon slot and takes the badge with it, so a table staged for deletion would look completely ordinary. The badge now takes over the leading slot when icons are off, so the row keeps its icon slot exactly when it has something to say. `TableRowLogic.showsLeadingIcon` is the pure decision, and it is the thing the new tests pin.

## Accessibility

Nothing is lost to VoiceOver. `TableRowLogic.accessibilityLabel` already announces the kind (`View: active_users`) independently of the icon, and a test now pins that it stays true with icons hidden.

Icons are not forced back on under Differentiate Without Color. Hiding them is an explicit, reversible, opt-in user choice, and the default is on.

## Tests

`TableRowLogicTests` covers the leading-icon truth table, including both pending states surviving with icons off. `GeneralSettingsObjectIconsTests` covers the default, the round trip, independence from `showObjectComments`, and that settings written before this key existed still decode with icons on.

No UI automation: driving a sidebar context menu needs a live connection, so it does not run deterministically in CI.

## Also here: the two compile errors that were blocking main

`main` at 74a1f541e did not build. Two independent breakages, each from a PR that was green on its own branch and went stale on merge.

**`activeDatabaseName` no longer exists.** `DatabaseTreeOutlineCoordinator.loadExternalSchemaNames` called `DatabaseManager.shared.activeDatabaseName(for:)`, which is defined nowhere. #2026 renamed it to `browseDatabaseName(for:)`; #2028 branched before the rename and merged after it. `browseDatabaseName(for:)` is the correct replacement, and its doc comment says so: "Where this connection is being browsed. Use it to seed a new tab and to drive the sidebar."

**Missing import breaks `#expect`.** `ColumnTypeSQLQuotingTests` from #2029 uses `#expect` on values whose type comes from `TableProPluginKit` but only imported `TablePro`, so under `MemberImportVisibility` the macro expansion could not see `isTrue` / `isFalse`. Adding the import fixes it.

Neither bug reached a release, so neither gets a CHANGELOG entry.
