### PR TITLE
feat(connections): show a full-window connecting surface with named stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Redshift external schemas now list their tables. Spectrum, federated query, cross-database, and datashare schemas showed up empty because their tables are not in the standard catalog.
 - External schemas are marked in the sidebar, and their tables show an external icon. External tables open read-only, because Redshift rejects `UPDATE` and `DELETE` on them.
 
+### Changed
+
+- Connecting to a database now fills the window instead of framing a spinner with an empty sidebar and inspector, and it names the step it is on: opening the tunnel, negotiating encryption, authenticating, preparing the session. PostgreSQL, CockroachDB, Redshift, ClickHouse, and Redis report their own handshake steps; the rest report the steps around the driver. A step that stalls says so rather than spinning silently.
+- A connection that fails now shows the database's own error wherever the connect started, including from a link or a database file, and offers Copy Details. Those routes used to drop the real message and report only that the connection had closed.
+- Opening a table or query from a link now opens its window straight away, so a slow connect has somewhere to report progress and a failed one has somewhere to explain itself.
+- A saved pre-connect script no longer runs when the app reopens a session on its own. The window waits with a Connect button, which asks before running it.
+
 ### Fixed
 
+- A dropped SSH tunnel that ran out of reconnect attempts left the window spinning forever with no way back. It now reports what happened and offers to try again.
+- A brief tunnel reconnect no longer closes your tabs. The window used to tear down the whole session on the blip, taking unsaved query edits with it.
+- The sidebar's filter field no longer sits over an empty sidebar while a connection is still being established.
 - The JSON view of a result now follows the grid: rows come in the order you sorted them, a column filter leaves its rows out, and hidden columns stay hidden. It used to show every row in fetch order, including rows the filter had removed, and columns you had hidden.
 - Copy JSON in the JSON view and Copy as JSON in the grid now produce the same output for the same rows.
 - The JSON view now updates when you change a column filter without running a new query.

--- a/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
+++ b/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
@@ -195,6 +195,10 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     // MARK: - Connection
 
     func connect() async throws {
+        try await connect(reportingStage: { _ in })
+    }
+
+    func connect(reportingStage report: @escaping ConnectionStageReporter) async throws {
         let urlConfig = URLSessionConfiguration.default
         urlConfig.timeoutIntervalForRequest = HttpQueryTimeout.sessionBootstrapRequestTimeout
         urlConfig.timeoutIntervalForResource = HttpQueryTimeout.sessionResourceTimeout
@@ -221,6 +225,7 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             throw ClickHouseError.connectionFailed
         }
 
