### PR TITLE
fix(coordinator): give each tab ownership of its execution so a retarget cannot be overwritten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A connection that fails now shows the database's own error wherever the connect started, including from a link or a database file, and offers Copy Details. Those routes used to drop the real message and report only that the connection had closed.
 - Opening a table or query from a link now opens its window straight away, so a slow connect has somewhere to report progress and a failed one has somewhere to explain itself.
 - A saved pre-connect script no longer runs when the app reopens a session on its own. The window waits with a Connect button, which asks before running it.
+- Running a query or opening a table now replaces whatever that tab was already running, instead of being ignored until the first one finished.
 
 ### Fixed
 
+- Clicking a table while another one is still loading now loads the table you clicked. The tab used to fill with the previous table's rows under the new table's name, and the table you clicked never loaded at all.
+- Stop no longer aborts a save, a discard, or a schema change. It cancels reads only, so a write can no longer be cut off half way.
 - A window being connected is now named after the connection instead of "SQL Query", which named a tab it did not have yet.
 - A window that loses its connection no longer keeps the name of the table it stopped showing. Its name and its native tab label now follow what the window is actually displaying.
 - The titlebar no longer repeats itself, so a window with no tabs open reads "My Database" rather than "My Database - My Database".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opening a table or query from a link now opens its window straight away, so a slow connect has somewhere to report progress and a failed one has somewhere to explain itself.
 - A saved pre-connect script no longer runs when the app reopens a session on its own. The window waits with a Connect button, which asks before running it.
 - Running a query or opening a table now replaces whatever that tab was already running, instead of being ignored until the first one finished.
+- Clicking through tables quickly no longer stutters on a connection over an SSH tunnel. Stopping the query you navigated away from used to hold up the click for up to 160ms while it opened a second connection to deliver the cancel.
 
 ### Fixed
 

