### PR TITLE
fix(coordinator): make the window title a function of the pane it is showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A window being connected is now named after the connection instead of "SQL Query", which named a tab it did not have yet.
+- A window that loses its connection no longer keeps the name of the table it stopped showing. Its name and its native tab label now follow what the window is actually displaying.
+- The titlebar no longer repeats itself, so a window with no tabs open reads "My Database" rather than "My Database - My Database".
+- A tab you named yourself is no longer renamed behind your back when the window reconnects. Any title ending in "Query" used to be treated as a placeholder and replaced.
+- Window naming now works in translated builds. The rule that decided whether a title was a placeholder compared it against English text, so it never matched outside English.
+- Renaming a connection now updates the name of any window already open on it.
 - A dropped SSH tunnel that ran out of reconnect attempts left the window spinning forever with no way back. It now reports what happened and offers to try again.
 - A brief tunnel reconnect no longer closes your tabs. The window used to tear down the whole session on the blip, taking unsaved query edits with it.
 - The sidebar's filter field no longer sits over an empty sidebar while a connection is still being established.

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -20,7 +20,9 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     // MARK: - Payload & Session
 
     let payload: EditorTabPayload?
-    let payloadConnection: DatabaseConnection?
+    /// Re-read when the connection record changes, so a rename reaches the window's name and
+    /// the connecting screen instead of freezing whatever the record said at creation.
+    private(set) var payloadConnection: DatabaseConnection?
     private var currentSession: ConnectionSession?
     private var sessionState: SessionStateFactory.SessionState?
     private var rightPanelState: RightPanelState?
@@ -82,6 +84,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
 
     private var connectionStatusCancellable: AnyCancellable?
     private var railVisibilityCancellable: AnyCancellable?
+    private var connectionUpdatedCancellable: AnyCancellable?
 
     // MARK: - Init
 
@@ -95,14 +98,6 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
             self.payloadConnection = nil
         }
 
-        let queryLanguageName: String? = {
-            guard let connectionId = payload?.connectionId,
-                  let connection = DatabaseManager.shared.activeSessions[connectionId]?.connection else {
-                return nil
-            }
-            return PluginManager.shared.queryLanguageName(for: connection.type)
-        }()
-
         var resolvedSession: ConnectionSession?
         if let connectionId = payload?.connectionId {
             resolvedSession = DatabaseManager.shared.activeSessions[connectionId]
@@ -111,17 +106,8 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         }
         self.currentSession = resolvedSession
 
-        let titleConnection = self.payloadConnection ?? resolvedSession?.connection
-        self.windowTitle = WindowTitleResolver.resolveTitle(
-            payload: payload,
-            databaseType: titleConnection?.type,
-            queryLanguageName: queryLanguageName
-        )
-        if let titleConnection {
-            self.windowSubtitle = WindowTitleResolver.resolveSubtitle(payload: payload, connection: titleConnection)
-        } else {
-            self.windowSubtitle = ""
-        }
+        self.windowTitle = ""
+        self.windowSubtitle = ""
 
         if let session = resolvedSession {
             self.rightPanelState = RightPanelState(connectionId: session.connection.id)
@@ -136,11 +122,6 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
                 state = SessionStateFactory.create(connection: session.connection, payload: payload)
             }
             self.sessionState = state
-            if payload?.intent == .newEmptyTab,
-               let tabTitle = state.coordinator.tabManager.selectedTab?.title,
-               !tabTitle.isBlank {
-                self.windowTitle = tabTitle
-            }
         }
 
         if resolvedSession?.driver != nil {
@@ -152,6 +133,10 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         }
 
         super.init(nibName: nil, bundle: nil)
+
+        /// AppKit renders a native tab's label even for a tab that is never activated, so the
+        /// title has to be right at creation rather than at first appearance.
+        applyWindowTitle()
     }
 
     @available(*, unavailable)
@@ -260,6 +245,11 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
             .sink { [weak self] _ in
                 self?.applyRailVisibility(workspaceCount: WorkspaceRailStore.entries.count)
             }
