### PR TITLE
perf(ai-chat): make streaming replies render smoothly and stop the panel-wide redraw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- AI chat replies now stream smoothly instead of arriving in visible jumps, and the panel no longer slows down as a reply grows. Every update used to redraw every message on screen.
+- The first words of an AI reply now appear as soon as they arrive, instead of waiting for the next batch.
+- Bold, italic, code, and link markers no longer flash as raw punctuation while an AI reply is still being written.
+- Code blocks in AI replies no longer jump to a different height the moment they finish.
 - Oracle connections now turn on TCP keepalive, so a session left idle is less likely to be dropped by a NAT or firewall. It was only ever enabled on a code path that Macs and iPhones do not take. (#2038)
 - On iPhone and iPad, connecting to a database on your own network now asks for Local Network access when it is actually needed, instead of guessing from the address. Networks that use public addresses were never asked about, so those connections failed with an unhelpful error. (#2040)
 - Connecting with no network, or on a captive portal, no longer reports a Local Network permission problem on iPhone and iPad. (#2040)

--- a/TablePro/Core/AI/Chat/ChatTurn.swift
+++ b/TablePro/Core/AI/Chat/ChatTurn.swift
@@ -94,8 +94,8 @@ extension ChatContentBlock {
     }
 }
 
-@MainActor
-struct ChatTurn: Identifiable {
+@MainActor @Observable
+final class ChatTurn: Identifiable {
     let id: UUID
     let role: ChatRole
     var blocks: [ChatContentBlock]
@@ -154,7 +154,7 @@ struct ChatTurn: Identifiable {
         )
     }
 
-    mutating func appendStreamingToken(_ chunk: String) {
+    func appendStreamingToken(_ chunk: String) {
         guard !chunk.isEmpty else { return }
         if let last = blocks.last, case .text = last.kind, last.isStreaming {
             last.appendText(chunk)
@@ -163,19 +163,19 @@ struct ChatTurn: Identifiable {
         }
     }
 
-    mutating func finishStreamingTextBlock() {
+    func finishStreamingTextBlock() {
         if let last = blocks.last, case .text = last.kind, last.isStreaming {
             last.finishStreaming()
         }
     }
 
-    mutating func appendBlock(_ block: ChatContentBlock) {
+    func appendBlock(_ block: ChatContentBlock) {
         finishStreamingTextBlock()
         blocks.append(block)
     }
 
     @discardableResult
-    mutating func appendReasoningDelta(providerBlockID: String, text: String, idMap: inout [String: UUID]) -> UUID {
+    func appendReasoningDelta(providerBlockID: String, text: String, idMap: inout [String: UUID]) -> UUID {
         if let existingUUID = idMap[providerBlockID],
            let existingBlock = blocks.first(where: { $0.id == existingUUID }) {
             existingBlock.appendReasoningText(text)
@@ -189,7 +189,7 @@ struct ChatTurn: Identifiable {
         return newUUID
     }
 
-    mutating func startReasoningBlock(providerBlockID: String, idMap: inout [String: UUID]) {
+    func startReasoningBlock(providerBlockID: String, idMap: inout [String: UUID]) {
         if idMap[providerBlockID] != nil { return }
         finishStreamingTextBlock()
         let newUUID = UUID()
@@ -197,7 +197,7 @@ struct ChatTurn: Identifiable {
         blocks.append(ChatContentBlock(id: newUUID, kind: .reasoning(ReasoningBlock()), isStreaming: true))
     }
 
-    mutating func finalizeReasoningBlock(providerBlockID: String, opaque: ReasoningOpaque?, idMap: inout [String: UUID]) {
+    func finalizeReasoningBlock(providerBlockID: String, opaque: ReasoningOpaque?, idMap: inout [String: UUID]) {
         guard let blockUUID = idMap.removeValue(forKey: providerBlockID),
               let block = blocks.first(where: { $0.id == blockUUID }) else { return }
         block.setReasoningOpaque(opaque)

--- a/TablePro/Core/AI/Chat/ReasoningBlockIDMap.swift
+++ b/TablePro/Core/AI/Chat/ReasoningBlockIDMap.swift
@@ -1,0 +1,11 @@
+//
+//  ReasoningBlockIDMap.swift
+//  TablePro
+//
+
+import Foundation
+
+@MainActor
+final class ReasoningBlockIDMap {
+    var value: [String: UUID] = [:]
+}

--- a/TablePro/Core/AI/Chat/StreamFlushClock.swift
+++ b/TablePro/Core/AI/Chat/StreamFlushClock.swift
@@ -1,0 +1,16 @@
+//
+//  StreamFlushClock.swift
+//  TablePro
+//
+
+import Foundation
+
+protocol StreamFlushClock: Sendable {
+    func sleep(for duration: Duration) async throws
+}
+
+struct ContinuousStreamFlushClock: StreamFlushClock {
+    func sleep(for duration: Duration) async throws {
+        try await Task.sleep(for: duration)
+    }
+}

--- a/TablePro/Core/AI/Chat/StreamTextBuffer.swift
+++ b/TablePro/Core/AI/Chat/StreamTextBuffer.swift
@@ -1,0 +1,52 @@
+//
+//  StreamTextBuffer.swift
+//  TablePro
+//
+
+import Foundation
+
+@MainActor
+final class StreamTextBuffer {
+    private var text: String = ""
+    private var usage: AITokenUsage?
+    private var reasoningByProviderID: [String: String] = [:]
+    private var reasoningOrder: [String] = []
+
+    var hasBufferedText: Bool { !text.isEmpty || usage != nil }
+
+    var hasBufferedReasoning: Bool { !reasoningOrder.isEmpty }
+
+    func appendText(_ chunk: String) {
+        guard !chunk.isEmpty else { return }
+        text += chunk
+    }
+
+    func setUsage(_ newUsage: AITokenUsage) {
+        usage = newUsage
+    }
+
+    func appendReasoning(providerBlockID: String, text chunk: String) {
+        guard !chunk.isEmpty else { return }
+        if reasoningByProviderID[providerBlockID] == nil {
+            reasoningOrder.append(providerBlockID)
+        }
+        reasoningByProviderID[providerBlockID, default: ""] += chunk
+    }
+
+    func drainText() -> (text: String, usage: AITokenUsage?) {
+        let drained = (text: text, usage: usage)
+        text = ""
+        usage = nil
+        return drained
+    }
+
+    func drainReasoning() -> [(providerBlockID: String, text: String)] {
+        let drained = reasoningOrder.compactMap { providerBlockID -> (String, String)? in
+            guard let chunk = reasoningByProviderID[providerBlockID], !chunk.isEmpty else { return nil }
+            return (providerBlockID, chunk)
+        }
+        reasoningByProviderID.removeAll()
+        reasoningOrder.removeAll()
+        return drained
+    }
+}

--- a/TablePro/ViewModels/AIChatViewModel+Streaming.swift
+++ b/TablePro/ViewModels/AIChatViewModel+Streaming.swift
@@ -279,17 +279,16 @@ extension AIChatViewModel {
 
     @MainActor
     func finalizeStreamingMessage(id: UUID) {
-        guard let idx = messages.firstIndex(where: { $0.id == id }) else { return }
-        messages[idx].finishStreamingTextBlock()
+        turn(withID: id)?.finishStreamingTextBlock()
     }
 
     @MainActor
     func resolveWalkthroughIfNeeded(id: UUID) {
         guard let beforeSQL = pendingWalkthroughBeforeSQL else { return }
         pendingWalkthroughBeforeSQL = nil
-        guard let idx = messages.firstIndex(where: { $0.id == id }) else { return }
+        guard let turn = turn(withID: id) else { return }
 
-        let textBlocks = messages[idx].blocks.filter { block in
+        let textBlocks = turn.blocks.filter { block in
             if case .text = block.kind { return true }
             return false
         }
@@ -311,17 +310,17 @@ extension AIChatViewModel {
         guard case .text(let openText) = tail[0].kind else { return }
         let prose = WalkthroughEnvelopeParser.stripFence(from: openText)
         let consumedIDs = Set(tail.dropFirst().map(\.id))
-        messages[idx].blocks.removeAll { consumedIDs.contains($0.id) }
+        turn.blocks.removeAll { consumedIDs.contains($0.id) }
 
         if prose.isEmpty {
-            messages[idx].blocks.removeAll { $0.id == tail[0].id }
+            turn.blocks.removeAll { $0.id == tail[0].id }
         } else {
             tail[0].setKind(.text(prose))
         }
 
         guard let envelope = WalkthroughEnvelopeParser.parse(from: joined) else { return }
         let walkthrough = SqlWalkthroughBlock(beforeSQL: beforeSQL, envelope: envelope)
-        messages[idx].appendBlock(.sqlWalkthrough(walkthrough))
+        turn.appendBlock(.sqlWalkthrough(walkthrough))
     }
 
     private func consumeStreamRound(
@@ -342,33 +341,108 @@ extension AIChatViewModel {
             )
         )
 
-        var pendingContent = ""
-        var pendingUsage: AITokenUsage?
+        let buffer = StreamTextBuffer()
+        let reasoningIDMap = ReasoningBlockIDMap()
+        let ticker = startFlushTicker(buffer: buffer, assistantID: assistantID, idMap: reasoningIDMap)
+        defer {
+            ticker.cancel()
+            if !Task.isCancelled {
+                drainBuffer(buffer, assistantID: assistantID, idMap: reasoningIDMap)
+            }
+        }
+
+        return try await runProducerLoop(
+            stream: stream,
+            buffer: buffer,
+            reasoningIDMap: reasoningIDMap,
+            assistantID: assistantID,
+            chatMode: chatMode
+        )
+    }
+
+    private func startFlushTicker(
+        buffer: StreamTextBuffer,
+        assistantID: UUID,
+        idMap: ReasoningBlockIDMap
+    ) -> Task<Void, Never> {
+        let clock = streamFlushClock
+        let interval = streamFlushInterval
+        return Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await clock.sleep(for: interval)
+                } catch {
+                    return
+                }
+                guard !Task.isCancelled, let self else { return }
+                self.drainBuffer(buffer, assistantID: assistantID, idMap: idMap)
+            }
+        }
+    }
+
+    @MainActor
+    private func drainBuffer(_ buffer: StreamTextBuffer, assistantID: UUID, idMap: ReasoningBlockIDMap) {
+        drainBufferedText(buffer, assistantID: assistantID)
+        drainBufferedReasoning(buffer, assistantID: assistantID, idMap: idMap)
+    }
+
+    @MainActor
+    private func drainBufferedText(_ buffer: StreamTextBuffer, assistantID: UUID) {
+        guard buffer.hasBufferedText else { return }
+        let drained = buffer.drainText()
+        guard let turn = turn(withID: assistantID) else { return }
+        if !drained.text.isEmpty {
+            turn.appendStreamingToken(drained.text)
+        }
+        if let usage = drained.usage {
+            turn.usage = usage
+        }
+    }
+
+    @MainActor
+    private func drainBufferedReasoning(
+        _ buffer: StreamTextBuffer,
+        assistantID: UUID,
+        idMap: ReasoningBlockIDMap
+    ) {
+        guard buffer.hasBufferedReasoning, let turn = turn(withID: assistantID) else { return }
+        for chunk in buffer.drainReasoning() {
+            turn.appendReasoningDelta(
+                providerBlockID: chunk.providerBlockID,
+                text: chunk.text,
+                idMap: &idMap.value
+            )
+        }
+    }
+
+    private func runProducerLoop(
+        stream: AsyncThrowingStream<ChatStreamEvent, Error>,
+        buffer: StreamTextBuffer,
+        reasoningIDMap: ReasoningBlockIDMap,
+        assistantID: UUID,
+        chatMode: AIChatMode
+    ) async throws -> StreamRoundResult {
         var toolUseOrder: [String] = []
         var toolUseNames: [String: String] = [:]
         var toolUseInputs: [String: String] = [:]
         var toolUseMetadata: [String: [String: String]] = [:]
-        var reasoningIDMap: [String: UUID] = [:]
-        let flushInterval: ContinuousClock.Duration = .milliseconds(150)
-        var lastFlushTime: ContinuousClock.Instant = .now
+        var hasRenderedFirstText = false
 
         for try await event in stream {
             guard !Task.isCancelled else { break }
             switch event {
             case .textDelta(let token):
-                pendingContent += token
+                drainBufferedReasoning(buffer, assistantID: assistantID, idMap: reasoningIDMap)
+                buffer.appendText(token)
+                if !hasRenderedFirstText, buffer.hasBufferedText {
+                    hasRenderedFirstText = true
+                    drainBufferedText(buffer, assistantID: assistantID)
+                }
             case .usage(let usage):
-                pendingUsage = usage
+                buffer.setUsage(usage)
             case .toolUseStart(let id, let name, let providerMetadata):
-                if !pendingContent.isEmpty {
-                    await self.flushPending(content: pendingContent, usage: pendingUsage, into: assistantID)
-                    pendingContent = ""
-                    pendingUsage = nil
-                    lastFlushTime = .now
-                }
-                await MainActor.run { [weak self] in
-                    self?.finalizeStreamingMessage(id: assistantID)
-                }
+                drainBuffer(buffer, assistantID: assistantID, idMap: reasoningIDMap)
+                finalizeStreamingMessage(id: assistantID)
                 if toolUseInputs[id] == nil {
                     toolUseOrder.append(id)
                     toolUseInputs[id] = ""
@@ -382,34 +456,26 @@ extension AIChatViewModel {
             case .toolUseEnd:
                 break
             case .toolInvocationRequest(let block, let replyToken):
-                await self.dispatchCopilotInvocation(
+                drainBuffer(buffer, assistantID: assistantID, idMap: reasoningIDMap)
+                await dispatchCopilotInvocation(
                     block: block, replyToken: replyToken,
                     assistantID: assistantID, mode: chatMode
                 )
             case .reasoningStart(let providerID):
-                if !pendingContent.isEmpty {
-                    await self.flushPending(content: pendingContent, usage: pendingUsage, into: assistantID)
-                    pendingContent = ""
-                    pendingUsage = nil
-                    lastFlushTime = .now
-                }
-                await self.startReasoning(providerID: providerID, assistantID: assistantID, idMap: &reasoningIDMap)
+                drainBuffer(buffer, assistantID: assistantID, idMap: reasoningIDMap)
+                turn(withID: assistantID)?
+                    .startReasoningBlock(providerBlockID: providerID, idMap: &reasoningIDMap.value)
             case .reasoningDelta(let providerID, let text):
-                await self.appendReasoning(providerID: providerID, text: text, assistantID: assistantID, idMap: &reasoningIDMap)
+                drainBufferedText(buffer, assistantID: assistantID)
+                buffer.appendReasoning(providerBlockID: providerID, text: text)
             case .reasoningEnd(let providerID, let opaque):
-                await self.finalizeReasoning(providerID: providerID, opaque: opaque, assistantID: assistantID, idMap: &reasoningIDMap)
+                drainBuffer(buffer, assistantID: assistantID, idMap: reasoningIDMap)
+                turn(withID: assistantID)?.finalizeReasoningBlock(
+                    providerBlockID: providerID,
+                    opaque: opaque,
+                    idMap: &reasoningIDMap.value
+                )
             }
-
-            if ContinuousClock.now - lastFlushTime >= flushInterval {
-                await self.flushPending(content: pendingContent, usage: pendingUsage, into: assistantID)
-                pendingContent = ""
-                pendingUsage = nil
-                lastFlushTime = .now
-            }
-        }
-
-        if !Task.isCancelled, !pendingContent.isEmpty || pendingUsage != nil {
-            await self.flushPending(content: pendingContent, usage: pendingUsage, into: assistantID)
         }
 
         return StreamRoundResult(
@@ -419,42 +485,6 @@ extension AIChatViewModel {
             toolUseMetadata: toolUseMetadata,
             cancelled: Task.isCancelled
         )
-    }
-
-    private func startReasoning(providerID: String, assistantID: UUID, idMap: inout [String: UUID]) async {
-        let captured = idMap
-        let updated = await MainActor.run { [weak self] () -> [String: UUID] in
-            guard let self,
-                  let idx = self.messages.firstIndex(where: { $0.id == assistantID }) else { return captured }
-            var localMap = captured
-            self.messages[idx].startReasoningBlock(providerBlockID: providerID, idMap: &localMap)
-            return localMap
-        }
-        idMap = updated
-    }
-
-    private func appendReasoning(providerID: String, text: String, assistantID: UUID, idMap: inout [String: UUID]) async {
-        let captured = idMap
-        let updated = await MainActor.run { [weak self] () -> [String: UUID] in
-            guard let self,
-                  let idx = self.messages.firstIndex(where: { $0.id == assistantID }) else { return captured }
-            var localMap = captured
-            _ = self.messages[idx].appendReasoningDelta(providerBlockID: providerID, text: text, idMap: &localMap)
-            return localMap
-        }
-        idMap = updated
-    }
-
-    private func finalizeReasoning(providerID: String, opaque: ReasoningOpaque?, assistantID: UUID, idMap: inout [String: UUID]) async {
-        let captured = idMap
-        let updated = await MainActor.run { [weak self] () -> [String: UUID] in
-            guard let self,
-                  let idx = self.messages.firstIndex(where: { $0.id == assistantID }) else { return captured }
-            var localMap = captured
-            self.messages[idx].finalizeReasoningBlock(providerBlockID: providerID, opaque: opaque, idMap: &localMap)
-            return localMap
-        }
-        idMap = updated
     }
 
     nonisolated static func buildSystemPrompt(
@@ -549,21 +579,6 @@ extension AIChatViewModel {
                 assistantTurn: assistantWire,
                 userTurn: userTurn
             )
-        }
-    }
-
-    func flushPending(content: String, usage: AITokenUsage?, into assistantID: UUID) async {
-        guard !content.isEmpty || usage != nil else { return }
-        await MainActor.run { [weak self] in
-            guard let self,
-                  let idx = self.messages.firstIndex(where: { $0.id == assistantID })
-            else { return }
-            if !content.isEmpty {
-                self.messages[idx].appendStreamingToken(content)
-            }
-            if let usage {
-                self.messages[idx].usage = usage
-            }
         }
     }
 

--- a/TablePro/ViewModels/AIChatViewModel+ToolApproval.swift
+++ b/TablePro/ViewModels/AIChatViewModel+ToolApproval.swift
@@ -125,16 +125,16 @@ extension AIChatViewModel {
 
     @MainActor
     func appendPendingToolUseBlocks(_ blocks: [ToolUseBlock], assistantID: UUID) {
-        guard let idx = messages.firstIndex(where: { $0.id == assistantID }) else { return }
+        guard let turn = turn(withID: assistantID) else { return }
         for block in blocks {
-            messages[idx].appendBlock(.toolUse(block))
+            turn.appendBlock(.toolUse(block))
         }
     }
 
     @MainActor
     func updateApprovalState(blockID: String, newState: ToolApprovalState, assistantID: UUID) {
-        guard let idx = messages.firstIndex(where: { $0.id == assistantID }) else { return }
-        for chatBlock in messages[idx].blocks {
+        guard let turn = turn(withID: assistantID) else { return }
+        for chatBlock in turn.blocks {
             if case .toolUse(var block) = chatBlock.kind, block.id == blockID {
                 block.approvalState = newState
                 chatBlock.setKind(.toolUse(block))

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -37,6 +37,9 @@ final class AIChatViewModel {
 
     var connection: DatabaseConnection?
 
+    @ObservationIgnored var streamFlushClock: StreamFlushClock = ContinuousStreamFlushClock()
+    @ObservationIgnored var streamFlushInterval: Duration = .milliseconds(50)
+
     var tables: [TableInfo] {
         guard let id = connection?.id else { return [] }
         return services.schemaService.tables(for: id)
@@ -175,6 +178,10 @@ final class AIChatViewModel {
         attachedContext.removeAll { $0.stableKey == item.stableKey }
     }
 
+    func turn(withID id: UUID) -> ChatTurn? {
+        messages.first { $0.id == id }
+    }
+
     func cancelStream() {
         pendingWalkthroughBeforeSQL = nil
         prepTask?.cancel()
@@ -185,8 +192,9 @@ final class AIChatViewModel {
 
         if case .streaming(let assistantID) = streamingState,
            let idx = messages.firstIndex(where: { $0.id == assistantID }) {
-            messages[idx].finishStreamingTextBlock()
-            if messages[idx].blocks.isEmpty {
+            let turn = messages[idx]
+            turn.finishStreamingTextBlock()
+            if turn.blocks.isEmpty {
                 messages.remove(at: idx)
             }
         }

--- a/TablePro/Views/AIChat/AIChatCodeBlockView.swift
+++ b/TablePro/Views/AIChat/AIChatCodeBlockView.swift
@@ -22,6 +22,7 @@ struct AIChatCodeBlockView: View, Equatable {
     @State private var isCopied: Bool = false
     @State private var isEditorReady = false
     @State private var editorState = SourceEditorState()
+    @State private var measuredWidth: CGFloat = 0
     @FocusedValue(\.commandActions) private var focusedActions
     @Bindable private var commandRegistry = CommandActionsRegistry.shared
 
@@ -108,24 +109,32 @@ struct AIChatCodeBlockView: View, Equatable {
 
     @ViewBuilder
     private var codeContent: some View {
-        if usesLightweightContent {
-            Text(code.isEmpty ? " " : code)
-                .font(.system(.body, design: .monospaced))
-                .foregroundStyle(.primary)
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(8)
-                .frame(minHeight: 32, alignment: .topLeading)
-                .background(Color(nsColor: .textBackgroundColor))
-        } else {
-            SourceEditor(
-                .constant(code),
-                language: treeSitterLanguage,
-                configuration: Self.makeConfiguration(),
-                state: $editorState
-            )
-            .frame(maxWidth: .infinity)
-            .frame(height: editorHeight)
+        Group {
+            if usesLightweightContent {
+                Text(code.isEmpty ? " " : code)
+                    .font(Font(Self.editorFont))
+                    .lineSpacing(CodeBlockHeightEstimator.extraLineSpacing(for: Self.editorFont))
+                    .foregroundStyle(.primary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(8)
+                    .frame(minHeight: CodeBlockHeightEstimator.minimumHeight, alignment: .topLeading)
+                    .background(Color(nsColor: .textBackgroundColor))
+            } else {
+                SourceEditor(
+                    .constant(code),
+                    language: treeSitterLanguage,
+                    configuration: Self.makeConfiguration(),
+                    state: $editorState
+                )
+                .frame(maxWidth: .infinity)
+                .frame(height: contentHeight)
+            }
+        }
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { newWidth in
+            measuredWidth = newWidth
         }
     }
 
@@ -177,21 +186,22 @@ struct AIChatCodeBlockView: View, Equatable {
         treeSitterLanguage.id != CodeLanguage.default.id
     }
 
-    private var editorHeight: CGFloat {
-        let lineHeight: CGFloat = 18
-        let editorInsets: CGFloat = 16
-        let lineCount = code.reduce(into: 1) { count, char in
-            if char == "\n" { count += 1 }
-        }
-        let height = CGFloat(lineCount) * lineHeight + editorInsets
-        return min(max(height, 32), 400)
+    private var contentHeight: CGFloat {
+        CodeBlockHeightEstimator.height(
+            for: code,
+            font: Self.editorFont,
+            availableWidth: measuredWidth
+        )
     }
+
+    private static let editorFont = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
 
     private static func makeConfiguration() -> SourceEditorConfiguration {
         SourceEditorConfiguration(
             appearance: .init(
                 theme: TableProEditorTheme.make(),
-                font: NSFont.monospacedSystemFont(ofSize: 12, weight: .regular),
+                font: editorFont,
+                lineHeightMultiple: Double(CodeBlockHeightEstimator.lineHeightMultiple),
                 wrapLines: true
             ),
             behavior: .init(

--- a/TablePro/Views/AIChat/AIChatMessageSpacing.swift
+++ b/TablePro/Views/AIChat/AIChatMessageSpacing.swift
@@ -1,0 +1,18 @@
+//
+//  AIChatMessageSpacing.swift
+//  TablePro
+//
+
+import Foundation
+
+@MainActor
+enum AIChatMessageSpacing {
+    static func spacedMessageIDs(for messages: [ChatTurn]) -> Set<UUID> {
+        var ids: Set<UUID> = []
+        for (previous, current) in zip(messages, messages.dropFirst())
+        where current.role == .user && previous.role == .assistant {
+            ids.insert(current.id)
+        }
+        return ids
+    }
+}

--- a/TablePro/Views/AIChat/AIChatMessageView.swift
+++ b/TablePro/Views/AIChat/AIChatMessageView.swift
@@ -8,7 +8,7 @@
 import AppKit
 import SwiftUI
 
-struct AIChatMessageView: View {
+struct AIChatMessageView: View, Equatable {
     private static let userBubbleTintOpacity: Double = 0.08
 
     let message: ChatTurn
@@ -18,6 +18,16 @@ struct AIChatMessageView: View {
     var onContinue: (() -> Void)?
     var onAdjustToolLimit: (() -> Void)?
     var pausedToolCallCount: Int?
+
+    static func == (lhs: AIChatMessageView, rhs: AIChatMessageView) -> Bool {
+        lhs.message === rhs.message
+            && (lhs.onRetry == nil) == (rhs.onRetry == nil)
+            && (lhs.onRegenerate == nil) == (rhs.onRegenerate == nil)
+            && (lhs.onEdit == nil) == (rhs.onEdit == nil)
+            && (lhs.onContinue == nil) == (rhs.onContinue == nil)
+            && (lhs.onAdjustToolLimit == nil) == (rhs.onAdjustToolLimit == nil)
+            && lhs.pausedToolCallCount == rhs.pausedToolCallCount
+    }
 
     private var attachedContextItems: [ContextItem] {
         message.blocks.compactMap { block in
@@ -186,6 +196,7 @@ struct AIChatMessageView: View {
             VStack(alignment: .leading, spacing: 6) {
                 ForEach(visibleBlocks) { block in
                     AIChatBlockView(block: block)
+                        .equatable()
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -194,8 +205,12 @@ struct AIChatMessageView: View {
     }
 }
 
-private struct AIChatBlockView: View {
+private struct AIChatBlockView: View, Equatable {
     @Bindable var block: ChatContentBlock
+
+    static func == (lhs: AIChatBlockView, rhs: AIChatBlockView) -> Bool {
+        lhs.block === rhs.block
+    }
 
     var body: some View {
         switch block.kind {

--- a/TablePro/Views/AIChat/AIChatPanelView.swift
+++ b/TablePro/Views/AIChat/AIChatPanelView.swift
@@ -98,14 +98,7 @@ struct AIChatPanelView: View {
 
     private var messageList: some View {
         let visibleMessages = viewModel.messages.filter { isVisibleInMessageList($0) }
-        let spacedMessageIDs: Set<UUID> = {
-            var ids = Set<UUID>()
-            for i in 1..<visibleMessages.count
-                where visibleMessages[i].role == .user && visibleMessages[i - 1].role == .assistant {
-                ids.insert(visibleMessages[i].id)
-            }
-            return ids
-        }()
+        let spacedMessageIDs = AIChatMessageSpacing.spacedMessageIDs(for: visibleMessages)
 
         let lastMessageID = visibleMessages.last?.id
         let isUserScrolledUp = !pinnedToBottom && bottomVisibleMessageID != nil
@@ -132,6 +125,7 @@ struct AIChatPanelView: View {
                             pausedToolCallCount: shouldShowContinue(for: message)
                                 ? viewModel.toolLimitPauseCount : nil
                         )
+                        .equatable()
                         .padding(.vertical, 4)
                         .id(message.id)
                     }

--- a/TablePro/Views/AIChat/CodeBlockHeightEstimator.swift
+++ b/TablePro/Views/AIChat/CodeBlockHeightEstimator.swift
@@ -1,0 +1,52 @@
+//
+//  CodeBlockHeightEstimator.swift
+//  TablePro
+//
+
+import AppKit
+
+enum CodeBlockHeightEstimator {
+    static let minimumHeight: CGFloat = 32
+    static let maximumHeight: CGFloat = 400
+    static let lineHeightMultiple: CGFloat = 1.2
+    private static let verticalInsets: CGFloat = 18
+    private static let horizontalInsets: CGFloat = 16
+
+    static func height(for code: String, font: NSFont, availableWidth: CGFloat) -> CGFloat {
+        guard availableWidth > 0 else { return fallbackHeight(for: code, font: font) }
+        let textWidth = max(availableWidth - horizontalInsets, 1)
+        let measured = (code as NSString).boundingRect(
+            with: CGSize(width: textWidth, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [.font: font]
+        ).height
+        return clamped(ceil(measured * pitchScale(for: font)) + verticalInsets)
+    }
+
+    static func fallbackHeight(for code: String, font: NSFont) -> CGFloat {
+        let lineCount = (code as NSString).components(separatedBy: "\n").count
+        return clamped(CGFloat(lineCount) * editorLineHeight(for: font) + verticalInsets)
+    }
+
+    static func editorLineHeight(for font: NSFont) -> CGFloat {
+        (font.ascender - font.descender + font.leading) * lineHeightMultiple
+    }
+
+    static func extraLineSpacing(for font: NSFont) -> CGFloat {
+        max(editorLineHeight(for: font) - layoutLineHeight(for: font), 0)
+    }
+
+    private static func layoutLineHeight(for font: NSFont) -> CGFloat {
+        NSLayoutManager().defaultLineHeight(for: font)
+    }
+
+    private static func pitchScale(for font: NSFont) -> CGFloat {
+        let layoutHeight = layoutLineHeight(for: font)
+        guard layoutHeight > 0 else { return lineHeightMultiple }
+        return max(editorLineHeight(for: font) / layoutHeight, 1)
+    }
+
+    private static func clamped(_ height: CGFloat) -> CGFloat {
+        min(max(height, minimumHeight), maximumHeight)
+    }
+}

--- a/TablePro/Views/AIChat/MarkdownInlineRepair.swift
+++ b/TablePro/Views/AIChat/MarkdownInlineRepair.swift
@@ -1,0 +1,189 @@
+//
+//  MarkdownInlineRepair.swift
+//  TablePro
+//
+
+import Foundation
+
+enum MarkdownInlineRepair {
+    private static let maximumRepairableLength = 20_000
+
+    private enum OpenDelimiter {
+        case codeSpan(runLength: Int)
+        case linkTarget
+        case strong
+
+        var closingText: String {
+            switch self {
+            case .codeSpan(let runLength): return String(repeating: "`", count: runLength)
+            case .linkTarget: return ")"
+            case .strong: return "**"
+            }
+        }
+    }
+
+    private struct ScanResult {
+        var stack: [OpenDelimiter] = []
+        var trailingRunStart: Int?
+        var trailingRunPushed = false
+    }
+
+    static func repairingDanglingSyntax(_ source: String) -> String {
+        guard !source.isEmpty, (source as NSString).length <= maximumRepairableLength else { return source }
+        let characters = Array(source)
+        var result = scan(characters)
+
+        var visibleCount = characters.count
+        if let trailingRunStart = result.trailingRunStart {
+            visibleCount = trailingRunStart
+            if result.trailingRunPushed, !result.stack.isEmpty {
+                result.stack.removeLast()
+            }
+        }
+
+        let closers = result.stack.reversed().map(\.closingText).joined()
+        if visibleCount == characters.count, closers.isEmpty { return source }
+        return String(characters[0..<visibleCount]) + closers
+    }
+
+    private static func scan(_ characters: [Character]) -> ScanResult {
+        var result = ScanResult()
+        var index = 0
+
+        while index < characters.count {
+            let character = characters[index]
+
+            if isInsideCodeSpan(result.stack) {
+                if character == "`" {
+                    index += consumeBacktickRun(at: index, in: characters, result: &result)
+                } else {
+                    result.trailingRunStart = nil
+                    index += 1
+                }
+                continue
+            }
+
+            if character == "\\" {
+                result.trailingRunStart = nil
+                index += 2
+                continue
+            }
+
+            if character == "`" {
+                index += consumeBacktickRun(at: index, in: characters, result: &result)
+                continue
+            }
+
+            if character == "]", index + 1 < characters.count, characters[index + 1] == "(" {
+                result.stack.append(.linkTarget)
+                result.trailingRunStart = nil
+                index += 2
+                continue
+            }
+
+            if character == ")" {
+                if case .linkTarget = result.stack.last { result.stack.removeLast() }
+                result.trailingRunStart = nil
+                index += 1
+                continue
+            }
+
+            if character == "*" {
+                index += consumeAsteriskRun(at: index, in: characters, result: &result)
+                continue
+            }
+
+            result.trailingRunStart = nil
+            index += 1
+        }
+
+        return result
+    }
+
+    private static func consumeBacktickRun(
+        at index: Int,
+        in characters: [Character],
+        result: inout ScanResult
+    ) -> Int {
+        let length = runLength(of: "`", in: characters, from: index)
+        var closed = false
+        var pushed = false
+
+        if case .codeSpan(let openLength) = result.stack.last, openLength == length {
+            result.stack.removeLast()
+            closed = true
+        } else if !isInsideCodeSpan(result.stack) {
+            result.stack.append(.codeSpan(runLength: length))
+            pushed = true
+        }
+
+        recordTrailingRun(start: index, length: length, closed: closed, pushed: pushed, in: characters, result: &result)
+        return length
+    }
+
+    private static func consumeAsteriskRun(
+        at index: Int,
+        in characters: [Character],
+        result: inout ScanResult
+    ) -> Int {
+        let length = runLength(of: "*", in: characters, from: index)
+        guard length >= 2 else {
+            result.trailingRunStart = nil
+            return length
+        }
+        var closed = false
+        var pushed = false
+
+        if case .strong = result.stack.last, canClose(at: index, in: characters) {
+            result.stack.removeLast()
+            closed = true
+        } else if canOpen(at: index + length, in: characters) {
+            result.stack.append(.strong)
+            pushed = true
+        }
+
+        recordTrailingRun(start: index, length: length, closed: closed, pushed: pushed, in: characters, result: &result)
+        return length
+    }
+
+    private static func recordTrailingRun(
+        start: Int,
+        length: Int,
+        closed: Bool,
+        pushed: Bool,
+        in characters: [Character],
+        result: inout ScanResult
+    ) {
+        guard start + length >= characters.count, !closed else {
+            result.trailingRunStart = nil
+            return
+        }
+        result.trailingRunStart = start
+        result.trailingRunPushed = pushed
+    }
+
+    private static func canOpen(at index: Int, in characters: [Character]) -> Bool {
+        guard index < characters.count else { return false }
+        return !characters[index].isWhitespace
+    }
+
+    private static func canClose(at index: Int, in characters: [Character]) -> Bool {
+        guard index > 0 else { return false }
+        return !characters[index - 1].isWhitespace
+    }
+
+    private static func isInsideCodeSpan(_ stack: [OpenDelimiter]) -> Bool {
+        if case .codeSpan = stack.last { return true }
+        return false
+    }
+
+    private static func runLength(of character: Character, in characters: [Character], from index: Int) -> Int {
+        var length = 0
+        var cursor = index
+        while cursor < characters.count, characters[cursor] == character {
+            length += 1
+            cursor += 1
+        }
+        return length
+    }
+}

--- a/TablePro/Views/AIChat/MarkdownView.swift
+++ b/TablePro/Views/AIChat/MarkdownView.swift
@@ -11,18 +11,27 @@
 import AppKit
 import SwiftUI
 
-struct MarkdownView: View {
+struct MarkdownView: View, Equatable {
     let source: String
     var isStreaming: Bool = false
 
     @State private var cache = MarkdownDocumentCache()
 
+    static func == (lhs: MarkdownView, rhs: MarkdownView) -> Bool {
+        lhs.source == rhs.source && lhs.isStreaming == rhs.isStreaming
+    }
+
     var body: some View {
         let blocks = cache.blocks(for: source)
+        let unsettledBlockID = isStreaming ? blocks.last?.id : nil
         VStack(alignment: .leading, spacing: 6) {
             ForEach(blocks) { block in
-                MarkdownBlockView(block: block, prefersLightweightCode: isStreaming)
-                    .equatable()
+                MarkdownBlockView(
+                    block: block,
+                    prefersLightweightCode: isStreaming,
+                    isSettled: block.id != unsettledBlockID
+                )
+                .equatable()
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -45,19 +54,22 @@ final class MarkdownDocumentCache {
 private struct MarkdownBlockView: View, Equatable {
     let block: MarkdownBlock
     let prefersLightweightCode: Bool
+    var isSettled: Bool = true
 
     static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.block == rhs.block && lhs.prefersLightweightCode == rhs.prefersLightweightCode
+        lhs.block == rhs.block
+            && lhs.prefersLightweightCode == rhs.prefersLightweightCode
+            && lhs.isSettled == rhs.isSettled
     }
 
     var body: some View {
         switch block.kind {
         case .paragraph(let text):
-            Text(MarkdownInline.parse(text))
+            Text(MarkdownInline.parse(text, isSettled: isSettled))
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
         case .header(let level, let text):
-            Text(MarkdownInline.parse(text))
+            Text(MarkdownInline.parse(text, isSettled: isSettled))
                 .font(headerFont(for: level))
                 .fontWeight(headerWeight(for: level))
                 .padding(.top, level == 1 ? 6 : 4)
@@ -72,12 +84,18 @@ private struct MarkdownBlockView: View, Equatable {
             )
             .equatable()
         case .unorderedList(let items):
-            MarkdownListView(items: items, style: .unordered, prefersLightweightCode: prefersLightweightCode)
+            MarkdownListView(
+                items: items,
+                style: .unordered,
+                prefersLightweightCode: prefersLightweightCode,
+                isSettled: isSettled
+            )
         case .orderedList(let start, let items):
             MarkdownListView(
                 items: items,
                 style: .ordered(start: start),
-                prefersLightweightCode: prefersLightweightCode
+                prefersLightweightCode: prefersLightweightCode,
+                isSettled: isSettled
             )
         case .blockquote(let lines):
             MarkdownBlockquoteView(lines: lines)
@@ -109,6 +127,7 @@ private struct MarkdownListView: View {
     let items: [MarkdownListItem]
     let style: ListStyle
     let prefersLightweightCode: Bool
+    var isSettled: Bool = true
 
     enum ListStyle: Equatable {
         case unordered
@@ -123,13 +142,17 @@ private struct MarkdownListView: View {
                         .foregroundStyle(.secondary)
                         .frame(minWidth: 16, alignment: .trailing)
                     VStack(alignment: .leading, spacing: 3) {
-                        Text(MarkdownInline.parse(item.text))
+                        Text(MarkdownInline.parse(item.text, isSettled: isSettled))
                             .textSelection(.enabled)
                             .frame(maxWidth: .infinity, alignment: .leading)
                         if !item.children.isEmpty {
                             ForEach(item.children) { child in
-                                MarkdownBlockView(block: child, prefersLightweightCode: prefersLightweightCode)
-                                    .equatable()
+                                MarkdownBlockView(
+                                    block: child,
+                                    prefersLightweightCode: prefersLightweightCode,
+                                    isSettled: isSettled
+                                )
+                                .equatable()
                             }
                             .padding(.leading, 4)
                         }
@@ -224,25 +247,32 @@ enum MarkdownInline {
     private static let cache: NSCache<NSString, NSAttributedString> = {
         let c = NSCache<NSString, NSAttributedString>()
         c.countLimit = 4_000
+        c.totalCostLimit = 8 * 1_024 * 1_024
         return c
     }()
 
-    static func parse(_ source: String) -> AttributedString {
+    private static let options = AttributedString.MarkdownParsingOptions(
+        interpretedSyntax: .inlineOnlyPreservingWhitespace
+    )
+
+    static func parse(_ source: String, isSettled: Bool = true) -> AttributedString {
+        guard isSettled else {
+            return attributedString(from: MarkdownInlineRepair.repairingDanglingSyntax(source))
+        }
         let key = source as NSString
         if let cached = cache.object(forKey: key) {
             return AttributedString(cached)
         }
-        let options = AttributedString.MarkdownParsingOptions(
-            interpretedSyntax: .inlineOnlyPreservingWhitespace
-        )
-        let attributed: AttributedString
-        if let parsed = try? AttributedString(markdown: source, options: options) {
-            attributed = parsed
-        } else {
-            attributed = AttributedString(source)
-        }
-        cache.setObject(NSAttributedString(attributed), forKey: key)
+        let attributed = attributedString(from: source)
+        cache.setObject(NSAttributedString(attributed), forKey: key, cost: key.length)
         return attributed
+    }
+
+    private static func attributedString(from source: String) -> AttributedString {
+        guard let parsed = try? AttributedString(markdown: source, options: options) else {
+            return AttributedString(source)
+        }
+        return parsed
     }
 }
 

--- a/TableProTests/Core/AI/ChatTurnObservationTests.swift
+++ b/TableProTests/Core/AI/ChatTurnObservationTests.swift
@@ -1,0 +1,137 @@
+//
+//  ChatTurnObservationTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Observation
+@testable import TablePro
+import Testing
+
+@Suite("ChatTurn observation granularity")
+@MainActor
+struct ChatTurnObservationTests {
+    private func makeStreamingTurn() -> (ChatTurn, ChatContentBlock) {
+        let block = ChatContentBlock.text("", isStreaming: true)
+        return (ChatTurn(role: .assistant, blocks: [block]), block)
+    }
+
+    @Test("Appending a streaming token leaves the messages array untouched")
+    func tokenAppendDoesNotInvalidateMessagesArray() {
+        let viewModel = AIChatViewModel()
+        let (turn, _) = makeStreamingTurn()
+        viewModel.messages.append(turn)
+
+        var messagesInvalidated = false
+        withObservationTracking {
+            _ = viewModel.messages.count
+        } onChange: {
+            messagesInvalidated = true
+        }
+
+        turn.appendStreamingToken("hello")
+
+        #expect(messagesInvalidated == false)
+        #expect(turn.plainText == "hello")
+    }
+
+    @Test("Appending a streaming token leaves the turn's block list untouched")
+    func tokenAppendDoesNotInvalidateBlockList() {
+        let (turn, _) = makeStreamingTurn()
+
+        var blockListInvalidated = false
+        withObservationTracking {
+            _ = turn.blocks.count
+        } onChange: {
+            blockListInvalidated = true
+        }
+
+        turn.appendStreamingToken("hello")
+
+        #expect(blockListInvalidated == false)
+    }
+
+    @Test("Appending a streaming token invalidates only the block that grew")
+    func tokenAppendInvalidatesGrowingBlock() {
+        let (turn, block) = makeStreamingTurn()
+
+        var blockInvalidated = false
+        withObservationTracking {
+            _ = block.kind
+        } onChange: {
+            blockInvalidated = true
+        }
+
+        turn.appendStreamingToken("hello")
+
+        #expect(blockInvalidated)
+    }
+
+    @Test("The message list's own reads survive a streaming token without invalidation")
+    func panelLevelReadsSurviveStreamingToken() {
+        let viewModel = AIChatViewModel()
+        let (turn, _) = makeStreamingTurn()
+        viewModel.messages.append(turn)
+        viewModel.streamingState = .streaming(assistantID: turn.id)
+
+        var panelInvalidated = false
+        withObservationTracking {
+            for message in viewModel.messages {
+                _ = message.id
+                _ = message.role
+                if !viewModel.isStreaming {
+                    _ = message.plainText
+                }
+            }
+        } onChange: {
+            panelInvalidated = true
+        }
+
+        turn.appendStreamingToken("hello")
+
+        #expect(panelInvalidated == false)
+    }
+
+    @Test("Starting a new block invalidates the owning turn but not the messages array")
+    func newBlockInvalidatesTurnOnly() {
+        let viewModel = AIChatViewModel()
+        let (turn, _) = makeStreamingTurn()
+        viewModel.messages.append(turn)
+
+        var messagesInvalidated = false
+        withObservationTracking {
+            _ = viewModel.messages.count
+        } onChange: {
+            messagesInvalidated = true
+        }
+
+        var blockListInvalidated = false
+        withObservationTracking {
+            _ = turn.blocks.count
+        } onChange: {
+            blockListInvalidated = true
+        }
+
+        turn.appendBlock(.toolUse(ToolUseBlock(id: "t1", name: "noop", input: .object([:]))))
+
+        #expect(messagesInvalidated == false)
+        #expect(blockListInvalidated)
+    }
+
+    @Test("Setting usage on one turn does not invalidate a sibling turn")
+    func usageUpdateIsScopedToItsTurn() {
+        let first = ChatTurn(role: .assistant, blocks: [ChatContentBlock.text("done")])
+        let (second, _) = makeStreamingTurn()
+
+        var siblingInvalidated = false
+        withObservationTracking {
+            _ = first.usage
+        } onChange: {
+            siblingInvalidated = true
+        }
+
+        second.usage = AITokenUsage(inputTokens: 10, outputTokens: 20)
+
+        #expect(siblingInvalidated == false)
+    }
+}

--- a/TableProTests/Core/AI/StreamTextBufferTests.swift
+++ b/TableProTests/Core/AI/StreamTextBufferTests.swift
@@ -1,0 +1,70 @@
+//
+//  StreamTextBufferTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("StreamTextBuffer")
+@MainActor
+struct StreamTextBufferTests {
+    @Test("Text appends accumulate and drain once")
+    func textAccumulatesAndDrainsOnce() {
+        let buffer = StreamTextBuffer()
+        buffer.appendText("Hel")
+        buffer.appendText("lo")
+
+        #expect(buffer.hasBufferedText)
+        #expect(buffer.drainText().text == "Hello")
+        #expect(buffer.hasBufferedText == false)
+        #expect(buffer.drainText().text.isEmpty)
+    }
+
+    @Test("Empty appends are ignored")
+    func emptyAppendsAreIgnored() {
+        let buffer = StreamTextBuffer()
+        buffer.appendText("")
+
+        #expect(buffer.hasBufferedText == false)
+    }
+
+    @Test("Usage survives until drained and counts as buffered content")
+    func usageIsBufferedAndDrained() {
+        let buffer = StreamTextBuffer()
+        buffer.setUsage(AITokenUsage(inputTokens: 3, outputTokens: 7))
+
+        #expect(buffer.hasBufferedText)
+        let drained = buffer.drainText()
+        #expect(drained.text.isEmpty)
+        #expect(drained.usage?.outputTokens == 7)
+        #expect(buffer.hasBufferedText == false)
+    }
+
+    @Test("Reasoning is kept per provider block and drained in arrival order")
+    func reasoningIsGroupedInArrivalOrder() {
+        let buffer = StreamTextBuffer()
+        buffer.appendReasoning(providerBlockID: "b1", text: "one ")
+        buffer.appendReasoning(providerBlockID: "b2", text: "two")
+        buffer.appendReasoning(providerBlockID: "b1", text: "more")
+
+        #expect(buffer.hasBufferedReasoning)
+        let drained = buffer.drainReasoning()
+        #expect(drained.map(\.providerBlockID) == ["b1", "b2"])
+        #expect(drained.first?.text == "one more")
+        #expect(buffer.hasBufferedReasoning == false)
+    }
+
+    @Test("Text and reasoning drain independently")
+    func textAndReasoningAreIndependent() {
+        let buffer = StreamTextBuffer()
+        buffer.appendText("visible")
+        buffer.appendReasoning(providerBlockID: "b1", text: "thinking")
+
+        _ = buffer.drainText()
+
+        #expect(buffer.hasBufferedReasoning)
+        #expect(buffer.drainReasoning().first?.text == "thinking")
+    }
+}

--- a/TableProTests/ViewModels/AIChatViewModelStreamingCadenceTests.swift
+++ b/TableProTests/ViewModels/AIChatViewModelStreamingCadenceTests.swift
@@ -1,0 +1,214 @@
+//
+//  AIChatViewModelStreamingCadenceTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+@testable import TablePro
+import Testing
+
+@Suite("AIChatViewModel streaming cadence", .serialized)
+@MainActor
+struct AIChatViewModelStreamingCadenceTests {
+    private final class NeverTickingClock: StreamFlushClock, @unchecked Sendable {
+        func sleep(for duration: Duration) async throws {
+            try await Task.sleep(for: .seconds(3_600))
+        }
+    }
+
+    private final class UnfoldingTransport: ChatTransport, @unchecked Sendable {
+        private let events: [ChatStreamEvent]
+        private let beforeEach: @MainActor (Int) -> Void
+        private var index = 0
+
+        init(events: [ChatStreamEvent], beforeEach: @escaping @MainActor (Int) -> Void) {
+            self.events = events
+            self.beforeEach = beforeEach
+        }
+
+        func streamChat(
+            turns: [ChatTurnWire],
+            options: ChatTransportOptions
+        ) -> AsyncThrowingStream<ChatStreamEvent, Error> {
+            AsyncThrowingStream { [self] in
+                let current = index
+                await MainActor.run { beforeEach(current) }
+                guard current < events.count else { return nil }
+                index += 1
+                return events[current]
+            }
+        }
+
+        func fetchAvailableModels() async throws -> [AIModelInfo] { [] }
+
+        func testConnection() async throws -> Bool { true }
+    }
+
+    private struct StreamFailure: Error {}
+
+    private final class FailingTransport: ChatTransport, @unchecked Sendable {
+        private let events: [ChatStreamEvent]
+
+        init(events: [ChatStreamEvent]) {
+            self.events = events
+        }
+
+        func streamChat(
+            turns: [ChatTurnWire],
+            options: ChatTransportOptions
+        ) -> AsyncThrowingStream<ChatStreamEvent, Error> {
+            AsyncThrowingStream { continuation in
+                for event in events {
+                    continuation.yield(event)
+                }
+                continuation.finish(throwing: StreamFailure())
+            }
+        }
+
+        func fetchAvailableModels() async throws -> [AIModelInfo] { [] }
+
+        func testConnection() async throws -> Bool { true }
+    }
+
+    private static func makeResolved(_ transport: ChatTransport) -> AIProviderFactory.ResolvedProvider {
+        AIProviderFactory.ResolvedProvider(
+            provider: transport,
+            model: "test-model",
+            config: AIProviderConfig(name: "Test", type: .claude)
+        )
+    }
+
+    private static func makeSettings() -> AISettings {
+        AISettings(
+            enabled: true,
+            includeSchema: false,
+            includeCurrentQuery: false,
+            includeQueryResults: false,
+            chatMode: .ask
+        )
+    }
+
+    private func runStream(
+        viewModel: AIChatViewModel,
+        transport: ChatTransport
+    ) async -> ChatTurn {
+        let assistant = ChatTurn(role: .assistant, blocks: [], modelId: "test-model", providerId: nil)
+        viewModel.messages.append(assistant)
+        viewModel.streamingState = .streaming(assistantID: assistant.id)
+        viewModel.runStream(
+            chatMessages: [],
+            promptContext: nil,
+            resolved: Self.makeResolved(transport),
+            assistantID: assistant.id,
+            settings: Self.makeSettings(),
+            registry: ChatToolRegistry()
+        )
+        await viewModel.streamingTask?.value
+        return assistant
+    }
+
+    @Test("The first token is shown before the next event is consumed")
+    func firstTokenIsFlushedImmediately() async {
+        let viewModel = AIChatViewModel()
+        viewModel.streamFlushClock = NeverTickingClock()
+        var snapshots: [String] = []
+
+        let transport = UnfoldingTransport(
+            events: [.textDelta("Alpha"), .textDelta("Beta"), .textDelta("Gamma")]
+        ) { [weak viewModel] _ in
+            snapshots.append(viewModel?.messages.last?.plainText ?? "")
+        }
+
+        let assistant = await runStream(viewModel: viewModel, transport: transport)
+
+        #expect(snapshots.first == "")
+        #expect(snapshots.count >= 2)
+        #expect(snapshots[1] == "Alpha")
+        #expect(assistant.plainText == "AlphaBetaGamma")
+    }
+
+    @Test("Later tokens coalesce instead of updating on every event")
+    func laterTokensAreCoalesced() async {
+        let viewModel = AIChatViewModel()
+        viewModel.streamFlushClock = NeverTickingClock()
+        var snapshots: [String] = []
+
+        let transport = UnfoldingTransport(
+            events: [.textDelta("Alpha"), .textDelta("Beta"), .textDelta("Gamma"), .textDelta("Delta")]
+        ) { [weak viewModel] _ in
+            snapshots.append(viewModel?.messages.last?.plainText ?? "")
+        }
+
+        let assistant = await runStream(viewModel: viewModel, transport: transport)
+
+        #expect(snapshots.dropFirst(2).allSatisfy { $0 == "Alpha" })
+        #expect(assistant.plainText == "AlphaBetaGammaDelta")
+    }
+
+    @Test("Buffered text is never lost when the stream ends")
+    func trailingTextIsAlwaysFlushed() async {
+        let viewModel = AIChatViewModel()
+        viewModel.streamFlushClock = NeverTickingClock()
+
+        let transport = UnfoldingTransport(
+            events: (1...50).map { .textDelta("chunk\($0) ") }
+        ) { _ in }
+
+        let assistant = await runStream(viewModel: viewModel, transport: transport)
+
+        let expected = (1...50).map { "chunk\($0) " }.joined()
+        #expect(assistant.plainText == expected)
+    }
+
+    @Test("Buffered text survives a stream that fails part way through")
+    func bufferedTextSurvivesAStreamFailure() async {
+        let viewModel = AIChatViewModel()
+        viewModel.streamFlushClock = NeverTickingClock()
+
+        let transport = FailingTransport(
+            events: [.textDelta("kept one "), .textDelta("kept two")]
+        )
+
+        let assistant = ChatTurn(role: .assistant, blocks: [], modelId: "test-model", providerId: nil)
+        viewModel.messages.append(assistant)
+        viewModel.streamingState = .streaming(assistantID: assistant.id)
+        viewModel.runStream(
+            chatMessages: [],
+            promptContext: nil,
+            resolved: Self.makeResolved(transport),
+            assistantID: assistant.id,
+            settings: Self.makeSettings(),
+            registry: ChatToolRegistry()
+        )
+        await viewModel.streamingTask?.value
+
+        #expect(assistant.plainText == "kept one kept two")
+    }
+
+    @Test("Text stays ahead of reasoning that arrives after it")
+    func textAndReasoningKeepArrivalOrder() async {
+        let viewModel = AIChatViewModel()
+        viewModel.streamFlushClock = NeverTickingClock()
+
+        let transport = UnfoldingTransport(
+            events: [
+                .textDelta("before "),
+                .reasoningDelta(id: "r1", text: "thinking"),
+                .reasoningEnd(id: "r1", opaque: nil)
+            ]
+        ) { _ in }
+
+        let assistant = await runStream(viewModel: viewModel, transport: transport)
+
+        let kinds = assistant.blocks.map { block -> String in
+            switch block.kind {
+            case .text: return "text"
+            case .reasoning: return "reasoning"
+            default: return "other"
+            }
+        }
+        #expect(kinds == ["text", "reasoning"])
+        #expect(assistant.plainText == "before ")
+    }
+}

--- a/TableProTests/Views/AIChat/AIChatMessageSpacingTests.swift
+++ b/TableProTests/Views/AIChat/AIChatMessageSpacingTests.swift
@@ -1,0 +1,59 @@
+//
+//  AIChatMessageSpacingTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("AI chat message spacing")
+@MainActor
+struct AIChatMessageSpacingTests {
+    private func turn(_ role: ChatRole) -> ChatTurn {
+        ChatTurn(role: role, blocks: [ChatContentBlock.text("body")])
+    }
+
+    @Test("An empty message list produces no spacing and does not trap")
+    func emptyListIsSafe() {
+        #expect(AIChatMessageSpacing.spacedMessageIDs(for: []).isEmpty)
+    }
+
+    @Test("A single message produces no spacing")
+    func singleMessageIsSafe() {
+        #expect(AIChatMessageSpacing.spacedMessageIDs(for: [turn(.user)]).isEmpty)
+    }
+
+    @Test("A user message following an assistant message is spaced")
+    func userAfterAssistantIsSpaced() {
+        let assistant = turn(.assistant)
+        let user = turn(.user)
+
+        let spaced = AIChatMessageSpacing.spacedMessageIDs(for: [assistant, user])
+
+        #expect(spaced == [user.id])
+    }
+
+    @Test("A user message following another user message is not spaced")
+    func userAfterUserIsNotSpaced() {
+        let first = turn(.user)
+        let second = turn(.user)
+
+        #expect(AIChatMessageSpacing.spacedMessageIDs(for: [first, second]).isEmpty)
+    }
+
+    @Test("Only the boundary messages in a longer conversation are spaced")
+    func spacesEveryAssistantToUserBoundary() {
+        let firstUser = turn(.user)
+        let firstAssistant = turn(.assistant)
+        let secondUser = turn(.user)
+        let secondAssistant = turn(.assistant)
+        let thirdUser = turn(.user)
+
+        let spaced = AIChatMessageSpacing.spacedMessageIDs(
+            for: [firstUser, firstAssistant, secondUser, secondAssistant, thirdUser]
+        )
+
+        #expect(spaced == [secondUser.id, thirdUser.id])
+    }
+}

--- a/TableProTests/Views/AIChat/CodeBlockHeightEstimatorTests.swift
+++ b/TableProTests/Views/AIChat/CodeBlockHeightEstimatorTests.swift
@@ -1,0 +1,76 @@
+//
+//  CodeBlockHeightEstimatorTests.swift
+//  TableProTests
+//
+
+import AppKit
+@testable import TablePro
+import Testing
+
+@Suite("Code block height estimation")
+struct CodeBlockHeightEstimatorTests {
+    private static let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+
+    private func height(_ code: String, width: CGFloat = 480) -> CGFloat {
+        CodeBlockHeightEstimator.height(for: code, font: Self.font, availableWidth: width)
+    }
+
+    @Test("A measured height stays within the clamp")
+    func heightStaysWithinClamp() {
+        let tall = String(repeating: "SELECT 1;\n", count: 200)
+
+        #expect(height("SELECT 1;") >= CodeBlockHeightEstimator.minimumHeight)
+        #expect(height(tall) == CodeBlockHeightEstimator.maximumHeight)
+    }
+
+    @Test("More lines never produce a shorter block")
+    func heightGrowsMonotonicallyWithLineCount() {
+        let one = height("SELECT 1;")
+        let three = height("SELECT 1;\nSELECT 2;\nSELECT 3;")
+
+        #expect(three > one)
+    }
+
+    @Test("A wrapping line is taller than the same text on a wide layout")
+    func wrappingIsAccountedFor() {
+        let line = String(repeating: "SELECT column_name FROM some_table ", count: 6)
+
+        #expect(height(line, width: 200) > height(line, width: 1_200))
+    }
+
+    @Test("A zero width falls back to the line-count estimate")
+    func zeroWidthUsesFallback() {
+        let code = "SELECT 1;\nSELECT 2;"
+
+        #expect(height(code, width: 0) == CodeBlockHeightEstimator.fallbackHeight(for: code, font: Self.font))
+    }
+
+    @Test("The estimate covers what the editor actually lays out at its line height multiple")
+    func estimateCoversEditorLineHeight() {
+        let lineCount = 10
+        let code = (1...lineCount).map { "SELECT \($0);" }.joined(separator: "\n")
+        let editorContent = CGFloat(lineCount) * CodeBlockHeightEstimator.editorLineHeight(for: Self.font)
+
+        #expect(height(code) >= editorContent)
+    }
+
+    @Test("The editor line height applies the multiple to the font's own metrics")
+    func editorLineHeightAppliesTheMultiple() {
+        let raw: CGFloat = Self.font.ascender - Self.font.descender + Self.font.leading
+
+        #expect(CodeBlockHeightEstimator.editorLineHeight(for: Self.font) == raw * CodeBlockHeightEstimator.lineHeightMultiple)
+        #expect(CodeBlockHeightEstimator.extraLineSpacing(for: Self.font) >= 0)
+    }
+
+    @Test("The estimate is never shorter than a plain unscaled text measurement")
+    func estimateIsNeverShorterThanPlainText() {
+        let code = (1...12).map { "SELECT column_\($0) FROM some_table;" }.joined(separator: "\n")
+        let plain = (code as NSString).boundingRect(
+            with: CGSize(width: CGFloat(464), height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [.font: Self.font]
+        ).height
+
+        #expect(height(code) >= plain)
+    }
+}

--- a/TableProTests/Views/AIChat/MarkdownInlineRepairTests.swift
+++ b/TableProTests/Views/AIChat/MarkdownInlineRepairTests.swift
@@ -1,0 +1,127 @@
+//
+//  MarkdownInlineRepairTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Markdown inline repair for streaming tails")
+struct MarkdownInlineRepairTests {
+    private func repaired(_ source: String) -> String {
+        MarkdownInlineRepair.repairingDanglingSyntax(source)
+    }
+
+    @Test("Settled text is never modified", arguments: [
+        "plain sentence with no markers",
+        "a **bold** run and an *italic* run",
+        "a `code` span",
+        "a [link](https://example.com) target",
+        "nested **bold with `code` inside**",
+        "escaped \\*not emphasis\\* stays literal",
+        ""
+    ])
+    func settledTextIsUnchanged(source: String) {
+        #expect(repaired(source) == source)
+    }
+
+    @Test("A dangling strong run is closed")
+    func closesDanglingStrong() {
+        #expect(repaired("this is **bold") == "this is **bold**")
+    }
+
+    @Test("Single asterisks are never speculatively closed", arguments: [
+        "this is *italic",
+        "COUNT(*) AS total",
+        "the *.sql files",
+        "run SELECT * FROM users",
+        "a pointer int *p here",
+        "lead *"
+    ])
+    func singleAsterisksAreLeftAlone(source: String) {
+        #expect(repaired(source) == source)
+    }
+
+    @Test("A closed triple-asterisk span is left untouched")
+    func tripleAsteriskSpanIsUntouched() {
+        #expect(repaired("a ***bold italic*** run") == "a ***bold italic*** run")
+        #expect(repaired("***bold italic***") == "***bold italic***")
+    }
+
+    @Test("A backslash inside a code span does not swallow the closing backtick")
+    func backslashInsideCodeSpanDoesNotSwallowTheFence() {
+        #expect(repaired("`a \\`") == "`a \\`")
+        #expect(repaired("call `path\\` now") == "call `path\\` now")
+    }
+
+    @Test("A dangling code span is closed with a matching run")
+    func closesDanglingCodeSpan() {
+        #expect(repaired("call `SELECT id") == "call `SELECT id`")
+    }
+
+    @Test("A dangling link target is closed before the emphasis around it")
+    func closesLinkTargetBeforeEmphasis() {
+        #expect(repaired("**[text](htt") == "**[text](htt)**")
+    }
+
+    @Test("A lone asterisk followed by whitespace is left alone")
+    func ignoresSelectStar() {
+        #expect(repaired("run SELECT * FROM users") == "run SELECT * FROM users")
+    }
+
+    @Test("Underscores in identifiers are never treated as emphasis")
+    func ignoresSnakeCaseIdentifiers() {
+        #expect(repaired("the user_id and created_at columns") == "the user_id and created_at columns")
+        #expect(repaired("a _leading underscore") == "a _leading underscore")
+    }
+
+    @Test("Markers inside a closed code span are not repaired")
+    func ignoresMarkersInsideCodeSpan() {
+        #expect(repaired("use `a ** b` here") == "use `a ** b` here")
+    }
+
+    @Test("An unclosed code span swallows later markers")
+    func unclosedCodeSpanClosesOnlyItself() {
+        #expect(repaired("use `a ** b") == "use `a ** b`")
+    }
+
+    @Test("Repair is stable when applied to its own output")
+    func repairIsIdempotent() {
+        let once = repaired("this is **bold")
+        #expect(repaired(once) == once)
+    }
+
+    @Test("Growing any reply one character at a time never adds or loses prose", arguments: [
+        "lead **bold text** tail",
+        "a ***triple*** and `code` here",
+        "SELECT COUNT(*) FROM t WHERE name LIKE '%a%'",
+        "see [the docs](https://example.com) for **more**",
+        "columns user_id, created_at and *.sql globs"
+    ])
+    func growingReplyNeverChangesProse(target: String) {
+        let closerCharacters: Set<Character> = ["*", "`", ")"]
+        let characters = Array(target)
+        for length in 1...characters.count {
+            let prefix = String(characters[0..<length])
+            let result = repaired(prefix)
+            #expect(
+                result.filter { !closerCharacters.contains($0) }
+                    == prefix.filter { !closerCharacters.contains($0) },
+                "prose changed for prefix \(prefix) -> \(result)"
+            )
+        }
+    }
+
+    @Test("A trailing marker that cannot yet be classified is hidden, not shown raw")
+    func trailingIncompleteMarkerIsHidden() {
+        #expect(repaired("lead **") == "lead ")
+        #expect(repaired("lead `") == "lead ")
+    }
+
+    @Test("Oversized input is returned untouched")
+    func oversizedInputIsSkipped() {
+        let huge = String(repeating: "a", count: 20_001) + "**bold"
+        #expect(repaired(huge) == huge)
+    }
+}


### PR DESCRIPTION
## Problem

Streaming AI replies felt laggy in four distinct ways: text arrived in visible chunks, the panel stuttered more the longer a reply grew, content flickered while generating, and nothing appeared for a noticeable moment after sending.

These turned out to have four different causes, and the markdown parser was not the main one. Measured on an -O build with the shipping parser extracted into a harness: a full re-parse of a realistic reply costs 0.2 ms (340 lines) to 1.5 ms (1360 lines). At the flush cadence that is under 1% CPU. An index-cursor rewrite of the parser was prototyped, verified byte-identical on every streaming prefix, and measured at only 1.3x to 2.5x, so it was dropped. `MarkdownBlockParser` is untouched.

The real causes:

| Symptom | Cause |
| --- | --- |
| Panel stutters, worse as the reply grows | `ChatTurn` was a struct inside an `@Observable` array. Observation has no per-element granularity for a value-type array, so appending one token invalidated the whole `messages` property and rebuilt an `AIChatMessageView` for every mounted message. |
| Text arrives in chunks | A fixed 150 ms flush, and the elapsed check only ran when the next network event arrived, so a pause in the model backlogged text and dumped it at once. |
| Delay before the first words | `lastFlushTime` was initialised before the event loop, so the first token waited out a full interval and needed a second event to trigger the check. |
| Flicker and layout jump | No repair for half-arrived inline markdown, so `**` showed as raw asterisks then popped into bold. Code block height was guessed from a line count that ignored wrapping. |

## Change

`ChatTurn` becomes a `@MainActor @Observable final class`. `ChatContentBlock` was already a class for exactly this reason; holding those blocks in a struct array discarded that granularity one level up. A streamed token now mutates one block in place, touching neither `messages` nor `ChatTurn.blocks`, so only the one block's view re-renders. Persistence is unaffected because `AIConversation` stores `[ChatTurnWire]`.

The rest:

- `StreamTextBuffer` plus an injectable `StreamFlushClock` and a real ticker task at 50 ms. The first non-empty delta flushes immediately, and the ticker fires on its own schedule. The final drain moved into a `defer` so buffered text survives a stream that fails part way through.
- Reasoning deltas now go through the same buffer. They previously hit the model on every SSE event with no coalescing at all.
- `.equatable()` on `AIChatMessageView`, `AIChatBlockView` and `MarkdownView` for the append and remove boundary, comparing reference identity plus closure presence.
- `MarkdownInlineRepair` closes dangling code spans, then link targets, then `**` runs, on the still-growing last block only. Order matters: in `**[text](htt` the link is innermost. A trailing marker run that cannot be classified yet is hidden rather than shown raw.
- `CodeBlockHeightEstimator` measures with `NSString.boundingRect` scaled to the editor's real line pitch, and `lineHeightMultiple` is now passed explicitly instead of relying on the default.
- `MarkdownInline`'s `NSCache` gained a `totalCostLimit` and skips the growing block, which was inserting a new dead entry every flush and evicting settled ones.
- Fixed a latent crash: `AIChatPanelView` ran `for i in 1..<visibleMessages.count`, which traps on an empty list. The outer gate checks the unfiltered `messages`, but the loop used the filtered list. Extracted into `AIChatMessageSpacing` so it is testable.

## On the inline repair

Two deliberate limits, both because this is a database client:

- Single `*` is never speculatively closed. Closing it corrupted `COUNT(*)`, `*.sql`, `SELECT * FROM` and `int *p`. Only `**` is repaired, which is what models actually emit for bold.
- `_` and `__` are ignored entirely, so `user_id` and `created_at` are never touched.

## Tests

New: `ChatTurnObservationTests` (uses `withObservationTracking` to assert a token append does not invalidate `messages`, and reproduces the message list's own read pattern so a reordering of the short-circuit in `shouldShowRegenerate` would fail), `StreamTextBufferTests`, `AIChatViewModelStreamingCadenceTests` (a back-pressured `AsyncThrowingStream(unfolding:)` transport plus a never-ticking clock, so first-paint and coalescing are asserted deterministically with no wall clock and no network), `MarkdownInlineRepairTests`, `CodeBlockHeightEstimatorTests`, `AIChatMessageSpacingTests`.

All 25 AI-related suites pass, including the pre-existing `ChatTurnInterleavingTests` and `AIChatViewModelToolLoopTests`. `swiftlint lint --strict` reports 0 violations across 1282 files.

Unrelated suites fail in this local environment (driver plugins do not activate headless, plus network and keychain access). They were checked rather than assumed: several are already listed in `.github/macos-test-quarantine.txt`, and there is no overlap between them and the 22 test files that reference any symbol this branch changes.

## Review findings folded in

An adversarial review of the diff caught two regressions introduced by this branch, both now fixed and covered by tests:

- The height estimator ignored CodeEdit's 1.2 `lineHeightMultiple`, and a self-sizing `minHeight` had been converted into a hard `height`. Finished code blocks would have clipped their last lines, which is worse than the jump being fixed.
- The repair mangled `COUNT(*)`, `*.sql` and `***bold italic***`, and a backslash before a closing backtick swallowed the fence.

It also flagged that `.toolInvocationRequest` was the one turn-mutating event that did not drain the buffer first, which would place pre-tool text below the tool card. Fixed.

## Verification needed

The build is green and tests pass, but two things want a human:

- Confirm text still streams in the running app. The `.equatable()` and `@Observable` interaction is the one part tests cannot cover.
- A VoiceOver pass on a streaming reply, since 50 ms triples how often the accessible value changes.
