### PR TITLE
fix(editor): restore the cursor and selection when a query tab reopens

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -66,6 +66,12 @@ jobs:
       - name: Run editor package tests
         run: swift test --package-path LocalPackages/CodeEditTextView
 
+      # Scoped to the controller suite on purpose. The rest of this package's tests
+      # (HighlighterTests, TagEditingTests) already fail on main and one of them aborts
+      # the runner, so gating on the whole package would keep CI permanently red.
+      - name: Run source editor controller tests
+        run: swift test --package-path LocalPackages/CodeEditSourceEditor --filter TextViewControllerTests
+
   app-tests:
     name: macOS App Tests
     runs-on: macos-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The SQL editor now returns the cursor to where you left it when a tab is reopened or the app restarts, and restores what you had selected, not just the caret. The saved position was never applied.
 - Autocomplete now keeps suggesting tables and columns after a connection drops and reconnects on its own. The reconnect cleared the schema it had loaded and never asked for it again, so a window that looked connected offered nothing but keywords for the rest of the session.
 - The JSON view of a result now updates when you run another query. It kept showing the previous result until you switched to the data grid and back, and a query that returned the same number of rows never updated at all.
 - The JSON view shows the whole result again when no row is selected. A selection left over from an earlier query made it show an empty list, and a column filter made it show the wrong rows.

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditor/SourceEditor.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditor/SourceEditor.swift
@@ -162,7 +162,7 @@ public struct SourceEditor: NSViewControllerRepresentable {
     }
 
     private func updateControllerWithState(_ state: SourceEditorState, controller: TextViewController) {
-        if let cursorPositions = state.cursorPositions, cursorPositions != state.cursorPositions {
+        if let cursorPositions = state.cursorPositions, cursorPositions != controller.cursorPositions {
             controller.setCursorPositions(cursorPositions)
         }
 

--- a/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/Controller/TextViewControllerTests.swift
+++ b/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/Controller/TextViewControllerTests.swift
@@ -391,6 +391,26 @@ final class TextViewControllerTests: XCTestCase {
         XCTAssertEqual(controller.cursorPositions[1].start.column, 2)
     }
 
+    func test_setCursorPositionsClampsARangeBeyondTheText() {
+        controller.setText("Hello")
+
+        controller.setCursorPositions([CursorPosition(range: NSRange(location: 2, length: 500))])
+
+        XCTAssertEqual(controller.cursorPositions.count, 1)
+        XCTAssertEqual(controller.cursorPositions[0].range.location, 2)
+        XCTAssertEqual(controller.cursorPositions[0].range.length, 3)
+    }
+
+    func test_setCursorPositionsClampsALocationBeyondTheText() {
+        controller.setText("Hello")
+
+        controller.setCursorPositions([CursorPosition(range: NSRange(location: 900, length: 0))])
+
+        XCTAssertEqual(controller.cursorPositions.count, 1)
+        XCTAssertEqual(controller.cursorPositions[0].range.location, 5)
+        XCTAssertEqual(controller.cursorPositions[0].range.length, 0)
+    }
+
     func test_cursorPositionRowColInit() {
         _ = controller.textView.becomeFirstResponder()
         controller.setText("Hello World")

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager.swift
@@ -89,9 +89,12 @@ public class TextSelectionManager: NSObject {
         let oldRanges = textSelections.map(\.range)
 
         textSelections.forEach { $0.view?.removeFromSuperview() }
-        // Remove duplicates, clamp out-of-bounds ranges, update suggested X position.
+        // Remove duplicates, drop malformed ranges, clamp stale ones, update suggested X position.
+        // A negative location is malformed and is discarded. A location past the end is a stale but
+        // well-formed range, which happens whenever the text shrinks under an existing selection;
+        // clamping keeps a usable selection there instead of leaving the view with none at all.
         let storageLength = textStorage?.length ?? 0
-        textSelections = Set(ranges.map { $0.clamped(toLength: storageLength) })
+        textSelections = Set(ranges.filter { $0.location >= 0 }.map { $0.clamped(toLength: storageLength) })
             .sorted(by: { $0.location < $1.location })
             .map {
                 let selection = TextSelection(range: $0)

--- a/TablePro/Extensions/NSRange+ClampToText.swift
+++ b/TablePro/Extensions/NSRange+ClampToText.swift
@@ -1,0 +1,19 @@
+//
+//  NSRange+ClampToText.swift
+//  TablePro
+//
+
+import Foundation
+
+internal extension NSRange {
+    /// Moves the range inside `0..<length`, keeping as much of it as still fits.
+    ///
+    /// A selection restored from disk was measured against the text as it was when the tab was
+    /// saved. The query can be shorter now, so the saved range has to be clamped against the text
+    /// the editor actually holds before it is applied.
+    func clampedToTextLength(_ length: Int) -> NSRange {
+        let start = Swift.min(Swift.max(location, 0), length)
+        let end = Swift.min(Swift.max(location + self.length, 0), length)
+        return NSRange(location: start, length: Swift.max(0, end - start))
+    }
+}

--- a/TablePro/Models/Query/QueryTab.swift
+++ b/TablePro/Models/Query/QueryTab.swift
@@ -35,10 +35,18 @@ struct QueryTab: Identifiable, Equatable {
     var pendingRestoredSort: [PersistedSortColumn]?
     var restoredPage: Int?
     var restoredCursorOffset: Int?
+    var restoredCursorLength: Int?
 
     private static func clampedCursorOffset(_ offset: Int?, in query: String) -> Int? {
         guard let offset, offset >= 0 else { return nil }
         return min(offset, (query as NSString).length)
+    }
+
+    private static func clampedCursorLength(_ length: Int?, from offset: Int?, in query: String) -> Int? {
+        guard let length, length > 0, let start = clampedCursorOffset(offset, in: query) else { return nil }
+        let available = (query as NSString).length - start
+        guard available > 0 else { return nil }
+        return min(length, available)
     }
 
     init(
@@ -70,6 +78,7 @@ struct QueryTab: Identifiable, Equatable {
         self.pendingRestoredSort = nil
         self.restoredPage = nil
         self.restoredCursorOffset = nil
+        self.restoredCursorLength = nil
     }
 
     init(from persisted: PersistedTab, defaultPageSize: Int) {
@@ -105,6 +114,11 @@ struct QueryTab: Identifiable, Equatable {
         self.pendingRestoredSort = persisted.sortColumns
         self.restoredPage = persisted.restoredPage.map { max(1, $0) }
         self.restoredCursorOffset = Self.clampedCursorOffset(persisted.cursorOffset, in: persisted.query)
+        self.restoredCursorLength = Self.clampedCursorLength(
+            persisted.cursorLength,
+            from: persisted.cursorOffset,
+            in: persisted.query
+        )
     }
 
     @MainActor static func buildBaseTableQuery(
@@ -182,6 +196,11 @@ struct QueryTab: Identifiable, Equatable {
             sortColumns: persistedSort,
             restoredPage: restoredPage,
             cursorOffset: Self.clampedCursorOffset(restoredCursorOffset, in: persistedQuery),
+            cursorLength: Self.clampedCursorLength(
+                restoredCursorLength,
+                from: restoredCursorOffset,
+                in: persistedQuery
+            ),
             columnWidths: widths,
             windowGroupIndex: windowGroupIndex
         )

--- a/TablePro/Models/Query/QueryTabState.swift
+++ b/TablePro/Models/Query/QueryTabState.swift
@@ -37,6 +37,7 @@ struct PersistedTab: Codable {
     var sortColumns: [PersistedSortColumn]?
     var restoredPage: Int?
     var cursorOffset: Int?
+    var cursorLength: Int?
     var columnWidths: [String: CGFloat]?
     var windowGroupIndex: Int?
 
@@ -58,6 +59,7 @@ struct PersistedTab: Codable {
         sortColumns: [PersistedSortColumn]? = nil,
         restoredPage: Int? = nil,
         cursorOffset: Int? = nil,
+        cursorLength: Int? = nil,
         columnWidths: [String: CGFloat]? = nil,
         windowGroupIndex: Int? = nil
     ) {
@@ -75,6 +77,7 @@ struct PersistedTab: Codable {
         self.sortColumns = sortColumns
         self.restoredPage = restoredPage
         self.cursorOffset = cursorOffset
+        self.cursorLength = cursorLength
         self.columnWidths = columnWidths
         self.windowGroupIndex = windowGroupIndex
     }
@@ -82,7 +85,7 @@ struct PersistedTab: Codable {
     private enum CodingKeys: String, CodingKey {
         case id, title, query, tabType, tableName, isView, databaseName, schemaName
         case sourceFileURL, erDiagramSchemaKey, queryParameters
-        case sortColumns, restoredPage, cursorOffset, columnWidths, windowGroupIndex
+        case sortColumns, restoredPage, cursorOffset, cursorLength, columnWidths, windowGroupIndex
         case overflowFileName
     }
 
@@ -102,6 +105,7 @@ struct PersistedTab: Codable {
         sortColumns = try container.decodeIfPresent([PersistedSortColumn].self, forKey: .sortColumns)
         restoredPage = try container.decodeIfPresent(Int.self, forKey: .restoredPage)
         cursorOffset = try container.decodeIfPresent(Int.self, forKey: .cursorOffset)
+        cursorLength = try container.decodeIfPresent(Int.self, forKey: .cursorLength)
         columnWidths = try container.decodeIfPresent([String: CGFloat].self, forKey: .columnWidths)
         windowGroupIndex = try container.decodeIfPresent(Int.self, forKey: .windowGroupIndex)
         overflowFileName = try container.decodeIfPresent(String.self, forKey: .overflowFileName)

--- a/TablePro/Views/Editor/QueryEditorView.swift
+++ b/TablePro/Views/Editor/QueryEditorView.swift
@@ -24,6 +24,7 @@ struct QueryEditorView: View {
     var connectionAIPolicy: AIConnectionPolicy?
     var tabID: UUID?
     var claimFocusOnAppear: Bool = false
+    var restoredCursorRange: NSRange?
     var onCloseTab: (() -> Void)?
     var onExecuteQuery: (() -> Void)?
     var onExplain: ((ClickHouseExplainVariant?) -> Void)?
@@ -67,6 +68,7 @@ struct QueryEditorView: View {
                 connectionAIPolicy: connectionAIPolicy,
                 tabID: tabID,
                 claimFocusOnAppear: claimFocusOnAppear,
+                restoredCursorRange: restoredCursorRange,
                 vimMode: $vimMode,
                 onCloseTab: onCloseTab,
                 onExecuteQuery: onExecuteQuery,

--- a/TablePro/Views/Editor/SQLEditorCoordinator.swift
+++ b/TablePro/Views/Editor/SQLEditorCoordinator.swift
@@ -52,10 +52,25 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
     @ObservationIgnored private var hasInstalledEditorServices = false
     @ObservationIgnored private weak var windowSentinel: WindowAccessorView?
 
+    @ObservationIgnored private var cursorRestorePending: NSRange?
+
     var pendingFocusClaim: Bool { focusClaimPending }
+
+    var pendingCursorRestore: NSRange? { cursorRestorePending }
 
     func scheduleEditorFocusClaim() {
         focusClaimPending = true
+    }
+
+    /// Latches a saved selection to apply once, the moment the editor is in a window.
+    ///
+    /// The caller sets this from `body`, which runs many times before the text view exists, so the
+    /// setter is idempotent and the value is consumed exactly once in `installEditorServices`.
+    /// Pushing it through the SwiftUI cursor binding instead would fight live typing, because the
+    /// binding is written on every selection change the user makes.
+    func scheduleCursorRestore(_ range: NSRange) {
+        guard !hasInstalledEditorServices else { return }
+        cursorRestorePending = range
     }
 
     /// Vim mode for UI observation
@@ -147,7 +162,11 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
             Self.logger.debug("Editor focus claim: pending=\(claimPending) isKey=\(window.isKeyWindow) made=\(made)")
         }
 
-        if controller.cursorPositions.isEmpty {
+        if let restored = cursorRestorePending {
+            cursorRestorePending = nil
+            let clamped = restored.clampedToTextLength(textView.textStorage.length)
+            controller.setCursorPositions([CursorPosition(range: clamped)], scrollToVisible: true)
+        } else if controller.cursorPositions.isEmpty {
             controller.setCursorPositions([CursorPosition(range: NSRange(location: 0, length: 0))])
         }
     }

--- a/TablePro/Views/Editor/SQLEditorView.swift
+++ b/TablePro/Views/Editor/SQLEditorView.swift
@@ -24,6 +24,7 @@ struct SQLEditorView: View {
     var connectionAIPolicy: AIConnectionPolicy?
     var tabID: UUID?
     var claimFocusOnAppear: Bool = false
+    var restoredCursorRange: NSRange?
     @Binding var vimMode: VimMode
     var onCloseTab: (() -> Void)?
     var onExecuteQuery: (() -> Void)?
@@ -52,6 +53,9 @@ struct SQLEditorView: View {
         coordinator.connectionId = connectionId
         if claimFocusOnAppear {
             coordinator.scheduleEditorFocusClaim()
+        }
+        if let restoredCursorRange {
+            coordinator.scheduleCursorRestore(restoredCursorRange)
         }
 
         return SourceEditor(

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -371,6 +371,7 @@ struct MainEditorContentView: View {
                         connectionAIPolicy: coordinator.connection.aiPolicy ?? AppSettingsManager.shared.ai.defaultConnectionPolicy,
                         tabID: tab.id,
                         claimFocusOnAppear: claimFocus,
+                        restoredCursorRange: coordinator.restoredCursorRange(for: tab.id),
                         onCloseTab: {
                             NSApp.keyWindow?.close()
                         },
@@ -413,7 +414,7 @@ struct MainEditorContentView: View {
             }
         )
         .onAppear {
-            coordinator.applyRestoredCursor(for: tab.id)
+            coordinator.clearRestoredCursor(for: tab.id)
             if coordinator.tabManager.pendingFocusTabId == tab.id {
                 coordinator.tabManager.pendingFocusTabId = nil
             }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -343,7 +343,9 @@ final class MainContentCoordinator {
             }
         }
         if tab.tabType == .query, tab.id == tabManager.selectedTabId {
-            enriched.restoredCursorOffset = cursorPositions.first?.range.location
+            let range = cursorPositions.first?.range
+            enriched.restoredCursorOffset = range?.location
+            enriched.restoredCursorLength = range.map(\.length)
         }
         return enriched
     }
@@ -365,14 +367,29 @@ final class MainContentCoordinator {
         }
     }
 
-    func applyRestoredCursor(for tabId: UUID) {
+    /// The selection a query tab was left with, as a range to hand straight to the editor.
+    ///
+    /// The editor applies this once through its own controller rather than through the cursor
+    /// binding, so this is a plain read. The value stays on the tab until the editor reports it
+    /// consumed, because `body` runs many times before the text view exists.
+    func restoredCursorRange(for tabId: UUID) -> NSRange? {
         guard let index = tabManager.tabs.firstIndex(where: { $0.id == tabId }),
               tabManager.tabs[index].tabType == .query,
-              let offset = tabManager.tabs[index].restoredCursorOffset else { return }
+              let offset = tabManager.tabs[index].restoredCursorOffset else { return nil }
         let length = (tabManager.tabs[index].content.query as NSString).length
         let clamped = min(max(0, offset), length)
-        cursorPositions = [CursorPosition(range: NSRange(location: clamped, length: 0))]
-        tabManager.mutate(at: index) { $0.restoredCursorOffset = nil }
+        let selectionLength = min(tabManager.tabs[index].restoredCursorLength ?? 0, length - clamped)
+        return NSRange(location: clamped, length: max(0, selectionLength))
+    }
+
+    func clearRestoredCursor(for tabId: UUID) {
+        guard let index = tabManager.tabs.firstIndex(where: { $0.id == tabId }),
+              tabManager.tabs[index].restoredCursorOffset != nil
+                  || tabManager.tabs[index].restoredCursorLength != nil else { return }
+        tabManager.mutate(at: index) {
+            $0.restoredCursorOffset = nil
+            $0.restoredCursorLength = nil
+        }
     }
 
     private static let periodicSaveInterval: Duration = .seconds(30)

--- a/TableProTests/Core/Services/PersistedTabRoundTripTests.swift
+++ b/TableProTests/Core/Services/PersistedTabRoundTripTests.swift
@@ -109,6 +109,46 @@ struct PersistedTabRoundTripTests {
         #expect(persisted.cursorOffset == 42)
     }
 
+    @Test("A selection round-trips, not just the caret")
+    func cursorSelectionRoundTrip() {
+        var tab = QueryTab(id: UUID(), title: "Q", query: "SELECT * FROM users", tabType: .query)
+        tab.restoredCursorOffset = 7
+        tab.restoredCursorLength = 5
+
+        let persisted = tab.toPersistedTab()
+        #expect(persisted.cursorOffset == 7)
+        #expect(persisted.cursorLength == 5)
+        let restored = QueryTab(from: persisted, defaultPageSize: 1_000)
+        #expect(restored.restoredCursorOffset == 7)
+        #expect(restored.restoredCursorLength == 5)
+    }
+
+    @Test("A selection that runs past a now-shorter query is trimmed, not dropped")
+    func cursorSelectionClampedToQueryLength() {
+        let persisted = PersistedTab(
+            id: UUID(),
+            title: "Q",
+            query: "SELECT",
+            tabType: .query,
+            tableName: nil,
+            cursorOffset: 3,
+            cursorLength: 10_000
+        )
+
+        let restored = QueryTab(from: persisted, defaultPageSize: 1_000)
+        #expect(restored.restoredCursorOffset == 3)
+        #expect(restored.restoredCursorLength == ("SELECT" as NSString).length - 3)
+    }
+
+    @Test("A caret with no selection persists no length")
+    func caretPersistsNoLength() {
+        var tab = QueryTab(id: UUID(), title: "Q", query: "SELECT 1", tabType: .query)
+        tab.restoredCursorOffset = 4
+        tab.restoredCursorLength = 0
+
+        #expect(tab.toPersistedTab().cursorLength == nil)
+    }
+
     @Test("Column widths round-trip")
     func columnWidthsRoundTrip() {
         var tab = tableTab()

--- a/TableProTests/Extensions/NSRangeClampToTextTests.swift
+++ b/TableProTests/Extensions/NSRangeClampToTextTests.swift
@@ -1,0 +1,37 @@
+//
+//  NSRangeClampToTextTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("NSRange clampedToTextLength")
+struct NSRangeClampToTextTests {
+    @Test("a range inside the text is untouched")
+    func rangeInsideTextIsUnchanged() {
+        #expect(NSRange(location: 2, length: 3).clampedToTextLength(10) == NSRange(location: 2, length: 3))
+    }
+
+    @Test("a range running past the end is trimmed to the end")
+    func rangePastEndIsTrimmed() {
+        #expect(NSRange(location: 8, length: 50).clampedToTextLength(10) == NSRange(location: 8, length: 2))
+    }
+
+    @Test("a location past the end collapses to a caret at the end")
+    func locationPastEndCollapsesToEnd() {
+        #expect(NSRange(location: 99, length: 4).clampedToTextLength(10) == NSRange(location: 10, length: 0))
+    }
+
+    @Test("a negative location is pulled back to the start")
+    func negativeLocationClampsToStart() {
+        #expect(NSRange(location: -5, length: 3).clampedToTextLength(10) == NSRange(location: 0, length: 0))
+    }
+
+    @Test("empty text collapses everything to zero")
+    func emptyTextCollapsesToZero() {
+        #expect(NSRange(location: 4, length: 9).clampedToTextLength(0) == NSRange(location: 0, length: 0))
+    }
+}


### PR DESCRIPTION
Item A of the follow-up work from #2047. The saved cursor position never reached the editor.

## Root cause: two bugs stacked

`SourceEditor.updateControllerWithState` guards the cursor push with `cursorPositions != state.cursorPositions`, a self-comparison that is always false, so the framework's downward cursor push is dead code. Its four sibling branches in the same function (`scrollPosition`, `findText`, `replaceText`, `findPanelVisible`) all correctly compare state against the *controller's* live value, so this is one branch that didn't follow the pattern the others established.

But fixing that alone changes nothing, because **TablePro never had a downward channel at all**: nothing writes `coordinator.cursorPositions` into `editorState.cursorPositions`. `applyRestoredCursor` wrote a value that had nowhere to go. Every restore path was broken the same way: relaunch, reopening a closed tab, session restore.

## The fix: a one-shot intent, not a live binding

Restoring through the cursor binding would fight live typing, because that binding is written on every selection change the user makes, and `updateNSView` also fires on unrelated environment changes (WWDC22 10075: "The update method can be called often").

So the restore uses the shape this codebase already standardized on. `SQLEditorCoordinator.installEditorServices` already does one-shot cursor placement (defaulting an empty document to offset 0) and `performFormatSQL` already calls `setCursorPositions` straight through the controller. Programmatic cursor placement in TablePro has never gone through the SwiftUI binding.

`scheduleCursorRestore(_:)` latches the saved range the same way `scheduleEditorFocusClaim()` latches focus: an idempotent setter called from `body`, consumed exactly once in `installEditorServices` once the window sentinel reports the view is really in a window, clamped against the text the editor actually holds at that moment. This also sidesteps a latent gap: `queryTabContent` has no `.id(tab.id)`, so `.onAppear` does not refire for a tab added in place, and the old code hung the restore on exactly that `.onAppear`.

The tautological comparison is fixed too, to match its siblings.

## The selection is restored, not just the caret

`enrichedForPersistence` saved only `range.location` and threw the length away. `PersistedTab` gains `cursorLength` as an optional decoded with `decodeIfPresent`, the same shape as the four fields added before it. This is local tab-state JSON, not a CloudKit-synced field, so none of the `ConnectionSyncField` deploy-before-write rules apply. Both ends are clamped on save and on restore, so a query that has since become shorter trims the selection instead of producing an out-of-bounds range.

## A regression from #2047, found and fixed here

Making `setSelectedRanges` clamp instead of drop (in #2047, to stop a shrinking document leaving the view with no selection at all) also made it accept a malformed `NSRange(location: -1, …)` that it used to discard, breaking `TextViewControllerTests.test_cursorPositionRangeInit`. Nothing caught it: #2047 wired CI for the *CodeEditTextView* package, and this test lives in *CodeEditSourceEditor*, which no workflow ran.

It now drops malformed ranges (negative location) and clamps stale-but-well-formed ones, which keeps both behaviours: an invalid position is still ignored, and a location past a now-shorter text still yields a usable selection.

## CI

Added a scoped step for `CodeEditSourceEditor`. Deliberately `--filter TextViewControllerTests` rather than the whole package: `HighlighterTests` (1 failure) and `TagEditingTests` (9 failures) already fail on `main`, and one of them aborts the test runner, so gating on the full package would keep CI permanently red. Verified against a clean `main` checkout before scoping it.

## Tests

- `PersistedTabRoundTripTests`: a selection round-trips, a selection past a now-shorter query is trimmed rather than dropped, a bare caret persists no length.
- `NSRangeClampToTextTests`: the clamp helper, including negative location and empty text.
- `TextViewControllerTests`: two new cases proving an out-of-bounds explicit range is clamped, the gap that let the crash class through. `test_cursorPositionRangeInit` passes again.

Full `CodeEditTextView` package green (171 tests). `TextViewControllerTests` green (21). App suites for tabs, persistence and the coordinator green.

## Not covered

The restore fires when the editor's controller is installed, which is a genuine remount: relaunch, reopening a closed tab into a new window, and the empty-window-to-first-tab transition. Switching between already-open native window tabs does not remount and does not need to, since the value was consumed once already.
