### PR TITLE
feat(sidebar): browse saved connections and groups from a Connections tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show Previous Workspace and Show Next Workspace move through the rail in the order it displays, on `Ctrl+Cmd+Up` and `Ctrl+Cmd+Down`. A shortcut you assigned yourself wins over a default added in a later release, and the default comes back if you reassign yours. (#1282)
 - Right-click a workspace in the rail to close every tab in it. A window holding a tab in another database stays open. (#1282)
 - The workspace rail takes the keyboard: arrow keys move the highlight, typing jumps to a name, and Return opens the workspace you land on. (#1282)
+- A Connections tab in the sidebar, next to Tables and Favorites, lists every saved connection as a tree of your groups. Double-click one, or press Return, to go to it: TablePro raises that connection's window if it is already open and opens one if it is not. A checkmark marks the connection you are in and a dot marks one open in another window. Filter the list from the sidebar's search field, and reach it with `Cmd+Option+3` or View > Show Connections Sidebar. (#1311)
 - Redshift external schemas now list their tables. Spectrum, federated query, cross-database, and datashare schemas showed up empty because their tables are not in the standard catalog.
 - External schemas are marked in the sidebar, and their tables show an external icon. External tables open read-only, because Redshift rejects `UPDATE` and `DELETE` on them.
 
@@ -83,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Reopening the last session no longer connects every window at once. The window you land on connects right away, and the rest connect when you switch to them.
+- Searching connections and groups on the welcome window now ignores accents, so typing `cafe` finds `Café`. It matches how the sidebar filters everything else. (#1311)
 - The Claude, OpenAI, and Codex model menus now list the current models.
 - A new connection window now opens over the window you were in rather than cascading, so switching connection from the rail reads as the window changing content. Move a window and it keeps where you put it. (#1282)
 - The sidebar's Tables and Favorites control now sits in the toolbar above the sidebar, next to the list it switches, instead of over the table content. It is a standard segmented control, so it shows which one is selected and works with keyboard control.

--- a/TablePro/Core/Services/Infrastructure/ConnectionActivation.swift
+++ b/TablePro/Core/Services/Infrastructure/ConnectionActivation.swift
@@ -1,0 +1,25 @@
+//
+//  ConnectionActivation.swift
+//  TablePro
+//
+
+import AppKit
+import Foundation
+
+/// Going to a saved connection means raising the window it already has, or opening one
+/// for it. A window never changes which connection it shows, so every surface that
+/// offers a list of connections routes here rather than retargeting anything in place.
+@MainActor
+internal enum ConnectionActivation {
+    internal static func open(connectionId: UUID) async {
+        do {
+            try await TabRouter.shared.route(.openConnection(connectionId))
+        } catch {
+            AlertHelper.showErrorSheet(
+                title: String(localized: "Connection Failed"),
+                message: error.localizedDescription,
+                window: NSApp.keyWindow
+            )
+        }
+    }
+}

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -98,7 +98,7 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
 // MARK: - Sidebar Toggle
 
 extension MainWindowToolbar {
-    private static let sidebarSegmentTabs: [SidebarTab] = [.tables, .favorites]
+    private static let sidebarSegmentTabs: [SidebarTab] = [.tables, .favorites, .connections]
 
     /// A one-of-N segmented toolbar control is `NSToolbarItemGroup` with `.selectOne`.
     /// Hand-building two `NSButton`s meant faking selection with border tricks and a
@@ -110,14 +110,18 @@ extension MainWindowToolbar {
     /// `defaultItemIdentifiers` listed it. Without the flag it lays out in the sidebar's own
     /// titlebar strip, and follows the divider when the sidebar collapses.
     internal static func makeSidebarSegmentGroup(target: AnyObject?, action: Selector) -> NSToolbarItemGroup {
-        let images = ["list.bullet", "star"].compactMap {
+        let images = ["list.bullet", "star", "cylinder.split.1x2"].compactMap {
             NSImage(systemSymbolName: $0, accessibilityDescription: nil)
         }
         let group = NSToolbarItemGroup(
             itemIdentifier: sidebarToggle,
             images: images,
             selectionMode: .selectOne,
-            labels: [String(localized: "Tables"), String(localized: "Favorites")],
+            labels: [
+                String(localized: "Tables"),
+                String(localized: "Favorites"),
+                String(localized: "Connections"),
+            ],
             target: target,
             action: action
         )

--- a/TablePro/Core/Services/Infrastructure/SidebarContainerViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/SidebarContainerViewController.swift
@@ -89,6 +89,7 @@ internal final class SidebarContainerViewController: NSViewController {
                     _ = state.selectedSidebarTab
                     _ = state.searchText
                     _ = state.favoritesSearchText
+                    _ = state.connectionsSearchText
                 } onChange: {
                     box.resume()
                 }
@@ -112,6 +113,9 @@ internal final class SidebarContainerViewController: NSViewController {
         case .favorites:
             activeText = state.favoritesSearchText
             placeholder = String(localized: "Filter favorites")
+        case .connections:
+            activeText = state.connectionsSearchText
+            placeholder = String(localized: "Filter connections")
         }
 
         if searchField.stringValue != activeText {
@@ -145,6 +149,8 @@ extension SidebarContainerViewController: NSSearchFieldDelegate {
             sidebarState.searchText = text
         case .favorites:
             sidebarState.favoritesSearchText = text
+        case .connections:
+            sidebarState.connectionsSearchText = text
         }
     }
 }

--- a/TablePro/Core/Services/Infrastructure/WorkspaceRailStore.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspaceRailStore.swift
@@ -34,9 +34,15 @@ internal struct WorkspaceRailEntry: Identifiable, Equatable {
 internal enum WorkspaceRailStore {
     /// Derived live from the open windows, their sessions and their tabs rather than
     /// cached, so a refresh can never blank the list it is refreshing.
-    internal static var entries: [WorkspaceRailEntry] {
-        let openIds = WindowLifecycleMonitor.shared.allConnectionIds()
+    /// Connections with a window on screen, whether or not the session finished
+    /// connecting. This is what a click interacts with: raise that window, or make one.
+    internal static var openConnectionIds: Set<UUID> {
+        WindowLifecycleMonitor.shared.allConnectionIds()
             .union(WindowManager.shared.allConnectionIds())
+    }
+
+    internal static var entries: [WorkspaceRailEntry] {
+        let openIds = openConnectionIds
         guard !openIds.isEmpty else { return [] }
 
         let sessions = DatabaseManager.shared.activeSessions

--- a/TablePro/Models/Connection/ConnectionGroupTree.swift
+++ b/TablePro/Models/Connection/ConnectionGroupTree.swift
@@ -85,14 +85,13 @@ func filterGroupTree(_ items: [ConnectionGroupTreeNode], searchText: String) -> 
     return items.compactMap { item in
         switch item {
         case .connection(let conn):
-            if conn.name.localizedCaseInsensitiveContains(searchText)
-                || conn.host.localizedCaseInsensitiveContains(searchText)
-                || conn.database.localizedCaseInsensitiveContains(searchText) {
+            let fields = [conn.name, conn.host, conn.database]
+            if fields.contains(where: { SidebarNameFilter.matches(query: searchText, candidate: $0) }) {
                 return item
             }
             return nil
         case .group(let group, let children):
-            if group.name.localizedCaseInsensitiveContains(searchText) {
+            if SidebarNameFilter.matches(query: searchText, candidate: group.name) {
                 return item
             }
             let filteredChildren = filterGroupTree(children, searchText: searchText)
@@ -102,6 +101,16 @@ func filterGroupTree(_ items: [ConnectionGroupTreeNode], searchText: String) -> 
             return nil
         }
     }
+}
+
+/// Resolves a `List` selection tag back to the node it stands for.
+func findGroupTreeNode(id: String, in items: [ConnectionGroupTreeNode]) -> ConnectionGroupTreeNode? {
+    for item in items {
+        if item.id == id { return item }
+        guard case .group(_, let children) = item else { continue }
+        if let match = findGroupTreeNode(id: id, in: children) { return match }
+    }
+    return nil
 }
 
 func filterGroupTreeByTags(_ items: [ConnectionGroupTreeNode], filter: TagFilter) -> [ConnectionGroupTreeNode] {

--- a/TablePro/Models/UI/KeyboardShortcutModels.swift
+++ b/TablePro/Models/UI/KeyboardShortcutModels.swift
@@ -127,6 +127,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case focusSidebarSearch
     case showSidebarTables
     case showSidebarFavorites
+    case showSidebarConnections
     case showPreviousTab
     case showNextTab
     case toggleWorkspaceRail
@@ -152,7 +153,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
              .reopenClosedTab, .quickSwitcher, .toggleTableBrowser,
              .toggleInspector, .toggleFilters, .toggleHistory, .toggleResults, .previousResultTab,
              .nextResultTab, .pinResultTab, .closeResultTab, .focusSidebarSearch,
-             .showSidebarTables, .showSidebarFavorites, .showPreviousTab, .showNextTab,
+             .showSidebarTables, .showSidebarFavorites, .showSidebarConnections,
+             .showPreviousTab, .showNextTab,
              .toggleWorkspaceRail, .showPreviousWorkspace, .showNextWorkspace:
             return .navigation
         }
@@ -243,6 +245,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .focusSidebarSearch: return String(localized: "Focus Sidebar Filter")
         case .showSidebarTables: return String(localized: "Show Tables Sidebar")
         case .showSidebarFavorites: return String(localized: "Show Favorites Sidebar")
+        case .showSidebarConnections: return String(localized: "Show Connections Sidebar")
         case .showPreviousTab: return String(localized: "Show Previous Tab")
         case .showNextTab: return String(localized: "Show Next Tab")
         case .toggleWorkspaceRail: return String(localized: "Toggle Workspace Rail")
@@ -527,6 +530,7 @@ struct KeyboardSettings: Codable, Equatable {
         .focusSidebarSearch: .character("f", command: true, option: true),
         .showSidebarTables: .character("1", command: true, option: true),
         .showSidebarFavorites: .character("2", command: true, option: true),
+        .showSidebarConnections: .character("3", command: true, option: true),
         .showPreviousTab: .character("[", command: true, shift: true),
         .showNextTab: .character("]", command: true, shift: true),
         .toggleWorkspaceRail: .character("0", command: true, option: true),

--- a/TablePro/Models/UI/SharedSidebarState.swift
+++ b/TablePro/Models/UI/SharedSidebarState.swift
@@ -13,6 +13,7 @@ import Foundation
 internal enum SidebarTab: String, CaseIterable {
     case tables
     case favorites
+    case connections
 }
 
 internal enum SidebarLayout: String, CaseIterable, Sendable {
@@ -26,6 +27,7 @@ final class SharedSidebarState {
 
     var searchText: String = ""
     var favoritesSearchText: String = ""
+    var connectionsSearchText: String = ""
 
     var recentTables: [RecentTableEntry] = []
 
@@ -124,6 +126,18 @@ final class SharedSidebarState {
         }
     }
 
+    var selectedConnectionsItem: String? {
+        didSet {
+            guard oldValue != selectedConnectionsItem else { return }
+            let key = SidebarPersistenceKey.selectedConnectionsItem(connectionId: connectionId)
+            if let selectedConnectionsItem {
+                UserDefaults.standard.set(selectedConnectionsItem, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+    }
+
     static var defaultLayout: SidebarLayout {
         get {
             guard let raw = UserDefaults.standard.string(forKey: SidebarPersistenceKey.defaultLayout),
@@ -159,6 +173,9 @@ final class SharedSidebarState {
         self.selectedFavorite = UserDefaults.standard.string(
             forKey: SidebarPersistenceKey.selectedFavorite(connectionId: connectionId)
         ).flatMap(FavoriteSelection.init(rawValue:))
+        self.selectedConnectionsItem = UserDefaults.standard.string(
+            forKey: SidebarPersistenceKey.selectedConnectionsItem(connectionId: connectionId)
+        )
         if AppSettingsManager.shared.general.showRecentTables {
             self.recentTables = RecentTablesStore.shared.entries(connectionId: connectionId)
         }
@@ -171,6 +188,7 @@ final class SharedSidebarState {
         self.sidebarLayout = .flat
         self.databaseFilterSelected = []
         self.selectedFavorite = nil
+        self.selectedConnectionsItem = nil
     }
 
     deinit {

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -29,6 +29,12 @@
         }
       }
     },
+    "Connections you save appear here, grouped the way you arrange them." : {
+
+    },
+    "%@, current connection" : {
+
+    },
     "\n\n… (%d more characters not shown)" : {
       "localizations" : {
         "tr" : {
@@ -314,6 +320,12 @@
         }
       }
     },
+    "Edit Connection..." : {
+
+    },
+    "Filter connections" : {
+
+    },
     "'%@' is a reserved Windows device name" : {
       "localizations" : {
         "tr" : {
@@ -342,6 +354,12 @@
         }
       }
     },
+    "No Other Connections" : {
+
+    },
+    "%@, open in another window" : {
+
+    },
     "“%@” owns database objects" : {
       "localizations" : {
         "tr" : {
@@ -369,6 +387,9 @@
           }
         }
       }
+    },
+    "Show Connections Sidebar" : {
+
     },
     "\"%@\" was changed since you opened it. Review the diff and choose how to resolve." : {
       "localizations" : {

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -784,6 +784,11 @@ struct AppMenuCommands: Commands {
             .optionalKeyboardShortcut(shortcut(for: .showSidebarFavorites))
             .disabled(!(actions?.isConnected ?? false))
 
+            Button("Show Connections Sidebar") {
+                actions?.showSidebarTab(.connections)
+            }
+            .optionalKeyboardShortcut(shortcut(for: .showSidebarConnections))
+
             Divider()
 
             Button("Toggle Results") {

--- a/TablePro/ViewModels/ConnectionGroupExpansionState.swift
+++ b/TablePro/ViewModels/ConnectionGroupExpansionState.swift
@@ -1,0 +1,71 @@
+//
+//  ConnectionGroupExpansionState.swift
+//  TablePro
+//
+
+import Foundation
+import Observation
+
+/// Which connection groups are expanded. A group is one thing wherever it is drawn,
+/// so the welcome window and every connection window's Connections tab share this
+/// state rather than each keeping their own copy.
+///
+/// Local only. `ConnectionGroup`'s CloudKit fields are written with raw string
+/// subscripts instead of a gated field enum, so a synced expansion flag would have
+/// no schema-parity guard behind it.
+@MainActor
+@Observable
+internal final class ConnectionGroupExpansionState {
+    internal static let shared = ConnectionGroupExpansionState()
+
+    internal private(set) var expandedGroupIds: Set<UUID> = []
+
+    @ObservationIgnored private let defaults: UserDefaults
+    @ObservationIgnored private let storageKey = "com.TablePro.expandedGroupIds"
+    @ObservationIgnored private let legacyCollapsedKey = "com.TablePro.collapsedGroupIds"
+
+    internal init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        let stored = defaults.stringArray(forKey: storageKey) ?? []
+        if stored.isEmpty {
+            defaults.removeObject(forKey: legacyCollapsedKey)
+        }
+        expandedGroupIds = Set(stored.compactMap { UUID(uuidString: $0) })
+    }
+
+    internal func isExpanded(_ groupId: UUID) -> Bool {
+        expandedGroupIds.contains(groupId)
+    }
+
+    internal func setExpanded(_ groupId: UUID, expanded: Bool) {
+        guard expandedGroupIds.contains(groupId) != expanded else { return }
+        var ids = expandedGroupIds
+        if expanded {
+            ids.insert(groupId)
+        } else {
+            ids.remove(groupId)
+        }
+        replace(with: ids)
+    }
+
+    internal func expand(_ ids: Set<UUID>) {
+        replace(with: expandedGroupIds.union(ids))
+    }
+
+    internal func collapse(_ ids: Set<UUID>) {
+        replace(with: expandedGroupIds.subtracting(ids))
+    }
+
+    /// Seeds every group as expanded the first time anything renders the tree, so a
+    /// new install shows its groups open instead of a column of closed rows.
+    internal func expandAllIfNeeded(groups: [ConnectionGroup]) {
+        guard expandedGroupIds.isEmpty, !groups.isEmpty else { return }
+        replace(with: Set(groups.map(\.id)))
+    }
+
+    internal func replace(with ids: Set<UUID>) {
+        guard expandedGroupIds != ids else { return }
+        expandedGroupIds = ids
+        defaults.set(ids.map(\.uuidString), forKey: storageKey)
+    }
+}

--- a/TablePro/ViewModels/WelcomeViewModel.swift
+++ b/TablePro/ViewModels/WelcomeViewModel.swift
@@ -79,19 +79,9 @@ final class WelcomeViewModel {
     /// alert appears after the sheet animation completes, no sleep needed.
     var pendingImportResultCount: Int?
 
-    var expandedGroupIds: Set<UUID> = {
-        let strings = UserDefaults.standard.stringArray(forKey: "com.TablePro.expandedGroupIds") ?? []
-        if strings.isEmpty {
-            UserDefaults.standard.removeObject(forKey: "com.TablePro.collapsedGroupIds")
-        }
-        return Set(strings.compactMap { UUID(uuidString: $0) })
-    }() {
-        didSet {
-            UserDefaults.standard.set(
-                Array(expandedGroupIds.map(\.uuidString)),
-                forKey: "com.TablePro.expandedGroupIds"
-            )
-        }
+    var expandedGroupIds: Set<UUID> {
+        get { ConnectionGroupExpansionState.shared.expandedGroupIds }
+        set { ConnectionGroupExpansionState.shared.replace(with: newValue) }
     }
 
     // MARK: - Notification Observers
@@ -183,12 +173,7 @@ final class WelcomeViewModel {
     func setUp() {
         guard connectionUpdatedCancellable == nil else { return }
 
-        if expandedGroupIds.isEmpty {
-            let allGroupIds = Set(groupStorage.loadGroups().map(\.id))
-            if !allGroupIds.isEmpty {
-                expandedGroupIds = allGroupIds
-            }
-        }
+        ConnectionGroupExpansionState.shared.expandAllIfNeeded(groups: groupStorage.loadGroups())
 
         connectionUpdatedCancellable = services.appEvents.connectionUpdated
             .receive(on: RunLoop.main)
@@ -412,6 +397,12 @@ final class WelcomeViewModel {
 
     // MARK: - Groups
 
+    /// Every window that draws the group tree reloads from this. Without it a rename
+    /// here would only ever repaint the welcome window.
+    private func broadcastGroupsChanged() {
+        services.appEvents.connectionUpdated.send(nil)
+    }
+
     func requestDeleteGroup(_ group: ConnectionGroup) {
         groupToDelete = group
         showDeleteGroupConfirmation = true
@@ -422,6 +413,7 @@ final class WelcomeViewModel {
         groupStorage.deleteGroup(group)
         groupToDelete = nil
         loadConnections()
+        broadcastGroupsChanged()
     }
 
     func beginRenameGroup(_ group: ConnectionGroup) {
@@ -444,6 +436,7 @@ final class WelcomeViewModel {
         groupStorage.updateGroup(updated)
         groups = groupStorage.loadGroups()
         rebuildTree()
+        broadcastGroupsChanged()
         renameGroupTarget = nil
     }
 
@@ -453,6 +446,7 @@ final class WelcomeViewModel {
         groupStorage.updateGroup(updated)
         groups = groupStorage.loadGroups()
         rebuildTree()
+        broadcastGroupsChanged()
     }
 
     func moveConnections(_ targets: [DatabaseConnection], toGroup groupId: UUID) {
@@ -468,6 +462,7 @@ final class WelcomeViewModel {
             return
         }
         rebuildTree()
+        broadcastGroupsChanged()
     }
 
     func removeFromGroup(_ targets: [DatabaseConnection]) {
@@ -483,6 +478,7 @@ final class WelcomeViewModel {
             return
         }
         rebuildTree()
+        broadcastGroupsChanged()
     }
 
     func createGroup(name: String, color: ConnectionColor, parentId: UUID?) {
@@ -499,6 +495,7 @@ final class WelcomeViewModel {
             pendingMoveToNewGroup = []
         }
         rebuildTree()
+        broadcastGroupsChanged()
     }
 
     func createSubgroup(under parentId: UUID) {
@@ -517,6 +514,7 @@ final class WelcomeViewModel {
         groupStorage.updateGroup(updated)
         groups = groupStorage.loadGroups()
         rebuildTree()
+        broadcastGroupsChanged()
     }
 
     // MARK: - Import / Export

--- a/TablePro/Views/Sidebar/ConnectionsTabView.swift
+++ b/TablePro/Views/Sidebar/ConnectionsTabView.swift
@@ -1,0 +1,269 @@
+//
+//  ConnectionsTabView.swift
+//  TablePro
+//
+
+import SwiftUI
+import TableProPluginKit
+
+/// Where a connection stands relative to the window drawing the list. Shape carries
+/// the state, so it reads the same to someone who cannot tell green from grey.
+internal enum ConnectionRowPresence: Equatable {
+    case current
+    case openElsewhere
+    case closed
+
+    internal static func resolve(
+        connectionId: UUID,
+        windowConnectionId: UUID,
+        openConnectionIds: Set<UUID>
+    ) -> ConnectionRowPresence {
+        if connectionId == windowConnectionId { return .current }
+        return openConnectionIds.contains(connectionId) ? .openElsewhere : .closed
+    }
+}
+
+/// Every saved connection, grouped the way the welcome window groups them, so another
+/// connection is reachable without leaving the window you are working in.
+///
+/// Opening one raises that connection's own window or makes it a new one. Nothing here
+/// retargets the window you are in: its tabs stay bound to the connection they were
+/// opened against.
+internal struct ConnectionsTabView: View {
+    internal let connectionId: UUID
+    @Bindable private var sharedSidebarState: SharedSidebarState
+
+    @State private var connections: [DatabaseConnection] = []
+    @State private var groups: [ConnectionGroup] = []
+    @State private var openConnectionIds: Set<UUID> = []
+
+    internal init(connectionId: UUID, sharedSidebarState: SharedSidebarState) {
+        self.connectionId = connectionId
+        self.sharedSidebarState = sharedSidebarState
+    }
+
+    private var searchText: String { sharedSidebarState.connectionsSearchText }
+
+    private var tree: [ConnectionGroupTreeNode] {
+        let built = buildGroupTreeIndexed(groups: groups, connections: connections)
+        return filterGroupTree(built, searchText: searchText)
+    }
+
+    /// A window opened from a URL runs a connection that was never saved, so counting
+    /// the saved list is not the same as asking whether anywhere else is reachable.
+    private var hasSomewhereElseToGo: Bool {
+        connections.contains { $0.id != connectionId }
+    }
+
+    internal var body: some View {
+        content
+            .onAppear(perform: reload)
+            .onReceive(AppEvents.shared.connectionUpdated) { _ in reload() }
+            .onReceive(AppEvents.shared.connectionWindowsChanged) { _ in
+                openConnectionIds = WorkspaceRailStore.openConnectionIds
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if !hasSomewhereElseToGo {
+            noOtherConnections
+        } else if tree.isEmpty {
+            noMatches
+        } else {
+            list
+        }
+    }
+
+    private var list: some View {
+        List(selection: $sharedSidebarState.selectedConnectionsItem) {
+            ConnectionTreeRows(
+                nodes: tree,
+                windowConnectionId: connectionId,
+                openConnectionIds: openConnectionIds
+            )
+        }
+        .sidebarListLayout()
+        .contextMenu(forSelectionType: String.self) { selection in
+            menu(for: selection.first)
+        } primaryAction: { selection in
+            open(selection.first)
+        }
+    }
+
+    @ViewBuilder
+    private func menu(for id: String?) -> some View {
+        if let id, let node = findGroupTreeNode(id: id, in: tree) {
+            switch node {
+            case .connection(let connection):
+                Button(String(localized: "Open")) {
+                    open(id)
+                }
+                .disabled(connection.id == connectionId)
+                Button(String(localized: "Edit Connection...")) {
+                    WindowOpener.shared.openConnectionForm(editing: connection.id)
+                }
+            case .group(let group, _):
+                Button(String(localized: "Expand All")) {
+                    ConnectionGroupExpansionState.shared.expand(subtree(of: group))
+                }
+                Button(String(localized: "Collapse All")) {
+                    ConnectionGroupExpansionState.shared.collapse(subtree(of: group))
+                }
+            }
+            Divider()
+        }
+        SidebarViewOptionsMenu()
+    }
+
+    private var noOtherConnections: some View {
+        ContentUnavailableView {
+            Label(String(localized: "No Other Connections"), systemImage: "cylinder.split.1x2")
+        } description: {
+            Text("Connections you save appear here, grouped the way you arrange them.")
+        } actions: {
+            Button(String(localized: "New Connection...")) {
+                WindowOpener.shared.openConnectionForm()
+            }
+        }
+    }
+
+    private var noMatches: some View {
+        ContentUnavailableView.search(text: searchText)
+    }
+
+    private func subtree(of group: ConnectionGroup) -> Set<UUID> {
+        collectAllDescendantGroupIds(groupId: group.id, groups: groups).union([group.id])
+    }
+
+    private func open(_ id: String?) {
+        guard let id, let node = findGroupTreeNode(id: id, in: tree) else { return }
+        guard case .connection(let connection) = node else { return }
+        guard connection.id != connectionId else { return }
+        Task { await ConnectionActivation.open(connectionId: connection.id) }
+    }
+
+    private func reload() {
+        connections = ConnectionStorage.shared.loadConnections()
+        groups = GroupStorage.shared.loadGroups()
+        openConnectionIds = WorkspaceRailStore.openConnectionIds
+        ConnectionGroupExpansionState.shared.expandAllIfNeeded(groups: groups)
+    }
+}
+
+/// Recursive because a group can hold groups, up to the three levels `GroupStorage`
+/// allows. Expansion never follows the filter: filtering removes rows, the way the
+/// favorites tree and the welcome window both already behave.
+private struct ConnectionTreeRows: View {
+    let nodes: [ConnectionGroupTreeNode]
+    let windowConnectionId: UUID
+    let openConnectionIds: Set<UUID>
+
+    var body: some View {
+        ForEach(nodes) { node in
+            switch node {
+            case .connection(let connection):
+                ConnectionSidebarRow(
+                    connection: connection,
+                    presence: ConnectionRowPresence.resolve(
+                        connectionId: connection.id,
+                        windowConnectionId: windowConnectionId,
+                        openConnectionIds: openConnectionIds
+                    )
+                )
+                .tag(node.id)
+            case .group(let group, let children):
+                DisclosureGroup(isExpanded: expansion(for: group)) {
+                    ConnectionTreeRows(
+                        nodes: children,
+                        windowConnectionId: windowConnectionId,
+                        openConnectionIds: openConnectionIds
+                    )
+                } label: {
+                    ConnectionGroupSidebarRow(group: group)
+                }
+                .tag(node.id)
+            }
+        }
+    }
+
+    private func expansion(for group: ConnectionGroup) -> Binding<Bool> {
+        Binding(
+            get: { ConnectionGroupExpansionState.shared.isExpanded(group.id) },
+            set: { ConnectionGroupExpansionState.shared.setExpanded(group.id, expanded: $0) }
+        )
+    }
+}
+
+private struct ConnectionGroupSidebarRow: View {
+    let group: ConnectionGroup
+
+    var body: some View {
+        Label {
+            Text(group.name)
+        } icon: {
+            Image(systemName: "folder")
+                .sidebarTint(group.color.isDefault ? .secondary : group.color.color)
+        }
+        .sidebarRowIcon(visible: AppSettingsManager.shared.general.showObjectIcons)
+    }
+}
+
+private struct ConnectionSidebarRow: View {
+    let connection: DatabaseConnection
+    let presence: ConnectionRowPresence
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Label {
+                Text(connection.name)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            } icon: {
+                connection.type.iconImage
+                    .sidebarTint(connection.displayColor)
+            }
+            .sidebarRowIcon(visible: AppSettingsManager.shared.general.showObjectIcons)
+
+            Spacer(minLength: 0)
+
+            presenceAccessory
+        }
+        .help(tooltip)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    @ViewBuilder
+    private var presenceAccessory: some View {
+        switch presence {
+        case .current:
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+        case .openElsewhere:
+            Image(systemName: "circle.fill")
+                .font(.system(size: 6))
+                .foregroundStyle(.green)
+        case .closed:
+            EmptyView()
+        }
+    }
+
+    private var tooltip: String {
+        let detail = PluginManager.shared.connectionMode(for: connection.type) == .fileBased
+            ? connection.database
+            : "\(connection.host)/\(connection.database)"
+        return "\(connection.name)\n\(detail)"
+    }
+
+    private var accessibilityLabel: String {
+        switch presence {
+        case .current:
+            return String(format: String(localized: "%@, current connection"), connection.name)
+        case .openElsewhere:
+            return String(format: String(localized: "%@, open in another window"), connection.name)
+        case .closed:
+            return connection.name
+        }
+    }
+}

--- a/TablePro/Views/Sidebar/SidebarPersistenceKey.swift
+++ b/TablePro/Views/Sidebar/SidebarPersistenceKey.swift
@@ -24,6 +24,10 @@ enum SidebarPersistenceKey {
         "sidebar.selectedFavoriteNodeId.\(connectionId.uuidString)"
     }
 
+    static func selectedConnectionsItem(connectionId: UUID) -> String {
+        "sidebar.selectedConnectionsItem.\(connectionId.uuidString)"
+    }
+
     static let defaultLayout = "sidebar.defaultLayout"
 
     static func layout(connectionId: UUID) -> String {

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -117,6 +117,8 @@ struct SidebarView: View {
                 } else {
                     Color.clear
                 }
+            case .connections:
+                ConnectionsTabView(connectionId: connectionId, sharedSidebarState: sidebarState)
             }
         }
         .onChange(of: sidebarState.searchText) { _, newValue in

--- a/TablePro/Views/Toolbar/ConnectionSwitcherPopover.swift
+++ b/TablePro/Views/Toolbar/ConnectionSwitcherPopover.swift
@@ -271,19 +271,7 @@ struct ConnectionSwitcherPopover: View {
 
     private func activate(connectionId: UUID) {
         dismiss()
-        Task {
-            do {
-                try await TabRouter.shared.route(.openConnection(connectionId))
-            } catch {
-                await MainActor.run {
-                    AlertHelper.showErrorSheet(
-                        title: String(localized: "Connection Failed"),
-                        message: error.localizedDescription,
-                        window: NSApp.keyWindow
-                    )
-                }
-            }
-        }
+        Task { await ConnectionActivation.open(connectionId: connectionId) }
     }
 
     private func connectionSubtitle(_ connection: DatabaseConnection) -> String {

--- a/TableProTests/Core/Storage/GroupStorageTests.swift
+++ b/TableProTests/Core/Storage/GroupStorageTests.swift
@@ -204,6 +204,69 @@ final class GroupStorageTests: XCTestCase {
         XCTAssertEqual(loaded[1].name, "Production")
     }
 
+    // MARK: - Depth Cap
+
+    private func saveThreeLevelChain() -> (ConnectionGroup, ConnectionGroup, ConnectionGroup) {
+        let level1 = ConnectionGroup(name: "Level 1")
+        let level2 = ConnectionGroup(name: "Level 2", parentId: level1.id)
+        let level3 = ConnectionGroup(name: "Level 3", parentId: level2.id)
+        storage.saveGroups([level1, level2, level3])
+        return (level1, level2, level3)
+    }
+
+    func testAddGroupRejectsAFourthLevel() {
+        let (_, _, level3) = saveThreeLevelChain()
+
+        storage.addGroup(ConnectionGroup(name: "Level 4", parentId: level3.id))
+
+        XCTAssertEqual(storage.loadGroups().count, 3)
+        XCTAssertNil(storage.loadGroups().first { $0.name == "Level 4" })
+    }
+
+    func testAddGroupAcceptsAThirdLevel() {
+        let level1 = ConnectionGroup(name: "Level 1")
+        let level2 = ConnectionGroup(name: "Level 2", parentId: level1.id)
+        storage.saveGroups([level1, level2])
+
+        storage.addGroup(ConnectionGroup(name: "Level 3", parentId: level2.id))
+
+        XCTAssertEqual(storage.loadGroups().count, 3)
+    }
+
+    func testUpdateGroupRejectsAMoveBeyondMaxDepth() {
+        let (_, _, level3) = saveThreeLevelChain()
+        let outsider = ConnectionGroup(name: "Outsider")
+        storage.addGroup(outsider)
+
+        var moved = outsider
+        moved.parentId = level3.id
+        storage.updateGroup(moved)
+
+        let reloaded = storage.group(for: outsider.id)
+        XCTAssertNil(reloaded?.parentId)
+    }
+
+    // MARK: - Cycle Prevention
+
+    func testUpdateGroupRejectsMakingAGroupItsOwnDescendant() {
+        let parent = ConnectionGroup(name: "Parent")
+        let child = ConnectionGroup(name: "Child", parentId: parent.id)
+        storage.saveGroups([parent, child])
+
+        var moved = parent
+        moved.parentId = child.id
+        storage.updateGroup(moved)
+
+        XCTAssertNil(storage.group(for: parent.id)?.parentId)
+    }
+
+    func testAddGroupRejectsAGroupParentedToItself() {
+        let id = UUID()
+        storage.addGroup(ConnectionGroup(id: id, name: "Self", parentId: id))
+
+        XCTAssertTrue(storage.loadGroups().isEmpty)
+    }
+
     // MARK: - Persistence
 
     func testGroupsPersistAcrossLoadCalls() {

--- a/TableProTests/Models/ConnectionGroupTreeTests.swift
+++ b/TableProTests/Models/ConnectionGroupTreeTests.swift
@@ -270,6 +270,139 @@ struct ConnectionGroupTreeTests {
         #expect(result.isEmpty)
     }
 
+    @Test("Search ignores diacritics, the way every other sidebar filter does")
+    func filterGroupTree_ignoresDiacritics() {
+        let conn = makeConnection(name: "Café")
+        let tree: [ConnectionGroupTreeNode] = [.connection(conn)]
+
+        #expect(connectionIds(from: filterGroupTree(tree, searchText: "cafe")) == [conn.id])
+    }
+
+    @Test("Search matches a group name without regard to diacritics or case")
+    func filterGroupTree_groupIgnoresDiacritics() {
+        let group = makeGroup(name: "Genève")
+        let conn = makeConnection(name: "db", groupId: group.id)
+        let tree: [ConnectionGroupTreeNode] = [.group(group, children: [.connection(conn)])]
+
+        #expect(groupIds(from: filterGroupTree(tree, searchText: "geneve")) == [group.id])
+    }
+
+    @Test("Search still matches in the middle of a name, not only at the start")
+    func filterGroupTree_matchesSubstring() {
+        let conn = makeConnection(name: "acme-staging-db")
+        let tree: [ConnectionGroupTreeNode] = [.connection(conn)]
+
+        #expect(connectionIds(from: filterGroupTree(tree, searchText: "staging")) == [conn.id])
+    }
+
+    @Test("Search matches a connection's host and database, not just its name")
+    func filterGroupTree_matchesHostAndDatabase() {
+        let byHost = makeConnection(name: "one", host: "db.internal")
+        let byDatabase = makeConnection(name: "two", database: "analytics")
+        let tree: [ConnectionGroupTreeNode] = [.connection(byHost), .connection(byDatabase)]
+
+        #expect(connectionIds(from: filterGroupTree(tree, searchText: "internal")) == [byHost.id])
+        #expect(connectionIds(from: filterGroupTree(tree, searchText: "analytics")) == [byDatabase.id])
+    }
+
+    @Test("A whitespace-only search matches everything rather than names containing a space")
+    func filterGroupTree_whitespaceQueryMatchesEverything() {
+        let spaced = makeConnection(name: "my db")
+        let unspaced = makeConnection(name: "prod")
+        let tree: [ConnectionGroupTreeNode] = [.connection(spaced), .connection(unspaced)]
+
+        #expect(connectionIds(from: filterGroupTree(tree, searchText: "   ")) == [spaced.id, unspaced.id])
+    }
+
+    // MARK: - filterGroupTreeByTags
+
+    @Test("A tag filter keeps only connections carrying the tag")
+    func filterGroupTreeByTags_keepsTaggedConnections() {
+        let tagId = UUID()
+        var tagged = makeConnection(name: "prod")
+        tagged.tagIds = [tagId]
+        let untagged = makeConnection(name: "local")
+        let tree: [ConnectionGroupTreeNode] = [.connection(tagged), .connection(untagged)]
+
+        let result = filterGroupTreeByTags(tree, filter: TagFilter(selectedIds: [tagId]))
+        #expect(connectionIds(from: result) == [tagged.id])
+    }
+
+    @Test("A tag filter drops a group whose connections all fail it")
+    func filterGroupTreeByTags_dropsEmptiedGroups() {
+        let tagId = UUID()
+        let group = makeGroup(name: "Acme")
+        let untagged = makeConnection(name: "local", groupId: group.id)
+        let tree: [ConnectionGroupTreeNode] = [.group(group, children: [.connection(untagged)])]
+
+        let result = filterGroupTreeByTags(tree, filter: TagFilter(selectedIds: [tagId]))
+        #expect(result.isEmpty)
+    }
+
+    @Test("An inactive tag filter returns the tree unchanged")
+    func filterGroupTreeByTags_inactiveFilterIsPassThrough() {
+        let group = makeGroup(name: "Acme")
+        let conn = makeConnection(name: "local", groupId: group.id)
+        let tree: [ConnectionGroupTreeNode] = [.group(group, children: [.connection(conn)])]
+
+        let result = filterGroupTreeByTags(tree, filter: TagFilter())
+        #expect(groupIds(from: result) == [group.id])
+        #expect(connectionIds(from: children(of: result[0])) == [conn.id])
+    }
+
+    // MARK: - findGroupTreeNode
+
+    @Test("A connection is found by the tag its row carries")
+    func findGroupTreeNode_findsConnection() {
+        let conn = makeConnection(name: "prod")
+        let tree: [ConnectionGroupTreeNode] = [.connection(conn)]
+
+        guard case .connection(let found)? = findGroupTreeNode(id: "conn-\(conn.id)", in: tree) else {
+            Issue.record("expected a connection node")
+            return
+        }
+        #expect(found.id == conn.id)
+    }
+
+    @Test("A group is found by the tag its row carries")
+    func findGroupTreeNode_findsGroup() {
+        let group = makeGroup(name: "Acme")
+        let tree: [ConnectionGroupTreeNode] = [.group(group, children: [])]
+
+        guard case .group(let found, _)? = findGroupTreeNode(id: "group-\(group.id)", in: tree) else {
+            Issue.record("expected a group node")
+            return
+        }
+        #expect(found.id == group.id)
+    }
+
+    @Test("A connection nested three groups deep is still found")
+    func findGroupTreeNode_findsDeeplyNestedConnection() {
+        let conn = makeConnection(name: "prod")
+        let inner = makeGroup(name: "Environments")
+        let middle = makeGroup(name: "Acme")
+        let outer = makeGroup(name: "Work")
+        let tree: [ConnectionGroupTreeNode] = [
+            .group(outer, children: [
+                .group(middle, children: [
+                    .group(inner, children: [.connection(conn)]),
+                ]),
+            ]),
+        ]
+
+        guard case .connection(let found)? = findGroupTreeNode(id: "conn-\(conn.id)", in: tree) else {
+            Issue.record("expected a connection node")
+            return
+        }
+        #expect(found.id == conn.id)
+    }
+
+    @Test("An id that is not in the tree finds nothing")
+    func findGroupTreeNode_missingIdFindsNothing() {
+        let tree: [ConnectionGroupTreeNode] = [.connection(makeConnection(name: "prod"))]
+        #expect(findGroupTreeNode(id: "conn-\(UUID())", in: tree) == nil)
+    }
+
     // MARK: - flattenVisibleConnections
 
     @Test("All groups expanded returns all connections in depth-first order")

--- a/TableProTests/Models/SharedSidebarStateTests.swift
+++ b/TableProTests/Models/SharedSidebarStateTests.swift
@@ -93,6 +93,31 @@ struct SharedSidebarStateTests {
         SharedSidebarState.removeConnection(id)
     }
 
+    @Test("connectionsSearchText persists across registry lookups for same connection")
+    @MainActor
+    func connectionsSearchTextPersists() {
+        let id = UUID()
+        let a = SharedSidebarState.forConnection(id)
+        a.connectionsSearchText = "staging"
+        let b = SharedSidebarState.forConnection(id)
+        #expect(b.connectionsSearchText == "staging")
+        SharedSidebarState.removeConnection(id)
+    }
+
+    @Test("Each sidebar tab keeps its own filter text")
+    @MainActor
+    func filterTextIsPerTab() {
+        let id = UUID()
+        let state = SharedSidebarState.forConnection(id)
+        state.searchText = "users"
+        state.favoritesSearchText = "daily"
+        state.connectionsSearchText = "staging"
+        #expect(state.searchText == "users")
+        #expect(state.favoritesSearchText == "daily")
+        #expect(state.connectionsSearchText == "staging")
+        SharedSidebarState.removeConnection(id)
+    }
+
     @Test("filter text is independent across different connections")
     @MainActor
     func filterTextIndependentAcrossConnections() {
@@ -118,6 +143,45 @@ struct SharedSidebarStateTests {
         let b = SharedSidebarState.forConnection(id)
         #expect(b.selectedFavorite == selection)
         a.selectedFavorite = nil
+        SharedSidebarState.removeConnection(id)
+    }
+
+    // MARK: - Connections Tab
+
+    @Test("The connections tab persists across registry lookups for same connection")
+    @MainActor
+    func connectionsTabPersists() {
+        let id = UUID()
+        let a = SharedSidebarState.forConnection(id)
+        a.selectedSidebarTab = .connections
+        let b = SharedSidebarState.forConnection(id)
+        #expect(b.selectedSidebarTab == .connections)
+        a.selectedSidebarTab = .tables
+        SharedSidebarState.removeConnection(id)
+    }
+
+    @Test("selectedConnectionsItem persists across registry lookups for same connection")
+    @MainActor
+    func selectedConnectionsItemPersists() {
+        let id = UUID()
+        let tag = "conn-\(UUID().uuidString)"
+        let a = SharedSidebarState.forConnection(id)
+        a.selectedConnectionsItem = tag
+        let b = SharedSidebarState.forConnection(id)
+        #expect(b.selectedConnectionsItem == tag)
+        a.selectedConnectionsItem = nil
+        SharedSidebarState.removeConnection(id)
+    }
+
+    @Test("Clearing selectedConnectionsItem does not resurrect the old value")
+    @MainActor
+    func clearedConnectionsItemStaysCleared() {
+        let id = UUID()
+        let a = SharedSidebarState.forConnection(id)
+        a.selectedConnectionsItem = "conn-\(UUID().uuidString)"
+        a.selectedConnectionsItem = nil
+        let b = SharedSidebarState.forConnection(id)
+        #expect(b.selectedConnectionsItem == nil)
         SharedSidebarState.removeConnection(id)
     }
 }

--- a/TableProTests/Services/MainWindowToolbarLayoutTests.swift
+++ b/TableProTests/Services/MainWindowToolbarLayoutTests.swift
@@ -24,11 +24,11 @@ struct MainWindowToolbarLayoutTests {
         #expect(group.isNavigational == false)
     }
 
-    @Test("Sidebar toggle stays an expanded one-of-two segmented control")
+    @Test("Sidebar toggle stays an expanded one-of-N segmented control, one segment per tab")
     func sidebarToggleIsExpandedSegmentedControl() {
         let group = MainWindowToolbar.makeSidebarSegmentGroup(target: nil, action: #selector(NSView.layout))
         #expect(group.controlRepresentation == .expanded)
         #expect(group.selectionMode == .selectOne)
-        #expect(group.subitems.count == 2)
+        #expect(group.subitems.count == SidebarTab.allCases.count)
     }
 }

--- a/TableProTests/ViewModels/ConnectionGroupExpansionStateTests.swift
+++ b/TableProTests/ViewModels/ConnectionGroupExpansionStateTests.swift
@@ -1,0 +1,167 @@
+//
+//  ConnectionGroupExpansionStateTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("Connection group expansion state")
+@MainActor
+struct ConnectionGroupExpansionStateTests {
+    private static let storageKey = "com.TablePro.expandedGroupIds"
+    private static let legacyCollapsedKey = "com.TablePro.collapsedGroupIds"
+
+    private func makeDefaults() throws -> (UserDefaults, String) {
+        let suiteName = "com.TablePro.tests.groupExpansion.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        return (defaults, suiteName)
+    }
+
+    private func makeGroup(_ name: String, parentId: UUID? = nil) -> ConnectionGroup {
+        ConnectionGroup(name: name, parentId: parentId)
+    }
+
+    @Test("A fresh store has nothing expanded")
+    func emptyByDefault() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(ConnectionGroupExpansionState(defaults: defaults).expandedGroupIds.isEmpty)
+    }
+
+    @Test("Expanding a group round-trips through UserDefaults")
+    func expansionRoundTrips() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = ConnectionGroupExpansionState(defaults: defaults)
+        let group = makeGroup("Acme")
+        state.setExpanded(group.id, expanded: true)
+        #expect(state.isExpanded(group.id))
+
+        let reloaded = ConnectionGroupExpansionState(defaults: defaults)
+        #expect(reloaded.isExpanded(group.id))
+    }
+
+    @Test("Collapsing a group removes it from the stored arrangement")
+    func collapseRemoves() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = ConnectionGroupExpansionState(defaults: defaults)
+        let group = makeGroup("Acme")
+        state.setExpanded(group.id, expanded: true)
+        state.setExpanded(group.id, expanded: false)
+
+        #expect(!ConnectionGroupExpansionState(defaults: defaults).isExpanded(group.id))
+    }
+
+    @Test("An arrangement the welcome window already wrote is read unchanged")
+    func readsExistingWelcomeArrangement() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let existing = [UUID(), UUID()]
+        defaults.set(existing.map(\.uuidString), forKey: Self.storageKey)
+
+        let state = ConnectionGroupExpansionState(defaults: defaults)
+        #expect(state.expandedGroupIds == Set(existing))
+    }
+
+    @Test("A stored arrangement leaves the retired collapsed-ids key alone")
+    func storedArrangementKeepsLegacyKey() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set([UUID().uuidString], forKey: Self.storageKey)
+        defaults.set(["stale"], forKey: Self.legacyCollapsedKey)
+
+        _ = ConnectionGroupExpansionState(defaults: defaults)
+        #expect(defaults.stringArray(forKey: Self.legacyCollapsedKey) == ["stale"])
+    }
+
+    @Test("With nothing stored, the retired collapsed-ids key is cleared")
+    func emptyArrangementClearsLegacyKey() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(["stale"], forKey: Self.legacyCollapsedKey)
+
+        _ = ConnectionGroupExpansionState(defaults: defaults)
+        #expect(defaults.stringArray(forKey: Self.legacyCollapsedKey) == nil)
+    }
+
+    @Test("A first run expands every group, so a new install shows its groups open")
+    func seedsEveryGroupOnFirstRun() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = ConnectionGroupExpansionState(defaults: defaults)
+        let groups = [makeGroup("Acme"), makeGroup("Side projects")]
+        state.expandAllIfNeeded(groups: groups)
+
+        #expect(state.expandedGroupIds == Set(groups.map(\.id)))
+    }
+
+    @Test("Seeding never reopens groups the user collapsed")
+    func seedingLeavesAnExistingArrangementAlone() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = ConnectionGroupExpansionState(defaults: defaults)
+        let kept = makeGroup("Acme")
+        let collapsed = makeGroup("Side projects")
+        state.setExpanded(kept.id, expanded: true)
+
+        state.expandAllIfNeeded(groups: [kept, collapsed])
+
+        #expect(state.expandedGroupIds == [kept.id])
+    }
+
+    @Test("Seeding with no groups leaves the arrangement empty")
+    func seedingWithoutGroupsStoresNothing() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = ConnectionGroupExpansionState(defaults: defaults)
+        state.expandAllIfNeeded(groups: [])
+
+        #expect(state.expandedGroupIds.isEmpty)
+    }
+
+    @Test("Expand and collapse apply to a whole subtree at once")
+    func expandAndCollapseSubtree() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = ConnectionGroupExpansionState(defaults: defaults)
+        let parent = makeGroup("Acme")
+        let child = makeGroup("Environments", parentId: parent.id)
+        let unrelated = makeGroup("Side projects")
+        state.setExpanded(unrelated.id, expanded: true)
+
+        state.expand([parent.id, child.id])
+        #expect(state.expandedGroupIds == [parent.id, child.id, unrelated.id])
+
+        state.collapse([parent.id, child.id])
+        #expect(state.expandedGroupIds == [unrelated.id])
+    }
+
+    @Test("Setting a group to the state it already has writes nothing")
+    func redundantSetIsIgnored() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = ConnectionGroupExpansionState(defaults: defaults)
+        let group = makeGroup("Acme")
+        state.setExpanded(group.id, expanded: true)
+        let written = defaults.stringArray(forKey: Self.storageKey)
+
+        state.setExpanded(group.id, expanded: true)
+
+        #expect(defaults.stringArray(forKey: Self.storageKey) == written)
+    }
+}

--- a/TableProTests/Views/Sidebar/ConnectionRowPresenceTests.swift
+++ b/TableProTests/Views/Sidebar/ConnectionRowPresenceTests.swift
@@ -1,0 +1,55 @@
+//
+//  ConnectionRowPresenceTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("Connection row presence")
+struct ConnectionRowPresenceTests {
+    private let windowConnectionId = UUID()
+
+    @Test("The window's own connection is the current one")
+    func ownConnectionIsCurrent() {
+        let presence = ConnectionRowPresence.resolve(
+            connectionId: windowConnectionId,
+            windowConnectionId: windowConnectionId,
+            openConnectionIds: [windowConnectionId]
+        )
+        #expect(presence == .current)
+    }
+
+    @Test("A connection with a window somewhere else is open elsewhere")
+    func otherOpenConnectionIsElsewhere() {
+        let other = UUID()
+        let presence = ConnectionRowPresence.resolve(
+            connectionId: other,
+            windowConnectionId: windowConnectionId,
+            openConnectionIds: [windowConnectionId, other]
+        )
+        #expect(presence == .openElsewhere)
+    }
+
+    @Test("A connection with no window is closed")
+    func unopenedConnectionIsClosed() {
+        let presence = ConnectionRowPresence.resolve(
+            connectionId: UUID(),
+            windowConnectionId: windowConnectionId,
+            openConnectionIds: [windowConnectionId]
+        )
+        #expect(presence == .closed)
+    }
+
+    @Test("The window's own connection reads as current even before its window registers")
+    func ownConnectionWinsOverMembership() {
+        let presence = ConnectionRowPresence.resolve(
+            connectionId: windowConnectionId,
+            windowConnectionId: windowConnectionId,
+            openConnectionIds: []
+        )
+        #expect(presence == .current)
+    }
+}

--- a/docs/databases/overview.mdx
+++ b/docs/databases/overview.mdx
@@ -154,6 +154,8 @@ Red for production, green for development. Set Safe Mode to **Read-Only** on pro
 
 Groups are folders in the connection list, nested up to 3 levels. Right-click empty space or a group to create, move, or delete one. Deleting a group removes its subgroups; the connections inside are ungrouped, not deleted.
 
+The same groups appear in the **Connections** tab of every connection window's sidebar, so you can reach another connection without coming back here. Create and rename them on the welcome window; the sidebar tab browses them. Whether a group is open or closed is shared between the two.
+
 ### Tags
 
 A connection can carry multiple tags, each with a name and color. When any connection has tags, a filter bar appears above the welcome list with one pill per tag. Click pills to filter; with two or more selected, a **Match Any** / **Match All** menu switches between OR and AND matching, and **Clear** resets the filter.
@@ -164,8 +166,14 @@ Hover a connection row and click the star, or right-click and choose **Add to Fa
 
 ## Switching Connections and Databases
 
+- **Connections tab**: the third segment of the sidebar's Tables / Favorites / Connections control lists every saved connection as a tree of your groups. Double-click one, or select it and press Return, to go to it. Filter with the sidebar's search field
 - **Switch Connection** (`Ctrl+Cmd+C`): a toolbar popover lists active sessions and saved connections. Type to filter, arrow keys to move, Return to switch
 - **Open Database** (`Cmd+K`): switch databases on the same server without reconnecting
+- **Workspace rail**: the strip on the leading edge switches between the connections and databases you already have open. See [Workspace Rail](/features/workspace-rail)
+
+Going to another connection raises that connection's window, or opens one if it is not open yet. A window always shows the connection it was opened for, so nothing you have in progress is replaced. The new window takes the position of the one you were in, so it reads as the window changing content.
+
+A connection in the Connections tab is marked with a checkmark when it is the one you are in, and a dot when it is open in another window. Right-click a connection for **Open** and **Edit Connection...**, or a group for **Expand All** and **Collapse All**.
 
 <Frame caption="Database switcher in toolbar">
   <img className="block dark:hidden" src="/images/database-switcher-toolbar.png" alt="Database switcher in toolbar" />

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -176,6 +176,7 @@ See [Filtering](/features/filtering) for the filter panel itself.
 | Focus sidebar filter | `Cmd+Option+F` |
 | Show Tables sidebar | `Cmd+Option+1` |
 | Show Favorites sidebar | `Cmd+Option+2` |
+| Show Connections sidebar | `Cmd+Option+3` |
 | Toggle inspector panel | `Cmd+Option+I` |
 | Toggle results | `Cmd+Option+R` |
 | Query history | `Cmd+Y` |


### PR DESCRIPTION
Closes #1311.

## What this adds

A **Connections tab** in the sidebar, a third segment beside Tables and Favorites, listing every saved connection as a tree of your groups. Reach it with `Cmd+Option+3` or **View > Show Connections Sidebar**.

- Double-click or Return opens a connection. Single click only selects, so a stray click cannot start a connect to production.
- Opening goes through the existing `TabRouter.openConnection`: it raises that connection's window, or opens one if it has none. Since #1282 every connection window shares one frame autosave slot, so the new window lands where the old one was and it reads as the window changing content.
- A checkmark marks the connection this window is on, a dot marks one open in another window, and nothing means closed. Shape carries the state, following the rule `WorkspaceRailCellView` already sets for the rail.
- Right-click a connection for **Open** and **Edit Connection...**; right-click a group for **Expand All** and **Collapse All**. Creating, renaming, recolouring and moving groups stays on the welcome window, so the validation for depth caps and cycles lives in one place.
- The sidebar's filter field filters the tree, per tab, alongside the existing Tables and Favorites filters.

Whether a group is open or closed is shared with the welcome window through the UserDefaults key it already uses, so there is no migration and the two surfaces agree.

## What this deliberately does not do

The issue also asks for clicking a connection to **switch the active connection in the current tab**. This PR does not do that, and it is not an oversight.

- No mature native client does it. TablePlus, DataGrip, MongoDB Compass, Sequel Ace and Postico all navigate to the connection's own window or tab. The two that came closest are cautionary: TablePlus's two-tier workspace tabs draw complaints that users cannot tell dev from prod (TablePlus#723), and Beekeeper Studio's in-place switcher is described by its own maintainers as "a stop gap before full multi-connection mode" that disconnects and reconnects, with open issues about losing in-progress queries.
- Apple's document model puts a stateful session holding unsaved work on the document side, and `NSDocument.canClose(withDelegate:shouldClose:contextInfo:)` plus the HIG on destructive actions say dirty state is never discarded silently. Gating every click behind a save/discard/cancel alert would remove the fluidity the request is asking for.
- TablePro has shipped and reverted this shape three times: #1669 and #1972 on tab retargeting, and the "Group all connections in one window" setting removed in #1282 because merging connections into one tab bar could not be undone.
- Mechanically, `MainContentCoordinator.connection`, `QueryExecutor.connection`, every `QueryTab.tableContext` and the AppKit `tabbingIdentifier` are value snapshots taken when the window is built. Retargeting means rebuilding the whole `SessionStateFactory` quartet, which is close-and-reopen wearing a disguise.

The third ask, a modifier-click to open in a new tab, has nothing left to do: with one window per connection, `TabRouter.openConnection` already raises or opens the right window, so there is no in-place behaviour to escape from. Apple does not document Cmd-click as a system convention either; Finder exposes the intent as a contextual menu item.

## Two root-cause fixes included

Both were pre-existing and both become visible the moment a second surface renders groups.

- **Group changes were never broadcast.** `confirmDeleteGroup`, `confirmRenameGroup`, `updateGroupColor`, `createGroup` and `moveGroup` in `WelcomeViewModel` called storage and rebuilt their own tree, but never sent `AppEvents.connectionUpdated`, unlike every connection mutation next to them. `moveConnections` and `removeFromGroup` had the same hole. Renaming a group would have left the new sidebar tab stale.
- **The group filter did not match the rest of the sidebar.** `filterGroupTree` used `localizedCaseInsensitiveContains` while every other filter in the same sidebar uses the tiered `SidebarNameFilter`. Now unified, so searching connections and groups ignores accents (`cafe` finds `Café`). This also changes welcome-window search, so it has its own CHANGELOG line.

## Design notes

- **Placement.** A third `SidebarTab` case rather than a section pinned above the object list. The pinned section would compete for vertical space with the table list and would have to be forked into all three tree strategies in `SidebarView.tablesContent`. The segmented control is Xcode's navigator-selector shape and already generalizes over `SidebarTab`.
- **SwiftUI, not `NSOutlineView`.** `FavoritesTabView` and `WelcomeWindowView` both already render nested `DisclosureGroup`s over this data. The documented macOS crash in this area is triggered by programmatically forcing `isExpanded` during an animated diff, so expansion here is never driven by the filter: filtering removes rows, exactly as the favorites tree and the welcome window already behave.
- **Expansion state is local only.** `ConnectionGroup`'s CloudKit fields are written with raw string subscripts and are not covered by the gated `ConnectionSyncField` enum, so a synced expansion flag would have had no schema-parity guard behind it.
- **"Current" is this window's own connection**, not `DatabaseManager.lastActiveSessionId`. Two connection windows side by side must each mark their own row, not agree on one.

## Tests

New: `ConnectionGroupExpansionStateTests` (11 tests, including that an arrangement the welcome window already wrote is read unchanged), `ConnectionRowPresenceTests` (4).

Extended: `ConnectionGroupTreeTests` with diacritic, substring, host/database and whitespace-query cases for the new filter, the first coverage for `filterGroupTreeByTags`, and `findGroupTreeNode`; `GroupStorageTests` with the depth-cap and cycle-prevention rejection paths, which had no direct coverage; `SharedSidebarStateTests` with the new tab, its filter text and its selection.

Updated: `MainWindowToolbarLayoutTests` asserted two toolbar segments and now asserts one per `SidebarTab`.

### Results

- Build succeeds; `swiftlint lint --strict` reports 0 violations in 1279 files.
- Targeted suites: 98 passed, 0 failed.
- Full suite: 9779 passed, 72 failed. Running the same failing suites against clean `main` gives 70 failures, so 70 are pre-existing. Exactly one was a real regression from this change (the toolbar segment count, fixed above). The remaining three differ in both directions between runs (`AWSSSOFetchTests`, `CopilotIdleStopControllerTests`, `SSEEventStreamTests`) and are timing-flaky.

### No UI automation, and why

`TableProUITests` has five files and no sidebar coverage at all. The flow worth automating is double-clicking a *second* saved connection and asserting its window is raised, and that needs a way to seed a second connectable saved connection into the test host, which does not exist today (`TABLEPRO_UI_TESTING` only disables auto-behaviours). Building that harness is out of proportion to this change, so the pure pieces are unit-tested instead and the activation path reuses `TabRouter.openConnection` unchanged.

## Docs

`docs/databases/overview.mdx` gains the new switching surface and cross-references it from the Groups section; `docs/features/keyboard-shortcuts.mdx` gains `Cmd+Option+3`.
