### PR TITLE
fix(ios): ask the system for Local Network access instead of guessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- On iPhone and iPad, connecting to a database on your own network now asks for Local Network access when it is actually needed, instead of guessing from the address. Networks that use public addresses were never asked about, so those connections failed with an unhelpful error. (#2040)
+- Connecting with no network, or on a captive portal, no longer reports a Local Network permission problem on iPhone and iPad. (#2040)
 - An open tab now keeps running against the database it was opened on, so changing the database in the sidebar no longer breaks it with a "table doesn't exist" error. (#2026)
 - Saving a table structure change no longer moves the sidebar and toolbar to that tab's database. (#2026)
 - Row edits, fetch all rows, and multi-statement scripts now write to the database the tab is bound to, not whichever database another tab last used. (#2026)

--- a/TableProMobile/TableProMobile/Helpers/AppError.swift
+++ b/TableProMobile/TableProMobile/Helpers/AppError.swift
@@ -62,7 +62,7 @@ enum ErrorClassifier {
         }
 
         let host = context.host ?? ""
-        let mayUseLocalNetwork = context.sshEnabled || LocalNetworkPermission.isLocalNetworkHost(host)
+        let mayUseLocalNetwork = context.sshEnabled || LocalNetworkPermission.mayBeLocalNetworkHost(host)
         let timedOut = message.contains("timeout") || message.contains("timed out") || message.contains("operation timed out") || message.contains("system error: 60")
         if mayUseLocalNetwork && timedOut {
             return network(error, context: context)
@@ -157,7 +157,7 @@ enum ErrorClassifier {
 
         let isTimeout = lowered.contains("timeout") || lowered.contains("timed out") || lowered.contains("operation timed out") || lowered.contains("system error: 60")
         let host = context.host ?? ""
-        let mayUseLocalNetwork = context.sshEnabled || LocalNetworkPermission.isLocalNetworkHost(host)
+        let mayUseLocalNetwork = context.sshEnabled || LocalNetworkPermission.mayBeLocalNetworkHost(host)
 
         if isTimeout && mayUseLocalNetwork {
             recovery = String(localized: "Local Network access may be blocked. Open Settings > Privacy & Security > Local Network and turn TablePro on.")

--- a/TableProMobile/TableProMobile/Platform/LocalNetworkPermission.swift
+++ b/TableProMobile/TableProMobile/Platform/LocalNetworkPermission.swift
@@ -1,3 +1,4 @@
+import dnssd
 import Foundation
 import Network
 import os
@@ -6,108 +7,157 @@ enum LocalNetworkPermissionError: Error, LocalizedError {
     case unavailable
 
     var errorDescription: String? {
-        String(localized: "Local Network access is required. Open Settings > Privacy & Security > Local Network and turn TablePro on.")
+        String(localized: """
+            Local Network access is required. Open Settings > Privacy & Security > Local Network \
+            and turn TablePro on. If it is already on, restart the device or update to iOS 18.6 or later.
+            """)
     }
 }
 
+/// There is no API that reports Local Network permission directly. The system
+/// only reveals it on a connection you actually make, so this opens a UDP
+/// connection to the host the caller is about to use and reads the reason off
+/// that connection's path. Connecting a UDP socket triggers the permission
+/// alert without putting a packet on the wire, so the probe costs nothing the
+/// caller was not already about to spend.
 actor LocalNetworkPermission {
     static let shared = LocalNetworkPermission()
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "LocalNetworkPermission")
-    private static let promptTimeout: Duration = .seconds(5)
-    private static let triggerServiceType = "_ssh._tcp"
+    private static let quietDeadline: Duration = .seconds(2)
+    private static let promptDeadline: Duration = .seconds(30)
+    private static let discardPort: NWEndpoint.Port = 9
 
-    enum Resolution: Sendable {
-        case unknown
+    private enum Outcome: Sendable {
         case granted
-        case unavailable
+        case denied
+        case indeterminate
     }
 
-    private var resolution: Resolution = .unknown
-    private var inFlight: Task<Resolution, Never>?
+    private enum Event: Sendable {
+        case granted
+        case denied
+        case ended
+        case quietDeadline
+        case promptDeadline
+    }
+
+    private var inFlight: [String: Task<Outcome, Never>] = [:]
 
     func ensureAccess(for host: String) async throws {
-        guard Self.isLocalNetworkHost(host) else { return }
-
-        switch resolution {
-        case .granted:
-            return
-        case .unavailable:
-            throw LocalNetworkPermissionError.unavailable
-        case .unknown:
-            let result = await resolve()
-            if case .unavailable = result {
-                throw LocalNetworkPermissionError.unavailable
-            }
-        }
+        guard !Self.isLoopback(host) else { return }
+        guard case .denied = await probe(host) else { return }
+        throw LocalNetworkPermissionError.unavailable
     }
 
-    private func resolve() async -> Resolution {
-        if let inFlight {
-            return await inFlight.value
+    /// Deliberately not cached. A UDP connection to a public host reports
+    /// `.ready` without any Local Network privilege, so caching that would skip
+    /// the probe for the next connection to a LAN host. Denial is not cached
+    /// either, because the user can grant the permission from the alert.
+    private func probe(_ host: String) async -> Outcome {
+        if let existing = inFlight[host] {
+            return await existing.value
         }
-
-        let task = Task<Resolution, Never> {
-            await Self.runPrompt()
-        }
-        inFlight = task
-
-        let result = await task.value
-        resolution = result
-        inFlight = nil
-        return result
+        let task = Task { await Self.runProbe(host: host) }
+        inFlight[host] = task
+        let outcome = await task.value
+        inFlight[host] = nil
+        return outcome
     }
 
-    private static func runPrompt() async -> Resolution {
-        let browser = NWBrowser(
-            for: .bonjourWithTXTRecord(type: triggerServiceType, domain: nil),
-            using: NWParameters()
-        )
-        let (stream, continuation) = AsyncStream<NWBrowser.State>.makeStream()
+    private static func runProbe(host: String) async -> Outcome {
+        let connection = NWConnection(host: NWEndpoint.Host(host), port: discardPort, using: .udp)
+        let (stream, continuation) = AsyncStream<Event>.makeStream()
 
-        browser.stateUpdateHandler = { state in
-            logger.info("NWBrowser state: \(String(describing: state), privacy: .public)")
-            continuation.yield(state)
+        connection.pathUpdateHandler = { path in
+            guard path.status == .unsatisfied, path.unsatisfiedReason == .localNetworkDenied else { return }
+            continuation.yield(.denied)
+        }
+
+        connection.stateUpdateHandler = { state in
             switch state {
-            case .ready, .failed, .cancelled, .waiting:
-                continuation.finish()
+            case .ready:
+                continuation.yield(.granted)
+            case .waiting(let error):
+                if isPolicyDenied(error) || connection.currentPath?.unsatisfiedReason == .localNetworkDenied {
+                    continuation.yield(.denied)
+                }
+            case .failed, .cancelled:
+                continuation.yield(.ended)
             default:
                 break
             }
         }
 
-        browser.start(queue: .global(qos: .userInitiated))
+        let deadlines = Task {
+            try? await Task.sleep(for: quietDeadline)
+            continuation.yield(.quietDeadline)
+            try? await Task.sleep(for: promptDeadline - quietDeadline)
+            continuation.yield(.promptDeadline)
+        }
 
-        let timeoutTask = Task {
-            try? await Task.sleep(for: promptTimeout)
+        connection.start(queue: .global(qos: .userInitiated))
+
+        defer {
+            deadlines.cancel()
+            connection.stateUpdateHandler = nil
+            connection.pathUpdateHandler = nil
+            connection.cancel()
             continuation.finish()
         }
 
-        var resolved: Resolution = .unknown
-        for await state in stream {
-            switch state {
-            case .ready:
-                resolved = .granted
-            case .waiting, .failed:
-                resolved = .unavailable
-            case .cancelled:
-                break
-            default:
-                continue
+        var sawDenial = false
+        for await event in stream {
+            switch event {
+            case .granted:
+                return .granted
+            case .denied:
+                sawDenial = true
+            case .quietDeadline:
+                // Nothing was reported, so this is an ordinary unreachable host
+                // or a network that is down. Let the driver report its own error.
+                if !sawDenial { return .indeterminate }
+            case .ended, .promptDeadline:
+                return sawDenial ? .denied : .indeterminate
             }
         }
-
-        timeoutTask.cancel()
-        browser.cancel()
-        return resolved
+        return sawDenial ? .denied : .indeterminate
     }
 
-    static func isLocalNetworkHost(_ host: String) -> Bool {
+    /// A `.local` name fails during mDNS resolution rather than at the path, so
+    /// the denial arrives as a DNS policy error instead of an unsatisfied path.
+    private static func isPolicyDenied(_ error: NWError) -> Bool {
+        guard case .dns(let code) = error else { return false }
+        return Int(code) == Int(kDNSServiceErr_PolicyDenied)
+    }
+
+    /// Loopback is the one destination the system never treats as local network,
+    /// so it is the only case worth skipping before probing. Everything else is
+    /// left to the system, which owns the definition.
+    static func isLoopback(_ host: String) -> Bool {
+        let lowered = host.lowercased()
+        if lowered == "localhost" || lowered.hasSuffix(".localhost") { return true }
+        if let address = IPv4Address(lowered) {
+            return Array(address.rawValue).first == 127
+        }
+        guard let address = IPv6Address(lowered) else { return false }
+        let bytes = Array(address.rawValue)
+        guard bytes.count == 16 else { return false }
+        if bytes == Array(repeating: 0, count: 15) + [1] { return true }
+        guard bytes[0..<10].allSatisfy({ $0 == 0 }), bytes[10] == 0xff, bytes[11] == 0xff else { return false }
+        return bytes[12] == 127
+    }
+
+    /// A hint for wording an error message, never a gate. TN3179 defines a local
+    /// network by the interface it is reachable on, which an address range
+    /// cannot answer, so this is right often enough to phrase a suggestion and
+    /// not right enough to decide whether to ask for permission.
+    static func mayBeLocalNetworkHost(_ host: String) -> Bool {
         let lowered = host.lowercased()
         if lowered.hasSuffix(".local") { return true }
-        if lowered == "localhost" { return false }
+        if isLoopback(lowered) { return false }
 
-        if let bytes = IPv4Address(host)?.rawValue, bytes.count == 4 {
+        if let bytes = IPv4Address(lowered)?.rawValue, bytes.count == 4 {
             let octets = Array(bytes)
             if octets[0] == 10 { return true }
             if octets[0] == 172, (16...31).contains(octets[1]) { return true }
@@ -116,7 +166,7 @@ actor LocalNetworkPermission {
             return false
         }
 
-        if let bytes = IPv6Address(host)?.rawValue, !bytes.isEmpty {
+        if let bytes = IPv6Address(lowered)?.rawValue, !bytes.isEmpty {
             let octets = Array(bytes)
             if (octets[0] & 0xfe) == 0xfc { return true }
             if octets.count >= 2, octets[0] == 0xfe, (octets[1] & 0xc0) == 0x80 { return true }

--- a/TableProMobile/TableProMobileTests/LocalNetworkPermissionTests.swift
+++ b/TableProMobile/TableProMobileTests/LocalNetworkPermissionTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+@testable import TableProMobile
+import Testing
+
+@Suite("LocalNetworkPermission host classification")
+struct LocalNetworkPermissionTests {
+    @Test("Loopback names and addresses are recognised", arguments: [
+        "localhost",
+        "LOCALHOST",
+        "db.localhost",
+        "127.0.0.1",
+        "127.1.2.3",
+        "::1",
+        "::ffff:127.0.0.1"
+    ])
+    func loopbackIsRecognised(host: String) {
+        #expect(LocalNetworkPermission.isLoopback(host))
+    }
+
+    @Test("Everything reachable off-device is not loopback", arguments: [
+        "192.168.1.10",
+        "10.0.0.5",
+        "8.8.8.8",
+        "128.30.2.121",
+        "nas.local",
+        "db.corp.internal",
+        "::",
+        "2001:4860:4860::8888",
+        ""
+    ])
+    func nonLoopbackIsNotSkipped(host: String) {
+        #expect(!LocalNetworkPermission.isLoopback(host))
+    }
+
+    @Test("A LAN on public addresses is probed rather than skipped")
+    func publicAddressLANIsStillProbed() {
+        // The old classifier skipped anything outside RFC1918, which meant a
+        // directly attached network using public addresses never reached the
+        // permission check at all.
+        #expect(!LocalNetworkPermission.isLoopback("128.30.2.121"))
+        #expect(!LocalNetworkPermission.isLoopback("nas.lan"))
+    }
+
+    @Test("The messaging hint still recognises the common private ranges", arguments: [
+        "10.0.0.5",
+        "172.16.4.1",
+        "172.31.255.254",
+        "192.168.0.1",
+        "169.254.1.1",
+        "nas.local",
+        "fd00::1",
+        "fe80::1"
+    ])
+    func hintMatchesPrivateRanges(host: String) {
+        #expect(LocalNetworkPermission.mayBeLocalNetworkHost(host))
+    }
+
+    @Test("The messaging hint does not claim public or loopback hosts", arguments: [
+        "8.8.8.8",
+        "128.30.2.121",
+        "172.32.0.1",
+        "172.15.0.1",
+        "localhost",
+        "127.0.0.1",
+        "2001:4860:4860::8888",
+        "db.example.com"
+    ])
+    func hintExcludesPublicAndLoopback(host: String) {
+        #expect(!LocalNetworkPermission.mayBeLocalNetworkHost(host))
+    }
+}


### PR DESCRIPTION
Closes #2040. Independent of #2034 and #2041, branches off `main`.

## The two bugs

**Local was decided by address range.** `isLocalNetworkHost` returned true only for RFC1918, link-local and ULA addresses plus a `.local` suffix. [TN3179](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy) defines it by the interface: *"A local network is an IP network associated with a broadcast-capable network interface... A local network address is any address on a local network."* No address range appears in the definition. So a LAN using public addresses, or any plain hostname like `nas.lan` or `db.corp.internal`, was never asked about and failed with an unhelpful driver error. Hostnames were the bigger hole in practice.

**Permission state was inferred from a Bonjour browse**, mapping `.ready` to granted and `.waiting` to denied. Bare `.waiting` is the ordinary transient state, so no network or a captive portal was reported to the user as a permission problem. The result was also cached for the process lifetime, so turning the toggle on in Settings did nothing until relaunch.

There is a third, worse possibility: two Apple forum threads report that `NWBrowser`'s first state update is always `.ready` regardless of privacy state. If that holds, the old code resolved `granted` on the first callback and **never fired in the one case it existed for**. Forum-attested only, so treat it as motivation rather than proof.

## What it does now

There is no API that reports this state in general. Quinn's FAQ-9 says so directly: *"There is no API that directly returns your local network access state."* The system only reveals it on a connection you actually make, via that connection's path, so the probe is now an `NWConnection` to the host the caller is about to use.

It is a **UDP** connection to the discard port. TN3179: *"connect a UDP socket to a local network address. This triggers the local network alert without generating any network traffic."* No SYN, no server log line, no failed-connect counter. The check is per destination address, so the port is irrelevant and `ensureAccess(for:)` keeps its signature. None of the six call sites move.

Classification is gone. Loopback is skipped, everything else is probed, and the system decides what counts as local. The probe is self-classifying, because the OS only reports `localNetworkDenied` for addresses it considers local.

**Two deadlines.** 2s of silence returns indeterminate and throws nothing, so airplane mode and captive portals cost 2s and produce the driver's real error rather than a permission error. Only once a denial is actually observed does it wait up to 30s, because the alert may be on screen and TN3179 guarantees the system retries automatically when the user grants.

**Nothing is cached.** A UDP connection to a public host reports `.ready` without any Local Network privilege, so caching granted would skip the probe for the next LAN connection. Denial is not cached either, since the user can grant it from the alert. Concurrency is handled by per-host single-flight instead.

`.local` names fail at mDNS resolution rather than at the path, so `kDNSServiceErr_PolicyDenied` is checked alongside the path reason. Both are Apple-documented signals.

## Knock-on change

`AppError` used the classifier twice to word a timeout message. That heuristic is fine for phrasing a hint and wrong as a gate, so it is renamed `mayBeLocalNetworkHost` and kept for messaging only. The gate no longer uses it.

## Verification

- SwiftLint `--strict` clean; the new files parse under `swiftc -parse` for `arm64-apple-ios18.0`.
- Unit tests for `isLoopback` and `mayBeLocalNetworkHost`, including the public-address-LAN case that was wrong before.

**Not verified, and it needs a device.** TN3179: *"The simulator doesn't support local network privacy. Test your local network privacy behavior on a real device."* The iOS build was not compiled here either, for the DerivedData reason noted on #2034. Please run this matrix on hardware:

1. Permission denied, LAN host: actionable error, no long hang.
2. Permission granted, LAN host: no added delay.
3. Undetermined, LAN host: alert appears, Allow proceeds without a second tap on Connect.
4. Airplane mode: must not mention permissions, must return in about 2s.
5. Public internet host: no added latency.

Deleting the app is the only clean way to reset the permission between runs.

## Residual risk

TN3179 documents the UDP connect as a *trigger* and `unsatisfiedReason` as a *detector* for TCP. Combining them is a synthesis, not something Apple spells out. If the reason never arrives for UDP on device, the fix is to switch the probe to `.tcp` on the real port, which is the fully documented form and costs one real connection per attempt. Every call site has `port` in scope.

`NSBonjourServices` in Info.plist is now unused, since resolving a `.local` name is a DNS operation rather than a Bonjour browse. Left in place; worth removing separately once `.local` connections are confirmed on device.