+        report(.preparingSession)
         if let result = try? await executeRaw("SELECT version()"),
            let versionStr = result.rows.first?.first?.asText {
             _serverVersion = versionStr

--- a/Plugins/PostgreSQLDriverPlugin/LibPQDriverCore.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQDriverCore.swift
@@ -20,6 +20,11 @@ final class LibPQDriverCore: @unchecked Sendable {
 
     var onPostConnect: (@Sendable () async -> Void)?
 
+    /// Set by `LibPQBackedDriver` for the span of one connect, so every driver built on this
+    /// core reports its handshake steps without having to thread a parameter through its own
+    /// `connect()` and duplicate the setup each one does around it.
+    var stageReporter: ConnectionStageReporter?
+
     var serverVersion: String? { libpqConnection?.serverVersion() }
     var serverVersionNumber: Int32 { libpqConnection?.serverVersionNumber() ?? 0 }
 
@@ -47,7 +52,7 @@ final class LibPQDriverCore: @unchecked Sendable {
             suppressServerSideCancel: singleConnectionMode
         )
 
-        try await pqConn.connect()
+        try await pqConn.connect(reportingStage: stageReporter ?? { _ in })
         libpqConnection = pqConn
 
         switch await probeSchema(pqConn, query: PostgreSQLSchemaQueries.currentSchema) {
@@ -191,6 +196,14 @@ protocol LibPQBackedDriver: PluginDatabaseDriver {
 extension LibPQBackedDriver {
     func connect() async throws {
         try await core.connect()
+    }
+
+    /// Routes back through `connect()` rather than calling the core directly, so a driver that
+    /// overrides `connect()` to probe catalogs or remap errors still runs its own version.
+    func connect(reportingStage report: @escaping ConnectionStageReporter) async throws {
+        core.stageReporter = report
+        defer { core.stageReporter = nil }
+        try await connect()
     }
 
     func disconnect() {

--- a/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
@@ -162,7 +162,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
 
     // MARK: - Connection Management
 
-    func connect() async throws {
+    func connect(reportingStage report: @escaping ConnectionStageReporter = { _ in }) async throws {
         stateLock.lock()
         _isConnectCancelled = false
         stateLock.unlock()
@@ -172,7 +172,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
                 on: queue,
                 cancellationCheck: { [weak self] in self?.isConnectCancelled ?? true }
             ) { [self] in
-                try performConnect()
+                try performConnect(reportingStage: report)
             }
         } onCancel: {
             cancelConnect()
@@ -191,7 +191,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
         return _isConnectCancelled
     }
 
-    private func performConnect() throws {
+    private func performConnect(reportingStage report: @escaping ConnectionStageReporter) throws {
         guard let connection = buildConnectionString().withCString({ PQconnectStart($0) }) else {
             throw LibPQPluginError.connectionFailed
         }
@@ -205,7 +205,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
             throw connectionError(from: connection)
         }
 
-        try pollUntilConnected(connection)
+        try pollUntilConnected(connection, reportingStage: report)
         configureEstablishedConnection(connection)
 
         stateLock.lock()
@@ -215,12 +215,17 @@ final class LibPQPluginConnection: @unchecked Sendable {
         adopted = true
     }
 
-    private func pollUntilConnected(_ connection: OpaquePointer) throws {
+    private func pollUntilConnected(
+        _ connection: OpaquePointer,
+        reportingStage report: @escaping ConnectionStageReporter
+    ) throws {
         let deadline = PQgetCurrentTimeUSec() + Self.connectTimeoutMicroseconds
         var status = PGRES_POLLING_WRITING
+        var lastHandshakeStatus: ConnStatusType?
 
         while true {
             try checkConnectCancellation()
+            reportHandshakeStage(of: connection, last: &lastHandshakeStatus, report: report)
 
             switch status {
             case PGRES_POLLING_OK:
@@ -247,6 +252,28 @@ final class LibPQPluginConnection: @unchecked Sendable {
             default:
                 status = PQconnectPoll(connection)
             }
+        }
+    }
+
+    /// `PGRES_POLLING_*` only says whether the socket wants a read or a write, so it cannot tell
+    /// a TLS handshake from an authentication exchange. `PQstatus` can, and reading it costs one
+    /// pointer dereference per poll slice.
+    private func reportHandshakeStage(
+        of connection: OpaquePointer,
+        last: inout ConnStatusType?,
+        report: ConnectionStageReporter
+    ) {
+        let current = PQstatus(connection)
+        guard current != last else { return }
+        last = current
+
+        switch current {
+        case CONNECTION_SSL_STARTUP:
+            report(.negotiatingEncryption)
+        case CONNECTION_AWAITING_RESPONSE, CONNECTION_AUTH_OK:
+            report(.authenticating)
+        default:
+            break
         }
     }
 

--- a/Plugins/RedisDriverPlugin/RedisPluginConnection.swift
+++ b/Plugins/RedisDriverPlugin/RedisPluginConnection.swift
@@ -165,14 +165,15 @@ final class RedisPluginConnection: @unchecked Sendable {
 
     // MARK: - Connection Management
 
-    func connect() async throws {
+    func connect(reportingStage report: @escaping ConnectionStageReporter = { _ in }) async throws {
         #if canImport(CRedis)
         _ = Self.initOnce
         try await pluginDispatchAsync(on: queue) { [self] in
             logger.debug("Connecting to Redis at \(self.host):\(self.port)")
 
-            try openContextSync(selectDatabase: database)
+            try openContextSync(selectDatabase: database, reportingStage: report)
 
+            report(.preparingSession)
             do {
                 let pingReply = try executeCommandSync(["PING"])
                 if case .error(let msg) = pingReply {
@@ -398,7 +399,10 @@ private extension RedisPluginConnection {
         }
     }
 
-    func openContextSync(selectDatabase dbIndex: Int) throws {
+    func openContextSync(
+        selectDatabase dbIndex: Int,
+        reportingStage report: ConnectionStageReporter = { _ in }
+    ) throws {
         let connectTimeout = timeval(tv_sec: 10, tv_usec: 0)
         guard let ctx = redisConnectWithTimeout(host, Int32(port), connectTimeout) else {
             logger.error("Failed to create Redis context")
@@ -423,7 +427,11 @@ private extension RedisPluginConnection {
 
         do {
             if sslConfig.isEnabled {
+                report(.negotiatingEncryption)
                 try connectSSL(ctx)
+            }
+            if let password, !password.isEmpty {
+                report(.authenticating)
             }
             try authenticateSync()
             if dbIndex != 0 {

--- a/Plugins/RedisDriverPlugin/RedisPluginDriver.swift
+++ b/Plugins/RedisDriverPlugin/RedisPluginDriver.swift
@@ -60,6 +60,10 @@ final class RedisPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     // MARK: - Connection Management
 
     func connect() async throws {
+        try await connect(reportingStage: { _ in })
+    }
+
+    func connect(reportingStage report: @escaping ConnectionStageReporter) async throws {
         let sslConfig = config.ssl
         let redisDb = Int(config.additionalFields["redisDatabase"] ?? "") ?? Int(config.database) ?? 0
 
@@ -72,7 +76,7 @@ final class RedisPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             sslConfig: sslConfig
         )
 
-        try await conn.connect()
+        try await conn.connect(reportingStage: report)
         redisConnection = conn
     }
 

--- a/Plugins/TableProPluginKit/ConnectionStage.swift
+++ b/Plugins/TableProPluginKit/ConnectionStage.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// A step a connection attempt passes through, reported as it starts so a window can say what
+/// it is waiting on instead of showing an unexplained spinner.
+///
+/// Left non-frozen so it can gain steps without an ABI bump, and `custom` carries an
+/// engine-specific step that does not earn a shared case.
+public enum ConnectionStage: Sendable, Equatable {
+    case resolvingTunnel
+    case runningPreConnectScript
+    case awaitingCredentials
+    case openingConnection
+    case negotiatingEncryption
+    case authenticating
+    case preparingSession
+    case custom(String)
+}
+
+/// Called on whatever thread the stage is observed from, so it must be cheap and must not
+/// assume the main actor. It is deliberately synchronous: the deepest call sites are C poll
+/// loops where a suspension point would change the timing of the connect itself.
+public typealias ConnectionStageReporter = @Sendable (ConnectionStage) -> Void

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -75,6 +75,7 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
     var capabilities: PluginCapabilities { get }
 
     func connect() async throws
+    func connect(reportingStage report: @escaping ConnectionStageReporter) async throws
     func disconnect()
     func ping() async throws
 
@@ -207,6 +208,12 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
 
 public extension PluginDatabaseDriver {
     var capabilities: PluginCapabilities { [] }
+
+    /// A driver that cannot see inside its own connect keeps the plain path. The app still
+    /// reports the stages either side of this call, so the window is never blank.
+    func connect(reportingStage report: @escaping ConnectionStageReporter) async throws {
+        try await connect()
+    }
 
     func fetchTriggers(table: String, schema: String?) async throws -> [PluginTriggerInfo] { [] }
 

--- a/TablePro/Core/Database/DatabaseDriver.swift
+++ b/TablePro/Core/Database/DatabaseDriver.swift
@@ -28,6 +28,9 @@ protocol DatabaseDriver: AnyObject, Sendable {
     /// Connect to the database
     func connect() async throws
 
+    /// Connect while reporting the steps this driver can see from inside its own handshake.
+    func connectReporting(stage report: @escaping ConnectionStageReporter) async throws
+
     /// Disconnect from the database
     func disconnect()
 
@@ -239,6 +242,10 @@ extension DatabaseDriver {
     /// Default implementation returns nil
     /// Override in drivers that support version querying
     var serverVersion: String? { nil }
+
+    func connectReporting(stage report: @escaping ConnectionStageReporter) async throws {
+        try await connect()
+    }
 
     var queryBuildingPluginDriver: (any PluginDatabaseDriver)? { nil }
 

--- a/TablePro/Core/Database/DatabaseManager+Sessions.swift
+++ b/TablePro/Core/Database/DatabaseManager+Sessions.swift
@@ -29,6 +29,7 @@ extension DatabaseManager {
         MacAnalyticsProvider.shared.markConnectionAttempted()
 
         let attempt = connectionAttempts.begin(for: connection.id)
+        disconnectReasons[connection.id] = nil
 
         let resolvedConnection: DatabaseConnection
         if LicenseManager.shared.isFeatureAvailable(.envVarReferences) {
@@ -46,6 +47,9 @@ extension DatabaseManager {
 
         let effectiveConnection: DatabaseConnection
         do {
+            if !resolvedConnection.enabledTunnelKinds.isEmpty {
+                reportStage(.resolvingTunnel, for: connection.id)
+            }
             effectiveConnection = try await buildEffectiveConnection(
                 for: resolvedConnection,
                 sshPasswordOverride: sshPasswordOverride
@@ -53,7 +57,8 @@ extension DatabaseManager {
         } catch {
             finalizeConnectionFailure(
                 for: connection.id,
-                cancelled: isAttemptCancelled(attempt, for: connection.id)
+                cancelled: isAttemptCancelled(attempt, for: connection.id),
+                error: error
             )
             throw error
         }
@@ -62,11 +67,13 @@ extension DatabaseManager {
            !script.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         {
             do {
+                reportStage(.runningPreConnectScript, for: connection.id)
                 try await PreConnectHookRunner.run(script: script)
             } catch {
                 finalizeConnectionFailure(
                     for: connection.id,
-                    cancelled: isAttemptCancelled(attempt, for: connection.id)
+                    cancelled: isAttemptCancelled(attempt, for: connection.id),
+                    error: error
                 )
                 throw error
             }
@@ -78,6 +85,7 @@ extension DatabaseManager {
                 passwordOverride = cached
             } else {
                 let isApiOnly = pluginManager.connectionMode(for: connection.type) == .apiOnly
+                reportStage(.awaitingCredentials, for: connection.id)
                 guard let prompted = await PasswordPromptHelper.prompt(
                     connectionName: connection.name,
                     isAPIToken: isApiOnly,
@@ -105,15 +113,17 @@ extension DatabaseManager {
             if !cancelled {
                 closeActiveTunnel(for: connection)
             }
-            finalizeConnectionFailure(for: connection.id, cancelled: cancelled)
+            finalizeConnectionFailure(for: connection.id, cancelled: cancelled, error: error)
             throw error
         }
 
         do {
-            try await driver.connect()
+            reportStage(.openingConnection, for: connection.id)
+            try await driver.connectReporting(stage: stageReporter(for: connection.id))
             try Task.checkCancellation()
             try ensureAttemptIsCurrent(attempt, for: connection.id, driver: driver)
 
+            reportStage(.preparingSession, for: connection.id)
             await applyTimeoutAndStartupCommands(
                 on: driver,
                 startupCommands: resolvedConnection.startupCommands,
@@ -166,7 +176,7 @@ extension DatabaseManager {
                 closeActiveTunnel(for: connection)
             }
 
-            finalizeConnectionFailure(for: connection.id, cancelled: cancelled)
+            finalizeConnectionFailure(for: connection.id, cancelled: cancelled, error: reportedError)
             throw reportedError
         }
     }
@@ -193,8 +203,15 @@ extension DatabaseManager {
         return resolved
     }
 
-    internal func finalizeConnectionFailure(for connectionId: UUID, cancelled: Bool) {
+    /// The classified error is recorded before the session entry goes away. Only the window that
+    /// started an attempt learns the outcome directly, so without this a connect kicked off from
+    /// anywhere else leaves the window to infer "the connection was closed" from an empty slot
+    /// while the real reason is thrown away.
+    internal func finalizeConnectionFailure(for connectionId: UUID, cancelled: Bool, error: Error? = nil) {
         guard !cancelled else { return }
+        if let error, !ConnectionFailureClassifier.isUserCancelled(error) {
+            recordDisconnectReason(ConnectionFailureClassifier.info(for: error), for: connectionId)
+        }
         removeSessionEntry(for: connectionId)
         if lastActiveSessionId == connectionId {
             lastActiveSessionId = activeSessions.keys.first
@@ -463,6 +480,43 @@ extension DatabaseManager {
         AppEvents.shared.connectionStatusChanged.send(
             ConnectionStatusChange(connectionId: connectionId, status: session.status)
         )
+    }
+
+    /// Seeds the session entry before a window opens, so a window can resolve its connection and
+    /// show the connecting surface for an attempt it does not own. A connection opened from a
+    /// link or a database file is never in storage, so this is the only way the window can name
+    /// what it is connecting to.
+    internal func registerPendingSession(_ connection: DatabaseConnection) {
+        guard activeSessions[connection.id] == nil else { return }
+        var session = ConnectionSession(connection: connection)
+        session.status = .connecting
+        setSession(session, for: connection.id)
+    }
+
+    internal func reportStage(_ stage: ConnectionStage, for connectionId: UUID) {
+        AppEvents.shared.connectionStageChanged.send(
+            ConnectionStageChange(connectionId: connectionId, stage: stage)
+        )
+    }
+
+    /// Handed to a driver, so it is called from whatever thread the handshake runs on and has
+    /// to hop back before touching the main-actor event bus.
+    internal func stageReporter(for connectionId: UUID) -> ConnectionStageReporter {
+        { stage in
+            Task { @MainActor in
+                AppEvents.shared.connectionStageChanged.send(
+                    ConnectionStageChange(connectionId: connectionId, stage: stage)
+                )
+            }
+        }
+    }
+
+    internal func recordDisconnectReason(_ info: ConnectionFailureInfo, for connectionId: UUID) {
+        disconnectReasons[connectionId] = info
+    }
+
+    internal func disconnectReason(for connectionId: UUID) -> ConnectionFailureInfo? {
+        disconnectReasons[connectionId]
     }
 
     internal func removeSessionEntry(for connectionId: UUID) {

--- a/TablePro/Core/Database/DatabaseManager+Tunnel.swift
+++ b/TablePro/Core/Database/DatabaseManager+Tunnel.swift
@@ -143,9 +143,28 @@ extension DatabaseManager {
 
         Self.logger.error("All \(kind, privacy: .public) reconnect attempts failed for: \(session.connection.name)")
 
-        updateSession(connectionId) { session in
-            session.status = .error(disconnectedMessage)
-            session.clearCachedData()
-        }
+        failTunnelRecovery(
+            connectionId: connectionId,
+            disconnectedMessage: disconnectedMessage,
+            attempts: maxRetries
+        )
+    }
+
+    /// Leaving the session entry in place kept `exists == true, hasDriver == nil`, which every
+    /// window reads as "still dialing", so an exhausted recovery painted a spinner that never
+    /// ended. The entry has to go, and the reason has to outlive it so the window can say why.
+    internal func failTunnelRecovery(connectionId: UUID, disconnectedMessage: String, attempts: Int) {
+        recordDisconnectReason(
+            ConnectionFailureInfo(
+                message: disconnectedMessage,
+                failureReason: String(
+                    format: String(localized: "Reconnecting failed after %d attempts."),
+                    attempts
+                ),
+                recoverySuggestion: String(localized: "Check the tunnel host and your network, then try again.")
+            ),
+            for: connectionId
+        )
+        finalizeConnectionFailure(for: connectionId, cancelled: false)
     }
 }

--- a/TablePro/Core/Database/DatabaseManager.swift
+++ b/TablePro/Core/Database/DatabaseManager.swift
@@ -64,6 +64,10 @@ final class DatabaseManager {
     /// and the wake-from-sleep handler fire for the same connection.
     @ObservationIgnored internal var recoveringConnectionIds = Set<UUID>()
 
+    /// Why a session was torn down, kept past the session entry so a window that only observes
+    /// the entry disappearing can still name the cause. Cleared when a fresh attempt begins.
+    @ObservationIgnored internal var disconnectReasons: [UUID: ConnectionFailureInfo] = [:]
+
     @ObservationIgnored internal var connectionUpdatedCancellable: AnyCancellable?
 
     @ObservationIgnored internal let ensureConnectedDedup = OnceTask<UUID, Void>()

--- a/TablePro/Core/Events/AppEvents.swift
+++ b/TablePro/Core/Events/AppEvents.swift
@@ -5,6 +5,7 @@
 
 import Combine
 import Foundation
+import TableProPluginKit
 
 @MainActor
 final class AppEvents {
@@ -29,6 +30,10 @@ final class AppEvents {
     // MARK: - Connections
 
     let connectionStatusChanged = PassthroughSubject<ConnectionStatusChange, Never>()
+
+    /// The step a connection attempt is currently on. Presentational detail inside the
+    /// connecting phase, never a second source of truth for which pane a window shows.
+    let connectionStageChanged = PassthroughSubject<ConnectionStageChange, Never>()
 
     /// Connection metadata changed (name, color, group, type, etc.).
     /// Payload is the affected connection's id, or `nil` for bulk updates
@@ -111,6 +116,11 @@ final class AppEvents {
 struct ConnectionStatusChange: Sendable {
     let connectionId: UUID
     let status: ConnectionStatus
+}
+
+struct ConnectionStageChange: Sendable {
+    let connectionId: UUID
+    let stage: ConnectionStage
 }
 
 struct DatabaseDidConnect: Sendable {

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -109,9 +109,13 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable {
     // MARK: - Connection Management
 
     func connect() async throws {
+        try await connectReporting(stage: { _ in })
+    }
+
+    func connectReporting(stage report: @escaping ConnectionStageReporter) async throws {
         state.withLock { $0.status = .connecting }
         do {
-            try await pluginDriver.connect()
+            try await pluginDriver.connect(reportingStage: report)
             state.withLock { $0.status = .connected }
         } catch {
             state.withLock { $0.status = .error(error.localizedDescription) }

--- a/TablePro/Core/Services/Infrastructure/ConnectionStageObserver.swift
+++ b/TablePro/Core/Services/Infrastructure/ConnectionStageObserver.swift
@@ -1,0 +1,57 @@
+//
+//  ConnectionStageObserver.swift
+//  TablePro
+//
+
+import Combine
+import Foundation
+import TableProPluginKit
+
+/// Owned by the connecting view rather than the window controller. The window rebuilds its
+/// panes only on a phase change, so holding the stage here keeps a stage tick from tearing
+/// down and rebuilding the whole SwiftUI subtree.
+@MainActor
+@Observable
+internal final class ConnectionStageObserver {
+    internal private(set) var stage: ConnectionStage?
+    internal private(set) var isTakingLonger = false
+
+    @ObservationIgnored private var cancellable: AnyCancellable?
+    @ObservationIgnored private var patienceTask: Task<Void, Never>?
+
+    private static let patience: Duration = .seconds(12)
+
+    internal init(connectionId: UUID?) {
+        guard let connectionId else { return }
+        cancellable = AppEvents.shared.connectionStageChanged
+            .filter { $0.connectionId == connectionId }
+            .receive(on: RunLoop.main)
+            .sink { [weak self] change in
+                self?.adopt(change.stage)
+            }
+        restartPatienceTimer()
+    }
+
+    deinit {
+        patienceTask?.cancel()
+    }
+
+    private func adopt(_ next: ConnectionStage) {
+        guard next != stage else { return }
+        stage = next
+        isTakingLonger = false
+        restartPatienceTimer()
+    }
+
+    /// A step that has not changed in a while is the one case where the user cannot tell a slow
+    /// server from a stalled app. Saying so is the whole difference between waiting and force
+    /// quitting.
+    private func restartPatienceTimer() {
+        patienceTask?.cancel()
+        patienceTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.patience)
+            guard !Task.isCancelled else { return }
+            self?.isTakingLonger = true
+        }
+    }
+}

--- a/TablePro/Core/Services/Infrastructure/ConnectionWindowPaneResolver.swift
+++ b/TablePro/Core/Services/Infrastructure/ConnectionWindowPaneResolver.swift
@@ -32,4 +32,15 @@ internal enum ConnectionWindowPaneResolver {
             return hasConnection ? .unavailable(reason) : .empty
         }
     }
+
+    /// A sidebar and an inspector with nothing to put in them are not chrome, they are two empty
+    /// columns that promise a session the window does not have yet.
+    internal static func hidesChrome(for pane: ConnectionWindowPane) -> Bool {
+        switch pane {
+        case .content:
+            return false
+        case .connecting, .unavailable, .empty:
+            return true
+        }
+    }
 }

--- a/TablePro/Core/Services/Infrastructure/ConnectionWindowPhaseMachine.swift
+++ b/TablePro/Core/Services/Infrastructure/ConnectionWindowPhaseMachine.swift
@@ -5,9 +5,20 @@
 
 import Foundation
 
+/// `exists` and `hasDriver` alone cannot tell "still dialing" from "gave up", which is why a
+/// session left behind by an exhausted tunnel recovery used to read as `.connecting` forever.
+/// `disconnectInfo` carries the reason the session went away so the window can say what happened
+/// instead of falling back to the generic closed-connection copy.
 internal struct ConnectionSessionSnapshot: Equatable, Sendable {
     internal let exists: Bool
     internal let hasDriver: Bool
+    internal let disconnectInfo: ConnectionFailureInfo?
+
+    internal init(exists: Bool, hasDriver: Bool, disconnectInfo: ConnectionFailureInfo? = nil) {
+        self.exists = exists
+        self.hasDriver = hasDriver
+        self.disconnectInfo = disconnectInfo
+    }
 
     internal static let absent = ConnectionSessionSnapshot(exists: false, hasDriver: false)
 }
@@ -37,9 +48,9 @@ internal enum ConnectionWindowPhaseMachine {
 
         switch phase {
         case .connecting:
-            return ownsAttempt ? .connecting : .unavailable(.disconnected)
+            return ownsAttempt ? .connecting : .unavailable(.disconnected(session.disconnectInfo))
         case .connected:
-            return .unavailable(.disconnected)
+            return .unavailable(.disconnected(session.disconnectInfo))
         case .idle, .unavailable, .closing:
             return phase
         }
@@ -70,9 +81,9 @@ internal enum ConnectionWindowPhaseMachine {
             return true
         case .unavailable(let reason):
             switch reason {
-            case .notConnected, .cancelled:
+            case .cancelled:
                 return false
-            case .disconnected, .failed, .pluginMissing:
+            case .notConnected, .disconnected, .failed, .pluginMissing:
                 return true
             }
         case .idle, .closing:

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController+Connection.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController+Connection.swift
@@ -17,6 +17,15 @@ internal extension MainSplitViewController {
         guard ConnectionWindowPhaseMachine.allowsActivationConnect(phase: phase) else { return }
         guard let connection = payloadConnection else { return }
         guard DatabaseManager.shared.activeSessions[connection.id]?.driver == nil else { return }
+
+        /// Reopening a session at launch is the app's gesture, not the user's, so it never runs a
+        /// saved script on its own. The window waits in its not-connected state instead, where
+        /// Connect asks first. Prompting here would also put one modal per restored connection on
+        /// screen at startup, which the HIG rules out twice over.
+        guard !connection.hasPreConnectScript else {
+            transition(to: .unavailable(.notConnected))
+            return
+        }
         connect(connection, cancellingPrevious: false)
     }
 
@@ -53,6 +62,10 @@ internal extension MainSplitViewController {
         transition(to: ConnectionWindowPhaseMachine.onAttemptStarted(phase: phase))
 
         Task { [weak self] in
+            guard await PreConnectScriptPrompt.confirmIfNeeded(for: connection) else {
+                self?.finishAttempt(token, outcome: .cancelled)
+                return
+            }
             if cancellingPrevious {
                 await DatabaseManager.shared.cancelEnsureConnected(connection.id)
             }

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -59,6 +59,8 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     private var detailHosting: NSHostingController<AnyView>!
     private var inspectorHosting: NSHostingController<AnyView>!
 
+    private var chromeState: ChromeState = .unapplied
+
     // MARK: - Panel Layout State
 
     /// Never version this key to force a relayout. `NSSplitView` clamps a restored frame against
@@ -193,14 +195,16 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         inspectorSplitItem.maximumThickness = NSSplitViewItem.unspecifiedDimension
         addSplitViewItem(inspectorSplitItem)
 
-        splitView.autosaveName = splitAutosaveName
-        applyDefaultCollapseStateIfNoAutosave()
-
         navigationSidebar.railController.onEntryCountChange = { [weak self] count in
             self?.applyRailVisibility(workspaceCount: count)
         }
 
+        /// The saved layout is restored before any phase-driven collapse, so the user's widths
+        /// are already in the live layout. Uncollapsing then returns the pane to the size
+        /// `NSSplitViewItem` remembers, rather than depending on a second restore.
+        restoreUserPaneLayout()
         rebuildPanes()
+        applyPaneChrome()
     }
 
     /// A divider dragged all the way in collapses the sidebar without going through
@@ -267,10 +271,16 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
 
     // MARK: - Toolbar
 
+    /// Only ever called with a live coordinator. The toolbar's delegate builds no item without
+    /// one, and `NSToolbar` asks it once, so a toolbar created early is permanently empty: a
+    /// later coordinator cannot refill it, and validation only speaks to items that already
+    /// exist. A window with no session shows a plain titlebar instead.
     func installToolbar(coordinator: MainContentCoordinator) {
         guard let window = view.window else { return }
         if toolbarOwner == nil {
             toolbarOwner = MainWindowToolbar(coordinator: coordinator)
+        } else {
+            toolbarOwner?.coordinator = coordinator
         }
         if let owner = toolbarOwner, window.toolbar !== owner.managedToolbar {
             window.toolbar = owner.managedToolbar
@@ -294,7 +304,11 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         }
 
         let session = DatabaseManager.shared.activeSessions[sid]
-        let snapshot = ConnectionSessionSnapshot(exists: session != nil, hasDriver: session?.driver != nil)
+        let snapshot = ConnectionSessionSnapshot(
+            exists: session != nil,
+            hasDriver: session?.driver != nil,
+            disconnectInfo: DatabaseManager.shared.disconnectReason(for: sid)
+        )
         let nextPhase = ConnectionWindowPhaseMachine.onSessionChanged(
             phase: phase,
             session: snapshot,
@@ -306,7 +320,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
             if alreadyRendered, phase == nextPhase { return }
             adoptSession(session)
             if phase == nextPhase { rebuildPanes() }
-        } else if phase == .connected, nextPhase != .connected {
+        } else if phase == .connected, nextPhase != .connected, !snapshot.exists {
             releaseSession(sid)
         }
 
@@ -336,6 +350,9 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         }
     }
 
+    /// Only called once the session entry is gone. A session that still exists without a driver
+    /// is reconnecting, and tearing the coordinator down for that takes the user's open tabs and
+    /// unsaved query edits with it over a network blip that repairs itself seconds later.
     private func releaseSession(_ connectionId: UUID) {
         Self.lifecycleLogger.info(
             "[close] MainSplitVC session removed connId=\(connectionId, privacy: .public)"
@@ -350,6 +367,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
 
     private func applyPhase() {
         rebuildPanes()
+        applyPaneChrome()
         SessionRecoveryTracker.sync()
     }
 
@@ -734,5 +752,71 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         let key = "NSSplitView Subview Frames \(splitAutosaveName)"
         guard UserDefaults.standard.object(forKey: key) == nil else { return }
         inspectorSplitItem.isCollapsed = true
+    }
+
+    // MARK: - Pane Chrome
+
+    private enum ChromeState {
+        case unapplied
+        case hidden
+        case revealed
+    }
+
+    /// A split item's collapse state is written into the autosave record, which is how the
+    /// inspector remembers being hidden. Collapsing the sidebar for a phase the user did not
+    /// choose would persist that as their layout and lose the width they set, so autosaving is
+    /// switched off for the whole span the chrome is hidden and switched back on to restore it.
+    func applyPaneChrome() {
+        if ConnectionWindowPaneResolver.hidesChrome(for: currentPane) {
+            hideWindowChrome()
+        } else {
+            revealWindowChrome()
+        }
+        toolbarOwner?.managedToolbar.validateVisibleItems()
+        recomputeWindowMinSize()
+    }
+
+    private func hideWindowChrome() {
+        guard chromeState != .hidden else { return }
+        chromeState = .hidden
+
+        resignFirstResponderInsideChrome()
+        splitView.autosaveName = ""
+        sidebarSplitItem.isCollapsed = true
+        inspectorSplitItem.isCollapsed = true
+        view.window?.recalculateKeyViewLoop()
+    }
+
+    private func revealWindowChrome() {
+        guard chromeState != .revealed else { return }
+        chromeState = .revealed
+
+        sidebarSplitItem.isCollapsed = false
+        restoreUserPaneLayout()
+        view.window?.recalculateKeyViewLoop()
+    }
+
+    private func restoreUserPaneLayout() {
+        splitView.autosaveName = splitAutosaveName
+        applyDefaultCollapseStateIfNoAutosave()
+    }
+
+    /// A collapsed pane keeps whatever first responder it held, which would leave the window
+    /// typing into a search field nobody can see.
+    private func resignFirstResponderInsideChrome() {
+        guard let window = view.window,
+              let responder = window.firstResponder as? NSView else { return }
+        guard responder.isDescendant(of: navigationSidebar.view)
+            || responder.isDescendant(of: inspectorHosting.view) else { return }
+        window.makeFirstResponder(nil)
+    }
+
+    /// Show/Hide Sidebar and Inspector stay in the responder chain while collapsed, so without
+    /// this the user can reopen an empty pane over a window that has no session yet.
+    override func validateUserInterfaceItem(_ item: any NSValidatedUserInterfaceItem) -> Bool {
+        if item.action == #selector(toggleSidebar(_:)) || item.action == #selector(toggleInspector(_:)) {
+            return currentPane == .content
+        }
+        return super.validateUserInterfaceItem(item)
     }
 }

--- a/TablePro/Core/Services/Infrastructure/PreConnectScriptPrompt.swift
+++ b/TablePro/Core/Services/Infrastructure/PreConnectScriptPrompt.swift
@@ -1,0 +1,39 @@
+//
+//  PreConnectScriptPrompt.swift
+//  TablePro
+//
+
+import AppKit
+import Foundation
+
+internal extension DatabaseConnection {
+    var trimmedPreConnectScript: String? {
+        guard let script = preConnectScript else { return nil }
+        let trimmed = script.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    var hasPreConnectScript: Bool {
+        trimmedPreConnectScript != nil
+    }
+}
+
+/// A pre-connect script is arbitrary shell code stored with the connection, so it only ever runs
+/// off a gesture the user makes in this session. Keeping the confirmation here rather than at
+/// each call site means no connect route can quietly skip it.
+@MainActor
+internal enum PreConnectScriptPrompt {
+    internal static func confirmIfNeeded(for connection: DatabaseConnection) async -> Bool {
+        guard let script = connection.trimmedPreConnectScript else { return true }
+        return await AlertHelper.confirmDestructive(
+            title: String(localized: "Pre-Connect Script"),
+            message: String(
+                format: String(localized: "Connection \"%@\" has a script that will run before connecting:\n\n%@"),
+                connection.name, script
+            ),
+            confirmButton: String(localized: "Run Script"),
+            cancelButton: String(localized: "Cancel"),
+            window: NSApp.keyWindow
+        )
+    }
+}

--- a/TablePro/Core/Services/Infrastructure/SidebarContainerViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/SidebarContainerViewController.swift
@@ -32,6 +32,7 @@ internal final class SidebarContainerViewController: NSViewController {
         view = NSView()
 
         searchField.translatesAutoresizingMaskIntoConstraints = false
+        searchField.isHidden = true
         searchField.placeholderString = String(localized: "Filter")
         searchField.controlSize = .regular
         searchField.sendsSearchStringImmediately = true

--- a/TablePro/Core/Services/Infrastructure/TabRouter.swift
+++ b/TablePro/Core/Services/Infrastructure/TabRouter.swift
@@ -103,11 +103,11 @@ internal final class TabRouter {
             if let splitVC = existing.contentViewController as? MainSplitViewController {
                 splitVC.retryConnection()
             } else {
+                try await runPreConnectScriptIfNeeded(connection)
                 try await DatabaseManager.shared.ensureConnected(connection)
             }
             return
         }
-        try await runPreConnectScriptIfNeeded(connection)
         let payload = EditorTabPayload(connectionId: connection.id, intent: .restoreOrDefault)
         WindowManager.shared.openTab(payload: payload, autoConnect: true)
         NSApp.activate(ignoringOtherApps: true)
@@ -129,7 +129,27 @@ internal final class TabRouter {
         } else {
             throw TabRouterError.connectionNotFound(connectionId)
         }
+        if focusExistingTableTab(connectionId: connectionId, database: database, schema: schema, table: table) {
+            NSApp.activate(ignoringOtherApps: true)
+            WindowOpener.shared.closeWelcome()
+            return
+        }
+
         try await runPreConnectScriptIfNeeded(connection)
+
+        let payload = EditorTabPayload(
+            connectionId: connectionId,
+            tabType: .table,
+            tableName: table,
+            databaseName: database,
+            schemaName: schema,
+            isView: isView
+        )
+        DatabaseManager.shared.registerPendingSession(connection)
+        WindowManager.shared.openTab(payload: payload)
+        NSApp.activate(ignoringOtherApps: true)
+        WindowOpener.shared.closeWelcome()
+
         try await DatabaseManager.shared.ensureConnected(
             connection,
             passwordOverride: passwordOverride,
@@ -141,24 +161,6 @@ internal final class TabRouter {
         } else if let database {
             await switchSchemaOrDatabase(connectionId: connectionId, target: database)
         }
-
-        if focusExistingTableTab(connectionId: connectionId, database: database, schema: schema, table: table) {
-            NSApp.activate(ignoringOtherApps: true)
-            WindowOpener.shared.closeWelcome()
-            return
-        }
-
-        let payload = EditorTabPayload(
-            connectionId: connectionId,
-            tabType: .table,
-            tableName: table,
-            databaseName: database,
-            schemaName: schema,
-            isView: isView
-        )
-        WindowManager.shared.openTab(payload: payload)
-        NSApp.activate(ignoringOtherApps: true)
-        WindowOpener.shared.closeWelcome()
     }
 
     private func focusExistingTableTab(
@@ -202,23 +204,25 @@ internal final class TabRouter {
         )
         guard confirmed else { throw TabRouterError.userCancelled }
 
-        try await runPreConnectScriptIfNeeded(connection)
-        try await DatabaseManager.shared.ensureConnected(connection)
-
         if focusExistingQueryTab(connectionId: connectionId, sql: sql) {
             NSApp.activate(ignoringOtherApps: true)
             WindowOpener.shared.closeWelcome()
             return
         }
 
+        try await runPreConnectScriptIfNeeded(connection)
+
         let payload = EditorTabPayload(
             connectionId: connectionId,
             tabType: .query,
             initialQuery: sql
         )
+        DatabaseManager.shared.registerPendingSession(connection)
         WindowManager.shared.openTab(payload: payload)
         NSApp.activate(ignoringOtherApps: true)
         WindowOpener.shared.closeWelcome()
+
+        try await DatabaseManager.shared.ensureConnected(connection)
     }
 
     private func focusExistingQueryTab(connectionId: UUID, sql: String) -> Bool {
@@ -298,14 +302,15 @@ internal final class TabRouter {
 
         try await runPreConnectScriptIfNeeded(connection)
         let payload = EditorTabPayload(connectionId: connection.id, intent: .restoreOrDefault)
+        DatabaseManager.shared.registerPendingSession(connection)
         WindowManager.shared.openTab(payload: payload)
         NSApp.activate(ignoringOtherApps: true)
+        WindowOpener.shared.closeWelcome()
         try await DatabaseManager.shared.ensureConnected(
             connection,
             passwordOverride: passwordOverride,
             sshPasswordOverride: sshPasswordOverride
         )
-        WindowOpener.shared.closeWelcome()
 
         if let schema = parsed.schema {
             await switchSchemaOrDatabase(connectionId: connection.id, target: schema)
@@ -336,10 +341,11 @@ internal final class TabRouter {
         )
 
         let payload = EditorTabPayload(connectionId: connection.id, intent: .restoreOrDefault)
+        DatabaseManager.shared.registerPendingSession(connection)
         WindowManager.shared.openTab(payload: payload)
         NSApp.activate(ignoringOtherApps: true)
-        try await DatabaseManager.shared.ensureConnected(connection)
         WindowOpener.shared.closeWelcome()
+        try await DatabaseManager.shared.ensureConnected(connection)
     }
 
     // MARK: - SQL File
@@ -394,19 +400,9 @@ internal final class TabRouter {
     }
 
     private func runPreConnectScriptIfNeeded(_ connection: DatabaseConnection) async throws {
-        guard let script = connection.preConnectScript,
-              !script.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-        let confirmed = await AlertHelper.confirmDestructive(
-            title: String(localized: "Pre-Connect Script"),
-            message: String(
-                format: String(localized: "Connection \"%@\" has a script that will run before connecting:\n\n%@"),
-                connection.name, script
-            ),
-            confirmButton: String(localized: "Run Script"),
-            cancelButton: String(localized: "Cancel"),
-            window: NSApp.keyWindow
-        )
-        guard confirmed else { throw TabRouterError.userCancelled }
+        guard await PreConnectScriptPrompt.confirmIfNeeded(for: connection) else {
+            throw TabRouterError.userCancelled
+        }
     }
 
     private func applyFilterFromParsedURL(parsed: ParsedConnectionURL, connectionId: UUID) async throws {

--- a/TablePro/Models/Connection/ConnectionStageLabelFormatter.swift
+++ b/TablePro/Models/Connection/ConnectionStageLabelFormatter.swift
@@ -1,0 +1,72 @@
+//
+//  ConnectionStageLabelFormatter.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+/// Two forms of the same stage. `stepLabel` sits under a heading that already names the
+/// connection and its endpoint, so it only has to say which step is running. `announcement`
+/// is spoken with no surrounding context, so it names the connection itself.
+///
+/// Neither form is ever a bare "Loading" or "Authenticating": the HIG calls those out by name
+/// as descriptions that add nothing, and a step that does not say what it is acting on is
+/// exactly that.
+internal enum ConnectionStageLabelFormatter {
+    internal static func stepLabel(for stage: ConnectionStage, connection: DatabaseConnection) -> String {
+        switch stage {
+        case .resolvingTunnel:
+            guard let via = tunnelDescription(for: connection) else {
+                return String(localized: "Opening the tunnel")
+            }
+            return String(format: String(localized: "Opening the tunnel through %@"), via)
+        case .runningPreConnectScript:
+            return String(localized: "Running the pre-connect script")
+        case .awaitingCredentials:
+            return String(localized: "Waiting for your password")
+        case .openingConnection:
+            return String(localized: "Opening the connection")
+        case .negotiatingEncryption:
+            return String(localized: "Negotiating encryption")
+        case .authenticating:
+            let username = trimmedUsername(of: connection)
+            guard !username.isEmpty else { return String(localized: "Checking your credentials") }
+            return String(format: String(localized: "Authenticating %@"), username)
+        case .preparingSession:
+            return String(localized: "Preparing the session")
+        case .custom(let text):
+            return text
+        @unknown default:
+            return String(localized: "Opening the connection")
+        }
+    }
+
+    internal static func announcement(for stage: ConnectionStage, connection: DatabaseConnection) -> String {
+        String(
+            format: String(localized: "%1$@ on %2$@"),
+            stepLabel(for: stage, connection: connection),
+            connection.name
+        )
+    }
+
+    private static func trimmedUsername(of connection: DatabaseConnection) -> String {
+        connection.username.trimmingCharacters(in: .whitespaces)
+    }
+
+    private static func tunnelDescription(for connection: DatabaseConnection) -> String? {
+        switch connection.activeTunnelKind {
+        case .ssh:
+            let host = connection.resolvedSSHConfig.host.trimmingCharacters(in: .whitespaces)
+            return host.isEmpty ? nil : host
+        case .cloudflare:
+            return "Cloudflare"
+        case .cloudSQLProxy:
+            return "Cloud SQL Auth Proxy"
+        case .socksProxy:
+            return String(localized: "the SOCKS proxy")
+        case .none:
+            return nil
+        }
+    }
+}

--- a/TablePro/Models/Connection/ConnectionWindowPhase.swift
+++ b/TablePro/Models/Connection/ConnectionWindowPhase.swift
@@ -20,7 +20,7 @@ internal struct ConnectionFailureInfo: Equatable, Sendable {
 internal enum ConnectionUnavailableReason: Equatable, Sendable {
     case notConnected
     case cancelled
-    case disconnected
+    case disconnected(ConnectionFailureInfo?)
     case failed(ConnectionFailureInfo)
     case pluginMissing(ConnectionFailureInfo)
 }

--- a/TablePro/Models/Connection/DatabaseConnection+Display.swift
+++ b/TablePro/Models/Connection/DatabaseConnection+Display.swift
@@ -18,7 +18,7 @@ extension DatabaseConnection {
         return components.joined(separator: " · ")
     }
 
-    private var endpointDescription: String {
+    var endpointDescription: String {
         if let socketPath = sshForwardUnixSocketPath, resolvedSSHConfig.enabled {
             return (socketPath as NSString).abbreviatingWithTildeInPath
         }

--- a/TablePro/Views/Connection/ConnectingStateView.swift
+++ b/TablePro/Views/Connection/ConnectingStateView.swift
@@ -5,25 +5,42 @@
 
 import AppKit
 import SwiftUI
+import TableProPluginKit
 
-struct ConnectingStateView: View {
-    let connection: DatabaseConnection
-    let onCancel: () -> Void
+/// Deliberately not built on `ContentUnavailableView`. Apple documents that view for content
+/// that cannot be shown, a network error or an empty list, and every case it names is a state
+/// the operation has already settled into. UIKit ships a separate `loading()` configuration for
+/// work in flight and macOS ships no equivalent, so a connecting surface is assembled here.
+internal struct ConnectingStateView: View {
+    internal let connection: DatabaseConnection
+    internal let onCancel: () -> Void
 
-    var body: some View {
-        ContentUnavailableView {
-            Label {
-                Text(String(format: String(localized: "Connecting to %@"), connection.name))
-            } icon: {
-                ConnectionTypeIcon(type: connection.type, pulses: true)
-            }
-        } description: {
-            VStack(spacing: 14) {
+    @State private var observer: ConnectionStageObserver
+
+    internal init(connection: DatabaseConnection, onCancel: @escaping () -> Void) {
+        self.connection = connection
+        self.onCancel = onCancel
+        _observer = State(wrappedValue: ConnectionStageObserver(connectionId: connection.id))
+    }
+
+    internal var body: some View {
+        VStack(spacing: 18) {
+            ConnectionTypeIcon(type: connection.type, pulses: true)
+                .font(.system(size: 40))
+                .foregroundStyle(.secondary)
+                .frame(height: 44)
+
+            VStack(spacing: 6) {
+                Text(connection.name)
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
                 ConnectionEndpointLabel(connection: connection)
-                ProgressView()
-                    .controlSize(.small)
             }
-        } actions: {
+
+            progressLine
+
             Button(role: .cancel, action: onCancel) {
                 Text(String(localized: "Cancel"))
                     .frame(minWidth: 80)
@@ -31,6 +48,54 @@ struct ConnectingStateView: View {
             .controlSize(.large)
             .keyboardShortcut(.cancelAction)
         }
+        .padding(40)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(accessibilityStatus)
+    }
+
+    @ViewBuilder
+    private var progressLine: some View {
+        VStack(spacing: 6) {
+            HStack(spacing: 8) {
+                ProgressView()
+                    .controlSize(.small)
+                Text(stepLabel)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+
+            if observer.isTakingLonger {
+                Text(String(localized: "This is taking longer than usual."))
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .frame(maxWidth: 420)
+        .multilineTextAlignment(.center)
+        .onChange(of: observer.stage) { _, newStage in
+            guard let newStage else { return }
+            announce(newStage)
+        }
+    }
+
+    private var stepLabel: String {
+        guard let stage = observer.stage else { return String(localized: "Opening the connection") }
+        return ConnectionStageLabelFormatter.stepLabel(for: stage, connection: connection)
+    }
+
+    private var accessibilityStatus: String {
+        guard let stage = observer.stage else {
+            return String(format: String(localized: "Connecting to %@"), connection.name)
+        }
+        return ConnectionStageLabelFormatter.announcement(for: stage, connection: connection)
+    }
+
+    /// Posted per step rather than continuously. `updatesFrequently` is documented as a hint to
+    /// poll, which is the wrong shape for a handful of discrete transitions.
+    private func announce(_ stage: ConnectionStage) {
+        AccessibilityNotification.Announcement(
+            ConnectionStageLabelFormatter.announcement(for: stage, connection: connection)
+        ).post()
     }
 }

--- a/TablePro/Views/Connection/ConnectionUnavailableView.swift
+++ b/TablePro/Views/Connection/ConnectionUnavailableView.swift
@@ -41,6 +41,15 @@ internal struct ConnectionUnavailableView: View {
                 Button(action: onManageConnections) {
                     Text(String(localized: "Manage Connections…"))
                 }
+
+                if let copyableDetails {
+                    Button {
+                        ClipboardService.shared.writeText(copyableDetails)
+                    } label: {
+                        Text(String(localized: "Copy Details"))
+                    }
+                    .help(String(localized: "Copy the full error to the clipboard"))
+                }
             }
             .controlSize(.large)
         }
@@ -79,13 +88,38 @@ internal struct ConnectionUnavailableView: View {
         switch reason {
         case .notConnected, .cancelled:
             return []
-        case .disconnected:
-            return [String(localized: "The connection was closed.")]
+        case .disconnected(let info):
+            guard let info else { return [String(localized: "The connection was closed.")] }
+            return lines(from: info)
         case .failed(let info), .pluginMissing(let info):
-            return [info.message, info.failureReason, info.recoverySuggestion]
-                .compactMap { $0 }
-                .filter { !$0.isEmpty }
+            return lines(from: info)
         }
+    }
+
+    private var failureInfo: ConnectionFailureInfo? {
+        switch reason {
+        case .notConnected, .cancelled:
+            return nil
+        case .disconnected(let info):
+            return info
+        case .failed(let info), .pluginMissing(let info):
+            return info
+        }
+    }
+
+    /// The driver's own words are the part worth pasting into a bug report, so they go to the
+    /// clipboard verbatim alongside enough context to identify the connection.
+    private var copyableDetails: String? {
+        guard let failureInfo else { return nil }
+        return ([headline, connection.connectionSubtitle] + lines(from: failureInfo))
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+    }
+
+    private func lines(from info: ConnectionFailureInfo) -> [String] {
+        [info.message, info.failureReason, info.recoverySuggestion]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
     }
 
     private var primaryActionTitle: String {

--- a/TableProTests/Core/Database/DatabaseManagerTunnelTests.swift
+++ b/TableProTests/Core/Database/DatabaseManagerTunnelTests.swift
@@ -160,4 +160,37 @@ struct DatabaseManagerTunnelTests {
         #expect(tunneled.port == 62_000)
         #expect(tunneled.additionalFields[DatabaseConnection.sshForwardUnixSocketPathKey] == nil)
     }
+
+    @Test("Exhausted tunnel recovery removes the session instead of leaving a spinner")
+    func exhaustedRecoveryRemovesTheSession() {
+        let connection = DatabaseConnection(
+            name: "dead tunnel",
+            host: "db.internal",
+            port: 5_432,
+            type: .postgresql
+        )
+        var session = ConnectionSession(connection: connection)
+        session.status = .connecting
+        DatabaseManager.shared.injectSession(session, for: connection.id)
+
+        DatabaseManager.shared.failTunnelRecovery(
+            connectionId: connection.id,
+            disconnectedMessage: "The SSH tunnel closed.",
+            attempts: 10
+        )
+
+        #expect(DatabaseManager.shared.activeSessions[connection.id] == nil)
+
+        let reason = DatabaseManager.shared.disconnectReason(for: connection.id)
+        #expect(reason?.message == "The SSH tunnel closed.")
+        #expect(reason?.failureReason?.contains("10") == true)
+
+        let snapshot = ConnectionSessionSnapshot(exists: false, hasDriver: false, disconnectInfo: reason)
+        let phase = ConnectionWindowPhaseMachine.onSessionChanged(
+            phase: .connecting,
+            session: snapshot,
+            ownsAttempt: false
+        )
+        #expect(phase != .connecting)
+    }
 }

--- a/TableProTests/Core/Services/Infrastructure/ConnectionWindowPaneResolverTests.swift
+++ b/TableProTests/Core/Services/Infrastructure/ConnectionWindowPaneResolverTests.swift
@@ -28,11 +28,29 @@ struct ConnectionWindowPaneResolverTests {
         #expect(pane != .empty)
     }
 
+    @Test("Only a window with content earns a sidebar and an inspector")
+    func chromeHiddenForEveryNonContentPane() {
+        #expect(!ConnectionWindowPaneResolver.hidesChrome(for: .content))
+        #expect(ConnectionWindowPaneResolver.hidesChrome(for: .connecting))
+        #expect(ConnectionWindowPaneResolver.hidesChrome(for: .empty))
+
+        let reasons: [ConnectionUnavailableReason] = [
+            .notConnected,
+            .cancelled,
+            .disconnected(nil),
+            .failed(Self.failure),
+            .pluginMissing(Self.failure)
+        ]
+        for reason in reasons {
+            #expect(ConnectionWindowPaneResolver.hidesChrome(for: .unavailable(reason)))
+        }
+    }
+
     @Test("Every unavailable reason reaches its pane")
     func everyUnavailableReasonResolves() {
         let reasons: [ConnectionUnavailableReason] = [
             .cancelled,
-            .disconnected,
+            .disconnected(nil),
             .failed(Self.failure),
             .pluginMissing(Self.failure)
         ]
@@ -117,7 +135,7 @@ struct ConnectionWindowPaneResolverTests {
             .connected,
             .closing,
             .unavailable(.cancelled),
-            .unavailable(.disconnected),
+            .unavailable(.disconnected(nil)),
             .unavailable(.failed(Self.failure)),
             .unavailable(.pluginMissing(Self.failure))
         ]

--- a/TableProTests/Core/Services/Infrastructure/ConnectionWindowPhaseMachineTests.swift
+++ b/TableProTests/Core/Services/Infrastructure/ConnectionWindowPhaseMachineTests.swift
@@ -69,7 +69,7 @@ struct ConnectionWindowPhaseMachineTests {
     func driverRecoversFromEveryUnavailableReason() {
         let reasons: [ConnectionUnavailableReason] = [
             .cancelled,
-            .disconnected,
+            .disconnected(nil),
             .failed(Self.failure),
             .pluginMissing(Self.failure)
         ]
@@ -126,7 +126,7 @@ struct ConnectionWindowPhaseMachineTests {
             ownsAttempt: false
         )
 
-        #expect(phase == .unavailable(.disconnected))
+        #expect(phase == .unavailable(.disconnected(nil)))
     }
 
     @Test("Losing a live session becomes disconnected, not connecting")
@@ -137,7 +137,19 @@ struct ConnectionWindowPhaseMachineTests {
             ownsAttempt: false
         )
 
-        #expect(phase == .unavailable(.disconnected))
+        #expect(phase == .unavailable(.disconnected(nil)))
+    }
+
+    @Test("A session torn down with a reason reports the reason, not the generic close")
+    func disconnectReasonReachesThePhase() {
+        let phase = ConnectionWindowPhaseMachine.onSessionChanged(
+            phase: .connected,
+            session: ConnectionSessionSnapshot(exists: false, hasDriver: false, disconnectInfo: Self.failure),
+            ownsAttempt: false
+        )
+
+        #expect(phase == .unavailable(.disconnected(Self.failure)))
+        #expect(phase != .unavailable(.disconnected(nil)))
     }
 
     @Test("A driverless session does not drag an unavailable window back to a spinner")
@@ -154,7 +166,7 @@ struct ConnectionWindowPhaseMachineTests {
     @Test("A failed connection is still worth reopening next launch")
     func failureRetainsRestoreIntent() {
         #expect(ConnectionWindowPhaseMachine.retainsRestoreIntent(phase: .unavailable(.failed(Self.failure))))
-        #expect(ConnectionWindowPhaseMachine.retainsRestoreIntent(phase: .unavailable(.disconnected)))
+        #expect(ConnectionWindowPhaseMachine.retainsRestoreIntent(phase: .unavailable(.disconnected(nil))))
         #expect(ConnectionWindowPhaseMachine.retainsRestoreIntent(phase: .unavailable(.pluginMissing(Self.failure))))
         #expect(ConnectionWindowPhaseMachine.retainsRestoreIntent(phase: .connecting))
         #expect(ConnectionWindowPhaseMachine.retainsRestoreIntent(phase: .connected))
@@ -171,7 +183,7 @@ struct ConnectionWindowPhaseMachineTests {
     func activationConnectEligibility() {
         #expect(ConnectionWindowPhaseMachine.allowsActivationConnect(phase: .idle))
         #expect(ConnectionWindowPhaseMachine.allowsActivationConnect(phase: .unavailable(.failed(Self.failure))))
-        #expect(ConnectionWindowPhaseMachine.allowsActivationConnect(phase: .unavailable(.disconnected)))
+        #expect(ConnectionWindowPhaseMachine.allowsActivationConnect(phase: .unavailable(.disconnected(nil))))
 
         #expect(!ConnectionWindowPhaseMachine.allowsActivationConnect(phase: .unavailable(.cancelled)))
         #expect(!ConnectionWindowPhaseMachine.allowsActivationConnect(phase: .unavailable(.pluginMissing(Self.failure))))

--- a/TableProTests/Models/Connection/ConnectionStageLabelFormatterTests.swift
+++ b/TableProTests/Models/Connection/ConnectionStageLabelFormatterTests.swift
@@ -1,0 +1,107 @@
+//
+//  ConnectionStageLabelFormatterTests.swift
+//  TableProTests
+//
+//  The HIG names "loading" and "authenticating" as descriptions that add nothing. A step label
+//  has to say what it is acting on, and the spoken form has to name the connection because it
+//  is heard without the window around it.
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("Connection stage labels")
+struct ConnectionStageLabelFormatterTests {
+    private static func connection(
+        name: String = "Prod DB",
+        username: String = "postgres"
+    ) -> DatabaseConnection {
+        DatabaseConnection(
+            name: name,
+            host: "db.internal",
+            port: 5_432,
+            username: username,
+            type: .postgresql
+        )
+    }
+
+    private static let stages: [ConnectionStage] = [
+        .resolvingTunnel,
+        .runningPreConnectScript,
+        .awaitingCredentials,
+        .openingConnection,
+        .negotiatingEncryption,
+        .authenticating,
+        .preparingSession
+    ]
+
+    @Test("No step is a bare verb")
+    func noStepIsABareVerb() {
+        let connection = Self.connection()
+        let banned = ["Loading", "Authenticating", "Connecting", "Please wait"]
+
+        for stage in Self.stages {
+            let label = ConnectionStageLabelFormatter.stepLabel(for: stage, connection: connection)
+            #expect(!label.isEmpty)
+            #expect(!banned.contains(label))
+        }
+    }
+
+    @Test("Authenticating names the user it is authenticating")
+    func authenticatingNamesTheUser() {
+        let label = ConnectionStageLabelFormatter.stepLabel(
+            for: .authenticating,
+            connection: Self.connection(username: "reporting_ro")
+        )
+
+        #expect(label.contains("reporting_ro"))
+    }
+
+    @Test("A connection with no username still gets a usable step")
+    func authenticatingWithoutUsername() {
+        let label = ConnectionStageLabelFormatter.stepLabel(
+            for: .authenticating,
+            connection: Self.connection(username: "  ")
+        )
+
+        #expect(!label.isEmpty)
+        #expect(!label.contains("  "))
+    }
+
+    @Test("Every spoken stage names the connection")
+    func announcementsNameTheConnection() {
+        let connection = Self.connection(name: "Prod DB")
+
+        for stage in Self.stages {
+            let announcement = ConnectionStageLabelFormatter.announcement(for: stage, connection: connection)
+            #expect(announcement.contains("Prod DB"))
+        }
+    }
+
+    @Test("A plugin's own wording is passed through untouched")
+    func customStagePassesThrough() {
+        let label = ConnectionStageLabelFormatter.stepLabel(
+            for: .custom("Discovering replica set members"),
+            connection: Self.connection()
+        )
+
+        #expect(label == "Discovering replica set members")
+    }
+
+    @Test("An SSH tunnel step names the host it goes through")
+    func tunnelStepNamesTheJumpHost() {
+        var sshConfig = SSHConfiguration()
+        sshConfig.enabled = true
+        sshConfig.host = "bastion.example.com"
+        sshConfig.username = "deploy"
+
+        var connection = Self.connection()
+        connection.sshTunnelMode = .inline(sshConfig)
+
+        let label = ConnectionStageLabelFormatter.stepLabel(for: .resolvingTunnel, connection: connection)
+
+        #expect(label.contains("bastion.example.com"))
+    }
+}

--- a/docs/databases/overview.mdx
+++ b/docs/databases/overview.mdx
@@ -131,7 +131,7 @@ File-based drivers (SQLite, DuckDB, Beancount) replace the host section with a f
 | Field | Description |
 |-------|-------------|
 | **Startup Commands** | SQL that runs after every connect. See [Startup Commands](#startup-commands) |
-| **Pre-Connect Script** | Shell script run before connecting. A non-zero exit aborts |
+| **Pre-Connect Script** | Shell script run before connecting. A non-zero exit aborts. TablePro shows the script and asks before running it, and never runs it when the app reopens a session at launch: that window waits with a **Connect** button |
 | **AI Policy** | Per-connection override for in-app AI agents |
 | **External Clients** | Access level for MCP clients: **Blocked**, **Read Only** (default), or **Read & Write**. See [External API](/external-api/index) |
 | **Local only** | Excludes this connection from iCloud Sync. See [iCloud Sync](/features/icloud-sync) |
@@ -179,6 +179,14 @@ When the sidebar is in tree layout, the filter button in the sidebar footer limi
 ## Dock Menu
 
 Right-click the TablePro Dock icon and pick a saved connection under **Open Connection**.
+
+## While a Connection Is Being Established
+
+The window fills with the connection's name, its endpoint, and the step currently running: opening the tunnel, running the pre-connect script, negotiating encryption, authenticating, preparing the session. The sidebar and inspector stay out of the way until there is a session to put in them, and come back at the width you left them.
+
+PostgreSQL, CockroachDB, Redshift, ClickHouse, and Redis report steps from inside their own handshake. Other drivers report the steps around the driver, because their client libraries connect in a single call with nothing observable in between. If a step stalls, the window says so. **Cancel**, or Escape, stops waiting immediately.
+
+A connection that fails stays in its window and shows the database's own error, with **Try Again**, **Manage Connections…**, and **Copy Details**. Nothing is reported as an alert, so reopening several connections at launch cannot bury you in dialogs.
 
 ## Connection Health Monitoring
 


### PR DESCRIPTION
Rebuilds the connecting screen as a full-window surface that names the step it is on, and fixes three bugs found while tracing the connect flow.

## The problem, in three parts

**Presentation.** `ConnectingStateView` used `ContentUnavailableView` to present work in flight. Apple documents that view for content that cannot be shown, and every cause it lists (a network error, an empty list, a fruitless search) is a state the operation has already settled into. UIKit ships a separate `UIContentUnavailableConfiguration.loading()` for work in progress; macOS and SwiftUI ship no equivalent, so a connecting surface has to be built from `ProgressView`. Meanwhile the window kept all three split items mounted, so the connecting state was real three-pane chrome wrapped around a spinner, with two empty columns and a live sidebar filter field over nothing.

**State model.** `ConnectionSessionSnapshot` was two booleans, `{exists, hasDriver}`. It could not say "failed", so a session left behind by an exhausted tunnel recovery read as `.connecting` forever.

**Entry points.** Six ways to start a connect, disagreeing on whether the window comes first. Only a window-owned attempt classified its failure, so a connect started anywhere else lost the real error and reported the generic closed-connection copy instead.

## What this changes

Sidebar and inspector collapse for any pane that is not `.content`, using `NSSplitViewItem.isCollapsed`. The alternatives were rejected on documented grounds: setting `NSWindow.contentViewController` is documented to resize the window and would take the split view out from under `NSTrackingSeparatorToolbarItem`, which requires both in the same window, and `transition(from:to:options:)` is documented to require sibling child view controllers.

Collapse state is written into the split view's autosave record, which is how the inspector remembers being hidden. Two things keep a phase the user did not choose from becoming their saved layout: autosaving is switched off for the whole span the chrome is hidden, and the saved layout is restored before any collapse so the pane returns to the width `NSSplitViewItem` already remembers.

Show/Hide Sidebar and Inspector are disabled through `validateUserInterfaceItem` while there is no session, and first responder moves out of a pane before it collapses.

The toolbar is still installed only once a coordinator exists, and `installToolbar` now takes a non-optional one so it cannot be built early again. The delegate returns no item without a coordinator and `NSToolbar` asks it once, so a toolbar created before the session lands is permanently empty: a later coordinator cannot refill it, and validation only speaks to items that already exist. A window with no session shows a plain titlebar, which is what the connecting design calls for anyway.

Stage reporting is a new `ConnectionStage` in PluginKit plus a `connect(reportingStage:)` requirement with a default implementation. The app reports the steps around the driver for every database. Drivers report their own handshake where it is genuinely observable: PostgreSQL, CockroachDB, Redshift and PGlite read `PQstatus` inside the poll loop they already run, Redis reports TLS, AUTH and session setup, ClickHouse reports its version round trip.

MySQL and SQLite are deliberately not instrumented. `mysql_real_connect` is one blocking call that does TCP, TLS and authentication with nothing observable in between, and `sqlite3_open` opens a local file. Inventing steps there would be progress theatre, so they report the honest app-side step.

Stage labels avoid the two words the HIG names as examples of a description that adds nothing ("loading", "authenticating"). The displayed step sits under a heading that already names the connection, so it only says which step is running; the spoken form names the connection because VoiceOver hears it without the window around it, posted per step through `AccessibilityNotification.Announcement` rather than the poll-based `updatesFrequently` trait.

## Bugs fixed

- A dropped SSH tunnel that ran out of reconnect attempts set an error status but never removed the session entry, so every window read it as still dialing and spun forever with no exit.
- The classified failure is now recorded before the session entry disappears, so every entry point shows the database's own error instead of "The connection was closed."
- Losing a session for a moment tore down the coordinator and took open tabs and unsaved query edits with it. A session that still exists is reconnecting, not gone.
- A saved pre-connect script ran unprompted when the app reopened a session at launch. That window now waits with a Connect button, which asks first. Prompting at launch instead would have put one modal per restored connection on screen, which the HIG rules out twice over.

## Testing

`swiftlint --strict` clean across 1291 files. Build succeeds. New and updated unit tests pass:

- `ConnectionStageLabelFormatterTests` covers every stage: no step is a bare verb, authenticating names the user, the spoken form names the connection, a plugin's own wording passes through.
- `ConnectionWindowPaneResolverTests` gains `hidesChrome` coverage for every pane and every unavailable reason.
- `ConnectionWindowPhaseMachineTests` gains the disconnect-reason case that would have caught the permanent spinner.
- `DatabaseManagerTunnelTests` gains a test that exhausted tunnel recovery removes the session.

No `TableProUITests` coverage was added. The connecting surface only exists while a connection is genuinely in flight, which needs a reachable server and is timing dependent, so it does not run deterministically in the UI test target. The parts that can be pinned down (pane and chrome resolution, phase transitions, stage labels, session teardown) are covered by unit tests above.

## PluginKit ABI

`scripts/check-pluginkit-abi.sh` reports a diff with zero removed symbols. The additions are a new type, a new typealias, and one protocol requirement that ships with a default implementation. That is additive by the rules in CLAUDE.md: no `currentPluginKitVersion` bump and no plugin re-release. Labelled `abi-additive`.

## Worth a second look

With both side panes collapsed the window minimum drops to 720pt, so a connecting window can sit narrower than a connected one and grows when the session arrives.

`registerPendingSession` seeds the session entry before the window opens, which is what lets a window name a connection that is not in storage, such as one from a link or a database file. A side effect is that those windows now build their coordinator before a driver exists, where previously they built it after the connect returned. Schema loading is armed off `databaseDidConnect` so it is unaffected, but the deep link and database file routes are worth exercising by hand.