+        connectionUpdatedCancellable = AppEvents.shared.connectionUpdated
+            .receive(on: RunLoop.main)
+            .sink { [weak self] changedId in
+                self?.handleConnectionRecordChange(changedId)
+            }
         handleConnectionStatusChange()
         applyRailVisibility(workspaceCount: WorkspaceRailStore.entries.count)
     }
@@ -267,6 +257,18 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     private func removeObservers() {
         connectionStatusCancellable = nil
         railVisibilityCancellable = nil
+        connectionUpdatedCancellable = nil
+    }
+
+    /// `nil` is the documented bulk-update payload, so it has to repaint too.
+    private func handleConnectionRecordChange(_ changedId: UUID?) {
+        guard let connectionId = payload?.connectionId ?? currentSession?.connection.id else { return }
+        guard changedId == nil || changedId == connectionId else { return }
+        guard let stored = ConnectionStorage.shared.loadConnections().first(where: { $0.id == connectionId })
+            ?? DatabaseManager.shared.activeSessions[connectionId]?.connection else { return }
+        payloadConnection = stored
+        applyWindowTitle()
+        rebuildPanes()
     }
 
     // MARK: - Toolbar
@@ -330,14 +332,6 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     private func adoptSession(_ session: ConnectionSession) {
         currentSession = session
 
-        if payload?.tableName == nil,
-           windowTitle.isBlank
-           || windowTitle == WindowTitleResolver.fallbackTitle
-           || windowTitle.hasSuffix(" Query") {
-            windowTitle = session.connection.name
-            windowSubtitle = session.connection.name
-        }
-
         if rightPanelState == nil {
             rightPanelState = RightPanelState(connectionId: session.connection.id)
         }
@@ -368,7 +362,23 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     private func applyPhase() {
         rebuildPanes()
         applyPaneChrome()
+        applyWindowTitle()
         SessionRecoveryTracker.sync()
+    }
+
+    /// Repainted on every phase change for the same reason the panes are. Leaving it out is
+    /// what let a window keep the name of a table it had stopped showing after the session
+    /// underneath it went away.
+    internal func applyWindowTitle() {
+        let resolved = WindowTitleResolver.resolveWindow(
+            pane: currentPane,
+            connection: paneConnection,
+            tab: sessionState?.tabManager.selectedTab,
+            hasTabs: !(sessionState?.tabManager.tabs.isEmpty ?? true),
+            queryLanguageName: paneConnection.map { PluginManager.shared.queryLanguageName(for: $0.type) } ?? nil
+        )
+        windowTitle = resolved.title
+        windowSubtitle = resolved.subtitle
     }
 
     internal func transition(to next: ConnectionWindowPhase) {

--- a/TablePro/Core/Services/Infrastructure/WindowTitleResolver.swift
+++ b/TablePro/Core/Services/Infrastructure/WindowTitleResolver.swift
@@ -7,10 +7,48 @@
 
 import Foundation
 
+/// Title and subtitle decided together. Resolving them apart is how a window ended up
+/// announcing "TablePro - TablePro": two callers each picked the connection name without
+/// knowing the other had.
+struct ResolvedWindowTitle: Equatable {
+    let title: String
+    let subtitle: String
+}
+
 @MainActor
 enum WindowTitleResolver {
     static var fallbackTitle: String {
         String(localized: "SQL Query")
+    }
+
+    /// The window's name is a function of the pane it is showing, exactly like its content and
+    /// its chrome. A window that is not showing content is not showing a document, so naming it
+    /// after a tab is naming something that is not there: that is how a connecting window came
+    /// to be called "SQL Query", and how a window that lost its session kept the name of the
+    /// table it had stopped displaying.
+    static func resolveWindow(
+        pane: ConnectionWindowPane,
+        connection: DatabaseConnection?,
+        tab: QueryTab?,
+        hasTabs: Bool,
+        queryLanguageName: String?
+    ) -> ResolvedWindowTitle {
+        let connectionName = connection?.name ?? ""
+
+        guard pane == .content else {
+            return connectionTitle(connectionName)
+        }
+        guard hasTabs, let connection else {
+            return connectionTitle(connectionName)
+        }
+
+        let title = resolveTitle(tab: tab, connection: connection, queryLanguageName: queryLanguageName)
+        let subtitle = resolveSubtitle(tab: tab, connection: connection)
+        return ResolvedWindowTitle(title: title, subtitle: subtitle == title ? "" : subtitle)
+    }
+
+    private static func connectionTitle(_ name: String) -> ResolvedWindowTitle {
+        ResolvedWindowTitle(title: name.isBlank ? fallbackTitle : name, subtitle: "")
     }
 
     static func resolveTitle(

--- a/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
@@ -278,16 +278,15 @@ extension MainContentView {
     /// Update window title, proxy icon, and dirty dot based on the selected tab.
     func updateWindowTitleAndFileState() {
         let selectedTab = tabManager.selectedTab
-        if selectedTab == nil, tabManager.tabs.isEmpty {
-            windowTitle = connection.name
-        } else {
-            windowTitle = WindowTitleResolver.resolveTitle(
-                tab: selectedTab,
-                connection: connection,
-                queryLanguageName: PluginManager.shared.queryLanguageName(for: connection.type)
-            )
-        }
-        windowSubtitle = WindowTitleResolver.resolveSubtitle(tab: selectedTab, connection: connection)
+        let resolved = WindowTitleResolver.resolveWindow(
+            pane: .content,
+            connection: connection,
+            tab: selectedTab,
+            hasTabs: !tabManager.tabs.isEmpty,
+            queryLanguageName: PluginManager.shared.queryLanguageName(for: connection.type)
+        )
+        windowTitle = resolved.title
+        windowSubtitle = resolved.subtitle
         coordinator.splitViewController?.updateDetailMinimumThickness(for: selectedTab?.tabType)
         viewWindow?.representedURL = selectedTab?.content.sourceFileURL
         viewWindow?.isDocumentEdited = selectedTab?.showsUnsavedIndicator ?? false

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -323,11 +323,6 @@ struct MainContentView: View {
                     "[open] MainContentView.onAppear start windowId=\(windowId, privacy: .public) connId=\(connection.id, privacy: .public) tabs=\(tabManager.tabs.count)"
                 )
                 coordinator.markActivated()
-
-                // Set window title for empty state (no tabs restored)
-                if tabManager.tabs.isEmpty {
-                    windowTitle = connection.name
-                }
                 setupCommandActions()
                 updateToolbarPendingState()
                 updateInspectorContext()

--- a/TableProTests/Services/WindowTitleResolverWindowTests.swift
+++ b/TableProTests/Services/WindowTitleResolverWindowTests.swift
@@ -1,0 +1,152 @@
+//
+//  WindowTitleResolverWindowTests.swift
+//  TableProTests
+//
+//  The window's name used to be decided by whoever wrote to it last. A connecting window was
+//  called "SQL Query" after a tab it did not have, a window that lost its session kept the name
+//  of the table it had stopped showing, and two callers each picked the connection name without
+//  knowing the other had, which is how a titlebar came to read "TablePro - TablePro".
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("WindowTitleResolver.resolveWindow")
+@MainActor
+struct WindowTitleResolverWindowTests {
+    private static func connection(name: String = "Prod DB") -> DatabaseConnection {
+        DatabaseConnection(
+            name: name,
+            host: "db.internal",
+            port: 5_432,
+            database: "shop",
+            username: "postgres",
+            type: .postgresql
+        )
+    }
+
+    private static let nonContentPanes: [ConnectionWindowPane] = [
+        .connecting,
+        .empty,
+        .unavailable(.notConnected),
+        .unavailable(.cancelled),
+        .unavailable(.disconnected(nil)),
+        .unavailable(.failed(ConnectionFailureInfo(message: "refused"))),
+        .unavailable(.pluginMissing(ConnectionFailureInfo(message: "missing"))),
+    ]
+
+    @Test("A window that is not showing content is named after its connection, never a tab")
+    func nonContentPanesUseTheConnectionName() {
+        let connection = Self.connection()
+
+        for pane in Self.nonContentPanes {
+            let resolved = WindowTitleResolver.resolveWindow(
+                pane: pane,
+                connection: connection,
+                tab: nil,
+                hasTabs: false,
+                queryLanguageName: "PostgreSQL"
+            )
+
+            #expect(resolved.title == "Prod DB")
+            #expect(resolved.subtitle.isEmpty)
+            #expect(resolved.title != WindowTitleResolver.fallbackTitle)
+        }
+    }
+
+    /// The regression that started this: a connecting window carries tabs restored from disk,
+    /// and naming it after one of them announced a table nobody could see yet.
+    @Test("Restored tabs do not leak into the name of a window that is still connecting")
+    func connectingIgnoresRestoredTabs() {
+        let resolved = WindowTitleResolver.resolveWindow(
+            pane: .connecting,
+            connection: Self.connection(),
+            tab: nil,
+            hasTabs: true,
+            queryLanguageName: "PostgreSQL"
+        )
+
+        #expect(resolved.title == "Prod DB")
+        #expect(resolved.subtitle.isEmpty)
+    }
+
+    @Test("A content window with no tabs is named after its connection and carries no subtitle")
+    func emptyContentWindowHasNoSubtitle() {
+        let resolved = WindowTitleResolver.resolveWindow(
+            pane: .content,
+            connection: Self.connection(),
+            tab: nil,
+            hasTabs: false,
+            queryLanguageName: "PostgreSQL"
+        )
+
+        #expect(resolved.title == "Prod DB")
+        #expect(resolved.subtitle.isEmpty)
+    }
+
+    @Test("The subtitle never repeats the title")
+    func subtitleNeverRepeatsTitle() {
+        let connection = Self.connection(name: "shop")
+
+        for pane in Self.nonContentPanes + [.content] {
+            let resolved = WindowTitleResolver.resolveWindow(
+                pane: pane,
+                connection: connection,
+                tab: nil,
+                hasTabs: false,
+                queryLanguageName: "PostgreSQL"
+            )
+
+            #expect(resolved.subtitle != resolved.title)
+        }
+    }
+
+    @Test("A connection with no name still produces a usable window name")
+    func blankConnectionNameFallsBack() {
+        let resolved = WindowTitleResolver.resolveWindow(
+            pane: .connecting,
+            connection: Self.connection(name: "   "),
+            tab: nil,
+            hasTabs: false,
+            queryLanguageName: nil
+        )
+
+        #expect(!resolved.title.isBlank)
+        #expect(resolved.title == WindowTitleResolver.fallbackTitle)
+    }
+
+    @Test("A window with no connection at all still produces a usable name")
+    func missingConnectionFallsBack() {
+        let resolved = WindowTitleResolver.resolveWindow(
+            pane: .empty,
+            connection: nil,
+            tab: nil,
+            hasTabs: false,
+            queryLanguageName: nil
+        )
+
+        #expect(resolved.title == WindowTitleResolver.fallbackTitle)
+        #expect(resolved.subtitle.isEmpty)
+    }
+
+    /// A user is free to name a tab "Weekly Query". The old placeholder detector matched any
+    /// title ending in " Query" and overwrote it, and matched the English rendering of a
+    /// localized format string, so it did nothing at all in a translated build.
+    @Test("A tab a user named themselves survives, whatever it ends with")
+    func userNamedTabSurvives() {
+        let connection = Self.connection()
+        var tab = QueryTab(id: UUID(), title: "Weekly Query", query: "SELECT 1", tabType: .query)
+        tab.tableContext.databaseName = "shop"
+
+        let resolved = WindowTitleResolver.resolveWindow(
+            pane: .content,
+            connection: connection,
+            tab: tab,
+            hasTabs: true,
+            queryLanguageName: "PostgreSQL"
+        )
+
+        #expect(resolved.title == "Weekly Query")
+    }
+}


### PR DESCRIPTION
The window title was the one part of the connection window that never became a function of its phase. Content and chrome already are, since #2053. The title was still decided by whoever wrote to it last.

Found by auditing every title path across four lenses (window lifecycle, compliance with the "Window tab titles" invariant in CLAUDE.md, behaviour under translation, test coverage), with each finding independently attacked before being accepted. 17 survived, 5 were refuted.

## What was wrong

**A connecting window was called "SQL Query".** `MainSplitViewController.init` resolved the title from a payload that describes no tab, so `resolveTitle` fell through every tier to `fallbackTitle`, which is literally the string "SQL Query". The window was named after a document it did not have.

**A window that lost its session kept the name of the table it had stopped showing.** `applyPhase()` repaints content and chrome and never touched the title, and the only ongoing title sink lives inside `MainContentView`, which is unmounted the moment the pane stops being `.content`. The pane would read "Connection closed" while the window and its native tab label still said `orders`. Reachable through exhausted tunnel recovery, which is easy to hit after waking from sleep, and through an MCP disconnect.

**Placeholder detection compared a title against English text.** `adoptSession` decided a title was disposable by testing `windowTitle == WindowTitleResolver.fallbackTitle || windowTitle.hasSuffix(" Query")`. Both halves compare against the rendering of a localized string, so the whole branch is dead in every translated build. In English it was worse than dead: a tab a user named "Weekly Query" was silently renamed on every reconnect.

**The titlebar repeated itself.** That same branch set title and subtitle to the same value, and a second site set the title to the connection name while the subtitle was already the connection name. Hence "TablePro - TablePro".

**The no-tabs rule existed twice** and the two copies disagreed, in `MainContentView.onAppear` and in `updateWindowTitleAndFileState()`.

**Renaming a connection never reached an open window**, because the window captured its connection record once at creation.

## The fix

One resolver entry point decides title and subtitle together:

```swift
static func resolveWindow(pane:connection:tab:hasTabs:queryLanguageName:) -> ResolvedWindowTitle
```

Not showing content, or showing content with no tabs, resolves to the connection name with no subtitle. Showing a tab resolves to the tab's title with its database binding as subtitle, suppressed when it would equal the title. Deciding both together is what makes the repetition impossible by construction rather than by a guard someone has to remember.

`applyPhase()` gains a title sink beside content and chrome, so a phase change repaints the name. `MainSplitViewController.init` calls it after `super.init`, which keeps the invariant that a native tab label is correct at creation rather than at first activation, since AppKit draws labels for tabs that are never activated.

The string-matching block in `adoptSession` is deleted rather than repaired. So is the duplicated no-tabs rule in `onAppear` and the `.newEmptyTab`-only title override, which is why a query tab opened from a link or from AI used to keep "SQL Query" while the tab itself read "Query 3": the resolver now reads the real selected tab whatever the intent was.

`payloadConnection` is re-read when the connection record changes, so a rename reaches both the window name and the connecting screen.

## Not a rewrite

`WindowTitleResolver`'s existing tab logic is untouched and its 47 tests still pass. It was never what was broken. The defect was that consumers made title decisions the resolver did not own.

## Testing

`swiftlint --strict` clean across 1291 files. Build succeeds. `WindowTitleResolverWindowTests` adds 7 tests covering what no test covered before, since every previous test exercised the pure resolver and nothing exercised a consumer-side decision: every non-content pane resolves to the connection name, restored tabs do not leak into the name of a window that is still connecting, an empty content window carries no subtitle, the subtitle never repeats the title, blank and missing connections still produce a usable name, and a tab a user named themselves survives a reconnect.

## Deferred

One confirmed finding is left out on purpose. New query tab names are the only tab titles never run through localization, and the counter behind "Query 3" is recovered by parsing the text of existing tab titles (`QueryTabManager.swift:107`). That is the same class of defect as the placeholder matcher fixed here, but it belongs to tab naming rather than window naming and deserves its own change.
