### PR TITLE
fix(coordinator): carry a cancelled navigation into the schema column fetch it started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Clicking quickly through the sidebar no longer keeps loading column details for tables you have already left. Each abandoned table held the connection for another 75-90ms, so every table clicked after it waited that much longer. (#2058)
 - Clicking a table while another one is still loading now loads the table you clicked. The tab used to fill with the previous table's rows under the new table's name, and the table you clicked never loaded at all.
 - Stop no longer aborts a save, a discard, or a schema change. It cancels reads only, so a write can no longer be cut off half way.
 - Ending a session while its window stayed open could lose that window's tabs. Tabs are now written to disk before the session goes away, which also covers the disconnect tool used by AI clients and Reset Sample Database.

--- a/TablePro/Core/Services/Query/SchemaColumnStore.swift
+++ b/TablePro/Core/Services/Query/SchemaColumnStore.swift
@@ -4,8 +4,16 @@ import Foundation
 final class SchemaColumnStore {
     typealias Entry = (columns: [String], primaryKeys: [String])
 
+    /// One fetch shared by every caller asking for the same key while it is in flight. It is only
+    /// cancelled once the last of them has given up, because cancelling on the first departure
+    /// would abandon a fetch the others are still waiting on.
+    private struct Load {
+        let task: Task<Void, Never>
+        var liveWaiters: Int
+    }
+
     private var entries: [String: Entry] = [:]
-    private var loads: [String: Task<Void, Never>] = [:]
+    private var loads: [String: Load] = [:]
     private var generation = 0
 
     func cached(_ key: String) -> Entry? {
@@ -16,30 +24,67 @@ final class SchemaColumnStore {
         entries[key] = entry
     }
 
+    /// Carries the caller's cancellation into the fetch. The shared task is unstructured, so it
+    /// inherits nothing from whoever awaits it: without this, a navigation the user has already
+    /// clicked past still runs its metadata query to the end, holding the serial metadata
+    /// connection while every table behind it waits.
+    ///
+    /// A cancelled caller that is not the last one waiting stays suspended until the fetch its
+    /// peers still want has finished. That costs nothing, because it discards the result as soon
+    /// as it resumes, and the alternative is taking the fetch away from a caller that needs it.
     func load(_ key: String, fetch: @escaping () async -> Entry?) async {
         if entries[key] != nil { return }
-        if let inFlight = loads[key] {
-            await inFlight.value
-            return
+
+        let task = joinLoad(key, fetch: fetch)
+        let startedGeneration = generation
+
+        await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            Task { @MainActor [weak self] in self?.withdrawWaiter(from: key) }
         }
 
-        let task = Task {
-            if let entry = await fetch() {
-                self.entries[key] = entry
-            }
-        }
-        loads[key] = task
-        let startedGeneration = generation
-        await task.value
-        if generation == startedGeneration {
-            loads[key] = nil
-        }
+        guard generation == startedGeneration else { return }
+        loads.removeValue(forKey: key)
     }
 
     func removeAll() {
         generation += 1
-        for task in loads.values { task.cancel() }
+        for load in loads.values { load.task.cancel() }
         loads.removeAll()
         entries.removeAll()
+    }
+
+    /// A cancelled load is never joined. Between the last waiter leaving and its `load` clearing
+    /// the entry there is a window where the task is already cancelled, and a caller that adopted
+    /// it would wait for a fetch that is never going to produce anything. Clicking back to a table
+    /// just after clicking away from it lands exactly there.
+    private func joinLoad(_ key: String, fetch: @escaping () async -> Entry?) -> Task<Void, Never> {
+        if var existing = loads[key], !existing.task.isCancelled {
+            existing.liveWaiters += 1
+            loads[key] = existing
+            return existing.task
+        }
+
+        let task = Task { [weak self] in
+            guard let entry = await fetch() else { return }
+            self?.entries[key] = entry
+        }
+        loads[key] = Load(task: task, liveWaiters: 1)
+        return task
+    }
+
+    #if DEBUG
+    internal func waiterCount(for key: String) -> Int {
+        loads[key]?.liveWaiters ?? 0
+    }
+    #endif
+
+    private func withdrawWaiter(from key: String) {
+        guard var load = loads[key] else { return }
+        load.liveWaiters -= 1
+        loads[key] = load
+        guard load.liveWaiters <= 0 else { return }
+        load.task.cancel()
     }
 }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ColumnFetchScope.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ColumnFetchScope.swift
@@ -35,14 +35,19 @@ extension MainContentCoordinator {
         }
     }
 
+    /// Re-resolves the tab by id after the await. An index taken before it points at whatever tab
+    /// occupies that slot now, which after a close or a reorder is a different tab entirely.
     @discardableResult
     func rebuildSelectedTableColumnScopedQuery() async -> Bool {
-        guard let (tab, tabIndex) = tabManager.selectedTabAndIndex,
+        guard let tab = tabManager.selectedTab,
               tab.tabType == .table,
               let tableName = tab.tableContext.tableName else { return false }
+        let tabId = tab.id
         await loadSchemaColumns(for: tableName, scope: scope(for: tab))
-        guard !Task.isCancelled, tabIndex < tabManager.tabs.count else { return false }
-        filterCoordinator.rebuildTableQuery(at: tabIndex)
+        guard !Task.isCancelled,
+              let index = tabManager.tabs.firstIndex(where: { $0.id == tabId }),
+              tabManager.tabs[index].tableContext.tableName == tableName else { return false }
+        filterCoordinator.rebuildTableQuery(at: index)
         return true
     }
 
@@ -60,6 +65,7 @@ extension MainContentCoordinator {
                 }
                 return (columns.map(\.name), columns.filter(\.isPrimaryKey).map(\.name))
             } catch {
+                guard !DatabaseCancellationDiagnosis.isCancellation(error) else { return nil }
                 columnScopeLog.error("loadSchemaColumns: fetchColumns failed for table=\(tableName, privacy: .public): \(error.localizedDescription, privacy: .public)")
                 return nil
             }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TableFirstLoad.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TableFirstLoad.swift
