### PR TITLE
fix(datagrid): make the JSON results view follow the grid as shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The JSON view of a result now follows the grid: rows come in the order you sorted them, a column filter leaves its rows out, and hidden columns stay hidden. It used to show every row in fetch order, including rows the filter had removed, and columns you had hidden.
+- Copy JSON in the JSON view and Copy as JSON in the grid now produce the same output for the same rows.
+- The JSON view now updates when you change a column filter without running a new query.
 - The SQL editor now returns the cursor to where you left it when a tab is reopened or the app restarts, and restores what you had selected, not just the caret. The saved position was never applied.
 - Autocomplete now keeps suggesting tables and columns after a connection drops and reconnects on its own. The reconnect cleared the schema it had loaded and never asked for it again, so a window that looked connected offered nothing but keywords for the rest of the session.
 - The JSON view of a result now updates when you run another query. It kept showing the previous result until you switched to the data grid and back, and a query that returned the same number of rows never updated at all.

--- a/TablePro/Core/Utilities/SQL/ResultJsonSerializer.swift
+++ b/TablePro/Core/Utilities/SQL/ResultJsonSerializer.swift
@@ -1,0 +1,72 @@
+//
+//  ResultJsonSerializer.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+/// The one place a result set becomes JSON.
+///
+/// The results pane's JSON view and the grid's Copy as JSON render the same rows, so they share
+/// this rather than each deciding for itself which rows and columns to include. Both follow the
+/// grid as shown: display order, no hidden columns, current column order.
+internal enum ResultJsonSerializer {
+    internal struct Output {
+        let json: String
+        let rowCount: Int
+    }
+
+    /// - Parameter selectedDisplayIndices: display positions to narrow to. Empty means every
+    ///   displayed row, which is what an untouched result set shows.
+    internal static func serialize(
+        tableRows: TableRows,
+        displayIDs: [RowID]?,
+        selectedDisplayIndices: Set<Int>,
+        columns projection: VisibleColumnProjection
+    ) -> Output {
+        let positions: [Int]
+        if selectedDisplayIndices.isEmpty {
+            positions = Array(0..<(displayIDs?.count ?? tableRows.rows.count))
+        } else {
+            positions = selectedDisplayIndices.sorted()
+        }
+
+        let rows: [[PluginCellValue]] = positions.compactMap { displayIndex in
+            DisplayRowMapping.row(forDisplay: displayIndex, displayIDs: displayIDs, in: tableRows)
+                .map { projection.values(Array($0.values)) }
+        }
+
+        let converter = JsonRowConverter(
+            columns: projection.columns(tableRows.columns),
+            columnTypes: projection.columnTypes(tableRows.columnTypes)
+        )
+        return Output(json: converter.generateJson(rows: rows), rowCount: rows.count)
+    }
+}
+
+internal extension VisibleColumnProjection {
+    /// Builds a projection from the layout the user arranged in the grid.
+    ///
+    /// Reads the persisted layout rather than the live `NSTableView` columns, because the grid is
+    /// not mounted while the results pane is showing JSON. Duplicate column names cannot be mapped
+    /// back to a single index, so a result with duplicates keeps every column.
+    static func fromColumnLayout(_ layout: ColumnLayoutState, columns: [String]) -> VisibleColumnProjection {
+        guard Set(columns).count == columns.count else { return .identity }
+        guard !layout.hiddenColumns.isEmpty || layout.columnOrder != nil else { return .identity }
+
+        let ordered: [String]
+        if let columnOrder = layout.columnOrder {
+            let known = columnOrder.filter { columns.contains($0) }
+            ordered = known + columns.filter { !known.contains($0) }
+        } else {
+            ordered = columns
+        }
+
+        let indices = ordered.compactMap { name -> Int? in
+            guard !layout.hiddenColumns.contains(name) else { return nil }
+            return columns.firstIndex(of: name)
+        }
+        return VisibleColumnProjection(indices: indices)
+    }
+}

--- a/TablePro/Views/Main/Child/DataTabGridDelegate.swift
+++ b/TablePro/Views/Main/Child/DataTabGridDelegate.swift
@@ -31,6 +31,10 @@ final class DataTabGridDelegate: DataGridViewDelegate {
         onSortStateChanged?(state)
     }
 