--- a/TablePro/Core/Coordinators/PaginationCoordinator.swift
+++ b/TablePro/Core/Coordinators/PaginationCoordinator.swift
@@ -134,15 +134,12 @@ final class PaginationCoordinator {
         parent.currentRowCountTask = nil
         parent.tabExecution.invalidateAll()
         parent.toolbarState.setExecuting(false)
-        for idx in parent.tabManager.tabs.indices {
-            if parent.tabManager.tabs[idx].execution.isExecuting
-                || parent.tabManager.tabs[idx].pagination.isLoadingMore
+        for idx in parent.tabManager.tabs.indices
+            where parent.tabManager.tabs[idx].pagination.isLoadingMore
                 || parent.tabManager.tabs[idx].pagination.isCountingExact {
-                parent.tabManager.mutate(at: idx) { tab in
-                    tab.execution.isExecuting = false
-                    tab.pagination.isLoadingMore = false
-                    tab.pagination.isCountingExact = false
-                }
+            parent.tabManager.mutate(at: idx) { tab in
+                tab.pagination.isLoadingMore = false
+                tab.pagination.isCountingExact = false
             }
         }
     }

--- a/TablePro/Core/Coordinators/PaginationCoordinator.swift
+++ b/TablePro/Core/Coordinators/PaginationCoordinator.swift
@@ -132,7 +132,7 @@ final class PaginationCoordinator {
         parent.cancelInFlightQueryTask()
         parent.currentRowCountTask?.cancel()
         parent.currentRowCountTask = nil
-        parent.queryGeneration += 1
+        parent.tabExecution.invalidateAll()
         parent.toolbarState.setExecuting(false)
         for idx in parent.tabManager.tabs.indices {
             if parent.tabManager.tabs[idx].execution.isExecuting
@@ -169,7 +169,7 @@ final class PaginationCoordinator {
 
         parent.tabManager.mutate(at: index) { $0.pagination.isCountingExact = true }
 
-        let capturedGeneration = parent.queryGeneration
+        let contentEpoch = parent.tabExecution.contentEpoch(for: tabId)
         parent.currentRowCountTask = Task(priority: .userInitiated) { [parent] in
             let count = await Self.exactRowCount(
                 scope: scope,
@@ -180,7 +180,7 @@ final class PaginationCoordinator {
             )
 
             guard !Task.isCancelled else { return }
-            guard capturedGeneration == parent.queryGeneration else { return }
+            guard parent.tabExecution.isSameContent(contentEpoch, for: tabId) else { return }
             parent.currentRowCountTask = nil
             parent.tabManager.mutate(tabId: tabId) { tab in
                 tab.pagination.isCountingExact = false
@@ -217,7 +217,7 @@ final class PaginationCoordinator {
     func fetchAllRows() {
         guard let (tab, _) = parent.tabManager.selectedTabAndIndex,
               !tab.pagination.isLoadingMore,
-              !tab.execution.isExecuting,
+              !parent.tabExecution.isExecuting(tab.id),
               tab.pagination.hasMoreRows,
               let baseQuery = tab.pagination.baseQueryForMore else { return }
 
@@ -258,7 +258,7 @@ final class PaginationCoordinator {
         guard let idx = parent.tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
         guard !parent.tabManager.tabs[idx].pagination.isLoadingMore else { return }
 
-        let capturedGeneration = parent.queryGeneration
+        let contentEpoch = parent.tabExecution.contentEpoch(for: tabId)
         let storedParamValues = parent.tabManager.tabs[idx].pagination.baseQueryParameterValues
 
         parent.tabManager.mutate(at: idx) { $0.pagination.isLoadingMore = true }
@@ -276,7 +276,7 @@ final class PaginationCoordinator {
                 let result = try await DatabaseManager.shared.withScopedDriver(
                     scope: scope,
                     route: route,
-                    tracksCancellation: true
+                    cancellation: .cancellableRead
                 ) { driver in
                     try await driver.executeUserQuery(
                         query: baseQuery,
@@ -291,7 +291,7 @@ final class PaginationCoordinator {
 
                 await MainActor.run { [weak self] in
                     guard let self, !parent.isTearingDown else { return }
-                    guard capturedGeneration == parent.queryGeneration else {
+                    guard parent.tabExecution.isSameContent(contentEpoch, for: tabId) else {
                         parent.tabManager.mutate(tabId: tabId) { $0.pagination.isLoadingMore = false }
                         parent.toolbarState.setExecuting(false)
                         return
@@ -321,7 +321,7 @@ final class PaginationCoordinator {
             } catch {
                 await MainActor.run { [weak self] in
                     guard let self else { return }
-                    let isStale = capturedGeneration != parent.queryGeneration
+                    let isStale = !parent.tabExecution.isSameContent(contentEpoch, for: tabId)
                     let isCancelled = DatabaseCancellationDiagnosis.isCancellation(error) || Task.isCancelled
                     parent.tabManager.mutate(tabId: tabId) { tab in
                         tab.pagination.isLoadingMore = false

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
@@ -271,7 +271,7 @@ extension QueryExecutionCoordinator {
     func launchPhase2Work(
         tableName: String,
         tabId: UUID,
-        capturedGeneration: Int,
+        claim: TabExecutionClaim,
         connectionType: DatabaseType,
         schemaTask: Task<FetchedTableSchema, Error>?
     ) {
@@ -290,11 +290,11 @@ extension QueryExecutionCoordinator {
                 if let schema {
                     applySchemaMetadata(schema, tabId: tabId, tableName: tableName)
                 }
-                if capturedGeneration == parent.queryGeneration {
+                if parent.tabExecution.isCurrent(claim) {
                     resolveRowCount(
                         tableName: tableName,
                         tabId: tabId,
-                        capturedGeneration: capturedGeneration,
+                        claim: claim,
                         connectionType: connectionType
                     )
                 }
@@ -398,13 +398,13 @@ extension QueryExecutionCoordinator {
     func launchPhase2Count(
         tableName: String,
         tabId: UUID,
-        capturedGeneration: Int,
+        claim: TabExecutionClaim,
         connectionType: DatabaseType
     ) {
         resolveRowCount(
             tableName: tableName,
             tabId: tabId,
-            capturedGeneration: capturedGeneration,
+            claim: claim,
             connectionType: connectionType
         )
     }
@@ -412,7 +412,7 @@ extension QueryExecutionCoordinator {
     func resolveRowCount(
         tableName: String,
         tabId: UUID,
-        capturedGeneration: Int,
+        claim: TabExecutionClaim,
         connectionType: DatabaseType
     ) {
         let isNonSQL = PluginManager.shared.editorLanguage(for: connectionType) != .sql
@@ -489,7 +489,7 @@ extension QueryExecutionCoordinator {
             }
 
             await MainActor.run {
-                guard capturedGeneration == parent.queryGeneration else { return }
+                guard parent.tabExecution.isCurrent(claim) else { return }
                 parent.currentRowCountTask = nil
                 guard let outcome else { return }
                 parent.tabManager.mutate(tabId: tabId) { tab in

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
@@ -151,7 +151,6 @@ extension QueryExecutionCoordinator {
             tab.execution.executionTime = executionTime
             tab.execution.rowsAffected = rowsAffected
             tab.execution.statusMessage = statusMessage
-            tab.execution.isExecuting = false
             tab.execution.lastExecutedAt = Date()
             tab.tableContext.tableName = tableName
             tab.tableContext.isEditable = isEditable
@@ -245,7 +244,6 @@ extension QueryExecutionCoordinator {
             tab.execution.executionTime = executionTime
             tab.execution.rowsAffected = 0
             tab.execution.statusMessage = nil
-            tab.execution.isExecuting = false
             tab.execution.lastExecutedAt = Date()
             tab.display.explainText = planText
             tab.display.explainPlan = plan
@@ -528,7 +526,6 @@ extension QueryExecutionCoordinator {
         parent.currentQueryTask = nil
         guard !DatabaseCancellationDiagnosis.isCancellation(error) else {
             parent.tabManager.mutate(tabId: tabId) { tab in
-                tab.execution.isExecuting = false
                 tab.pagination.isLoadingMore = false
             }
             parent.toolbarState.setExecuting(false)
@@ -537,7 +534,6 @@ extension QueryExecutionCoordinator {
         parent.tabManager.mutate(tabId: tabId) { tab in
             tab.execution.errorMessage = DatabaseWriteRejectionDiagnosis.formatted(error)
             tab.execution.errorQuery = sql
-            tab.execution.isExecuting = false
             tab.execution.lastExecutedAt = Date()
         }
         parent.toolbarState.setExecuting(false)

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+MultiStatement.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+MultiStatement.swift
@@ -86,7 +86,6 @@ extension QueryExecutionCoordinator {
         parent.toolbarState.lastQueryDuration = cumulativeTime
 
         if !parent.tabExecution.isCurrent(claim) {
-            parent.tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
             return
         }
         guard let idx = parent.tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
@@ -128,7 +127,6 @@ extension QueryExecutionCoordinator {
             tab.schemaVersion += 1
             tab.execution.executionTime = cumulativeTime
             tab.execution.rowsAffected = totalRowsAffected
-            tab.execution.isExecuting = false
             tab.execution.lastExecutedAt = Date()
             tab.execution.errorMessage = nil
 

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+MultiStatement.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+MultiStatement.swift
@@ -74,7 +74,7 @@ extension QueryExecutionCoordinator {
 
     func applyMultiStatementResults(
         tabId: UUID,
-        capturedGeneration: Int,
+        claim: TabExecutionClaim,
         cumulativeTime: TimeInterval,
         totalRowsAffected: Int,
         lastSelectResult: QueryResult?,
@@ -85,7 +85,7 @@ extension QueryExecutionCoordinator {
         parent.toolbarState.setExecuting(false)
         parent.toolbarState.lastQueryDuration = cumulativeTime
 
-        if capturedGeneration != parent.queryGeneration {
+        if !parent.tabExecution.isCurrent(claim) {
             parent.tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
             return
         }

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+Parameters.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+Parameters.swift
@@ -97,7 +97,6 @@ extension QueryExecutionCoordinator {
         }
 
         parent.tabManager.mutate(at: index) { tab in
-            tab.execution.isExecuting = true
             tab.execution.executionTime = nil
             tab.execution.errorMessage = nil
             tab.display.explainText = nil
@@ -202,7 +201,6 @@ extension QueryExecutionCoordinator {
                 await MainActor.run { [weak self] in
                     guard let self else { return }
                     parent.tabManager.mutate(tabId: tabId) { tab in
-                        tab.execution.isExecuting = false
                         tab.pagination.isLoadingMore = false
                     }
                     parent.currentQueryTask = nil
@@ -253,7 +251,6 @@ extension QueryExecutionCoordinator {
         parent.currentQueryTask?.cancel()
 
         parent.tabManager.mutate(at: index) { tab in
-            tab.execution.isExecuting = true
             tab.execution.executionTime = nil
             tab.execution.errorMessage = nil
         }
@@ -288,7 +285,6 @@ extension QueryExecutionCoordinator {
 
             switch outcome {
             case .cancelled:
-                parent.tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
                 parent.currentQueryTask = nil
                 parent.toolbarState.setExecuting(false)
             case .completed(let results):
@@ -489,7 +485,6 @@ extension QueryExecutionCoordinator {
             parent.toolbarState.lastQueryDuration = fetchResult.executionTime
 
             if !parent.tabExecution.isCurrent(claim) || Task.isCancelled {
-                parent.tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
                 return
             }
 
@@ -537,7 +532,6 @@ extension QueryExecutionCoordinator {
         if !parent.tabExecution.isCurrent(claim) {
             await MainActor.run { [weak self] in
                 guard let self else { return }
-                parent.tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
                 parent.currentQueryTask = nil
                 parent.toolbarState.setExecuting(false)
             }
@@ -561,7 +555,6 @@ extension QueryExecutionCoordinator {
             parent.tabManager.mutate(tabId: tabId) { tab in
                 tab.execution.errorMessage = contextMsg
                 tab.execution.errorQuery = failedStatement
-                tab.execution.isExecuting = false
                 tab.execution.executionTime = cumulativeTime
 
                 tab.display.replaceUnpinnedResults(with: capturedResultSets)

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+Parameters.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+Parameters.swift
@@ -77,7 +77,7 @@ extension QueryExecutionCoordinator {
         originalSQL: String? = nil
     ) {
         guard let (selectedTab, index) = parent.tabManager.selectedTabAndIndex,
-              !selectedTab.execution.isExecuting else { return }
+              !parent.tabExecution.isExecuting(selectedTab.id) else { return }
 
         guard let scope = parent.scope(for: selectedTab) else {
             parent.tabManager.mutate(at: index) {
@@ -95,8 +95,6 @@ extension QueryExecutionCoordinator {
             }
             parent.currentQueryTask = nil
         }
-        parent.queryGeneration += 1
-        let capturedGeneration = parent.queryGeneration
 
         parent.tabManager.mutate(at: index) { tab in
             tab.execution.isExecuting = true
@@ -114,6 +112,7 @@ extension QueryExecutionCoordinator {
 
         let conn = parent.connection
         let tabId = parent.tabManager.tabs[index].id
+        let claim = parent.tabExecution.claim(tabId)
 
         let rowCap = resolveRowCap(sql: sql, tabType: tab.tabType, bypassLimit: bypassRowLimit)
         let (tableName, isEditable) = parent.resolveTableEditability(tab: tab, sql: sql)
@@ -139,7 +138,7 @@ extension QueryExecutionCoordinator {
                 let fetchResult = try await DatabaseManager.shared.withScopedDriver(
                     scope: scope,
                     route: DatabaseManager.shared.executionRoute(for: scope),
-                    tracksCancellation: true
+                    cancellation: .cancellableRead
                 ) { [queryExecutor = parent.queryExecutor] driver in
                     try await queryExecutor.executeQuery(
                         driver: driver,
@@ -167,7 +166,7 @@ extension QueryExecutionCoordinator {
                     isEditable: isEditable,
                     sql: sql,
                     connection: conn,
-                    capturedGeneration: capturedGeneration,
+                    claim: claim,
                     originalParameters: originalParameters,
                     nativeParameters: parameters,
                     originalSQL: originalSQL
@@ -178,7 +177,7 @@ extension QueryExecutionCoordinator {
                         launchPhase2Work(
                             tableName: tableName,
                             tabId: tabId,
-                            capturedGeneration: capturedGeneration,
+                            claim: claim,
                             connectionType: conn.type,
                             schemaTask: schemaTask
                         )
@@ -186,14 +185,14 @@ extension QueryExecutionCoordinator {
                         launchPhase2Count(
                             tableName: tableName,
                             tabId: tabId,
-                            capturedGeneration: capturedGeneration,
+                            claim: claim,
                             connectionType: conn.type
                         )
                     }
                 } else if !isEditable || tableName == nil {
                     await MainActor.run { [weak self] in
                         guard let self else { return }
-                        guard capturedGeneration == parent.queryGeneration else { return }
+                        guard parent.tabExecution.isCurrent(claim) else { return }
                         guard !Task.isCancelled else { return }
                         parent.changeManager.clearChangesAndUndoHistory()
                     }
@@ -209,7 +208,7 @@ extension QueryExecutionCoordinator {
                     parent.currentQueryTask = nil
                     parent.toolbarState.setExecuting(false)
                     if DatabaseCancellationDiagnosis.isCancellation(error) || Task.isCancelled { return }
-                    guard capturedGeneration == parent.queryGeneration else { return }
+                    guard parent.tabExecution.isCurrent(claim) else { return }
                     handleQueryExecutionError(error, sql: sql, tabId: tabId, connection: conn)
                 }
             }
@@ -225,7 +224,7 @@ extension QueryExecutionCoordinator {
         bypassRowLimit: Bool = false
     ) {
         guard let (selectedTab, index) = parent.tabManager.selectedTabAndIndex,
-              !selectedTab.execution.isExecuting else { return }
+              !parent.tabExecution.isExecuting(selectedTab.id) else { return }
 
         let missing = parameters.filter {
             !$0.isNull && $0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -252,8 +251,6 @@ extension QueryExecutionCoordinator {
         )?.parameterStyle ?? .questionMark
 
         parent.currentQueryTask?.cancel()
-        parent.queryGeneration += 1
-        let capturedGeneration = parent.queryGeneration
 
         parent.tabManager.mutate(at: index) { tab in
             tab.execution.isExecuting = true
@@ -264,6 +261,7 @@ extension QueryExecutionCoordinator {
 
         let conn = parent.connection
         let tabId = parent.tabManager.tabs[index].id
+        let claim = parent.tabExecution.claim(tabId)
         let totalCount = statements.count
         let tabType = parent.tabManager.tabs[index].tabType
 
@@ -285,7 +283,7 @@ extension QueryExecutionCoordinator {
                 prepared: prepared,
                 scope: scope,
                 mode: transactionKind.declaresWrite ? .readWrite : .serverDefault,
-                capturedGeneration: capturedGeneration
+                claim: claim
             )
 
             switch outcome {
@@ -304,7 +302,7 @@ extension QueryExecutionCoordinator {
                 let lastSelectIndex = results.lastIndex { !$0.columns.isEmpty }
                 applyMultiStatementResults(
                     tabId: tabId,
-                    capturedGeneration: capturedGeneration,
+                    claim: claim,
                     cumulativeTime: results.reduce(0) { $0 + $1.executionTime },
                     totalRowsAffected: results.reduce(0) { $0 + $1.rowsAffected },
                     lastSelectResult: lastSelectIndex.map { results[$0] },
@@ -323,7 +321,7 @@ extension QueryExecutionCoordinator {
                     errorDescription: errorDescription,
                     connection: conn,
                     tabId: tabId,
-                    capturedGeneration: capturedGeneration,
+                    claim: claim,
                     statements: statements,
                     executedCount: results.count,
                     totalCount: totalCount,
@@ -359,18 +357,18 @@ extension QueryExecutionCoordinator {
         prepared: [PreparedStatement],
         scope: DatabaseScope,
         mode: PluginTransactionAccessMode,
-        capturedGeneration: Int
+        claim: TabExecutionClaim
     ) async -> MultiStatementOutcome {
         do {
             return try await DatabaseManager.shared.withScopedDriver(
                 scope: scope,
                 route: DatabaseManager.shared.executionRoute(for: scope),
-                tracksCancellation: true
+                cancellation: .cancellableRead
             ) { driver in
                 await self.runPreparedStatements(
                     prepared,
                     mode: mode,
-                    capturedGeneration: capturedGeneration,
+                    claim: claim,
                     driver: driver
                 )
             }
@@ -385,7 +383,7 @@ extension QueryExecutionCoordinator {
     private func runPreparedStatements(
         _ prepared: [PreparedStatement],
         mode: PluginTransactionAccessMode,
-        capturedGeneration: Int,
+        claim: TabExecutionClaim,
         driver: DatabaseDriver
     ) async -> MultiStatementOutcome {
         let useTransaction = driver.supportsTransactions
@@ -399,7 +397,7 @@ extension QueryExecutionCoordinator {
 
         var results: [QueryResult] = []
         for statement in prepared {
-            guard !Task.isCancelled, capturedGeneration == parent.queryGeneration else {
+            guard !Task.isCancelled, parent.tabExecution.isCurrent(claim) else {
                 await rollback(driver: driver, useTransaction: useTransaction)
                 return .cancelled
             }
@@ -476,7 +474,7 @@ extension QueryExecutionCoordinator {
         isEditable: Bool,
         sql: String,
         connection: DatabaseConnection,
-        capturedGeneration: Int,
+        claim: TabExecutionClaim,
         originalParameters: [QueryParameter],
         nativeParameters: [Any?],
         originalSQL: String? = nil
@@ -490,7 +488,7 @@ extension QueryExecutionCoordinator {
             parent.toolbarState.setExecuting(false)
             parent.toolbarState.lastQueryDuration = fetchResult.executionTime
 
-            if capturedGeneration != parent.queryGeneration || Task.isCancelled {
+            if !parent.tabExecution.isCurrent(claim) || Task.isCancelled {
                 parent.tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
                 return
             }
@@ -528,7 +526,7 @@ extension QueryExecutionCoordinator {
         errorDescription: String,
         connection: DatabaseConnection,
         tabId: UUID,
-        capturedGeneration: Int,
+        claim: TabExecutionClaim,
         statements: [String],
         executedCount: Int,
         totalCount: Int,
@@ -536,7 +534,7 @@ extension QueryExecutionCoordinator {
         failedSQL: String?,
         resultSets: inout [ResultSet]
     ) async {
-        if capturedGeneration != parent.queryGeneration {
+        if !parent.tabExecution.isCurrent(claim) {
             await MainActor.run { [weak self] in
                 guard let self else { return }
                 parent.tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator.swift
@@ -17,7 +17,7 @@ final class QueryExecutionCoordinator {
 
     func runAllStatements() {
         guard let (tab, index) = parent.tabManager.selectedTabAndIndex,
-              !tab.execution.isExecuting,
+              !parent.tabExecution.isExecuting(tab.id),
               tab.tabType == .query else { return }
 
         let fullQuery = tab.content.query

--- a/TablePro/Core/Coordinators/RowEditingCoordinator+Discard.swift
+++ b/TablePro/Core/Coordinators/RowEditingCoordinator+Discard.swift
@@ -39,7 +39,7 @@ extension RowEditingCoordinator {
         _ = try await DatabaseManager.shared.withScopedDriver(
             scope: scope,
             route: DatabaseManager.shared.executionRoute(for: scope),
-            tracksCancellation: true
+            cancellation: .protectedWrite
         ) { driver in
             try await Self.runStatementsInTransaction(statements, mode: mode, on: driver)
         }

--- a/TablePro/Core/Coordinators/RowEditingCoordinator+SaveChanges.swift
+++ b/TablePro/Core/Coordinators/RowEditingCoordinator+SaveChanges.swift
@@ -180,7 +180,7 @@ extension RowEditingCoordinator {
                 let executionTimes = try await DatabaseManager.shared.withScopedDriver(
                     scope: scope,
                     route: route,
-                    tracksCancellation: true
+                    cancellation: .protectedWrite
                 ) { driver in
                     try await Self.runStatementsInTransaction(
                         validStatements,

--- a/TablePro/Core/Database/DatabaseManager+Metadata.swift
+++ b/TablePro/Core/Database/DatabaseManager+Metadata.swift
@@ -53,6 +53,7 @@ extension DatabaseManager {
             scope: scope,
             route: metadataRoute(for: scope),
             workload: workload,
+            cancellation: .untracked,
             body
         )
     }

--- a/TablePro/Core/Database/DatabaseManager+Schema.swift
+++ b/TablePro/Core/Database/DatabaseManager+Schema.swift
@@ -28,7 +28,9 @@ extension DatabaseManager {
     ) async throws {
         let route = executionRoute(for: scope)
 
-        let statements = try await withScopedDriver(scope: scope, route: route) { driver in
+        let statements = try await withScopedDriver(
+            scope: scope, route: route, cancellation: .untracked
+        ) { driver in
             let pkConstraintName = await Self.fetchPrimaryKeyConstraintName(
                 tableName: tableName,
                 databaseType: databaseType,
@@ -67,7 +69,7 @@ extension DatabaseManager {
             )
         }
 
-        try await withScopedDriver(scope: scope, route: route, tracksCancellation: true) { driver in
+        try await withScopedDriver(scope: scope, route: route, cancellation: .protectedWrite) { driver in
             let useTransaction = driver.supportsTransactions
             if useTransaction {
                 try await driver.beginTransaction(mode: schemaKind.declaresWrite ? .readWrite : .serverDefault)

--- a/TablePro/Core/Database/DatabaseManager+ScopedDriver.swift
+++ b/TablePro/Core/Database/DatabaseManager+ScopedDriver.swift
@@ -55,23 +55,26 @@ extension DatabaseManager {
         return .pooled
     }
 
-    /// `tracksCancellation` registers the leased driver so Stop can reach it. Only user
-    /// SQL opts in: a metadata read shares the connection but must never become the handle
-    /// Stop aborts, and must never clear the handle a running query registered.
+    /// `cancellation` decides whether Stop, or a navigation that supersedes a tab, can reach the
+    /// leased driver. The parameter has no default on purpose: a new call site must state which it
+    /// is, because getting it wrong silently either makes a query uncancellable or makes a commit
+    /// killable.
     func withScopedDriver<T: Sendable>(
         scope: DatabaseScope,
         route: ScopedDriverRoute,
         workload: MetadataConnectionPool.Workload = .interactive,
-        tracksCancellation: Bool = false,
+        cancellation: DriverCancellationPolicy,
         _ body: @Sendable @escaping (DatabaseDriver) async throws -> T
     ) async throws -> T {
         let leased: @Sendable (DatabaseDriver) async throws -> T
-        if tracksCancellation {
+        if cancellation.isTracked {
             let connectionId = scope.connectionId
             let token = UUID()
+            let entry = RunningDriver(driver: nil, policy: cancellation)
             leased = { driver in
                 await MainActor.run {
-                    DatabaseManager.shared.runningDrivers[connectionId, default: [:]][token] = driver
+                    DatabaseManager.shared.runningDrivers[connectionId, default: [:]][token] =
+                        entry.adopting(driver)
                 }
                 do {
                     let value = try await body(driver)
@@ -107,15 +110,22 @@ extension DatabaseManager {
 
     /// Stop has to reach the handle the query is actually running on, which is no longer
     /// always the session driver now that a cross-database tab runs on a pooled connection.
-    func cancelRunningQuery(for connectionId: UUID) throws {
+    ///
+    /// A `.protectedWrite` lease is never reachable: a commit, a rollback or a DDL statement that is
+    /// half applied is data loss, and both Stop and a superseding navigation would otherwise abort
+    /// one. The empty-map fallback is deliberately only taken for an explicit user Stop, because it
+    /// cancels whatever the session driver happens to be running without knowing what that is.
+    func cancelRunningQuery(for connectionId: UUID, reach: DriverCancellationReach = .userStop) throws {
         let running = runningDrivers[connectionId] ?? [:]
-        guard !running.isEmpty else {
-            try driver(for: connectionId)?.cancelQuery()
+        let cancellable = running.values.filter { $0.policy == .cancellableRead }
+        guard cancellable.isEmpty else {
+            for entry in cancellable {
+                try entry.driver?.cancelQuery()
+            }
             return
         }
-        for driver in running.values {
-            try driver.cancelQuery()
-        }
+        guard running.isEmpty, reach == .userStop else { return }
+        try driver(for: connectionId)?.cancelQuery()
     }
 
     /// A pooled connection is keyed by database, so one that rewrites the connection's

--- a/TablePro/Core/Database/DatabaseManager+ScopedDriver.swift
+++ b/TablePro/Core/Database/DatabaseManager+ScopedDriver.swift
@@ -115,17 +115,35 @@ extension DatabaseManager {
     /// half applied is data loss, and both Stop and a superseding navigation would otherwise abort
     /// one. The empty-map fallback is deliberately only taken for an explicit user Stop, because it
     /// cancels whatever the session driver happens to be running without knowing what that is.
+    /// Stop stays synchronous because the user is waiting on it. A navigation supersede does not:
+    /// a PostgreSQL cancel opens a second connection to deliver the request, which through an SSH
+    /// tunnel costs 70-160ms, and paying that on the main thread turns fast browsing into a stutter.
+    /// Correctness never depended on the cancel landing first, because the tab's execution claim
+    /// already discards whatever the superseded query returns; the cancel is only there to stop the
+    /// server doing work nobody wants.
     func cancelRunningQuery(for connectionId: UUID, reach: DriverCancellationReach = .userStop) throws {
-        let running = runningDrivers[connectionId] ?? [:]
-        let cancellable = running.values.filter { $0.policy == .cancellableRead }
-        guard cancellable.isEmpty else {
-            for entry in cancellable {
-                try entry.driver?.cancelQuery()
+        let targets = cancellationTargets(for: connectionId, reach: reach)
+        guard !targets.isEmpty else { return }
+        guard reach == .userStop else {
+            DispatchQueue.global(qos: .utility).async {
+                for driver in targets { try? driver.cancelQuery() }
             }
             return
         }
-        guard running.isEmpty, reach == .userStop else { return }
-        try driver(for: connectionId)?.cancelQuery()
+        for driver in targets {
+            try driver.cancelQuery()
+        }
+    }
+
+    private func cancellationTargets(
+        for connectionId: UUID,
+        reach: DriverCancellationReach
+    ) -> [DatabaseDriver] {
+        let running = runningDrivers[connectionId] ?? [:]
+        let cancellable = running.values.filter { $0.policy == .cancellableRead }.compactMap(\.driver)
+        guard cancellable.isEmpty else { return cancellable }
+        guard running.isEmpty, reach == .userStop else { return [] }
+        return [driver(for: connectionId)].compactMap { $0 }
     }
 
     /// A pooled connection is keyed by database, so one that rewrites the connection's

--- a/TablePro/Core/Database/DatabaseManager.swift
+++ b/TablePro/Core/Database/DatabaseManager.swift
@@ -84,7 +84,7 @@ final class DatabaseManager {
     /// The drivers each connection is currently executing user SQL on, keyed by an
     /// operation token so a finishing operation can only release its own handle. Stop
     /// reaches the right one even when a cross-database tab runs on a pooled connection.
-    @ObservationIgnored internal var runningDrivers: [UUID: [UUID: DatabaseDriver]] = [:]
+    @ObservationIgnored internal var runningDrivers: [UUID: [UUID: RunningDriver]] = [:]
 
     /// Session for `lastActiveSessionId`, subject to the same caveats.
     var lastActiveSession: ConnectionSession? {

--- a/TablePro/Core/Database/DriverCancellationPolicy.swift
+++ b/TablePro/Core/Database/DriverCancellationPolicy.swift
@@ -1,0 +1,48 @@
+//
+//  DriverCancellationPolicy.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Whether a leased driver may be aborted, and by whom.
+///
+/// Cancellation used to be a bool, and `cancelRunningQuery` aborted every tracked handle. That was
+/// survivable while only an explicit Stop cancelled anything; once a navigation that supersedes a
+/// tab also cancels, an untyped abort routinely reaches a commit or a DDL statement, which is data
+/// loss rather than a lost result.
+internal enum DriverCancellationPolicy: Equatable, Sendable {
+    /// Metadata and schema reads that share the connection. Never registered, so they can neither be
+    /// aborted nor clear the handle a real query registered.
+    case untracked
+
+    /// User SQL and table loads. Safe to abort: the worst case is a result nobody wanted.
+    case cancellableRead
+
+    /// Commits, rollbacks, row writes and DDL. Registered so the connection is known to be busy, but
+    /// never abortable, because a half-applied write cannot be undone by retrying.
+    case protectedWrite
+
+    var isTracked: Bool {
+        self != .untracked
+    }
+}
+
+/// How far a cancellation request is allowed to reach when nothing is registered.
+internal enum DriverCancellationReach: Equatable, Sendable {
+    /// The user pressed Stop. May fall back to the session driver, since the intent is explicit.
+    case userStop
+
+    /// A navigation superseded a tab. Only ever aborts a lease it can see, because guessing at the
+    /// session driver here would abort work belonging to a different tab.
+    case supersededNavigation
+}
+
+internal struct RunningDriver {
+    let driver: DatabaseDriver?
+    let policy: DriverCancellationPolicy
+
+    func adopting(_ driver: DatabaseDriver) -> RunningDriver {
+        RunningDriver(driver: driver, policy: policy)
+    }
+}

--- a/TablePro/Core/Diagnostics/TableLoadTrace.swift
+++ b/TablePro/Core/Diagnostics/TableLoadTrace.swift
@@ -37,7 +37,7 @@ internal enum TableLoadAnomaly: String {
     case supersededByNewNavigation
     case blockedByInFlightExecution
     case loadAlreadyInFlight
-    case staleGenerationDropped
+    case staleResultDropped
     case resultTableMismatch
     case connectionNotReady
     case executionCancelled
@@ -50,7 +50,7 @@ internal enum TableLoadAnomaly: String {
         switch self {
         case .blockedByInFlightExecution, .resultTableMismatch:
             return true
-        case .supersededByNewNavigation, .loadAlreadyInFlight, .staleGenerationDropped,
+        case .supersededByNewNavigation, .loadAlreadyInFlight, .staleResultDropped,
              .connectionNotReady, .executionCancelled, .preparationAbandoned:
             return false
         }

--- a/TablePro/Core/Diagnostics/TableLoadTrace.swift
+++ b/TablePro/Core/Diagnostics/TableLoadTrace.swift
@@ -1,0 +1,228 @@
+//
+//  TableLoadTrace.swift
+//  TablePro
+//
+
+import Foundation
+
+internal enum TableLoadOrigin: String {
+    case sidebar
+    case newWindowTab
+    case restore
+    case reExecute
+    case inPlace
+    case programmatic
+}
+
+internal enum TableLoadStage: String {
+    case openTableTab
+    case addFirstTab
+    case replaceTabContent
+    case cancelPreviousLoad
+    case lazyLoadScheduled
+    case prepareFirstLoad
+    case schemaColumnsBegin
+    case schemaColumnsEnd
+    case executeRequested
+    case executeStarted
+    case driverFetchBegin
+    case driverFetchEnd
+    case applyResultBegin
+    case gridReloadBegin
+    case gridReloadEnd
+    case mainRunLoopIdle
+}
+
+internal enum TableLoadAnomaly: String {
+    case supersededByNewNavigation
+    case blockedByInFlightExecution
+    case loadAlreadyInFlight
+    case staleGenerationDropped
+    case resultTableMismatch
+    case connectionNotReady
+    case executionCancelled
+    case preparationAbandoned
+
+    /// A defect misleads the user about what they are looking at, so it is logged at
+    /// error level and shows up without enabling debug capture. The rest are expected
+    /// outcomes of ordinary navigation and stay informational.
+    var isDefect: Bool {
+        switch self {
+        case .blockedByInFlightExecution, .resultTableMismatch:
+            return true
+        case .supersededByNewNavigation, .loadAlreadyInFlight, .staleGenerationDropped,
+             .connectionNotReady, .executionCancelled, .preparationAbandoned:
+            return false
+        }
+    }
+}
+
+/// Identifies one navigation for its whole lifetime. Execution carries the token into its
+/// async closure so a late result is attributed to the navigation that issued it, not to
+/// whichever navigation happens to own the tab when the result lands.
+internal struct TableLoadTraceToken: Sendable, Equatable {
+    let sequence: Int
+    let tabId: UUID
+    let table: String
+}
+
+internal struct TableLoadTiming: Equatable {
+    let token: TableLoadTraceToken
+    let previousStage: TableLoadStage?
+    let sinceStart: Duration
+    let sincePrevious: Duration
+}
+
+internal struct TableLoadTraceRecorder {
+    internal struct Entry: Equatable {
+        let token: TableLoadTraceToken
+        let origin: TableLoadOrigin
+        let startedAt: ContinuousClock.Instant
+        var lastEventAt: ContinuousClock.Instant
+        var lastStage: TableLoadStage?
+        var startedExecution: Bool
+        var isFinished: Bool
+    }
+
+    internal static let retainedTraceLimit = 32
+
+    private var entries: [Int: Entry] = [:]
+    private var sequenceOrder: [Int] = []
+    private var activeSequenceByTab: [UUID: Int] = [:]
+    private var evictedSequences: [Int] = []
+    private var nextSequence = 1
+
+    internal init() {}
+
+    /// The adapter keeps its own per-sequence signpost state, which this type cannot reach. Handing
+    /// back what was evicted is what lets it close those intervals instead of leaking them.
+    internal mutating func takeEvictedSequences() -> [Int] {
+        defer { evictedSequences.removeAll() }
+        return evictedSequences
+    }
+
+    /// Starting a navigation on a tab that still has one in flight is the shape the user
+    /// sees as "the grid filled with the wrong table", so the abandoned trace is reported
+    /// rather than silently dropped.
+    /// `startedAt` lets a navigation that began in another window (a sidebar click that opens a new
+    /// native window tab) date its trace from the click rather than from when the receiving window
+    /// got around to loading, which is where most of that wait actually goes.
+    internal mutating func begin(
+        tabId: UUID,
+        table: String,
+        origin: TableLoadOrigin,
+        at instant: ContinuousClock.Instant,
+        startedAt: ContinuousClock.Instant? = nil
+    ) -> (token: TableLoadTraceToken, superseded: TableLoadTiming?) {
+        let superseded = measure(tabId: tabId, at: instant)
+        if let previous = activeSequenceByTab[tabId] {
+            entries[previous]?.isFinished = true
+        }
+
+        let token = TableLoadTraceToken(sequence: nextSequence, tabId: tabId, table: table)
+        nextSequence += 1
+        entries[token.sequence] = Entry(
+            token: token,
+            origin: origin,
+            startedAt: startedAt ?? instant,
+            lastEventAt: instant,
+            lastStage: nil,
+            startedExecution: false,
+            isFinished: false
+        )
+        sequenceOrder.append(token.sequence)
+        activeSequenceByTab[tabId] = token.sequence
+        pruneFinishedTraces()
+        return (token, superseded)
+    }
+
+    internal mutating func record(
+        _ stage: TableLoadStage,
+        token: TableLoadTraceToken,
+        at instant: ContinuousClock.Instant
+    ) -> TableLoadTiming? {
+        guard let timing = measure(token: token, at: instant) else { return nil }
+        entries[token.sequence]?.lastEventAt = instant
+        entries[token.sequence]?.lastStage = stage
+        if stage == .executeStarted { entries[token.sequence]?.startedExecution = true }
+        return timing
+    }
+
+    /// A trace that reached `.executeStarted` owns a query that is still on its way back, so nothing
+    /// may close it early: the result has to be able to report against it when it lands.
+    internal func hasStartedExecution(_ token: TableLoadTraceToken) -> Bool {
+        entries[token.sequence]?.startedExecution ?? false
+    }
+
+    internal mutating func record(
+        _ stage: TableLoadStage,
+        tabId: UUID,
+        at instant: ContinuousClock.Instant
+    ) -> TableLoadTiming? {
+        guard let sequence = activeSequenceByTab[tabId], let entry = entries[sequence] else { return nil }
+        return record(stage, token: entry.token, at: instant)
+    }
+
+    internal func measure(token: TableLoadTraceToken, at instant: ContinuousClock.Instant) -> TableLoadTiming? {
+        guard let entry = entries[token.sequence] else { return nil }
+        return TableLoadTiming(
+            token: entry.token,
+            previousStage: entry.lastStage,
+            sinceStart: entry.startedAt.duration(to: instant),
+            sincePrevious: entry.lastEventAt.duration(to: instant)
+        )
+    }
+
+    internal func measure(tabId: UUID, at instant: ContinuousClock.Instant) -> TableLoadTiming? {
+        guard let sequence = activeSequenceByTab[tabId], let entry = entries[sequence] else { return nil }
+        return measure(token: entry.token, at: instant)
+    }
+
+    internal mutating func finish(
+        token: TableLoadTraceToken,
+        at instant: ContinuousClock.Instant
+    ) -> TableLoadTiming? {
+        guard let timing = measure(token: token, at: instant) else { return nil }
+        entries[token.sequence]?.isFinished = true
+        entries[token.sequence]?.lastEventAt = instant
+        if activeSequenceByTab[token.tabId] == token.sequence {
+            activeSequenceByTab[token.tabId] = nil
+        }
+        pruneFinishedTraces()
+        return timing
+    }
+
+    internal func activeToken(for tabId: UUID) -> TableLoadTraceToken? {
+        guard let sequence = activeSequenceByTab[tabId] else { return nil }
+        return entries[sequence]?.token
+    }
+
+    internal func entry(for token: TableLoadTraceToken) -> Entry? {
+        entries[token.sequence]
+    }
+
+    internal func isActive(_ token: TableLoadTraceToken) -> Bool {
+        activeSequenceByTab[token.tabId] == token.sequence
+    }
+
+    /// Finished traces go first so an in-flight one stays addressable by a late result, but an
+    /// unfinished trace is still evicted once the window overflows: a navigation abandoned before
+    /// it ever executed never finishes, and keeping those would grow the map without bound.
+    private mutating func pruneFinishedTraces() {
+        guard sequenceOrder.count > Self.retainedTraceLimit else { return }
+        let finished = sequenceOrder.filter { entries[$0]?.isFinished == true }
+        var evictable = finished + sequenceOrder.filter { entries[$0]?.isFinished == false }
+        var overflow = sequenceOrder.count - Self.retainedTraceLimit
+        var evicted: Set<Int> = []
+        while overflow > 0, !evictable.isEmpty {
+            let sequence = evictable.removeFirst()
+            entries[sequence] = nil
+            evicted.insert(sequence)
+            overflow -= 1
+        }
+        guard !evicted.isEmpty else { return }
+        sequenceOrder.removeAll { evicted.contains($0) }
+        activeSequenceByTab = activeSequenceByTab.filter { !evicted.contains($0.value) }
+        evictedSequences.append(contentsOf: evicted)
+    }
+}

--- a/TablePro/Core/Diagnostics/TableLoadTracer.swift
+++ b/TablePro/Core/Diagnostics/TableLoadTracer.swift
@@ -1,0 +1,226 @@
+//
+//  TableLoadTracer.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+/// Time tracing for the table browse path: sidebar click, tab open, query execution,
+/// grid reload, frame presented.
+///
+/// Stage lines are logged at debug level, so they cost nothing until capture is turned on
+/// (`log stream --level debug --predicate 'subsystem == "com.TablePro"'`). Anomalies that
+/// mislead the user are logged at error level and are always captured. Every trace is also
+/// an Instruments interval under Points of Interest.
+@MainActor
+internal final class TableLoadTracer {
+    internal static let shared = TableLoadTracer()
+
+    private struct Interval {
+        let id: OSSignpostID
+        let state: OSSignpostIntervalState
+    }
+
+    private static let handoffExpiry = Duration.seconds(30)
+
+    private let logger = Logger(subsystem: "com.TablePro", category: "TableLoad")
+    private let signposter = OSSignposter(subsystem: "com.TablePro", category: .pointsOfInterest)
+    private var recorder = TableLoadTraceRecorder()
+    private var intervals: [Int: Interval] = [:]
+    private var handoffs: [String: ContinuousClock.Instant] = [:]
+    private var applyScope: TableLoadTraceToken?
+    private let clock = ContinuousClock()
+
+    private init() {}
+
+    /// A sidebar click that opens a new native window tab finishes in a different coordinator, so the
+    /// click instant is parked here and picked up by whichever window ends up doing the load. Without
+    /// it the trace starts after the window has already mounted and hides that cost.
+    internal func noteWindowTabHandoff(connectionId: UUID, table: String) {
+        handoffs[Self.handoffKey(connectionId: connectionId, table: table)] = clock.now
+        let cutoff = clock.now
+        handoffs = handoffs.filter { $0.value.duration(to: cutoff) < Self.handoffExpiry }
+    }
+
+    private static func handoffKey(connectionId: UUID, table: String) -> String {
+        "\(connectionId.uuidString)|\(table)"
+    }
+
+    @discardableResult
+    internal func begin(
+        tabId: UUID,
+        table: String,
+        origin: TableLoadOrigin,
+        connectionId: UUID? = nil
+    ) -> TableLoadTraceToken {
+        let now = clock.now
+        var resolvedOrigin = origin
+        var startedAt: ContinuousClock.Instant?
+        if let connectionId,
+           let handoff = handoffs.removeValue(forKey: Self.handoffKey(connectionId: connectionId, table: table)) {
+            startedAt = handoff
+            resolvedOrigin = .newWindowTab
+        }
+        let (token, superseded) = recorder.begin(
+            tabId: tabId,
+            table: table,
+            origin: resolvedOrigin,
+            at: now,
+            startedAt: startedAt
+        )
+        let origin = resolvedOrigin
+
+        if let superseded {
+            report(.supersededByNewNavigation, timing: superseded, detail: "replacedBy=#\(token.sequence)")
+            endInterval(for: superseded.token, outcome: "superseded")
+        }
+
+        let signpostID = signposter.makeSignpostID()
+        let state = signposter.beginInterval(
+            "TableLoad",
+            id: signpostID,
+            "#\(token.sequence, privacy: .public) \(token.table, privacy: .public)"
+        )
+        intervals[token.sequence] = Interval(id: signpostID, state: state)
+        logger.debug(
+            "\(Self.prefix(token), privacy: .public) +0.0ms START origin=\(origin.rawValue, privacy: .public)"
+        )
+        closeEvictedIntervals()
+        return token
+    }
+
+    /// A navigation the recorder dropped still owns an open signpost interval here. Closing it keeps
+    /// `intervals` bounded and stops Instruments from showing a interval that never ends.
+    private func closeEvictedIntervals() {
+        for sequence in recorder.takeEvictedSequences() {
+            guard let interval = intervals.removeValue(forKey: sequence) else { continue }
+            signposter.endInterval("TableLoad", interval.state, "evicted")
+        }
+    }
+
+    internal func stage(_ stage: TableLoadStage, token: TableLoadTraceToken, detail: String? = nil) {
+        guard let timing = recorder.record(stage, token: token, at: clock.now) else { return }
+        emit(stage, timing: timing, detail: detail)
+    }
+
+    /// Stages that bracket a suspension timestamp themselves with `ContinuousClock.now` and report
+    /// once the caller resumes, so the recorded instant is when the work actually happened rather
+    /// than when the log call got scheduled. The gap between a driver fetch measured this way and
+    /// the driver's own reported time is main actor queueing delay, which is the point.
+    internal func stage(
+        _ stage: TableLoadStage,
+        token: TableLoadTraceToken,
+        at instant: ContinuousClock.Instant,
+        detail: String? = nil
+    ) {
+        guard let timing = recorder.record(stage, token: token, at: instant) else { return }
+        emit(stage, timing: timing, detail: detail)
+    }
+
+    internal func stage(_ stage: TableLoadStage, tabId: UUID, detail: String? = nil) {
+        guard let timing = recorder.record(stage, tabId: tabId, at: clock.now) else { return }
+        emit(stage, timing: timing, detail: detail)
+    }
+
+    internal func anomaly(_ anomaly: TableLoadAnomaly, token: TableLoadTraceToken, detail: String? = nil) {
+        guard let timing = recorder.measure(token: token, at: clock.now) else { return }
+        report(anomaly, timing: timing, detail: detail)
+    }
+
+    internal func anomaly(_ anomaly: TableLoadAnomaly, tabId: UUID, detail: String? = nil) {
+        guard let timing = recorder.measure(tabId: tabId, at: clock.now) else { return }
+        report(anomaly, timing: timing, detail: detail)
+    }
+
+    internal func finish(token: TableLoadTraceToken, outcome: String) {
+        guard let timing = recorder.finish(token: token, at: clock.now) else { return }
+        logger.debug(
+            """
+            \(Self.prefix(timing.token), privacy: .public) \
+            +\(Self.milliseconds(timing.sinceStart), privacy: .public)ms \
+            END outcome=\(outcome, privacy: .public)
+            """
+        )
+        endInterval(for: timing.token, outcome: outcome)
+        closeEvictedIntervals()
+    }
+
+    internal func activeToken(for tabId: UUID) -> TableLoadTraceToken? {
+        recorder.activeToken(for: tabId)
+    }
+
+    internal func isActive(_ token: TableLoadTraceToken) -> Bool {
+        recorder.isActive(token)
+    }
+
+    internal func hasStartedExecution(_ token: TableLoadTraceToken) -> Bool {
+        recorder.hasStartedExecution(token)
+    }
+
+    /// The grid reload runs deep inside the result-apply call chain, well past any parameter this
+    /// diagnostic could ride on without pushing itself into a domain API. Scoping the applying token
+    /// here keeps the reload cost on the navigation that produced the rows, which in the late-result
+    /// case is deliberately not the navigation that currently owns the tab. A clear-the-grid reload
+    /// outside any apply has no scope and is left untraced rather than charged to the wrong trace.
+    internal func beginApplyScope(_ token: TableLoadTraceToken?) {
+        applyScope = token
+    }
+
+    internal func endApplyScope() {
+        applyScope = nil
+    }
+
+    internal var applyingToken: TableLoadTraceToken? {
+        applyScope
+    }
+
+    private func emit(_ stage: TableLoadStage, timing: TableLoadTiming, detail: String?) {
+        logger.debug(
+            """
+            \(Self.prefix(timing.token), privacy: .public) \
+            +\(Self.milliseconds(timing.sinceStart), privacy: .public)ms \
+            (+\(Self.milliseconds(timing.sincePrevious), privacy: .public)ms) \
+            \(stage.rawValue, privacy: .public)\(Self.suffix(detail), privacy: .public)
+            """
+        )
+        guard let interval = intervals[timing.token.sequence] else { return }
+        signposter.emitEvent("TableLoadStage", id: interval.id, "\(stage.rawValue)")
+    }
+
+    private func report(_ anomaly: TableLoadAnomaly, timing: TableLoadTiming, detail: String?) {
+        let line = """
+            \(Self.prefix(timing.token)) \
+            +\(Self.milliseconds(timing.sinceStart))ms \
+            ANOMALY \(anomaly.rawValue) after=\(timing.previousStage?.rawValue ?? "start")\(Self.suffix(detail))
+            """
+        if anomaly.isDefect {
+            logger.error("\(line, privacy: .public)")
+        } else {
+            logger.info("\(line, privacy: .public)")
+        }
+        guard let interval = intervals[timing.token.sequence] else { return }
+        signposter.emitEvent("TableLoadAnomaly", id: interval.id, "\(anomaly.rawValue)")
+    }
+
+    private func endInterval(for token: TableLoadTraceToken, outcome: String) {
+        guard let interval = intervals.removeValue(forKey: token.sequence) else { return }
+        signposter.endInterval("TableLoad", interval.state, "\(outcome)")
+    }
+
+    private static func prefix(_ token: TableLoadTraceToken) -> String {
+        "[tableload #\(token.sequence) \(token.table)]"
+    }
+
+    private static func suffix(_ detail: String?) -> String {
+        guard let detail, !detail.isEmpty else { return "" }
+        return " \(detail)"
+    }
+
+    private static func milliseconds(_ duration: Duration) -> String {
+        let components = duration.components
+        let value = Double(components.seconds) * 1_000
+            + Double(components.attoseconds) / 1_000_000_000_000_000
+        return String(format: "%.1f", value)
+    }
+}

--- a/TablePro/Core/Execution/TabExecutionRegistry.swift
+++ b/TablePro/Core/Execution/TabExecutionRegistry.swift
@@ -1,0 +1,93 @@
+//
+//  TabExecutionRegistry.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Identity of one execution on one tab.
+///
+/// Validation is epoch-only and deliberately does not compare the tab's live table, database or
+/// schema fields. `resolveTableTabSchemaIfNeeded` rewrites `schemaName` mid-flight whenever the
+/// schema could not be resolved when the tab was created, which is the ordinary session-restore and
+/// pre-connect path, so a field comparison would discard results that are perfectly valid. The
+/// registry invalidates on retarget instead, which is strictly stronger: a claim minted before a
+/// retarget is never current after it, whether or not a successor execution ever starts.
+internal struct TabExecutionClaim: Hashable, Sendable {
+    let tabId: UUID
+    let epoch: Int
+}
+
+internal enum TabExecutionPhase: Equatable, Sendable {
+    case preparing
+    case executing
+    case applying
+}
+
+/// Per-tab owner of "which navigation owns this tab's execution", shaped after
+/// `ConnectionAttemptRegistry` one level down: connection identity becomes tab identity.
+///
+/// Replaces a per-window generation counter, a stored per-tab `isExecuting` bool, and two task
+/// handles that a tab retarget participated in none of. Busy state is derived from membership here,
+/// never stored on the tab, because a stored flag is exactly what let a retargeted tab stay busy
+/// forever and silently swallow every later navigation.
+internal struct TabExecutionRegistry {
+    private struct Entry {
+        let epoch: Int
+        var phase: TabExecutionPhase
+    }
+
+    private var entries: [UUID: Entry] = [:]
+    private var lastEpoch: Int = 0
+
+    internal init() {}
+
+    internal mutating func claim(_ tabId: UUID) -> TabExecutionClaim {
+        lastEpoch += 1
+        entries[tabId] = Entry(epoch: lastEpoch, phase: .preparing)
+        return TabExecutionClaim(tabId: tabId, epoch: lastEpoch)
+    }
+
+    internal func isCurrent(_ claim: TabExecutionClaim) -> Bool {
+        entries[claim.tabId]?.epoch == claim.epoch
+    }
+
+    internal mutating func advance(_ claim: TabExecutionClaim, to phase: TabExecutionPhase) {
+        guard isCurrent(claim) else { return }
+        entries[claim.tabId]?.phase = phase
+    }
+
+    /// Retarget, explicit cancel, tab close, teardown. Removing the entry rather than bumping a
+    /// counter is what makes "no successor execution ever started" still invalidate, which is
+    /// precisely the case the old per-window counter could not represent and the bug walked through.
+    internal mutating func invalidate(_ tabId: UUID) {
+        entries.removeValue(forKey: tabId)
+    }
+
+    internal mutating func invalidateAll() {
+        entries.removeAll()
+    }
+
+    /// Ends a claim that ran to completion. A claim that is no longer current settles nothing, so a
+    /// late result cannot clear the busy state of the navigation that superseded it.
+    internal mutating func settle(_ claim: TabExecutionClaim) {
+        guard isCurrent(claim) else { return }
+        entries.removeValue(forKey: claim.tabId)
+    }
+
+    internal func phase(for tabId: UUID) -> TabExecutionPhase? {
+        entries[tabId]?.phase
+    }
+
+    internal func isExecuting(_ tabId: UUID) -> Bool {
+        entries[tabId] != nil
+    }
+
+    internal var executingTabIds: Set<UUID> {
+        Set(entries.keys)
+    }
+
+    internal var isAnyExecuting: Bool {
+        !entries.isEmpty
+    }
+}

--- a/TablePro/Core/Execution/TabExecutionRegistry.swift
+++ b/TablePro/Core/Execution/TabExecutionRegistry.swift
@@ -38,6 +38,7 @@ internal struct TabExecutionRegistry {
     }
 
     private var entries: [UUID: Entry] = [:]
+    private var contentEpochs: [UUID: Int] = [:]
     private var lastEpoch: Int = 0
 
     internal init() {}
@@ -45,7 +46,19 @@ internal struct TabExecutionRegistry {
     internal mutating func claim(_ tabId: UUID) -> TabExecutionClaim {
         lastEpoch += 1
         entries[tabId] = Entry(epoch: lastEpoch, phase: .preparing)
+        contentEpochs[tabId] = lastEpoch
         return TabExecutionClaim(tabId: tabId, epoch: lastEpoch)
+    }
+
+    /// Identity of what the tab is currently showing, which outlives the claim that produced it.
+    /// Background work that augments an already-applied result (exact row count, fetch all) has no
+    /// claim of its own to validate, so it captures this and compares before writing back.
+    internal func contentEpoch(for tabId: UUID) -> Int {
+        contentEpochs[tabId] ?? 0
+    }
+
+    internal func isSameContent(_ epoch: Int, for tabId: UUID) -> Bool {
+        contentEpoch(for: tabId) == epoch
     }
 
     internal func isCurrent(_ claim: TabExecutionClaim) -> Bool {
@@ -62,10 +75,22 @@ internal struct TabExecutionRegistry {
     /// precisely the case the old per-window counter could not represent and the bug walked through.
     internal mutating func invalidate(_ tabId: UUID) {
         entries.removeValue(forKey: tabId)
+        lastEpoch += 1
+        contentEpochs[tabId] = lastEpoch
     }
 
     internal mutating func invalidateAll() {
+        let tabIds = Set(entries.keys).union(contentEpochs.keys)
         entries.removeAll()
+        for tabId in tabIds {
+            lastEpoch += 1
+            contentEpochs[tabId] = lastEpoch
+        }
+    }
+
+    internal mutating func forget(_ tabId: UUID) {
+        entries.removeValue(forKey: tabId)
+        contentEpochs.removeValue(forKey: tabId)
     }
 
     /// Ends a claim that ran to completion. A claim that is no longer current settles nothing, so a

--- a/TablePro/Core/Execution/TabExecutionRegistry.swift
+++ b/TablePro/Core/Execution/TabExecutionRegistry.swift
@@ -18,12 +18,6 @@ internal struct TabExecutionClaim: Hashable, Sendable {
     let epoch: Int
 }
 
-internal enum TabExecutionPhase: Equatable, Sendable {
-    case preparing
-    case executing
-    case applying
-}
-
 /// Per-tab owner of "which navigation owns this tab's execution", shaped after
 /// `ConnectionAttemptRegistry` one level down: connection identity becomes tab identity.
 ///
@@ -34,7 +28,6 @@ internal enum TabExecutionPhase: Equatable, Sendable {
 internal struct TabExecutionRegistry {
     private struct Entry {
         let epoch: Int
-        var phase: TabExecutionPhase
     }
 
     private var entries: [UUID: Entry] = [:]
@@ -45,7 +38,7 @@ internal struct TabExecutionRegistry {
 
     internal mutating func claim(_ tabId: UUID) -> TabExecutionClaim {
         lastEpoch += 1
-        entries[tabId] = Entry(epoch: lastEpoch, phase: .preparing)
+        entries[tabId] = Entry(epoch: lastEpoch)
         contentEpochs[tabId] = lastEpoch
         return TabExecutionClaim(tabId: tabId, epoch: lastEpoch)
     }
@@ -63,11 +56,6 @@ internal struct TabExecutionRegistry {
 
     internal func isCurrent(_ claim: TabExecutionClaim) -> Bool {
         entries[claim.tabId]?.epoch == claim.epoch
-    }
-
-    internal mutating func advance(_ claim: TabExecutionClaim, to phase: TabExecutionPhase) {
-        guard isCurrent(claim) else { return }
-        entries[claim.tabId]?.phase = phase
     }
 
     /// Retarget, explicit cancel, tab close, teardown. Removing the entry rather than bumping a
@@ -88,11 +76,6 @@ internal struct TabExecutionRegistry {
         }
     }
 
-    internal mutating func forget(_ tabId: UUID) {
-        entries.removeValue(forKey: tabId)
-        contentEpochs.removeValue(forKey: tabId)
-    }
-
     /// Ends a claim that ran to completion. A claim that is no longer current settles nothing, so a
     /// late result cannot clear the busy state of the navigation that superseded it.
     internal mutating func settle(_ claim: TabExecutionClaim) {
@@ -100,16 +83,8 @@ internal struct TabExecutionRegistry {
         entries.removeValue(forKey: claim.tabId)
     }
 
-    internal func phase(for tabId: UUID) -> TabExecutionPhase? {
-        entries[tabId]?.phase
-    }
-
     internal func isExecuting(_ tabId: UUID) -> Bool {
         entries[tabId] != nil
-    }
-
-    internal var executingTabIds: Set<UUID> {
-        Set(entries.keys)
     }
 
     internal var isAnyExecuting: Bool {

--- a/TablePro/Core/MCP/MCPConnectionBridge.swift
+++ b/TablePro/Core/MCP/MCPConnectionBridge.swift
@@ -188,7 +188,8 @@ public actor MCPConnectionBridge {
         let route = await MainActor.run { DatabaseManager.shared.executionRoute(for: scope) }
         let result: QueryResult = try await DatabaseManager.shared.withScopedDriver(
             scope: scope,
-            route: route
+            route: route,
+            cancellation: .untracked
         ) { driver in
             try await withThrowingTaskGroup(of: QueryResult.self) { group in
                 group.addTask {

--- a/TablePro/Models/Query/QueryTabManager.swift
+++ b/TablePro/Models/Query/QueryTabManager.swift
@@ -168,6 +168,11 @@ final class QueryTabManager {
 
     var onTableOpened: ((_ tableName: String, _ schemaName: String?, _ databaseName: String, _ isView: Bool, _ isPreview: Bool) -> Void)?
 
+    /// Fired the instant a tab stops being about the table it was about. Whoever owns execution
+    /// listens here rather than at the navigation call sites, because a retarget that forgets to
+    /// invalidate is exactly how a finished query paints its rows into a tab showing something else.
+    var onTabRetargeted: ((UUID) -> Void)?
+
     private func notifyTableOpened(
         tableName: String, schemaName: String?, databaseName: String, isView: Bool, isPreview: Bool
     ) {
@@ -345,6 +350,8 @@ final class QueryTabManager {
             quoteIdentifier: quoteIdentifier
         )
         let pageSize = AppSettingsManager.shared.dataGrid.defaultPageSize
+
+        onTabRetargeted?(selectedId)
 
         var tab = tabs[selectedIndex]
         tab.tabType = .table

--- a/TablePro/Models/Query/QueryTabState.swift
+++ b/TablePro/Models/Query/QueryTabState.swift
@@ -345,8 +345,10 @@ struct ColumnLayoutState: Equatable {
     }
 }
 
+/// Deliberately has no `isExecuting`. Busy state is derived from `TabExecutionRegistry`, because a
+/// stored flag could not be reset by a tab retarget and so kept a retargeted tab busy forever,
+/// silently swallowing every later navigation.
 struct TabExecutionState: Equatable {
-    var isExecuting: Bool = false
     var executionTime: TimeInterval?
     var statusMessage: String?
     var errorMessage: String?
@@ -355,8 +357,7 @@ struct TabExecutionState: Equatable {
     var lastExecutedAt: Date?
 
     static func == (lhs: TabExecutionState, rhs: TabExecutionState) -> Bool {
-        lhs.isExecuting == rhs.isExecuting
-            && lhs.executionTime == rhs.executionTime
+        lhs.executionTime == rhs.executionTime
             && lhs.statusMessage == rhs.statusMessage
             && lhs.errorMessage == rhs.errorMessage
             && lhs.rowsAffected == rhs.rowsAffected

--- a/TablePro/Views/Export/ExportDialog.swift
+++ b/TablePro/Views/Export/ExportDialog.swift
@@ -828,7 +828,8 @@ struct ExportDialog: View {
             try await DatabaseManager.shared.withScopedDriver(
                 scope: scope,
                 route: route,
-                workload: .bulk
+                workload: .bulk,
+                cancellation: .untracked
             ) { driver in
                 try await runTableExport(on: driver, to: url)
             }
@@ -883,7 +884,8 @@ struct ExportDialog: View {
                 try await DatabaseManager.shared.withScopedDriver(
                     scope: scope,
                     route: route,
-                    workload: .bulk
+                    workload: .bulk,
+                    cancellation: .untracked
                 ) { driver in
                     try await runStreamingExport(on: driver, query: query, to: url)
                 }

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -572,7 +572,8 @@ struct MainEditorContentView: View {
 
                     let resolvedRows = resolvedTableRows(for: tab)
                     if let rs = tab.display.activeResultSet, rs.resultColumns.isEmpty,
-                       rs.errorMessage == nil, tab.execution.lastExecutedAt != nil, !tab.execution.isExecuting
+                       rs.errorMessage == nil, tab.execution.lastExecutedAt != nil,
+                       !coordinator.tabExecution.isExecuting(tab.id)
                     {
                         ResultSuccessView(
                             rowsAffected: rs.rowsAffected,
@@ -580,7 +581,7 @@ struct MainEditorContentView: View {
                             statusMessage: rs.statusMessage
                         )
                     } else if resolvedRows.columns.isEmpty && tab.execution.errorMessage == nil
-                        && tab.execution.lastExecutedAt != nil && !tab.execution.isExecuting
+                        && tab.execution.lastExecutedAt != nil && !coordinator.tabExecution.isExecuting(tab.id)
                     {
                         if tab.display.resultSets.isEmpty {
                             Spacer()
@@ -611,7 +612,7 @@ struct MainEditorContentView: View {
 
                         if tab.tabType == .query && !resolvedRows.columns.isEmpty
                             && resolvedRows.rows.isEmpty && tab.execution.lastExecutedAt != nil
-                            && !tab.execution.isExecuting && !tab.filterState.hasAppliedFilters
+                            && !coordinator.tabExecution.isExecuting(tab.id) && !tab.filterState.hasAppliedFilters
                         {
                             emptyResultView(executionTime: tab.display.activeResultSet?.executionTime ?? tab.execution.executionTime)
                         } else {

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ClickHouse.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ClickHouse.swift
@@ -62,7 +62,6 @@ extension MainContentCoordinator {
         Task {
             guard let driver = DatabaseManager.shared.driver(for: connectionId) else { return }
 
-            tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = true }
             toolbarState.setExecuting(true)
 
             do {
@@ -84,13 +83,11 @@ extension MainContentCoordinator {
                     } else {
                         tab.display.explainPlan = nil
                     }
-                    tab.execution.isExecuting = false
                 }
             } catch {
                 tabManager.mutate(tabId: tabId) { tab in
                     tab.display.explainText = "Error: \(error.localizedDescription)"
                     tab.display.explainPlan = nil
-                    tab.execution.isExecuting = false
                 }
             }
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ClickHouse.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ClickHouse.swift
@@ -26,7 +26,7 @@ extension MainContentCoordinator {
     /// Accepts the plugin-kit `ExplainVariant` type for generic dispatch.
     func runVariantExplain(_ variant: ExplainVariant) {
         guard let (tab, _) = tabManager.selectedTabAndIndex,
-              !tab.execution.isExecuting else { return }
+              !tabExecution.isExecuting(tab.id) else { return }
 
         let fullQuery = tab.content.query
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+LoadTracing.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+LoadTracing.swift
@@ -6,12 +6,12 @@
 import Foundation
 
 extension MainContentCoordinator {
-    func traceExecutionStarted(_ token: TableLoadTraceToken?, generation: Int, isAutoLoad: Bool) {
+    func traceExecutionStarted(_ token: TableLoadTraceToken?, epoch: Int, isAutoLoad: Bool) {
         guard let token else { return }
         TableLoadTracer.shared.stage(
             .executeStarted,
             token: token,
-            detail: "generation=\(generation) isAutoLoad=\(isAutoLoad)"
+            detail: "epoch=\(epoch) isAutoLoad=\(isAutoLoad)"
         )
     }
 
@@ -75,7 +75,7 @@ extension MainContentCoordinator {
         let tracer = TableLoadTracer.shared
         let owner = tracer.activeToken(for: token.tabId)
         tracer.anomaly(
-            .staleGenerationDropped,
+            .staleResultDropped,
             token: token,
             detail: "tabOwnedBy=\(owner.map { "#\($0.sequence)" } ?? "none") cancelled=\(Task.isCancelled)"
         )

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+LoadTracing.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+LoadTracing.swift
@@ -70,13 +70,14 @@ extension MainContentCoordinator {
         tracer.finish(token: token, outcome: "cancelled")
     }
 
-    func traceStaleResultDropped(_ token: TableLoadTraceToken?, captured: Int, current: Int) {
+    func traceStaleResultDropped(_ token: TableLoadTraceToken?) {
         guard let token else { return }
         let tracer = TableLoadTracer.shared
+        let owner = tracer.activeToken(for: token.tabId)
         tracer.anomaly(
             .staleGenerationDropped,
             token: token,
-            detail: "captured=\(captured) current=\(current) cancelled=\(Task.isCancelled)"
+            detail: "tabOwnedBy=\(owner.map { "#\($0.sequence)" } ?? "none") cancelled=\(Task.isCancelled)"
         )
         tracer.finish(token: token, outcome: "staleDropped")
     }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+LoadTracing.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+LoadTracing.swift
@@ -1,0 +1,142 @@
+//
+//  MainContentCoordinator+LoadTracing.swift
+//  TablePro
+//
+
+import Foundation
+
+extension MainContentCoordinator {
+    func traceExecutionStarted(_ token: TableLoadTraceToken?, generation: Int, isAutoLoad: Bool) {
+        guard let token else { return }
+        TableLoadTracer.shared.stage(
+            .executeStarted,
+            token: token,
+            detail: "generation=\(generation) isAutoLoad=\(isAutoLoad)"
+        )
+    }
+
+    /// Ending the trace here is only right when it never got a query of its own. If it did, the result
+    /// is still on its way back and has to be able to report against it, so the trace stays open and
+    /// whatever the query does next closes it.
+    func traceExecutionBlocked(tabId: UUID, site: String) {
+        let tracer = TableLoadTracer.shared
+        guard let token = tracer.activeToken(for: tabId) else { return }
+        tracer.anomaly(
+            .blockedByInFlightExecution,
+            token: token,
+            detail: "site=\(site) hasInFlightQuery=\(currentQueryTask != nil)"
+        )
+        guard !tracer.hasStartedExecution(token) else { return }
+        tracer.finish(token: token, outcome: "blocked")
+    }
+
+    func traceNavigationAbandoned(tabId: UUID, reason: String) {
+        let tracer = TableLoadTracer.shared
+        guard let token = tracer.activeToken(for: tabId), !tracer.hasStartedExecution(token) else { return }
+        tracer.anomaly(.preparationAbandoned, token: token, detail: reason)
+        tracer.finish(token: token, outcome: reason)
+    }
+
+    func traceFetchCompleted(
+        _ token: TableLoadTraceToken?,
+        began: ContinuousClock.Instant,
+        ended: ContinuousClock.Instant,
+        result: QueryFetchResult
+    ) {
+        guard let token else { return }
+        let tracer = TableLoadTracer.shared
+        tracer.stage(.driverFetchBegin, token: token, at: began)
+        tracer.stage(
+            .driverFetchEnd,
+            token: token,
+            at: ended,
+            detail: """
+                rows=\(result.rows.count) cols=\(result.columns.count) \
+                driverMs=\(Int(result.executionTime * 1_000))
+                """
+        )
+    }
+
+    func traceFetchCancelled(
+        _ token: TableLoadTraceToken?,
+        began: ContinuousClock.Instant,
+        ended: ContinuousClock.Instant
+    ) {
+        guard let token else { return }
+        let tracer = TableLoadTracer.shared
+        tracer.stage(.driverFetchBegin, token: token, at: began)
+        tracer.stage(.driverFetchEnd, token: token, at: ended)
+        tracer.anomaly(.executionCancelled, token: token)
+        tracer.finish(token: token, outcome: "cancelled")
+    }
+
+    func traceStaleResultDropped(_ token: TableLoadTraceToken?, captured: Int, current: Int) {
+        guard let token else { return }
+        let tracer = TableLoadTracer.shared
+        tracer.anomaly(
+            .staleGenerationDropped,
+            token: token,
+            detail: "captured=\(captured) current=\(current) cancelled=\(Task.isCancelled)"
+        )
+        tracer.finish(token: token, outcome: "staleDropped")
+    }
+
+    /// A result whose table no longer matches what the tab shows is the defect the user sees as
+    /// "the grid filled with the table I navigated away from", so it is called out before the
+    /// result is applied rather than inferred later from the row data.
+    func traceApplyingResult(_ token: TableLoadTraceToken?, tabId: UUID) {
+        guard let token else { return }
+        let tracer = TableLoadTracer.shared
+        let currentTable = tabManager.tabs.first(where: { $0.id == tabId })?.tableContext.tableName
+        if let currentTable, currentTable != token.table {
+            tracer.anomaly(
+                .resultTableMismatch,
+                token: token,
+                detail: "resultTable=\(token.table) tabNowShows=\(currentTable)"
+            )
+        }
+        tracer.stage(.applyResultBegin, token: token)
+        tracer.beginApplyScope(token)
+    }
+
+    /// The trace for a query that has no navigation behind it, so re-executions on an already loaded
+    /// tab (pagination, sort, filter, refresh, save-and-reload) still produce a timeline and can still
+    /// report `blockedByInFlightExecution`.
+    func adoptOrBeginExecutionTrace(tabId: UUID) -> TableLoadTraceToken? {
+        let tracer = TableLoadTracer.shared
+        if let existing = tracer.activeToken(for: tabId) { return existing }
+        guard let tab = tabManager.tabs.first(where: { $0.id == tabId }) else { return nil }
+        return tracer.begin(
+            tabId: tabId,
+            table: tab.tableContext.tableName ?? tab.title,
+            origin: .reExecute
+        )
+    }
+
+    func traceConnectUnavailable(_ token: TableLoadTraceToken?) {
+        guard let token else { return }
+        let tracer = TableLoadTracer.shared
+        tracer.anomaly(.connectionNotReady, token: token, detail: "site=ensureConnected")
+        tracer.finish(token: token, outcome: "notConnected")
+    }
+
+    func traceExecutionFailed(_ token: TableLoadTraceToken?, error: Error) {
+        guard let token else { return }
+        TableLoadTracer.shared.finish(token: token, outcome: "failed:\(type(of: error))")
+    }
+
+    /// Ends the trace one run loop turn after the grid reload. `reloadData()` only invalidates,
+    /// so the cell work it schedules runs later in the same turn; closing the trace on the next
+    /// turn is what makes that cost visible instead of hiding it after the last stage.
+    func scheduleTraceCompletion(_ token: TableLoadTraceToken?, outcome: String) {
+        TableLoadTracer.shared.endApplyScope()
+        guard let token else { return }
+        DispatchQueue.main.async {
+            MainActor.assumeIsolated {
+                let tracer = TableLoadTracer.shared
+                tracer.stage(.mainRunLoopIdle, token: token)
+                tracer.finish(token: token, outcome: outcome)
+            }
+        }
+    }
+}

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -69,6 +69,9 @@ extension MainContentCoordinator {
             activateGridFocus: activateGridFocus,
             includeSiblings: navigationModel != .inPlace
         ) {
+            navigationLogger.debug(
+                "[tableload] activateExistingTab table=\(tableName, privacy: .public)"
+            )
             return
         }
 
@@ -79,6 +82,9 @@ extension MainContentCoordinator {
         // During database switch, update the existing tab in-place instead of
         // opening a new native window tab.
         if case .loading = SchemaService.shared.state(for: connectionId) {
+            navigationLogger.debug(
+                "[tableload] deferredToSchemaLoad table=\(tableName, privacy: .public) hasTabs=\(!self.tabManager.tabs.isEmpty)"
+            )
             if tabManager.tabs.isEmpty {
                 do {
                     try tabManager.addTableTab(
@@ -114,6 +120,10 @@ extension MainContentCoordinator {
         if navigationModel == .inPlace {
             if let oldTab = tabManager.selectedTab, let oldTableName = oldTab.tableContext.tableName {
                 saveLastFilters(for: oldTableName)
+            }
+            if let tabId = tabManager.selectedTabId {
+                let token = TableLoadTracer.shared.begin(tabId: tabId, table: tableName, origin: .inPlace)
+                TableLoadTracer.shared.stage(.openTableTab, token: token, detail: "path=inPlace")
             }
             do {
                 let replaced = try tabManager.replaceTabContent(
@@ -154,6 +164,10 @@ extension MainContentCoordinator {
         }
 
         promotePreviewTab()
+        navigationLogger.debug(
+            "[tableload] handoffToNewWindowTab table=\(tableName, privacy: .public)"
+        )
+        TableLoadTracer.shared.noteWindowTabHandoff(connectionId: connection.id, table: tableName)
         let payload = EditorTabPayload(
             connectionId: connection.id,
             tabType: .table,
@@ -241,7 +255,10 @@ extension MainContentCoordinator {
             navigationLogger.error("openTableTab tab creation failed: \(error.localizedDescription, privacy: .public)")
             return
         }
-        if let (_, tabIndex) = tabManager.selectedTabAndIndex {
+        if let (tab, tabIndex) = tabManager.selectedTabAndIndex {
+            let token = TableLoadTracer.shared.begin(tabId: tab.id, table: tableName, origin: .sidebar)
+            TableLoadTracer.shared.stage(.openTableTab, token: token, detail: "path=addFirstTab")
+            TableLoadTracer.shared.stage(.addFirstTab, token: token)
             tabManager.mutate(at: tabIndex) { tab in
                 tab.tableContext.isView = isView
                 tab.tableContext.isEditable = !isView
@@ -267,9 +284,26 @@ extension MainContentCoordinator {
         showStructure: Bool,
         createAsPreview: Bool
     ) {
-        if let oldTableName = tabManager.selectedTab?.tableContext.tableName {
-            saveLastFilters(for: oldTableName)
+        let previousTableName = tabManager.selectedTab?.tableContext.tableName
+        if let previousTableName {
+            saveLastFilters(for: previousTableName)
         }
+
+        var token: TableLoadTraceToken?
+        if let tabId = tabManager.selectedTabId {
+            let wasExecuting = tabManager.selectedTab?.execution.isExecuting ?? false
+            let started = TableLoadTracer.shared.begin(tabId: tabId, table: tableName, origin: .sidebar)
+            token = started
+            TableLoadTracer.shared.stage(
+                .openTableTab,
+                token: started,
+                detail: """
+                    path=reuseActiveTab from=\(previousTableName ?? "none") \
+                    wasExecuting=\(wasExecuting) hasInFlightQuery=\(currentQueryTask != nil)
+                    """
+            )
+        }
+
         do {
             try tabManager.replaceTabContent(
                 tableName: tableName,
@@ -281,8 +315,10 @@ extension MainContentCoordinator {
             )
         } catch {
             navigationLogger.error("openTableTab replaceTabContent failed: \(error.localizedDescription, privacy: .public)")
+            if let token { TableLoadTracer.shared.finish(token: token, outcome: "replaceFailed") }
             return
         }
+        if let token { TableLoadTracer.shared.stage(.replaceTabContent, token: token) }
         clearFilterState()
         if let (tab, tabIndex) = tabManager.selectedTabAndIndex {
             setActiveTableRows(TableRows(), for: tab.id)
@@ -295,6 +331,7 @@ extension MainContentCoordinator {
         restoreLastHiddenColumnsForTable()
         restoreFiltersForTable(tableName)
         if let tabId = tabManager.selectedTab?.id {
+            if let token { TableLoadTracer.shared.stage(.cancelPreviousLoad, token: token) }
             cancelTableLoad(for: tabId)
         }
         lazyLoadCurrentTabIfNeeded()

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -291,7 +291,7 @@ extension MainContentCoordinator {
 
         var token: TableLoadTraceToken?
         if let tabId = tabManager.selectedTabId {
-            let wasExecuting = tabManager.selectedTab?.execution.isExecuting ?? false
+            let wasExecuting = tabExecution.isExecuting(tabId)
             let started = TableLoadTracer.shared.begin(tabId: tabId, table: tableName, origin: .sidebar)
             token = started
             TableLoadTracer.shared.stage(

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
@@ -24,9 +24,9 @@ extension MainContentCoordinator {
         traceToken: TableLoadTraceToken?
     ) {
         tabManager.mutate(tabId: tabId) { tab in
-            tab.execution.isExecuting = false
             tab.pagination.isLoadingMore = false
         }
+        tabExecution.settle(claim)
         currentQueryTask = nil
         toolbarState.setExecuting(false)
         traceExecutionFailed(traceToken, error: error)

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
@@ -13,6 +13,37 @@ extension MainContentCoordinator {
         aiViewModel?.handleFixError(query: query, error: error)
     }
 
+    func finishFailedQuery(
+        _ error: Error,
+        tabId: UUID,
+        sql: String,
+        connection conn: DatabaseConnection,
+        capturedGeneration: Int,
+        isAutoLoad: Bool,
+        trigger: TableLoadTrigger,
+        traceToken: TableLoadTraceToken?
+    ) {
+        tabManager.mutate(tabId: tabId) { tab in
+            tab.execution.isExecuting = false
+            tab.pagination.isLoadingMore = false
+        }
+        currentQueryTask = nil
+        toolbarState.setExecuting(false)
+        traceExecutionFailed(traceToken, error: error)
+        if DatabaseCancellationDiagnosis.isCancellation(error) || Task.isCancelled { return }
+        guard capturedGeneration == queryGeneration else { return }
+        if isAutoLoad, services.databaseManager.driver(for: connectionId)?.status != .connected {
+            pendingLoadTrigger = trigger
+            return
+        }
+        handleQueryExecutionError(error, sql: sql, tabId: tabId, connection: conn)
+    }
+
+    func clearChangesIfCurrent(generation: Int) {
+        guard generation == queryGeneration, !Task.isCancelled else { return }
+        changeManager.clearChangesAndUndoHistory()
+    }
+
     func resolveRowCap(sql: String, tabType: TabType, bypassLimit: Bool = false) -> Int? {
         queryExecutionCoordinator.resolveRowCap(sql: sql, tabType: tabType, bypassLimit: bypassLimit)
     }
@@ -58,6 +89,32 @@ extension MainContentCoordinator {
             connection: conn,
             isTruncated: isTruncated,
             queryParameterValues: queryParameterValues
+        )
+    }
+
+    func launchPhase2(
+        tableName: String,
+        tabId: UUID,
+        capturedGeneration: Int,
+        connectionType: DatabaseType,
+        needsMetadataFetch: Bool,
+        schemaTask: Task<FetchedTableSchema, Error>?
+    ) {
+        guard needsMetadataFetch else {
+            launchPhase2Count(
+                tableName: tableName,
+                tabId: tabId,
+                capturedGeneration: capturedGeneration,
+                connectionType: connectionType
+            )
+            return
+        }
+        launchPhase2Work(
+            tableName: tableName,
+            tabId: tabId,
+            capturedGeneration: capturedGeneration,
+            connectionType: connectionType,
+            schemaTask: schemaTask
         )
     }
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
@@ -18,7 +18,7 @@ extension MainContentCoordinator {
         tabId: UUID,
         sql: String,
         connection conn: DatabaseConnection,
-        capturedGeneration: Int,
+        claim: TabExecutionClaim,
         isAutoLoad: Bool,
         trigger: TableLoadTrigger,
         traceToken: TableLoadTraceToken?
@@ -31,7 +31,7 @@ extension MainContentCoordinator {
         toolbarState.setExecuting(false)
         traceExecutionFailed(traceToken, error: error)
         if DatabaseCancellationDiagnosis.isCancellation(error) || Task.isCancelled { return }
-        guard capturedGeneration == queryGeneration else { return }
+        guard tabExecution.isCurrent(claim) else { return }
         if isAutoLoad, services.databaseManager.driver(for: connectionId)?.status != .connected {
             pendingLoadTrigger = trigger
             return
@@ -39,8 +39,8 @@ extension MainContentCoordinator {
         handleQueryExecutionError(error, sql: sql, tabId: tabId, connection: conn)
     }
 
-    func clearChangesIfCurrent(generation: Int) {
-        guard generation == queryGeneration, !Task.isCancelled else { return }
+    func clearChangesIfCurrent(claim: TabExecutionClaim) {
+        guard tabExecution.isCurrent(claim), !Task.isCancelled else { return }
         changeManager.clearChangesAndUndoHistory()
     }
 
@@ -95,7 +95,7 @@ extension MainContentCoordinator {
     func launchPhase2(
         tableName: String,
         tabId: UUID,
-        capturedGeneration: Int,
+        claim: TabExecutionClaim,
         connectionType: DatabaseType,
         needsMetadataFetch: Bool,
         schemaTask: Task<FetchedTableSchema, Error>?
@@ -104,7 +104,7 @@ extension MainContentCoordinator {
             launchPhase2Count(
                 tableName: tableName,
                 tabId: tabId,
-                capturedGeneration: capturedGeneration,
+                claim: claim,
                 connectionType: connectionType
             )
             return
@@ -112,7 +112,7 @@ extension MainContentCoordinator {
         launchPhase2Work(
             tableName: tableName,
             tabId: tabId,
-            capturedGeneration: capturedGeneration,
+            claim: claim,
             connectionType: connectionType,
             schemaTask: schemaTask
         )
@@ -121,14 +121,14 @@ extension MainContentCoordinator {
     func launchPhase2Work(
         tableName: String,
         tabId: UUID,
-        capturedGeneration: Int,
+        claim: TabExecutionClaim,
         connectionType: DatabaseType,
         schemaTask: Task<FetchedTableSchema, Error>?
     ) {
         queryExecutionCoordinator.launchPhase2Work(
             tableName: tableName,
             tabId: tabId,
-            capturedGeneration: capturedGeneration,
+            claim: claim,
             connectionType: connectionType,
             schemaTask: schemaTask
         )
@@ -137,13 +137,13 @@ extension MainContentCoordinator {
     func launchPhase2Count(
         tableName: String,
         tabId: UUID,
-        capturedGeneration: Int,
+        claim: TabExecutionClaim,
         connectionType: DatabaseType
     ) {
         queryExecutionCoordinator.launchPhase2Count(
             tableName: tableName,
             tabId: tabId,
-            capturedGeneration: capturedGeneration,
+            claim: claim,
             connectionType: connectionType
         )
     }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TableFirstLoad.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TableFirstLoad.swift
@@ -8,7 +8,21 @@ import TableProPluginKit
 
 extension MainContentCoordinator {
     func openTableTabQuery(tabId: UUID, trigger: TableLoadTrigger = .userInitiated) async {
-        guard await prepareTableTabFirstLoad(tabId: tabId) else { return }
+        let tracer = TableLoadTracer.shared
+        let token = tracer.activeToken(for: tabId)
+        if let token { tracer.stage(.prepareFirstLoad, token: token) }
+
+        guard await prepareTableTabFirstLoad(tabId: tabId) else {
+            if let token {
+                tracer.anomaly(
+                    .preparationAbandoned,
+                    token: token,
+                    detail: "cancelled=\(Task.isCancelled) stillSelected=\(tabManager.selectedTabId == tabId)"
+                )
+                tracer.finish(token: token, outcome: "prepareAbandoned")
+            }
+            return
+        }
         executeTableTabQueryDirectly(trigger: trigger)
     }
 
@@ -32,7 +46,11 @@ extension MainContentCoordinator {
             return true
         }
 
+        let tracer = TableLoadTracer.shared
+        let token = tracer.activeToken(for: tabId)
+        if let token { tracer.stage(.schemaColumnsBegin, token: token) }
         await loadSchemaColumns(for: tableName, scope: scope(for: tab))
+        if let token { tracer.stage(.schemaColumnsEnd, token: token) }
 
         guard !Task.isCancelled,
               tabManager.selectedTabId == tabId,

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TableFirstLoad.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TableFirstLoad.swift
@@ -17,7 +17,7 @@ extension MainContentCoordinator {
                 tracer.anomaly(
                     .preparationAbandoned,
                     token: token,
-                    detail: "cancelled=\(Task.isCancelled) stillSelected=\(tabManager.selectedTabId == tabId)"
+                    detail: "cancelled=\(Task.isCancelled)"
                 )
                 tracer.finish(token: token, outcome: "prepareAbandoned")
             }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TableRowsMutation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TableRowsMutation.swift
@@ -80,7 +80,19 @@ extension MainContentCoordinator {
         guard let idx = tabManager.selectedTabIndex,
               idx < tabManager.tabs.count,
               tabManager.tabs[idx].id == tabId else { return }
+
+        let tracer = TableLoadTracer.shared
+        let token = tracer.applyingToken
+        if let token {
+            tracer.stage(
+                .gridReloadBegin,
+                token: token,
+                detail: "rows=\(tabSessionRegistry.tableRows(for: tabId).rows.count)"
+            )
+        }
         dataTabDelegate?.tableViewCoordinator?.applyFullReplace()
+        if let token { tracer.stage(.gridReloadEnd, token: token) }
+
         if pendingScrollToTopAfterReplace.remove(tabId) != nil {
             dataTabDelegate?.tableViewCoordinator?.scrollToTop()
         }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+WindowLifecycle.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+WindowLifecycle.swift
@@ -135,12 +135,28 @@ extension MainContentCoordinator {
         guard let tab = tabManager.selectedTab else { return }
         guard deferredRestoreLoadTabId != tab.id else { return }
         guard canAutoLoadTableTab(tab) else { return }
-        guard tableLoadTasks[tab.id] == nil else { return }
+
+        let tracer = TableLoadTracer.shared
+        let carriedToken = tracer.activeToken(for: tab.id)
+        let traceToken = carriedToken ?? tracer.begin(
+            tabId: tab.id,
+            table: tab.tableContext.tableName ?? "",
+            origin: trigger == .restore ? .restore : .programmatic,
+            connectionId: connectionId
+        )
+
+        guard tableLoadTasks[tab.id] == nil else {
+            tracer.anomaly(.loadAlreadyInFlight, token: traceToken)
+            if carriedToken == nil { tracer.finish(token: traceToken, outcome: "loadAlreadyInFlight") }
+            return
+        }
 
         clearAbandonedExecutingFlagIfNeeded(for: tab)
 
         guard let session = DatabaseManager.shared.session(for: connectionId),
               session.isConnected else {
+            tracer.anomaly(.connectionNotReady, token: traceToken)
+            tracer.finish(token: traceToken, outcome: "notConnected")
             pendingLoadTrigger = trigger
             return
         }
@@ -149,6 +165,7 @@ extension MainContentCoordinator {
         Self.lifecycleLogger.debug(
             "[switch] coordinator.lazyLoadCurrentTabIfNeeded executing tabId=\(tabId, privacy: .public)"
         )
+        tracer.stage(.lazyLoadScheduled, token: traceToken)
         let token = UUID()
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
@@ -195,6 +212,11 @@ extension MainContentCoordinator {
 
     private func clearAbandonedExecutingFlagIfNeeded(for tab: QueryTab) {
         guard tab.execution.isExecuting, currentQueryTask == nil else { return }
+        TableLoadTracer.shared.anomaly(
+            .preparationAbandoned,
+            tabId: tab.id,
+            detail: "clearedStaleIsExecuting"
+        )
         tabManager.mutate(tabId: tab.id) { $0.execution.isExecuting = false }
     }
 }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+WindowLifecycle.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+WindowLifecycle.swift
@@ -146,8 +146,9 @@ extension MainContentCoordinator {
         )
 
         guard tableLoadTasks[tab.id] == nil else {
+            guard carriedToken == nil else { return }
             tracer.anomaly(.loadAlreadyInFlight, token: traceToken)
-            if carriedToken == nil { tracer.finish(token: traceToken, outcome: "loadAlreadyInFlight") }
+            tracer.finish(token: traceToken, outcome: "loadAlreadyInFlight")
             return
         }
 
@@ -162,9 +163,6 @@ extension MainContentCoordinator {
         }
 
         let tabId = tab.id
-        Self.lifecycleLogger.debug(
-            "[switch] coordinator.lazyLoadCurrentTabIfNeeded executing tabId=\(tabId, privacy: .public)"
-        )
         tracer.stage(.lazyLoadScheduled, token: traceToken)
         let token = UUID()
         let task = Task { @MainActor [weak self] in

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+WindowLifecycle.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+WindowLifecycle.swift
@@ -211,12 +211,12 @@ extension MainContentCoordinator {
     }
 
     private func clearAbandonedExecutingFlagIfNeeded(for tab: QueryTab) {
-        guard tab.execution.isExecuting, currentQueryTask == nil else { return }
+        guard tabExecution.isExecuting(tab.id), currentQueryTask == nil else { return }
         TableLoadTracer.shared.anomaly(
             .preparationAbandoned,
             tabId: tab.id,
-            detail: "clearedStaleIsExecuting"
+            detail: "clearedAbandonedClaim"
         )
-        tabManager.mutate(tabId: tab.id) { $0.execution.isExecuting = false }
+        tabExecution.invalidate(tab.id)
     }
 }

--- a/TablePro/Views/Main/Extensions/MainContentView+EventHandlers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+EventHandlers.swift
@@ -113,6 +113,15 @@ extension MainContentView {
             isActiveTabReusable: coordinator.isActiveTabReusable
         )
 
+        MainContentView.lifecycleLogger.debug(
+            """
+            [tableload] sidebarSelection table=\(table.name, privacy: .public) \
+            decision=\(String(describing: result), privacy: .public) \
+            currentTab=\(tabManager.selectedTab?.tableContext.tableName ?? "none", privacy: .public) \
+            isExecuting=\(tabManager.selectedTab?.execution.isExecuting ?? false)
+            """
+        )
+
         switch result {
         case .skip:
             return

--- a/TablePro/Views/Main/Extensions/MainContentView+EventHandlers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+EventHandlers.swift
@@ -118,7 +118,7 @@ extension MainContentView {
             [tableload] sidebarSelection table=\(table.name, privacy: .public) \
             decision=\(String(describing: result), privacy: .public) \
             currentTab=\(tabManager.selectedTab?.tableContext.tableName ?? "none", privacy: .public) \
-            isExecuting=\(tabManager.selectedTab?.execution.isExecuting ?? false)
+            isExecuting=\(coordinator.tabExecution.isAnyExecuting)
             """
         )
 

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -1237,7 +1237,7 @@ final class MainContentCoordinator {
                     // that cleared the spinner or nilled the task handle would be reporting on a
                     // query that is still running, so the gate comes before all of them.
                     guard tabExecution.isCurrent(claim), !Task.isCancelled else {
-                        traceStaleResultDropped(traceToken, captured: claim.epoch, current: 0)
+                        traceStaleResultDropped(traceToken)
                         return
                     }
                     tabExecution.advance(claim, to: .applying)

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -931,17 +931,27 @@ final class MainContentCoordinator {
     /// Table tab queries are always app-generated SELECTs, so they skip dangerous-query
     /// checks but still respect safe mode levels that apply to all queries.
     func executeTableTabQueryDirectly(trigger: TableLoadTrigger = .userInitiated) {
-        guard let (tab, index) = tabManager.selectedTabAndIndex,
-              !tab.execution.isExecuting else { return }
+        guard let (tab, index) = tabManager.selectedTabAndIndex else { return }
+        guard !tab.execution.isExecuting else {
+            traceExecutionBlocked(tabId: tab.id, site: "executeTableTabQueryDirectly")
+            return
+        }
+        TableLoadTracer.shared.stage(.executeRequested, tabId: tab.id)
 
         let sql = tab.content.query
-        guard !sql.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        guard !sql.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            traceNavigationAbandoned(tabId: tab.id, reason: "emptyQuery")
+            return
+        }
 
         let level = safeModeLevel
         if level.appliesToAllQueries && level.requiresConfirmation,
            tab.execution.lastExecutedAt == nil
         {
-            guard !isShowingSafeModePrompt else { return }
+            guard !isShowingSafeModePrompt else {
+                traceNavigationAbandoned(tabId: tab.id, reason: "safeModePromptAlreadyOpen")
+                return
+            }
             isShowingSafeModePrompt = true
             Task {
                 defer { isShowingSafeModePrompt = false }
@@ -960,6 +970,7 @@ final class MainContentCoordinator {
                 case .authorized:
                     executeQueryInternal(sql, isAutoLoad: true, trigger: trigger)
                 case .denied(let reason):
+                    traceNavigationAbandoned(tabId: tab.id, reason: "safeModeDenied")
                     tabManager.mutate(at: index) { $0.execution.errorMessage = reason }
                 }
             }
@@ -1116,8 +1127,11 @@ final class MainContentCoordinator {
         trigger: TableLoadTrigger = .userInitiated,
         bypassRowLimit: Bool = false
     ) {
-        guard let (selectedTab, index) = tabManager.selectedTabAndIndex,
-              !selectedTab.execution.isExecuting else { return }
+        guard let (selectedTab, index) = tabManager.selectedTabAndIndex else { return }
+        guard !selectedTab.execution.isExecuting else {
+            traceExecutionBlocked(tabId: selectedTab.id, site: "executeQueryInternal")
+            return
+        }
 
         cancelInFlightQueryTask()
         queryGeneration += 1
@@ -1139,6 +1153,9 @@ final class MainContentCoordinator {
 
         let conn = connection
         let tabId = tabManager.tabs[index].id
+
+        let traceToken = adoptOrBeginExecutionTrace(tabId: tabId)
+        traceExecutionStarted(traceToken, generation: capturedGeneration, isAutoLoad: isAutoLoad)
 
         let rowCap = resolveRowCap(sql: sql, tabType: tab.tabType, bypassLimit: bypassRowLimit)
         let (tableName, isEditable) = resolveTableEditability(tab: tab, sql: sql)
@@ -1172,6 +1189,7 @@ final class MainContentCoordinator {
                 } catch {
                     await MainActor.run { [weak self] in
                         guard let self else { return }
+                        traceConnectUnavailable(traceToken)
                         tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
                         currentQueryTask = nil
                         toolbarState.setExecuting(false)
@@ -1188,6 +1206,7 @@ final class MainContentCoordinator {
                 schemaTask = nil
             }
 
+            let fetchBeganAt = ContinuousClock.now
             do {
                 let fetchResult = try await services.databaseManager.withScopedDriver(
                     scope: scope,
@@ -1201,9 +1220,11 @@ final class MainContentCoordinator {
                         rowCap: rowCap
                     )
                 }
+                let fetchEndedAt = ContinuousClock.now
 
                 guard !Task.isCancelled else {
                     schemaTask?.cancel()
+                    traceFetchCancelled(traceToken, began: fetchBeganAt, ended: fetchEndedAt)
                     await resetExecutionState(tabId: tabId, executionTime: fetchResult.executionTime)
                     return
                 }
@@ -1214,6 +1235,7 @@ final class MainContentCoordinator {
 
                 await MainActor.run { [weak self] in
                     guard let self else { return }
+                    traceFetchCompleted(traceToken, began: fetchBeganAt, ended: fetchEndedAt, result: fetchResult)
                     currentQueryTask = nil
                     if services.pluginManager.supportsQueryProgress(for: self.connection.type) {
                         self.clearClickHouseProgress()
@@ -1222,9 +1244,16 @@ final class MainContentCoordinator {
                     toolbarState.lastQueryDuration = fetchResult.executionTime
 
                     if capturedGeneration != queryGeneration || Task.isCancelled {
+                        traceStaleResultDropped(
+                            traceToken,
+                            captured: capturedGeneration,
+                            current: queryGeneration
+                        )
                         tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
                         return
                     }
+
+                    traceApplyingResult(traceToken, tabId: tabId)
 
                     applyPhase1Result(
                         tabId: tabId,
@@ -1242,51 +1271,34 @@ final class MainContentCoordinator {
                         connection: conn,
                         isTruncated: fetchResult.isTruncated
                     )
+
+                    scheduleTraceCompletion(traceToken, outcome: "completed")
                 }
 
                 if isEditable, let tableName {
-                    if needsMetadataFetch {
-                        launchPhase2Work(
-                            tableName: tableName,
-                            tabId: tabId,
-                            capturedGeneration: capturedGeneration,
-                            connectionType: conn.type,
-                            schemaTask: schemaTask
-                        )
-                    } else {
-                        launchPhase2Count(
-                            tableName: tableName,
-                            tabId: tabId,
-                            capturedGeneration: capturedGeneration,
-                            connectionType: conn.type
-                        )
-                    }
+                    launchPhase2(
+                        tableName: tableName,
+                        tabId: tabId,
+                        capturedGeneration: capturedGeneration,
+                        connectionType: conn.type,
+                        needsMetadataFetch: needsMetadataFetch,
+                        schemaTask: schemaTask
+                    )
                 } else if !isEditable || tableName == nil {
-                    await MainActor.run { [weak self] in
-                        guard let self else { return }
-                        guard capturedGeneration == queryGeneration else { return }
-                        guard !Task.isCancelled else { return }
-                        changeManager.clearChangesAndUndoHistory()
-                    }
+                    clearChangesIfCurrent(generation: capturedGeneration)
                 }
             } catch {
                 schemaTask?.cancel()
-                await MainActor.run { [weak self] in
-                    guard let self else { return }
-                    tabManager.mutate(tabId: tabId) { tab in
-                        tab.execution.isExecuting = false
-                        tab.pagination.isLoadingMore = false
-                    }
-                    currentQueryTask = nil
-                    toolbarState.setExecuting(false)
-                    if DatabaseCancellationDiagnosis.isCancellation(error) || Task.isCancelled { return }
-                    guard capturedGeneration == queryGeneration else { return }
-                    if isAutoLoad, services.databaseManager.driver(for: connectionId)?.status != .connected {
-                        pendingLoadTrigger = trigger
-                        return
-                    }
-                    handleQueryExecutionError(error, sql: sql, tabId: tabId, connection: conn)
-                }
+                finishFailedQuery(
+                    error,
+                    tabId: tabId,
+                    sql: sql,
+                    connection: conn,
+                    capturedGeneration: capturedGeneration,
+                    isAutoLoad: isAutoLoad,
+                    trigger: trigger,
+                    traceToken: traceToken
+                )
             }
         }
     }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -865,8 +865,11 @@ final class MainContentCoordinator {
     // MARK: - Query Execution
 
     func runQuery(trigger: TableLoadTrigger = .userInitiated, bypassRowLimit: Bool = false) {
-        guard let (tab, index) = tabManager.selectedTabAndIndex,
-              !tabExecution.isExecuting(tab.id) else { return }
+        guard let (tab, index) = tabManager.selectedTabAndIndex else { return }
+        guard !tabExecution.isExecuting(tab.id) else {
+            traceExecutionBlocked(tabId: tab.id, site: "runQuery")
+            return
+        }
 
         if tab.tabType == .table {
             executeTableTabQueryDirectly(trigger: trigger)
@@ -1031,8 +1034,11 @@ final class MainContentCoordinator {
 
     /// Run EXPLAIN on the current query (database-type-aware prefix)
     func runExplainQuery() {
-        guard let (tab, _) = tabManager.selectedTabAndIndex,
-              !tabExecution.isExecuting(tab.id) else { return }
+        guard let (tab, _) = tabManager.selectedTabAndIndex else { return }
+        guard !tabExecution.isExecuting(tab.id) else {
+            traceExecutionBlocked(tabId: tab.id, site: "runExplainQuery")
+            return
+        }
 
         let fullQuery = tab.content.query
 
@@ -1155,7 +1161,7 @@ final class MainContentCoordinator {
         let tabId = tabManager.tabs[index].id
 
         let traceToken = adoptOrBeginExecutionTrace(tabId: tabId)
-        traceExecutionStarted(traceToken, generation: claim.epoch, isAutoLoad: isAutoLoad)
+        traceExecutionStarted(traceToken, epoch: claim.epoch, isAutoLoad: isAutoLoad)
 
         let rowCap = resolveRowCap(sql: sql, tabType: tab.tabType, bypassLimit: bypassRowLimit)
         let (tableName, isEditable) = resolveTableEditability(tab: tab, sql: sql)
@@ -1179,7 +1185,6 @@ final class MainContentCoordinator {
             toolbarState.setExecuting(false)
             return
         }
-        tabExecution.advance(claim, to: .executing)
 
         currentQueryTask = Task { [weak self] in
             guard let self else { return }
@@ -1245,8 +1250,6 @@ final class MainContentCoordinator {
                         traceStaleResultDropped(traceToken)
                         return
                     }
-                    tabExecution.advance(claim, to: .applying)
-
                     currentQueryTask = nil
                     if services.pluginManager.supportsQueryProgress(for: self.connection.type) {
                         self.clearClickHouseProgress()

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -203,7 +203,12 @@ final class MainContentCoordinator {
 
     /// Per-tab execution ownership. Replaces a per-window generation counter, a stored per-tab
     /// `isExecuting` bool and two task handles that a tab retarget participated in none of.
-    @ObservationIgnored internal var tabExecution = TabExecutionRegistry()
+    ///
+    /// Deliberately observed rather than `@ObservationIgnored`: busy state is derived from
+    /// membership here, so the views that used to read the stored flag have to be able to see it
+    /// change. It is a value type, so every claim, settle and invalidate is a write to this
+    /// property and invalidates its readers.
+    internal var tabExecution = TabExecutionRegistry()
     @ObservationIgnored internal var currentQueryTask: Task<Void, Never>?
     @ObservationIgnored internal var currentRowCountTask: Task<Void, Never>?
     @ObservationIgnored internal var tableLoadTasks: [UUID: (token: UUID, task: Task<Void, Never>)] = [:]
@@ -1186,7 +1191,7 @@ final class MainContentCoordinator {
                     await MainActor.run { [weak self] in
                         guard let self else { return }
                         traceConnectUnavailable(traceToken)
-                        tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
+                        tabExecution.settle(claim)
                         currentQueryTask = nil
                         toolbarState.setExecuting(false)
                         pendingLoadTrigger = trigger
@@ -1323,7 +1328,7 @@ final class MainContentCoordinator {
     /// Reset execution state when a query is cancelled
     @MainActor
     internal func resetExecutionState(tabId: UUID, executionTime: TimeInterval) {
-        tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
+        tabExecution.invalidate(tabId)
         currentQueryTask = nil
         toolbarState.setExecuting(false)
         toolbarState.lastQueryDuration = executionTime

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -201,7 +201,9 @@ final class MainContentCoordinator {
 
     // MARK: - Internal State
 
-    @ObservationIgnored internal var queryGeneration: Int = 0
+    /// Per-tab execution ownership. Replaces a per-window generation counter, a stored per-tab
+    /// `isExecuting` bool and two task handles that a tab retarget participated in none of.
+    @ObservationIgnored internal var tabExecution = TabExecutionRegistry()
     @ObservationIgnored internal var currentQueryTask: Task<Void, Never>?
     @ObservationIgnored internal var currentRowCountTask: Task<Void, Never>?
     @ObservationIgnored internal var tableLoadTasks: [UUID: (token: UUID, task: Task<Void, Never>)] = [:]
@@ -504,6 +506,9 @@ final class MainContentCoordinator {
         ConnectionDataCache.shared(for: connection.id).ensureLoaded()
         changeManager.undoManagerProvider = { [weak self] in self?.contentWindow?.undoManager }
         changeManager.onUndoApplied = { [weak self] result in self?.handleUndoResult(result) }
+        tabManager.onTabRetargeted = { [weak self] tabId in
+            self?.supersedeExecution(for: tabId)
+        }
 
         // Synchronous save at quit time. NotificationCenter with queue: .main
         // delivers the closure on the main thread, satisfying assumeIsolated's
@@ -856,7 +861,7 @@ final class MainContentCoordinator {
 
     func runQuery(trigger: TableLoadTrigger = .userInitiated, bypassRowLimit: Bool = false) {
         guard let (tab, index) = tabManager.selectedTabAndIndex,
-              !tab.execution.isExecuting else { return }
+              !tabExecution.isExecuting(tab.id) else { return }
 
         if tab.tabType == .table {
             executeTableTabQueryDirectly(trigger: trigger)
@@ -932,10 +937,6 @@ final class MainContentCoordinator {
     /// checks but still respect safe mode levels that apply to all queries.
     func executeTableTabQueryDirectly(trigger: TableLoadTrigger = .userInitiated) {
         guard let (tab, index) = tabManager.selectedTabAndIndex else { return }
-        guard !tab.execution.isExecuting else {
-            traceExecutionBlocked(tabId: tab.id, site: "executeTableTabQueryDirectly")
-            return
-        }
         TableLoadTracer.shared.stage(.executeRequested, tabId: tab.id)
 
         let sql = tab.content.query
@@ -1026,7 +1027,7 @@ final class MainContentCoordinator {
     /// Run EXPLAIN on the current query (database-type-aware prefix)
     func runExplainQuery() {
         guard let (tab, _) = tabManager.selectedTabAndIndex,
-              !tab.execution.isExecuting else { return }
+              !tabExecution.isExecuting(tab.id) else { return }
 
         let fullQuery = tab.content.query
 
@@ -1128,17 +1129,11 @@ final class MainContentCoordinator {
         bypassRowLimit: Bool = false
     ) {
         guard let (selectedTab, index) = tabManager.selectedTabAndIndex else { return }
-        guard !selectedTab.execution.isExecuting else {
-            traceExecutionBlocked(tabId: selectedTab.id, site: "executeQueryInternal")
-            return
-        }
 
-        cancelInFlightQueryTask()
-        queryGeneration += 1
-        let capturedGeneration = queryGeneration
+        supersedeExecution(for: selectedTab.id)
+        let claim = tabExecution.claim(selectedTab.id)
 
         tabManager.mutate(at: index) { tab in
-            tab.execution.isExecuting = true
             tab.execution.executionTime = nil
             tab.execution.errorMessage = nil
             tab.display.explainText = nil
@@ -1155,7 +1150,7 @@ final class MainContentCoordinator {
         let tabId = tabManager.tabs[index].id
 
         let traceToken = adoptOrBeginExecutionTrace(tabId: tabId)
-        traceExecutionStarted(traceToken, generation: capturedGeneration, isAutoLoad: isAutoLoad)
+        traceExecutionStarted(traceToken, generation: claim.epoch, isAutoLoad: isAutoLoad)
 
         let rowCap = resolveRowCap(sql: sql, tabType: tab.tabType, bypassLimit: bypassRowLimit)
         let (tableName, isEditable) = resolveTableEditability(tab: tab, sql: sql)
@@ -1172,13 +1167,14 @@ final class MainContentCoordinator {
             )
         }
         guard let scope = scope(for: tab) else {
+            tabExecution.settle(claim)
             tabManager.mutate(at: index) { tab in
-                tab.execution.isExecuting = false
                 tab.execution.errorMessage = String(localized: "Not connected to database")
             }
             toolbarState.setExecuting(false)
             return
         }
+        tabExecution.advance(claim, to: .executing)
 
         currentQueryTask = Task { [weak self] in
             guard let self else { return }
@@ -1211,7 +1207,7 @@ final class MainContentCoordinator {
                 let fetchResult = try await services.databaseManager.withScopedDriver(
                     scope: scope,
                     route: services.databaseManager.executionRoute(for: scope),
-                    tracksCancellation: true
+                    cancellation: .cancellableRead
                 ) { [queryExecutor] driver in
                     try await queryExecutor.executeQuery(
                         driver: driver,
@@ -1236,22 +1232,22 @@ final class MainContentCoordinator {
                 await MainActor.run { [weak self] in
                     guard let self else { return }
                     traceFetchCompleted(traceToken, began: fetchBeganAt, ended: fetchEndedAt, result: fetchResult)
+
+                    // Every write below belongs to whoever owns the tab now. A superseded result
+                    // that cleared the spinner or nilled the task handle would be reporting on a
+                    // query that is still running, so the gate comes before all of them.
+                    guard tabExecution.isCurrent(claim), !Task.isCancelled else {
+                        traceStaleResultDropped(traceToken, captured: claim.epoch, current: 0)
+                        return
+                    }
+                    tabExecution.advance(claim, to: .applying)
+
                     currentQueryTask = nil
                     if services.pluginManager.supportsQueryProgress(for: self.connection.type) {
                         self.clearClickHouseProgress()
                     }
                     toolbarState.setExecuting(false)
                     toolbarState.lastQueryDuration = fetchResult.executionTime
-
-                    if capturedGeneration != queryGeneration || Task.isCancelled {
-                        traceStaleResultDropped(
-                            traceToken,
-                            captured: capturedGeneration,
-                            current: queryGeneration
-                        )
-                        tabManager.mutate(tabId: tabId) { $0.execution.isExecuting = false }
-                        return
-                    }
 
                     traceApplyingResult(traceToken, tabId: tabId)
 
@@ -1272,6 +1268,7 @@ final class MainContentCoordinator {
                         isTruncated: fetchResult.isTruncated
                     )
 
+                    tabExecution.settle(claim)
                     scheduleTraceCompletion(traceToken, outcome: "completed")
                 }
 
@@ -1279,13 +1276,13 @@ final class MainContentCoordinator {
                     launchPhase2(
                         tableName: tableName,
                         tabId: tabId,
-                        capturedGeneration: capturedGeneration,
+                        claim: claim,
                         connectionType: conn.type,
                         needsMetadataFetch: needsMetadataFetch,
                         schemaTask: schemaTask
                     )
                 } else if !isEditable || tableName == nil {
-                    clearChangesIfCurrent(generation: capturedGeneration)
+                    clearChangesIfCurrent(claim: claim)
                 }
             } catch {
                 schemaTask?.cancel()
@@ -1294,7 +1291,7 @@ final class MainContentCoordinator {
                     tabId: tabId,
                     sql: sql,
                     connection: conn,
-                    capturedGeneration: capturedGeneration,
+                    claim: claim,
                     isAutoLoad: isAutoLoad,
                     trigger: trigger,
                     traceToken: traceToken
@@ -1303,15 +1300,24 @@ final class MainContentCoordinator {
         }
     }
 
-    internal func cancelInFlightQueryTask() {
+    internal func cancelInFlightQueryTask(reach: DriverCancellationReach = .userStop) {
         guard currentQueryTask != nil else { return }
         currentQueryTask?.cancel()
         do {
-            try services.databaseManager.cancelRunningQuery(for: connectionId)
+            try services.databaseManager.cancelRunningQuery(for: connectionId, reach: reach)
         } catch {
             Self.logger.warning("cancelQuery failed: \(error.localizedDescription, privacy: .public)")
         }
         currentQueryTask = nil
+    }
+
+    /// Ends whatever the tab was doing so a new navigation owns it outright. Invalidating before the
+    /// new claim is minted is what makes "the user navigated away and no successor ever ran" still
+    /// discard the old result, which a counter that only moved on a successful start could not do.
+    internal func supersedeExecution(for tabId: UUID) {
+        tabExecution.invalidate(tabId)
+        cancelTableLoad(for: tabId)
+        cancelInFlightQueryTask(reach: .supersededNavigation)
     }
 
     /// Reset execution state when a query is cancelled

--- a/TableProTests/Core/Diagnostics/TableLoadTraceRecorderTests.swift
+++ b/TableProTests/Core/Diagnostics/TableLoadTraceRecorderTests.swift
@@ -260,7 +260,7 @@ struct TableLoadTraceRecorderTests {
     func classifiesDefectAnomalies() {
         #expect(TableLoadAnomaly.blockedByInFlightExecution.isDefect)
         #expect(TableLoadAnomaly.resultTableMismatch.isDefect)
-        #expect(TableLoadAnomaly.staleGenerationDropped.isDefect == false)
+        #expect(TableLoadAnomaly.staleResultDropped.isDefect == false)
         #expect(TableLoadAnomaly.supersededByNewNavigation.isDefect == false)
         #expect(TableLoadAnomaly.executionCancelled.isDefect == false)
         #expect(TableLoadAnomaly.connectionNotReady.isDefect == false)

--- a/TableProTests/Core/Diagnostics/TableLoadTraceRecorderTests.swift
+++ b/TableProTests/Core/Diagnostics/TableLoadTraceRecorderTests.swift
@@ -1,0 +1,270 @@
+//
+//  TableLoadTraceRecorderTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("TableLoadTraceRecorder")
+struct TableLoadTraceRecorderTests {
+    private let base = ContinuousClock.now
+
+    private func instant(_ milliseconds: Int) -> ContinuousClock.Instant {
+        base.advanced(by: .milliseconds(milliseconds))
+    }
+
+    @Test("Elapsed time is measured from the start of the trace")
+    func measuresElapsedFromStart() throws {
+        var recorder = TableLoadTraceRecorder()
+        let tabId = UUID()
+        let started = recorder.begin(tabId: tabId, table: "users", origin: .sidebar, at: instant(0))
+
+        let recorded = recorder.record(.executeStarted, token: started.token, at: instant(120))
+        let timing = try #require(recorded)
+
+        #expect(timing.sinceStart == .milliseconds(120))
+        #expect(timing.sincePrevious == .milliseconds(120))
+        #expect(timing.previousStage == nil)
+    }
+
+    @Test("Each stage reports the gap since the stage before it")
+    func measuresGapBetweenStages() throws {
+        var recorder = TableLoadTraceRecorder()
+        let tabId = UUID()
+        let started = recorder.begin(tabId: tabId, table: "users", origin: .sidebar, at: instant(0))
+
+        _ = recorder.record(.executeStarted, token: started.token, at: instant(10))
+        let recorded = recorder.record(.driverFetchEnd, token: started.token, at: instant(310))
+        let timing = try #require(recorded)
+
+        #expect(timing.sinceStart == .milliseconds(310))
+        #expect(timing.sincePrevious == .milliseconds(300))
+        #expect(timing.previousStage == .executeStarted)
+    }
+
+    @Test("Navigating again on the same tab reports the abandoned trace")
+    func reportsSupersededTrace() throws {
+        var recorder = TableLoadTraceRecorder()
+        let tabId = UUID()
+        let first = recorder.begin(tabId: tabId, table: "users", origin: .sidebar, at: instant(0))
+        _ = recorder.record(.driverFetchBegin, token: first.token, at: instant(20))
+
+        let second = recorder.begin(tabId: tabId, table: "orders", origin: .sidebar, at: instant(50))
+
+        let superseded = try #require(second.superseded)
+        #expect(superseded.token == first.token)
+        #expect(superseded.sinceStart == .milliseconds(50))
+        #expect(superseded.previousStage == .driverFetchBegin)
+        #expect(second.token.table == "orders")
+        #expect(second.token.sequence == first.token.sequence + 1)
+    }
+
+    @Test("A first navigation on a tab has nothing to supersede")
+    func firstNavigationSupersedesNothing() {
+        var recorder = TableLoadTraceRecorder()
+        let started = recorder.begin(tabId: UUID(), table: "users", origin: .sidebar, at: instant(0))
+        #expect(started.superseded == nil)
+    }
+
+    @Test("A superseded trace stays addressable so its late result is still attributed to it")
+    func lateResultKeepsItsOwnTrace() throws {
+        var recorder = TableLoadTraceRecorder()
+        let tabId = UUID()
+        let first = recorder.begin(tabId: tabId, table: "users", origin: .sidebar, at: instant(0))
+        let second = recorder.begin(tabId: tabId, table: "orders", origin: .sidebar, at: instant(50))
+
+        let recorded = recorder.record(.applyResultBegin, token: first.token, at: instant(900))
+        let late = try #require(recorded)
+
+        #expect(late.token.table == "users")
+        #expect(late.sinceStart == .milliseconds(900))
+        #expect(recorder.isActive(first.token) == false)
+        #expect(recorder.isActive(second.token))
+        #expect(recorder.activeToken(for: tabId) == second.token)
+    }
+
+    @Test("Finishing a superseded trace does not clear the tab's active trace")
+    func finishingSupersededKeepsActiveTrace() throws {
+        var recorder = TableLoadTraceRecorder()
+        let tabId = UUID()
+        let first = recorder.begin(tabId: tabId, table: "users", origin: .sidebar, at: instant(0))
+        let second = recorder.begin(tabId: tabId, table: "orders", origin: .sidebar, at: instant(50))
+
+        _ = recorder.finish(token: first.token, at: instant(900))
+
+        #expect(recorder.activeToken(for: tabId) == second.token)
+    }
+
+    @Test("Finishing the active trace clears it from the tab")
+    func finishingActiveTraceClearsTab() throws {
+        var recorder = TableLoadTraceRecorder()
+        let tabId = UUID()
+        let started = recorder.begin(tabId: tabId, table: "users", origin: .sidebar, at: instant(0))
+
+        let finished = recorder.finish(token: started.token, at: instant(400))
+        let timing = try #require(finished)
+
+        #expect(timing.sinceStart == .milliseconds(400))
+        #expect(recorder.activeToken(for: tabId) == nil)
+    }
+
+    @Test("Measuring does not advance the previous stage, so the next stage keeps its real gap")
+    func measuringDoesNotAdvanceStages() throws {
+        var recorder = TableLoadTraceRecorder()
+        let started = recorder.begin(tabId: UUID(), table: "users", origin: .sidebar, at: instant(0))
+        _ = recorder.record(.executeStarted, token: started.token, at: instant(10))
+
+        _ = recorder.measure(token: started.token, at: instant(200))
+        let recorded = recorder.record(.applyResultBegin, token: started.token, at: instant(310))
+        let next = try #require(recorded)
+
+        #expect(next.sincePrevious == .milliseconds(300))
+        #expect(next.previousStage == .executeStarted)
+    }
+
+    @Test("Stages recorded by tab id land on that tab's active trace")
+    func recordsByTabId() throws {
+        var recorder = TableLoadTraceRecorder()
+        let tabId = UUID()
+        let started = recorder.begin(tabId: tabId, table: "users", origin: .sidebar, at: instant(0))
+
+        let recorded = recorder.record(.gridReloadBegin, tabId: tabId, at: instant(75))
+        let timing = try #require(recorded)
+
+        #expect(timing.token == started.token)
+        #expect(timing.sinceStart == .milliseconds(75))
+    }
+
+    @Test("An unknown tab produces no timing rather than a fabricated one")
+    func unknownTabProducesNoTiming() {
+        var recorder = TableLoadTraceRecorder()
+        #expect(recorder.record(.gridReloadBegin, tabId: UUID(), at: instant(10)) == nil)
+        #expect(recorder.measure(tabId: UUID(), at: instant(10)) == nil)
+        #expect(recorder.activeToken(for: UUID()) == nil)
+    }
+
+    @Test("The retained trace window is bounded even when traces never finish")
+    func prunesUnfinishedTracesBeyondTheWindow() throws {
+        var recorder = TableLoadTraceRecorder()
+        let overflow = TableLoadTraceRecorder.retainedTraceLimit + 20
+        var tokens: [TableLoadTraceToken] = []
+        for index in 0..<overflow {
+            tokens.append(
+                recorder.begin(tabId: UUID(), table: "t\(index)", origin: .sidebar, at: instant(index)).token
+            )
+        }
+
+        let retained = tokens.filter { recorder.entry(for: $0) != nil }
+        #expect(retained.count <= TableLoadTraceRecorder.retainedTraceLimit)
+
+        let newest = try #require(tokens.last)
+        #expect(recorder.entry(for: newest) != nil)
+    }
+
+    @Test("Finished traces are evicted before in-flight ones")
+    func evictsFinishedTracesFirst() throws {
+        var recorder = TableLoadTraceRecorder()
+        let inFlightTab = UUID()
+        let inFlight = recorder.begin(tabId: inFlightTab, table: "keep", origin: .sidebar, at: instant(0))
+
+        for index in 0..<(TableLoadTraceRecorder.retainedTraceLimit + 5) {
+            let token = recorder.begin(
+                tabId: UUID(), table: "t\(index)", origin: .sidebar, at: instant(index + 1)
+            ).token
+            _ = recorder.finish(token: token, at: instant(index + 2))
+        }
+
+        #expect(recorder.entry(for: inFlight.token) != nil)
+        #expect(recorder.activeToken(for: inFlightTab) == inFlight.token)
+    }
+
+    @Test("Evicted sequences are handed back once so their signpost intervals can be closed")
+    func reportsEvictedSequencesOnce() {
+        var recorder = TableLoadTraceRecorder()
+        var tokens: [TableLoadTraceToken] = []
+        for index in 0..<(TableLoadTraceRecorder.retainedTraceLimit + 10) {
+            let token = recorder.begin(
+                tabId: UUID(), table: "t\(index)", origin: .sidebar, at: instant(index)
+            ).token
+            _ = recorder.finish(token: token, at: instant(index))
+            tokens.append(token)
+        }
+
+        let evicted = recorder.takeEvictedSequences()
+        #expect(evicted.isEmpty == false)
+        #expect(Set(evicted).count == evicted.count)
+        for sequence in evicted {
+            #expect(tokens.contains { $0.sequence == sequence })
+        }
+        for sequence in evicted {
+            #expect(recorder.entry(for: TableLoadTraceToken(sequence: sequence, tabId: UUID(), table: "")) == nil)
+        }
+        #expect(recorder.takeEvictedSequences().isEmpty)
+    }
+
+    @Test("A trace with no evictions hands back nothing")
+    func reportsNoEvictionsWhenUnderTheLimit() {
+        var recorder = TableLoadTraceRecorder()
+        let started = recorder.begin(tabId: UUID(), table: "users", origin: .sidebar, at: instant(0))
+        _ = recorder.finish(token: started.token, at: instant(10))
+        #expect(recorder.takeEvictedSequences().isEmpty)
+    }
+
+    @Test("A trace only counts as executing once it reaches executeStarted")
+    func tracksWhetherExecutionStarted() {
+        var recorder = TableLoadTraceRecorder()
+        let started = recorder.begin(tabId: UUID(), table: "users", origin: .sidebar, at: instant(0))
+
+        _ = recorder.record(.lazyLoadScheduled, token: started.token, at: instant(5))
+        #expect(recorder.hasStartedExecution(started.token) == false)
+
+        _ = recorder.record(.executeStarted, token: started.token, at: instant(10))
+        #expect(recorder.hasStartedExecution(started.token))
+
+        _ = recorder.record(.driverFetchEnd, token: started.token, at: instant(90))
+        #expect(recorder.hasStartedExecution(started.token))
+    }
+
+    @Test("A handoff start time dates the trace from the click, not from when the window loaded")
+    func datesTraceFromHandoffInstant() throws {
+        var recorder = TableLoadTraceRecorder()
+        let started = recorder.begin(
+            tabId: UUID(),
+            table: "users",
+            origin: .newWindowTab,
+            at: instant(800),
+            startedAt: instant(0)
+        )
+
+        let recorded = recorder.record(.executeStarted, token: started.token, at: instant(900))
+        let timing = try #require(recorded)
+
+        #expect(timing.sinceStart == .milliseconds(900))
+        #expect(timing.sincePrevious == .milliseconds(100))
+    }
+
+    @Test("Without a handoff the trace is dated from the call")
+    func datesTraceFromCallWhenNoHandoff() throws {
+        var recorder = TableLoadTraceRecorder()
+        let started = recorder.begin(tabId: UUID(), table: "users", origin: .sidebar, at: instant(800))
+
+        let recorded = recorder.record(.executeStarted, token: started.token, at: instant(900))
+        let timing = try #require(recorded)
+
+        #expect(timing.sinceStart == .milliseconds(100))
+    }
+
+    @Test("Only anomalies that mislead the user are treated as defects")
+    func classifiesDefectAnomalies() {
+        #expect(TableLoadAnomaly.blockedByInFlightExecution.isDefect)
+        #expect(TableLoadAnomaly.resultTableMismatch.isDefect)
+        #expect(TableLoadAnomaly.staleGenerationDropped.isDefect == false)
+        #expect(TableLoadAnomaly.supersededByNewNavigation.isDefect == false)
+        #expect(TableLoadAnomaly.executionCancelled.isDefect == false)
+        #expect(TableLoadAnomaly.connectionNotReady.isDefect == false)
+        #expect(TableLoadAnomaly.loadAlreadyInFlight.isDefect == false)
+        #expect(TableLoadAnomaly.preparationAbandoned.isDefect == false)
+    }
+}

--- a/TableProTests/Core/Execution/TabExecutionRegistryTests.swift
+++ b/TableProTests/Core/Execution/TabExecutionRegistryTests.swift
@@ -86,39 +86,14 @@ struct TabExecutionRegistryTests {
         #expect(registry.isCurrent(live))
     }
 
-    @Test("A stale claim cannot advance the phase")
-    func staleClaimCannotAdvancePhase() {
-        var registry = TabExecutionRegistry()
-        let tabId = UUID()
-        let stale = registry.claim(tabId)
-        _ = registry.claim(tabId)
 
-        registry.advance(stale, to: .applying)
 
-        #expect(registry.phase(for: tabId) == .preparing)
-    }
-
-    @Test("The current claim advances through its phases")
-    func currentClaimAdvancesPhases() {
-        var registry = TabExecutionRegistry()
-        let tabId = UUID()
-        let claim = registry.claim(tabId)
-        #expect(registry.phase(for: tabId) == .preparing)
-
-        registry.advance(claim, to: .executing)
-        #expect(registry.phase(for: tabId) == .executing)
-
-        registry.advance(claim, to: .applying)
-        #expect(registry.phase(for: tabId) == .applying)
-    }
-
-    @Test("An unknown tab has no phase and is not executing")
+    @Test("An unknown tab is idle")
     func unknownTabIsIdle() {
         let registry = TabExecutionRegistry()
         let tabId = UUID()
-        #expect(registry.phase(for: tabId) == nil)
         #expect(registry.isExecuting(tabId) == false)
-        #expect(registry.executingTabIds.isEmpty)
+        #expect(registry.isAnyExecuting == false)
     }
 
     @Test("Teardown invalidates every tab at once")
@@ -134,19 +109,6 @@ struct TabExecutionRegistryTests {
         #expect(registry.isAnyExecuting == false)
     }
 
-    @Test("Executing tab ids report every live claim")
-    func reportsExecutingTabIds() {
-        var registry = TabExecutionRegistry()
-        let tabA = UUID()
-        let tabB = UUID()
-        let claimA = registry.claim(tabA)
-        _ = registry.claim(tabB)
-
-        #expect(registry.executingTabIds == [tabA, tabB])
-
-        registry.settle(claimA)
-        #expect(registry.executingTabIds == [tabB])
-    }
 
     /// Epochs are window-global so two tabs never share one, which keeps a claim comparable on its
     /// own without also carrying the tab's mutable identity fields.

--- a/TableProTests/Core/Execution/TabExecutionRegistryTests.swift
+++ b/TableProTests/Core/Execution/TabExecutionRegistryTests.swift
@@ -1,0 +1,160 @@
+//
+//  TabExecutionRegistryTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("TabExecutionRegistry")
+struct TabExecutionRegistryTests {
+    @Test("A fresh claim is current")
+    func freshClaimIsCurrent() {
+        var registry = TabExecutionRegistry()
+        let claim = registry.claim(UUID())
+        #expect(registry.isCurrent(claim))
+    }
+
+    @Test("Claiming the same tab again invalidates the previous claim")
+    func reclaimingInvalidatesPredecessor() {
+        var registry = TabExecutionRegistry()
+        let tabId = UUID()
+        let first = registry.claim(tabId)
+        let second = registry.claim(tabId)
+
+        #expect(registry.isCurrent(first) == false)
+        #expect(registry.isCurrent(second))
+    }
+
+    /// The exact case the per-window generation counter could not represent: the user navigated
+    /// away and the successor never started, so nothing ever bumped the counter and the in-flight
+    /// result stayed "current" all the way into the grid.
+    @Test("Invalidating with no successor still kills the in-flight claim")
+    func invalidateWithoutSuccessorKillsClaim() {
+        var registry = TabExecutionRegistry()
+        let tabId = UUID()
+        let claim = registry.claim(tabId)
+
+        registry.invalidate(tabId)
+
+        #expect(registry.isCurrent(claim) == false)
+        #expect(registry.isExecuting(tabId) == false)
+    }
+
+    @Test("Claims on different tabs do not invalidate each other")
+    func claimsAreScopedPerTab() {
+        var registry = TabExecutionRegistry()
+        let tabA = UUID()
+        let tabB = UUID()
+        let claimA = registry.claim(tabA)
+        let claimB = registry.claim(tabB)
+
+        registry.invalidate(tabB)
+
+        #expect(registry.isCurrent(claimA))
+        #expect(registry.isCurrent(claimB) == false)
+    }
+
+    @Test("Busy state is derived from membership, not stored")
+    func busyStateIsDerived() {
+        var registry = TabExecutionRegistry()
+        let tabId = UUID()
+        #expect(registry.isExecuting(tabId) == false)
+
+        let claim = registry.claim(tabId)
+        #expect(registry.isExecuting(tabId))
+        #expect(registry.isAnyExecuting)
+
+        registry.settle(claim)
+        #expect(registry.isExecuting(tabId) == false)
+        #expect(registry.isAnyExecuting == false)
+    }
+
+    /// A late result must not clear the busy state of the navigation that superseded it, or the
+    /// window reports idle while a query is still running.
+    @Test("A stale claim settles nothing")
+    func staleClaimCannotSettle() {
+        var registry = TabExecutionRegistry()
+        let tabId = UUID()
+        let stale = registry.claim(tabId)
+        let live = registry.claim(tabId)
+
+        registry.settle(stale)
+
+        #expect(registry.isExecuting(tabId))
+        #expect(registry.isCurrent(live))
+    }
+
+    @Test("A stale claim cannot advance the phase")
+    func staleClaimCannotAdvancePhase() {
+        var registry = TabExecutionRegistry()
+        let tabId = UUID()
+        let stale = registry.claim(tabId)
+        _ = registry.claim(tabId)
+
+        registry.advance(stale, to: .applying)
+
+        #expect(registry.phase(for: tabId) == .preparing)
+    }
+
+    @Test("The current claim advances through its phases")
+    func currentClaimAdvancesPhases() {
+        var registry = TabExecutionRegistry()
+        let tabId = UUID()
+        let claim = registry.claim(tabId)
+        #expect(registry.phase(for: tabId) == .preparing)
+
+        registry.advance(claim, to: .executing)
+        #expect(registry.phase(for: tabId) == .executing)
+
+        registry.advance(claim, to: .applying)
+        #expect(registry.phase(for: tabId) == .applying)
+    }
+
+    @Test("An unknown tab has no phase and is not executing")
+    func unknownTabIsIdle() {
+        let registry = TabExecutionRegistry()
+        let tabId = UUID()
+        #expect(registry.phase(for: tabId) == nil)
+        #expect(registry.isExecuting(tabId) == false)
+        #expect(registry.executingTabIds.isEmpty)
+    }
+
+    @Test("Teardown invalidates every tab at once")
+    func invalidateAllClearsEveryTab() {
+        var registry = TabExecutionRegistry()
+        let claimA = registry.claim(UUID())
+        let claimB = registry.claim(UUID())
+
+        registry.invalidateAll()
+
+        #expect(registry.isCurrent(claimA) == false)
+        #expect(registry.isCurrent(claimB) == false)
+        #expect(registry.isAnyExecuting == false)
+    }
+
+    @Test("Executing tab ids report every live claim")
+    func reportsExecutingTabIds() {
+        var registry = TabExecutionRegistry()
+        let tabA = UUID()
+        let tabB = UUID()
+        let claimA = registry.claim(tabA)
+        _ = registry.claim(tabB)
+
+        #expect(registry.executingTabIds == [tabA, tabB])
+
+        registry.settle(claimA)
+        #expect(registry.executingTabIds == [tabB])
+    }
+
+    /// Epochs are window-global so two tabs never share one, which keeps a claim comparable on its
+    /// own without also carrying the tab's mutable identity fields.
+    @Test("Epochs are unique across tabs")
+    func epochsAreUniqueAcrossTabs() {
+        var registry = TabExecutionRegistry()
+        let claimA = registry.claim(UUID())
+        let claimB = registry.claim(UUID())
+        #expect(claimA.epoch != claimB.epoch)
+    }
+}

--- a/TableProTests/Core/Execution/TabRetargetInvalidationTests.swift
+++ b/TableProTests/Core/Execution/TabRetargetInvalidationTests.swift
@@ -17,7 +17,6 @@ struct TabRetargetInvalidationTests {
         let tabId = UUID()
 
         let tableA = registry.claim(tabId)
-        registry.advance(tableA, to: .executing)
 
         registry.invalidate(tabId)
 
@@ -32,7 +31,6 @@ struct TabRetargetInvalidationTests {
         let tabId = UUID()
 
         let tableA = registry.claim(tabId)
-        registry.advance(tableA, to: .executing)
         registry.invalidate(tabId)
 
         #expect(registry.isExecuting(tabId) == false)
@@ -64,13 +62,10 @@ struct TabRetargetInvalidationTests {
         let tableA = registry.claim(tabId)
         registry.invalidate(tabId)
         let tableB = registry.claim(tabId)
-        registry.advance(tableB, to: .executing)
 
         registry.settle(tableA)
-        registry.advance(tableA, to: .applying)
 
         #expect(registry.isCurrent(tableB))
-        #expect(registry.phase(for: tabId) == .executing)
         #expect(registry.isExecuting(tabId))
     }
 
@@ -120,18 +115,6 @@ struct TabRetargetInvalidationTests {
         #expect(registry.isAnyExecuting == false)
     }
 
-    @Test("Closing a tab forgets it entirely")
-    func forgetClearsEverything() {
-        var registry = TabExecutionRegistry()
-        let tabId = UUID()
-        let claim = registry.claim(tabId)
-
-        registry.forget(tabId)
-
-        #expect(registry.isCurrent(claim) == false)
-        #expect(registry.isExecuting(tabId) == false)
-        #expect(registry.contentEpoch(for: tabId) == 0)
-    }
 }
 
 @Suite("DriverCancellationPolicy")

--- a/TableProTests/Core/Execution/TabRetargetInvalidationTests.swift
+++ b/TableProTests/Core/Execution/TabRetargetInvalidationTests.swift
@@ -1,0 +1,154 @@
+//
+//  TabRetargetInvalidationTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+/// Pins the confirmed race: clicking table B while table A's query is in flight used to block B's
+/// query entirely and then paint A's rows into the tab that had already become B.
+@Suite("Tab retarget invalidates in-flight execution")
+struct TabRetargetInvalidationTests {
+    @Test("A result that started before the retarget is not current after it")
+    func retargetInvalidatesInFlightResult() {
+        var registry = TabExecutionRegistry()
+        let tabId = UUID()
+
+        let tableA = registry.claim(tabId)
+        registry.advance(tableA, to: .executing)
+
+        registry.invalidate(tabId)
+
+        #expect(registry.isCurrent(tableA) == false)
+    }
+
+    /// Step 3 of the confirmed chain. The old stored bool stayed true through the retarget, so the
+    /// second table's query was refused and never ran at all.
+    @Test("The retargeted tab is free to execute immediately")
+    func retargetedTabIsNotBusy() {
+        var registry = TabExecutionRegistry()
+        let tabId = UUID()
+
+        let tableA = registry.claim(tabId)
+        registry.advance(tableA, to: .executing)
+        registry.invalidate(tabId)
+
+        #expect(registry.isExecuting(tabId) == false)
+
+        let tableB = registry.claim(tabId)
+        #expect(registry.isCurrent(tableB))
+        #expect(registry.isCurrent(tableA) == false)
+    }
+
+    /// Step 4. The old counter only moved when a successor execution started, so a retarget whose
+    /// successor was refused left the in-flight result looking perfectly current.
+    @Test("Invalidation holds even when no successor execution ever starts")
+    func invalidationHoldsWithoutSuccessor() {
+        var registry = TabExecutionRegistry()
+        let tabId = UUID()
+        let tableA = registry.claim(tabId)
+
+        registry.invalidate(tabId)
+
+        #expect(registry.isCurrent(tableA) == false)
+        #expect(registry.isExecuting(tabId) == false)
+    }
+
+    @Test("The superseding execution survives its predecessor's late completion")
+    func lateCompletionCannotDisturbSuccessor() {
+        var registry = TabExecutionRegistry()
+        let tabId = UUID()
+
+        let tableA = registry.claim(tabId)
+        registry.invalidate(tabId)
+        let tableB = registry.claim(tabId)
+        registry.advance(tableB, to: .executing)
+
+        registry.settle(tableA)
+        registry.advance(tableA, to: .applying)
+
+        #expect(registry.isCurrent(tableB))
+        #expect(registry.phase(for: tabId) == .executing)
+        #expect(registry.isExecuting(tabId))
+    }
+
+    /// Background work that augments an applied result has no claim of its own, so it captures the
+    /// tab's content identity instead. A retarget must invalidate that too.
+    @Test("Content identity changes on retarget so background work cannot write back")
+    func retargetChangesContentIdentity() {
+        var registry = TabExecutionRegistry()
+        let tabId = UUID()
+        let claim = registry.claim(tabId)
+        registry.settle(claim)
+
+        let captured = registry.contentEpoch(for: tabId)
+        #expect(registry.isSameContent(captured, for: tabId))
+
+        registry.invalidate(tabId)
+
+        #expect(registry.isSameContent(captured, for: tabId) == false)
+    }
+
+    @Test("Content identity survives a settled claim so a row count can still apply")
+    func contentIdentitySurvivesSettle() {
+        var registry = TabExecutionRegistry()
+        let tabId = UUID()
+        let claim = registry.claim(tabId)
+        let captured = registry.contentEpoch(for: tabId)
+
+        registry.settle(claim)
+
+        #expect(registry.isSameContent(captured, for: tabId))
+    }
+
+    @Test("Cancelling every query invalidates every tab's content identity")
+    func cancelAllInvalidatesEveryTab() {
+        var registry = TabExecutionRegistry()
+        let tabA = UUID()
+        let tabB = UUID()
+        _ = registry.claim(tabA)
+        _ = registry.claim(tabB)
+        let capturedA = registry.contentEpoch(for: tabA)
+        let capturedB = registry.contentEpoch(for: tabB)
+
+        registry.invalidateAll()
+
+        #expect(registry.isSameContent(capturedA, for: tabA) == false)
+        #expect(registry.isSameContent(capturedB, for: tabB) == false)
+        #expect(registry.isAnyExecuting == false)
+    }
+
+    @Test("Closing a tab forgets it entirely")
+    func forgetClearsEverything() {
+        var registry = TabExecutionRegistry()
+        let tabId = UUID()
+        let claim = registry.claim(tabId)
+
+        registry.forget(tabId)
+
+        #expect(registry.isCurrent(claim) == false)
+        #expect(registry.isExecuting(tabId) == false)
+        #expect(registry.contentEpoch(for: tabId) == 0)
+    }
+}
+
+@Suite("DriverCancellationPolicy")
+struct DriverCancellationPolicyTests {
+    @Test("Only untracked leases stay invisible to cancellation")
+    func trackingReflectsPolicy() {
+        #expect(DriverCancellationPolicy.untracked.isTracked == false)
+        #expect(DriverCancellationPolicy.cancellableRead.isTracked)
+        #expect(DriverCancellationPolicy.protectedWrite.isTracked)
+    }
+
+    /// A commit or a DDL statement is registered so the connection reads as busy, but aborting one
+    /// half way is data loss, so it must never be a cancellation target.
+    @Test("A protected write is tracked but is not a cancellation target")
+    func protectedWriteIsTrackedButNotCancellable() {
+        let policy = DriverCancellationPolicy.protectedWrite
+        #expect(policy.isTracked)
+        #expect(policy != .cancellableRead)
+    }
+}

--- a/TableProTests/Views/Main/MainContentCoordinatorLazyLoadTests.swift
+++ b/TableProTests/Views/Main/MainContentCoordinatorLazyLoadTests.swift
@@ -237,7 +237,7 @@ struct MainContentCoordinatorLazyLoadTests {
         #expect(coordinator.pendingLoadTrigger == nil)
     }
 
-    @Test("Clears an abandoned executing flag when no in-flight task remains")
+    @Test("Clears an abandoned claim when no in-flight task remains")
     func recoversAbandonedExecutingFlag() {
         let (coordinator, tabManager) = makeCoordinator()
         let tabId = addTableTab(to: tabManager)
@@ -245,12 +245,12 @@ struct MainContentCoordinatorLazyLoadTests {
             Issue.record("expected tab to exist")
             return
         }
-        tabManager.tabs[idx].execution.isExecuting = true
+        _ = coordinator.tabExecution.claim(tabId)
         coordinator.currentQueryTask = nil
 
         coordinator.lazyLoadCurrentTabIfNeeded()
 
-        #expect(tabManager.tabs[idx].execution.isExecuting == false)
+        #expect(coordinator.tabExecution.isExecuting(tabId) == false)
         #expect(coordinator.pendingLoadTrigger == .userInitiated)
     }
 
@@ -290,13 +290,13 @@ struct MainContentCoordinatorLazyLoadTests {
             Issue.record("expected tab to exist")
             return
         }
-        let executingBefore = tabManager.tabs[idx].execution.isExecuting
+        let executingBefore = coordinator.tabExecution.isExecuting(tabId)
         let executedAtBefore = tabManager.tabs[idx].execution.lastExecutedAt
         let toolbarBefore = coordinator.toolbarState.isExecuting
 
         coordinator.handleWindowDidBecomeKey()
 
-        let executingAfter = tabManager.tabs[idx].execution.isExecuting
+        let executingAfter = coordinator.tabExecution.isExecuting(tabId)
         let executedAtAfter = tabManager.tabs[idx].execution.lastExecutedAt
         let toolbarAfter = coordinator.toolbarState.isExecuting
 

--- a/TableProTests/Views/Main/MainContentCoordinatorRefreshTests.swift
+++ b/TableProTests/Views/Main/MainContentCoordinatorRefreshTests.swift
@@ -81,7 +81,7 @@ struct MainContentCoordinatorRefreshTests {
     ) -> Task<Void, Never> {
         let inFlight = Task<Void, Never> { _ = try? await Task.sleep(for: .seconds(60)) }
         coordinator.currentQueryTask = inFlight
-        tabManager.tabs[index].execution.isExecuting = true
+        _ = coordinator.tabExecution.claim(tabManager.tabs[index].id)
         tabManager.tabs[index].execution.lastExecutedAt = Date()
         return inFlight
     }
@@ -95,15 +95,15 @@ struct MainContentCoordinatorRefreshTests {
             return
         }
         let staleTask = simulateInFlightQuery(coordinator, tabManager, at: idx)
-        let initialGeneration = coordinator.queryGeneration
+        let initialEpoch = coordinator.tabExecution.contentEpoch(for: tabId)
 
         coordinator.handleRefresh(hasPendingTableOps: false, onDiscard: {})
         defer { coordinator.currentQueryTask?.cancel() }
 
         #expect(staleTask.isCancelled == true)
-        #expect(coordinator.queryGeneration == initialGeneration + 2)
+        #expect(coordinator.tabExecution.contentEpoch(for: tabId) != initialEpoch)
         #expect(coordinator.currentQueryTask != nil)
-        #expect(tabManager.tabs[idx].execution.isExecuting == true)
+        #expect(coordinator.tabExecution.isExecuting(tabId) == true)
     }
 
     @Test("Refresh on an idle table tab starts an execution")
@@ -115,14 +115,14 @@ struct MainContentCoordinatorRefreshTests {
             return
         }
         tabManager.tabs[idx].execution.lastExecutedAt = Date()
-        let initialGeneration = coordinator.queryGeneration
+        let initialEpoch = coordinator.tabExecution.contentEpoch(for: tabId)
 
         coordinator.handleRefresh(hasPendingTableOps: false, onDiscard: {})
         defer { coordinator.currentQueryTask?.cancel() }
 
-        #expect(coordinator.queryGeneration == initialGeneration + 2)
+        #expect(coordinator.tabExecution.contentEpoch(for: tabId) != initialEpoch)
         #expect(coordinator.currentQueryTask != nil)
-        #expect(tabManager.tabs[idx].execution.isExecuting == true)
+        #expect(coordinator.tabExecution.isExecuting(tabId) == true)
     }
 
     @Test("Refresh rebuilds the table query from current state before executing")
@@ -153,14 +153,14 @@ struct MainContentCoordinatorRefreshTests {
         let inFlight = Task<Void, Never> { _ = try? await Task.sleep(for: .seconds(60)) }
         defer { inFlight.cancel() }
         coordinator.currentQueryTask = inFlight
-        tabManager.tabs[idx].execution.isExecuting = true
-        let initialGeneration = coordinator.queryGeneration
+        _ = coordinator.tabExecution.claim(tabId)
+        let initialEpoch = coordinator.tabExecution.contentEpoch(for: tabId)
 
         coordinator.handleRefresh(hasPendingTableOps: false, onDiscard: {})
 
         #expect(inFlight.isCancelled == false)
-        #expect(coordinator.queryGeneration == initialGeneration)
-        #expect(tabManager.tabs[idx].execution.isExecuting == true)
+        #expect(coordinator.tabExecution.contentEpoch(for: tabId) == initialEpoch)
+        #expect(coordinator.tabExecution.isExecuting(tabId) == true)
     }
 
     @Test("Refresh in structure view leaves execution state untouched")
@@ -174,13 +174,13 @@ struct MainContentCoordinatorRefreshTests {
         tabManager.tabs[idx].display.resultsViewMode = .structure
         let staleTask = simulateInFlightQuery(coordinator, tabManager, at: idx)
         defer { staleTask.cancel() }
-        let initialGeneration = coordinator.queryGeneration
+        let initialEpoch = coordinator.tabExecution.contentEpoch(for: tabId)
 
         coordinator.handleRefresh(hasPendingTableOps: false, onDiscard: {})
 
         #expect(staleTask.isCancelled == false)
-        #expect(coordinator.queryGeneration == initialGeneration)
-        #expect(tabManager.tabs[idx].execution.isExecuting == true)
+        #expect(coordinator.tabExecution.contentEpoch(for: tabId) == initialEpoch)
+        #expect(coordinator.tabExecution.isExecuting(tabId) == true)
     }
 
     @Test("cancelCurrentQuery leaves the driver alone when no query is in flight")
@@ -277,11 +277,11 @@ struct MainContentCoordinatorRefreshTests {
         handler.refresh = { refreshCalled = true }
         coordinator.structureActions = handler
 
-        let initialGeneration = coordinator.queryGeneration
+        let initialEpoch = coordinator.tabExecution.contentEpoch(for: tabId)
         coordinator.handleRefresh(hasPendingTableOps: false, onDiscard: {})
 
         #expect(refreshCalled == true)
-        #expect(coordinator.queryGeneration == initialGeneration)
+        #expect(coordinator.tabExecution.contentEpoch(for: tabId) == initialEpoch)
         #expect(coordinator.currentQueryTask == nil)
     }
 
@@ -298,15 +298,15 @@ struct MainContentCoordinatorRefreshTests {
             coordinator.refreshCoalesceTask?.cancel()
             coordinator.currentQueryTask?.cancel()
         }
-        let initialGeneration = coordinator.queryGeneration
+        let initialEpoch = coordinator.tabExecution.contentEpoch(for: tabId)
 
         coordinator.requestRefresh(hasPendingTableOps: false, onDiscard: {})
-        let generationAfterLeading = coordinator.queryGeneration
+        let epochAfterLeading = coordinator.tabExecution.contentEpoch(for: tabId)
         coordinator.requestRefresh(hasPendingTableOps: false, onDiscard: {})
-        let generationAfterSecond = coordinator.queryGeneration
+        let epochAfterSecond = coordinator.tabExecution.contentEpoch(for: tabId)
 
-        #expect(generationAfterLeading == initialGeneration + 2)
-        #expect(generationAfterSecond == generationAfterLeading)
+        #expect(epochAfterLeading != initialEpoch)
+        #expect(epochAfterSecond == epochAfterLeading)
         #expect(coordinator.refreshPendingTrailing == true)
         #expect(coordinator.refreshCoalesceTask != nil)
     }
@@ -323,11 +323,11 @@ struct MainContentCoordinatorRefreshTests {
         defer { coordinator.currentQueryTask?.cancel() }
 
         coordinator.requestRefresh(hasPendingTableOps: false, onDiscard: {})
-        let generationAfterLeading = coordinator.queryGeneration
+        let epochAfterLeading = coordinator.tabExecution.contentEpoch(for: tabId)
 
         try? await Task.sleep(for: .milliseconds(400))
 
-        #expect(coordinator.queryGeneration == generationAfterLeading)
+        #expect(coordinator.tabExecution.contentEpoch(for: tabId) == epochAfterLeading)
         #expect(coordinator.refreshPendingTrailing == false)
         #expect(coordinator.refreshCoalesceTask == nil)
     }


### PR DESCRIPTION
## The bug

Clicking table B while table A's query was still running left the tab showing **A's rows under B's name**, and B never loaded at all. Reproduced live and captured with the new tracing:

```
#27 analytics_events  +21.9ms   executeStarted generation=19
#27 analytics_events  +114.1ms  ANOMALY supersededByNewNavigation replacedBy=#28

#28 account_tokens    +0.1ms    openTableTab from=analytics_events wasExecuting=true hasInFlightQuery=true
#28 account_tokens    +9.8ms    ANOMALY blockedByInFlightExecution
#28 account_tokens    +9.8ms    END outcome=blocked          <- account_tokens never ran a query

#27 analytics_events  +1164.4ms driverFetchEnd rows=1000 driverMs=1127
#27 analytics_events  +1164.7ms ANOMALY resultTableMismatch resultTable=analytics_events tabNowShows=account_tokens
#27 analytics_events  +1166.0ms gridReloadBegin rows=1000    <- painted anyway
```

It fired three times in one short browsing session. The tab is retargeted durably, not transiently: `applyPhase1Result` writes `tableContext.tableName` back, and Refresh then confirms the wrong table rather than recovering.

## Why it needed a refactor rather than a patch

"Which navigation owns this tab's execution" was spread across five uncoordinated mechanisms, and a tab retarget participated in none of them:

| Mechanism | Scope | Sites |
| --- | --- | --- |
| `queryGeneration` | per **window** | 5 writes / 16 reads |
| `execution.isExecuting` | per tab, stored `Bool` | 19 writes / 15 reads (11 blocking guards) |
| `currentQueryTask` | per **window** | 22 writes across 6 files |
| `tableLoadTasks` | per tab, wrapper only | never owned the real fetch |
| `ConnectionToolbarState.isExecuting` | per **window** | a third independent flag |

35 sites mutate tab state after an `await`. **None validated both "same tab" and "same navigation".**

The counter could not represent this bug's shape. It only advanced when a successor execution *started*, and here the successor was refused by a stale flag, so nothing advanced and the old result stayed valid all the way into the grid.

## The change

`TabExecutionRegistry`, keyed per tab, modelled on the existing `ConnectionAttemptRegistry` one level down.

- `claim(tabId)` mints an epoch and invalidates the predecessor.
- `invalidate(tabId)` **removes** the entry rather than bumping a counter, so "the user navigated away and no successor ever ran" still invalidates.
- Busy state is **derived** from membership, never stored, so a retargeted tab cannot stay busy forever.
- `QueryTabManager.replaceTabContent` fires `onTabRetargeted`, wired to cancel the driver read and invalidate. The retarget is now an event the model sees.
- The staleness gate moved **ahead of every shared-state write** in the result handler. A superseded result no longer clears the spinner or nils the task handle belonging to its successor.

### Two traps a design bake-off caught

Two independent reviewers each found a real defect in the other's preferred design. Both are avoided here:

1. **The apply gate is epoch-only.** It deliberately does not compare the tab's live `(tableName, databaseName, schemaName)`. `resolveTableTabSchemaIfNeeded` rewrites `schemaName` mid-flight whenever the schema was unresolvable at tab creation, which is the ordinary session-restore path, so a field comparison would discard valid rows on restore.
2. **The `tableName` write is kept for query tabs.** `resolveTableEditability` derives a query tab's `tableName` from the SQL per result, so that write is load-bearing there and a tautology for table tabs.

### Data-loss fix shipped alongside

`cancelRunningQuery` iterated *every* running driver and its fallback ignored scoping, so Stop could already `KILL QUERY` a commit or a DDL statement. Making navigation issue cancels would have turned that from rare into routine. `DriverCancellationPolicy` (`untracked` / `cancellableRead` / `protectedWrite`) now classifies every lease. The parameter has **no default value**, so a new call site cannot silently pick wrong.

## Behaviour change

The 11 blocking guards are gone: an entry point now supersedes instead of being silently ignored. CHANGELOG updated under Changed and Fixed.

## Testing

- `TabExecutionRegistryTests` (12) and `TabRetargetInvalidationTests` (10) pin each proven step of the chain, including the no-successor case the old counter could not express.
- `DriverCancellationPolicyTests` pins that a protected write is tracked but never a cancellation target.
- `MainContentCoordinatorRefreshTests` converted to the new model. Its in-flight *setup* was rewritten to take a real claim rather than setting the stale bool; assertions were not weakened.
- 114 tests green locally across the execution, tracing, pagination and tab-manager suites; `swiftlint --strict` clean across `TablePro/`.

**No deterministic `TableProUITests` coverage is possible** (CLAUDE.md rule 4): reproducing the race needs a query still in flight when a second table is clicked, which needs a live server with a slow query. The regression is pinned by the pure suites plus the retarget tests instead.

## Reviewer notes

- Worth exercising Redis, DuckDB, CSV and SQLite: plugins whose driver has no `cancelQuery` fall back to the no-op default, so supersede there means the first statement still runs to completion holding the connection gate.
- The `.inPlace` (Redis) navigation branch now invalidates via the retarget hook, but `pluginDispatchAsync` installs no cancellation handler, so a late `SELECT` can still leave the connection on a database no tab asked for. Not introduced here, not fixed here.
