### PR TITLE
fix(plugin-oracle): enable TCP keepalive on Apple platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Oracle connections now turn on TCP keepalive, so a session left idle is less likely to be dropped by a NAT or firewall. It was only ever enabled on a code path that Macs and iPhones do not take. (#2038)
 - An open tab now keeps running against the database it was opened on, so changing the database in the sidebar no longer breaks it with a "table doesn't exist" error. (#2026)
 - Saving a table structure change no longer moves the sidebar and toolbar to that tab's database. (#2026)
 - Row edits, fetch all rows, and multi-statement scripts now write to the database the tab is bound to, not whichever database another tab last used. (#2026)

--- a/Packages/TableProOracle/Package.resolved
+++ b/Packages/TableProOracle/Package.resolved
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/TableProApp/oracle-nio",
       "state" : {
-        "revision" : "23c77812ed90259243a761d7fdea19db47d3ca41"
+        "revision" : "a5b3b355f24c807ce481f0cd68f2e9b0f5ec64e5"
       }
     },
     {

--- a/Packages/TableProOracle/Package.swift
+++ b/Packages/TableProOracle/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/TableProApp/oracle-nio",
-            revision: "23c77812ed90259243a761d7fdea19db47d3ca41"
+            revision: "a5b3b355f24c807ce481f0cd68f2e9b0f5ec64e5"
         ),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.29.0"),

--- a/TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d2a64118b7173c5448dbdddd34fc090bd8c35bf8ef198e84a0d2a409f05bd756",
+  "originHash" : "a7ea40e42fc733b91e578fa5c5641697f677c5a7f07b2274a3865fc661698ab3",
   "pins" : [
     {
       "identity" : "bigint",
@@ -24,7 +24,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/TableProApp/oracle-nio",
       "state" : {
-        "revision" : "23c77812ed90259243a761d7fdea19db47d3ca41"
+        "revision" : "a5b3b355f24c807ce481f0cd68f2e9b0f5ec64e5"
       }
     },
     {

--- a/TableProMobile/TableProMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TableProMobile/TableProMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c9d7d02aa50c949c62d1478830d106fc079061e3003d59b796e7255be6eaa1be",
+  "originHash" : "fa5148407a13f55422d2128e0ec0fd6c4d156ebce806581c5ca4377fbaa42305",
   "pins" : [
     {
       "identity" : "bigint",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/TableProApp/oracle-nio",
       "state" : {
-        "revision" : "23c77812ed90259243a761d7fdea19db47d3ca41"
+        "revision" : "a5b3b355f24c807ce481f0cd68f2e9b0f5ec64e5"
       }
     },
     {


### PR DESCRIPTION
Closes #2038. Stacked on #2034, so review that first.

## What was actually wrong

Half of what I filed in #2038 was wrong, and the research corrected it.

**TCP_NODELAY was never missing.** `NIOTSConnectionBootstrap.init?(validatingGroup:)` appends it to itself, exactly as `ClientBootstrap` does. Confirmed by connecting a real NIOTS channel to a live listener and reading the options back: `[baseline-no-options] TCP_NODELAY=1`. The explicit `TCP_NODELAY` call already in the `ClientBootstrap` branch is itself redundant. So there was no Nagle latency to fix.

**Keepalive was genuinely missing.** `SO_KEEPALIVE` is set only on the `ClientBootstrap` branch, and Apple platforms never take it: `defaultEventLoopGroup` returns `NIOTSEventLoopGroup.singleton` under `canImport(Network)`, which is true on macOS as well as iOS. Both shipped apps ran without keepalive.

## The fix

[TableProApp/oracle-nio#8](https://github.com/TableProApp/oracle-nio/pull/8) adds `SO_KEEPALIVE` plus a 60 second keepalive idle to the NIOTS branch. This re-pins to that revision, `a5b3b35`.

The idle time matters more than the flag. The system default is two hours, long enough for a NAT or firewall to drop an idle Oracle session first, which is the failure this prevents.

Socket options are safe to set on a NIOTS bootstrap: `StateManagedNWConnectionChannel.setOption0` routes `SocketOption` through `TCPOptions.applyChannelOption`, which maps `SO_KEEPALIVE` and `TCP_KEEPALIVE` onto `NWProtocolTCP.Options`. An *unsupported* option throws `NIOTSErrors.UnsupportedSocketOption` and fails the connect, so this was worth checking rather than assuming.

`TCP_KEEPALIVE` is Darwin only (Linux spells it `TCP_KEEPIDLE`), so it stays inside the existing `#if canImport(Network)` guard and the `ClientBootstrap` branch is untouched. The two branches are therefore not identical: the NIOTS one tunes idle, the socket one keeps the system default.

## Verification

- `swift test` on `Packages/TableProOracle` against the new pin: 62 of 62 passing, after a clean `.build`.
- All three committed `Package.resolved` files re-resolved to `a5b3b35`: the package's own, and both Xcode projects'.
- The patch was compiled through TablePro's real dependency path before being pushed.

Not verified: that keepalive probes actually keep a session alive through a specific NAT. That needs a long-idle connection behind real network equipment.

## Note

[TableProApp/oracle-nio#8](https://github.com/TableProApp/oracle-nio/pull/8) is open against `tablepro-main` and not merged. The pin is by exact revision so this works either way, but the fork PR should be merged so `tablepro-main` does not lose the change on a future re-pin.