+    func dataGridDisplayOrderChanged() {
+        coordinator?.gridDisplayRevision &+= 1
+    }
+
     func dataGridAddRow() {
         onAddRow?()
     }

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -558,7 +558,9 @@ struct MainEditorContentView: View {
                     tableRows: resolvedTableRows(for: tab),
                     selectedRowIndices: selectionState.indices,
                     displayIDs: coordinator.activeGridDisplayIDs,
-                    dataRevision: coordinator.tabSessionRegistry.session(for: tab.id)?.dataRevision ?? 0
+                    dataRevision: coordinator.tabSessionRegistry.session(for: tab.id)?.dataRevision ?? 0,
+                    displayRevision: coordinator.gridDisplayRevision,
+                    columnLayout: tab.columnLayout
                 )
                 .id(tab.id)
             case .data:

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -141,6 +141,11 @@ final class MainContentCoordinator {
     weak var rightPanelState: RightPanelState?
 
     /// Direct reference to the data tab grid delegate — enables row mutation operations to
+    /// Observable mirror of the grid's display revision, so views outside the grid re-render when
+    /// the value filter or the displayed order changes. The grid's own state lives on a plain
+    /// AppKit object reached through observation-ignored hops, so it cannot invalidate a view.
+    var gridDisplayRevision: Int = 0
+
     /// dispatch insertRows/removeRows directly to the NSTableView via DataGridViewDelegate.
     @ObservationIgnored weak var dataTabDelegate: DataTabGridDelegate?
 

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -17,8 +17,14 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     var paginationOffsetProvider: @MainActor () -> Int = { 0 }
     var changeManager: AnyChangeManager
     var isEditable: Bool
-    var sortedIDs: [RowID]?
-    var valueFilteredIDs: [RowID]?
+    var sortedIDs: [RowID]? { didSet { bumpDisplayRevision() } }
+    var valueFilteredIDs: [RowID]? { didSet { bumpDisplayRevision() } }
+    /// Ticks whenever the displayed row order or the value filter changes.
+    ///
+    /// `displayIDs` reaches SwiftUI only through weak, observation-ignored hops, so a filter change
+    /// produces no signal on its own. Views that render the same rows outside the grid key off this
+    /// instead of comparing the id array, which is O(rows) on every body evaluation.
+    private(set) var displayRevision: Int = 0
     var valueFilterState = GridValueFilterState()
     var displayIDs: [RowID]? { valueFilteredIDs ?? sortedIDs }
     private(set) var columnDisplayFormats: [ValueDisplayFormat?] = []
@@ -346,6 +352,11 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         visualIndex.rebuild(from: changeManager, sortedIDs: displayIDs)
         updateCache()
         tableView.removeRows(at: indices, withAnimation: Self.rowAnimation(.slideUp))
+    }
+
+    private func bumpDisplayRevision() {
+        displayRevision &+= 1
+        delegate?.dataGridDisplayOrderChanged()
     }
 
     /// Drops the row selection before a wholesale replacement.

