### PR TITLE
feat(plugin-oracle): support SYSDBA and SYSOPER logons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Oracle connections can now sign in as SYSDBA or SYSOPER, on both Mac and mobile. Administrative logons previously had no way to connect. (#2039)
 - Oracle now works in TablePro Mobile: connect, browse schemas and tables, run queries, and edit rows, with a Service Name or SID picker and the same SSL modes as the Mac app. (#2033)
 - When an Oracle listener rejects the connect identifier, the connection form now names which one was wrong and offers to switch between Service Name and SID in one tap. (#2033)
 - Redshift external schemas now list their tables. Spectrum, federated query, cross-database, and datashare schemas showed up empty because their tables are not in the standard catalog.

--- a/Packages/TableProOracle/Sources/TableProOracleCore/OracleConnectionOptions.swift
+++ b/Packages/TableProOracle/Sources/TableProOracleCore/OracleConnectionOptions.swift
@@ -6,10 +6,20 @@ public struct OracleConnectionOptions: Sendable, Equatable {
         case sid
     }
 
+    /// The privilege the session is opened with. SYSDBA and SYSOPER are
+    /// administrative logons that Oracle treats as a different identity from a
+    /// normal connection by the same user.
+    public enum Role: String, Sendable, Equatable, Codable, CaseIterable {
+        case normal
+        case sysdba
+        case sysoper
+    }
+
     public enum AdditionalFieldKey {
         public static let connectionType = "oracleConnectionType"
         public static let serviceName = "oracleServiceName"
         public static let sid = "oracleSID"
+        public static let role = "oracleRole"
     }
 
     public static let defaultPort = 1_521
@@ -23,6 +33,7 @@ public struct OracleConnectionOptions: Sendable, Equatable {
     public var identifierMode: IdentifierMode
     public var serviceName: String
     public var sid: String
+    public var role: Role
     public var tls: OracleTLSDescription
     public var loginTimeoutSeconds: Double
 
@@ -35,6 +46,7 @@ public struct OracleConnectionOptions: Sendable, Equatable {
         identifierMode: IdentifierMode = .service,
         serviceName: String = "",
         sid: String = "",
+        role: Role = .normal,
         tls: OracleTLSDescription = OracleTLSDescription(),
         loginTimeoutSeconds: Double = OracleConnectionOptions.defaultLoginTimeoutSeconds
     ) {
@@ -46,6 +58,7 @@ public struct OracleConnectionOptions: Sendable, Equatable {
         self.identifierMode = identifierMode
         self.serviceName = serviceName
         self.sid = sid
+        self.role = role
         self.tls = tls
         self.loginTimeoutSeconds = loginTimeoutSeconds
     }
@@ -57,5 +70,9 @@ public struct OracleConnectionOptions: Sendable, Equatable {
 
     public static func identifierMode(from additionalFields: [String: String]) -> IdentifierMode {
         IdentifierMode(rawValue: additionalFields[AdditionalFieldKey.connectionType] ?? "") ?? .service
+    }
+
+    public static func role(from additionalFields: [String: String]) -> Role {
+        Role(rawValue: additionalFields[AdditionalFieldKey.role] ?? "") ?? .normal
     }
 }

--- a/Packages/TableProOracle/Sources/TableProOracleCore/OracleCoreConnection.swift
+++ b/Packages/TableProOracle/Sources/TableProOracleCore/OracleCoreConnection.swift
@@ -76,7 +76,7 @@ public final class OracleCoreConnection: @unchecked Sendable {
             ? .sid(identifier)
             : .serviceName(identifier)
         let tls = try OracleTLSMapper.tls(for: options.tls)
-        let connectConfig = OracleNIO.OracleConnection.Configuration(
+        var configuration = OracleNIO.OracleConnection.Configuration(
             host: options.host,
             port: options.port,
             service: service,
@@ -84,6 +84,8 @@ public final class OracleCoreConnection: @unchecked Sendable {
             password: options.password,
             tls: tls
         )
+        configuration.mode = Self.authenticationMode(for: options.role)
+        let connectConfig = configuration
         let connectLogger = nioLogger
 
         let connectionId = Self.connectionCounter.withLock { counter -> Int in
@@ -128,6 +130,14 @@ public final class OracleCoreConnection: @unchecked Sendable {
                 throw OracleCoreError.tlsHandshakeFailed(kind: kind, serverMessage: detail)
             }
             throw OracleCoreError.connectionFailed(detail)
+        }
+    }
+
+    static func authenticationMode(for role: OracleConnectionOptions.Role) -> OracleNIO.AuthenticationMode {
+        switch role {
+        case .normal: return .default
+        case .sysdba: return .sysDBA
+        case .sysoper: return .sysOPER
         }
     }
 

--- a/Packages/TableProOracle/Tests/TableProOracleCoreTests/OracleRoleTests.swift
+++ b/Packages/TableProOracle/Tests/TableProOracleCoreTests/OracleRoleTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import TableProOracleCore
+
+final class OracleRoleTests: XCTestCase {
+    func testRoleKeyMatchesTheMacKey() {
+        XCTAssertEqual(OracleConnectionOptions.AdditionalFieldKey.role, "oracleRole")
+    }
+
+    func testRoleRawValuesAreStableWireStrings() {
+        XCTAssertEqual(OracleConnectionOptions.Role.normal.rawValue, "normal")
+        XCTAssertEqual(OracleConnectionOptions.Role.sysdba.rawValue, "sysdba")
+        XCTAssertEqual(OracleConnectionOptions.Role.sysoper.rawValue, "sysoper")
+    }
+
+    func testRoleDefaultsToNormalWhenAbsent() {
+        XCTAssertEqual(OracleConnectionOptions.role(from: [:]), .normal)
+    }
+
+    func testRoleDefaultsToNormalForAnUnknownValue() {
+        let fields = [OracleConnectionOptions.AdditionalFieldKey.role: "sysasm"]
+        XCTAssertEqual(OracleConnectionOptions.role(from: fields), .normal)
+    }
+
+    func testRoleIsReadFromAdditionalFields() {
+        for role in OracleConnectionOptions.Role.allCases {
+            let fields = [OracleConnectionOptions.AdditionalFieldKey.role: role.rawValue]
+            XCTAssertEqual(OracleConnectionOptions.role(from: fields), role)
+        }
+    }
+
+    func testEveryRoleMapsToTheMatchingOracleAuthenticationMode() {
+        XCTAssertEqual(
+            OracleCoreConnection.authenticationMode(for: .normal).description,
+            "DEFAULT"
+        )
+        XCTAssertEqual(
+            OracleCoreConnection.authenticationMode(for: .sysdba).description,
+            "SYSDBA"
+        )
+        XCTAssertEqual(
+            OracleCoreConnection.authenticationMode(for: .sysoper).description,
+            "SYSOPER"
+        )
+    }
+
+    func testOptionsDefaultToANormalLogon() {
+        let options = OracleConnectionOptions(host: "localhost", user: "scott", password: "tiger")
+        XCTAssertEqual(options.role, .normal)
+    }
+}

--- a/Plugins/OracleDriverPlugin/OraclePlugin.swift
+++ b/Plugins/OracleDriverPlugin/OraclePlugin.swift
@@ -51,6 +51,25 @@ final class OraclePlugin: NSObject, TableProPlugin, DriverPlugin, PluginDiagnost
                 fieldId: OracleConnectionOptions.AdditionalFieldKey.connectionType,
                 values: [OracleConnectionOptions.IdentifierMode.sid.rawValue]
             )
+        ),
+        ConnectionField(
+            id: OracleConnectionOptions.AdditionalFieldKey.role,
+            label: "Role",
+            defaultValue: OracleConnectionOptions.Role.normal.rawValue,
+            fieldType: .dropdown(options: [
+                ConnectionField.DropdownOption(
+                    value: OracleConnectionOptions.Role.normal.rawValue,
+                    label: "Normal"
+                ),
+                ConnectionField.DropdownOption(
+                    value: OracleConnectionOptions.Role.sysdba.rawValue,
+                    label: "SYSDBA"
+                ),
+                ConnectionField.DropdownOption(
+                    value: OracleConnectionOptions.Role.sysoper.rawValue,
+                    label: "SYSOPER"
+                )
+            ])
         )
     ]
 
@@ -286,6 +305,7 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             identifierMode: OracleConnectionOptions.identifierMode(from: config.additionalFields),
             serviceName: config.additionalFields[OracleConnectionOptions.AdditionalFieldKey.serviceName] ?? "",
             sid: config.additionalFields[OracleConnectionOptions.AdditionalFieldKey.sid] ?? "",
+            role: OracleConnectionOptions.role(from: config.additionalFields),
             tls: config.ssl.oracleTLSDescription
         ))
         do {

--- a/TableProMobile/TableProMobile/Drivers/OracleDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/OracleDriver.swift
@@ -42,6 +42,7 @@ final class OracleDriver: DatabaseDriver, @unchecked Sendable {
             identifierMode: OracleConnectionOptions.identifierMode(from: connection.additionalFields),
             serviceName: connection.additionalFields[OracleConnectionOptions.AdditionalFieldKey.serviceName] ?? "",
             sid: connection.additionalFields[OracleConnectionOptions.AdditionalFieldKey.sid] ?? "",
+            role: OracleConnectionOptions.role(from: connection.additionalFields),
             tls: ssl.oracleTLSDescription
         ))
         host = connection.host

--- a/TableProMobile/TableProMobile/ViewModels/ConnectionFormViewModel.swift
+++ b/TableProMobile/TableProMobile/ViewModels/ConnectionFormViewModel.swift
@@ -37,6 +37,7 @@ final class ConnectionFormViewModel {
     var oracleConnectionType: OracleConnectionOptions.IdentifierMode = .service
     var oracleServiceName = ""
     var oracleSID = ""
+    var oracleRole: OracleConnectionOptions.Role = .normal
 
     // Organization
     var groupId: UUID?
@@ -92,6 +93,7 @@ final class ConnectionFormViewModel {
         oracleConnectionType = OracleConnectionOptions.identifierMode(from: conn.additionalFields)
         oracleServiceName = conn.additionalFields[OracleConnectionOptions.AdditionalFieldKey.serviceName] ?? ""
         oracleSID = conn.additionalFields[OracleConnectionOptions.AdditionalFieldKey.sid] ?? ""
+        oracleRole = OracleConnectionOptions.role(from: conn.additionalFields)
         sshEnabled = conn.sshEnabled
         groupId = conn.groupId
         tagId = conn.tagId
@@ -416,6 +418,7 @@ final class ConnectionFormViewModel {
                 oracleConnectionType.rawValue
             conn.additionalFields[OracleConnectionOptions.AdditionalFieldKey.serviceName] = oracleServiceName
             conn.additionalFields[OracleConnectionOptions.AdditionalFieldKey.sid] = oracleSID
+            conn.additionalFields[OracleConnectionOptions.AdditionalFieldKey.role] = oracleRole.rawValue
         }
         conn.safeModeLevel = safeModeLevel
         if sshEnabled {

--- a/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
@@ -301,6 +301,12 @@ struct ConnectionFormView: View {
                     .autocorrectionDisabled()
                     .keyboardType(.asciiCapable)
             }
+
+            Picker(String(localized: "Role"), selection: $viewModel.oracleRole) {
+                Text(String(localized: "Normal")).tag(OracleConnectionOptions.Role.normal)
+                Text(verbatim: "SYSDBA").tag(OracleConnectionOptions.Role.sysdba)
+                Text(verbatim: "SYSOPER").tag(OracleConnectionOptions.Role.sysoper)
+            }
         }
     }
 

--- a/TableProMobile/TableProMobileTests/ConnectionFormViewModelOracleTests.swift
+++ b/TableProMobile/TableProMobileTests/ConnectionFormViewModelOracleTests.swift
@@ -95,6 +95,27 @@ struct ConnectionFormViewModelOracleTests {
         #expect(secured.sslConfiguration?.mode == .verifyCa)
     }
 
+    @Test("Role defaults to Normal and hydrates from additionalFields")
+    func hydratesRole() {
+        let plain = ConnectionFormViewModel(editing: makeOracleConnection(additionalFields: [:]))
+        #expect(plain.oracleRole == .normal)
+
+        let admin = ConnectionFormViewModel(editing: makeOracleConnection(additionalFields: [
+            OracleConnectionOptions.AdditionalFieldKey.role: "sysdba"
+        ]))
+        #expect(admin.oracleRole == .sysdba)
+    }
+
+    @Test("Saving writes the role under the key the Mac app reads")
+    func writesRole() {
+        let viewModel = ConnectionFormViewModel()
+        viewModel.type = .oracle
+        viewModel.host = "db.example.com"
+        viewModel.oracleRole = .sysoper
+
+        #expect(viewModel.buildConnection().additionalFields["oracleRole"] == "sysoper")
+    }
+
     @Test("An Oracle connection round-trips through the form unchanged")
     func roundTripsThroughTheForm() {
         let original = makeOracleConnection(

--- a/docs/databases/oracle.mdx
+++ b/docs/databases/oracle.mdx
@@ -35,6 +35,7 @@ Enter host, port, username, password, and service name, then click **Save & Conn
 | **Port** | `1521` | Listener port |
 | **Service Name** | - | **Required**. Check `tnsnames.ora` if unclear. To connect by SID instead, set **Connection Type** to SID and enter the SID. |
 | **Username** | - | Requires username/password auth (no OS auth) |
+| **Role** | `Normal` | Set to SYSDBA or SYSOPER for an administrative logon. The account needs the matching privilege, and Oracle treats the session as `SYS` rather than as the user you signed in with. |
 
 <Frame caption="Oracle connection form">
   <img className="block dark:hidden" src="/images/oracle-connection-form.png" alt="Oracle connection form with Connection Type and Service Name fields" />
@@ -49,7 +50,11 @@ Enter host, port, username, password, and service name, then click **Save & Conn
 
 **Remote**: Standard host/port/credentials, service name from DBA
 
-**Oracle Cloud (ADB)**: Copy host, port, and service name (format `mydb_tp`) from the TLS connection string in the Oracle Cloud Console, then set SSL mode to **Required** (or **Verify CA** with the CA certificate). No wallet needed: the connection uses one-way TLS, and the driver does not read Oracle wallet files.
+**Oracle Cloud (ADB)**: Copy host, port, and service name (format `mydb_tp`) from the TLS connection string in the Oracle Cloud Console, then set SSL mode to **Required** (or **Verify CA** with the CA certificate). TablePro connects with one-way TLS and does not read Oracle wallet files.
+
+This needs the database to allow TLS without mutual TLS, which means setting **Mutual TLS (mTLS) authentication** to *Not Required* and giving the database an access control list or a private endpoint. Oracle rejects the connection otherwise. Use the TLS connection string, not the mTLS one: mTLS is served on port 1522 only, while TLS is on 1521 or 1522.
+
+If you have an older wallet that stopped working, this is the path to switch to. Oracle's DigiCert G1 roots were distrusted in April 2026, so ADB wallets generated on or before 28 January 2026 no longer connect. One-way TLS is unaffected.
 
 ## SSL/TLS
 


### PR DESCRIPTION
Addresses the first item of #2039. Stacked on #2034.

## Scope

#2039 lists four things. This ships **Role only**, and I want to be explicit that the other three are not in here.

Role is the one that needs no new field type, no file to acquire, no storage decision, and no Mac/iOS asymmetry. It is also the one with a real hole underneath it: there was no way to open an administrative session at all, on either platform.

## It needed no fork change

OracleNIO already carries the auth mode on the wire. `OracleConnection.Configuration` has `public var mode: AuthenticationMode`, and `AuthenticationMode` exposes `.sysDBA` and `.sysOPER` factories that `OracleFrontendMessageEncoder` turns into the protocol flags. The fork exercises it in its own `privilegedTest()`. So this is a TablePro-side change: a field, a key, and a mapping.

## Shape

`OracleConnectionOptions.Role` (`normal` / `sysdba` / `sysoper`) with a new `oracleRole` additionalFields key, mapped to `AuthenticationMode` in the core so both platforms get it from one place. The macOS plugin declares a Role dropdown; the iOS form gets a matching picker.

Unknown role values fall back to `normal` rather than failing, so a connection carrying a value this build does not know about still opens as an ordinary session.

## Docs correction, unrelated to the code

`docs/databases/oracle.mdx` claimed ADB needs no wallet, unqualified. That is only true when mTLS is set to *Not Required* **and** the database has an access control list or private endpoint, which the page never said. It also matters more now: Oracle's DigiCert G1 roots were distrusted in April 2026, so ADB wallets generated on or before 28 January 2026 have stopped working, and users arriving with a dead wallet land on exactly this page. One-way TLS, the mode TablePro supports, is unaffected. Corrected, with the port detail (mTLS is 1522 only).

## Verification

- `swift test` on `Packages/TableProOracle`: 69 of 69 passing, up from 62. New tests cover the wire-string stability of the role key and values, unknown-value fallback, and that each role maps to the matching `AuthenticationMode`.
- iOS form round-trip tests for hydrate and save.
- SwiftLint `--strict` clean.
- Not compiled: the macOS plugin target and the iOS app, same DerivedData limitation as #2034.
- Not verified against a server: no Oracle instance here has a SYSDBA account to test against. A SYSDBA logon should be confirmed on a real database before release, since the privilege flag is only observable on the wire.

## Release note

This adds a field to `OraclePlugin.additionalConnectionFields`, so the registry plugin needs a `plugin-oracle-v*` re-release for Mac users to see the Role dropdown. Not an ABI change and no version bump.

## Still open on #2039

TNS mode, Oracle Wallet, and certificate import on iOS. Worth recording that the research changed their ordering: OracleNIO ships `TLSConfiguration.makeOracleWalletConfiguration(wallet:walletPassword:)` and a `pemFile:` variant, so **wallet on macOS is now the cheapest of the three**, roughly a folder-path field, a password field, and a branch in `OracleTLSMapper`. It reads `ewallet.pem`; ADB Dedicated wallets ship only `ewallet.p12` and would need `NIOSSLPKCS12Bundle`. Never target `cwallet.sso`, which is unspecified and machine-bound. iOS remains the blocker there, because a wallet is a folder and a sandboxed app cannot address one by path. TNS still needs a parser written from scratch.