### PR TITLE
ci: stop running the source editor package tests that cannot build on the runner

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -63,14 +63,14 @@ jobs:
         with:
           xcode-version: '26.4.1'
 
+      # CodeEditSourceEditor is deliberately not run here. `swift test` cannot build it on this
+      # runner: its CodeEditSymbols dependency fails with "type 'Bundle' has no member 'module'",
+      # after a SwiftPM cache warning about a missing maintenance.lock. It builds fine inside the
+      # Xcode project, so the app target still compiles it; only the standalone package test run
+      # is broken. Its own suites also fail on main (HighlighterTests, TagEditingTests, plus one
+      # that aborts the runner), so this needs fixing at the package level before it can gate.
       - name: Run editor package tests
         run: swift test --package-path LocalPackages/CodeEditTextView
-
-      # Scoped to the controller suite on purpose. The rest of this package's tests
-      # (HighlighterTests, TagEditingTests) already fail on main and one of them aborts
-      # the runner, so gating on the whole package would keep CI permanently red.
-      - name: Run source editor controller tests
-        run: swift test --package-path LocalPackages/CodeEditSourceEditor --filter TextViewControllerTests
 
   app-tests:
     name: macOS App Tests


### PR DESCRIPTION
`main` is red. The `CodeEditSourceEditor` test step I added in #2049 cannot build on the runner, so it fails every PR and every push to main.

The failure is a build error, not a test failure:

```
CodeEditSymbols/Sources/CodeEditSymbols/CodeEditSymbols.swift:14:42: error: type 'Bundle' has no member 'module'
error: fatalError
```

preceded by `warning: 'textstory': skipping cache due to an error: The file "maintenance.lock" doesn't exist`. The resource-bundle accessor for a dependency checkout is not generated under `swift test` on this runner. It builds locally under Xcode 27 with a warm `.build`, which is why I did not catch it, and it builds fine inside the Xcode project, so the app target is unaffected.

Removing the step restores the gate. The comment left in its place records why, so it does not get re-added blind: the package also has pre-existing failures on main (`HighlighterTests`, `TagEditingTests`, and one test that aborts the runner), so it needs fixing at the package level before it can gate anything.

`CodeEditTextView` still runs and still passes, so the editor package that carries the double-click and selection regression tests remains covered.

Cost of the gap: `TextViewControllerTests` is no longer gated on CI. It passes locally via `swift test --package-path LocalPackages/CodeEditSourceEditor --filter TextViewControllerTests`.