### PR TITLE
feat(datagrid): add case sensitivity to data grid filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Filter rows now have a Match Case option in the operator menu. Contains, not contains, starts with, and ends with ignore case on every database that can express it, so PostgreSQL and DuckDB now behave like MySQL and SQLite already did. Equals, IN, and regex still match case until you say otherwise. (#2048)
+- Databases whose collation decides case sensitivity, such as MySQL and SQL Server, show the option greyed out with the reason, as do Cassandra and Redis, which cannot ignore case at all. (#2048)
+- MongoDB, Elasticsearch, DynamoDB, and etcd filters can now match case. They always ignored it before, with no way to turn that off. (#2048)
 - Oracle connections can now sign in as SYSDBA or SYSOPER, on both Mac and mobile. Administrative logons previously had no way to connect. (#2039)
 - Oracle now works in TablePro Mobile: connect, browse schemas and tables, run queries, and edit rows, with a Service Name or SID picker and the same SSL modes as the Mac app. (#2033)
 - When an Oracle listener rejects the connect identifier, the connection form now names which one was wrong and offers to switch between Service Name and SID in one tap. (#2033)

--- a/Packages/TableProCore/Sources/TableProModels/TableFilter.swift
+++ b/Packages/TableProCore/Sources/TableProModels/TableFilter.swift
@@ -8,6 +8,7 @@ public struct TableFilter: Identifiable, Codable, Sendable {
     public var secondValue: String
     public var isEnabled: Bool
     public var rawSQL: String?
+    public var isCaseSensitive: Bool
 
     public static let rawSQLColumn = "__raw_sql__"
 
@@ -37,7 +38,8 @@ public struct TableFilter: Identifiable, Codable, Sendable {
         value: String = "",
         secondValue: String = "",
         isEnabled: Bool = true,
-        rawSQL: String? = nil
+        rawSQL: String? = nil,
+        isCaseSensitive: Bool? = nil
     ) {
         self.id = id
         self.columnName = columnName
@@ -46,6 +48,25 @@ public struct TableFilter: Identifiable, Codable, Sendable {
         self.secondValue = secondValue
         self.isEnabled = isEnabled
         self.rawSQL = rawSQL
+        self.isCaseSensitive = isCaseSensitive ?? filterOperator.defaultIsCaseSensitive
+    }
+
+    public enum CodingKeys: String, CodingKey {
+        case id, columnName, filterOperator, value, secondValue, isEnabled, rawSQL, isCaseSensitive
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let decodedOperator = try container.decodeIfPresent(FilterOperator.self, forKey: .filterOperator) ?? .equal
+        self.id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        self.columnName = try container.decodeIfPresent(String.self, forKey: .columnName) ?? ""
+        self.filterOperator = decodedOperator
+        self.value = try container.decodeIfPresent(String.self, forKey: .value) ?? ""
+        self.secondValue = try container.decodeIfPresent(String.self, forKey: .secondValue) ?? ""
+        self.isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
+        self.rawSQL = try container.decodeIfPresent(String.self, forKey: .rawSQL)
+        self.isCaseSensitive = try container.decodeIfPresent(Bool.self, forKey: .isCaseSensitive)
+            ?? decodedOperator.defaultIsCaseSensitive
     }
 }
 
@@ -66,6 +87,25 @@ public enum FilterOperator: String, Codable, Sendable, CaseIterable {
     case contains
     case startsWith
     case endsWith
+
+    public var supportsCaseSensitivity: Bool {
+        switch self {
+        case .like, .notLike, .contains, .startsWith, .endsWith, .equal, .notEqual, .in, .notIn:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Pattern matching ignores case by default; exact and list matching does not
+    public var defaultIsCaseSensitive: Bool {
+        switch self {
+        case .like, .notLike, .contains, .startsWith, .endsWith:
+            return false
+        default:
+            return true
+        }
+    }
 
     public var sqlSymbol: String {
         switch self {

--- a/Packages/TableProCore/Sources/TableProQuery/FilterSQLGenerator.swift
+++ b/Packages/TableProCore/Sources/TableProQuery/FilterSQLGenerator.swift
@@ -31,12 +31,13 @@ public struct FilterSQLGenerator: Sendable {
 
         let quotedColumn = quoteIdentifier(filter.columnName)
         let escapedValue = escapeValue(filter.value)
+        let folding = caseFolding(for: filter)
 
         switch filter.filterOperator {
         case .equal:
-            return "\(quotedColumn) = \(escapedValue)"
+            return comparisonCondition(quotedColumn, "=", escapedValue, folding: folding)
         case .notEqual:
-            return "\(quotedColumn) != \(escapedValue)"
+            return comparisonCondition(quotedColumn, "!=", escapedValue, folding: folding)
         case .greaterThan:
             return "\(quotedColumn) > \(escapedValue)"
         case .greaterThanOrEqual:
@@ -46,32 +47,66 @@ public struct FilterSQLGenerator: Sendable {
         case .lessThanOrEqual:
             return "\(quotedColumn) <= \(escapedValue)"
         case .like:
-            return "\(quotedColumn) LIKE \(escapedValue)\(likeEscape)"
+            return likeCondition(quotedColumn, escapedValue, negated: false, folding: folding)
         case .notLike:
-            return "\(quotedColumn) NOT LIKE \(escapedValue)\(likeEscape)"
+            return likeCondition(quotedColumn, escapedValue, negated: true, folding: folding)
         case .isNull:
             return "\(quotedColumn) IS NULL"
         case .isNotNull:
             return "\(quotedColumn) IS NOT NULL"
         case .in:
-            let values = parseInValues(filter.value)
-            return "\(quotedColumn) IN (\(values))"
+            return listCondition(quotedColumn, filter.value, negated: false, folding: folding)
         case .notIn:
-            let values = parseInValues(filter.value)
-            return "\(quotedColumn) NOT IN (\(values))"
+            return listCondition(quotedColumn, filter.value, negated: true, folding: folding)
         case .between:
             let escapedSecond = escapeValue(filter.secondValue)
             return "\(quotedColumn) BETWEEN \(escapedValue) AND \(escapedSecond)"
         case .contains:
             let pattern = escapeLikePattern(filter.value)
-            return "\(quotedColumn) LIKE '%\(pattern)%'\(likeEscape)"
+            return likeCondition(quotedColumn, "'%\(pattern)%'", negated: false, folding: folding)
         case .startsWith:
             let pattern = escapeLikePattern(filter.value)
-            return "\(quotedColumn) LIKE '\(pattern)%'\(likeEscape)"
+            return likeCondition(quotedColumn, "'\(pattern)%'", negated: false, folding: folding)
         case .endsWith:
             let pattern = escapeLikePattern(filter.value)
-            return "\(quotedColumn) LIKE '%\(pattern)'\(likeEscape)"
+            return likeCondition(quotedColumn, "'%\(pattern)'", negated: false, folding: folding)
         }
+    }
+
+    private func caseFolding(for filter: TableFilter) -> PluginSQLCaseFolding {
+        PluginSQLCaseFolding.resolve(
+            style: dialect.caseSensitivityStyle,
+            foldFunction: dialect.caseFoldFunction,
+            isCaseSensitive: filter.isCaseSensitive || !filter.filterOperator.supportsCaseSensitivity
+        )
+    }
+
+    private func comparisonCondition(
+        _ column: String, _ operatorText: String, _ literal: String, folding: PluginSQLCaseFolding
+    ) -> String {
+        guard folding.foldsComparisonOperands, literal.hasPrefix("'") else {
+            return "\(column) \(operatorText) \(literal)"
+        }
+        return "\(folding.fold(column)) \(operatorText) \(folding.fold(literal))"
+    }
+
+    private func likeCondition(
+        _ column: String, _ pattern: String, negated: Bool, folding: PluginSQLCaseFolding
+    ) -> String {
+        let keyword = negated ? folding.notLikeKeyword : folding.likeKeyword
+        return "\(folding.foldingLikeOperand(column)) \(keyword) \(folding.foldingLikeOperand(pattern))\(likeEscape)"
+    }
+
+    private func listCondition(
+        _ column: String, _ rawValue: String, negated: Bool, folding: PluginSQLCaseFolding
+    ) -> String {
+        let keyword = negated ? "NOT IN" : "IN"
+        let items = rawValue.split(separator: ",")
+            .map { escapeValue($0.trimmingCharacters(in: .whitespaces)) }
+        let foldable = folding.foldsComparisonOperands && items.allSatisfy { $0.hasPrefix("'") }
+        let rendered = foldable ? items.map { folding.fold($0) } : items
+        let subject = foldable ? folding.fold(column) : column
+        return "\(subject) \(keyword) (\(rendered.joined(separator: ", ")))"
     }
 
     private var likeEscape: String {
@@ -118,13 +153,5 @@ public struct FilterSQLGenerator: Sendable {
                 .replacingOccurrences(of: "_", with: "\\_")
         }
         return result
-    }
-
-    private func parseInValues(_ value: String) -> String {
-        let parts = value.components(separatedBy: ",")
-        return parts.map { part in
-            let trimmed = part.trimmingCharacters(in: .whitespaces)
-            return escapeValue(trimmed)
-        }.joined(separator: ", ")
     }
 }

--- a/Packages/TableProCore/Tests/TableProQueryTests/FilterSQLGeneratorCaseSensitivityTests.swift
+++ b/Packages/TableProCore/Tests/TableProQueryTests/FilterSQLGeneratorCaseSensitivityTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import TableProModels
+import TableProPluginKit
+import Testing
+@testable import TableProQuery
+
+@Suite("Mobile Filter Case Sensitivity")
+struct MobileFilterSQLGeneratorCaseSensitivityTests {
+
+    private static let postgresql = SQLDialectDescriptor(
+        identifierQuote: "\"", keywords: [], functions: [], dataTypes: [],
+        likeEscapeStyle: .explicit, caseSensitivityStyle: .ilikeOperator
+    )
+
+    private static let oracle = SQLDialectDescriptor(
+        identifierQuote: "\"", keywords: [], functions: [], dataTypes: [],
+        likeEscapeStyle: .explicit, caseSensitivityStyle: .caseFoldFunction
+    )
+
+    private static let mysql = SQLDialectDescriptor(
+        identifierQuote: "`", keywords: [], functions: [], dataTypes: [],
+        likeEscapeStyle: .implicit, caseSensitivityStyle: .collationDefined
+    )
+
+    private func clause(
+        _ dialect: SQLDialectDescriptor,
+        _ filterOperator: FilterOperator,
+        value: String = "smith",
+        isCaseSensitive: Bool? = nil
+    ) -> String {
+        FilterSQLGenerator(dialect: dialect).generateWhereClause(
+            from: [TableFilter(
+                columnName: "name",
+                filterOperator: filterOperator,
+                value: value,
+                isCaseSensitive: isCaseSensitive
+            )],
+            logicMode: .and
+        )
+    }
+
+    @Test("Pattern operators ignore case by default")
+    func testPatternDefaults() {
+        #expect(TableFilter(filterOperator: .contains).isCaseSensitive == false)
+        #expect(TableFilter(filterOperator: .like).isCaseSensitive == false)
+        #expect(TableFilter(filterOperator: .equal).isCaseSensitive)
+    }
+
+    @Test("PostgreSQL contains ignoring case uses ILIKE")
+    func testPostgresContains() {
+        #expect(clause(Self.postgresql, .contains) == "WHERE \"name\" ILIKE '%smith%' ESCAPE '!'")
+    }
+
+    @Test("PostgreSQL contains matching case keeps LIKE")
+    func testPostgresContainsMatchingCase() {
+        #expect(clause(Self.postgresql, .contains, isCaseSensitive: true) == "WHERE \"name\" LIKE '%smith%' ESCAPE '!'")
+    }
+
+    @Test("Oracle contains ignoring case folds both sides")
+    func testOracleContains() {
+        #expect(clause(Self.oracle, .contains) == "WHERE LOWER(\"name\") LIKE LOWER('%smith%') ESCAPE '!'")
+    }
+
+    @Test("MySQL emits the same SQL whichever way the row is set")
+    func testMySQLUnchanged() {
+        #expect(clause(Self.mysql, .contains) == clause(Self.mysql, .contains, isCaseSensitive: true))
+    }
+
+    @Test("Equals ignoring case folds both sides")
+    func testEqualsIgnoringCase() {
+        #expect(clause(Self.postgresql, .equal, isCaseSensitive: false) == "WHERE LOWER(\"name\") = LOWER('smith')")
+    }
+
+    @Test("Equals matching case stays untouched")
+    func testEqualsMatchingCase() {
+        #expect(clause(Self.postgresql, .equal) == "WHERE \"name\" = 'smith'")
+    }
+
+    @Test("IN ignoring case folds the column and every value")
+    func testInListIgnoringCase() {
+        let sql = clause(Self.postgresql, .in, value: "a,b", isCaseSensitive: false)
+        #expect(sql == "WHERE LOWER(\"name\") IN (LOWER('a'), LOWER('b'))")
+    }
+
+    @Test("A saved filter with no case key decodes to the operator default")
+    func testLegacyDecode() throws {
+        let json = """
+        {"id":"8B9E4F1C-2A3D-4B5E-9F60-1234567890AB","columnName":"name",
+         "filterOperator":"contains","value":"smith","secondValue":"","isEnabled":true}
+        """
+        let filter = try JSONDecoder().decode(TableFilter.self, from: Data(json.utf8))
+        #expect(filter.isCaseSensitive == false)
+    }
+}

--- a/Plugins/BeancountDriverPlugin/BeancountPlugin.swift
+++ b/Plugins/BeancountDriverPlugin/BeancountPlugin.swift
@@ -64,7 +64,8 @@ final class BeancountPlugin: NSObject, TableProPlugin, DriverPlugin {
         regexSyntax: .unsupported,
         booleanLiteralStyle: .numeric,
         likeEscapeStyle: .explicit,
-        paginationStyle: .limit
+        paginationStyle: .limit,
+        caseSensitivityStyle: .collationDefined
     )
 
     func createDriver(config: DriverConnectionConfig) -> any PluginDatabaseDriver {

--- a/Plugins/BigQueryDriverPlugin/BigQueryPlugin.swift
+++ b/Plugins/BigQueryDriverPlugin/BigQueryPlugin.swift
@@ -159,8 +159,9 @@ final class BigQueryPlugin: NSObject, TableProPlugin, DriverPlugin {
         ],
         regexSyntax: .unsupported,
         booleanLiteralStyle: .truefalse,
-        likeEscapeStyle: .explicit,
-        paginationStyle: .limit
+        likeEscapeStyle: .implicit,
+        paginationStyle: .limit,
+        caseSensitivityStyle: .caseFoldFunction
     )
 
     static let explainVariants: [ExplainVariant] = [

--- a/Plugins/BigQueryDriverPlugin/BigQueryPluginDriver.swift
+++ b/Plugins/BigQueryDriverPlugin/BigQueryPluginDriver.swift
@@ -564,6 +564,25 @@ internal final class BigQueryPluginDriver: PluginDatabaseDriver, @unchecked Send
         offset: Int,
         columnKinds: [String: PluginColumnKind]
     ) -> String? {
+        buildFilteredQuery(
+            table: table, schema: schema,
+            queryFilters: filters.map { PluginQueryFilter(column: $0.column, op: $0.op, value: $0.value) },
+            logicMode: logicMode, sortColumns: sortColumns, columns: columns,
+            limit: limit, offset: offset, columnKinds: columnKinds
+        )
+    }
+
+    func buildFilteredQuery(
+        table: String,
+        schema: String?,
+        queryFilters: [PluginQueryFilter],
+        logicMode: String,
+        sortColumns: [(columnIndex: Int, ascending: Bool)],
+        columns: [String],
+        limit: Int,
+        offset: Int,
+        columnKinds: [String: PluginColumnKind]
+    ) -> String? {
         let dataset: String = lock.withLock {
             let ds = schema ?? _currentDataset ?? ""
             _columnCache["\(ds).\(table)"] = columns
@@ -571,7 +590,7 @@ internal final class BigQueryPluginDriver: PluginDatabaseDriver, @unchecked Send
         }
         return BigQueryQueryBuilder.encodeFilteredQuery(
             table: table, dataset: dataset,
-            filters: filters, logicMode: logicMode,
+            filters: queryFilters, logicMode: logicMode,
             sortColumns: sortColumns, limit: limit, offset: offset, columnKinds: columnKinds
         )
     }

--- a/Plugins/BigQueryDriverPlugin/BigQueryQueryBuilder.swift
+++ b/Plugins/BigQueryDriverPlugin/BigQueryQueryBuilder.swift
@@ -34,10 +34,18 @@ internal struct BigQueryFilterSpec: Codable {
     let op: String
     let value: String
     var kind: String?
+    var caseSensitive: Bool?
 
     var columnKind: PluginColumnKind? {
         guard let kind else { return nil }
         return PluginColumnKind(rawValue: kind)
+    }
+
+    var folding: PluginSQLCaseFolding {
+        PluginSQLCaseFolding.resolve(
+            style: .caseFoldFunction,
+            isCaseSensitive: caseSensitive ?? true
+        )
     }
 }
 
@@ -75,7 +83,7 @@ internal struct BigQueryQueryBuilder {
     static func encodeFilteredQuery(
         table: String,
         dataset: String,
-        filters: [(column: String, op: String, value: String)],
+        filters: [PluginQueryFilter],
         logicMode: String,
         sortColumns: [(columnIndex: Int, ascending: Bool)],
         limit: Int,
@@ -90,7 +98,9 @@ internal struct BigQueryQueryBuilder {
             offset: offset,
             filters: filters.map {
                 BigQueryFilterSpec(
-                    column: $0.column, op: $0.op, value: $0.value, kind: columnKinds[$0.column]?.rawValue
+                    column: $0.column, op: $0.op, value: $0.value,
+                    kind: columnKinds[$0.column]?.rawValue,
+                    caseSensitive: $0.isCaseSensitive
                 )
             },
             logicMode: logicMode,
@@ -126,7 +136,7 @@ internal struct BigQueryQueryBuilder {
     static func encodeCombinedQuery(
         table: String,
         dataset: String,
-        filters: [(column: String, op: String, value: String)],
+        filters: [PluginQueryFilter],
         logicMode: String,
         searchText: String,
         searchColumns: [String],
@@ -140,7 +150,11 @@ internal struct BigQueryQueryBuilder {
             sortColumns: sortColumns.map { .init(columnIndex: $0.columnIndex, ascending: $0.ascending) },
             limit: limit,
             offset: offset,
-            filters: filters.map { BigQueryFilterSpec(column: $0.column, op: $0.op, value: $0.value) },
+            filters: filters.map {
+                BigQueryFilterSpec(
+                    column: $0.column, op: $0.op, value: $0.value, caseSensitive: $0.isCaseSensitive
+                )
+            },
             logicMode: logicMode,
             searchText: searchText,
             searchColumns: searchColumns
@@ -304,18 +318,20 @@ internal struct BigQueryQueryBuilder {
         let escaped = filter.value.replacingOccurrences(of: "'", with: "''")
         let kind = filter.columnKind
         let isNullKeyword = filter.value.lowercased() == "null" && !PluginSQLLiteral.isKnownTextLike(kind)
+        let folding = filter.folding
+        let foldedColumn = folding.foldingLikeOperand(col)
 
         switch filter.op.uppercased() {
         case "=":
             if isNullKeyword {
                 return "\(col) IS NULL"
             }
-            return "\(col) = \(formatFilterValue(filter.value, kind: kind))"
+            return comparisonClause(col, "=", filter.value, kind: kind, folding: folding)
         case "!=", "<>":
             if isNullKeyword {
                 return "\(col) IS NOT NULL"
             }
-            return "\(col) != \(formatFilterValue(filter.value, kind: kind))"
+            return comparisonClause(col, "!=", filter.value, kind: kind, folding: folding)
         case ">":
             return "\(col) > \(formatFilterValue(filter.value, kind: kind))"
         case ">=":
@@ -325,24 +341,47 @@ internal struct BigQueryQueryBuilder {
         case "<=":
             return "\(col) <= \(formatFilterValue(filter.value, kind: kind))"
         case "LIKE":
-            return "\(col) LIKE '\(escaped)'"
+            return "\(foldedColumn) \(folding.likeKeyword) \(folding.foldingLikeOperand("'\(escaped)'"))"
         case "NOT LIKE":
-            return "\(col) NOT LIKE '\(escaped)'"
+            return "\(foldedColumn) \(folding.notLikeKeyword) \(folding.foldingLikeOperand("'\(escaped)'"))"
         case "IN", "NOT IN":
             let values = filter.value.split(separator: ",").map { val in
                 let trimmed = val.trimmingCharacters(in: .whitespaces)
-                return formatFilterValue(trimmed, kind: kind)
+                return foldedLiteral(formatFilterValue(trimmed, kind: kind), folding: folding)
             }
-            return "\(col) \(filter.op.uppercased()) (\(values.joined(separator: ", ")))"
+            let column = values.contains(where: { $0.hasPrefix(folding.foldFunction) })
+                ? folding.fold(col) : col
+            return "\(column) \(filter.op.uppercased()) (\(values.joined(separator: ", ")))"
         case "IS NULL":
             return "\(col) IS NULL"
         case "IS NOT NULL":
             return "\(col) IS NOT NULL"
         case "CONTAINS":
-            return "CAST(\(col) AS STRING) LIKE '%\(escaped)%'"
+            let castColumn = "CAST(\(col) AS STRING)"
+            return "\(folding.foldingLikeOperand(castColumn)) \(folding.likeKeyword) "
+                + folding.foldingLikeOperand("'%\(escaped)%'")
         default:
             return nil
         }
+    }
+
+    private static func comparisonClause(
+        _ column: String,
+        _ operatorText: String,
+        _ value: String,
+        kind: PluginColumnKind?,
+        folding: PluginSQLCaseFolding
+    ) -> String {
+        let literal = formatFilterValue(value, kind: kind)
+        let foldedValue = foldedLiteral(literal, folding: folding)
+        guard foldedValue != literal else { return "\(column) \(operatorText) \(literal)" }
+        return "\(folding.fold(column)) \(operatorText) \(foldedValue)"
+    }
+
+    /// Folding a number is a type error, so only text literals fold.
+    private static func foldedLiteral(_ literal: String, folding: PluginSQLCaseFolding) -> String {
+        guard folding.foldsComparisonOperands, literal.hasPrefix("'") else { return literal }
+        return folding.fold(literal)
     }
 
     private static func encodeParams(_ params: BigQueryQueryParams) -> String {

--- a/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
+++ b/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
@@ -94,7 +94,8 @@ internal final class CassandraPlugin: NSObject, TableProPlugin, DriverPlugin {
             booleanLiteralStyle: .truefalse,
             likeEscapeStyle: .explicit,
             paginationStyle: .limit,
-            autoLimitStyle: .limit
+            autoLimitStyle: .limit,
+            caseSensitivityStyle: .unsupported
         )
     }
 

--- a/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
+++ b/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
@@ -105,7 +105,9 @@ final class ClickHousePlugin: NSObject, TableProPlugin, DriverPlugin {
         booleanLiteralStyle: .numeric,
         likeEscapeStyle: .implicit,
         paginationStyle: .limit,
-        requiresBackslashEscaping: true
+        requiresBackslashEscaping: true,
+        caseSensitivityStyle: .caseFoldFunction,
+        caseFoldFunction: "lowerUTF8"
     )
 
     func createDriver(config: DriverConnectionConfig) -> any PluginDatabaseDriver {

--- a/Plugins/CloudflareD1DriverPlugin/CloudflareD1Plugin.swift
+++ b/Plugins/CloudflareD1DriverPlugin/CloudflareD1Plugin.swift
@@ -88,7 +88,8 @@ final class CloudflareD1Plugin: NSObject, TableProPlugin, DriverPlugin {
         regexSyntax: .unsupported,
         booleanLiteralStyle: .numeric,
         likeEscapeStyle: .explicit,
-        paginationStyle: .limit
+        paginationStyle: .limit,
+        caseSensitivityStyle: .collationDefined
     )
 
     static let additionalConnectionFields: [ConnectionField] = [

--- a/Plugins/DuckDBDriverPlugin/DuckDBPlugin.swift
+++ b/Plugins/DuckDBDriverPlugin/DuckDBPlugin.swift
@@ -150,7 +150,8 @@ final class DuckDBPlugin: NSObject, TableProPlugin, DriverPlugin {
         regexSyntax: .regexpMatches,
         booleanLiteralStyle: .truefalse,
         likeEscapeStyle: .explicit,
-        paginationStyle: .limit
+        paginationStyle: .limit,
+        caseSensitivityStyle: .ilikeOperator
     )
 
     func createDriver(config: DriverConnectionConfig) -> any PluginDatabaseDriver {

--- a/Plugins/DynamoDBDriverPlugin/DynamoDBPlugin.swift
+++ b/Plugins/DynamoDBDriverPlugin/DynamoDBPlugin.swift
@@ -55,7 +55,8 @@ final class DynamoDBPlugin: NSObject, TableProPlugin, DriverPlugin {
             "begins_with", "contains", "size", "attribute_type",
             "attribute_exists", "attribute_not_exists"
         ],
-        dataTypes: ["S", "N", "B", "BOOL", "NULL", "L", "M", "SS", "NS", "BS"]
+        dataTypes: ["S", "N", "B", "BOOL", "NULL", "L", "M", "SS", "NS", "BS"],
+        caseSensitivityStyle: .driverManaged
     )
 
     static let columnTypesByCategory: [String: [String]] = [

--- a/Plugins/DynamoDBDriverPlugin/DynamoDBPluginDriver.swift
+++ b/Plugins/DynamoDBDriverPlugin/DynamoDBPluginDriver.swift
@@ -453,12 +453,14 @@ internal final class DynamoDBPluginDriver: PluginDatabaseDriver, @unchecked Send
 
     func buildFilteredQuery(
         table: String,
-        filters: [(column: String, op: String, value: String)],
+        schema: String?,
+        queryFilters filters: [PluginQueryFilter],
         logicMode: String,
         sortColumns: [(columnIndex: Int, ascending: Bool)],
         columns: [String],
         limit: Int,
-        offset: Int
+        offset: Int,
+        columnKinds: [String: PluginColumnKind]
     ) -> String? {
         let (keySchema, attrTypes) = lock.withLock {
             let desc = _tableDescriptionCache[table]
@@ -1137,17 +1139,6 @@ internal final class DynamoDBPluginDriver: PluginDatabaseDriver, @unchecked Send
         return total
     }
 
-    private func applyClientFilter(
-        items: [[String: DynamoDBAttributeValue]],
-        column: String,
-        op: String,
-        value: String
-    ) -> [[String: DynamoDBAttributeValue]] {
-        items.filter { item in
-            matchesItemFilter(item, column: column, op: op, value: value)
-        }
-    }
-
     private func applyClientFilters(
         items: [[String: DynamoDBAttributeValue]],
         filters: [DynamoDBFilterSpec],
@@ -1156,49 +1147,44 @@ internal final class DynamoDBPluginDriver: PluginDatabaseDriver, @unchecked Send
         guard !filters.isEmpty else { return items }
         return items.filter { item in
             if logicMode.uppercased() == "OR" {
-                return filters.contains { filter in
-                    matchesItemFilter(item, column: filter.column, op: filter.op, value: filter.value)
-                }
+                return filters.contains { matchesItemFilter(item, filter: $0) }
             }
-            return filters.allSatisfy { filter in
-                matchesItemFilter(item, column: filter.column, op: filter.op, value: filter.value)
-            }
+            return filters.allSatisfy { matchesItemFilter(item, filter: $0) }
         }
     }
 
     private func matchesItemFilter(
         _ item: [String: DynamoDBAttributeValue],
-        column: String,
-        op: String,
-        value: String
+        filter: DynamoDBFilterSpec
     ) -> Bool {
-        if column == "*" {
-            for (_, attrValue) in item {
-                let str = DynamoDBItemFlattener.attributeValueToString(attrValue)
-                if matchesFilter(str, op: op, value: value) {
-                    return true
-                }
+        if filter.column == "*" {
+            return item.values.contains { attrValue in
+                matchesFilter(
+                    DynamoDBItemFlattener.attributeValueToString(attrValue),
+                    op: filter.op, value: filter.value, ignoresCase: filter.ignoresCase
+                )
             }
-            return false
         }
 
-        guard let attrValue = item[column] else { return false }
+        guard let attrValue = item[filter.column] else { return false }
         let str = DynamoDBItemFlattener.attributeValueToString(attrValue)
-        return matchesFilter(str, op: op, value: value)
+        return matchesFilter(str, op: filter.op, value: filter.value, ignoresCase: filter.ignoresCase)
     }
 
-    private func matchesFilter(_ str: String, op: String, value: String) -> Bool {
+    private func matchesFilter(_ str: String, op: String, value: String, ignoresCase: Bool) -> Bool {
+        let subject = ignoresCase ? str.lowercased() : str
+        let needle = ignoresCase ? value.lowercased() : value
         switch op.uppercased() {
         case "=":
-            return str == value
+            return subject == needle
         case "!=", "<>":
-            return str != value
+            return subject != needle
         case "CONTAINS":
-            return str.localizedCaseInsensitiveContains(value)
+            return subject.contains(needle)
         case "STARTS WITH":
-            return str.lowercased().hasPrefix(value.lowercased())
+            return subject.hasPrefix(needle)
         case "ENDS WITH":
-            return str.lowercased().hasSuffix(value.lowercased())
+            return subject.hasSuffix(needle)
         case ">":
             if let d1 = Double(str), let d2 = Double(value) { return d1 > d2 }
             return str > value

--- a/Plugins/DynamoDBDriverPlugin/DynamoDBQueryBuilder.swift
+++ b/Plugins/DynamoDBDriverPlugin/DynamoDBQueryBuilder.swift
@@ -16,7 +16,14 @@ struct DynamoDBFilterSpec: Codable {
     let value: String
     var caseSensitive: Bool?
 
-    var ignoresCase: Bool { !(caseSensitive ?? true) }
+    /// Operators that matched without regard to case before a filter row could say otherwise.
+    /// A scan tag saved by an older build carries no setting and must keep behaving as it did.
+    private static let ignoreCaseByDefault: Set<String> = ["CONTAINS", "STARTS WITH", "ENDS WITH"]
+
+    var ignoresCase: Bool {
+        guard let caseSensitive else { return Self.ignoreCaseByDefault.contains(op.uppercased()) }
+        return !caseSensitive
+    }
 }
 
 // MARK: - Parsed Query Types

--- a/Plugins/DynamoDBDriverPlugin/DynamoDBQueryBuilder.swift
+++ b/Plugins/DynamoDBDriverPlugin/DynamoDBQueryBuilder.swift
@@ -14,6 +14,9 @@ struct DynamoDBFilterSpec: Codable {
     let column: String
     let op: String
     let value: String
+    var caseSensitive: Bool?
+
+    var ignoresCase: Bool { !(caseSensitive ?? true) }
 }
 
 // MARK: - Parsed Query Types
@@ -62,7 +65,7 @@ struct DynamoDBQueryBuilder {
 
     func buildFilteredQuery(
         table: String,
-        filters: [(column: String, op: String, value: String)],
+        filters: [PluginQueryFilter],
         logicMode: String,
         sortColumns: [(columnIndex: Int, ascending: Bool)],
         columns: [String],
@@ -77,7 +80,9 @@ struct DynamoDBQueryBuilder {
         {
             let pkType = attributeTypes[pk.name] ?? "S"
             let remainingFilters = filters.filter { !($0.column == pk.name && $0.op == "=") }
-            let specs = remainingFilters.map { DynamoDBFilterSpec(column: $0.column, op: $0.op, value: $0.value) }
+            let specs = remainingFilters.map {
+                DynamoDBFilterSpec(column: $0.column, op: $0.op, value: $0.value, caseSensitive: $0.isCaseSensitive)
+            }
             return Self.encodeQueryQuery(
                 tableName: table,
                 partitionKeyName: pk.name,
@@ -90,7 +95,9 @@ struct DynamoDBQueryBuilder {
             )
         }
 
-        let specs = filters.map { DynamoDBFilterSpec(column: $0.column, op: $0.op, value: $0.value) }
+        let specs = filters.map {
+            DynamoDBFilterSpec(column: $0.column, op: $0.op, value: $0.value, caseSensitive: $0.isCaseSensitive)
+        }
         return Self.encodeScanQuery(
             tableName: table, limit: limit, offset: offset,
             filters: specs, logicMode: logicMode

--- a/Plugins/ElasticsearchDriverPlugin/ElasticsearchPlugin.swift
+++ b/Plugins/ElasticsearchDriverPlugin/ElasticsearchPlugin.swift
@@ -13,6 +13,7 @@ final class ElasticsearchPlugin: NSObject, TableProPlugin, DriverPlugin {
     static let pluginVersion = "1.0.0"
     static let pluginDescription = "Elasticsearch support via the REST API with a Query DSL console"
     static let capabilities: [PluginCapability] = [.databaseDriver]
+    static let caseSensitivityStyle: SQLDialectDescriptor.CaseSensitivityStyle = .driverManaged
 
     static let databaseTypeId = "Elasticsearch"
     static let databaseDisplayName = "Elasticsearch"

--- a/Plugins/ElasticsearchDriverPlugin/ElasticsearchPluginDriver+Execution.swift
+++ b/Plugins/ElasticsearchDriverPlugin/ElasticsearchPluginDriver+Execution.swift
@@ -78,7 +78,7 @@ extension ElasticsearchPluginDriver {
     ) async throws -> [[String: Any]] {
         if parsed.from + parsed.size <= Self.maxResultWindow {
             var body = ElasticsearchQueryBuilder.searchBody(
-                for: parsed, fields: fields, size: parsed.size, caseInsensitive: supportsCaseInsensitiveSearch
+                for: parsed, fields: fields, size: parsed.size, supportsCaseInsensitive: supportsCaseInsensitiveSearch
             )
             body["from"] = parsed.from
             Self.logger.debug("POST /\(index, privacy: .public)/_search body=\(Self.jsonString(body), privacy: .public)")
@@ -121,7 +121,7 @@ extension ElasticsearchPluginDriver {
             try Task.checkCancellation()
             var body = ElasticsearchQueryBuilder.searchBody(
                 for: parsed, fields: fields, size: Self.deepPageBatchSize,
-                tiebreaker: true, searchAfter: searchAfter, caseInsensitive: supportsCaseInsensitiveSearch
+                tiebreaker: true, searchAfter: searchAfter, supportsCaseInsensitive: supportsCaseInsensitiveSearch
             )
             body["pit"] = ["id": pit, "keep_alive": Self.pitKeepAlive]
             let response = try await conn.search(index: nil, body: body)

--- a/Plugins/ElasticsearchDriverPlugin/ElasticsearchPluginDriver.swift
+++ b/Plugins/ElasticsearchDriverPlugin/ElasticsearchPluginDriver.swift
@@ -134,7 +134,7 @@ internal final class ElasticsearchPluginDriver: PluginDatabaseDriver, @unchecked
         let fields = ElasticsearchMappingFlattener.fieldInfo(from: try await cachedMappingColumns(table))
         let specs = ElasticsearchQueryBuilder.specs(from: queryFilters)
         let query = ElasticsearchQueryBuilder.queryClause(
-            filters: specs, logicMode: logicMode, fields: fields, caseInsensitive: supportsCaseInsensitiveSearch
+            filters: specs, logicMode: logicMode, fields: fields, supportsCaseInsensitive: supportsCaseInsensitiveSearch
         )
         return try await conn.count(index: table, query: query)
     }

--- a/Plugins/ElasticsearchDriverPlugin/ElasticsearchPluginDriver.swift
+++ b/Plugins/ElasticsearchDriverPlugin/ElasticsearchPluginDriver.swift
@@ -127,12 +127,12 @@ internal final class ElasticsearchPluginDriver: PluginDatabaseDriver, @unchecked
 
     func fetchFilteredRowCount(
         table: String,
-        filters: [(column: String, op: String, value: String)],
+        queryFilters: [PluginQueryFilter],
         logicMode: String
     ) async throws -> Int? {
         guard let conn = connection else { throw ElasticsearchError.notConnected }
         let fields = ElasticsearchMappingFlattener.fieldInfo(from: try await cachedMappingColumns(table))
-        let specs = filters.map { ElasticsearchFilterSpec(column: $0.column, op: $0.op, value: $0.value) }
+        let specs = ElasticsearchQueryBuilder.specs(from: queryFilters)
         let query = ElasticsearchQueryBuilder.queryClause(
             filters: specs, logicMode: logicMode, fields: fields, caseInsensitive: supportsCaseInsensitiveSearch
         )
@@ -180,12 +180,14 @@ internal final class ElasticsearchPluginDriver: PluginDatabaseDriver, @unchecked
 
     func buildFilteredQuery(
         table: String,
-        filters: [(column: String, op: String, value: String)],
+        schema: String?,
+        queryFilters filters: [PluginQueryFilter],
         logicMode: String,
         sortColumns: [(columnIndex: Int, ascending: Bool)],
         columns: [String],
         limit: Int,
-        offset: Int
+        offset: Int,
+        columnKinds: [String: PluginColumnKind]
     ) -> String? {
         let sorts = sortSpecs(from: sortColumns, columns: columns)
         Self.logger.debug("""

--- a/Plugins/ElasticsearchDriverPlugin/ElasticsearchQueryBuilder.swift
+++ b/Plugins/ElasticsearchDriverPlugin/ElasticsearchQueryBuilder.swift
@@ -14,8 +14,13 @@ struct ElasticsearchFilterSpec: Codable, Equatable {
     let value: String
     var caseSensitive: Bool?
 
-    func ignoresCase(default fallback: Bool) -> Bool {
-        guard let caseSensitive else { return fallback }
+    /// Operators that matched without regard to case before a filter row could say otherwise.
+    private static let ignoreCaseByDefault: Set<String> = [
+        "CONTAINS", "NOT CONTAINS", "STARTS WITH", "ENDS WITH", "REGEX"
+    ]
+
+    var ignoresCase: Bool {
+        guard let caseSensitive else { return Self.ignoreCaseByDefault.contains(op.uppercased()) }
         return !caseSensitive
     }
 }
@@ -183,11 +188,12 @@ struct ElasticsearchQueryBuilder {
         size: Int,
         tiebreaker: Bool = false,
         searchAfter: [Any]? = nil,
-        caseInsensitive: Bool = true
+        supportsCaseInsensitive: Bool = true
     ) -> [String: Any] {
         var body: [String: Any] = ["size": size]
         body["query"] = queryClause(
-            filters: parsed.filters, logicMode: parsed.logicMode, fields: fields, caseInsensitive: caseInsensitive
+            filters: parsed.filters, logicMode: parsed.logicMode, fields: fields,
+            supportsCaseInsensitive: supportsCaseInsensitive
         )
         body["sort"] = sortClause(parsed.sorts, fields: fields, tiebreaker: tiebreaker)
         if let searchAfter {
@@ -200,12 +206,12 @@ struct ElasticsearchQueryBuilder {
         filters: [ElasticsearchFilterSpec],
         logicMode: String,
         fields: [String: ElasticsearchFieldInfo],
-        caseInsensitive: Bool = true
+        supportsCaseInsensitive: Bool = true
     ) -> [String: Any] {
         let active = filters.filter { !($0.column == rawColumn && $0.value.trimmingCharacters(in: .whitespaces).isEmpty) }
         guard !active.isEmpty else { return ["match_all": [String: Any]()] }
 
-        let clauses = active.map { clause(for: $0, fields: fields, caseInsensitive: caseInsensitive) }
+        let clauses = active.map { clause(for: $0, fields: fields, supportsCaseInsensitive: supportsCaseInsensitive) }
         let occur = logicMode.uppercased() == "OR" ? "should" : "must"
         var bool: [String: Any] = [occur: clauses]
         if occur == "should" {
@@ -259,15 +265,18 @@ struct ElasticsearchQueryBuilder {
 
     // MARK: - Per-Filter Clause
 
+    /// `supportsCaseInsensitive` reports whether the cluster understands the `case_insensitive`
+    /// option, added in 7.10. It gates what may be sent, never what the filter asked for.
     static func clause(
         for filter: ElasticsearchFilterSpec,
         fields: [String: ElasticsearchFieldInfo],
-        caseInsensitive: Bool = true
+        supportsCaseInsensitive: Bool = true
     ) -> [String: Any] {
         let column = filter.column
         let op = filter.op.uppercased()
         let value = filter.value
-        let ignoresCase = filter.ignoresCase(default: caseInsensitive)
+        let ignoresCase = filter.ignoresCase
+        let sendsOption = ignoresCase && supportsCaseInsensitive
 
         if column == rawColumn {
             return ["query_string": ["query": value, "lenient": true]]
@@ -275,9 +284,9 @@ struct ElasticsearchQueryBuilder {
 
         switch op {
         case "=":
-            return equalsClause(column: column, value: value, fields: fields, caseInsensitive: ignoresCase)
+            return equalsClause(column: column, value: value, fields: fields, caseInsensitive: sendsOption)
         case "!=", "<>":
-            return mustNot(equalsClause(column: column, value: value, fields: fields, caseInsensitive: ignoresCase))
+            return mustNot(equalsClause(column: column, value: value, fields: fields, caseInsensitive: sendsOption))
         case ">":
             return ["range": [column: ["gt": typedValue(value, column: column, fields: fields)]]]
         case ">=":
@@ -294,22 +303,28 @@ struct ElasticsearchQueryBuilder {
                 "lte": typedValue(bounds[1], column: column, fields: fields),
             ]]]
         case "CONTAINS":
-            return containsClause(column: column, value: value, fields: fields, caseInsensitive: ignoresCase)
+            return containsClause(
+                column: column, value: value, fields: fields,
+                ignoresCase: ignoresCase, sendsOption: sendsOption
+            )
         case "NOT CONTAINS":
-            return mustNot(containsClause(column: column, value: value, fields: fields, caseInsensitive: ignoresCase))
+            return mustNot(containsClause(
+                column: column, value: value, fields: fields,
+                ignoresCase: ignoresCase, sendsOption: sendsOption
+            ))
         case "STARTS WITH":
             if isTextField(column, fields: fields), ignoresCase {
                 return ["match_phrase_prefix": [column: value]]
             }
-            return prefixClause(keywordField(column, fields: fields), value: value, caseInsensitive: ignoresCase)
+            return prefixClause(keywordField(column, fields: fields), value: value, caseInsensitive: sendsOption)
         case "ENDS WITH":
-            return wildcardClause(keywordField(column, fields: fields), pattern: "*\(escapeWildcard(value))", caseInsensitive: ignoresCase)
+            return wildcardClause(keywordField(column, fields: fields), pattern: "*\(escapeWildcard(value))", caseInsensitive: sendsOption)
         case "IN":
-            return listClause(column: column, value: value, fields: fields, caseInsensitive: ignoresCase)
+            return listClause(column: column, value: value, fields: fields, caseInsensitive: sendsOption)
         case "NOT IN":
-            return mustNot(listClause(column: column, value: value, fields: fields, caseInsensitive: ignoresCase))
+            return mustNot(listClause(column: column, value: value, fields: fields, caseInsensitive: sendsOption))
         case "REGEX":
-            return regexpClause(keywordField(column, fields: fields), value: value, caseInsensitive: ignoresCase)
+            return regexpClause(keywordField(column, fields: fields), value: value, caseInsensitive: sendsOption)
         case "IS NULL", "IS_NULL", "IS EMPTY", "IS_EMPTY":
             return ["bool": [
                 "should": [mustNot(["exists": ["field": column]]), ["term": [keywordField(column, fields: fields): ""]]],
@@ -325,13 +340,20 @@ struct ElasticsearchQueryBuilder {
         }
     }
 
+    /// A text field is analyzed, so `match` already disregards case on every server version.
+    /// Only the keyword path needs the option, and therefore the version gate.
     private static func containsClause(
-        column: String, value: String, fields: [String: ElasticsearchFieldInfo], caseInsensitive: Bool
+        column: String, value: String, fields: [String: ElasticsearchFieldInfo],
+        ignoresCase: Bool, sendsOption: Bool
     ) -> [String: Any] {
-        if isTextField(column, fields: fields), caseInsensitive {
+        if isTextField(column, fields: fields), ignoresCase {
             return ["match": [column: value]]
         }
-        return wildcardClause(keywordField(column, fields: fields), pattern: "*\(escapeWildcard(value))*", caseInsensitive: caseInsensitive)
+        return wildcardClause(
+            keywordField(column, fields: fields),
+            pattern: "*\(escapeWildcard(value))*",
+            caseInsensitive: sendsOption
+        )
     }
 
     private static func wildcardClause(_ field: String, pattern: String, caseInsensitive: Bool) -> [String: Any] {

--- a/Plugins/ElasticsearchDriverPlugin/ElasticsearchQueryBuilder.swift
+++ b/Plugins/ElasticsearchDriverPlugin/ElasticsearchQueryBuilder.swift
@@ -6,11 +6,18 @@
 //
 
 import Foundation
+import TableProPluginKit
 
 struct ElasticsearchFilterSpec: Codable, Equatable {
     let column: String
     let op: String
     let value: String
+    var caseSensitive: Bool?
+
+    func ignoresCase(default fallback: Bool) -> Bool {
+        guard let caseSensitive else { return fallback }
+        return !caseSensitive
+    }
 }
 
 struct ElasticsearchSortSpec: Codable, Equatable {
@@ -54,16 +61,22 @@ struct ElasticsearchQueryBuilder {
 
     func buildFilteredQuery(
         index: String,
-        filters: [(column: String, op: String, value: String)],
+        filters: [PluginQueryFilter],
         logicMode: String,
         sorts: [ElasticsearchSortSpec],
         limit: Int,
         offset: Int
     ) -> String {
-        let specs = filters.map { ElasticsearchFilterSpec(column: $0.column, op: $0.op, value: $0.value) }
-        return Self.encodeSearch(
-            index: index, from: offset, size: limit, sorts: sorts, filters: specs, logicMode: logicMode
+        Self.encodeSearch(
+            index: index, from: offset, size: limit, sorts: sorts,
+            filters: Self.specs(from: filters), logicMode: logicMode
         )
+    }
+
+    static func specs(from filters: [PluginQueryFilter]) -> [ElasticsearchFilterSpec] {
+        filters.map {
+            ElasticsearchFilterSpec(column: $0.column, op: $0.op, value: $0.value, caseSensitive: $0.isCaseSensitive)
+        }
     }
 
     // MARK: - Encoding
@@ -254,6 +267,7 @@ struct ElasticsearchQueryBuilder {
         let column = filter.column
         let op = filter.op.uppercased()
         let value = filter.value
+        let ignoresCase = filter.ignoresCase(default: caseInsensitive)
 
         if column == rawColumn {
             return ["query_string": ["query": value, "lenient": true]]
@@ -261,9 +275,9 @@ struct ElasticsearchQueryBuilder {
 
         switch op {
         case "=":
-            return equalsClause(column: column, value: value, fields: fields)
+            return equalsClause(column: column, value: value, fields: fields, caseInsensitive: ignoresCase)
         case "!=", "<>":
-            return mustNot(equalsClause(column: column, value: value, fields: fields))
+            return mustNot(equalsClause(column: column, value: value, fields: fields, caseInsensitive: ignoresCase))
         case ">":
             return ["range": [column: ["gt": typedValue(value, column: column, fields: fields)]]]
         case ">=":
@@ -280,22 +294,22 @@ struct ElasticsearchQueryBuilder {
                 "lte": typedValue(bounds[1], column: column, fields: fields),
             ]]]
         case "CONTAINS":
-            return containsClause(column: column, value: value, fields: fields, caseInsensitive: caseInsensitive)
+            return containsClause(column: column, value: value, fields: fields, caseInsensitive: ignoresCase)
         case "NOT CONTAINS":
-            return mustNot(containsClause(column: column, value: value, fields: fields, caseInsensitive: caseInsensitive))
+            return mustNot(containsClause(column: column, value: value, fields: fields, caseInsensitive: ignoresCase))
         case "STARTS WITH":
-            if isTextField(column, fields: fields) {
+            if isTextField(column, fields: fields), ignoresCase {
                 return ["match_phrase_prefix": [column: value]]
             }
-            return prefixClause(keywordField(column, fields: fields), value: value, caseInsensitive: caseInsensitive)
+            return prefixClause(keywordField(column, fields: fields), value: value, caseInsensitive: ignoresCase)
         case "ENDS WITH":
-            return wildcardClause(keywordField(column, fields: fields), pattern: "*\(escapeWildcard(value))", caseInsensitive: caseInsensitive)
+            return wildcardClause(keywordField(column, fields: fields), pattern: "*\(escapeWildcard(value))", caseInsensitive: ignoresCase)
         case "IN":
-            return ["terms": [keywordField(column, fields: fields): splitList(value)]]
+            return listClause(column: column, value: value, fields: fields, caseInsensitive: ignoresCase)
         case "NOT IN":
-            return mustNot(["terms": [keywordField(column, fields: fields): splitList(value)]])
+            return mustNot(listClause(column: column, value: value, fields: fields, caseInsensitive: ignoresCase))
         case "REGEX":
-            return regexpClause(keywordField(column, fields: fields), value: value, caseInsensitive: caseInsensitive)
+            return regexpClause(keywordField(column, fields: fields), value: value, caseInsensitive: ignoresCase)
         case "IS NULL", "IS_NULL", "IS EMPTY", "IS_EMPTY":
             return ["bool": [
                 "should": [mustNot(["exists": ["field": column]]), ["term": [keywordField(column, fields: fields): ""]]],
@@ -314,7 +328,7 @@ struct ElasticsearchQueryBuilder {
     private static func containsClause(
         column: String, value: String, fields: [String: ElasticsearchFieldInfo], caseInsensitive: Bool
     ) -> [String: Any] {
-        if isTextField(column, fields: fields) {
+        if isTextField(column, fields: fields), caseInsensitive {
             return ["match": [column: value]]
         }
         return wildcardClause(keywordField(column, fields: fields), pattern: "*\(escapeWildcard(value))*", caseInsensitive: caseInsensitive)
@@ -349,15 +363,37 @@ struct ElasticsearchQueryBuilder {
     private static func equalsClause(
         column: String,
         value: String,
-        fields: [String: ElasticsearchFieldInfo]
+        fields: [String: ElasticsearchFieldInfo],
+        caseInsensitive: Bool = false
     ) -> [String: Any] {
         if isTextField(column, fields: fields) {
             if let keyword = matchableKeywordField(column, fields: fields), keyword != column {
-                return ["term": [keyword: value]]
+                return termClause(keyword, value: value, caseInsensitive: caseInsensitive)
             }
             return ["match_phrase": [column: value]]
         }
-        return ["term": [column: typedValue(value, column: column, fields: fields)]]
+        guard caseInsensitive else {
+            return ["term": [column: typedValue(value, column: column, fields: fields)]]
+        }
+        return termClause(column, value: value, caseInsensitive: true)
+    }
+
+    /// `terms` has no case_insensitive option, so an ignore-case list becomes a should of terms.
+    private static func listClause(
+        column: String,
+        value: String,
+        fields: [String: ElasticsearchFieldInfo],
+        caseInsensitive: Bool
+    ) -> [String: Any] {
+        let field = keywordField(column, fields: fields)
+        guard caseInsensitive else { return ["terms": [field: splitList(value)]] }
+        let clauses = splitList(value).map { termClause(field, value: $0, caseInsensitive: true) }
+        return ["bool": ["should": clauses, "minimum_should_match": 1]]
+    }
+
+    private static func termClause(_ field: String, value: String, caseInsensitive: Bool) -> [String: Any] {
+        guard caseInsensitive else { return ["term": [field: value]] }
+        return ["term": [field: ["value": value, "case_insensitive": true]]]
     }
 
     private static func keywordField(_ column: String, fields: [String: ElasticsearchFieldInfo]) -> String {

--- a/Plugins/EtcdDriverPlugin/EtcdPlugin.swift
+++ b/Plugins/EtcdDriverPlugin/EtcdPlugin.swift
@@ -40,6 +40,7 @@ final class EtcdPlugin: NSObject, TableProPlugin, DriverPlugin {
     static let defaultPrimaryKeyColumn: String? = "Key"
     static let structureColumnFields: [StructureColumnField] = [.name, .type, .nullable]
     static let sqlDialect: SQLDialectDescriptor? = nil
+    static let caseSensitivityStyle: SQLDialectDescriptor.CaseSensitivityStyle = .driverManaged
     static let columnTypesByCategory: [String: [String]] = ["String": ["string"]]
 
     static let additionalConnectionFields: [ConnectionField] = [

--- a/Plugins/EtcdDriverPlugin/EtcdPluginDriver.swift
+++ b/Plugins/EtcdDriverPlugin/EtcdPluginDriver.swift
@@ -177,6 +177,7 @@ final class EtcdPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 sortAscending: parsed.sortAscending,
                 filterType: parsed.filterType,
                 filterValue: parsed.filterValue,
+                isCaseSensitive: parsed.isCaseSensitive,
                 client: client,
                 continuation: continuation
             )
@@ -200,6 +201,7 @@ final class EtcdPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         sortAscending: Bool,
         filterType: EtcdFilterType,
         filterValue: String,
+        isCaseSensitive: Bool,
         client: EtcdHttpClient,
         continuation: AsyncThrowingStream<PluginStreamElement, Error>.Continuation
     ) async throws {
@@ -227,7 +229,7 @@ final class EtcdPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             if needsClientFilter {
                 let key = EtcdHttpClient.base64Decode(kv.key)
                 let value = kv.value.map { EtcdHttpClient.base64Decode($0) }
-                if !matchesFilter(key: key, value: value, filterType: filterType, filterValue: filterValue) {
+                if !matchesFilter(key: key, value: value, filterType: filterType, filterValue: filterValue, isCaseSensitive: isCaseSensitive) {
                     continue
                 }
             }
@@ -426,12 +428,14 @@ final class EtcdPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func buildFilteredQuery(
         table: String,
-        filters: [(column: String, op: String, value: String)],
+        schema: String?,
+        queryFilters filters: [PluginQueryFilter],
         logicMode: String,
         sortColumns: [(columnIndex: Int, ascending: Bool)],
         columns: [String],
         limit: Int,
-        offset: Int
+        offset: Int,
+        columnKinds: [String: PluginColumnKind]
     ) -> String? {
         let prefix = resolvedPrefix(for: table)
         return EtcdQueryBuilder().buildFilteredQuery(
@@ -872,13 +876,17 @@ final class EtcdPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 sortAscending: parsed.sortAscending,
                 filterType: parsed.filterType,
                 filterValue: parsed.filterValue,
+                isCaseSensitive: parsed.isCaseSensitive,
                 client: client,
                 startTime: startTime
             )
         }
 
         if let parsed = EtcdQueryBuilder.parseCountQuery(query) {
-            let count = try await countKeys(prefix: parsed.prefix, filterType: parsed.filterType, filterValue: parsed.filterValue, client: client)
+            let count = try await countKeys(
+                prefix: parsed.prefix, filterType: parsed.filterType, filterValue: parsed.filterValue,
+                isCaseSensitive: parsed.isCaseSensitive, client: client
+            )
             return PluginQueryResult(
                 columns: ["Count"],
                 columnTypeNames: ["Int64"],
@@ -900,6 +908,7 @@ final class EtcdPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         sortAscending: Bool,
         filterType: EtcdFilterType,
         filterValue: String,
+        isCaseSensitive: Bool,
         client: EtcdHttpClient,
         startTime: Date
     ) async throws -> PluginQueryResult {
@@ -922,7 +931,7 @@ final class EtcdPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             kvs = kvs.filter { kv in
                 let key = EtcdHttpClient.base64Decode(kv.key)
                 let value = kv.value.map { EtcdHttpClient.base64Decode($0) }
-                return matchesFilter(key: key, value: value, filterType: filterType, filterValue: filterValue)
+                return matchesFilter(key: key, value: value, filterType: filterType, filterValue: filterValue, isCaseSensitive: isCaseSensitive)
             }
         }
 
@@ -940,6 +949,7 @@ final class EtcdPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         prefix: String,
         filterType: EtcdFilterType,
         filterValue: String,
+        isCaseSensitive: Bool = true,
         client: EtcdHttpClient
     ) async throws -> Int {
         let (b64Key, b64RangeEnd) = Self.allKeysRange(for: prefix)
@@ -960,7 +970,7 @@ final class EtcdPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         return kvs.filter { kv in
             let key = EtcdHttpClient.base64Decode(kv.key)
             let value = kv.value.map { EtcdHttpClient.base64Decode($0) }
-            return matchesFilter(key: key, value: value, filterType: filterType, filterValue: filterValue)
+            return matchesFilter(key: key, value: value, filterType: filterType, filterValue: filterValue, isCaseSensitive: isCaseSensitive)
         }.count
     }
 
@@ -1001,25 +1011,28 @@ final class EtcdPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         return key
     }
 
-    private func matchesFilter(key: String, value: String? = nil, filterType: EtcdFilterType, filterValue: String) -> Bool {
+    private func matchesFilter(
+        key: String,
+        value: String? = nil,
+        filterType: EtcdFilterType,
+        filterValue: String,
+        isCaseSensitive: Bool
+    ) -> Bool {
+        let fold = { (text: String) in isCaseSensitive ? text : text.lowercased() }
+        let needle = fold(filterValue)
+        let foldedKey = fold(key)
+        let foldedValue = value.map(fold)
         switch filterType {
         case .none:
             return true
         case .contains:
-            if key.localizedCaseInsensitiveContains(filterValue) {
-                return true
-            }
-            return value?.localizedCaseInsensitiveContains(filterValue) ?? false
+            return foldedKey.contains(needle) || (foldedValue?.contains(needle) ?? false)
         case .startsWith:
-            let lowerFilter = filterValue.lowercased()
-            if key.lowercased().hasPrefix(lowerFilter) {
-                return true
-            }
-            return value?.lowercased().hasPrefix(lowerFilter) ?? false
+            return foldedKey.hasPrefix(needle) || (foldedValue?.hasPrefix(needle) ?? false)
         case .endsWith:
-            return key.lowercased().hasSuffix(filterValue.lowercased())
+            return foldedKey.hasSuffix(needle)
         case .equals:
-            return key == filterValue
+            return foldedKey == needle
         }
     }
 

--- a/Plugins/EtcdDriverPlugin/EtcdQueryBuilder.swift
+++ b/Plugins/EtcdDriverPlugin/EtcdQueryBuilder.swift
@@ -23,12 +23,14 @@ struct EtcdParsedQuery {
     let sortAscending: Bool
     let filterType: EtcdFilterType
     let filterValue: String
+    var isCaseSensitive = false
 }
 
 struct EtcdParsedCountQuery {
     let prefix: String
     let filterType: EtcdFilterType
     let filterValue: String
+    var isCaseSensitive = false
 }
 
 struct EtcdQueryBuilder {
@@ -44,13 +46,13 @@ struct EtcdQueryBuilder {
         let sortAsc = sortColumns.first?.ascending ?? true
         return Self.encodeRangeQuery(
             prefix: prefix, limit: limit, offset: offset,
-            sortAscending: sortAsc, filterType: .none, filterValue: ""
+            sortAscending: sortAsc, filterType: .none, filterValue: "", isCaseSensitive: false
         )
     }
 
     func buildFilteredQuery(
         prefix: String,
-        filters: [(column: String, op: String, value: String)],
+        filters: [PluginQueryFilter],
         logicMode: String,
         sortColumns: [(columnIndex: Int, ascending: Bool)],
         limit: Int,
@@ -59,36 +61,47 @@ struct EtcdQueryBuilder {
         if hasUnsupportedFilters(filters) { return nil }
         let sortAsc = sortColumns.first?.ascending ?? true
         let (filterType, filterValue) = extractKeyFilter(from: filters)
+        let isCaseSensitive = filters.first { $0.column == "Key" }?.isCaseSensitive ?? true
         return Self.encodeRangeQuery(
             prefix: prefix, limit: limit, offset: offset,
-            sortAscending: sortAsc, filterType: filterType, filterValue: filterValue
+            sortAscending: sortAsc, filterType: filterType, filterValue: filterValue,
+            isCaseSensitive: isCaseSensitive
         )
     }
 
     func buildCountQuery(prefix: String) -> String {
-        Self.encodeCountQuery(prefix: prefix, filterType: .none, filterValue: "")
+        Self.encodeCountQuery(prefix: prefix, filterType: .none, filterValue: "", isCaseSensitive: false)
     }
 
     // MARK: - Encoding
 
     private static func encodeRangeQuery(
         prefix: String, limit: Int, offset: Int,
-        sortAscending: Bool, filterType: EtcdFilterType, filterValue: String
+        sortAscending: Bool, filterType: EtcdFilterType, filterValue: String,
+        isCaseSensitive: Bool
     ) -> String {
         let b64Prefix = Data(prefix.utf8).base64EncodedString()
         let b64Filter = Data(filterValue.utf8).base64EncodedString()
-        return "\(rangeTag)\(b64Prefix):\(limit):\(offset):\(sortAscending ? "1" : "0"):\(filterType.rawValue):\(b64Filter)"
+        return "\(rangeTag)\(b64Prefix):\(limit):\(offset):\(sortAscending ? "1" : "0")"
+            + ":\(filterType.rawValue):\(b64Filter):\(isCaseSensitive ? "1" : "0")"
     }
 
     private static func encodeCountQuery(
-        prefix: String, filterType: EtcdFilterType, filterValue: String
+        prefix: String, filterType: EtcdFilterType, filterValue: String,
+        isCaseSensitive: Bool
     ) -> String {
         let b64Prefix = Data(prefix.utf8).base64EncodedString()
         let b64Filter = Data(filterValue.utf8).base64EncodedString()
-        return "\(countTag)\(b64Prefix):\(filterType.rawValue):\(b64Filter)"
+        return "\(countTag)\(b64Prefix):\(filterType.rawValue):\(b64Filter):\(isCaseSensitive ? "1" : "0")"
     }
 
     // MARK: - Decoding
+
+    private static func decodeBase64Segment(_ segment: String) -> String {
+        guard let data = Data(base64Encoded: segment),
+              let decoded = String(data: data, encoding: .utf8) else { return "" }
+        return decoded
+    }
 
     static func parseRangeQuery(_ query: String) -> EtcdParsedQuery? {
         guard query.hasPrefix(rangeTag) else { return nil }
@@ -104,18 +117,12 @@ struct EtcdQueryBuilder {
         let sortAscending = parts[3] == "1"
         let filterType = EtcdFilterType(rawValue: parts[4]) ?? .none
 
-        let filterB64 = parts[5...].joined(separator: ":")
-        let filterValue: String
-        if let filterData = Data(base64Encoded: filterB64),
-           let decoded = String(data: filterData, encoding: .utf8) {
-            filterValue = decoded
-        } else {
-            filterValue = ""
-        }
+        let filterValue = decodeBase64Segment(parts[5])
 
         return EtcdParsedQuery(
             prefix: prefix, limit: limit, offset: offset,
-            sortAscending: sortAscending, filterType: filterType, filterValue: filterValue
+            sortAscending: sortAscending, filterType: filterType, filterValue: filterValue,
+            isCaseSensitive: parts.count > 6 && parts[6] == "1"
         )
     }
 
@@ -129,17 +136,11 @@ struct EtcdQueryBuilder {
               let prefix = String(data: prefixData, encoding: .utf8) else { return nil }
 
         let filterType = EtcdFilterType(rawValue: parts[1]) ?? .none
-        let filterB64 = parts[2...].joined(separator: ":")
-        let filterValue: String
-        if let filterData = Data(base64Encoded: filterB64),
-           let decoded = String(data: filterData, encoding: .utf8) {
-            filterValue = decoded
-        } else {
-            filterValue = ""
-        }
+        let filterValue = decodeBase64Segment(parts[2])
 
         return EtcdParsedCountQuery(
-            prefix: prefix, filterType: filterType, filterValue: filterValue
+            prefix: prefix, filterType: filterType, filterValue: filterValue,
+            isCaseSensitive: parts.count > 3 && parts[3] == "1"
         )
     }
 
@@ -151,15 +152,11 @@ struct EtcdQueryBuilder {
 
     /// Returns true if any filter targets a column other than "Key",
     /// which etcd cannot handle server-side (Value, Lease, Version, etc.).
-    private func hasUnsupportedFilters(
-        _ filters: [(column: String, op: String, value: String)]
-    ) -> Bool {
+    private func hasUnsupportedFilters(_ filters: [PluginQueryFilter]) -> Bool {
         filters.contains { $0.column != "Key" }
     }
 
-    private func extractKeyFilter(
-        from filters: [(column: String, op: String, value: String)]
-    ) -> (EtcdFilterType, String) {
+    private func extractKeyFilter(from filters: [PluginQueryFilter]) -> (EtcdFilterType, String) {
         let keyFilters = filters.filter { $0.column == "Key" }
         guard let filter = keyFilters.first else { return (.none, "") }
 

--- a/Plugins/LibSQLDriverPlugin/LibSQLPlugin.swift
+++ b/Plugins/LibSQLDriverPlugin/LibSQLPlugin.swift
@@ -92,7 +92,8 @@ final class LibSQLPlugin: NSObject, TableProPlugin, DriverPlugin {
         regexSyntax: .unsupported,
         booleanLiteralStyle: .numeric,
         likeEscapeStyle: .explicit,
-        paginationStyle: .limit
+        paginationStyle: .limit,
+        caseSensitivityStyle: .collationDefined
     )
 
     static let additionalConnectionFields: [ConnectionField] = [

--- a/Plugins/MSSQLDriverPlugin/MSSQLPlugin.swift
+++ b/Plugins/MSSQLDriverPlugin/MSSQLPlugin.swift
@@ -181,7 +181,8 @@ final class MSSQLPlugin: NSObject, TableProPlugin, DriverPlugin {
         booleanLiteralStyle: .numeric,
         likeEscapeStyle: .explicit,
         paginationStyle: .offsetFetch,
-        autoLimitStyle: .top
+        autoLimitStyle: .top,
+        caseSensitivityStyle: .collationDefined
     )
 
     static let supportsDropDatabase = true

--- a/Plugins/MongoDBDriverPlugin/MongoDBPlugin.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBPlugin.swift
@@ -105,6 +105,7 @@ final class MongoDBPlugin: NSObject, TableProPlugin, DriverPlugin {
     static let defaultPrimaryKeyColumn: String? = "_id"
 
     static let sqlDialect: SQLDialectDescriptor? = nil
+    static let caseSensitivityStyle: SQLDialectDescriptor.CaseSensitivityStyle = .driverManaged
 
     static var statementCompletions: [CompletionEntry] {
         [

--- a/Plugins/MongoDBDriverPlugin/MongoDBPluginDriver.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBPluginDriver.swift
@@ -354,24 +354,24 @@ final class MongoDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func fetchFilteredRowCount(
         table: String,
-        filters: [(column: String, op: String, value: String)],
+        queryFilters: [PluginQueryFilter],
         logicMode: String
     ) async throws -> Int? {
-        try await documentCount(table: table, filters: filters, logicMode: logicMode, background: true)
+        try await documentCount(table: table, filters: queryFilters, logicMode: logicMode, background: true)
     }
 
     func fetchExactRowCount(
         table: String,
         schema: String?,
-        filters: [(column: String, op: String, value: String)],
+        queryFilters: [PluginQueryFilter],
         logicMode: String
     ) async throws -> Int? {
-        try await documentCount(table: table, filters: filters, logicMode: logicMode, background: false)
+        try await documentCount(table: table, filters: queryFilters, logicMode: logicMode, background: false)
     }
 
     private func documentCount(
         table: String,
-        filters: [(column: String, op: String, value: String)],
+        filters: [PluginQueryFilter],
         logicMode: String,
         background: Bool
     ) async throws -> Int? {
@@ -669,16 +669,18 @@ final class MongoDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func buildFilteredQuery(
         table: String,
-        filters: [(column: String, op: String, value: String)],
+        schema: String?,
+        queryFilters: [PluginQueryFilter],
         logicMode: String,
         sortColumns: [(columnIndex: Int, ascending: Bool)],
         columns: [String],
         limit: Int,
-        offset: Int
+        offset: Int,
+        columnKinds: [String: PluginColumnKind]
     ) -> String? {
         let builder = MongoDBQueryBuilder()
         return builder.buildFilteredQuery(
-            collection: table, filters: filters, logicMode: logicMode,
+            collection: table, queryFilters: queryFilters, logicMode: logicMode,
             sortColumns: sortColumns, columns: columns, limit: limit, offset: offset
         )
     }

--- a/Plugins/MongoDBDriverPlugin/MongoDBQueryBuilder.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBQueryBuilder.swift
@@ -37,14 +37,14 @@ struct MongoDBQueryBuilder {
     /// Build: db.collection.find({filter}).sort({}).skip(offset).limit(limit)
     func buildFilteredQuery(
         collection: String,
-        filters: [(column: String, op: String, value: String)],
+        queryFilters: [PluginQueryFilter],
         logicMode: String = "and",
         sortColumns: [(columnIndex: Int, ascending: Bool)] = [],
         columns: [String] = [],
         limit: Int = 200,
         offset: Int = 0
     ) -> String {
-        let filterDoc = buildFilterDocument(from: filters, logicMode: logicMode)
+        let filterDoc = buildFilterDocument(from: queryFilters, logicMode: logicMode)
         var query = "\(Self.mongoCollectionAccessor(collection)).find(\(filterDoc))"
 
         if let sort = buildSortDocument(sortColumns: sortColumns, columns: columns) {
@@ -76,13 +76,16 @@ struct MongoDBQueryBuilder {
 
     /// Convert filter tuples to MongoDB filter document string
     func buildFilterDocument(
-        from filters: [(column: String, op: String, value: String)],
+        from filters: [PluginQueryFilter],
         logicMode: String = "and"
     ) -> String {
         guard !filters.isEmpty else { return "{}" }
 
         let conditions = filters.compactMap { filter -> String? in
-            buildCondition(column: filter.column, op: filter.op, value: filter.value)
+            buildCondition(
+                column: filter.column, op: filter.op, value: filter.value,
+                ignoresCase: !filter.isCaseSensitive
+            )
         }
 
         guard !conditions.isEmpty else { return "{}" }
@@ -107,7 +110,7 @@ struct MongoDBQueryBuilder {
         return "db.\(name)"
     }
 
-    private func buildCondition(column: String, op: String, value: String) -> String? {
+    private func buildCondition(column: String, op: String, value: String, ignoresCase: Bool) -> String? {
         let field = Self.escapeJsonString(column)
 
         switch op {
@@ -115,12 +118,14 @@ struct MongoDBQueryBuilder {
             if let oid = objectIdJson(value) {
                 return "\"$or\": [{\"\(field)\": \(oid)}, {\"\(field)\": \(jsonValue(value))}]"
             }
-            return "\"\(field)\": \(jsonValue(value))"
+            guard ignoresCase else { return "\"\(field)\": \(jsonValue(value))" }
+            return "\"\(field)\": \(Self.regexBody(pattern: anchoredPattern(value), ignoresCase: true))"
         case "!=":
             if let oid = objectIdJson(value) {
                 return "\"\(field)\": {\"$nin\": [\(oid), \(jsonValue(value))]}"
             }
-            return "\"\(field)\": {\"$ne\": \(jsonValue(value))}"
+            guard ignoresCase else { return "\"\(field)\": {\"$ne\": \(jsonValue(value))}" }
+            return "\"\(field)\": {\"$not\": \(Self.regexBody(pattern: anchoredPattern(value), ignoresCase: true))}"
         case ">":
             return "\"\(field)\": {\"$gt\": \(jsonValue(value))}"
         case ">=":
@@ -130,13 +135,16 @@ struct MongoDBQueryBuilder {
         case "<=":
             return "\"\(field)\": {\"$lte\": \(jsonValue(value))}"
         case "CONTAINS":
-            return "\"\(field)\": \(Self.regexBody(pattern: escapeRegexChars(value)))"
+            return "\"\(field)\": \(Self.regexBody(pattern: escapeRegexChars(value), ignoresCase: ignoresCase))"
         case "NOT CONTAINS":
-            return "\"\(field)\": {\"$not\": \(Self.regexBody(pattern: escapeRegexChars(value)))}"
+            let body = Self.regexBody(pattern: escapeRegexChars(value), ignoresCase: ignoresCase)
+            return "\"\(field)\": {\"$not\": \(body)}"
         case "STARTS WITH":
-            return "\"\(field)\": \(Self.regexBody(pattern: "^\(escapeRegexChars(value))"))"
+            let pattern = "^\(escapeRegexChars(value))"
+            return "\"\(field)\": \(Self.regexBody(pattern: pattern, ignoresCase: ignoresCase))"
         case "ENDS WITH":
-            return "\"\(field)\": \(Self.regexBody(pattern: "\(escapeRegexChars(value))$"))"
+            let pattern = "\(escapeRegexChars(value))$"
+            return "\"\(field)\": \(Self.regexBody(pattern: pattern, ignoresCase: ignoresCase))"
         case "IS NULL":
             return "\"\(field)\": null"
         case "IS NOT NULL":
@@ -146,12 +154,16 @@ struct MongoDBQueryBuilder {
         case "IS NOT EMPTY":
             return "\"\(field)\": {\"$ne\": \"\"}"
         case "REGEX":
-            return "\"\(field)\": \(Self.regexBody(pattern: value))"
+            return "\"\(field)\": \(Self.regexBody(pattern: value, ignoresCase: ignoresCase))"
         case "IN":
+            guard !ignoresCase else { return caseInsensitiveListCondition(field: field, value: value) }
             let items = value.split(separator: ",")
                 .flatMap { inValues(String($0).trimmingCharacters(in: .whitespaces)) }
             return "\"\(field)\": {\"$in\": [\(items.joined(separator: ", "))]}"
         case "NOT IN":
+            guard !ignoresCase else {
+                return caseInsensitiveListCondition(field: field, value: value, negated: true)
+            }
             let items = value.split(separator: ",")
                 .flatMap { inValues(String($0).trimmingCharacters(in: .whitespaces)) }
             return "\"\(field)\": {\"$nin\": [\(items.joined(separator: ", "))]}"
@@ -203,8 +215,25 @@ struct MongoDBQueryBuilder {
         return "{\"$oid\": \"\(value)\"}"
     }
 
-    private static func regexBody(pattern: String) -> String {
-        "{\"$regex\": \"\(escapeJsonString(pattern))\", \"$options\": \"i\"}"
+    private static func regexBody(pattern: String, ignoresCase: Bool) -> String {
+        guard ignoresCase else { return "{\"$regex\": \"\(escapeJsonString(pattern))\"}" }
+        return "{\"$regex\": \"\(escapeJsonString(pattern))\", \"$options\": \"i\"}"
+    }
+
+    private func anchoredPattern(_ value: String) -> String {
+        "^\(escapeRegexChars(value))$"
+    }
+
+    /// `$in` cannot carry regex options, so an ignore-case list becomes a set of anchored matches.
+    private func caseInsensitiveListCondition(field: String, value: String, negated: Bool = false) -> String {
+        let clauses = value.split(separator: ",")
+            .map { String($0).trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .map { item in
+                "{\"\(field)\": \(Self.regexBody(pattern: anchoredPattern(item), ignoresCase: true))}"
+            }
+        let logicOp = negated ? "$nor" : "$or"
+        return "\"\(logicOp)\": [\(clauses.joined(separator: ", "))]"
     }
 
     static func escapeJsonString(_ value: String) -> String {

--- a/Plugins/MySQLDriverPlugin/MySQLPlugin.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPlugin.swift
@@ -92,7 +92,8 @@ final class MySQLPlugin: NSObject, TableProPlugin, DriverPlugin {
         booleanLiteralStyle: .numeric,
         likeEscapeStyle: .implicit,
         paginationStyle: .limit,
-        requiresBackslashEscaping: true
+        requiresBackslashEscaping: true,
+        caseSensitivityStyle: .collationDefined
     )
 
     static let supportsDropDatabase = true

--- a/Plugins/OracleDriverPlugin/OraclePlugin.swift
+++ b/Plugins/OracleDriverPlugin/OraclePlugin.swift
@@ -150,7 +150,8 @@ final class OraclePlugin: NSObject, TableProPlugin, DriverPlugin, PluginDiagnost
         likeEscapeStyle: .explicit,
         paginationStyle: .offsetFetch,
         offsetFetchOrderBy: "ORDER BY 1",
-        autoLimitStyle: .fetchFirst
+        autoLimitStyle: .fetchFirst,
+        caseSensitivityStyle: .caseFoldFunction
     )
 
     func createDriver(config: DriverConnectionConfig) -> any PluginDatabaseDriver {
@@ -1217,15 +1218,37 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         offset: Int,
         columnKinds: [String: PluginColumnKind]
     ) -> String? {
+        buildFilteredQuery(
+            table: table, schema: schema,
+            queryFilters: filters.map { PluginQueryFilter(column: $0.column, op: $0.op, value: $0.value) },
+            logicMode: logicMode, sortColumns: sortColumns, columns: columns,
+            limit: limit, offset: offset, columnKinds: columnKinds
+        )
+    }
+
+    func buildFilteredQuery(
+        table: String,
+        schema: String?,
+        queryFilters: [PluginQueryFilter],
+        logicMode: String,
+        sortColumns: [(columnIndex: Int, ascending: Bool)],
+        columns: [String],
+        limit: Int,
+        offset: Int,
+        columnKinds: [String: PluginColumnKind]
+    ) -> String? {
         var query = "SELECT * FROM \(oracleQualifiedName(schema: schema, table: table))"
         let whereClause = PluginSQLFilter.buildWhereClause(
-            filters: filters,
+            filters: queryFilters,
             logicMode: logicMode,
             columnKinds: columnKinds,
+            caseSensitivityStyle: .caseFoldFunction,
             quoteIdentifier: oracleQuoteIdentifier,
             escapeTypedValue: oracleEscapeValue,
-            regexCondition: { quoted, value in
-                "REGEXP_LIKE(\(quoted), '\(value.replacingOccurrences(of: "'", with: "''"))')"
+            regexCondition: { quoted, value, ignoresCase in
+                let pattern = value.replacingOccurrences(of: "'", with: "''")
+                guard ignoresCase else { return "REGEXP_LIKE(\(quoted), '\(pattern)')" }
+                return "REGEXP_LIKE(\(quoted), '\(pattern)', 'i')"
             }
         )
         if !whereClause.isEmpty {

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPlugin.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPlugin.swift
@@ -120,7 +120,8 @@ final class PostgreSQLPlugin: NSObject, TableProPlugin, DriverPlugin {
         regexSyntax: .tilde,
         booleanLiteralStyle: .truefalse,
         likeEscapeStyle: .explicit,
-        paginationStyle: .limit
+        paginationStyle: .limit,
+        caseSensitivityStyle: .ilikeOperator
     )
 
     static func driverVariant(for databaseTypeId: String) -> String? {

--- a/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
+++ b/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
@@ -88,7 +88,8 @@ final class SQLitePlugin: NSObject, TableProPlugin, DriverPlugin {
         regexSyntax: .unsupported,
         booleanLiteralStyle: .numeric,
         likeEscapeStyle: .explicit,
-        paginationStyle: .limit
+        paginationStyle: .limit,
+        caseSensitivityStyle: .collationDefined
     )
 
     func createDriver(config: DriverConnectionConfig) -> any PluginDatabaseDriver {

--- a/Plugins/SnowflakeDriverPlugin/SnowflakePlugin.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakePlugin.swift
@@ -254,7 +254,8 @@ final class SnowflakePlugin: NSObject, TableProPlugin, DriverPlugin {
         regexSyntax: .regexpLike,
         booleanLiteralStyle: .truefalse,
         likeEscapeStyle: .explicit,
-        paginationStyle: .limit
+        paginationStyle: .limit,
+        caseSensitivityStyle: .ilikeOperator
     )
 
     static let explainVariants: [ExplainVariant] = [

--- a/Plugins/SurrealDBDriverPlugin/SurrealDBPlugin.swift
+++ b/Plugins/SurrealDBDriverPlugin/SurrealDBPlugin.swift
@@ -96,7 +96,8 @@ final class SurrealDBPlugin: NSObject, TableProPlugin, DriverPlugin {
         booleanLiteralStyle: .truefalse,
         likeEscapeStyle: .explicit,
         paginationStyle: .limit,
-        autoLimitStyle: .limit
+        autoLimitStyle: .limit,
+        caseSensitivityStyle: .unsupported
     )
 
     static let additionalConnectionFields: [ConnectionField] = surrealDBPluginConnectionFields()

--- a/Plugins/TableProPluginKit/DriverPlugin.swift
+++ b/Plugins/TableProPluginKit/DriverPlugin.swift
@@ -37,6 +37,7 @@ public protocol DriverPlugin: TableProPlugin {
     static var defaultGroupName: String { get }
     static var columnTypesByCategory: [String: [String]] { get }
     static var sqlDialect: SQLDialectDescriptor? { get }
+    static var caseSensitivityStyle: SQLDialectDescriptor.CaseSensitivityStyle { get }
     static var statementCompletions: [CompletionEntry] { get }
     static var tableEntityName: String { get }
     static var containerEntityName: String { get }
@@ -108,6 +109,9 @@ public extension DriverPlugin {
         ]
     }
     static var sqlDialect: SQLDialectDescriptor? { nil }
+    static var caseSensitivityStyle: SQLDialectDescriptor.CaseSensitivityStyle {
+        sqlDialect?.caseSensitivityStyle ?? .unsupported
+    }
     static var statementCompletions: [CompletionEntry] { [] }
     static var tableEntityName: String { "Tables" }
     static var containerEntityName: String { "Database" }

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -133,10 +133,13 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
     func buildBrowseQuery(table: String, schema: String?, sortColumns: [(columnIndex: Int, ascending: Bool)], columns: [String], limit: Int, offset: Int) -> String?
     func buildFilteredQuery(table: String, schema: String?, filters: [(column: String, op: String, value: String)], logicMode: String, sortColumns: [(columnIndex: Int, ascending: Bool)], columns: [String], limit: Int, offset: Int) -> String?
     func buildFilteredQuery(table: String, schema: String?, filters: [(column: String, op: String, value: String)], logicMode: String, sortColumns: [(columnIndex: Int, ascending: Bool)], columns: [String], limit: Int, offset: Int, columnKinds: [String: PluginColumnKind]) -> String?
+    func buildFilteredQuery(table: String, schema: String?, queryFilters: [PluginQueryFilter], logicMode: String, sortColumns: [(columnIndex: Int, ascending: Bool)], columns: [String], limit: Int, offset: Int, columnKinds: [String: PluginColumnKind]) -> String?
     // Filtered row count (optional, for NoSQL plugins; SQL plugins use COUNT(*) WHERE)
     func fetchFilteredRowCount(table: String, filters: [(column: String, op: String, value: String)], logicMode: String) async throws -> Int?
+    func fetchFilteredRowCount(table: String, queryFilters: [PluginQueryFilter], logicMode: String) async throws -> Int?
     // User-initiated exact row count (allowed to be slow; background count caps must not apply)
     func fetchExactRowCount(table: String, schema: String?, filters: [(column: String, op: String, value: String)], logicMode: String) async throws -> Int?
+    func fetchExactRowCount(table: String, schema: String?, queryFilters: [PluginQueryFilter], logicMode: String) async throws -> Int?
     // Statement generation (optional, for NoSQL plugins)
     func generateStatements(table: String, columns: [String], primaryKeyColumns: [String], changes: [PluginRowChange], insertedRowData: [Int: [PluginCellValue]], deletedRowIndices: Set<Int>, insertedRowIndices: Set<Int>) -> [(statement: String, parameters: [PluginCellValue])]?
     func generateStatements(table: String, schema: String?, columns: [String], primaryKeyColumns: [String], changes: [PluginRowChange], insertedRowData: [Int: [PluginCellValue]], deletedRowIndices: Set<Int>, insertedRowIndices: Set<Int>) -> [(statement: String, parameters: [PluginCellValue])]?
@@ -337,9 +340,18 @@ public extension PluginDatabaseDriver {
     func buildFilteredQuery(table: String, schema: String?, filters: [(column: String, op: String, value: String)], logicMode: String, sortColumns: [(columnIndex: Int, ascending: Bool)], columns: [String], limit: Int, offset: Int, columnKinds: [String: PluginColumnKind]) -> String? {
         buildFilteredQuery(table: table, schema: schema, filters: filters, logicMode: logicMode, sortColumns: sortColumns, columns: columns, limit: limit, offset: offset)
     }
+    func buildFilteredQuery(table: String, schema: String?, queryFilters: [PluginQueryFilter], logicMode: String, sortColumns: [(columnIndex: Int, ascending: Bool)], columns: [String], limit: Int, offset: Int, columnKinds: [String: PluginColumnKind]) -> String? {
+        buildFilteredQuery(table: table, schema: schema, filters: queryFilters.asTuples, logicMode: logicMode, sortColumns: sortColumns, columns: columns, limit: limit, offset: offset, columnKinds: columnKinds)
+    }
     func fetchFilteredRowCount(table: String, filters: [(column: String, op: String, value: String)], logicMode: String) async throws -> Int? { nil }
+    func fetchFilteredRowCount(table: String, queryFilters: [PluginQueryFilter], logicMode: String) async throws -> Int? {
+        try await fetchFilteredRowCount(table: table, filters: queryFilters.asTuples, logicMode: logicMode)
+    }
     func fetchExactRowCount(table: String, schema: String?, filters: [(column: String, op: String, value: String)], logicMode: String) async throws -> Int? {
         try await fetchFilteredRowCount(table: table, filters: filters, logicMode: logicMode)
+    }
+    func fetchExactRowCount(table: String, schema: String?, queryFilters: [PluginQueryFilter], logicMode: String) async throws -> Int? {
+        try await fetchExactRowCount(table: table, schema: schema, filters: queryFilters.asTuples, logicMode: logicMode)
     }
     func generateStatements(table: String, columns: [String], primaryKeyColumns: [String], changes: [PluginRowChange], insertedRowData: [Int: [PluginCellValue]], deletedRowIndices: Set<Int>, insertedRowIndices: Set<Int>) -> [(statement: String, parameters: [PluginCellValue])]? { nil }
     func generateStatements(table: String, schema: String?, columns: [String], primaryKeyColumns: [String], changes: [PluginRowChange], insertedRowData: [Int: [PluginCellValue]], deletedRowIndices: Set<Int>, insertedRowIndices: Set<Int>) -> [(statement: String, parameters: [PluginCellValue])]? {

--- a/Plugins/TableProPluginKit/PluginQueryFilter.swift
+++ b/Plugins/TableProPluginKit/PluginQueryFilter.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct PluginQueryFilter: Sendable {
+    public let column: String
+    public let op: String
+    public let value: String
+    public let isCaseSensitive: Bool
+
+    public init(column: String, op: String, value: String, isCaseSensitive: Bool = true) {
+        self.column = column
+        self.op = op
+        self.value = value
+        self.isCaseSensitive = isCaseSensitive
+    }
+
+    public var asTuple: (column: String, op: String, value: String) {
+        (column, op, value)
+    }
+}
+
+public extension [PluginQueryFilter] {
+    var asTuples: [(column: String, op: String, value: String)] {
+        map(\.asTuple)
+    }
+}

--- a/Plugins/TableProPluginKit/PluginSQLCaseFolding.swift
+++ b/Plugins/TableProPluginKit/PluginSQLCaseFolding.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+public struct PluginSQLCaseFolding: Sendable {
+    public let likeKeyword: String
+    public let notLikeKeyword: String
+    public let foldsLikeOperands: Bool
+    public let foldsComparisonOperands: Bool
+    public let usesRegexForLike: Bool
+    public let foldFunction: String
+
+    public static func resolve(
+        style: SQLDialectDescriptor.CaseSensitivityStyle,
+        foldFunction: String = SQLDialectDescriptor.defaultCaseFoldFunction,
+        isCaseSensitive: Bool
+    ) -> PluginSQLCaseFolding {
+        guard !isCaseSensitive else { return caseSensitive(foldFunction: foldFunction) }
+        switch style {
+        case .ilikeOperator:
+            return PluginSQLCaseFolding(
+                likeKeyword: "ILIKE",
+                notLikeKeyword: "NOT ILIKE",
+                foldsLikeOperands: false,
+                foldsComparisonOperands: true,
+                usesRegexForLike: false,
+                foldFunction: foldFunction
+            )
+        case .caseFoldFunction:
+            return PluginSQLCaseFolding(
+                likeKeyword: "LIKE",
+                notLikeKeyword: "NOT LIKE",
+                foldsLikeOperands: true,
+                foldsComparisonOperands: true,
+                usesRegexForLike: false,
+                foldFunction: foldFunction
+            )
+        case .regexFlag:
+            return PluginSQLCaseFolding(
+                likeKeyword: "LIKE",
+                notLikeKeyword: "NOT LIKE",
+                foldsLikeOperands: false,
+                foldsComparisonOperands: false,
+                usesRegexForLike: true,
+                foldFunction: foldFunction
+            )
+        case .driverManaged, .collationDefined, .unsupported:
+            return caseSensitive(foldFunction: foldFunction)
+        }
+    }
+
+    public static func isAdjustable(style: SQLDialectDescriptor.CaseSensitivityStyle) -> Bool {
+        switch style {
+        case .ilikeOperator, .caseFoldFunction, .regexFlag, .driverManaged:
+            return true
+        case .collationDefined, .unsupported:
+            return false
+        }
+    }
+
+    public func fold(_ expression: String) -> String {
+        "\(foldFunction)(\(expression))"
+    }
+
+    public func foldingComparison(_ expression: String) -> String {
+        foldsComparisonOperands ? fold(expression) : expression
+    }
+
+    public func foldingLikeOperand(_ expression: String) -> String {
+        foldsLikeOperands ? fold(expression) : expression
+    }
+
+    private static func caseSensitive(foldFunction: String) -> PluginSQLCaseFolding {
+        PluginSQLCaseFolding(
+            likeKeyword: "LIKE",
+            notLikeKeyword: "NOT LIKE",
+            foldsLikeOperands: false,
+            foldsComparisonOperands: false,
+            usesRegexForLike: false,
+            foldFunction: foldFunction
+        )
+    }
+}

--- a/Plugins/TableProPluginKit/PluginSQLFilter+CaseSensitivity.swift
+++ b/Plugins/TableProPluginKit/PluginSQLFilter+CaseSensitivity.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+public extension PluginSQLFilter {
+    static func buildWhereClause(
+        filters: [PluginQueryFilter],
+        logicMode: String,
+        columnKinds: [String: PluginColumnKind],
+        caseSensitivityStyle: SQLDialectDescriptor.CaseSensitivityStyle,
+        caseFoldFunction: String = SQLDialectDescriptor.defaultCaseFoldFunction,
+        quoteIdentifier: (String) -> String,
+        escapeTypedValue: (_ value: String, _ kind: PluginColumnKind?) -> String,
+        regexCondition: (_ quotedColumn: String, _ pattern: String, _ ignoresCase: Bool) -> String?
+    ) -> String {
+        let conditions = filters.compactMap { filter in
+            buildFilterCondition(
+                filter: filter,
+                kind: columnKinds[filter.column],
+                caseSensitivityStyle: caseSensitivityStyle,
+                caseFoldFunction: caseFoldFunction,
+                quoteIdentifier: quoteIdentifier,
+                escapeTypedValue: escapeTypedValue,
+                regexCondition: regexCondition
+            )
+        }
+        guard !conditions.isEmpty else { return "" }
+        let separator = logicMode == "and" ? " AND " : " OR "
+        return conditions.joined(separator: separator)
+    }
+
+    static func buildFilterCondition(
+        filter: PluginQueryFilter,
+        kind: PluginColumnKind?,
+        caseSensitivityStyle: SQLDialectDescriptor.CaseSensitivityStyle,
+        caseFoldFunction: String = SQLDialectDescriptor.defaultCaseFoldFunction,
+        quoteIdentifier: (String) -> String,
+        escapeTypedValue: (_ value: String, _ kind: PluginColumnKind?) -> String,
+        regexCondition: (_ quotedColumn: String, _ pattern: String, _ ignoresCase: Bool) -> String?
+    ) -> String? {
+        let folding = PluginSQLCaseFolding.resolve(
+            style: caseSensitivityStyle,
+            foldFunction: caseFoldFunction,
+            isCaseSensitive: filter.isCaseSensitive
+        )
+        let quoted = quoteIdentifier(filter.column)
+        let escape = { (value: String) in escapeTypedValue(value, kind) }
+
+        switch filter.op {
+        case "=", "!=":
+            let negated = filter.op == "!="
+            return comparisonCondition(
+                quoted: quoted, value: filter.value, negated: negated, folding: folding,
+                escapeValue: escape, regexCondition: regexCondition
+            )
+        case "CONTAINS", "NOT CONTAINS", "STARTS WITH", "ENDS WITH":
+            return likeFamilyCondition(
+                quoted: quoted, op: filter.op, value: filter.value, folding: folding,
+                regexCondition: regexCondition
+            )
+        case "IN", "NOT IN":
+            return listCondition(
+                quoted: quoted, op: filter.op, value: filter.value, folding: folding, escapeValue: escape
+            )
+        case "REGEX":
+            return regexCondition(quoted, filter.value, !filter.isCaseSensitive)
+        default:
+            return buildFilterCondition(
+                column: filter.column,
+                op: filter.op,
+                value: filter.value,
+                kind: kind,
+                quoteIdentifier: quoteIdentifier,
+                escapeTypedValue: escapeTypedValue,
+                regexCondition: { column, value in regexCondition(column, value, false) }
+            )
+        }
+    }
+
+    private static func comparisonCondition(
+        quoted: String,
+        value: String,
+        negated: Bool,
+        folding: PluginSQLCaseFolding,
+        escapeValue: (String) -> String,
+        regexCondition: (String, String, Bool) -> String?
+    ) -> String? {
+        if folding.usesRegexForLike {
+            let pattern = PluginSQLRegexPattern.pattern(
+                matchingLiteral: value, anchoring: .exact, ignoresCase: false
+            )
+            guard let condition = regexCondition(quoted, pattern, true) else { return nil }
+            return negated ? "NOT (\(condition))" : condition
+        }
+        let operatorText = negated ? "!=" : "="
+        return "\(folding.foldingComparison(quoted)) \(operatorText) \(folding.foldingComparison(escapeValue(value)))"
+    }
+
+    private static func likeFamilyCondition(
+        quoted: String,
+        op: String,
+        value: String,
+        folding: PluginSQLCaseFolding,
+        regexCondition: (String, String, Bool) -> String?
+    ) -> String? {
+        if folding.usesRegexForLike {
+            guard let condition = regexCondition(quoted, regexPattern(op: op, value: value), true) else { return nil }
+            return op == "NOT CONTAINS" ? "NOT (\(condition))" : condition
+        }
+        let keyword = op == "NOT CONTAINS" ? folding.notLikeKeyword : folding.likeKeyword
+        let pattern = "'\(likePattern(op: op, value: value))'"
+        let column = folding.foldingLikeOperand(quoted)
+        return "\(column) \(keyword) \(folding.foldingLikeOperand(pattern)) ESCAPE '\\'"
+    }
+
+    private static func listCondition(
+        quoted: String,
+        op: String,
+        value: String,
+        folding: PluginSQLCaseFolding,
+        escapeValue: (String) -> String
+    ) -> String? {
+        let values = value.split(separator: ",")
+            .map { folding.foldingComparison(escapeValue($0.trimmingCharacters(in: .whitespaces))) }
+            .joined(separator: ", ")
+        guard !values.isEmpty else { return nil }
+        let keyword = op == "NOT IN" ? "NOT IN" : "IN"
+        return "\(folding.foldingComparison(quoted)) \(keyword) (\(values))"
+    }
+
+    private static func likePattern(op: String, value: String) -> String {
+        let escaped = escapeForLike(value)
+        switch op {
+        case "STARTS WITH": return "\(escaped)%"
+        case "ENDS WITH": return "%\(escaped)"
+        default: return "%\(escaped)%"
+        }
+    }
+
+    private static func regexPattern(op: String, value: String) -> String {
+        let anchoring: PluginSQLRegexPattern.Anchoring
+        switch op {
+        case "STARTS WITH": anchoring = .prefix
+        case "ENDS WITH": anchoring = .suffix
+        default: anchoring = .unanchored
+        }
+        return PluginSQLRegexPattern.pattern(matchingLiteral: value, anchoring: anchoring, ignoresCase: false)
+    }
+}

--- a/Plugins/TableProPluginKit/PluginSQLRegexPattern.swift
+++ b/Plugins/TableProPluginKit/PluginSQLRegexPattern.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+public enum PluginSQLRegexPattern {
+    public enum Anchoring: String, Sendable {
+        case unanchored
+        case prefix
+        case suffix
+        case exact
+    }
+
+    public static func escapedLiteral(_ value: String) -> String {
+        var escaped = ""
+        escaped.reserveCapacity(value.utf8.count * 2)
+        for character in value {
+            if metacharacters.contains(character) { escaped.append("\\") }
+            escaped.append(character)
+        }
+        return escaped
+    }
+
+    public static func pattern(
+        matchingLiteral value: String,
+        anchoring: Anchoring,
+        ignoresCase: Bool
+    ) -> String {
+        let literal = escapedLiteral(value)
+        let body: String
+        switch anchoring {
+        case .unanchored:
+            body = literal
+        case .prefix:
+            body = "^\(literal)"
+        case .suffix:
+            body = "\(literal)$"
+        case .exact:
+            body = "^\(literal)$"
+        }
+        return ignoresCase ? "(?i)\(body)" : body
+    }
+
+    private static let metacharacters: Set<Character> = [
+        "\\", ".", "*", "+", "?", "(", ")", "[", "]", "{", "}", "|", "^", "$"
+    ]
+}

--- a/Plugins/TableProPluginKit/SQLDialectDescriptor.swift
+++ b/Plugins/TableProPluginKit/SQLDialectDescriptor.swift
@@ -34,6 +34,19 @@ public struct SQLDialectDescriptor: Sendable {
     // Query limit style
     public let autoLimitStyle: AutoLimitStyle
 
+    // Case-insensitive matching
+    public let caseSensitivityStyle: CaseSensitivityStyle
+    public let caseFoldFunction: String
+
+    public enum CaseSensitivityStyle: String, Sendable {
+        case ilikeOperator    // PostgreSQL, CockroachDB, PGlite, DuckDB, Snowflake
+        case caseFoldFunction // Oracle, BigQuery, ClickHouse, Redshift
+        case regexFlag        // Trino
+        case driverManaged    // MongoDB, Elasticsearch, DynamoDB, etcd
+        case collationDefined // MySQL, MSSQL, SQLite and their compatible engines
+        case unsupported      // Cassandra, Redis, and any plugin built before this field
+    }
+
     @frozen
     public enum RegexSyntax: String, Sendable {
         case regexp        // MySQL: column REGEXP 'pattern'
@@ -60,6 +73,7 @@ public struct SQLDialectDescriptor: Sendable {
         case offsetFetch // Oracle, MSSQL: OFFSET n ROWS FETCH NEXT m ROWS ONLY
     }
 
+    @_disfavoredOverload
     public init(
         identifierQuote: String,
         keywords: Set<String>,
@@ -74,6 +88,40 @@ public struct SQLDialectDescriptor: Sendable {
         requiresBackslashEscaping: Bool = false,
         autoLimitStyle: AutoLimitStyle = .limit
     ) {
+        self.init(
+            identifierQuote: identifierQuote,
+            keywords: keywords,
+            functions: functions,
+            dataTypes: dataTypes,
+            tableOptions: tableOptions,
+            regexSyntax: regexSyntax,
+            booleanLiteralStyle: booleanLiteralStyle,
+            likeEscapeStyle: likeEscapeStyle,
+            paginationStyle: paginationStyle,
+            offsetFetchOrderBy: offsetFetchOrderBy,
+            requiresBackslashEscaping: requiresBackslashEscaping,
+            autoLimitStyle: autoLimitStyle,
+            caseSensitivityStyle: .unsupported,
+            caseFoldFunction: Self.defaultCaseFoldFunction
+        )
+    }
+
+    public init(
+        identifierQuote: String,
+        keywords: Set<String>,
+        functions: Set<String>,
+        dataTypes: Set<String>,
+        tableOptions: [String] = [],
+        regexSyntax: RegexSyntax = .unsupported,
+        booleanLiteralStyle: BooleanLiteralStyle = .numeric,
+        likeEscapeStyle: LikeEscapeStyle = .explicit,
+        paginationStyle: PaginationStyle = .limit,
+        offsetFetchOrderBy: String = "ORDER BY (SELECT NULL)",
+        requiresBackslashEscaping: Bool = false,
+        autoLimitStyle: AutoLimitStyle = .limit,
+        caseSensitivityStyle: CaseSensitivityStyle = .unsupported,
+        caseFoldFunction: String = SQLDialectDescriptor.defaultCaseFoldFunction
+    ) {
         self.identifierQuote = identifierQuote
         self.keywords = keywords
         self.functions = functions
@@ -86,5 +134,31 @@ public struct SQLDialectDescriptor: Sendable {
         self.offsetFetchOrderBy = offsetFetchOrderBy
         self.requiresBackslashEscaping = requiresBackslashEscaping
         self.autoLimitStyle = autoLimitStyle
+        self.caseSensitivityStyle = caseSensitivityStyle
+        self.caseFoldFunction = caseFoldFunction
+    }
+
+    public static let defaultCaseFoldFunction = "LOWER"
+
+    public func withCaseSensitivityStyle(
+        _ style: CaseSensitivityStyle,
+        caseFoldFunction: String = SQLDialectDescriptor.defaultCaseFoldFunction
+    ) -> SQLDialectDescriptor {
+        SQLDialectDescriptor(
+            identifierQuote: identifierQuote,
+            keywords: keywords,
+            functions: functions,
+            dataTypes: dataTypes,
+            tableOptions: tableOptions,
+            regexSyntax: regexSyntax,
+            booleanLiteralStyle: booleanLiteralStyle,
+            likeEscapeStyle: likeEscapeStyle,
+            paginationStyle: paginationStyle,
+            offsetFetchOrderBy: offsetFetchOrderBy,
+            requiresBackslashEscaping: requiresBackslashEscaping,
+            autoLimitStyle: autoLimitStyle,
+            caseSensitivityStyle: style,
+            caseFoldFunction: caseFoldFunction
+        )
     }
 }

--- a/Plugins/TeradataDriverPlugin/TeradataPlugin.swift
+++ b/Plugins/TeradataDriverPlugin/TeradataPlugin.swift
@@ -99,7 +99,8 @@ final class TeradataPlugin: NSObject, TableProPlugin, DriverPlugin {
             "DATE", "TIME", "TIMESTAMP", "INTERVAL", "PERIOD",
             "JSON", "XML", "ST_GEOMETRY",
         ],
-        autoLimitStyle: .top
+        autoLimitStyle: .top,
+        caseSensitivityStyle: .unsupported
     )
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "TeradataPlugin")

--- a/Plugins/TrinoDriverPlugin/TrinoPlugin.swift
+++ b/Plugins/TrinoDriverPlugin/TrinoPlugin.swift
@@ -134,7 +134,8 @@ final class TrinoPlugin: NSObject, TableProPlugin, DriverPlugin {
         booleanLiteralStyle: .truefalse,
         likeEscapeStyle: .explicit,
         paginationStyle: .offsetFetch,
-        offsetFetchOrderBy: ""
+        offsetFetchOrderBy: "",
+        caseSensitivityStyle: .regexFlag
     )
 
     static let explainVariants: [ExplainVariant] = [

--- a/TablePro/Core/Database/FilterSQLGenerator.swift
+++ b/TablePro/Core/Database/FilterSQLGenerator.swift
@@ -66,6 +66,7 @@ struct FilterSQLGenerator {
 
         let quotedColumn = quoteIdentifierFn(filter.columnName)
         let columnType = columnTypesByName[filter.columnName]
+        let folding = caseFolding(for: filter, columnType: columnType)
 
         switch filter.filterOperator {
         case .equal:
@@ -73,7 +74,10 @@ struct FilterSQLGenerator {
             case .null:
                 return "\(quotedColumn) IS NULL"
             case .value(let literal):
-                return "\(quotedColumn) = \(literal)"
+                return generateComparisonCondition(
+                    column: quotedColumn, literal: literal, rawValue: filter.value,
+                    negated: false, folding: folding
+                )
             }
 
         case .notEqual:
@@ -81,20 +85,16 @@ struct FilterSQLGenerator {
             case .null:
                 return "\(quotedColumn) IS NOT NULL"
             case .value(let literal):
-                return "\(quotedColumn) != \(literal)"
+                return generateComparisonCondition(
+                    column: quotedColumn, literal: literal, rawValue: filter.value,
+                    negated: true, folding: folding
+                )
             }
 
-        case .contains:
-            return generateLikeCondition(column: quotedColumn, pattern: "%\(escapeLikeWildcards(filter.value))%")
-
-        case .notContains:
-            return generateNotLikeCondition(column: quotedColumn, pattern: "%\(escapeLikeWildcards(filter.value))%")
-
-        case .startsWith:
-            return generateLikeCondition(column: quotedColumn, pattern: "\(escapeLikeWildcards(filter.value))%")
-
-        case .endsWith:
-            return generateLikeCondition(column: quotedColumn, pattern: "%\(escapeLikeWildcards(filter.value))")
+        case .contains, .notContains, .startsWith, .endsWith:
+            return generateLikeFamilyCondition(
+                column: quotedColumn, filter: filter, folding: folding
+            )
 
         case .greaterThan:
             return "\(quotedColumn) > \(renderLiteral(filter.value, columnType: columnType).sqlText)"
@@ -128,12 +128,14 @@ struct FilterSQLGenerator {
 
         case .inList:
             return generateInCondition(
-                column: quotedColumn, values: filter.value, columnType: columnType, negated: false
+                column: quotedColumn, values: filter.value, columnType: columnType,
+                negated: false, folding: folding
             )
 
         case .notInList:
             return generateInCondition(
-                column: quotedColumn, values: filter.value, columnType: columnType, negated: true
+                column: quotedColumn, values: filter.value, columnType: columnType,
+                negated: true, folding: folding
             )
 
         case .between:
@@ -143,17 +145,40 @@ struct FilterSQLGenerator {
             return "\(quotedColumn) BETWEEN \(lower) AND \(upper)"
 
         case .regex:
-            let syntax = dialect.regexSyntax
-            if syntax == .unsupported {
-                let escaped = escapeSQLQuote(filter.value)
-                return "\(quotedColumn) LIKE '%\(escaped)%'"
+            guard dialect.regexSyntax != .unsupported else {
+                let pattern = "'%\(escapeSQLQuote(filter.value))%'"
+                return "\(folding.foldingLikeOperand(quotedColumn)) \(folding.likeKeyword) "
+                    + folding.foldingLikeOperand(pattern)
             }
-            if syntax == .match {
-                let escapedPattern = escapeStringValue(filter.value)
-                return "match(\(quotedColumn), '\(escapedPattern)')"
-            }
-            return generateRegexCondition(column: quotedColumn, pattern: filter.value)
+            return generateRegexCondition(
+                column: quotedColumn, pattern: filter.value, ignoresCase: !filter.isCaseSensitive
+            )
         }
+    }
+
+    // MARK: - Case Sensitivity
+
+    private func caseFolding(for filter: TableFilter, columnType: ColumnType?) -> PluginSQLCaseFolding {
+        let matchesCase = filter.isCaseSensitive
+            || !filter.filterOperator.supportsCaseSensitivity
+            || !allowsCaseFolding(columnType)
+        return PluginSQLCaseFolding.resolve(
+            style: dialect.caseSensitivityStyle,
+            foldFunction: dialect.caseFoldFunction,
+            isCaseSensitive: matchesCase
+        )
+    }
+
+    /// Folding a non-text column is a type error on strict engines, so only fold
+    /// columns that are text or whose type the grid has not resolved.
+    private func allowsCaseFolding(_ columnType: ColumnType?) -> Bool {
+        columnType == nil || ColumnTypeSQLQuoting.isKnownTextLike(columnType)
+    }
+
+    private func foldedComparison(_ literal: String, folding: PluginSQLCaseFolding) -> String? {
+        guard folding.foldsComparisonOperands else { return literal }
+        guard literal.hasPrefix("'") else { return nil }
+        return folding.fold(literal)
     }
 
     // MARK: - IN Conditions
@@ -164,7 +189,8 @@ struct FilterSQLGenerator {
         column: String,
         values: String,
         columnType: ColumnType?,
-        negated: Bool
+        negated: Bool,
+        folding: PluginSQLCaseFolding
     ) -> String? {
         let parsed = parseListValues(values)
         guard !parsed.isEmpty else { return nil }
@@ -176,15 +202,16 @@ struct FilterSQLGenerator {
             case .null:
                 hasNull = true
             case .value(let literal):
-                nonNullValues.append(literal)
+                nonNullValues.append(folding.foldingComparison(literal))
             }
         }
 
+        let foldedColumn = folding.foldingComparison(column)
         let inClause: String? = nonNullValues.isEmpty ? nil : {
             let list = nonNullValues.joined(separator: ", ")
             return negated
-                ? "\(column) NOT IN (\(list))"
-                : "\(column) IN (\(list))"
+                ? "\(foldedColumn) NOT IN (\(list))"
+                : "\(foldedColumn) IN (\(list))"
         }()
 
         let nullClause: String? = hasNull ? {
@@ -214,32 +241,99 @@ struct FilterSQLGenerator {
         return " ESCAPE '!'"
     }
 
-    private func generateLikeCondition(column: String, pattern: String) -> String {
-        let quotedPattern = escapeSQLQuote(pattern)
-        return "\(column) LIKE '\(quotedPattern)'\(likeEscapeClause)"
+    private func generateLikeFamilyCondition(
+        column: String,
+        filter: TableFilter,
+        folding: PluginSQLCaseFolding
+    ) -> String {
+        let negated = filter.filterOperator == .notContains
+        if folding.usesRegexForLike {
+            let pattern = PluginSQLRegexPattern.pattern(
+                matchingLiteral: filter.value,
+                anchoring: regexAnchoring(for: filter.filterOperator),
+                ignoresCase: false
+            )
+            let condition = generateRegexCondition(column: column, pattern: pattern, ignoresCase: true)
+            return negated ? "NOT (\(condition))" : condition
+        }
+        let escaped = escapeLikeWildcards(filter.value)
+        let pattern: String
+        switch filter.filterOperator {
+        case .startsWith:
+            pattern = "\(escaped)%"
+        case .endsWith:
+            pattern = "%\(escaped)"
+        default:
+            pattern = "%\(escaped)%"
+        }
+        return generateLikeCondition(column: column, pattern: pattern, negated: negated, folding: folding)
     }
 
-    private func generateNotLikeCondition(column: String, pattern: String) -> String {
-        let quotedPattern = escapeSQLQuote(pattern)
-        return "\(column) NOT LIKE '\(quotedPattern)'\(likeEscapeClause)"
+    private func generateLikeCondition(
+        column: String,
+        pattern: String,
+        negated: Bool,
+        folding: PluginSQLCaseFolding
+    ) -> String {
+        let quotedPattern = "'\(escapeSQLQuote(pattern))'"
+        let keyword = negated ? folding.notLikeKeyword : folding.likeKeyword
+        let operand = folding.foldingLikeOperand(column)
+        return "\(operand) \(keyword) \(folding.foldingLikeOperand(quotedPattern))\(likeEscapeClause)"
+    }
+
+    private func generateComparisonCondition(
+        column: String,
+        literal: String,
+        rawValue: String,
+        negated: Bool,
+        folding: PluginSQLCaseFolding
+    ) -> String {
+        if folding.usesRegexForLike {
+            let pattern = PluginSQLRegexPattern.pattern(
+                matchingLiteral: rawValue, anchoring: .exact, ignoresCase: false
+            )
+            let condition = generateRegexCondition(column: column, pattern: pattern, ignoresCase: true)
+            return negated ? "NOT (\(condition))" : condition
+        }
+        let operatorText = negated ? "!=" : "="
+        guard let foldedValue = foldedComparison(literal, folding: folding) else {
+            return "\(column) \(operatorText) \(literal)"
+        }
+        let foldedColumn = folding.foldsComparisonOperands ? folding.fold(column) : column
+        return "\(foldedColumn) \(operatorText) \(foldedValue)"
+    }
+
+    private func regexAnchoring(for filterOperator: FilterOperator) -> PluginSQLRegexPattern.Anchoring {
+        switch filterOperator {
+        case .startsWith:
+            return .prefix
+        case .endsWith:
+            return .suffix
+        default:
+            return .unanchored
+        }
     }
 
     // MARK: - REGEX Conditions
 
-    private func generateRegexCondition(column: String, pattern: String) -> String {
+    private func generateRegexCondition(column: String, pattern: String, ignoresCase: Bool) -> String {
         let escapedPattern = escapeStringValue(pattern)
 
         switch dialect.regexSyntax {
         case .regexp:
-            return "\(column) REGEXP '\(escapedPattern)'"
+            guard ignoresCase else { return "\(column) REGEXP '\(escapedPattern)'" }
+            return "REGEXP_LIKE(\(column), '\(escapedPattern)', 'i')"
         case .tilde:
-            return "\(column) ~ '\(escapedPattern)'"
+            return "\(column) \(ignoresCase ? "~*" : "~") '\(escapedPattern)'"
         case .regexpMatches:
-            return "regexp_matches(\(column), '\(escapedPattern)')"
+            guard ignoresCase else { return "regexp_matches(\(column), '\(escapedPattern)')" }
+            return "regexp_matches(\(column), '\(escapedPattern)', 'i')"
         case .regexpLike:
-            return "REGEXP_LIKE(\(column), '\(escapedPattern)')"
+            guard ignoresCase else { return "REGEXP_LIKE(\(column), '\(escapedPattern)')" }
+            return "REGEXP_LIKE(\(column), '\(escapedPattern)', 'i')"
         case .match:
-            return "match(\(column), '\(escapedPattern)')"
+            guard ignoresCase else { return "match(\(column), '\(escapedPattern)')" }
+            return "match(\(column), '(?i)\(escapedPattern)')"
         case .unsupported:
             return "\(column) LIKE '%\(escapedPattern)%'"
         }
@@ -358,19 +452,11 @@ extension FilterSQLGenerator {
     ) -> String {
         // Use plugin dispatch for NoSQL drivers (MongoDB, Redis, etc.)
         if let pluginDriver {
-            let filterTuples = filters
+            let queryFilters = filters
                 .filter { $0.isEnabled && !$0.columnName.isEmpty }
-                .map { filter in
-                    let value: String
-                    if filter.filterOperator == .between, let second = filter.secondValue {
-                        value = "\(filter.value),\(second)"
-                    } else {
-                        value = filter.value
-                    }
-                    return (filter.columnName, filter.filterOperator.rawValue, value)
-                }
+                .map(\.asPluginQueryFilter)
             if let result = pluginDriver.buildFilteredQuery(
-                table: tableName, schema: schemaName, filters: filterTuples,
+                table: tableName, schema: schemaName, queryFilters: queryFilters,
                 logicMode: logicMode == .and ? "and" : "or",
                 sortColumns: [], columns: [],
                 limit: limit, offset: 0,

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -308,24 +308,24 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable {
     }
 
     func fetchFilteredRowCount(table: String, filters: [TableFilter], logicMode: FilterLogicMode) async throws -> Int? {
-        let tuples = filters
+        let queryFilters = filters
             .filter { $0.isEnabled && !$0.columnName.isEmpty }
-            .map(\.asPluginFilterTuple)
+            .map(\.asPluginQueryFilter)
         return try await pluginDriver.fetchFilteredRowCount(
             table: table,
-            filters: tuples,
+            queryFilters: queryFilters,
             logicMode: logicMode == .and ? "and" : "or"
         )
     }
 
     func fetchExactRowCount(table: String, filters: [TableFilter], logicMode: FilterLogicMode) async throws -> Int? {
-        let tuples = filters
+        let queryFilters = filters
             .filter { $0.isEnabled && !$0.columnName.isEmpty }
-            .map(\.asPluginFilterTuple)
+            .map(\.asPluginQueryFilter)
         return try await pluginDriver.fetchExactRowCount(
             table: table,
             schema: pluginDriver.currentSchema,
-            filters: tuples,
+            queryFilters: queryFilters,
             logicMode: logicMode == .and ? "and" : "or"
         )
     }

--- a/TablePro/Core/Plugins/PluginManager+Registration.swift
+++ b/TablePro/Core/Plugins/PluginManager+Registration.swift
@@ -214,6 +214,16 @@ extension PluginManager {
             .editor.sqlDialect
     }
 
+    /// How this engine can express case-insensitive matching. SQL engines answer from their
+    /// dialect; document stores have no dialect and declare it on the plugin directly.
+    func caseSensitivityStyle(for databaseType: DatabaseType) -> SQLDialectDescriptor.CaseSensitivityStyle {
+        if let dialect = sqlDialect(for: databaseType) {
+            return dialect.caseSensitivityStyle
+        }
+        guard let plugin = driverPlugin(for: databaseType) else { return .unsupported }
+        return type(of: plugin).caseSensitivityStyle
+    }
+
     func statementCompletions(for databaseType: DatabaseType) -> [CompletionEntry] {
         PluginMetadataRegistry.shared.snapshot(forTypeId: databaseType.pluginTypeId)?
             .editor.statementCompletions ?? []

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+CloudDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+CloudDefaults.swift
@@ -59,7 +59,8 @@ extension PluginMetadataRegistry {
                             "begins_with", "contains", "size", "attribute_type",
                             "attribute_exists", "attribute_not_exists",
                         ],
-                        dataTypes: ["S", "N", "B", "BOOL", "NULL", "L", "M", "SS", "NS", "BS"]
+                        dataTypes: ["S", "N", "B", "BOOL", "NULL", "L", "M", "SS", "NS", "BS"],
+                        caseSensitivityStyle: .driverManaged
                     ),
                     statementCompletions: [
                         CompletionEntry(label: "SELECT", insertText: "SELECT"),
@@ -238,8 +239,9 @@ extension PluginMetadataRegistry {
                         ],
                         regexSyntax: .unsupported,
                         booleanLiteralStyle: .truefalse,
-                        likeEscapeStyle: .explicit,
-                        paginationStyle: .limit
+                        likeEscapeStyle: .implicit,
+                        paginationStyle: .limit,
+                        caseSensitivityStyle: .caseFoldFunction
                     ),
                     statementCompletions: [
                         CompletionEntry(label: "SELECT", insertText: "SELECT"),
@@ -482,7 +484,8 @@ extension PluginMetadataRegistry {
                         regexSyntax: .regexpLike,
                         booleanLiteralStyle: .truefalse,
                         likeEscapeStyle: .explicit,
-                        paginationStyle: .limit
+                        paginationStyle: .limit,
+                        caseSensitivityStyle: .ilikeOperator
                     ),
                     statementCompletions: [
                         CompletionEntry(label: "SELECT", insertText: "SELECT"),

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
@@ -295,7 +295,8 @@ extension PluginMetadataRegistry {
                             "CHAR", "VARCHAR", "CLOB", "BYTE", "VARBYTE", "BLOB",
                             "DATE", "TIME", "TIMESTAMP", "INTERVAL", "PERIOD", "JSON", "XML",
                         ],
-                        autoLimitStyle: .top
+                        autoLimitStyle: .top,
+                        caseSensitivityStyle: .unsupported
                     ),
                     statementCompletions: [],
                     columnTypesByCategory: [
@@ -392,7 +393,8 @@ extension PluginMetadataRegistry {
                         booleanLiteralStyle: .truefalse,
                         likeEscapeStyle: .explicit,
                         paginationStyle: .offsetFetch,
-                        offsetFetchOrderBy: ""
+                        offsetFetchOrderBy: "",
+                        caseSensitivityStyle: .regexFlag
                     ),
                     statementCompletions: [],
                     columnTypesByCategory: [
@@ -670,7 +672,8 @@ extension PluginMetadataRegistry {
                         regexSyntax: .unsupported,
                         booleanLiteralStyle: .numeric,
                         likeEscapeStyle: .explicit,
-                        paginationStyle: .limit
+                        paginationStyle: .limit,
+                        caseSensitivityStyle: .collationDefined
                     ),
                     statementCompletions: [],
                     columnTypesByCategory: [

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryIngredients.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryIngredients.swift
@@ -77,7 +77,9 @@ extension PluginMetadataRegistry {
             booleanLiteralStyle: .numeric,
             likeEscapeStyle: .implicit,
             paginationStyle: .limit,
-            requiresBackslashEscaping: true
+            requiresBackslashEscaping: true,
+            caseSensitivityStyle: .caseFoldFunction,
+            caseFoldFunction: "lowerUTF8"
         )
 
         let clickhouseColumnTypes: [String: [String]] = [
@@ -147,7 +149,8 @@ extension PluginMetadataRegistry {
             booleanLiteralStyle: .numeric,
             likeEscapeStyle: .explicit,
             paginationStyle: .offsetFetch,
-            autoLimitStyle: .top
+            autoLimitStyle: .top,
+            caseSensitivityStyle: .collationDefined
         )
 
         let mssqlColumnTypes: [String: [String]] = [
@@ -213,7 +216,8 @@ extension PluginMetadataRegistry {
             likeEscapeStyle: .explicit,
             paginationStyle: .offsetFetch,
             offsetFetchOrderBy: "ORDER BY 1",
-            autoLimitStyle: .fetchFirst
+            autoLimitStyle: .fetchFirst,
+            caseSensitivityStyle: .caseFoldFunction
         )
 
         let oracleColumnTypes: [String: [String]] = [
@@ -278,7 +282,8 @@ extension PluginMetadataRegistry {
             regexSyntax: .regexpMatches,
             booleanLiteralStyle: .truefalse,
             likeEscapeStyle: .explicit,
-            paginationStyle: .limit
+            paginationStyle: .limit,
+            caseSensitivityStyle: .ilikeOperator
         )
 
         let duckdbColumnTypes: [String: [String]] = [
@@ -338,7 +343,8 @@ extension PluginMetadataRegistry {
             booleanLiteralStyle: .truefalse,
             likeEscapeStyle: .explicit,
             paginationStyle: .limit,
-            autoLimitStyle: .limit
+            autoLimitStyle: .limit,
+            caseSensitivityStyle: .unsupported
         )
 
         let cassandraColumnTypes: [String: [String]] = [
@@ -512,7 +518,8 @@ extension PluginMetadataRegistry {
             regexSyntax: .unsupported,
             booleanLiteralStyle: .numeric,
             likeEscapeStyle: .explicit,
-            paginationStyle: .limit
+            paginationStyle: .limit,
+            caseSensitivityStyle: .collationDefined
         )
 
         let d1ColumnTypes: [String: [String]] = [

--- a/TablePro/Core/Plugins/PluginMetadataRegistry.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry.swift
@@ -32,7 +32,7 @@ struct PluginMetadataSnapshot: Sendable {
 
     let capabilities: CapabilityFlags
     let schema: SchemaInfo
-    let editor: EditorConfig
+    var editor: EditorConfig
     let connection: ConnectionConfig
 
     struct CapabilityFlags: Sendable {
@@ -149,7 +149,7 @@ struct PluginMetadataSnapshot: Sendable {
     }
 
     struct EditorConfig: Sendable {
-        let sqlDialect: SQLDialectDescriptor?
+        var sqlDialect: SQLDialectDescriptor?
         let statementCompletions: [CompletionEntry]
         let columnTypesByCategory: [String: [String]]
 
@@ -352,7 +352,8 @@ final class PluginMetadataRegistry: @unchecked Sendable {
             booleanLiteralStyle: .numeric,
             likeEscapeStyle: .implicit,
             paginationStyle: .limit,
-            requiresBackslashEscaping: true
+            requiresBackslashEscaping: true,
+            caseSensitivityStyle: .collationDefined
         )
 
         let mysqlColumnTypes: [String: [String]] = [
@@ -407,8 +408,12 @@ final class PluginMetadataRegistry: @unchecked Sendable {
             regexSyntax: .tilde,
             booleanLiteralStyle: .truefalse,
             likeEscapeStyle: .explicit,
-            paginationStyle: .limit
+            paginationStyle: .limit,
+            caseSensitivityStyle: .ilikeOperator
         )
+
+        // Redshift ILIKE only folds ASCII, so it uses LOWER on both sides instead.
+        let redshiftDialect = postgresqlDialect.withCaseSensitivityStyle(.caseFoldFunction)
 
         let postgresqlColumnTypes: [String: [String]] = [
             "Integer": ["SMALLINT", "INTEGER", "BIGINT", "SERIAL", "BIGSERIAL", "SMALLSERIAL"],
@@ -471,7 +476,8 @@ final class PluginMetadataRegistry: @unchecked Sendable {
             regexSyntax: .unsupported,
             booleanLiteralStyle: .numeric,
             likeEscapeStyle: .explicit,
-            paginationStyle: .limit
+            paginationStyle: .limit,
+            caseSensitivityStyle: .collationDefined
         )
 
         let sqliteColumnTypes: [String: [String]] = [
@@ -705,7 +711,7 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                     structureColumnFields: [.name, .type, .nullable, .defaultValue, .autoIncrement, .comment]
                 ),
                 editor: PluginMetadataSnapshot.EditorConfig(
-                    sqlDialect: postgresqlDialect,
+                    sqlDialect: redshiftDialect,
                     statementCompletions: [],
                     columnTypesByCategory: postgresqlColumnTypes
                 ),
@@ -935,6 +941,7 @@ final class PluginMetadataRegistry: @unchecked Sendable {
         }
         if let registryDefault = defaultSnapshots[typeId] {
             resolved = resolved.withIsDownloadable(registryDefault.isDownloadable)
+            Self.adoptCuratedCaseSensitivity(&resolved, registryDefault: registryDefault)
             if Self.declaresLegacySchemaOnlyRouting(resolved, registryDefault: registryDefault) {
                 Logger(subsystem: "com.TablePro", category: "PluginMetadataRegistry").notice(
                     "Plugin '\(typeId, privacy: .public)' declares legacy two-tier switching for a schema-only engine; applying the app's switch routing"
@@ -946,6 +953,23 @@ final class PluginMetadataRegistry: @unchecked Sendable {
         for scheme in resolved.urlSchemes {
             schemeIndex[scheme.lowercased()] = typeId
         }
+    }
+
+    /// A plugin built before case-insensitive matching existed reports `.unsupported`,
+    /// which would leave its engine without the option until the plugin is re-released.
+    /// The app's curated entry knows the engine, so it fills the gap.
+    static func adoptCuratedCaseSensitivity(
+        _ snapshot: inout PluginMetadataSnapshot,
+        registryDefault: PluginMetadataSnapshot
+    ) {
+        guard let dialect = snapshot.editor.sqlDialect,
+              dialect.caseSensitivityStyle == .unsupported,
+              let curated = registryDefault.editor.sqlDialect,
+              curated.caseSensitivityStyle != .unsupported else { return }
+        snapshot.editor.sqlDialect = dialect.withCaseSensitivityStyle(
+            curated.caseSensitivityStyle,
+            caseFoldFunction: curated.caseFoldFunction
+        )
     }
 
     /// A plugin built before its engine moved to schema-only switching still

--- a/TablePro/Core/Services/Query/TableQueryBuilder.swift
+++ b/TablePro/Core/Services/Query/TableQueryBuilder.swift
@@ -103,11 +103,11 @@ struct TableQueryBuilder {
     ) -> String {
         if let pluginDriver {
             let sortCols = sortColumnsAsTuples(sortState)
-            let filterTuples = filters
+            let queryFilters = filters
                 .filter { $0.isEnabled && !$0.columnName.isEmpty }
-                .map(\.asPluginFilterTuple)
+                .map(\.asPluginQueryFilter)
             if let result = pluginDriver.buildFilteredQuery(
-                table: tableName, schema: schemaName, filters: filterTuples,
+                table: tableName, schema: schemaName, queryFilters: queryFilters,
                 logicMode: logicMode == .and ? "and" : "or",
                 sortColumns: sortCols, columns: selectColumns ?? columns, limit: limit, offset: offset,
                 columnKinds: pluginColumnKinds(columns: columns, columnTypes: columnTypes)

--- a/TablePro/Models/Database/TableFilter.swift
+++ b/TablePro/Models/Database/TableFilter.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import TableProPluginKit
 
 /// Represents a filter operator for WHERE clause generation
 enum FilterOperator: String, CaseIterable, Identifiable, Codable {
@@ -43,6 +44,27 @@ enum FilterOperator: String, CaseIterable, Identifiable, Codable {
     /// Whether this operator requires two values (for BETWEEN)
     var requiresSecondValue: Bool {
         self == .between
+    }
+
+    /// Whether matching for this operator has a case dimension the user can control
+    var supportsCaseSensitivity: Bool {
+        switch self {
+        case .contains, .notContains, .startsWith, .endsWith,
+             .equal, .notEqual, .inList, .notInList, .regex:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Pattern matching ignores case by default; exact, list and regex matching does not
+    var defaultIsCaseSensitive: Bool {
+        switch self {
+        case .contains, .notContains, .startsWith, .endsWith:
+            return false
+        default:
+            return true
+        }
     }
 
     /// Display name for UI
@@ -100,6 +122,7 @@ struct TableFilter: Identifiable, Equatable, Hashable, Codable {
     var secondValue: String?
     var isEnabled: Bool
     var rawSQL: String?
+    var isCaseSensitive: Bool
 
     /// Special column name for raw SQL mode
     static let rawSQLColumn = "__RAW__"
@@ -111,7 +134,8 @@ struct TableFilter: Identifiable, Equatable, Hashable, Codable {
         value: String = "",
         secondValue: String? = nil,
         isEnabled: Bool = true,
-        rawSQL: String? = nil
+        rawSQL: String? = nil,
+        isCaseSensitive: Bool? = nil
     ) {
         self.id = id
         self.columnName = columnName
@@ -120,6 +144,25 @@ struct TableFilter: Identifiable, Equatable, Hashable, Codable {
         self.secondValue = secondValue
         self.isEnabled = isEnabled
         self.rawSQL = rawSQL
+        self.isCaseSensitive = isCaseSensitive ?? filterOperator.defaultIsCaseSensitive
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, columnName, filterOperator, value, secondValue, isEnabled, rawSQL, isCaseSensitive
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let decodedOperator = try container.decodeIfPresent(FilterOperator.self, forKey: .filterOperator) ?? .equal
+        self.id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        self.columnName = try container.decodeIfPresent(String.self, forKey: .columnName) ?? ""
+        self.filterOperator = decodedOperator
+        self.value = try container.decodeIfPresent(String.self, forKey: .value) ?? ""
+        self.secondValue = try container.decodeIfPresent(String.self, forKey: .secondValue)
+        self.isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
+        self.rawSQL = try container.decodeIfPresent(String.self, forKey: .rawSQL)
+        self.isCaseSensitive = try container.decodeIfPresent(Bool.self, forKey: .isCaseSensitive)
+            ?? decodedOperator.defaultIsCaseSensitive
     }
 
     /// Whether this filter is valid (has enough info to apply)
@@ -170,9 +213,9 @@ struct TableFilter: Identifiable, Equatable, Hashable, Codable {
 }
 
 extension TableFilter {
-    var asPluginFilterTuple: (column: String, op: String, value: String) {
+    var asPluginQueryFilter: PluginQueryFilter {
         if isRawSQL {
-            return (columnName, filterOperator.rawValue, rawSQL ?? "")
+            return PluginQueryFilter(column: columnName, op: filterOperator.rawValue, value: rawSQL ?? "")
         }
         let resolvedValue: String
         if filterOperator == .between, let second = secondValue {
@@ -180,7 +223,12 @@ extension TableFilter {
         } else {
             resolvedValue = value
         }
-        return (columnName, filterOperator.rawValue, resolvedValue)
+        return PluginQueryFilter(
+            column: columnName,
+            op: filterOperator.rawValue,
+            value: resolvedValue,
+            isCaseSensitive: isCaseSensitive
+        )
     }
 }
 

--- a/TablePro/Views/Filter/FilterCaseSensitivityPresentation.swift
+++ b/TablePro/Views/Filter/FilterCaseSensitivityPresentation.swift
@@ -1,0 +1,35 @@
+//
+//  FilterCaseSensitivityPresentation.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+/// Resolves how a filter row presents its case setting, given the operator and what the engine can express.
+struct FilterCaseSensitivityPresentation: Equatable {
+    let showsControl: Bool
+    let isAdjustable: Bool
+    let showsIndicator: Bool
+    let fixedReason: String?
+
+    init(filterOperator: FilterOperator, isCaseSensitive: Bool, style: SQLDialectDescriptor.CaseSensitivityStyle) {
+        let supportsCase = filterOperator.supportsCaseSensitivity
+        let adjustable = PluginSQLCaseFolding.isAdjustable(style: style)
+        self.showsControl = supportsCase
+        self.isAdjustable = supportsCase && adjustable
+        self.fixedReason = supportsCase && !adjustable ? Self.reason(for: style) : nil
+        self.showsIndicator = supportsCase
+            && adjustable
+            && isCaseSensitive != filterOperator.defaultIsCaseSensitive
+    }
+
+    private static func reason(for style: SQLDialectDescriptor.CaseSensitivityStyle) -> String {
+        switch style {
+        case .collationDefined:
+            return String(localized: "Set by the column's collation")
+        default:
+            return String(localized: "Not supported by this database")
+        }
+    }
+}

--- a/TablePro/Views/Filter/FilterPanelView.swift
+++ b/TablePro/Views/Filter/FilterPanelView.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import TableProPluginKit
 
 struct FilterPanelView: View {
     let coordinator: MainContentCoordinator
@@ -27,6 +28,10 @@ struct FilterPanelView: View {
 
     private var filterState: TabFilterState {
         coordinator.selectedTabFilterState
+    }
+
+    private var caseSensitivityStyle: SQLDialectDescriptor.CaseSensitivityStyle {
+        PluginManager.shared.caseSensitivityStyle(for: databaseType)
     }
 
     var body: some View {
@@ -225,6 +230,7 @@ struct FilterPanelView: View {
                     filter: coordinator.filterBinding(for: filter),
                     columns: columns,
                     completions: completionItems(),
+                    caseSensitivityStyle: caseSensitivityStyle,
                     enumValuesByColumn: enumValuesByColumn,
                     rawSQLCompletionProvider: rawSQLCompletionProvider,
                     onAdd: {

--- a/TablePro/Views/Filter/FilterRowView.swift
+++ b/TablePro/Views/Filter/FilterRowView.swift
@@ -4,11 +4,13 @@
 //
 
 import SwiftUI
+import TableProPluginKit
 
 struct FilterRowView: View {
     @Binding var filter: TableFilter
     let columns: [String]
     let completions: [String]
+    var caseSensitivityStyle: SQLDialectDescriptor.CaseSensitivityStyle = .unsupported
     var enumValuesByColumn: [String: [String]] = [:]
     var rawSQLCompletionProvider: RawSQLFilterCompletionProvider?
     let onAdd: () -> Void
@@ -162,18 +164,69 @@ struct FilterRowView: View {
     }
 
     private var operatorPicker: some View {
-        Picker("", selection: $filter.filterOperator) {
-            ForEach(FilterOperator.allCases) { op in
-                OperatorMenuLabel(op: op).tag(op)
+        Menu {
+            Picker("", selection: $filter.filterOperator) {
+                ForEach(FilterOperator.allCases) { op in
+                    OperatorMenuLabel(op: op).tag(op)
+                }
             }
+            .pickerStyle(.inline)
+            .labelsHidden()
+
+            if casePresentation.showsControl {
+                Divider()
+                Toggle(String(localized: "Match Case"), isOn: $filter.isCaseSensitive)
+                    .disabled(!casePresentation.isAdjustable)
+                if let reason = casePresentation.fixedReason {
+                    Text(reason).disabled(true)
+                }
+            }
+        } label: {
+            operatorMenuTitle
         }
-        .pickerStyle(.menu)
+        .menuStyle(.button)
         .controlSize(.small)
         .fixedSize()
-        .labelsHidden()
         .accessibilityLabel(String(localized: "Filter operator"))
-        .accessibilityValue(filter.filterOperator.displayName)
-        .help(String(localized: "Select filter operator"))
+        .accessibilityValue(operatorAccessibilityValue)
+        .help(caseSensitivityHelp)
+    }
+
+    @ViewBuilder
+    private var operatorMenuTitle: some View {
+        HStack(spacing: 3) {
+            OperatorMenuLabel(op: filter.filterOperator)
+            if casePresentation.showsIndicator {
+                Image(systemName: "textformat")
+                    .imageScale(.small)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var casePresentation: FilterCaseSensitivityPresentation {
+        FilterCaseSensitivityPresentation(
+            filterOperator: filter.filterOperator,
+            isCaseSensitive: filter.isCaseSensitive,
+            style: caseSensitivityStyle
+        )
+    }
+
+    private var caseSensitivityHelp: String {
+        let presentation = casePresentation
+        guard presentation.showsControl else { return String(localized: "Select filter operator") }
+        if let reason = presentation.fixedReason { return reason }
+        return filter.isCaseSensitive
+            ? String(localized: "Matching is case-sensitive")
+            : String(localized: "Matching ignores case")
+    }
+
+    private var operatorAccessibilityValue: String {
+        guard casePresentation.isAdjustable else { return filter.filterOperator.displayName }
+        let caseMode = filter.isCaseSensitive
+            ? String(localized: "Match Case")
+            : String(localized: "Ignore Case")
+        return "\(filter.filterOperator.displayName), \(caseMode)"
     }
 
     @ViewBuilder

--- a/TableProMobile/TableProMobile/Helpers/SQLBuilder.swift
+++ b/TableProMobile/TableProMobile/Helpers/SQLBuilder.swift
@@ -287,6 +287,10 @@ enum SQLBuilder {
         return "ORDER BY " + clauses.joined(separator: ", ")
     }
 
+    static func caseSensitivityStyle(for type: DatabaseType) -> SQLDialectDescriptor.CaseSensitivityStyle {
+        dialectDescriptor(for: type).caseSensitivityStyle
+    }
+
     private static func dialectDescriptor(for type: DatabaseType) -> SQLDialectDescriptor {
         switch type {
         case .mysql, .mariadb:
@@ -296,15 +300,26 @@ enum SQLBuilder {
                 functions: [],
                 dataTypes: [],
                 likeEscapeStyle: .implicit,
-                requiresBackslashEscaping: true
+                requiresBackslashEscaping: true,
+                caseSensitivityStyle: .collationDefined
             )
-        case .postgresql, .redshift:
+        case .postgresql:
             return SQLDialectDescriptor(
                 identifierQuote: "\"",
                 keywords: [],
                 functions: [],
                 dataTypes: [],
-                likeEscapeStyle: .explicit
+                likeEscapeStyle: .explicit,
+                caseSensitivityStyle: .ilikeOperator
+            )
+        case .redshift:
+            return SQLDialectDescriptor(
+                identifierQuote: "\"",
+                keywords: [],
+                functions: [],
+                dataTypes: [],
+                likeEscapeStyle: .explicit,
+                caseSensitivityStyle: .caseFoldFunction
             )
         case .mssql:
             return SQLDialectDescriptor(
@@ -312,7 +327,8 @@ enum SQLBuilder {
                 keywords: [],
                 functions: [],
                 dataTypes: [],
-                likeEscapeStyle: .explicit
+                likeEscapeStyle: .explicit,
+                caseSensitivityStyle: .collationDefined
             )
         case .oracle:
             return SQLDialectDescriptor(
@@ -320,7 +336,17 @@ enum SQLBuilder {
                 keywords: [],
                 functions: [],
                 dataTypes: [],
-                likeEscapeStyle: .explicit
+                likeEscapeStyle: .explicit,
+                caseSensitivityStyle: .caseFoldFunction
+            )
+        case .sqlite:
+            return SQLDialectDescriptor(
+                identifierQuote: "\"",
+                keywords: [],
+                functions: [],
+                dataTypes: [],
+                likeEscapeStyle: .explicit,
+                caseSensitivityStyle: .collationDefined
             )
         default:
             return SQLDialectDescriptor(

--- a/TableProMobile/TableProMobile/Views/Components/FilterSheetView.swift
+++ b/TableProMobile/TableProMobile/Views/Components/FilterSheetView.swift
@@ -1,11 +1,15 @@
 import SwiftUI
+import TableProCoreTypes
 import TableProModels
+import TableProPluginKit
+import TableProQuery
 
 struct FilterSheetView: View {
     @Environment(\.dismiss) private var dismiss
     @Binding var filters: [TableFilter]
     @Binding var logicMode: FilterLogicMode
     let columns: [ColumnInfo]
+    let databaseType: DatabaseType
     let onApply: () -> Void
     let onClear: () -> Void
 
@@ -15,6 +19,10 @@ struct FilterSheetView: View {
 
     private var hasValidFilters: Bool {
         draft.contains { $0.isEnabled && $0.isValid }
+    }
+
+    private var isCaseSensitivityAdjustable: Bool {
+        PluginSQLCaseFolding.isAdjustable(style: SQLBuilder.caseSensitivityStyle(for: databaseType))
     }
 
     private func bindingForFilter(_ id: UUID) -> Binding<TableFilter>? {
@@ -54,6 +62,10 @@ struct FilterSheetView: View {
                                 TextField("Value", text: binding.value)
                                     .textInputAutocapitalization(.never)
                                     .autocorrectionDisabled()
+                            }
+
+                            if filter.filterOperator.supportsCaseSensitivity, isCaseSensitivityAdjustable {
+                                Toggle("Match Case", isOn: binding.isCaseSensitive)
                             }
 
                             if filter.filterOperator == .between {

--- a/TableProMobile/TableProMobile/Views/DataBrowserView.swift
+++ b/TableProMobile/TableProMobile/Views/DataBrowserView.swift
@@ -82,6 +82,7 @@ struct DataBrowserView: View {
                     filters: $viewModel.filters,
                     logicMode: $viewModel.filterLogicMode,
                     columns: columns,
+                    databaseType: connection.type,
                     onApply: { Task { await viewModel.applyFilters() } },
                     onClear: { Task { await viewModel.clearFilters() } }
                 )

--- a/TableProTests/Core/Database/FilterCaseSensitivityPersistenceTests.swift
+++ b/TableProTests/Core/Database/FilterCaseSensitivityPersistenceTests.swift
@@ -1,0 +1,115 @@
+//
+//  FilterCaseSensitivityPersistenceTests.swift
+//  TableProTests
+//
+//  Round-tripping filters saved before case sensitivity existed (#2048)
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+@testable import TablePro
+
+@Suite("Filter Case Sensitivity Persistence")
+struct FilterCaseSensitivityPersistenceTests {
+
+    private func decode(_ json: String) throws -> TableFilter {
+        try JSONDecoder().decode(TableFilter.self, from: Data(json.utf8))
+    }
+
+    @Test("A saved pattern filter with no case key decodes to ignore case")
+    func testLegacyPatternFilterDecodes() throws {
+        let filter = try decode("""
+        {"id":"8B9E4F1C-2A3D-4B5E-9F60-1234567890AB","columnName":"name",
+         "filterOperator":"CONTAINS","value":"smith","isEnabled":true}
+        """)
+        #expect(filter.filterOperator == .contains)
+        #expect(filter.isCaseSensitive == false)
+    }
+
+    @Test("A saved equals filter with no case key decodes to match case")
+    func testLegacyEqualsFilterDecodes() throws {
+        let filter = try decode("""
+        {"id":"8B9E4F1C-2A3D-4B5E-9F60-1234567890AB","columnName":"name",
+         "filterOperator":"=","value":"smith","isEnabled":true}
+        """)
+        #expect(filter.isCaseSensitive)
+    }
+
+    @Test("An explicit case key wins over the operator default")
+    func testExplicitKeyWins() throws {
+        let filter = try decode("""
+        {"id":"8B9E4F1C-2A3D-4B5E-9F60-1234567890AB","columnName":"name",
+         "filterOperator":"CONTAINS","value":"smith","isEnabled":true,"isCaseSensitive":true}
+        """)
+        #expect(filter.isCaseSensitive)
+    }
+
+    @Test("A filter round-trips through JSON unchanged")
+    func testRoundTrip() throws {
+        let original = TableFilter(
+            columnName: "name", filterOperator: .startsWith, value: "s", isCaseSensitive: true
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(TableFilter.self, from: data)
+        #expect(decoded == original)
+        #expect(decoded.isCaseSensitive)
+    }
+
+    @Test("Every preset in a batch survives when one carries the new key")
+    func testPresetBatchDecodes() throws {
+        let json = """
+        [{"id":"8B9E4F1C-2A3D-4B5E-9F60-1234567890AB","columnName":"a",
+          "filterOperator":"CONTAINS","value":"x","isEnabled":true},
+         {"id":"9B9E4F1C-2A3D-4B5E-9F60-1234567890AB","columnName":"b",
+          "filterOperator":"CONTAINS","value":"y","isEnabled":true,"isCaseSensitive":true}]
+        """
+        let filters = try JSONDecoder().decode([TableFilter].self, from: Data(json.utf8))
+        #expect(filters.count == 2)
+        #expect(filters[0].isCaseSensitive == false)
+        #expect(filters[1].isCaseSensitive)
+    }
+
+    @Test("The plugin transfer type carries the row's case setting")
+    func testPluginFilterCarriesCase() {
+        let filter = TableFilter(columnName: "name", filterOperator: .contains, value: "x")
+        #expect(filter.asPluginQueryFilter.isCaseSensitive == false)
+
+        let exact = TableFilter(columnName: "name", filterOperator: .equal, value: "x")
+        #expect(exact.asPluginQueryFilter.isCaseSensitive)
+    }
+
+    @Test("A dialect built with the pre-existing initializer reports no case support")
+    func testLegacyDialectInitializerDefaults() {
+        let dialect = SQLDialectDescriptor(
+            identifierQuote: "\"", keywords: [], functions: [], dataTypes: [],
+            regexSyntax: .tilde, booleanLiteralStyle: .truefalse,
+            likeEscapeStyle: .explicit, paginationStyle: .limit,
+            offsetFetchOrderBy: "ORDER BY 1", requiresBackslashEscaping: false,
+            autoLimitStyle: .limit
+        )
+        #expect(dialect.caseSensitivityStyle == .unsupported)
+        #expect(dialect.caseFoldFunction == "LOWER")
+        #expect(PluginSQLCaseFolding.isAdjustable(style: dialect.caseSensitivityStyle) == false)
+    }
+
+    @Test("Copying a dialect keeps every other field")
+    func testWithCaseSensitivityStylePreservesFields() {
+        let base = SQLDialectDescriptor(
+            identifierQuote: "`", keywords: ["SELECT"], functions: ["NOW"], dataTypes: ["INT"],
+            tableOptions: ["ENGINE="], regexSyntax: .regexp, booleanLiteralStyle: .numeric,
+            likeEscapeStyle: .implicit, paginationStyle: .limit,
+            requiresBackslashEscaping: true, autoLimitStyle: .top
+        )
+        let copy = base.withCaseSensitivityStyle(.caseFoldFunction, caseFoldFunction: "lowerUTF8")
+        #expect(copy.caseSensitivityStyle == .caseFoldFunction)
+        #expect(copy.caseFoldFunction == "lowerUTF8")
+        #expect(copy.identifierQuote == "`")
+        #expect(copy.keywords == ["SELECT"])
+        #expect(copy.tableOptions == ["ENGINE="])
+        #expect(copy.regexSyntax == .regexp)
+        #expect(copy.likeEscapeStyle == .implicit)
+        #expect(copy.requiresBackslashEscaping)
+        #expect(copy.autoLimitStyle == .top)
+    }
+}

--- a/TableProTests/Core/Database/FilterSQLGeneratorCaseSensitivityTests.swift
+++ b/TableProTests/Core/Database/FilterSQLGeneratorCaseSensitivityTests.swift
@@ -1,0 +1,295 @@
+//
+//  FilterSQLGeneratorCaseSensitivityTests.swift
+//  TableProTests
+//
+//  Per-dialect case-insensitive matching (#2048)
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+@testable import TablePro
+
+@Suite("Filter SQL Generator Case Sensitivity")
+struct FilterSQLGeneratorCaseSensitivityTests {
+
+    private static let postgresql = SQLDialectDescriptor(
+        identifierQuote: "\"", keywords: [], functions: [], dataTypes: [],
+        regexSyntax: .tilde, booleanLiteralStyle: .truefalse,
+        likeEscapeStyle: .explicit, paginationStyle: .limit,
+        caseSensitivityStyle: .ilikeOperator
+    )
+
+    private static let redshift = SQLDialectDescriptor(
+        identifierQuote: "\"", keywords: [], functions: [], dataTypes: [],
+        regexSyntax: .tilde, booleanLiteralStyle: .truefalse,
+        likeEscapeStyle: .explicit, paginationStyle: .limit,
+        caseSensitivityStyle: .caseFoldFunction
+    )
+
+    private static let duckdb = SQLDialectDescriptor(
+        identifierQuote: "\"", keywords: [], functions: [], dataTypes: [],
+        regexSyntax: .regexpMatches, booleanLiteralStyle: .truefalse,
+        likeEscapeStyle: .explicit, paginationStyle: .limit,
+        caseSensitivityStyle: .ilikeOperator
+    )
+
+    private static let mysql = SQLDialectDescriptor(
+        identifierQuote: "`", keywords: [], functions: [], dataTypes: [],
+        regexSyntax: .regexp, booleanLiteralStyle: .numeric,
+        likeEscapeStyle: .implicit, paginationStyle: .limit,
+        caseSensitivityStyle: .collationDefined
+    )
+
+    private static let clickhouse = SQLDialectDescriptor(
+        identifierQuote: "`", keywords: [], functions: [], dataTypes: [],
+        regexSyntax: .match, booleanLiteralStyle: .numeric,
+        likeEscapeStyle: .implicit, paginationStyle: .limit,
+        caseSensitivityStyle: .caseFoldFunction, caseFoldFunction: "lowerUTF8"
+    )
+
+    private static let oracle = SQLDialectDescriptor(
+        identifierQuote: "\"", keywords: [], functions: [], dataTypes: [],
+        regexSyntax: .regexpLike, booleanLiteralStyle: .numeric,
+        likeEscapeStyle: .explicit, paginationStyle: .offsetFetch,
+        caseSensitivityStyle: .caseFoldFunction
+    )
+
+    private static let trino = SQLDialectDescriptor(
+        identifierQuote: "\"", keywords: [], functions: [], dataTypes: [],
+        regexSyntax: .regexpLike, booleanLiteralStyle: .truefalse,
+        likeEscapeStyle: .explicit, paginationStyle: .offsetFetch,
+        caseSensitivityStyle: .regexFlag
+    )
+
+    private static let bigquery = SQLDialectDescriptor(
+        identifierQuote: "`", keywords: [], functions: [], dataTypes: [],
+        regexSyntax: .unsupported, booleanLiteralStyle: .truefalse,
+        likeEscapeStyle: .implicit, paginationStyle: .limit,
+        caseSensitivityStyle: .caseFoldFunction
+    )
+
+    private static let cassandra = SQLDialectDescriptor(
+        identifierQuote: "\"", keywords: [], functions: [], dataTypes: [],
+        regexSyntax: .unsupported, booleanLiteralStyle: .truefalse,
+        likeEscapeStyle: .explicit, paginationStyle: .limit,
+        caseSensitivityStyle: .unsupported
+    )
+
+    private func condition(
+        _ dialect: SQLDialectDescriptor,
+        _ filterOperator: FilterOperator,
+        value: String = "smith",
+        isCaseSensitive: Bool? = nil,
+        columnTypes: [ColumnType] = []
+    ) -> String? {
+        let generator = FilterSQLGenerator(
+            dialect: dialect, columns: ["name"], columnTypes: columnTypes
+        )
+        return generator.generateCondition(from: TableFilter(
+            columnName: "name",
+            filterOperator: filterOperator,
+            value: value,
+            isCaseSensitive: isCaseSensitive
+        ))
+    }
+
+    // MARK: - Defaults
+
+    @Test("Pattern operators ignore case by default")
+    func testPatternDefaultsToIgnoreCase() {
+        #expect(TableFilter(filterOperator: .contains).isCaseSensitive == false)
+        #expect(TableFilter(filterOperator: .notContains).isCaseSensitive == false)
+        #expect(TableFilter(filterOperator: .startsWith).isCaseSensitive == false)
+        #expect(TableFilter(filterOperator: .endsWith).isCaseSensitive == false)
+    }
+
+    @Test("Exact, list and regex operators match case by default")
+    func testExactDefaultsToMatchCase() {
+        #expect(TableFilter(filterOperator: .equal).isCaseSensitive)
+        #expect(TableFilter(filterOperator: .notEqual).isCaseSensitive)
+        #expect(TableFilter(filterOperator: .inList).isCaseSensitive)
+        #expect(TableFilter(filterOperator: .regex).isCaseSensitive)
+    }
+
+    // MARK: - ILIKE Dialects
+
+    @Test("PostgreSQL contains ignoring case uses ILIKE")
+    func testPostgresContainsUsesILike() {
+        #expect(condition(Self.postgresql, .contains) == "\"name\" ILIKE '%smith%' ESCAPE '!'")
+    }
+
+    @Test("PostgreSQL contains matching case keeps LIKE")
+    func testPostgresContainsMatchCase() {
+        #expect(condition(Self.postgresql, .contains, isCaseSensitive: true) == "\"name\" LIKE '%smith%' ESCAPE '!'")
+    }
+
+    @Test("PostgreSQL not contains ignoring case uses NOT ILIKE")
+    func testPostgresNotContainsUsesNotILike() {
+        #expect(condition(Self.postgresql, .notContains) == "\"name\" NOT ILIKE '%smith%' ESCAPE '!'")
+    }
+
+    @Test("PostgreSQL starts with ignoring case anchors the pattern")
+    func testPostgresStartsWith() {
+        #expect(condition(Self.postgresql, .startsWith) == "\"name\" ILIKE 'smith%' ESCAPE '!'")
+    }
+
+    @Test("PostgreSQL ends with ignoring case anchors the pattern")
+    func testPostgresEndsWith() {
+        #expect(condition(Self.postgresql, .endsWith) == "\"name\" ILIKE '%smith' ESCAPE '!'")
+    }
+
+    @Test("DuckDB contains ignoring case uses ILIKE")
+    func testDuckDBContainsUsesILike() {
+        #expect(condition(Self.duckdb, .contains) == "\"name\" ILIKE '%smith%' ESCAPE '!'")
+    }
+
+    // MARK: - Case-Fold Dialects
+
+    @Test("Oracle contains ignoring case folds both sides")
+    func testOracleContainsFoldsBothSides() {
+        #expect(condition(Self.oracle, .contains) == "LOWER(\"name\") LIKE LOWER('%smith%') ESCAPE '!'")
+    }
+
+    @Test("ClickHouse folds with its Unicode-aware function")
+    func testClickHouseUsesLowerUtf8() {
+        #expect(condition(Self.clickhouse, .contains) == "lowerUTF8(`name`) LIKE lowerUTF8('%smith%')")
+    }
+
+    @Test("Redshift folds instead of using its ASCII-only ILIKE")
+    func testRedshiftFoldsInsteadOfILike() {
+        #expect(condition(Self.redshift, .contains) == "LOWER(\"name\") LIKE LOWER('%smith%') ESCAPE '!'")
+    }
+
+    // MARK: - Collation-Defined And Unsupported Dialects
+
+    @Test("MySQL emits the same SQL whichever way the row is set")
+    func testMySQLIgnoresTheFlag() {
+        let ignoring = condition(Self.mysql, .contains)
+        let matching = condition(Self.mysql, .contains, isCaseSensitive: true)
+        #expect(ignoring == "`name` LIKE '%smith%'")
+        #expect(ignoring == matching)
+    }
+
+    @Test("MySQL never emits a fold function")
+    func testMySQLNeverFolds() {
+        #expect(condition(Self.mysql, .equal, isCaseSensitive: false) == "`name` = 'smith'")
+    }
+
+    @Test("Cassandra emits the same SQL whichever way the row is set")
+    func testUnsupportedDialectIgnoresTheFlag() {
+        let ignoring = condition(Self.cassandra, .contains)
+        let matching = condition(Self.cassandra, .contains, isCaseSensitive: true)
+        #expect(ignoring == matching)
+    }
+
+    // MARK: - Exact And List Matching
+
+    @Test("Equals ignoring case folds both sides")
+    func testEqualsIgnoringCaseFolds() {
+        #expect(condition(Self.postgresql, .equal, isCaseSensitive: false) == "LOWER(\"name\") = LOWER('smith')")
+    }
+
+    @Test("Not equals ignoring case folds both sides")
+    func testNotEqualsIgnoringCaseFolds() {
+        #expect(condition(Self.postgresql, .notEqual, isCaseSensitive: false) == "LOWER(\"name\") != LOWER('smith')")
+    }
+
+    @Test("Equals matching case stays untouched")
+    func testEqualsMatchingCaseUnchanged() {
+        #expect(condition(Self.postgresql, .equal) == "\"name\" = 'smith'")
+    }
+
+    @Test("IN list ignoring case folds the column and every value")
+    func testInListIgnoringCaseFolds() {
+        let sql = condition(Self.postgresql, .inList, value: "a,b", isCaseSensitive: false)
+        #expect(sql == "LOWER(\"name\") IN (LOWER('a'), LOWER('b'))")
+    }
+
+    @Test("A numeric column never gets a fold function wrapped around it")
+    func testNumericColumnIsNeverFolded() {
+        let sql = condition(
+            Self.postgresql, .equal, value: "42", isCaseSensitive: false, columnTypes: [.integer(rawType: "INT")]
+        )
+        #expect(sql == "\"name\" = 42")
+    }
+
+    // MARK: - Regex
+
+    @Test("PostgreSQL regex ignoring case uses the case-insensitive operator")
+    func testPostgresRegexIgnoringCase() {
+        #expect(condition(Self.postgresql, .regex, value: "a.*", isCaseSensitive: false) == "\"name\" ~* 'a.*'")
+    }
+
+    @Test("PostgreSQL regex matching case keeps the plain operator")
+    func testPostgresRegexMatchingCase() {
+        #expect(condition(Self.postgresql, .regex, value: "a.*") == "\"name\" ~ 'a.*'")
+    }
+
+    @Test("DuckDB regex ignoring case passes the flag argument")
+    func testDuckDBRegexIgnoringCase() {
+        let sql = condition(Self.duckdb, .regex, value: "a.*", isCaseSensitive: false)
+        #expect(sql == "regexp_matches(\"name\", 'a.*', 'i')")
+    }
+
+    @Test("MySQL regex ignoring case switches to the function form")
+    func testMySQLRegexIgnoringCase() {
+        let sql = condition(Self.mysql, .regex, value: "a.*", isCaseSensitive: false)
+        #expect(sql == "REGEXP_LIKE(`name`, 'a.*', 'i')")
+    }
+
+    @Test("ClickHouse regex ignoring case uses an inline flag")
+    func testClickHouseRegexIgnoringCase() {
+        let sql = condition(Self.clickhouse, .regex, value: "a.*", isCaseSensitive: false)
+        #expect(sql == "match(`name`, '(?i)a.*')")
+    }
+
+    @Test("A dialect with no regex degrades to LIKE and still folds")
+    func testRegexFallbackStillFolds() {
+        let sql = condition(Self.bigquery, .regex, value: "a.*", isCaseSensitive: false)
+        #expect(sql == "LOWER(`name`) LIKE LOWER('%a.*%')")
+    }
+
+    // MARK: - Trino
+
+    @Test("Trino contains ignoring case uses an unanchored regex")
+    func testTrinoContains() {
+        #expect(condition(Self.trino, .contains) == "REGEXP_LIKE(\"name\", 'smith', 'i')")
+    }
+
+    @Test("Trino starts with ignoring case anchors at the start")
+    func testTrinoStartsWith() {
+        #expect(condition(Self.trino, .startsWith) == "REGEXP_LIKE(\"name\", '^smith', 'i')")
+    }
+
+    @Test("Trino ends with ignoring case anchors at the end")
+    func testTrinoEndsWith() {
+        #expect(condition(Self.trino, .endsWith) == "REGEXP_LIKE(\"name\", 'smith$', 'i')")
+    }
+
+    @Test("Trino equals ignoring case anchors both ends")
+    func testTrinoEquals() {
+        let sql = condition(Self.trino, .equal, isCaseSensitive: false)
+        #expect(sql == "REGEXP_LIKE(\"name\", '^smith$', 'i')")
+    }
+
+    @Test("Trino matching case keeps plain LIKE")
+    func testTrinoMatchingCaseKeepsLike() {
+        let sql = condition(Self.trino, .contains, isCaseSensitive: true)
+        #expect(sql == "\"name\" LIKE '%smith%' ESCAPE '!'")
+    }
+
+    @Test("Trino escapes regex metacharacters in the value")
+    func testTrinoEscapesMetacharacters() {
+        let sql = condition(Self.trino, .contains, value: "a.b*c")
+        #expect(sql == "REGEXP_LIKE(\"name\", 'a\\.b\\*c', 'i')")
+    }
+
+    // MARK: - Wildcard Escaping
+
+    @Test("Wildcards in the value stay escaped when ignoring case")
+    func testWildcardEscapingSurvivesFolding() {
+        let sql = condition(Self.postgresql, .contains, value: "50%")
+        #expect(sql == "\"name\" ILIKE '%50!%%' ESCAPE '!'")
+    }
+}

--- a/TableProTests/Models/TableFilterTests.swift
+++ b/TableProTests/Models/TableFilterTests.swift
@@ -192,14 +192,14 @@ struct TableFilterTests {
             value: "",
             rawSQL: "name:Widget"
         )
-        let tuple = filter.asPluginFilterTuple
-        #expect(tuple.column == TableFilter.rawSQLColumn)
-        #expect(tuple.value == "name:Widget")
+        let pluginFilter = filter.asPluginQueryFilter
+        #expect(pluginFilter.column == TableFilter.rawSQLColumn)
+        #expect(pluginFilter.value == "name:Widget")
     }
 
-    @Test("Plugin tuple uses value for a column filter")
-    func pluginTupleUsesValueForColumn() {
+    @Test("Plugin filter uses value for a column filter")
+    func pluginFilterUsesValueForColumn() {
         let filter = TableFilter(columnName: "name", filterOperator: .equal, value: "Widget")
-        #expect(filter.asPluginFilterTuple.value == "Widget")
+        #expect(filter.asPluginQueryFilter.value == "Widget")
     }
 }

--- a/TableProTests/Plugins/BigQueryQueryBuilderTests.swift
+++ b/TableProTests/Plugins/BigQueryQueryBuilderTests.swift
@@ -42,7 +42,7 @@ struct BigQueryQueryBuilderFilteredTests {
     func filteredReturnsTag() {
         let query = BigQueryQueryBuilder.encodeFilteredQuery(
             table: "users", dataset: "main",
-            filters: [(column: "name", op: "=", value: "Alice")],
+            filters: [PluginQueryFilter(column: "name", op: "=", value: "Alice")],
             logicMode: "AND", sortColumns: [], limit: 100, offset: 0
         )
         #expect(query.hasPrefix(BigQueryQueryBuilder.filterTag))
@@ -53,8 +53,8 @@ struct BigQueryQueryBuilderFilteredTests {
         let query = BigQueryQueryBuilder.encodeFilteredQuery(
             table: "events", dataset: "analytics",
             filters: [
-                (column: "type", op: "=", value: "click"),
-                (column: "count", op: ">", value: "10")
+                PluginQueryFilter(column: "type", op: "=", value: "click"),
+                PluginQueryFilter(column: "count", op: ">", value: "10")
             ],
             logicMode: "OR", sortColumns: [], limit: 200, offset: 0
         )
@@ -98,7 +98,7 @@ struct BigQueryQueryBuilderCombinedTests {
     func combinedReturnsTag() {
         let query = BigQueryQueryBuilder.encodeCombinedQuery(
             table: "users", dataset: "main",
-            filters: [(column: "active", op: "=", value: "true")],
+            filters: [PluginQueryFilter(column: "active", op: "=", value: "true")],
             logicMode: "AND", searchText: "test",
             searchColumns: ["name"], sortColumns: [], limit: 100, offset: 0
         )
@@ -109,7 +109,7 @@ struct BigQueryQueryBuilderCombinedTests {
     func combinedPreservesBoth() {
         let query = BigQueryQueryBuilder.encodeCombinedQuery(
             table: "users", dataset: "main",
-            filters: [(column: "status", op: "!=", value: "deleted")],
+            filters: [PluginQueryFilter(column: "status", op: "!=", value: "deleted")],
             logicMode: "AND", searchText: "alice",
             searchColumns: ["name", "email"], sortColumns: [], limit: 100, offset: 0
         )
@@ -128,7 +128,7 @@ struct BigQueryQueryBuilderIsTaggedTests {
             table: "t", dataset: "d", sortColumns: [], limit: 10, offset: 0
         )
         let filter = BigQueryQueryBuilder.encodeFilteredQuery(
-            table: "t", dataset: "d", filters: [(column: "a", op: "=", value: "b")],
+            table: "t", dataset: "d", filters: [PluginQueryFilter(column: "a", op: "=", value: "b")],
             logicMode: "AND", sortColumns: [], limit: 10, offset: 0
         )
         #expect(BigQueryQueryBuilder.isTaggedQuery(browse))

--- a/TableProTests/Plugins/DocumentStoreCaseSensitivityTests.swift
+++ b/TableProTests/Plugins/DocumentStoreCaseSensitivityTests.swift
@@ -1,0 +1,199 @@
+//
+//  DocumentStoreCaseSensitivityTests.swift
+//  TableProTests
+//
+//  Case sensitivity in the drivers that match without SQL (#2048)
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@Suite("MongoDB Case Sensitivity")
+struct MongoDBCaseSensitivityTests {
+    private let builder = MongoDBQueryBuilder()
+
+    private func document(_ op: String, _ value: String, isCaseSensitive: Bool) -> String {
+        builder.buildFilterDocument(from: [
+            PluginQueryFilter(column: "name", op: op, value: value, isCaseSensitive: isCaseSensitive)
+        ])
+    }
+
+    @Test("Contains ignoring case asks for the ignore-case option")
+    func testContainsIgnoringCase() {
+        #expect(document("CONTAINS", "ali", isCaseSensitive: false).contains("\"$options\": \"i\""))
+    }
+
+    @Test("Contains matching case asks for no option")
+    func testContainsMatchingCase() {
+        #expect(!document("CONTAINS", "ali", isCaseSensitive: true).contains("$options"))
+    }
+
+    @Test("Starts with and ends with follow the same setting")
+    func testAnchoredOperators() {
+        #expect(document("STARTS WITH", "a", isCaseSensitive: false).contains("\"$options\": \"i\""))
+        #expect(!document("ENDS WITH", "a", isCaseSensitive: true).contains("$options"))
+    }
+
+    @Test("Equals matching case stays an exact value match")
+    func testEqualsMatchingCase() {
+        #expect(document("=", "Alice", isCaseSensitive: true) == "{\"name\": \"Alice\"}")
+    }
+
+    @Test("Equals ignoring case becomes an anchored ignore-case match")
+    func testEqualsIgnoringCase() {
+        let doc = document("=", "Alice", isCaseSensitive: false)
+        #expect(doc.contains("^Alice$"))
+        #expect(doc.contains("\"$options\": \"i\""))
+    }
+
+    @Test("Equals ignoring case escapes regex metacharacters in the value")
+    func testEqualsIgnoringCaseEscapes() {
+        #expect(document("=", "a.b", isCaseSensitive: false).contains("^a\\\\.b$"))
+    }
+
+    @Test("IN matching case keeps the list operator")
+    func testInListMatchingCase() {
+        #expect(document("IN", "a,b", isCaseSensitive: true).contains("$in"))
+    }
+
+    @Test("IN ignoring case becomes a set of anchored matches")
+    func testInListIgnoringCase() {
+        let doc = document("IN", "a,b", isCaseSensitive: false)
+        #expect(doc.contains("$or"))
+        #expect(doc.contains("^a$"))
+        #expect(doc.contains("^b$"))
+    }
+
+    @Test("NOT IN ignoring case negates the whole set")
+    func testNotInListIgnoringCase() {
+        #expect(document("NOT IN", "a,b", isCaseSensitive: false).contains("$nor"))
+    }
+}
+
+@Suite("Elasticsearch Case Sensitivity")
+struct ElasticsearchCaseSensitivityTests {
+    private let keywordField = ["status": ElasticsearchFieldInfo(type: "keyword", hasKeywordSubfield: false)]
+
+    private func clause(_ op: String, _ value: String, isCaseSensitive: Bool) -> [String: Any] {
+        ElasticsearchQueryBuilder.clause(
+            for: ElasticsearchFilterSpec(
+                column: "status", op: op, value: value, caseSensitive: isCaseSensitive
+            ),
+            fields: keywordField
+        )
+    }
+
+    @Test("Contains ignoring case sets the wildcard option")
+    func testContainsIgnoringCase() {
+        let wildcard = clause("CONTAINS", "x", isCaseSensitive: false)["wildcard"] as? [String: Any]
+        let options = wildcard?["status"] as? [String: Any]
+        #expect(options?["case_insensitive"] as? Bool == true)
+    }
+
+    @Test("Contains matching case leaves the option off")
+    func testContainsMatchingCase() {
+        let wildcard = clause("CONTAINS", "x", isCaseSensitive: true)["wildcard"] as? [String: Any]
+        let options = wildcard?["status"] as? [String: Any]
+        #expect(options?["case_insensitive"] == nil)
+    }
+
+    @Test("Equals ignoring case uses a term with the option")
+    func testEqualsIgnoringCase() {
+        let term = clause("=", "active", isCaseSensitive: false)["term"] as? [String: Any]
+        let options = term?["status"] as? [String: Any]
+        #expect(options?["case_insensitive"] as? Bool == true)
+        #expect(options?["value"] as? String == "active")
+    }
+
+    @Test("IN matching case keeps the terms query")
+    func testInListMatchingCase() {
+        #expect(clause("IN", "a,b", isCaseSensitive: true)["terms"] != nil)
+    }
+
+    @Test("IN ignoring case becomes a should of terms, since terms has no option")
+    func testInListIgnoringCase() {
+        let bool = clause("IN", "a,b", isCaseSensitive: false)["bool"] as? [String: Any]
+        let should = bool?["should"] as? [[String: Any]]
+        #expect(should?.count == 2)
+        #expect(bool?["minimum_should_match"] as? Int == 1)
+    }
+
+    @Test("Regex ignoring case sets the option")
+    func testRegexIgnoringCase() {
+        let regexp = clause("REGEX", "a.*", isCaseSensitive: false)["regexp"] as? [String: Any]
+        let options = regexp?["status"] as? [String: Any]
+        #expect(options?["case_insensitive"] as? Bool == true)
+    }
+}
+
+@Suite("etcd Case Sensitivity")
+struct EtcdCaseSensitivityTests {
+    private let builder = EtcdQueryBuilder()
+
+    private func parsed(_ isCaseSensitive: Bool) -> EtcdParsedQuery? {
+        let query = builder.buildFilteredQuery(
+            prefix: "/app",
+            filters: [
+                PluginQueryFilter(column: "Key", op: "CONTAINS", value: "cfg", isCaseSensitive: isCaseSensitive)
+            ],
+            logicMode: "AND",
+            sortColumns: [],
+            limit: 100,
+            offset: 0
+        )
+        return query.flatMap { EtcdQueryBuilder.parseRangeQuery($0) }
+    }
+
+    @Test("The encoded query carries the row's case setting")
+    func testCaseFlagRoundTrips() {
+        #expect(parsed(true)?.isCaseSensitive == true)
+        #expect(parsed(false)?.isCaseSensitive == false)
+    }
+
+    @Test("The rest of the query survives the extra field")
+    func testOtherFieldsSurvive() {
+        let range = parsed(false)
+        #expect(range?.prefix == "/app")
+        #expect(range?.filterType == .contains)
+        #expect(range?.filterValue == "cfg")
+        #expect(range?.limit == 100)
+    }
+}
+
+@Suite("BigQuery Case Sensitivity")
+struct BigQueryCaseSensitivityTests {
+    private func sql(_ op: String, _ value: String, isCaseSensitive: Bool) -> String {
+        let query = BigQueryQueryBuilder.encodeFilteredQuery(
+            table: "users", dataset: "main",
+            filters: [
+                PluginQueryFilter(column: "name", op: op, value: value, isCaseSensitive: isCaseSensitive)
+            ],
+            logicMode: "AND", sortColumns: [], limit: 10, offset: 0
+        )
+        guard let params = BigQueryQueryBuilder.decode(query) else { return "" }
+        return BigQueryQueryBuilder.buildSQL(from: params, projectId: "p", columns: ["name"])
+    }
+
+    @Test("Contains ignoring case folds both sides")
+    func testContainsIgnoringCase() {
+        let generated = sql("CONTAINS", "ali", isCaseSensitive: false)
+        #expect(generated.contains("LOWER(CAST(`name` AS STRING)) LIKE LOWER('%ali%')"))
+    }
+
+    @Test("Contains matching case stays untouched")
+    func testContainsMatchingCase() {
+        #expect(sql("CONTAINS", "ali", isCaseSensitive: true).contains("CAST(`name` AS STRING) LIKE '%ali%'"))
+    }
+
+    @Test("Equals ignoring case folds both sides")
+    func testEqualsIgnoringCase() {
+        #expect(sql("=", "Alice", isCaseSensitive: false).contains("LOWER(`name`) = LOWER('Alice')"))
+    }
+
+    @Test("BigQuery never emits an ESCAPE clause, which it does not support")
+    func testNoEscapeClause() {
+        #expect(!sql("CONTAINS", "ali", isCaseSensitive: false).contains("ESCAPE"))
+        #expect(!sql("CONTAINS", "ali", isCaseSensitive: true).contains("ESCAPE"))
+    }
+}

--- a/TableProTests/Plugins/DocumentStoreCaseSensitivityTests.swift
+++ b/TableProTests/Plugins/DocumentStoreCaseSensitivityTests.swift
@@ -125,6 +125,26 @@ struct ElasticsearchCaseSensitivityTests {
         let options = regexp?["status"] as? [String: Any]
         #expect(options?["case_insensitive"] as? Bool == true)
     }
+
+    @Test("A server too old for the option never receives it, whatever the row asks for")
+    func testVersionGateWinsOverTheRow() {
+        let gated = ElasticsearchQueryBuilder.clause(
+            for: ElasticsearchFilterSpec(column: "status", op: "CONTAINS", value: "x", caseSensitive: false),
+            fields: keywordField,
+            supportsCaseInsensitive: false
+        )
+        let options = (gated["wildcard"] as? [String: Any])?["status"] as? [String: Any]
+        #expect(options?["case_insensitive"] == nil)
+    }
+
+    @Test("A spec with no case setting keeps the behaviour each operator had before")
+    func testOperatorDefaultsMatchPriorBehaviour() {
+        #expect(ElasticsearchFilterSpec(column: "a", op: "CONTAINS", value: "x").ignoresCase)
+        #expect(ElasticsearchFilterSpec(column: "a", op: "STARTS WITH", value: "x").ignoresCase)
+        #expect(ElasticsearchFilterSpec(column: "a", op: "REGEX", value: "x").ignoresCase)
+        #expect(ElasticsearchFilterSpec(column: "a", op: "=", value: "x").ignoresCase == false)
+        #expect(ElasticsearchFilterSpec(column: "a", op: "IN", value: "x").ignoresCase == false)
+    }
 }
 
 @Suite("etcd Case Sensitivity")
@@ -195,5 +215,35 @@ struct BigQueryCaseSensitivityTests {
     func testNoEscapeClause() {
         #expect(!sql("CONTAINS", "ali", isCaseSensitive: false).contains("ESCAPE"))
         #expect(!sql("CONTAINS", "ali", isCaseSensitive: true).contains("ESCAPE"))
+    }
+}
+
+@Suite("DynamoDB Case Sensitivity")
+struct DynamoDBCaseSensitivityTests {
+    @Test("A scan tag saved before this option existed keeps each operator's old behaviour")
+    func testLegacySpecDefaults() {
+        #expect(DynamoDBFilterSpec(column: "a", op: "CONTAINS", value: "x").ignoresCase)
+        #expect(DynamoDBFilterSpec(column: "a", op: "STARTS WITH", value: "x").ignoresCase)
+        #expect(DynamoDBFilterSpec(column: "a", op: "ENDS WITH", value: "x").ignoresCase)
+        #expect(DynamoDBFilterSpec(column: "a", op: "=", value: "x").ignoresCase == false)
+        #expect(DynamoDBFilterSpec(column: "a", op: "!=", value: "x").ignoresCase == false)
+    }
+
+    @Test("An explicit setting wins over the operator default")
+    func testExplicitSettingWins() {
+        #expect(DynamoDBFilterSpec(column: "a", op: "CONTAINS", value: "x", caseSensitive: true).ignoresCase == false)
+        #expect(DynamoDBFilterSpec(column: "a", op: "=", value: "x", caseSensitive: false).ignoresCase)
+    }
+
+    @Test("The setting survives the encode and decode round trip")
+    func testRoundTrip() throws {
+        let query = DynamoDBQueryBuilder().buildFilteredQuery(
+            table: "Users",
+            filters: [PluginQueryFilter(column: "name", op: "CONTAINS", value: "al", isCaseSensitive: true)],
+            logicMode: "AND", sortColumns: [], columns: [], limit: 10, offset: 0,
+            keySchema: []
+        )
+        let parsed = try #require(query.flatMap { DynamoDBQueryBuilder.parseScanQuery($0) })
+        #expect(parsed.filters.first?.ignoresCase == false)
     }
 }

--- a/TableProTests/Plugins/DynamoDBQueryBuilderTests.swift
+++ b/TableProTests/Plugins/DynamoDBQueryBuilderTests.swift
@@ -39,7 +39,7 @@ struct DynamoDBQueryBuilderFilteredTests {
     func nonPkFilterReturnsScan() {
         let query = builder.buildFilteredQuery(
             table: "Users",
-            filters: [(column: "name", op: "=", value: "Alice")],
+            filters: [PluginQueryFilter(column: "name", op: "=", value: "Alice")],
             logicMode: "AND",
             sortColumns: [],
             columns: ["id", "name"],
@@ -56,7 +56,7 @@ struct DynamoDBQueryBuilderFilteredTests {
     func pkFilterReturnsQuery() {
         let query = builder.buildFilteredQuery(
             table: "Users",
-            filters: [(column: "id", op: "=", value: "pk1")],
+            filters: [PluginQueryFilter(column: "id", op: "=", value: "pk1")],
             logicMode: "AND",
             sortColumns: [],
             columns: ["id", "name"],
@@ -74,8 +74,8 @@ struct DynamoDBQueryBuilderFilteredTests {
         let query = builder.buildFilteredQuery(
             table: "Users",
             filters: [
-                (column: "id", op: "=", value: "pk1"),
-                (column: "name", op: "CONTAINS", value: "Al")
+                PluginQueryFilter(column: "id", op: "=", value: "pk1"),
+                PluginQueryFilter(column: "name", op: "CONTAINS", value: "Al")
             ],
             logicMode: "AND",
             sortColumns: [],
@@ -99,8 +99,8 @@ struct DynamoDBQueryBuilderFilteredTests {
         let query = builder.buildFilteredQuery(
             table: "Users",
             filters: [
-                (column: "name", op: "=", value: "Alice"),
-                (column: "age", op: ">", value: "25")
+                PluginQueryFilter(column: "name", op: "=", value: "Alice"),
+                PluginQueryFilter(column: "age", op: ">", value: "25")
             ],
             logicMode: "AND",
             sortColumns: [],
@@ -127,7 +127,7 @@ struct DynamoDBQueryBuilderCombinedTests {
     func filtersOnly() {
         let query = builder.buildCombinedQuery(
             table: "Users",
-            filters: [(column: "name", op: "=", value: "Alice")],
+            filters: [PluginQueryFilter(column: "name", op: "=", value: "Alice")],
             logicMode: "AND",
             searchText: "",
             sortColumns: [],
@@ -166,7 +166,7 @@ struct DynamoDBQueryBuilderCombinedTests {
     func filtersAndSearch() {
         let query = builder.buildCombinedQuery(
             table: "Users",
-            filters: [(column: "name", op: "=", value: "Alice")],
+            filters: [PluginQueryFilter(column: "name", op: "=", value: "Alice")],
             logicMode: "AND",
             searchText: "test",
             sortColumns: [],
@@ -234,7 +234,7 @@ struct DynamoDBQueryBuilderParseQueryTests {
         let builder = DynamoDBQueryBuilder()
         let query = builder.buildFilteredQuery(
             table: "Users",
-            filters: [(column: "id", op: "=", value: "pk1")],
+            filters: [PluginQueryFilter(column: "id", op: "=", value: "pk1")],
             logicMode: "AND",
             sortColumns: [],
             columns: ["id", "name"],
@@ -311,7 +311,7 @@ struct DynamoDBQueryBuilderIsTaggedTests {
         let builder = DynamoDBQueryBuilder()
         let query = builder.buildFilteredQuery(
             table: "T",
-            filters: [(column: "id", op: "=", value: "x")],
+            filters: [PluginQueryFilter(column: "id", op: "=", value: "x")],
             logicMode: "AND",
             sortColumns: [],
             columns: ["id"],

--- a/TableProTests/Plugins/ElasticsearchDriverTests.swift
+++ b/TableProTests/Plugins/ElasticsearchDriverTests.swift
@@ -59,7 +59,7 @@ struct ElasticsearchQueryBuilderEncodingTests {
     func filteredRoundTrip() {
         let query = builder.buildFilteredQuery(
             index: "users",
-            filters: [(column: "age", op: ">", value: "21")],
+            filters: [PluginQueryFilter(column: "age", op: ">", value: "21")],
             logicMode: "AND",
             sorts: [ElasticsearchSortSpec(column: "name", ascending: true)],
             limit: 100,

--- a/TableProTests/Plugins/ElasticsearchDriverTests.swift
+++ b/TableProTests/Plugins/ElasticsearchDriverTests.swift
@@ -194,12 +194,12 @@ struct ElasticsearchQueryDSLTests {
     func caseInsensitiveGated() {
         let on = ElasticsearchQueryBuilder.clause(
             for: ElasticsearchFilterSpec(column: "status", op: "CONTAINS", value: "x"),
-            fields: keywordField, caseInsensitive: true
+            fields: keywordField, supportsCaseInsensitive: true
         )
         #expect((on["wildcard"] as? [String: Any]).map { ($0["status"] as? [String: Any])?["case_insensitive"] as? Bool } == true)
         let off = ElasticsearchQueryBuilder.clause(
             for: ElasticsearchFilterSpec(column: "status", op: "CONTAINS", value: "x"),
-            fields: keywordField, caseInsensitive: false
+            fields: keywordField, supportsCaseInsensitive: false
         )
         let offOptions = (off["wildcard"] as? [String: Any])?["status"] as? [String: Any]
         #expect(offOptions?["case_insensitive"] == nil)

--- a/TableProTests/Plugins/EtcdQueryBuilderTests.swift
+++ b/TableProTests/Plugins/EtcdQueryBuilderTests.swift
@@ -77,7 +77,7 @@ struct EtcdQueryBuilderFilteredTests {
     func keyEqualsFilter() {
         let query = builder.buildFilteredQuery(
             prefix: "",
-            filters: [(column: "Key", op: "=", value: "/app/config")],
+            filters: [PluginQueryFilter(column: "Key", op: "=", value: "/app/config")],
             logicMode: "AND",
             sortColumns: [],
             limit: 100,
@@ -93,7 +93,7 @@ struct EtcdQueryBuilderFilteredTests {
     func keyContainsFilter() {
         let query = builder.buildFilteredQuery(
             prefix: "",
-            filters: [(column: "Key", op: "CONTAINS", value: "config")],
+            filters: [PluginQueryFilter(column: "Key", op: "CONTAINS", value: "config")],
             logicMode: "AND",
             sortColumns: [],
             limit: 100,
@@ -109,7 +109,7 @@ struct EtcdQueryBuilderFilteredTests {
     func keyStartsWithFilter() {
         let query = builder.buildFilteredQuery(
             prefix: "",
-            filters: [(column: "Key", op: "STARTS WITH", value: "/app")],
+            filters: [PluginQueryFilter(column: "Key", op: "STARTS WITH", value: "/app")],
             logicMode: "AND",
             sortColumns: [],
             limit: 100,
@@ -125,7 +125,7 @@ struct EtcdQueryBuilderFilteredTests {
     func keyEndsWithFilter() {
         let query = builder.buildFilteredQuery(
             prefix: "",
-            filters: [(column: "Key", op: "ENDS WITH", value: ".json")],
+            filters: [PluginQueryFilter(column: "Key", op: "ENDS WITH", value: ".json")],
             logicMode: "AND",
             sortColumns: [],
             limit: 100,
@@ -141,7 +141,7 @@ struct EtcdQueryBuilderFilteredTests {
     func unsupportedValueFilter() {
         let query = builder.buildFilteredQuery(
             prefix: "",
-            filters: [(column: "Value", op: "CONTAINS", value: "test")],
+            filters: [PluginQueryFilter(column: "Value", op: "CONTAINS", value: "test")],
             logicMode: "AND",
             sortColumns: [],
             limit: 100,
@@ -154,7 +154,7 @@ struct EtcdQueryBuilderFilteredTests {
     func unsupportedLeaseFilter() {
         let query = builder.buildFilteredQuery(
             prefix: "",
-            filters: [(column: "Lease", op: "=", value: "123")],
+            filters: [PluginQueryFilter(column: "Lease", op: "=", value: "123")],
             logicMode: "AND",
             sortColumns: [],
             limit: 100,
@@ -168,8 +168,8 @@ struct EtcdQueryBuilderFilteredTests {
         let query = builder.buildFilteredQuery(
             prefix: "",
             filters: [
-                (column: "Key", op: "CONTAINS", value: "test"),
-                (column: "Value", op: "CONTAINS", value: "data")
+                PluginQueryFilter(column: "Key", op: "CONTAINS", value: "test"),
+                PluginQueryFilter(column: "Value", op: "CONTAINS", value: "data")
             ],
             logicMode: "AND",
             sortColumns: [],
@@ -183,7 +183,7 @@ struct EtcdQueryBuilderFilteredTests {
     func unknownFilterOp() {
         let query = builder.buildFilteredQuery(
             prefix: "",
-            filters: [(column: "Key", op: "REGEX", value: ".*")],
+            filters: [PluginQueryFilter(column: "Key", op: "REGEX", value: ".*")],
             logicMode: "AND",
             sortColumns: [],
             limit: 100,
@@ -205,7 +205,7 @@ struct EtcdQueryBuilderCombinedTests {
     func searchTextTakesPrecedence() {
         let query = builder.buildCombinedQuery(
             prefix: "",
-            filters: [(column: "Key", op: "=", value: "exact")],
+            filters: [PluginQueryFilter(column: "Key", op: "=", value: "exact")],
             logicMode: "AND",
             searchText: "search",
             sortColumns: [],
@@ -222,7 +222,7 @@ struct EtcdQueryBuilderCombinedTests {
     func emptySearchFallsBackToFilters() {
         let query = builder.buildCombinedQuery(
             prefix: "",
-            filters: [(column: "Key", op: "=", value: "exact")],
+            filters: [PluginQueryFilter(column: "Key", op: "=", value: "exact")],
             logicMode: "AND",
             searchText: "",
             sortColumns: [],
@@ -239,7 +239,7 @@ struct EtcdQueryBuilderCombinedTests {
     func combinedUnsupportedFilter() {
         let query = builder.buildCombinedQuery(
             prefix: "",
-            filters: [(column: "Value", op: "CONTAINS", value: "test")],
+            filters: [PluginQueryFilter(column: "Value", op: "CONTAINS", value: "test")],
             logicMode: "AND",
             searchText: "",
             sortColumns: [],

--- a/TableProTests/Plugins/MongoDBQueryBuilderTests.swift
+++ b/TableProTests/Plugins/MongoDBQueryBuilderTests.swift
@@ -110,7 +110,7 @@ struct MongoDBQueryBuilderTests {
     func filteredQueryEquals() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [(column: "name", op: "=", value: "Alice")]
+            queryFilters: [PluginQueryFilter(column: "name", op: "=", value: "Alice")]
         )
         #expect(query.contains("\"name\": \"Alice\""))
     }
@@ -119,7 +119,7 @@ struct MongoDBQueryBuilderTests {
     func filteredQueryNumericEquals() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [(column: "age", op: "=", value: "30")]
+            queryFilters: [PluginQueryFilter(column: "age", op: "=", value: "30")]
         )
         #expect(query.contains("\"age\": 30"))
     }
@@ -128,7 +128,7 @@ struct MongoDBQueryBuilderTests {
     func filteredQueryBoolean() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [(column: "active", op: "=", value: "true")]
+            queryFilters: [PluginQueryFilter(column: "active", op: "=", value: "true")]
         )
         #expect(query.contains("\"active\": true"))
     }
@@ -137,9 +137,9 @@ struct MongoDBQueryBuilderTests {
     func filteredQueryMultipleAnd() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [
-                (column: "name", op: "=", value: "Alice"),
-                (column: "age", op: ">", value: "25")
+            queryFilters: [
+                PluginQueryFilter(column: "name", op: "=", value: "Alice"),
+                PluginQueryFilter(column: "age", op: ">", value: "25")
             ],
             logicMode: "and"
         )
@@ -152,9 +152,9 @@ struct MongoDBQueryBuilderTests {
     func filteredQueryMultipleOr() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [
-                (column: "name", op: "=", value: "Alice"),
-                (column: "name", op: "=", value: "Bob")
+            queryFilters: [
+                PluginQueryFilter(column: "name", op: "=", value: "Alice"),
+                PluginQueryFilter(column: "name", op: "=", value: "Bob")
             ],
             logicMode: "or"
         )
@@ -165,7 +165,7 @@ struct MongoDBQueryBuilderTests {
     func filteredQuerySingleFilter() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [(column: "name", op: "=", value: "Alice")]
+            queryFilters: [PluginQueryFilter(column: "name", op: "=", value: "Alice")]
         )
         #expect(!query.contains("$and"))
         #expect(!query.contains("$or"))
@@ -175,7 +175,7 @@ struct MongoDBQueryBuilderTests {
     func filteredQueryNotEqual() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [(column: "status", op: "!=", value: "inactive")]
+            queryFilters: [PluginQueryFilter(column: "status", op: "!=", value: "inactive")]
         )
         #expect(query.contains("\"$ne\": \"inactive\""))
     }
@@ -184,7 +184,7 @@ struct MongoDBQueryBuilderTests {
     func filteredQueryGte() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [(column: "age", op: ">=", value: "18")]
+            queryFilters: [PluginQueryFilter(column: "age", op: ">=", value: "18")]
         )
         #expect(query.contains("\"$gte\": 18"))
     }
@@ -193,7 +193,7 @@ struct MongoDBQueryBuilderTests {
     func filteredQueryLt() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [(column: "score", op: "<", value: "100")]
+            queryFilters: [PluginQueryFilter(column: "score", op: "<", value: "100")]
         )
         #expect(query.contains("\"$lt\": 100"))
     }
@@ -202,17 +202,29 @@ struct MongoDBQueryBuilderTests {
     func filteredQueryContains() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [(column: "name", op: "CONTAINS", value: "ali")]
+            queryFilters: [
+                PluginQueryFilter(column: "name", op: "CONTAINS", value: "ali", isCaseSensitive: false)
+            ]
         )
         #expect(query.contains("\"$regex\": \"ali\""))
         #expect(query.contains("\"$options\": \"i\""))
+    }
+
+    @Test("Filtered query with CONTAINS matching case drops the ignore-case option")
+    func filteredQueryContainsMatchingCase() {
+        let query = builder.buildFilteredQuery(
+            collection: "users",
+            queryFilters: [PluginQueryFilter(column: "name", op: "CONTAINS", value: "ali")]
+        )
+        #expect(query.contains("\"$regex\": \"ali\""))
+        #expect(!query.contains("$options"))
     }
 
     @Test("Filtered query with NOT CONTAINS operator")
     func filteredQueryNotContains() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [(column: "name", op: "NOT CONTAINS", value: "test")]
+            queryFilters: [PluginQueryFilter(column: "name", op: "NOT CONTAINS", value: "test")]
         )
         #expect(query.contains("\"$not\""))
         #expect(query.contains("\"$regex\": \"test\""))
@@ -222,7 +234,7 @@ struct MongoDBQueryBuilderTests {
     func filteredQueryStartsWith() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [(column: "name", op: "STARTS WITH", value: "Al")]
+            queryFilters: [PluginQueryFilter(column: "name", op: "STARTS WITH", value: "Al")]
         )
         #expect(query.contains("\"$regex\": \"^Al\""))
     }
@@ -231,7 +243,7 @@ struct MongoDBQueryBuilderTests {
     func filteredQueryEndsWith() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [(column: "name", op: "ENDS WITH", value: "ice")]
+            queryFilters: [PluginQueryFilter(column: "name", op: "ENDS WITH", value: "ice")]
         )
         #expect(query.contains("\"$regex\": \"ice$\""))
     }
@@ -240,7 +252,7 @@ struct MongoDBQueryBuilderTests {
     func filteredQueryIsNull() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [(column: "email", op: "IS NULL", value: "")]
+            queryFilters: [PluginQueryFilter(column: "email", op: "IS NULL", value: "")]
         )
         #expect(query.contains("\"email\": null"))
     }
@@ -249,7 +261,7 @@ struct MongoDBQueryBuilderTests {
     func filteredQueryIsNotNull() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [(column: "email", op: "IS NOT NULL", value: "")]
+            queryFilters: [PluginQueryFilter(column: "email", op: "IS NOT NULL", value: "")]
         )
         #expect(query.contains("\"email\": {\"$ne\": null}"))
     }
@@ -258,7 +270,7 @@ struct MongoDBQueryBuilderTests {
     func filteredQueryIsEmpty() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [(column: "bio", op: "IS EMPTY", value: "")]
+            queryFilters: [PluginQueryFilter(column: "bio", op: "IS EMPTY", value: "")]
         )
         #expect(query.contains("\"bio\": \"\""))
     }
@@ -267,7 +279,7 @@ struct MongoDBQueryBuilderTests {
     func filteredQueryIsNotEmpty() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [(column: "bio", op: "IS NOT EMPTY", value: "")]
+            queryFilters: [PluginQueryFilter(column: "bio", op: "IS NOT EMPTY", value: "")]
         )
         #expect(query.contains("\"bio\": {\"$ne\": \"\"}"))
     }
@@ -276,7 +288,7 @@ struct MongoDBQueryBuilderTests {
     func filteredQueryRegex() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [(column: "name", op: "REGEX", value: "^[A-Z].*")]
+            queryFilters: [PluginQueryFilter(column: "name", op: "REGEX", value: "^[A-Z].*")]
         )
         #expect(query.contains("\"$regex\": \"^[A-Z].*\""))
     }
@@ -285,7 +297,7 @@ struct MongoDBQueryBuilderTests {
     func filteredQueryWithSortAndOffset() {
         let query = builder.buildFilteredQuery(
             collection: "users",
-            filters: [(column: "name", op: "=", value: "Alice")],
+            queryFilters: [PluginQueryFilter(column: "name", op: "=", value: "Alice")],
             sortColumns: [(columnIndex: 0, ascending: true)],
             columns: ["name"],
             limit: 50,
@@ -301,7 +313,7 @@ struct MongoDBQueryBuilderTests {
     @Test("Filter document with IN operator")
     func filterDocumentIn() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "status", op: "IN", value: "active, inactive, pending")]
+            from: [PluginQueryFilter(column: "status", op: "IN", value: "active, inactive, pending")]
         )
         #expect(doc.contains("\"$in\""))
         #expect(doc.contains("\"active\""))
@@ -312,7 +324,7 @@ struct MongoDBQueryBuilderTests {
     @Test("Filter document with IN operator numeric values")
     func filterDocumentInNumeric() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "age", op: "IN", value: "18, 25, 30")]
+            from: [PluginQueryFilter(column: "age", op: "IN", value: "18, 25, 30")]
         )
         #expect(doc.contains("\"$in\": [18, 25, 30]"))
     }
@@ -320,7 +332,7 @@ struct MongoDBQueryBuilderTests {
     @Test("Filter document with NOT IN operator")
     func filterDocumentNotIn() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "status", op: "NOT IN", value: "banned, deleted")]
+            from: [PluginQueryFilter(column: "status", op: "NOT IN", value: "banned, deleted")]
         )
         #expect(doc.contains("\"$nin\""))
         #expect(doc.contains("\"banned\""))
@@ -330,7 +342,7 @@ struct MongoDBQueryBuilderTests {
     @Test("Filter document with BETWEEN operator")
     func filterDocumentBetween() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "age", op: "BETWEEN", value: "18, 65")]
+            from: [PluginQueryFilter(column: "age", op: "BETWEEN", value: "18, 65")]
         )
         #expect(doc.contains("\"$gte\": 18"))
         #expect(doc.contains("\"$lte\": 65"))
@@ -339,7 +351,7 @@ struct MongoDBQueryBuilderTests {
     @Test("Filter document with BETWEEN invalid format returns empty")
     func filterDocumentBetweenInvalid() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "age", op: "BETWEEN", value: "18")]
+            from: [PluginQueryFilter(column: "age", op: "BETWEEN", value: "18")]
         )
         #expect(doc == "{}")
     }
@@ -353,7 +365,7 @@ struct MongoDBQueryBuilderTests {
     @Test("Filter document with unknown operator returns empty object")
     func filterDocumentUnknownOp() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "x", op: "UNKNOWN_OP", value: "y")]
+            from: [PluginQueryFilter(column: "x", op: "UNKNOWN_OP", value: "y")]
         )
         #expect(doc == "{}")
     }
@@ -361,7 +373,7 @@ struct MongoDBQueryBuilderTests {
     @Test("Filter document with float value")
     func filterDocumentFloat() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "price", op: "=", value: "19.99")]
+            from: [PluginQueryFilter(column: "price", op: "=", value: "19.99")]
         )
         #expect(doc.contains("\"price\": 19.99"))
     }
@@ -369,7 +381,7 @@ struct MongoDBQueryBuilderTests {
     @Test("Filter document emits JSON-valid scientific numbers")
     func filterDocumentScientificNumber() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "score", op: "=", value: "1.5e-3")]
+            from: [PluginQueryFilter(column: "score", op: "=", value: "1.5e-3")]
         )
         let parsed = parseFilter(doc)
         #expect(parsed?["score"] as? Double == 0.0015)
@@ -380,7 +392,7 @@ struct MongoDBQueryBuilderTests {
         let values = [".5", "1.", "+7", "01", "NaN", "Infinity"]
         for value in values {
             let doc = builder.buildFilterDocument(
-                from: [(column: "score", op: "=", value: value)]
+                from: [PluginQueryFilter(column: "score", op: "=", value: value)]
             )
             let parsed = parseFilter(doc)
             #expect(parsed?["score"] as? String == value)
@@ -390,7 +402,7 @@ struct MongoDBQueryBuilderTests {
     @Test("Filter document quotes integers that overflow Int64 to preserve precision")
     func filterDocumentQuotesInt64Overflow() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "code", op: "=", value: "12345678901234567890")]
+            from: [PluginQueryFilter(column: "code", op: "=", value: "12345678901234567890")]
         )
         let parsed = parseFilter(doc)
         #expect(parsed?["code"] as? String == "12345678901234567890")
@@ -400,7 +412,7 @@ struct MongoDBQueryBuilderTests {
     func filterDocumentQuotesOutOfRangeExponent() {
         for value in ["1e400", "-1e400", "1.5e400"] {
             let doc = builder.buildFilterDocument(
-                from: [(column: "score", op: "=", value: value)]
+                from: [PluginQueryFilter(column: "score", op: "=", value: value)]
             )
             let parsed = parseFilter(doc)
             #expect(parsed?["score"] as? String == value)
@@ -410,7 +422,7 @@ struct MongoDBQueryBuilderTests {
     @Test("Filter document emits the largest Int64 integer unquoted")
     func filterDocumentEmitsMaxInt64() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "code", op: "=", value: "9223372036854775807")]
+            from: [PluginQueryFilter(column: "code", op: "=", value: "9223372036854775807")]
         )
         #expect(doc.contains("\"code\": 9223372036854775807"))
     }
@@ -418,7 +430,7 @@ struct MongoDBQueryBuilderTests {
     @Test("Filter document with null literal")
     func filterDocumentNullLiteral() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "field", op: "=", value: "null")]
+            from: [PluginQueryFilter(column: "field", op: "=", value: "null")]
         )
         #expect(doc.contains("\"field\": null"))
     }
@@ -430,7 +442,7 @@ struct MongoDBQueryBuilderTests {
     func combinedQuery() {
         let query = builder.buildCombinedQuery(
             collection: "users",
-            filters: [(column: "age", op: ">", value: "25")],
+            filters: [PluginQueryFilter(column: "age", op: ">", value: "25")],
             searchText: "john",
             searchColumns: ["name", "email"]
         )
@@ -444,7 +456,7 @@ struct MongoDBQueryBuilderTests {
     func combinedQueryWithSortAndOffset() {
         let query = builder.buildCombinedQuery(
             collection: "users",
-            filters: [(column: "age", op: ">", value: "18")],
+            filters: [PluginQueryFilter(column: "age", op: ">", value: "18")],
             searchText: "test",
             searchColumns: ["name"],
             sortColumns: [(columnIndex: 0, ascending: false)],
@@ -518,7 +530,7 @@ struct MongoDBQueryBuilderTests {
     @Test("Equals on an ObjectId value matches both the ObjectId and the string form")
     func equalsObjectIdDualMatch() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "_id", op: "=", value: "66c0fa26dfcb27034e646356")]
+            from: [PluginQueryFilter(column: "_id", op: "=", value: "66c0fa26dfcb27034e646356")]
         )
         let parsed = parseFilter(doc)
         let branches = parsed?["$or"] as? [[String: Any]]
@@ -531,7 +543,7 @@ struct MongoDBQueryBuilderTests {
     @Test("Equals on a non-ObjectId string stays a plain string match")
     func equalsNonObjectIdString() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "_id", op: "=", value: "user-123")]
+            from: [PluginQueryFilter(column: "_id", op: "=", value: "user-123")]
         )
         #expect(!doc.contains("$or"))
         #expect(!doc.contains("$oid"))
@@ -541,7 +553,7 @@ struct MongoDBQueryBuilderTests {
     @Test("Equals on a 23-character hex value is not treated as an ObjectId")
     func equalsShortHexNotObjectId() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "_id", op: "=", value: "66c0fa26dfcb27034e64635")]
+            from: [PluginQueryFilter(column: "_id", op: "=", value: "66c0fa26dfcb27034e64635")]
         )
         #expect(!doc.contains("$oid"))
     }
@@ -549,7 +561,7 @@ struct MongoDBQueryBuilderTests {
     @Test("Equals on a 24-character non-hex value is not treated as an ObjectId")
     func equalsNonHexNotObjectId() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "_id", op: "=", value: "zzc0fa26dfcb27034e646356")]
+            from: [PluginQueryFilter(column: "_id", op: "=", value: "zzc0fa26dfcb27034e646356")]
         )
         #expect(!doc.contains("$oid"))
     }
@@ -557,7 +569,7 @@ struct MongoDBQueryBuilderTests {
     @Test("ObjectId matching applies to non-_id reference fields too")
     func equalsObjectIdReferenceField() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "userId", op: "=", value: "66c0fa26dfcb27034e646356")]
+            from: [PluginQueryFilter(column: "userId", op: "=", value: "66c0fa26dfcb27034e646356")]
         )
         let branches = parseFilter(doc)?["$or"] as? [[String: Any]]
         let oid = (branches?.first?["userId"] as? [String: Any])?["$oid"] as? String
@@ -567,7 +579,7 @@ struct MongoDBQueryBuilderTests {
     @Test("Not-equals on an ObjectId value excludes both the ObjectId and the string form")
     func notEqualsObjectIdDualMatch() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "_id", op: "!=", value: "66c0fa26dfcb27034e646356")]
+            from: [PluginQueryFilter(column: "_id", op: "!=", value: "66c0fa26dfcb27034e646356")]
         )
         let nin = (parseFilter(doc)?["_id"] as? [String: Any])?["$nin"] as? [Any]
         #expect(nin?.count == 2)
@@ -579,7 +591,7 @@ struct MongoDBQueryBuilderTests {
     @Test("IN expands an ObjectId item to both forms and leaves plain items alone")
     func inExpandsObjectIdItems() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "_id", op: "IN", value: "66c0fa26dfcb27034e646356, plain-id")]
+            from: [PluginQueryFilter(column: "_id", op: "IN", value: "66c0fa26dfcb27034e646356, plain-id")]
         )
         let inArray = (parseFilter(doc)?["_id"] as? [String: Any])?["$in"] as? [Any]
         #expect(inArray?.count == 3)
@@ -593,7 +605,7 @@ struct MongoDBQueryBuilderTests {
     @Test("NOT IN expands an ObjectId item to both forms")
     func notInExpandsObjectIdItems() {
         let doc = builder.buildFilterDocument(
-            from: [(column: "_id", op: "NOT IN", value: "66c0fa26dfcb27034e646356, plain-id")]
+            from: [PluginQueryFilter(column: "_id", op: "NOT IN", value: "66c0fa26dfcb27034e646356, plain-id")]
         )
         let ninArray = (parseFilter(doc)?["_id"] as? [String: Any])?["$nin"] as? [Any]
         #expect(ninArray?.count == 3)
@@ -607,8 +619,8 @@ struct MongoDBQueryBuilderTests {
     func objectIdEqualsCombinedWithAndFilter() {
         let doc = builder.buildFilterDocument(
             from: [
-                (column: "_id", op: "=", value: "66c0fa26dfcb27034e646356"),
-                (column: "shop", op: "=", value: "acme")
+                PluginQueryFilter(column: "_id", op: "=", value: "66c0fa26dfcb27034e646356"),
+                PluginQueryFilter(column: "shop", op: "=", value: "acme")
             ],
             logicMode: "and"
         )
@@ -631,7 +643,9 @@ struct MongoDBQueryBuilderTests {
     func regexInjectionContained() {
         let payload = ".*\"}, \"$where\": \"function(){return true}\", \"_\":{\"a\":\""
         let doc = parseFilter(
-            builder.buildFilterDocument(from: [(column: "name", op: "REGEX", value: payload)])
+            builder.buildFilterDocument(from: [
+                PluginQueryFilter(column: "name", op: "REGEX", value: payload, isCaseSensitive: false)
+            ])
         )
         #expect(doc != nil)
         #expect(doc.map { Array($0.keys) } == ["name"])
@@ -641,11 +655,23 @@ struct MongoDBQueryBuilderTests {
         #expect(inner?["$options"] as? String == "i")
     }
 
+    @Test("Regex injection payload stays contained when matching case")
+    func regexInjectionContainedMatchingCase() {
+        let payload = ".*\"}, \"$where\": \"function(){return true}\", \"_\":{\"a\":\""
+        let doc = parseFilter(
+            builder.buildFilterDocument(from: [PluginQueryFilter(column: "name", op: "REGEX", value: payload)])
+        )
+        #expect(doc.map { Array($0.keys) } == ["name"])
+        let inner = doc?["name"] as? [String: Any]
+        #expect(inner.map { Array($0.keys) } == ["$regex"])
+        #expect(inner?["$regex"] as? String == payload)
+    }
+
     @Test("CONTAINS value cannot break out of the regex string to inject operators")
     func containsInjectionContained() {
         let payload = "\"}, \"$where\": \"return true"
         let doc = parseFilter(
-            builder.buildFilterDocument(from: [(column: "name", op: "CONTAINS", value: payload)])
+            builder.buildFilterDocument(from: [PluginQueryFilter(column: "name", op: "CONTAINS", value: payload)])
         )
         #expect(doc != nil)
         #expect(doc.map { Array($0.keys) } == ["name"])
@@ -657,7 +683,7 @@ struct MongoDBQueryBuilderTests {
     func notContainsInjectionContained() {
         let payload = "\"}}, \"$where\": \"1==1"
         let doc = parseFilter(
-            builder.buildFilterDocument(from: [(column: "name", op: "NOT CONTAINS", value: payload)])
+            builder.buildFilterDocument(from: [PluginQueryFilter(column: "name", op: "NOT CONTAINS", value: payload)])
         )
         #expect(doc != nil)
         #expect(doc.map { Array($0.keys) } == ["name"])
@@ -668,7 +694,7 @@ struct MongoDBQueryBuilderTests {
     @Test("STARTS WITH escapes embedded double quotes as data")
     func startsWithEscapesQuote() {
         let doc = parseFilter(
-            builder.buildFilterDocument(from: [(column: "name", op: "STARTS WITH", value: "Al\"ce")])
+            builder.buildFilterDocument(from: [PluginQueryFilter(column: "name", op: "STARTS WITH", value: "Al\"ce")])
         )
         #expect(doc != nil)
         let inner = doc?["name"] as? [String: Any]
@@ -678,7 +704,7 @@ struct MongoDBQueryBuilderTests {
     @Test("ENDS WITH escapes embedded double quotes as data")
     func endsWithEscapesQuote() {
         let doc = parseFilter(
-            builder.buildFilterDocument(from: [(column: "name", op: "ENDS WITH", value: "ce\"Al")])
+            builder.buildFilterDocument(from: [PluginQueryFilter(column: "name", op: "ENDS WITH", value: "ce\"Al")])
         )
         #expect(doc != nil)
         let inner = doc?["name"] as? [String: Any]
@@ -688,7 +714,7 @@ struct MongoDBQueryBuilderTests {
     @Test("CONTAINS escapes a backslash to a literal-backslash regex")
     func containsEscapesBackslash() {
         let doc = parseFilter(
-            builder.buildFilterDocument(from: [(column: "path", op: "CONTAINS", value: "\\")])
+            builder.buildFilterDocument(from: [PluginQueryFilter(column: "path", op: "CONTAINS", value: "\\")])
         )
         #expect(doc != nil)
         let inner = doc?["path"] as? [String: Any]
@@ -699,7 +725,7 @@ struct MongoDBQueryBuilderTests {
     func regexPreservesMetacharacters() {
         let value = "^[A-Z].*\\d$"
         let doc = parseFilter(
-            builder.buildFilterDocument(from: [(column: "name", op: "REGEX", value: value)])
+            builder.buildFilterDocument(from: [PluginQueryFilter(column: "name", op: "REGEX", value: value)])
         )
         #expect(doc != nil)
         let inner = doc?["name"] as? [String: Any]
@@ -709,7 +735,7 @@ struct MongoDBQueryBuilderTests {
     @Test("REGEX keeps an embedded double quote as data")
     func regexEscapesQuote() {
         let doc = parseFilter(
-            builder.buildFilterDocument(from: [(column: "name", op: "REGEX", value: "a\"b")])
+            builder.buildFilterDocument(from: [PluginQueryFilter(column: "name", op: "REGEX", value: "a\"b")])
         )
         #expect(doc != nil)
         let inner = doc?["name"] as? [String: Any]
@@ -719,7 +745,7 @@ struct MongoDBQueryBuilderTests {
     @Test("CONTAINS treats regex metacharacters as literals")
     func containsTreatsMetacharactersLiterally() {
         let doc = parseFilter(
-            builder.buildFilterDocument(from: [(column: "name", op: "CONTAINS", value: "a.b")])
+            builder.buildFilterDocument(from: [PluginQueryFilter(column: "name", op: "CONTAINS", value: "a.b")])
         )
         #expect(doc != nil)
         let inner = doc?["name"] as? [String: Any]

--- a/TableProTests/Views/FilterCaseSensitivityPresentationTests.swift
+++ b/TableProTests/Views/FilterCaseSensitivityPresentationTests.swift
@@ -1,0 +1,81 @@
+//
+//  FilterCaseSensitivityPresentationTests.swift
+//  TableProTests
+//
+//  How a filter row presents its case setting (#2048)
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+@testable import TablePro
+
+@Suite("Filter Case Sensitivity Presentation")
+struct FilterCaseSensitivityPresentationTests {
+
+    private func presentation(
+        _ filterOperator: FilterOperator,
+        isCaseSensitive: Bool,
+        style: SQLDialectDescriptor.CaseSensitivityStyle
+    ) -> FilterCaseSensitivityPresentation {
+        FilterCaseSensitivityPresentation(
+            filterOperator: filterOperator, isCaseSensitive: isCaseSensitive, style: style
+        )
+    }
+
+    @Test("Operators with no case dimension hide the control")
+    func testOperatorsWithoutCaseDimension() {
+        for filterOperator in [FilterOperator.isNull, .isNotNull, .isEmpty, .isNotEmpty, .between, .greaterThan] {
+            let result = presentation(filterOperator, isCaseSensitive: true, style: .ilikeOperator)
+            #expect(result.showsControl == false)
+            #expect(result.isAdjustable == false)
+            #expect(result.showsIndicator == false)
+        }
+    }
+
+    @Test("An engine with ILIKE offers the control")
+    func testIlikeEngineIsAdjustable() {
+        let result = presentation(.contains, isCaseSensitive: false, style: .ilikeOperator)
+        #expect(result.showsControl)
+        #expect(result.isAdjustable)
+        #expect(result.fixedReason == nil)
+    }
+
+    @Test("A collation-driven engine shows the control but explains why it is fixed")
+    func testCollationDefinedIsFixed() {
+        let result = presentation(.contains, isCaseSensitive: false, style: .collationDefined)
+        #expect(result.showsControl)
+        #expect(result.isAdjustable == false)
+        #expect(result.fixedReason == "Set by the column's collation")
+    }
+
+    @Test("An engine that cannot ignore case says so")
+    func testUnsupportedIsFixed() {
+        let result = presentation(.contains, isCaseSensitive: false, style: .unsupported)
+        #expect(result.isAdjustable == false)
+        #expect(result.fixedReason == "Not supported by this database")
+    }
+
+    @Test("A driver that matches on its own offers the control")
+    func testDriverManagedIsAdjustable() {
+        #expect(presentation(.contains, isCaseSensitive: true, style: .driverManaged).isAdjustable)
+    }
+
+    @Test("The indicator stays off while a row uses its operator's usual setting")
+    func testIndicatorHiddenAtDefault() {
+        #expect(presentation(.contains, isCaseSensitive: false, style: .ilikeOperator).showsIndicator == false)
+        #expect(presentation(.equal, isCaseSensitive: true, style: .ilikeOperator).showsIndicator == false)
+    }
+
+    @Test("The indicator appears once a row departs from that setting")
+    func testIndicatorShownOnDeviation() {
+        #expect(presentation(.contains, isCaseSensitive: true, style: .ilikeOperator).showsIndicator)
+        #expect(presentation(.equal, isCaseSensitive: false, style: .ilikeOperator).showsIndicator)
+    }
+
+    @Test("A fixed engine never shows the indicator, since the row cannot deviate")
+    func testIndicatorHiddenWhenFixed() {
+        #expect(presentation(.contains, isCaseSensitive: true, style: .collationDefined).showsIndicator == false)
+        #expect(presentation(.contains, isCaseSensitive: true, style: .unsupported).showsIndicator == false)
+    }
+}

--- a/docs/features/filtering.mdx
+++ b/docs/features/filtering.mdx
@@ -37,6 +37,18 @@ Redis shows a key-pattern search bar (for example `user:*`) with a key-type pick
 
 BETWEEN shows two value fields. IN/NOT IN takes comma-separated values.
 
+## Case Sensitivity
+
+Contains, not contains, starts with, and ends with ignore case. Equals, not equals, IN, NOT IN, and regex match case. Open the operator menu and use **Match Case** to change either one for that row. A small `Aa` icon on the operator button marks a row that is not using its usual setting.
+
+TablePro picks the fastest form each database offers: `ILIKE` on PostgreSQL, DuckDB, CockroachDB, and Snowflake, and `LOWER()` on both sides for Oracle, BigQuery, ClickHouse, and Redshift, whose `ILIKE` only folds ASCII. Trino has no `ILIKE`, so it uses `regexp_like` with the `i` flag.
+
+<Note>
+On MySQL, MariaDB, SQL Server, SQLite, libSQL, and Cloudflare D1 the column's collation decides case sensitivity and TablePro cannot override it per query, so **Match Case** is greyed out. The default collation on these databases already ignores case. Cassandra and Redis have no case-insensitive matching at all, so the option is greyed out there too.
+</Note>
+
+Filters saved before this option existed follow the same rules, so a saved "contains" filter now ignores case on PostgreSQL, DuckDB, Oracle, and BigQuery. Turn **Match Case** on to get the old behavior back.
+
 ## Raw SQL
 
 The default mode. Type any WHERE condition directly:


### PR DESCRIPTION
Closes #2048.

## The problem

Case sensitivity had no representation anywhere: not in `TableFilter`, not in `FilterSQLGenerator`, and not in the `(column, op, value)` tuple that crosses into plugins. Case-sensitive `contains` on DuckDB is one visible instance of that missing dimension.

The gap was masked in opposite directions, which is why it read as a bug rather than a missing feature. MySQL, SQLite and SQL Server looked correct because their default collation already folds case. MongoDB, Elasticsearch, DynamoDB and etcd looked correct because they hardcoded `i`-mode with no way to turn it off. PostgreSQL, DuckDB, Oracle and BigQuery were simply where the absence showed.

## What changed

`TableFilter` gains `isCaseSensitive`, modelled on `NSComparisonPredicate.Options.caseInsensitive` and the `[c]` predicate-format modifier rather than doubling the operator enum. The operator dropdown stays at 18 entries.

Contains, not contains, starts with and ends with ignore case. Equals, not equals, IN, NOT IN and regex match case. Both are per row, and the setting lives in the operator menu under a divider, so picking an operator is still two clicks and the row gains no width. A row that departs from its operator's usual setting shows an `Aa` icon on the button, so the common case looks exactly as it does today.

`SQLDialectDescriptor` gains a `caseSensitivityStyle` that decides what each engine emits:

| Style | Engines | Ignore-case emits |
|---|---|---|
| `ilikeOperator` | PostgreSQL, CockroachDB, PGlite, DuckDB, Snowflake | `ILIKE` for the LIKE family, `LOWER()` for equals/IN |
| `caseFoldFunction` | Oracle, BigQuery, ClickHouse (`lowerUTF8`), Redshift | `LOWER(col) LIKE LOWER(pat)` |
| `regexFlag` | Trino | `regexp_like(col, pat, 'i')`, anchored per operator |
| `driverManaged` | MongoDB, Elasticsearch, DynamoDB, etcd | the driver's own mechanism |
| `collationDefined` | MySQL, MariaDB, SQL Server, SQLite, libSQL, Turso, D1 | today's SQL; control disabled |
| `unsupported` | Cassandra, ScyllaDB, Redis, any stale plugin binary | today's SQL; control disabled |

Two calls worth flagging:

- **Redshift and ClickHouse get `caseFoldFunction`, not `ilikeOperator`, even though both have `ILIKE`.** AWS documents Redshift's `ILIKE` as folding single-byte ASCII only and tells you to use `LOWER` for multibyte; ClickHouse folds by English rules on single-byte assumptions. Using their native operator would be silently wrong on non-ASCII data.
- **`collationDefined`, not "always case-insensitive".** TablePro cannot observe a column's collation, so claiming SQL Server always ignores case would be false on a `_CS_AS` database or a MySQL `_bin` column. The disabled control's tooltip says case sensitivity follows the column's collation, which is true.

## ABI

`SQLDialectDescriptor`'s single public init is called by every shipped registry plugin binary, so it gained a **new overload** with `@_disfavoredOverload` on the existing one, per the 0.49.0 `columnMeta:` lesson. Same technique for a new `buildFilteredQuery` / `fetchFilteredRowCount` / `fetchExactRowCount` overload taking a new `PluginQueryFilter` struct; the default implementations forward to the existing tuple versions, so an un-updated plugin returns exactly the SQL it returns today rather than dropping the filter.

Verified by building TableProPluginKit at `main` and at this branch and diffing exported symbols: **0 removed, 79 added.** `scripts/check-pluginkit-abi.sh` reports the diff, and every line in it is an addition apart from the old initializer, which reappears with an identical signature (`@_disfavoredOverload` does not change mangling). **No `currentPluginKitVersion` bump and no plugin re-release needed.**

A stale registry plugin reports `unsupported` and keeps today's behaviour. To avoid making users wait for a plugin release, `PluginMetadataRegistry.adoptCuratedCaseSensitivity` lets the app's curated entry fill that gap for engines it already knows, the same shape as the existing `withSwitchRouting` fallback. So DuckDB users get `ILIKE` on the next app build, without updating the DuckDB plugin.

## Behaviour change to be aware of

The new default applies to filters already saved to disk, so a saved `contains` filter now ignores case on PostgreSQL, DuckDB, ClickHouse, Snowflake, Redshift, CockroachDB, Oracle, BigQuery and Trino. That is the point of the change, and it is what makes those engines agree with MySQL, SQLite and MongoDB, but it is a change on upgrade rather than only a new feature. Match Case restores the old behaviour per row. MySQL, SQLite, SQL Server and the document stores see no change at all.

## One adjacent fix included

BigQuery's dialect declared `likeEscapeStyle: .explicit`, so the exact-row-count path emitted `LIKE '%x%' ESCAPE '!'`. BigQuery has no `ESCAPE` clause, so that count query was a syntax error. It is a one-line correction inside the function this change rewrites, and shipping the new feature on top of it would have shipped it broken. Left out as separate issues: SQL Server not escaping `[` / `[^` in LIKE patterns, and MySQL under `NO_BACKSLASH_ESCAPES`. Neither is touched by this change.

## Tests

291 passing across the affected suites, including:

- a dialect x operator matrix over `FilterSQLGenerator` covering ILIKE, fold, regex-flag, collation-defined and unsupported engines
- legacy JSON with no case key decoding to the per-operator default, and a preset batch surviving a mix of old and new rows
- a guard that the pre-existing `SQLDialectDescriptor` initializer still yields `unsupported`, which is what keeps stale plugins safe
- MongoDB, Elasticsearch, DynamoDB, etcd and BigQuery builders in both directions
- a numeric column never getting a fold function wrapped around it, which would be a type error on strict engines
- the mobile generator mirrored in `TableProQueryTests`

No `TableProUITests` coverage: the filter panel needs a live connection and an open table tab, which the existing UI tests do not set up and which would not run deterministically in CI. The presentation rules were extracted into `FilterCaseSensitivityPresentation`, a pure type, and unit-tested instead.

## Verified

- macOS app builds; TablePro Mobile builds for the arm64 simulator slice
- `swiftlint lint --strict` clean across 1285 files
- PluginKit ABI symbol diff clean, as above