--- a/TablePro/Views/Results/DataGridView+RowActions.swift
+++ b/TablePro/Views/Results/DataGridView+RowActions.swift
@@ -168,15 +168,15 @@ extension TableViewCoordinator {
     }
 
     func copyRowsAsJson(at indices: Set<Int>) {
-        let projection = selectedColumnProjection()
-        let rows = indices.sorted().compactMap { displayRow(at: $0).map { projection.values(Array($0.values)) } }
-        guard !rows.isEmpty else { return }
-        let tableRows = tableRowsProvider()
-        let converter = JsonRowConverter(
-            columns: projection.columns(tableRows.columns),
-            columnTypes: projection.columnTypes(tableRows.columnTypes)
+        guard !indices.isEmpty else { return }
+        let output = ResultJsonSerializer.serialize(
+            tableRows: tableRowsProvider(),
+            displayIDs: displayIDs,
+            selectedDisplayIndices: indices,
+            columns: selectedColumnProjection()
         )
-        ClipboardService.shared.writeText(converter.generateJson(rows: rows))
+        guard output.rowCount > 0 else { return }
+        ClipboardService.shared.writeText(output.json)
     }
 
     func copyRowsAsCsv(at indices: Set<Int>, includeHeaders: Bool) {

--- a/TablePro/Views/Results/DataGridViewDelegate.swift
+++ b/TablePro/Views/Results/DataGridViewDelegate.swift
@@ -36,9 +36,11 @@ protocol DataGridViewDelegate: AnyObject {
     func dataGridDidRemoveRows(at indices: IndexSet)
     func dataGridDidReplaceAllRows()
     func dataGridAttach(tableViewCoordinator: TableViewCoordinator)
+    func dataGridDisplayOrderChanged()
 }
 
 extension DataGridViewDelegate {
+    func dataGridDisplayOrderChanged() {}
     func dataGridDidEditCell(row: Int, column: Int, newValue: String?) {}
     func dataGridDeleteRows(_ indices: Set<Int>) {}
     func dataGridCopyRows(_ indices: Set<Int>) {}

--- a/TablePro/Views/Results/ResultsJsonView.swift
+++ b/TablePro/Views/Results/ResultsJsonView.swift
@@ -11,6 +11,8 @@ internal struct ResultsJsonView: View {
     let selectedRowIndices: Set<Int>
     let displayIDs: [RowID]?
     let dataRevision: Int
+    let displayRevision: Int
+    let columnLayout: ColumnLayoutState
 
     @State private var viewMode: JSONViewMode
     @State private var treeSearchText = ""
@@ -27,12 +29,16 @@ internal struct ResultsJsonView: View {
         tableRows: TableRows,
         selectedRowIndices: Set<Int>,
         displayIDs: [RowID]?,
-        dataRevision: Int
+        dataRevision: Int,
+        displayRevision: Int,
+        columnLayout: ColumnLayoutState
     ) {
         self.tableRows = tableRows
         self.selectedRowIndices = selectedRowIndices
         self.displayIDs = displayIDs
         self.dataRevision = dataRevision
+        self.displayRevision = displayRevision
+        self.columnLayout = columnLayout
         self._viewMode = State(initialValue: AppSettingsManager.shared.editor.jsonViewerPreferredMode)
         self._resolvedRowCount = State(
             initialValue: selectedRowIndices.isEmpty ? tableRows.count : selectedRowIndices.count
@@ -41,11 +47,20 @@ internal struct ResultsJsonView: View {
 
     private struct RenderKey: Equatable {
         let dataRevision: Int
+        let displayRevision: Int
         let selectedRowIndices: Set<Int>
+        let hiddenColumns: Set<String>
+        let columnOrder: [String]?
     }
 
     private var renderKey: RenderKey {
-        RenderKey(dataRevision: dataRevision, selectedRowIndices: selectedRowIndices)
+        RenderKey(
+            dataRevision: dataRevision,
+            displayRevision: displayRevision,
+            selectedRowIndices: selectedRowIndices,
+            hiddenColumns: columnLayout.hiddenColumns,
+            columnOrder: columnLayout.columnOrder
+        )
     }
 
     private var rowCountText: String {
@@ -169,9 +184,15 @@ internal struct ResultsJsonView: View {
         let snapshot = tableRows
         let ids = displayIDs
         let selectedIndices = selectedRowIndices
+        let layout = columnLayout
 
         let result = await Task.detached(priority: .userInitiated) {
-            Self.computeJson(tableRows: snapshot, displayIDs: ids, selectedIndices: selectedIndices)
+            Self.computeJson(
+                tableRows: snapshot,
+                displayIDs: ids,
+                selectedIndices: selectedIndices,
+                columnLayout: layout
+            )
         }.value
 
         guard !Task.isCancelled else { return }
@@ -189,31 +210,25 @@ internal struct ResultsJsonView: View {
         hasRendered = true
     }
 
-    /// Selection indices are display positions, so they are resolved through
-    /// ``DisplayRowMapping`` rather than used to subscript `tableRows.rows` directly: a
-    /// per-column value filter or a sort makes the two diverge.
+    /// Renders the rows the grid is showing, through the same serializer as Copy as JSON.
     nonisolated static func computeJson(
         tableRows: TableRows,
         displayIDs: [RowID]?,
-        selectedIndices: Set<Int>
+        selectedIndices: Set<Int>,
+        columnLayout: ColumnLayoutState
     ) -> (json: String, pretty: String, resolvedCount: Int, parseResult: Result<JSONTreeNode, JSONTreeParseError>) {
-        let displayRows: [[PluginCellValue]]
-        if selectedIndices.isEmpty {
-            displayRows = tableRows.rows.map { Array($0.values) }
-        } else {
-            displayRows = selectedIndices.sorted().compactMap { displayIndex in
-                DisplayRowMapping.row(forDisplay: displayIndex, displayIDs: displayIDs, in: tableRows)
-                    .map { Array($0.values) }
-            }
-        }
-        let converter = JsonRowConverter(columns: tableRows.columns, columnTypes: tableRows.columnTypes)
-        let json = converter.generateJson(rows: displayRows)
-        let pretty = json.prettyPrintedAsJson() ?? json
+        let output = ResultJsonSerializer.serialize(
+            tableRows: tableRows,
+            displayIDs: displayIDs,
+            selectedDisplayIndices: selectedIndices,
+            columns: .fromColumnLayout(columnLayout, columns: tableRows.columns)
+        )
+        let pretty = output.json.prettyPrintedAsJson() ?? output.json
         return (
-            json: json,
+            json: output.json,
             pretty: pretty,
-            resolvedCount: displayRows.count,
-            parseResult: JSONTreeParser.parse(json)
+            resolvedCount: output.rowCount,
+            parseResult: JSONTreeParser.parse(output.json)
         )
     }
 }

--- a/TableProTests/Views/Results/ResultsJsonViewTests.swift
+++ b/TableProTests/Views/Results/ResultsJsonViewTests.swift
@@ -31,12 +31,14 @@ struct ResultsJsonViewTests {
 
     private func compute(
         displayIDs: [RowID]? = nil,
-        selectedIndices: Set<Int>
+        selectedIndices: Set<Int>,
+        columnLayout: ColumnLayoutState = ColumnLayoutState()
     ) -> (json: String, pretty: String, resolvedCount: Int, parseResult: Result<JSONTreeNode, JSONTreeParseError>) {
         ResultsJsonView.computeJson(
             tableRows: makeTableRows(),
             displayIDs: displayIDs,
-            selectedIndices: selectedIndices
+            selectedIndices: selectedIndices,
+            columnLayout: columnLayout
         )
     }
 
@@ -49,12 +51,63 @@ struct ResultsJsonViewTests {
         #expect(result.json.contains("\"d\""))
     }
 
+    @Test("no selection follows the displayed order, not the fetch order")
+    func noSelectionFollowsDisplayOrder() {
+        let result = compute(displayIDs: [.existing(2), .existing(0)], selectedIndices: [])
+
+        #expect(result.resolvedCount == 2)
+        let first = result.json.range(of: "\"c\"")
+        let second = result.json.range(of: "\"a\"")
+        #expect(first != nil)
+        #expect(second != nil)
+        if let first, let second {
+            #expect(first.lowerBound < second.lowerBound)
+        }
+    }
+
+    @Test("no selection excludes rows a value filter removed")
+    func noSelectionExcludesFilteredRows() {
+        let result = compute(displayIDs: [.existing(0), .existing(2)], selectedIndices: [])
+
+        #expect(result.resolvedCount == 2)
+        #expect(!result.json.contains("\"b\""))
+        #expect(!result.json.contains("\"d\""))
+    }
+
+    @Test("a hidden column is left out")
+    func hiddenColumnIsExcluded() {
+        var layout = ColumnLayoutState()
+        layout.hiddenColumns = ["status"]
+
+        let result = compute(selectedIndices: [], columnLayout: layout)
+
+        #expect(!result.json.contains("status"))
+        #expect(result.json.contains("name"))
+    }
+
+    @Test("columns follow the order the user arranged")
+    func columnsFollowUserOrder() {
+        var layout = ColumnLayoutState()
+        layout.columnOrder = ["name", "status"]
+
+        let result = compute(selectedIndices: [], columnLayout: layout)
+
+        let name = result.json.range(of: "name")
+        let status = result.json.range(of: "status")
+        #expect(name != nil)
+        #expect(status != nil)
+        if let name, let status {
+            #expect(name.lowerBound < status.lowerBound)
+        }
+    }
+
     @Test("an empty result renders an empty array")
     func emptyResultRendersEmptyArray() {
         let result = ResultsJsonView.computeJson(
             tableRows: TableRows(),
             displayIDs: nil,
-            selectedIndices: []
+            selectedIndices: [],
+            columnLayout: ColumnLayoutState()
         )
 
         #expect(result.resolvedCount == 0)


### PR DESCRIPTION
Items B and C of the follow-up work from #2047. The JSON results view rendered something the grid was not showing.

## What was wrong

**It ignored the value filter entirely.** With no selection, `computeJson` walked `tableRows.rows` directly and never consulted `displayIDs`. So a filter that hid rows in the grid still emitted them as JSON. That is a set-membership bug, not just an ordering one.

**It was internally inconsistent.** With rows selected it resolved through `DisplayRowMapping` and therefore followed display order; with nothing selected it used fetch order. One control, two contracts, switched by invisible state.

**It ignored hidden columns and column order.** It built its converter from the raw `tableRows.columns`. A column you hid in the grid still appeared in the JSON pane, and columns came in query order rather than the order you dragged them into. `docs/features/data-grid.mdx` already promises the opposite: "Copies follow the grid as shown: hidden columns are left out and columns keep their current order."

**It never re-rendered when only the filter changed.** `displayIDs` reaches SwiftUI through `@ObservationIgnored weak` hops onto a plain AppKit object, so a filter change produces no observation signal at all, and it was not in the render key either. The view was correct only by accident: switching into JSON mode remounts it, so it happened to read fresh values on the way in.

## The fix

**One serializer.** `ResultJsonSerializer` is now the single place a result set becomes JSON, and both the JSON view and the grid's Copy as JSON go through it. Same rows in, same bytes out. This follows DataGrip, whose Text view is rendered by the same data extractors that power its copy, rather than by a second implementation that has to be kept in agreement.

Row resolution is now uniform: an empty selection means every *displayed* row, a non-empty selection means those display positions, and both resolve through `DisplayRowMapping`. The special case is gone rather than duplicated.

**Columns come from the persisted layout**, not the live `NSTableView`, because the grid is not mounted while the results pane is showing JSON. `VisibleColumnProjection.fromColumnLayout` builds the projection from `ColumnLayoutState`. A result set with duplicate column names cannot be mapped back to single indices, so it keeps every column rather than guessing.

**An observable display revision.** `TableViewCoordinator` ticks `displayRevision` from `didSet` on `sortedIDs` and `valueFilteredIDs`, so a future write site cannot forget to bump it, and notifies through the delegate. `DataTabGridDelegate` already holds the coordinator, so it mirrors the tick onto `MainContentCoordinator.gridDisplayRevision`, which is observable and therefore actually invalidates the view. The render key holds that `Int` rather than the id array: comparing up to 1000 `RowID`s on every body evaluation is the cost Apple's own guidance warns about ("keep your view bodies fast", "rely on limited dependencies"), and a fresh array is built on every filter recompute so the copy-on-write fast path never applies.

This mirrors `TabSession.dataRevision` and `TableStructureView.displayVersion`, the two existing precedents for exactly this problem. Apple documents no guidance on version counters versus deep comparison, so this is an engineering call, not a platform rule.

Sorting was already covered and is unchanged: data-tab sorting is a requery, which bumps `dataRevision`.

## Tests

`ResultsJsonViewTests` gains: no selection follows display order; no selection excludes rows a filter removed; a hidden column is left out; columns follow the user's order. The existing selection, out-of-range and empty-result cases still pass against the shared serializer.

Lint clean, `ResultsJsonViewTests`, `MainContentCoordinatorSelectionResetTests`, `TabSessionRegistryTests`, `DisplayRowMappingTests` and `JsonRowConverterTests` all green.

## Scope note

Export is untouched. If TablePro's export re-runs the query rather than serializing the view, that is a defensible split, but it should be stated in the export UI: DataGrip resolved the same question as Works as Intended and its users still file bugs about it, because nothing tells them.