@@ -48,6 +48,7 @@ extension MainContentCoordinator {
 
         let tracer = TableLoadTracer.shared
         let token = tracer.activeToken(for: tabId)
+        let schemaName = tab.tableContext.schemaName
         if let token { tracer.stage(.schemaColumnsBegin, token: token) }
         await loadSchemaColumns(for: tableName, scope: scope(for: tab))
         if let token { tracer.stage(.schemaColumnsEnd, token: token) }
@@ -55,7 +56,8 @@ extension MainContentCoordinator {
         guard !Task.isCancelled,
               tabManager.selectedTabId == tabId,
               let index = tabManager.tabs.firstIndex(where: { $0.id == tabId }),
-              tabManager.tabs[index].tableContext.tableName == tableName else { return false }
+              tabManager.tabs[index].tableContext.tableName == tableName,
+              tabManager.tabs[index].tableContext.schemaName == schemaName else { return false }
 
         let restoreApplied = applyPendingRestoredViewState(at: index)
         let sortApplied = restoreApplied ? false : applyResolvedDefaultSort(at: index, hint: hint)

--- a/TableProTests/Core/Services/Query/SchemaColumnStoreCancellationTests.swift
+++ b/TableProTests/Core/Services/Query/SchemaColumnStoreCancellationTests.swift
@@ -1,0 +1,184 @@
+//
+//  SchemaColumnStoreCancellationTests.swift
+//  TableProTests
+//
+//  The shared fetch is an unstructured task, so it inherits nothing from whoever awaits it.
+//  Clicking past a table used to leave its metadata query running to the end, holding the serial
+//  metadata connection while every table behind it queued (#2058).
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Schema column store cancellation", .serialized)
+@MainActor
+struct SchemaColumnStoreCancellationTests {
+    @Test("Cancelling the only waiter cancels the fetch")
+    func soleWaiterCancellationStopsTheFetch() async {
+        let store = SchemaColumnStore()
+        let probe = FetchProbe()
+
+        let waiter = Task { await store.load("users", fetch: probe.fetch) }
+        #expect(await Self.wait(until: { probe.startCount == 1 }))
+
+        waiter.cancel()
+        await waiter.value
+
+        #expect(probe.cancelCount == 1)
+        #expect(probe.finishCount == 0)
+    }
+
+    /// Two tabs opening the same table share one fetch. The first one to be clicked past must not
+    /// take the result away from the one still waiting for it.
+    ///
+    /// The cancelled waiter stays suspended until the fetch it shares finishes. Nothing can be
+    /// done about that without abandoning the caller mid-load, and it costs nothing: the caller
+    /// discards the result the moment it resumes. Releasing the probe is therefore what lets the
+    /// cancelled waiter return, not the cancel.
+    @Test("A second waiter keeps the fetch alive when the first is cancelled")
+    func remainingWaiterKeepsTheFetchAlive() async {
+        let store = SchemaColumnStore()
+        let probe = FetchProbe()
+
+        let first = Task { await store.load("users", fetch: probe.fetch) }
+        #expect(await Self.wait(until: { probe.startCount == 1 }))
+        let second = Task { await store.load("users", fetch: probe.fetch) }
+        #expect(await Self.wait(until: { store.waiterCount(for: "users") == 2 }))
+
+        first.cancel()
+        #expect(await Self.wait(until: { store.waiterCount(for: "users") == 1 }))
+        #expect(probe.cancelCount == 0)
+
+        probe.release()
+        await first.value
+        await second.value
+
+        #expect(probe.finishCount == 1)
+        #expect(store.cached("users")?.columns == ["id", "name"])
+    }
+
+    /// Clicking away from a table and straight back to it. The abandoned fetch is cancelled but
+    /// its entry can still be in the map, and adopting it would mean waiting on a fetch that is
+    /// never going to produce anything.
+    @Test("A caller arriving after a cancel starts a fresh fetch")
+    func callerAfterCancellationStartsAFreshFetch() async {
+        let store = SchemaColumnStore()
+        let probe = FetchProbe()
+
+        let abandoned = Task { await store.load("users", fetch: probe.fetch) }
+        #expect(await Self.wait(until: { probe.startCount == 1 }))
+        abandoned.cancel()
+        await abandoned.value
+
+        probe.release()
+        await store.load("users", fetch: probe.fetch)
+
+        #expect(probe.startCount == 2)
+        #expect(store.cached("users")?.columns == ["id", "name"])
+    }
+
+    @Test("Callers for the same key share one fetch")
+    func concurrentCallersShareOneFetch() async {
+        let store = SchemaColumnStore()
+        let probe = FetchProbe()
+
+        let first = Task { await store.load("users", fetch: probe.fetch) }
+        let second = Task { await store.load("users", fetch: probe.fetch) }
+        #expect(await Self.wait(until: { store.waiterCount(for: "users") == 2 }))
+
+        probe.release()
+        await first.value
+        await second.value
+
+        #expect(probe.startCount == 1)
+    }
+
+    @Test("A cached entry is served without fetching again")
+    func cachedEntrySkipsTheFetch() async {
+        let store = SchemaColumnStore()
+        let probe = FetchProbe()
+        probe.release()
+
+        await store.load("users", fetch: probe.fetch)
+        await store.load("users", fetch: probe.fetch)
+
+        #expect(probe.startCount == 1)
+        #expect(store.cached("users")?.primaryKeys == ["id"])
+    }
+
+    @Test("Clearing the store cancels an in-flight fetch")
+    func removeAllCancelsInFlightFetches() async {
+        let store = SchemaColumnStore()
+        let probe = FetchProbe()
+
+        let waiter = Task { await store.load("users", fetch: probe.fetch) }
+        #expect(await Self.wait(until: { probe.startCount == 1 }))
+
+        store.removeAll()
+        await waiter.value
+
+        #expect(probe.cancelCount == 1)
+        #expect(store.cached("users") == nil)
+    }
+
+    /// A fetch that fails leaves no entry, so the next caller is free to try again rather than
+    /// being served a hole.
+    @Test("A failed fetch caches nothing and the next caller retries")
+    func failedFetchLetsTheNextCallerRetry() async {
+        let store = SchemaColumnStore()
+        let probe = FetchProbe()
+        probe.release()
+        probe.result = nil
+
+        await store.load("users", fetch: probe.fetch)
+        #expect(store.cached("users") == nil)
+
+        probe.result = (["id"], ["id"])
+        await store.load("users", fetch: probe.fetch)
+
+        #expect(probe.startCount == 2)
+        #expect(store.cached("users")?.columns == ["id"])
+    }
+
+    private static func wait(
+        until condition: () -> Bool,
+        within timeout: Duration = .seconds(2)
+    ) async -> Bool {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if condition() { return true }
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        return false
+    }
+}
+
+/// Hangs until released or cancelled, so a test can hold a fetch open and decide how it ends.
+@MainActor
+private final class FetchProbe {
+    private(set) var startCount = 0
+    private(set) var cancelCount = 0
+    private(set) var finishCount = 0
+    var result: SchemaColumnStore.Entry? = (["id", "name"], ["id"])
+
+    private var isReleased = false
+
+    func release() {
+        isReleased = true
+    }
+
+    func fetch() async -> SchemaColumnStore.Entry? {
+        startCount += 1
+        while !isReleased, !Task.isCancelled {
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        guard !Task.isCancelled else {
+            cancelCount += 1
+            return nil
+        }
+        finishCount += 1
+        return result
+    }
+}


### PR DESCRIPTION
Closes #2058.

Clicking through the sidebar quickly burned 75-90ms per navigation on schema-column loading that was thrown away. From the trace in the issue, ten consecutive clicks each reached `schemaColumnsEnd` well after being superseded, and only the eleventh displayed anything.

## Why cancelling did nothing

`cancelTableLoad` cancels the wrapper task, and `prepareTableTabFirstLoad` checks `Task.isCancelled` afterwards, so the result was correctly discarded. The work still ran to completion, and the reason is one line in `SchemaColumnStore`:

```swift
let task = Task { if let entry = await fetch() { self.entries[key] = entry } }
loads[key] = task
await task.value
```

That inner task is unstructured, so it inherits nothing from whoever awaits it. Cancelling the caller could not reach the fetch at all. Every `Task.checkCancellation()` further down, in `MetadataConnectionPool.runSerially` and `withPinnedSessionDriver`, was checking a task that was never cancelled.

This is not only wasted server work. Both of those paths are serial, so an abandoned fetch holds the metadata connection and every table clicked after it queues behind it. That is what makes ten fast clicks feel progressively slower rather than merely wasteful.

## What this changes

`SchemaColumnStore.load` now wraps its wait in `withTaskCancellationHandler` and carries the caller's cancellation into the shared fetch.

The fetch is shared by every caller asking for the same key, so it cannot simply be cancelled when one of them leaves. The store counts live waiters and only cancels once the last has withdrawn. Two tabs opening the same table still share one fetch, and clicking past one of them does not take the result away from the other.

A cancelled load is also never joined. Between the last waiter leaving and its `load` clearing the entry there is a window where the task is cancelled but still in the map; a caller adopting it would wait on a fetch that will never produce anything. Clicking away from a table and straight back to it lands exactly there.

Two related fixes in the same area:

- A cancellation is no longer logged as a fetch failure. `loadSchemaColumns` logged every `catch` at error level, so normal navigation would have filled the log with errors once cancellation started working.
- `rebuildSelectedTableColumnScopedQuery` captured a tab index before its await and rebuilt at that index afterwards, with only a bounds check. After a tab close or reorder that index is a different tab. It now re-resolves by tab id and re-checks the table name, matching the guard `prepareTableTabFirstLoad` already used.
- That guard now also compares the schema. A retarget to a same-named table in another schema used to pass it.

## Tests

`SchemaColumnStoreCancellationTests` covers the sole waiter cancelling the fetch, a second waiter keeping it alive, a caller arriving after a cancel starting fresh, coalescing, the cached path, `removeAll`, and a failed fetch leaving the next caller free to retry. The store takes its fetch as a closure, so all of it runs without a database.

`swiftlint lint --strict` reports 0 violations in 1299 files.

## Not fixed here

Cancellation is cooperative, so a fetch already blocked inside the driver still runs to completion. The win is on queued fetches, which is what the measured case is: clicks 5 through 13 in the issue's trace were all waiting behind the serial gate. See also #2061.
