### PR TITLE
feat(connections): disconnect a connection without closing its window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show Previous Workspace and Show Next Workspace move through the rail in the order it displays, on `Ctrl+Cmd+Up` and `Ctrl+Cmd+Down`. A shortcut you assigned yourself wins over a default added in a later release, and the default comes back if you reassign yours. (#1282)
 - Right-click a workspace in the rail to close every tab in it. A window holding a tab in another database stays open. (#1282)
 - The workspace rail takes the keyboard: arrow keys move the highlight, typing jumps to a name, and Return opens the workspace you land on. (#1282)
+- A Connection menu with Disconnect and Reconnect. Disconnecting ends the session without closing the window, which shows a Reconnect screen in place of its tabs. Your tabs are saved before the session ends. You can also right-click a workspace in the rail, or a connection in the connection list, to disconnect it.
+- Disconnecting asks first only when a window has unsaved changes or a query still running. A connection you disconnected is not reopened the next time you launch, and clicking back into its window no longer reconnects it on its own.
 - Redshift external schemas now list their tables. Spectrum, federated query, cross-database, and datashare schemas showed up empty because their tables are not in the standard catalog.
 - External schemas are marked in the sidebar, and their tables show an external icon. External tables open read-only, because Redshift rejects `UPDATE` and `DELETE` on them.
 
@@ -32,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Ending a session while its window stayed open could lose that window's tabs. Tabs are now written to disk before the session goes away, which also covers the disconnect tool used by AI clients and Reset Sample Database.
+- A window that reconnects brings its tabs back instead of coming back empty. Rebuilding a window's contents made it count as two windows, and the restore that refills the tabs stands down when it sees a second window on the connection.
+- Closing a window that never loaded any tabs no longer deletes the tabs saved for that connection. Only a window that had tabs can report that you closed them all.
 - A window being connected is now named after the connection instead of "SQL Query", which named a tab it did not have yet.
 - A window that loses its connection no longer keeps the name of the table it stopped showing. Its name and its native tab label now follow what the window is actually displaying.
 - The titlebar no longer repeats itself, so a window with no tabs open reads "My Database" rather than "My Database - My Database".

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -66,6 +66,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let passwordSyncExpected = syncSettings.enabled && syncSettings.syncConnections && syncSettings.syncPasswords
         UserDefaults.standard.set(passwordSyncExpected, forKey: KeychainHelper.passwordSyncEnabledKey)
         DatabaseManager.shared.startObservingSystemEvents()
+        DatabaseManager.shared.tabStatePersister = SessionTabStatePersister()
 
         Task { await CloudflareTunnelManager.shared.sweepStalePidsIfNeeded() }
         Task { await CloudSQLProxyManager.shared.sweepStalePidsIfNeeded() }

--- a/TablePro/Core/Database/DatabaseManager+Sessions.swift
+++ b/TablePro/Core/Database/DatabaseManager+Sessions.swift
@@ -30,6 +30,7 @@ extension DatabaseManager {
 
         let attempt = connectionAttempts.begin(for: connection.id)
         disconnectReasons[connection.id] = nil
+        userRequestedDisconnects.remove(connection.id)
 
         let resolvedConnection: DatabaseConnection
         if LicenseManager.shared.isFeatureAvailable(.envVarReferences) {
@@ -366,13 +367,31 @@ extension DatabaseManager {
         }
     }
 
-    func disconnectSession(_ sessionId: UUID) async {
+    /// Ends a session. The window that was showing it stays open, so the tabs are written to disk
+    /// first: `MainContentCoordinator.teardown()` clears them from memory and only the window-close
+    /// path saves on its way out, which is how a disconnect used to take a window's tabs with it.
+    func disconnectSession(_ sessionId: UUID, origin: SessionDisconnectOrigin = .appManaged) async {
         let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
         guard let session = activeSessions[sessionId] else {
             lifecycleLogger.info(
                 "[close] disconnectSession: no session found connId=\(sessionId, privacy: .public)"
             )
             return
+        }
+        /// Two disconnects for one session would both run the whole teardown, and the second one's
+        /// tail would land after the user had already reconnected, tearing the new session down.
+        guard !disconnectsInFlight.contains(sessionId) else {
+            lifecycleLogger.info(
+                "[close] disconnectSession: already in flight connId=\(sessionId, privacy: .public)"
+            )
+            return
+        }
+        disconnectsInFlight.insert(sessionId)
+        defer { disconnectsInFlight.remove(sessionId) }
+
+        tabStatePersister?.persistTabState(for: sessionId)
+        if origin == .userRequested {
+            userRequestedDisconnects.insert(sessionId)
         }
         let totalStart = Date()
         lifecycleLogger.info(
@@ -517,6 +536,10 @@ extension DatabaseManager {
 
     internal func disconnectReason(for connectionId: UUID) -> ConnectionFailureInfo? {
         disconnectReasons[connectionId]
+    }
+
+    internal func wasDisconnectedByUser(_ connectionId: UUID) -> Bool {
+        userRequestedDisconnects.contains(connectionId)
     }
 
     internal func removeSessionEntry(for connectionId: UUID) {

--- a/TablePro/Core/Database/DatabaseManager.swift
+++ b/TablePro/Core/Database/DatabaseManager.swift
@@ -68,6 +68,19 @@ final class DatabaseManager {
     /// the entry disappearing can still name the cause. Cleared when a fresh attempt begins.
     @ObservationIgnored internal var disconnectReasons: [UUID: ConnectionFailureInfo] = [:]
 
+    /// Connections the user disconnected on purpose. Kept past the session entry for the same
+    /// reason `disconnectReasons` is: the window learns the session went away by watching the
+    /// entry disappear, and a deliberate disconnect is not the same event as losing a connection.
+    @ObservationIgnored internal var userRequestedDisconnects = Set<UUID>()
+
+    /// Sessions currently being torn down, so a second disconnect cannot run the teardown again and
+    /// finish it against a session the user has since reconnected.
+    @ObservationIgnored internal var disconnectsInFlight = Set<UUID>()
+
+    /// Installed at launch. Every disconnect writes the connection's tabs to disk through this
+    /// before the session entry goes away, because the window can outlive the session.
+    @ObservationIgnored internal var tabStatePersister: (any SessionTabStatePersisting)?
+
     @ObservationIgnored internal var connectionUpdatedCancellable: AnyCancellable?
 
     @ObservationIgnored internal let ensureConnectedDedup = OnceTask<UUID, Void>()

--- a/TablePro/Core/Database/SessionDisconnectOrigin.swift
+++ b/TablePro/Core/Database/SessionDisconnectOrigin.swift
@@ -1,0 +1,14 @@
+//
+//  SessionDisconnectOrigin.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Who ended the session. A closing window or a tool call is the app tidying up after itself; a
+/// user choosing Disconnect is a decision the window has to reflect and "Reopen Last Session" has
+/// to respect. Defaulting to `appManaged` keeps quit and window close out of the user-intent path.
+internal enum SessionDisconnectOrigin: Equatable, Sendable {
+    case appManaged
+    case userRequested
+}

--- a/TablePro/Core/Database/SessionTabStatePersisting.swift
+++ b/TablePro/Core/Database/SessionTabStatePersisting.swift
@@ -1,0 +1,14 @@
+//
+//  SessionTabStatePersisting.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Disconnecting leaves the window open, so a connection's tabs have to reach disk before the
+/// session goes away and the coordinator holding them is torn down. `DatabaseManager` cannot reach
+/// the view layer, so the app installs the persister at launch and every disconnect runs through it.
+@MainActor
+internal protocol SessionTabStatePersisting: AnyObject {
+    func persistTabState(for connectionId: UUID)
+}

--- a/TablePro/Core/Services/Infrastructure/CommandActionsRegistry.swift
+++ b/TablePro/Core/Services/Infrastructure/CommandActionsRegistry.swift
@@ -25,5 +25,11 @@ final class CommandActionsRegistry {
     /// key window is not a main window (welcome / connection-form / settings).
     var current: MainContentCommandActions?
 
+    /// The key window's connection lifecycle state. Separate from `current` because
+    /// `MainContentCommandActions` only exists while the window is showing a session, and
+    /// Disconnect and Reconnect have to stay correct on either side of that: Reconnect is needed
+    /// precisely when there is no session left to own the actions.
+    var connectionWindow: ConnectionWindowCommandState?
+
     private init() {}
 }

--- a/TablePro/Core/Services/Infrastructure/ConnectionDisconnectAction.swift
+++ b/TablePro/Core/Services/Infrastructure/ConnectionDisconnectAction.swift
@@ -1,0 +1,42 @@
+//
+//  ConnectionDisconnectAction.swift
+//  TablePro
+//
+
+import AppKit
+import Foundation
+
+/// The one path a user-requested disconnect takes, whatever surface asked for it. The menu bar, the
+/// workspace rail and the connection list all land here so the confirmation exists once and reads
+/// the same everywhere.
+@MainActor
+internal enum ConnectionDisconnectAction {
+    internal static func disconnect(
+        connectionId: UUID,
+        connectionName: String,
+        presentingWindow: NSWindow?
+    ) async {
+        if let message = confirmationMessage(for: connectionId) {
+            let confirmed = await AlertHelper.confirmDestructive(
+                title: String(format: String(localized: "Disconnect from “%@”?"), connectionName),
+                message: message,
+                confirmButton: String(localized: "Disconnect"),
+                window: presentingWindow
+            )
+            guard confirmed else { return }
+        }
+        await DatabaseManager.shared.disconnectSession(connectionId, origin: .userRequested)
+    }
+
+    /// Nil means disconnect without asking. Losing work the user cannot get back is worth an alert;
+    /// ending a session they asked to end is not, which is why a clean connection never sees one.
+    private static func confirmationMessage(for connectionId: UUID) -> String? {
+        if MainContentCoordinator.hasUnsavedWork(forConnection: connectionId) {
+            return String(localized: "Unsaved changes will be lost.")
+        }
+        if MainContentCoordinator.hasRunningQuery(forConnection: connectionId) {
+            return String(localized: "A query is still running. Disconnecting cancels it.")
+        }
+        return nil
+    }
+}

--- a/TablePro/Core/Services/Infrastructure/ConnectionMenuPolicy.swift
+++ b/TablePro/Core/Services/Infrastructure/ConnectionMenuPolicy.swift
@@ -1,0 +1,15 @@
+//
+//  ConnectionMenuPolicy.swift
+//  TablePro
+//
+
+import Foundation
+
+/// A context menu shows only what applies to the row it was opened on, so the rail hides Disconnect
+/// on a workspace with no live session rather than dimming it. The menu bar does the opposite and
+/// keeps both commands visible, which is why the two surfaces ask different questions here.
+internal enum ConnectionMenuPolicy {
+    internal static func showsDisconnect(status: ConnectionStatus) -> Bool {
+        status.isConnected
+    }
+}

--- a/TablePro/Core/Services/Infrastructure/ConnectionWindowPhaseMachine.swift
+++ b/TablePro/Core/Services/Infrastructure/ConnectionWindowPhaseMachine.swift
@@ -13,14 +13,27 @@ internal struct ConnectionSessionSnapshot: Equatable, Sendable {
     internal let exists: Bool
     internal let hasDriver: Bool
     internal let disconnectInfo: ConnectionFailureInfo?
+    /// The user asked for this. A session that goes away on its own is something to report and
+    /// recover from; one the user ended is neither, and it must not be replayed on the next launch.
+    internal let wasDisconnectedByUser: Bool
 
-    internal init(exists: Bool, hasDriver: Bool, disconnectInfo: ConnectionFailureInfo? = nil) {
+    internal init(
+        exists: Bool,
+        hasDriver: Bool,
+        disconnectInfo: ConnectionFailureInfo? = nil,
+        wasDisconnectedByUser: Bool = false
+    ) {
         self.exists = exists
         self.hasDriver = hasDriver
         self.disconnectInfo = disconnectInfo
+        self.wasDisconnectedByUser = wasDisconnectedByUser
     }
 
     internal static let absent = ConnectionSessionSnapshot(exists: false, hasDriver: false)
+
+    internal var lostSessionReason: ConnectionUnavailableReason {
+        wasDisconnectedByUser ? .disconnectedByUser : .disconnected(disconnectInfo)
+    }
 }
 
 internal enum ConnectionWindowPhaseMachine {
@@ -48,9 +61,9 @@ internal enum ConnectionWindowPhaseMachine {
 
         switch phase {
         case .connecting:
-            return ownsAttempt ? .connecting : .unavailable(.disconnected(session.disconnectInfo))
+            return ownsAttempt ? .connecting : .unavailable(session.lostSessionReason)
         case .connected:
-            return .unavailable(.disconnected(session.disconnectInfo))
+            return .unavailable(session.lostSessionReason)
         case .idle, .unavailable, .closing:
             return phase
         }
@@ -81,12 +94,31 @@ internal enum ConnectionWindowPhaseMachine {
             return true
         case .unavailable(let reason):
             switch reason {
-            case .cancelled:
+            case .cancelled, .disconnectedByUser:
                 return false
             case .notConnected, .disconnected, .failed, .pluginMissing:
                 return true
             }
         case .idle, .closing:
+            return false
+        }
+    }
+
+    /// Whether the user can ask this window to connect. Distinct from `allowsActivationConnect`,
+    /// which answers whether the app may dial on its own: a window the user disconnected must not
+    /// reconnect just because they clicked back into it, but Reconnect has to stay available.
+    internal static func allowsManualConnect(phase: ConnectionWindowPhase) -> Bool {
+        switch phase {
+        case .idle:
+            return true
+        case .unavailable(let reason):
+            switch reason {
+            case .notConnected, .cancelled, .disconnected, .disconnectedByUser, .failed:
+                return true
+            case .pluginMissing:
+                return false
+            }
+        case .connecting, .connected, .closing:
             return false
         }
     }
@@ -99,7 +131,7 @@ internal enum ConnectionWindowPhaseMachine {
             switch reason {
             case .notConnected, .disconnected, .failed:
                 return true
-            case .cancelled, .pluginMissing:
+            case .cancelled, .disconnectedByUser, .pluginMissing:
                 return false
             }
         case .connecting, .connected, .closing:

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController+Connection.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController+Connection.swift
@@ -34,6 +34,42 @@ internal extension MainSplitViewController {
         connect(connection, cancellingPrevious: true)
     }
 
+    /// The window stays open and repaints itself from its own phase once the session entry goes
+    /// away, so this only has to end the session. Every other window on the connection hears the
+    /// same status change and reaches the same phase on its own.
+    func requestDisconnect() {
+        guard let connection = payloadConnection else { return }
+        Task {
+            await ConnectionDisconnectAction.disconnect(
+                connectionId: connection.id,
+                connectionName: connection.name,
+                presentingWindow: view.window
+            )
+        }
+    }
+
+    func publishConnectionCommandState() {
+        CommandActionsRegistry.shared.connectionWindow = connectionCommandState
+    }
+
+    /// Clears only what this window published. A resign fires before the next window's become, and
+    /// windows of one connection close independently, so anything else clears someone else's state.
+    func clearConnectionCommandStateIfOwned() {
+        guard CommandActionsRegistry.shared.connectionWindow?.owner == ObjectIdentifier(self) else { return }
+        CommandActionsRegistry.shared.connectionWindow = nil
+    }
+
+    var connectionCommandState: ConnectionWindowCommandState? {
+        guard let connection = payloadConnection else { return nil }
+        return ConnectionWindowCommandState(
+            owner: ObjectIdentifier(self),
+            connectionId: connection.id,
+            connectionName: connection.name,
+            canDisconnect: phase == .connected,
+            canReconnect: ConnectionWindowPhaseMachine.allowsManualConnect(phase: phase)
+        )
+    }
+
     func cancelConnectionAttempt() {
         attemptToken = nil
         transition(to: .unavailable(.cancelled))
@@ -51,7 +87,7 @@ internal extension MainSplitViewController {
         case .pluginMissing:
             guard let connection = payloadConnection else { return }
             WelcomeRouter.shared.routePluginInstall(connection)
-        case .notConnected, .cancelled, .disconnected, .failed:
+        case .notConnected, .cancelled, .disconnected, .disconnectedByUser, .failed:
             retryConnection()
         }
     }

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -309,7 +309,8 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         let snapshot = ConnectionSessionSnapshot(
             exists: session != nil,
             hasDriver: session?.driver != nil,
-            disconnectInfo: DatabaseManager.shared.disconnectReason(for: sid)
+            disconnectInfo: DatabaseManager.shared.disconnectReason(for: sid),
+            wasDisconnectedByUser: DatabaseManager.shared.wasDisconnectedByUser(sid)
         )
         let nextPhase = ConnectionWindowPhaseMachine.onSessionChanged(
             phase: phase,
@@ -364,6 +365,9 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         applyPaneChrome()
         applyWindowTitle()
         SessionRecoveryTracker.sync()
+        if view.window?.isKeyWindow == true {
+            publishConnectionCommandState()
+        }
     }
 
     /// Repainted on every phase change for the same reason the panes are. Leaving it out is

--- a/TablePro/Core/Services/Infrastructure/TabPersistenceCoordinator+AggregatedSave.swift
+++ b/TablePro/Core/Services/Infrastructure/TabPersistenceCoordinator+AggregatedSave.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import os
 
 extension TabPersistenceCoordinator {
     /// Save persisted state from the tabs aggregated across all windows for the connection.
@@ -17,12 +18,30 @@ extension TabPersistenceCoordinator {
         saveNow(windowedTabs: aggregatedTabs, selectedTabId: selectedId)
     }
 
+    /// The disconnect path: synchronous like the close path, because the session is about to go
+    /// away and every coordinator holding these tabs is torn down straight after, and
+    /// never-clearing like `saveAggregated()`, because the user asked to end a session, not to
+    /// close their tabs. `saveAggregated()` alone cannot serve this: it defers the write through
+    /// `scheduleSave`, which cancels the previous task, so a sibling window's save can drop it.
+    func saveAggregatedSync() {
+        let aggregatedTabs = MainContentCoordinator.aggregatedTabs(for: connectionId)
+        guard !aggregatedTabs.isEmpty else { return }
+        let selectedId = MainContentCoordinator.aggregatedSelectedTabId(for: connectionId)
+        saveNowSync(windowedTabs: aggregatedTabs, selectedTabId: selectedId)
+    }
+
     /// Synchronous variant for the window-close path, where the run loop may
     /// not be available to service Tasks before the window tears down. This is the one
     /// path where an empty aggregate means the user closed everything, so it clears.
     func saveOrClearAggregatedSync() {
         let aggregatedTabs = MainContentCoordinator.aggregatedTabs(for: connectionId)
         if aggregatedTabs.isEmpty {
+            guard hasObservedTabs else {
+                Self.logger.info(
+                    "[persist] clear withheld, window never held a tab connId=\(self.connectionId, privacy: .public)"
+                )
+                return
+            }
             clearForUserClosedAllTabs()
         } else {
             let selectedId = MainContentCoordinator.aggregatedSelectedTabId(for: connectionId)

--- a/TablePro/Core/Services/Infrastructure/TabPersistenceCoordinator.swift
+++ b/TablePro/Core/Services/Infrastructure/TabPersistenceCoordinator.swift
@@ -22,13 +22,23 @@ internal struct RestoreResult {
 
 @MainActor @Observable
 internal final class TabPersistenceCoordinator {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
+    internal static let logger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
     let connectionId: UUID
 
     @ObservationIgnored private var saveTask: Task<Void, Never>?
 
+    /// Whether this window has ever had a tab of its own. Only a window that held tabs can report
+    /// that the user closed them all; one that never saw any is not evidence of anything. A window
+    /// left over from a disconnect is exactly that case, and treating its empty tab list as an
+    /// instruction deleted the state the disconnect had just saved.
+    private(set) var hasObservedTabs = false
+
     init(connectionId: UUID) {
         self.connectionId = connectionId
+    }
+
+    internal func markObservedTabs() {
+        hasObservedTabs = true
     }
 
     // MARK: - Save
@@ -46,6 +56,7 @@ internal final class TabPersistenceCoordinator {
             Self.logger.debug("[persist] saveNow skipped empty tab set connId=\(self.connectionId, privacy: .public)")
             return
         }
+        hasObservedTabs = true
         let persisted = windowedTabs.map { $0.tab.toPersistedTab(windowGroupIndex: $0.windowGroupIndex) }
         let normalizedSelectedId = windowedTabs.contains(where: { $0.tab.id == selectedTabId })
             ? selectedTabId : windowedTabs.first?.tab.id
@@ -67,6 +78,7 @@ internal final class TabPersistenceCoordinator {
             Self.logger.debug("[persist] saveNowSync skipped empty tab set connId=\(self.connectionId, privacy: .public)")
             return
         }
+        hasObservedTabs = true
         let persisted = windowedTabs.map { $0.tab.toPersistedTab(windowGroupIndex: $0.windowGroupIndex) }
         let normalizedSelectedId = windowedTabs.contains(where: { $0.tab.id == selectedTabId })
             ? selectedTabId : windowedTabs.first?.tab.id
@@ -144,6 +156,7 @@ internal final class TabPersistenceCoordinator {
         guard !state.tabs.isEmpty else {
             return RestoreResult(tabs: [], selectedTabId: nil, source: .none)
         }
+        hasObservedTabs = true
 
         let defaultPageSize = AppSettingsManager.shared.dataGrid.defaultPageSize
         var restoredTabs = state.tabs.map { QueryTab(from: $0, defaultPageSize: defaultPageSize) }

--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -128,6 +128,7 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
 
         if let splitVC = window.contentViewController as? MainSplitViewController {
             splitVC.startActivationConnectIfNeeded()
+            splitVC.publishConnectionCommandState()
         }
 
         guard let coordinator = MainContentCoordinator.coordinator(forWindow: window) else { return }
@@ -148,9 +149,9 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
     internal func windowDidResignKey(_ notification: Notification) {
         let seq = MainContentCoordinator.nextSwitchSeq()
         let t0 = Date()
-        guard let window = notification.object as? NSWindow,
-              let coordinator = MainContentCoordinator.coordinator(forWindow: window)
-        else { return }
+        guard let window = notification.object as? NSWindow else { return }
+        (window.contentViewController as? MainSplitViewController)?.clearConnectionCommandStateIfOwned()
+        guard let coordinator = MainContentCoordinator.coordinator(forWindow: window) else { return }
         Self.lifecycleLogger.debug(
             "[switch] windowDidResignKey seq=\(seq) controllerId=\(self.controllerId, privacy: .public)"
         )
@@ -169,7 +170,10 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         guard let window = notification.object as? NSWindow else { return }
         Self.lifecycleLogger.info("[close] windowWillClose seq=\(seq) controllerId=\(self.controllerId, privacy: .public)")
 
-        (window.contentViewController as? MainSplitViewController)?.markWindowClosing()
+        if let splitVC = window.contentViewController as? MainSplitViewController {
+            splitVC.markWindowClosing()
+            splitVC.clearConnectionCommandStateIfOwned()
+        }
 
         cancelPendingConnectionIfNeeded()
 

--- a/TablePro/Core/Services/Infrastructure/WindowLifecycleMonitor.swift
+++ b/TablePro/Core/Services/Infrastructure/WindowLifecycleMonitor.swift
@@ -46,6 +46,21 @@ internal final class WindowLifecycleMonitor {
         Self.lifecycleLogger.info(
             "[open] WindowLifecycleMonitor.register windowId=\(windowId, privacy: .public) connId=\(connectionId, privacy: .public) registeredBefore=\(self.entries.count)"
         )
+        /// A window id belongs to the SwiftUI content mounted in the window, not to the window, so a
+        /// window whose content is rebuilt registers again under a new id. Reconnecting rebuilds it.
+        /// Leaving the superseded entry behind makes one window count as two, which is what stopped a
+        /// reconnected window from restoring its tabs: the restore stands down when it sees a sibling.
+        let supersededIds = entries.compactMap { key, value -> UUID? in
+            key != windowId && value.window === window ? key : nil
+        }
+        for supersededId in supersededIds {
+            guard let superseded = entries.removeValue(forKey: supersededId) else { continue }
+            for observer in superseded.observers {
+                NotificationCenter.default.removeObserver(observer)
+            }
+            forgetFocus(windowId: supersededId, connectionId: superseded.connectionId)
+        }
+
         // Remove any existing entry for this windowId to avoid duplicate observers
         if let existing = entries[windowId] {
             if existing.window !== window {

--- a/TablePro/Core/Services/Infrastructure/WorkspaceRailViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspaceRailViewController.swift
@@ -361,6 +361,26 @@ internal final class WorkspaceRailViewController: NSViewController {
               let coordinator = MainContentCoordinator.coordinator(forWindow: window) else { return }
         coordinator.commandActions?.closeWorkspace(container: workspace.container)
     }
+
+    /// Ends the session, which every workspace of the connection shares, so the other rows for it
+    /// go quiet too. No window closes: each one repaints from its own phase.
+    @objc
+    private func disconnectWorkspace(_ sender: NSMenuItem) {
+        guard let workspace = sender.representedObject as? WorkspaceID,
+              let entry = entries.first(where: { $0.workspace.connectionId == workspace.connectionId })
+        else { return }
+        /// The rail's own window, not the connection's most recent one: the user is looking at this
+        /// window, and the connection's most recent window can be behind it or miniaturized, which
+        /// would put the confirmation sheet somewhere they cannot see and read as a dead menu item.
+        let presentingWindow = view.window
+        Task {
+            await ConnectionDisconnectAction.disconnect(
+                connectionId: workspace.connectionId,
+                connectionName: entry.connection.name,
+                presentingWindow: presentingWindow
+            )
+        }
+    }
 }
 
 // MARK: - NSMenuDelegate
@@ -379,6 +399,16 @@ extension WorkspaceRailViewController: NSMenuDelegate {
         item.target = self
         item.representedObject = entries[row].workspace
         menu.addItem(item)
+
+        guard ConnectionMenuPolicy.showsDisconnect(status: entries[row].status) else { return }
+        let disconnectItem = NSMenuItem(
+            title: String(localized: "Disconnect"),
+            action: #selector(disconnectWorkspace(_:)),
+            keyEquivalent: ""
+        )
+        disconnectItem.target = self
+        disconnectItem.representedObject = entries[row].workspace
+        menu.addItem(disconnectItem)
     }
 }
 

--- a/TablePro/Core/Storage/SessionRecoveryTracker.swift
+++ b/TablePro/Core/Storage/SessionRecoveryTracker.swift
@@ -24,6 +24,16 @@ enum SessionRecoveryTracker {
             RecoveryCandidate(connectionId: $0, isActivated: false, retainsRestoreIntent: true)
         }
         return RecoveryConnectionList.connectionIds(from: activated + pending)
+            .filter { !wasEndedByUser($0) }
+    }
+
+    /// A connection the user disconnected is never replayed, whatever its windows still report. A
+    /// window subscribes to session changes only while it is on screen, so a native tab that AppKit
+    /// joined but never displayed sits frozen at the phase it was born with and would otherwise vote
+    /// to reopen a session the user deliberately ended. The flag clears when a fresh connect begins.
+    private static func wasEndedByUser(_ connectionId: UUID) -> Bool {
+        guard DatabaseManager.shared.wasDisconnectedByUser(connectionId) else { return false }
+        return DatabaseManager.shared.activeSessions[connectionId] == nil
     }
 
     /// Rewrite the recovery list from the live window set. Called whenever that set

--- a/TablePro/Models/Connection/ConnectionWindowCommandState.swift
+++ b/TablePro/Models/Connection/ConnectionWindowCommandState.swift
@@ -1,0 +1,20 @@
+//
+//  ConnectionWindowCommandState.swift
+//  TablePro
+//
+
+import Foundation
+
+/// What the menu bar needs to know about the key window's connection. A value, not the controller,
+/// because the registry that publishes it is observed by the menus: holding the controller would
+/// leave Disconnect enabled after a disconnect, since the reference never changes when the phase does.
+internal struct ConnectionWindowCommandState: Equatable, Sendable {
+    /// Which window published this. Several windows can share a connection, so the connection id
+    /// cannot answer "is this mine to clear": a background tab of the same connection closing used
+    /// to wipe the key window's state and leave both commands disabled with nothing to restore them.
+    internal let owner: ObjectIdentifier
+    internal let connectionId: UUID
+    internal let connectionName: String
+    internal let canDisconnect: Bool
+    internal let canReconnect: Bool
+}

--- a/TablePro/Models/Connection/ConnectionWindowPhase.swift
+++ b/TablePro/Models/Connection/ConnectionWindowPhase.swift
@@ -21,6 +21,7 @@ internal enum ConnectionUnavailableReason: Equatable, Sendable {
     case notConnected
     case cancelled
     case disconnected(ConnectionFailureInfo?)
+    case disconnectedByUser
     case failed(ConnectionFailureInfo)
     case pluginMissing(ConnectionFailureInfo)
 }

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -6191,6 +6191,9 @@
         }
       }
     },
+    "A query is still running. Disconnecting cancels it." : {
+
+    },
     "A service account key is required" : {
       "localizations" : {
         "tr" : {
@@ -30525,6 +30528,9 @@
           }
         }
       }
+    },
+    "Disconnect from “%@”?" : {
+
     },
     "Disconnect the selected client" : {
       "localizations" : {
@@ -95909,6 +95915,9 @@
           }
         }
       }
+    },
+    "Unsaved changes will be lost." : {
+
     },
     "Unset" : {
       "extractionState" : "stale",

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -149,6 +149,18 @@ struct AppMenuCommands: Commands {
         focusedActions ?? commandRegistry.current
     }
 
+    /// Disconnect and Reconnect are the two commands that outlive a session, so they read the
+    /// window's phase instead of `actions`, which only exists while a session is being shown.
+    private var connectionWindow: ConnectionWindowCommandState? {
+        commandRegistry.connectionWindow
+    }
+
+    /// Resolved when the command fires rather than cached, because `MainSplitViewController` is the
+    /// key window's own content view controller and a stored reference would outlive the window.
+    private var keyConnectionWindow: MainSplitViewController? {
+        NSApp.keyWindow?.contentViewController as? MainSplitViewController
+    }
+
     private var sidebarLayoutBinding: Binding<SidebarLayout> {
         Binding(
             get: { actions?.sidebarLayout ?? .flat },
@@ -433,6 +445,19 @@ struct AppMenuCommands: Commands {
                     || !(actions?.supportsRestore ?? false)
                     || actions?.isReadOnly ?? false
             )
+        }
+
+        // Connection menu
+        CommandMenu("Connection") {
+            Button(String(localized: "Disconnect")) {
+                keyConnectionWindow?.requestDisconnect()
+            }
+            .disabled(!(connectionWindow?.canDisconnect ?? false))
+
+            Button(String(localized: "Reconnect")) {
+                keyConnectionWindow?.retryConnection()
+            }
+            .disabled(!(connectionWindow?.canReconnect ?? false))
         }
 
         // Query menu

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -590,140 +590,8 @@ struct AppMenuCommands: Commands {
             .disabled(!(actions?.isConnected ?? false))
         }
 
-        // Edit menu - Undo/Redo (smart handling for both text editor and data grid)
-        CommandGroup(replacing: .undoRedo) {
-            Button(NSApp.keyWindow?.undoManager?.undoMenuItemTitle ?? String(localized: "Undo")) {
-                // Inspector windows and text views both handle undo: via the
-                // AppKit responder chain. Data grid tabs route through actions.
-                if keyWindowIsInspector ||
-                    (NSApp.keyWindow?.firstResponder is NSTextView) ||
-                    (NSApp.keyWindow?.firstResponder is TextView) {
-                    NSApp.sendAction(#selector(TableProResponderActions.undo(_:)), to: nil, from: nil)
-                } else {
-                    actions?.undoChange()
-                }
-            }
-            .optionalKeyboardShortcut(shortcut(for: .undo))
+        editCommands
 
-            Button(NSApp.keyWindow?.undoManager?.redoMenuItemTitle ?? String(localized: "Redo")) {
-                if keyWindowIsInspector ||
-                    (NSApp.keyWindow?.firstResponder is NSTextView) ||
-                    (NSApp.keyWindow?.firstResponder is TextView) {
-                    NSApp.sendAction(#selector(TableProResponderActions.redo(_:)), to: nil, from: nil)
-                } else {
-                    actions?.redoChange()
-                }
-            }
-            .optionalKeyboardShortcut(shortcut(for: .redo))
-        }
-
-        PasteboardCommands(settingsManager: settingsManager, commandRegistry: commandRegistry)
-
-        // Edit menu - Find + row operations (after pasteboard)
-        CommandGroup(after: .pasteboard) {
-            Divider()
-
-            Button(String(localized: "Find...")) {
-                switch commandFRoute {
-                case .inspectorFilter:
-                    NSApp.sendAction(#selector(InspectorViewController.toggleInspectorFilter(_:)), to: nil, from: nil)
-                case .editorFind:
-                    EditorEventRouter.shared.showFindPanelForKeyWindow()
-                case .tableFilter:
-                    break
-                }
-            }
-            .optionalKeyboardShortcut(commandFRoute == .tableFilter ? nil : KeyboardShortcut("f", modifiers: .command))
-            .disabled(commandFRoute == .tableFilter)
-
-            Button(String(localized: "Find Next")) {
-                EditorEventRouter.shared.findNext()
-            }
-            .optionalKeyboardShortcut(shortcut(for: .findNext))
-            .disabled(!(actions?.isConnected ?? false))
-
-            Button(String(localized: "Find Previous")) {
-                EditorEventRouter.shared.findPrevious()
-            }
-            .optionalKeyboardShortcut(shortcut(for: .findPrevious))
-            .disabled(!(actions?.isConnected ?? false))
-
-            Divider()
-
-            Button("Add Row") {
-                actions?.addNewRow()
-            }
-            .dataGridShortcut(.addRow, keyboard: settingsManager.keyboard, yieldingTo: actions)
-            .disabled(!(actions?.isCurrentTabEditable ?? false) || actions?.isReadOnly ?? false)
-
-            Button("Duplicate Row") {
-                actions?.duplicateRow()
-            }
-            .dataGridShortcut(.duplicateRow, keyboard: settingsManager.keyboard, yieldingTo: actions)
-            .disabled(!(actions?.isCurrentTabEditable ?? false) || actions?.isReadOnly ?? false)
-
-            Divider()
-
-            Button("Insert Row Above") {
-                NSApp.sendAction(#selector(InspectorViewController.inspectorInsertRowAbove(_:)), to: nil, from: nil)
-            }
-            .disabled(!keyWindowIsInspector)
-
-            Button("Insert Row Below") {
-                NSApp.sendAction(#selector(InspectorViewController.inspectorInsertRowBelow(_:)), to: nil, from: nil)
-            }
-            .disabled(!keyWindowIsInspector)
-
-            Button("Delete Rows") {
-                NSApp.sendAction(#selector(InspectorViewController.inspectorDeleteSelectedRows(_:)), to: nil, from: nil)
-            }
-            .disabled(!keyWindowIsInspector)
-
-            Button("Insert Column Left") {
-                NSApp.sendAction(#selector(InspectorViewController.inspectorInsertColumnLeft(_:)), to: nil, from: nil)
-            }
-            .disabled(!keyWindowIsInspector)
-
-            Button("Insert Column Right") {
-                NSApp.sendAction(#selector(InspectorViewController.inspectorInsertColumnRight(_:)), to: nil, from: nil)
-            }
-            .disabled(!keyWindowIsInspector)
-
-            Button("Split Column…") {
-                NSApp.sendAction(#selector(InspectorViewController.inspectorSplitColumn(_:)), to: nil, from: nil)
-            }
-            .disabled(!keyWindowIsInspector)
-
-            Button("Merge Columns…") {
-                NSApp.sendAction(#selector(InspectorViewController.inspectorMergeColumns(_:)), to: nil, from: nil)
-            }
-            .disabled(!keyWindowIsInspector)
-
-            Button("Delete Column") {
-                NSApp.sendAction(#selector(InspectorViewController.inspectorDeleteColumn(_:)), to: nil, from: nil)
-            }
-            .disabled(!keyWindowIsInspector)
-
-            Button("Switch First Row Between Header/Data") {
-                NSApp.sendAction(#selector(InspectorViewController.inspectorToggleHeaderRow(_:)), to: nil, from: nil)
-            }
-            .optionalKeyboardShortcut(shortcut(for: .toggleHeaderRow))
-            .disabled(!keyWindowIsInspector)
-
-            Button(String(localized: "Set CSV Properties…")) {
-                NSApp.sendAction(#selector(InspectorViewController.inspectorSetCSVProperties(_:)), to: nil, from: nil)
-            }
-            .disabled(!keyWindowIsInspector)
-
-            Divider()
-
-            // Table operations (work when tables selected in sidebar)
-            Button("Truncate Table") {
-                actions?.truncateTables()
-            }
-            .dataGridShortcut(.truncateTable, keyboard: settingsManager.keyboard, yieldingTo: actions)
-            .disabled(!(actions?.hasTableSelection ?? false) || actions?.isReadOnly ?? false)
-        }
 
         // View menu
         CommandGroup(after: .sidebar) {
@@ -935,6 +803,149 @@ struct AppMenuCommands: Commands {
                     NSWorkspace.shared.open(url)
                 }
             }
+        }
+    }
+
+    /// Grouped because `@CommandsBuilder` takes at most ten children, and the menu bar was
+    /// already at ten. Adding an eleventh fails to build with "Extra argument in call" on the
+    /// toolchain CI uses, while a newer one accepts it, so the limit only shows up on the runner.
+    /// These three all belong to the Edit menu and are placement-driven, so nesting them changes
+    /// nothing about where their items land.
+    @CommandsBuilder
+    private var editCommands: some Commands {
+        // Edit menu - Undo/Redo (smart handling for both text editor and data grid)
+        CommandGroup(replacing: .undoRedo) {
+            Button(NSApp.keyWindow?.undoManager?.undoMenuItemTitle ?? String(localized: "Undo")) {
+                // Inspector windows and text views both handle undo: via the
+                // AppKit responder chain. Data grid tabs route through actions.
+                if keyWindowIsInspector ||
+                    (NSApp.keyWindow?.firstResponder is NSTextView) ||
+                    (NSApp.keyWindow?.firstResponder is TextView) {
+                    NSApp.sendAction(#selector(TableProResponderActions.undo(_:)), to: nil, from: nil)
+                } else {
+                    actions?.undoChange()
+                }
+            }
+            .optionalKeyboardShortcut(shortcut(for: .undo))
+
+            Button(NSApp.keyWindow?.undoManager?.redoMenuItemTitle ?? String(localized: "Redo")) {
+                if keyWindowIsInspector ||
+                    (NSApp.keyWindow?.firstResponder is NSTextView) ||
+                    (NSApp.keyWindow?.firstResponder is TextView) {
+                    NSApp.sendAction(#selector(TableProResponderActions.redo(_:)), to: nil, from: nil)
+                } else {
+                    actions?.redoChange()
+                }
+            }
+            .optionalKeyboardShortcut(shortcut(for: .redo))
+        }
+
+        PasteboardCommands(settingsManager: settingsManager, commandRegistry: commandRegistry)
+
+        // Edit menu - Find + row operations (after pasteboard)
+        CommandGroup(after: .pasteboard) {
+            Divider()
+
+            Button(String(localized: "Find...")) {
+                switch commandFRoute {
+                case .inspectorFilter:
+                    NSApp.sendAction(#selector(InspectorViewController.toggleInspectorFilter(_:)), to: nil, from: nil)
+                case .editorFind:
+                    EditorEventRouter.shared.showFindPanelForKeyWindow()
+                case .tableFilter:
+                    break
+                }
+            }
+            .optionalKeyboardShortcut(commandFRoute == .tableFilter ? nil : KeyboardShortcut("f", modifiers: .command))
+            .disabled(commandFRoute == .tableFilter)
+
+            Button(String(localized: "Find Next")) {
+                EditorEventRouter.shared.findNext()
+            }
+            .optionalKeyboardShortcut(shortcut(for: .findNext))
+            .disabled(!(actions?.isConnected ?? false))
+
+            Button(String(localized: "Find Previous")) {
+                EditorEventRouter.shared.findPrevious()
+            }
+            .optionalKeyboardShortcut(shortcut(for: .findPrevious))
+            .disabled(!(actions?.isConnected ?? false))
+
+            Divider()
+
+            Button("Add Row") {
+                actions?.addNewRow()
+            }
+            .dataGridShortcut(.addRow, keyboard: settingsManager.keyboard, yieldingTo: actions)
+            .disabled(!(actions?.isCurrentTabEditable ?? false) || actions?.isReadOnly ?? false)
+
+            Button("Duplicate Row") {
+                actions?.duplicateRow()
+            }
+            .dataGridShortcut(.duplicateRow, keyboard: settingsManager.keyboard, yieldingTo: actions)
+            .disabled(!(actions?.isCurrentTabEditable ?? false) || actions?.isReadOnly ?? false)
+
+            Divider()
+
+            Button("Insert Row Above") {
+                NSApp.sendAction(#selector(InspectorViewController.inspectorInsertRowAbove(_:)), to: nil, from: nil)
+            }
+            .disabled(!keyWindowIsInspector)
+
+            Button("Insert Row Below") {
+                NSApp.sendAction(#selector(InspectorViewController.inspectorInsertRowBelow(_:)), to: nil, from: nil)
+            }
+            .disabled(!keyWindowIsInspector)
+
+            Button("Delete Rows") {
+                NSApp.sendAction(#selector(InspectorViewController.inspectorDeleteSelectedRows(_:)), to: nil, from: nil)
+            }
+            .disabled(!keyWindowIsInspector)
+
+            Button("Insert Column Left") {
+                NSApp.sendAction(#selector(InspectorViewController.inspectorInsertColumnLeft(_:)), to: nil, from: nil)
+            }
+            .disabled(!keyWindowIsInspector)
+
+            Button("Insert Column Right") {
+                NSApp.sendAction(#selector(InspectorViewController.inspectorInsertColumnRight(_:)), to: nil, from: nil)
+            }
+            .disabled(!keyWindowIsInspector)
+
+            Button("Split Column…") {
+                NSApp.sendAction(#selector(InspectorViewController.inspectorSplitColumn(_:)), to: nil, from: nil)
+            }
+            .disabled(!keyWindowIsInspector)
+
+            Button("Merge Columns…") {
+                NSApp.sendAction(#selector(InspectorViewController.inspectorMergeColumns(_:)), to: nil, from: nil)
+            }
+            .disabled(!keyWindowIsInspector)
+
+            Button("Delete Column") {
+                NSApp.sendAction(#selector(InspectorViewController.inspectorDeleteColumn(_:)), to: nil, from: nil)
+            }
+            .disabled(!keyWindowIsInspector)
+
+            Button("Switch First Row Between Header/Data") {
+                NSApp.sendAction(#selector(InspectorViewController.inspectorToggleHeaderRow(_:)), to: nil, from: nil)
+            }
+            .optionalKeyboardShortcut(shortcut(for: .toggleHeaderRow))
+            .disabled(!keyWindowIsInspector)
+
+            Button(String(localized: "Set CSV Properties…")) {
+                NSApp.sendAction(#selector(InspectorViewController.inspectorSetCSVProperties(_:)), to: nil, from: nil)
+            }
+            .disabled(!keyWindowIsInspector)
+
+            Divider()
+
+            // Table operations (work when tables selected in sidebar)
+            Button("Truncate Table") {
+                actions?.truncateTables()
+            }
+            .dataGridShortcut(.truncateTable, keyboard: settingsManager.keyboard, yieldingTo: actions)
+            .disabled(!(actions?.hasTableSelection ?? false) || actions?.isReadOnly ?? false)
         }
     }
 }

--- a/TablePro/Views/Connection/ConnectionUnavailableView.swift
+++ b/TablePro/Views/Connection/ConnectionUnavailableView.swift
@@ -64,6 +64,9 @@ internal struct ConnectionUnavailableView: View {
         case .disconnected:
             Image(systemName: "bolt.horizontal.circle")
                 .symbolRenderingMode(.hierarchical)
+        case .disconnectedByUser:
+            Image(systemName: "cable.connector.slash")
+                .symbolRenderingMode(.hierarchical)
         case .failed:
             Image(systemName: "exclamationmark.triangle")
                 .symbolRenderingMode(.hierarchical)
@@ -77,7 +80,7 @@ internal struct ConnectionUnavailableView: View {
         switch reason {
         case .notConnected, .cancelled:
             return String(format: String(localized: "Not connected to %@"), connection.name)
-        case .disconnected:
+        case .disconnected, .disconnectedByUser:
             return String(format: String(localized: "Disconnected from %@"), connection.name)
         case .failed, .pluginMissing:
             return String(format: String(localized: "Could not connect to %@"), connection.name)
@@ -86,7 +89,7 @@ internal struct ConnectionUnavailableView: View {
 
     private var detailLines: [String] {
         switch reason {
-        case .notConnected, .cancelled:
+        case .notConnected, .cancelled, .disconnectedByUser:
             return []
         case .disconnected(let info):
             guard let info else { return [String(localized: "The connection was closed.")] }
@@ -98,7 +101,7 @@ internal struct ConnectionUnavailableView: View {
 
     private var failureInfo: ConnectionFailureInfo? {
         switch reason {
-        case .notConnected, .cancelled:
+        case .notConnected, .cancelled, .disconnectedByUser:
             return nil
         case .disconnected(let info):
             return info
@@ -126,7 +129,7 @@ internal struct ConnectionUnavailableView: View {
         switch reason {
         case .notConnected, .cancelled:
             return String(localized: "Connect")
-        case .disconnected:
+        case .disconnected, .disconnectedByUser:
             return String(localized: "Reconnect")
         case .failed:
             return String(localized: "Try Again")

--- a/TablePro/Views/Connection/WelcomeContextMenus.swift
+++ b/TablePro/Views/Connection/WelcomeContextMenus.swift
@@ -3,6 +3,7 @@
 //  TablePro
 //
 
+import AppKit
 import Combine
 import SwiftUI
 
@@ -125,6 +126,22 @@ extension WelcomeWindowView {
     private func singleConnectionContextMenu(for connection: DatabaseConnection) -> some View {
         Button { vm.connectToDatabase(connection) } label: {
             Label(String(localized: "Connect"), systemImage: "play.fill")
+        }
+
+        if ConnectionMenuPolicy.showsDisconnect(
+            status: DatabaseManager.shared.session(for: connection.id)?.status ?? .disconnected
+        ) {
+            Button(role: .destructive) {
+                Task {
+                    await ConnectionDisconnectAction.disconnect(
+                        connectionId: connection.id,
+                        connectionName: connection.name,
+                        presentingWindow: NSApp.keyWindow
+                    )
+                }
+            } label: {
+                Label(String(localized: "Disconnect"), systemImage: "cable.connector.slash")
+            }
         }
 
         Divider()

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Registry.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Registry.swift
@@ -23,6 +23,21 @@ extension MainContentCoordinator {
         activeCoordinators.values.contains { $0.hasAnyUnsavedWork() }
     }
 
+    /// Disconnecting ends the session behind every window on the connection, so what is at risk is
+    /// never just the window the command came from. The rail and the connection list can both fire
+    /// it for a connection whose windows are all in the background.
+    static func hasUnsavedWork(forConnection connectionId: UUID) -> Bool {
+        activeCoordinators.values
+            .filter { $0.connectionId == connectionId }
+            .contains { $0.hasAnyUnsavedWork() }
+    }
+
+    static func hasRunningQuery(forConnection connectionId: UUID) -> Bool {
+        activeCoordinators.values
+            .filter { $0.connectionId == connectionId }
+            .contains { $0.toolbarState.isExecuting }
+    }
+
     static func allTabs(for connectionId: UUID) -> [QueryTab] {
         activeCoordinators.values
             .filter { $0.connectionId == connectionId }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TabStatePersistence.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TabStatePersistence.swift
@@ -1,0 +1,18 @@
+//
+//  MainContentCoordinator+TabStatePersistence.swift
+//  TablePro
+//
+
+import Foundation
+
+/// The view-layer half of `SessionTabStatePersisting`. One coordinator is enough to ask, because
+/// `saveAggregatedSync()` collects the tabs of every window on the connection, not just its own.
+@MainActor
+internal final class SessionTabStatePersister: SessionTabStatePersisting {
+    internal func persistTabState(for connectionId: UUID) {
+        MainContentCoordinator.allActiveCoordinators()
+            .first { $0.connectionId == connectionId }?
+            .persistence
+            .saveAggregatedSync()
+    }
+}

--- a/TableProTests/Core/Database/DatabaseManagerDisconnectTests.swift
+++ b/TableProTests/Core/Database/DatabaseManagerDisconnectTests.swift
@@ -1,0 +1,106 @@
+//
+//  DatabaseManagerDisconnectTests.swift
+//  TableProTests
+//
+//  A disconnect leaves the window open, so the tabs have to be written to disk before the session
+//  goes away: the coordinator holding them is torn down straight after, and only the window-close
+//  path used to save on its way out. That is how the MCP disconnect tool and Reset Sample Database
+//  could take a window's tabs with them.
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("Database manager disconnect", .serialized)
+@MainActor
+struct DatabaseManagerDisconnectTests {
+    private final class TabStatePersisterSpy: SessionTabStatePersisting {
+        private(set) var persistedConnectionIds: [UUID] = []
+        private(set) var sessionsPresentAtPersist: [Bool] = []
+
+        func persistTabState(for connectionId: UUID) {
+            persistedConnectionIds.append(connectionId)
+            sessionsPresentAtPersist.append(DatabaseManager.shared.activeSessions[connectionId] != nil)
+        }
+    }
+
+    private func withInstalledSpy(_ body: (TabStatePersisterSpy) async -> Void) async {
+        let spy = TabStatePersisterSpy()
+        let previous = DatabaseManager.shared.tabStatePersister
+        DatabaseManager.shared.tabStatePersister = spy
+        await body(spy)
+        DatabaseManager.shared.tabStatePersister = previous
+    }
+
+    @Test("Disconnecting persists the connection's tabs while the session still exists")
+    func disconnectPersistsTabsBeforeTeardown() async {
+        await withInstalledSpy { spy in
+            let id = UUID()
+            DatabaseManager.shared.injectSession(
+                ConnectionSession(connection: TestFixtures.makeConnection(id: id, name: "Persisted")),
+                for: id
+            )
+
+            await DatabaseManager.shared.disconnectSession(id)
+
+            #expect(spy.persistedConnectionIds == [id])
+            #expect(spy.sessionsPresentAtPersist == [true])
+        }
+    }
+
+    @Test("A disconnect with no session persists nothing")
+    func disconnectWithoutSessionPersistsNothing() async {
+        await withInstalledSpy { spy in
+            await DatabaseManager.shared.disconnectSession(UUID())
+
+            #expect(spy.persistedConnectionIds.isEmpty)
+        }
+    }
+
+    @Test("A user-requested disconnect is recorded as deliberate")
+    func userRequestedDisconnectIsRecorded() async {
+        let id = UUID()
+        DatabaseManager.shared.injectSession(
+            ConnectionSession(connection: TestFixtures.makeConnection(id: id, name: "Deliberate")),
+            for: id
+        )
+        defer { DatabaseManager.shared.userRequestedDisconnects.remove(id) }
+
+        await DatabaseManager.shared.disconnectSession(id, origin: .userRequested)
+
+        #expect(DatabaseManager.shared.wasDisconnectedByUser(id))
+    }
+
+    /// Quitting and closing a window both run through `disconnectSession`. Recording those as
+    /// deliberate would drop every connection from "Reopen Last Session", because a deliberate
+    /// disconnect is the one unavailable state that does not retain restore intent.
+    @Test("An app-managed disconnect is not recorded as deliberate")
+    func appManagedDisconnectIsNotRecorded() async {
+        let id = UUID()
+        DatabaseManager.shared.injectSession(
+            ConnectionSession(connection: TestFixtures.makeConnection(id: id, name: "Closed")),
+            for: id
+        )
+        defer { DatabaseManager.shared.userRequestedDisconnects.remove(id) }
+
+        await DatabaseManager.shared.disconnectSession(id)
+
+        #expect(!DatabaseManager.shared.wasDisconnectedByUser(id))
+    }
+
+    @Test("Disconnecting removes the session entry")
+    func disconnectRemovesSessionEntry() async {
+        let id = UUID()
+        DatabaseManager.shared.injectSession(
+            ConnectionSession(connection: TestFixtures.makeConnection(id: id, name: "Gone")),
+            for: id
+        )
+        defer { DatabaseManager.shared.userRequestedDisconnects.remove(id) }
+
+        await DatabaseManager.shared.disconnectSession(id, origin: .userRequested)
+
+        #expect(DatabaseManager.shared.activeSessions[id] == nil)
+    }
+}

--- a/TableProTests/Core/Services/ConnectionMenuPolicyTests.swift
+++ b/TableProTests/Core/Services/ConnectionMenuPolicyTests.swift
@@ -1,0 +1,26 @@
+//
+//  ConnectionMenuPolicyTests.swift
+//  TableProTests
+//
+//  A context menu shows only what applies to the row it was opened on, so Disconnect is absent on a
+//  workspace with no live session rather than present and dimmed.
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Connection menu policy")
+struct ConnectionMenuPolicyTests {
+    @Test("Disconnect is offered for a live session")
+    func offeredWhenConnected() {
+        #expect(ConnectionMenuPolicy.showsDisconnect(status: .connected))
+    }
+
+    @Test("Disconnect is hidden for every state without a live session")
+    func hiddenWithoutLiveSession() {
+        #expect(!ConnectionMenuPolicy.showsDisconnect(status: .disconnected))
+        #expect(!ConnectionMenuPolicy.showsDisconnect(status: .connecting))
+        #expect(!ConnectionMenuPolicy.showsDisconnect(status: .error("refused")))
+    }
+}

--- a/TableProTests/Core/Services/Infrastructure/ConnectionWindowPhaseMachineTests.swift
+++ b/TableProTests/Core/Services/Infrastructure/ConnectionWindowPhaseMachineTests.swift
@@ -191,4 +191,48 @@ struct ConnectionWindowPhaseMachineTests {
         #expect(!ConnectionWindowPhaseMachine.allowsActivationConnect(phase: .connected))
         #expect(!ConnectionWindowPhaseMachine.allowsActivationConnect(phase: .closing))
     }
+
+    @Test("A session the user ended is not reported as a lost connection")
+    func deliberateSessionLossIsDistinctFromLosingOne() {
+        let deliberate = ConnectionWindowPhaseMachine.onSessionChanged(
+            phase: .connected,
+            session: ConnectionSessionSnapshot(exists: false, hasDriver: false, wasDisconnectedByUser: true),
+            ownsAttempt: false
+        )
+        let involuntary = ConnectionWindowPhaseMachine.onSessionChanged(
+            phase: .connected,
+            session: .absent,
+            ownsAttempt: false
+        )
+
+        #expect(deliberate == .unavailable(.disconnectedByUser))
+        #expect(involuntary == .unavailable(.disconnected(nil)))
+    }
+
+    @Test("A window the user disconnected is not reopened next launch")
+    func deliberateDisconnectDropsRestoreIntent() {
+        #expect(!ConnectionWindowPhaseMachine.retainsRestoreIntent(phase: .unavailable(.disconnectedByUser)))
+    }
+
+    /// Clicking back into the window must not undo the disconnect, but Reconnect has to work, which
+    /// is why the automatic and the manual connect answer this differently.
+    @Test("A deliberate disconnect blocks the automatic connect but not Reconnect")
+    func deliberateDisconnectConnectEligibility() {
+        #expect(!ConnectionWindowPhaseMachine.allowsActivationConnect(phase: .unavailable(.disconnectedByUser)))
+        #expect(ConnectionWindowPhaseMachine.allowsManualConnect(phase: .unavailable(.disconnectedByUser)))
+    }
+
+    @Test("Reconnect is offered wherever a window has no session, except a missing plugin")
+    func manualConnectEligibility() {
+        #expect(ConnectionWindowPhaseMachine.allowsManualConnect(phase: .idle))
+        #expect(ConnectionWindowPhaseMachine.allowsManualConnect(phase: .unavailable(.notConnected)))
+        #expect(ConnectionWindowPhaseMachine.allowsManualConnect(phase: .unavailable(.cancelled)))
+        #expect(ConnectionWindowPhaseMachine.allowsManualConnect(phase: .unavailable(.disconnected(nil))))
+        #expect(ConnectionWindowPhaseMachine.allowsManualConnect(phase: .unavailable(.failed(Self.failure))))
+
+        #expect(!ConnectionWindowPhaseMachine.allowsManualConnect(phase: .unavailable(.pluginMissing(Self.failure))))
+        #expect(!ConnectionWindowPhaseMachine.allowsManualConnect(phase: .connecting))
+        #expect(!ConnectionWindowPhaseMachine.allowsManualConnect(phase: .connected))
+        #expect(!ConnectionWindowPhaseMachine.allowsManualConnect(phase: .closing))
+    }
 }

--- a/TableProTests/Core/Services/TabPersistenceClearGuardTests.swift
+++ b/TableProTests/Core/Services/TabPersistenceClearGuardTests.swift
@@ -1,0 +1,46 @@
+//
+//  TabPersistenceClearGuardTests.swift
+//  TableProTests
+//
+//  A window left over from a disconnect holds no tabs, and its empty tab list is not the user saying
+//  they closed everything. Reading it that way deleted the tabs the disconnect had just saved.
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("Tab persistence clear guard", .serialized)
+@MainActor
+struct TabPersistenceClearGuardTests {
+    @Test("A coordinator that never held a tab does not clear saved state")
+    func neverHeldTabsWithholdsClear() {
+        let persistence = TabPersistenceCoordinator(connectionId: UUID())
+
+        #expect(!persistence.hasObservedTabs)
+
+        persistence.saveOrClearAggregatedSync()
+
+        #expect(!persistence.hasObservedTabs)
+    }
+
+    @Test("Saving a non-empty tab set earns the right to clear later")
+    func savingTabsMarksThemObserved() {
+        let persistence = TabPersistenceCoordinator(connectionId: UUID())
+        let tab = QueryTab(id: UUID(), title: "Scratch", query: "SELECT 1", tabType: .table)
+
+        persistence.saveNowSync(tabs: [tab], selectedTabId: tab.id)
+
+        #expect(persistence.hasObservedTabs)
+    }
+
+    @Test("An empty save neither writes nor earns the right to clear")
+    func emptySaveIsInert() {
+        let persistence = TabPersistenceCoordinator(connectionId: UUID())
+
+        persistence.saveNowSync(tabs: [], selectedTabId: nil)
+
+        #expect(!persistence.hasObservedTabs)
+    }
+}

--- a/TableProTests/Core/Services/WindowLifecycleMonitorRegistrationTests.swift
+++ b/TableProTests/Core/Services/WindowLifecycleMonitorRegistrationTests.swift
@@ -1,0 +1,66 @@
+//
+//  WindowLifecycleMonitorRegistrationTests.swift
+//  TableProTests
+//
+//  A window id belongs to the content mounted in the window, so rebuilding that content registers the
+//  same NSWindow again under a new id. Keeping both entries made one window count as two, which is
+//  what stopped a reconnected window from restoring its tabs: the restore stands down on a sibling.
+//
+
+import AppKit
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Window lifecycle monitor registration", .serialized)
+@MainActor
+struct WindowLifecycleMonitorRegistrationTests {
+    private func makeWindow() -> NSWindow {
+        NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: true
+        )
+    }
+
+    @Test("Re-registering one window under a new id leaves it a single window")
+    func rereigsteringSupersedesTheOldEntry() {
+        let monitor = WindowLifecycleMonitor.shared
+        let connectionId = UUID()
+        let window = makeWindow()
+        let firstId = UUID()
+        let secondId = UUID()
+        defer {
+            monitor.unregisterWindow(for: firstId)
+            monitor.unregisterWindow(for: secondId)
+        }
+
+        monitor.register(window: window, connectionId: connectionId, windowId: firstId)
+        monitor.register(window: window, connectionId: connectionId, windowId: secondId)
+
+        #expect(!monitor.hasOtherWindows(for: connectionId, excluding: secondId))
+        #expect(monitor.window(for: secondId) === window)
+        #expect(monitor.window(for: firstId) == nil)
+    }
+
+    @Test("Two genuine windows on one connection still see each other")
+    func distinctWindowsRemainSiblings() {
+        let monitor = WindowLifecycleMonitor.shared
+        let connectionId = UUID()
+        let first = makeWindow()
+        let second = makeWindow()
+        let firstId = UUID()
+        let secondId = UUID()
+        defer {
+            monitor.unregisterWindow(for: firstId)
+            monitor.unregisterWindow(for: secondId)
+        }
+
+        monitor.register(window: first, connectionId: connectionId, windowId: firstId)
+        monitor.register(window: second, connectionId: connectionId, windowId: secondId)
+
+        #expect(monitor.hasOtherWindows(for: connectionId, excluding: secondId))
+        #expect(monitor.hasOtherWindows(for: connectionId, excluding: firstId))
+    }
+}

--- a/docs/features/tabs.mdx
+++ b/docs/features/tabs.mdx
@@ -74,6 +74,16 @@ Each connection gets its own window with its own tab bar, so a tab bar only ever
 
 To move between open connections, use the [workspace rail](/features/workspace-rail) on the leading edge of the window.
 
+### Disconnecting
+
+**Connection > Disconnect** ends the session without closing the window. The window shows a Reconnect screen in place of its tabs, and the tabs are saved before the session ends. Use **Connection > Reconnect**, or the Reconnect button on the screen itself.
+
+A connection with one window open restores its tabs as soon as you reconnect. A connection with several windows open restores them the next time you open the connection instead.
+
+Disconnecting asks first only when a window has unsaved changes or a query still running. It applies to the whole connection, so every window and workspace on it shows the same Reconnect screen. Nothing reconnects on its own afterwards: a connection you disconnected is not reopened at the next launch, and clicking back into its window leaves it disconnected until you ask.
+
+You can also disconnect by right-clicking a workspace in the [workspace rail](/features/workspace-rail), or a connection in the connection list.
+
 ## Database Binding
 
 A tab is bound to the connection, database, and schema it was opened on, fixed for the life of the tab. Every query, refresh, filter, sort, structure read, and structure save the tab performs uses that binding, not whatever the sidebar shows at the time.

--- a/docs/features/workspace-rail.mdx
+++ b/docs/features/workspace-rail.mdx
@@ -54,6 +54,10 @@ The rail takes the keyboard too. Click into it and the arrow keys move the highl
 
 Right-click a workspace and choose **Close Workspace** to close every tab in it. A window holding a tab in another database stays open, because that tab is not part of the workspace you are closing. Unsaved work is confirmed first, the same as closing a window.
 
+## Disconnecting
+
+Right-click a workspace and choose **Disconnect** to end its connection. The item only appears while the connection is live. Unlike Close Workspace, this covers every window and workspace of that connection, and no window closes: each one shows a Reconnect screen in place of its tabs, with the tabs saved before the session ends. See [disconnecting](/features/tabs#disconnecting).
+
 ## Reordering
 
 Drag entries to arrange them. The order is shared by every window and remembered across launches.


### PR DESCRIPTION
Adds a way to disconnect an active connection, which the app had no UI for at all, and fixes four bugs found while tracing what a disconnect does to an open window. Two of them lose the user's tabs.

From user feedback: "Maybe I didn't find where, but a way to disconnect an active DB connection." They had not missed it. `DatabaseManager.disconnectSession(_:)` did all the real work already, and the only callers were window-close teardown, the MCP `disconnect` tool, and Reset Sample Database. The only way to end a session was to close the window, which took its tabs with it.

## Where it lives

A top-level `Connection` menu with `Disconnect` and `Reconnect`, plus the same Disconnect on the workspace rail's context menu and on a connection's row in the connection list. All three go through one `ConnectionDisconnectAction`, so the confirmation exists once and reads the same everywhere.

The menu bar is the surface people look at first, and the HIG is explicit that leaving a command out of it "risks making them difficult for everyone to find". The File menu was the other candidate and was rejected on the HIG's own description of it: commands that manage the files an app supports, with no slot for ending a session with a server. Apple renames that File slot to `Connection` in Screen Sharing and to `Shell` in Terminal, but neither app handles files and TablePro does, so the app-specific menu between View and Window is the sanctioned home. `CommandMenu` inserts exactly there, and declaring it before `Query` satisfies the HIG's most-general-first ordering.

Both items stay visible with one enabled, per "if a menu bar item isn't actionable, disable the action instead of hiding it". The rail does the opposite and omits Disconnect on a row with no live session, because a context menu "displays only the actions that are relevant". That split is the whole reason the enable rule is a separate pure function, `ConnectionMenuPolicy`, instead of a condition inline in the view controller: the rail's menu had no test coverage at all.

Neither command takes a keyboard shortcut. Cmd+E is what Finder uses for Eject, but the HIG reserves it for "use the selection for a find operation" and only permits redefining a standard shortcut when "its action doesn't make sense in your experience". TablePro has a full editor with Find, so it does not qualify. Shift+Cmd+Q is the system Log Out. TablePlus, the closest benchmark, ships no shortcut for Disconnect either.

## What a disconnect does

The window stays open. Every competitor surveyed agrees on that, and TablePlus shipped it as a bug fix ("TablePlus no longer close workspace after disconnected"). The window lands on the `ContentUnavailableView` pane the app already has, with Reconnect, and no error text: nothing failed, so it does not read like a failure.

That needed a sixth `ConnectionUnavailableReason`, `.disconnectedByUser`, rather than a flag on `.disconnected`. It answers two questions differently and the compiler makes every switch answer them. It drops restore intent, so a connection you disconnected is not replayed at the next launch, which puts a deliberate disconnect alongside a cancelled connect under the rule already written down: a database that was down is not a user who gave up, but a user who disconnected is. It also blocks the activation connect, so clicking back into the window cannot silently undo the disconnect. Reconnect still has to work from that same phase, which is a separate question, so `allowsManualConnect` now answers it instead of `allowsActivationConnect` doing double duty.

Intent reaches the phase machine as a defaulted `origin:` parameter on `disconnectSession`, not a flag set inside it. Window close and quit run through the same primitive, and recording those as deliberate would drop every connection out of "Reopen Last Session".

There is no confirmation unless a window of that connection has unsaved changes or a query running. The HIG asks for an alert when data loss is "unexpected and irreversible" and against one when "data loss is the expected result", and none of TablePlus, DataGrip, Postico, Sequel Ace or Beekeeper prompt on disconnect. When there is something to lose it is a two-way sheet, shaped like Terminal's "Do you want to terminate running processes in this window?", which also fires only when there is work in flight. Save is not offered because `saveAndClose` is built around the window going away; Cancel is the way to save first. The check spans every window of the connection, since the rail and the connection list can both fire for a connection whose windows are all in the background.

## Bugs fixed

Each of these predates this change, and each is reachable from the new command.

- `MainContentCoordinator.teardown()` cleared `tabManager.tabs` and the pending edits with no save, and only the window-close path saved on its way out. Ending a session while its window stayed open therefore discarded that window's tab state, including through the MCP `disconnect` tool and Reset Sample Database. Every disconnect now writes the tabs first, through an injected `SessionTabStatePersisting` so `DatabaseManager` still cannot see the view layer. It uses a new `saveAggregatedSync()`: synchronous like the close path, because the coordinators holding those tabs are torn down immediately after, and never-clearing like `saveAggregated()`, because a disconnect is not the user closing their tabs. `saveAggregated()` alone could not serve, since it defers through `scheduleSave`, which cancels the previous task and can drop the write.

- Reconnecting never restored anything, not even a single window. `WindowLifecycleMonitor.unregisterWindow(for:)` has no callers, and a window's id belongs to the SwiftUI content mounted inside it, so rebuilding that content (which a reconnect does) registered the same `NSWindow` a second time under a new id. `hasOtherWindows` was then permanently true and the restore that repopulates the tabs stood down every time. `register` now supersedes any entry for the same window. This was also giving `handleWindowClose` a duplicate to miss.

- Closing a window that never loaded any tabs deleted the connection's saved tabs, because `saveOrClearAggregatedSync()` read the empty aggregate as "the user closed everything". A reconnected window is exactly that case, so a disconnect followed by a reconnect and a window close erased the state the disconnect had just written. Only a window that has actually seen a tab can clear now.

- A native tab window that AppKit joined but never displayed keeps whatever phase it was born with, because `installObservers()` runs from `viewWillAppear`. Its frozen `.connected` was enough to vote a deliberately disconnected connection back into `LastOpenConnections.json`. `SessionRecoveryTracker` now excludes a connection the user ended, whatever its windows still report.

Two smaller ones from the same pass: the rail's confirmation sheet anchored to the connection's most recent window, which can be behind the one the user is looking at or miniaturized, and now anchors to the rail's own window; and `disconnectSession` gained an in-flight guard so two overlapping disconnects cannot have the second one finish its teardown against a session that has since reconnected.

## Known limitation

A connection with several windows open still comes back empty on an in-place reconnect. Restore is a "one window fans out into N" operation, so with siblings present every window correctly stands down and none of them claims it. The tabs are safe on disk and come back the next time the connection is opened, and `docs/features/tabs.mdx` says so rather than promising otherwise. Fixing it means teaching the restore to hand tabs to windows that already exist instead of opening new ones, which is a change of its own shape.

## Testing

Build succeeds. `swiftlint lint --strict` clean across 1294 files. 71 tests pass across 11 suites, including the pre-existing persistence, session, window-title and rail suites.

- `DatabaseManagerDisconnectTests` is new. Its first case is the regression test for the tab loss: a spy persister records whether the session still existed when it was asked, so the save cannot drift back to after the teardown. It also pins that only a user-requested origin records intent, which is what keeps quit and window close out of it.
- `WindowLifecycleMonitorRegistrationTests` is new and covers both directions: one window registered twice is one window, two genuine windows on a connection still see each other.
- `TabPersistenceClearGuardTests` is new and covers the clear guard, including that an empty save neither writes nor earns the right to clear.
- `ConnectionMenuPolicyTests` is new and covers the rail's hide-not-dim rule, which had no coverage.
- `ConnectionWindowPhaseMachineTests` gains four cases: a deliberate session loss is distinct from losing one, it drops restore intent, it blocks the activation connect while still allowing Reconnect, and Reconnect is offered from every sessionless phase except a missing plugin.

No `TableProUITests` coverage. The flow needs a native `NSAlert` sheet driven across several connection windows, and the assertion that matters ("the window is still open and its tabs came back") is about window-tab and disk state rather than anything the UI test harness reads today. The parts that carry the logic are pure functions with unit tests instead.
