### PR TITLE
refactor(tabs): strip the QueryTab mirror off TabSession so a retarget cannot leave it stale

### DIFF
--- a/TablePro/Core/Coordinators/FilterCoordinator.swift
+++ b/TablePro/Core/Coordinators/FilterCoordinator.swift
@@ -4,10 +4,7 @@
 //
 
 import Foundation
-import os
 import SwiftUI
-
-private let filterStateLog = Logger(subsystem: "com.TablePro", category: "FilterState")
 
 @MainActor @Observable
 final class FilterCoordinator {
@@ -639,14 +636,5 @@ final class FilterCoordinator {
         var newState = parent.tabManager.tabs[index].filterState
         mutate(&newState)
         parent.tabManager.mutate(at: index) { $0.filterState = newState }
-        let tabId = parent.tabManager.tabs[index].id
-        if let session = parent.tabSessionRegistry.session(for: tabId) {
-            session.filterState = newState
-        } else {
-            filterStateLog.error(
-                "TabSession missing for selected tab \(tabId, privacy: .public); QueryTab updated but session mirror skipped"
-            )
-            assertionFailure("TabSession missing for selected tab: registry sync regression")
-        }
     }
 }

--- a/TablePro/Models/Query/QueryTabManager.swift
+++ b/TablePro/Models/Query/QueryTabManager.swift
@@ -45,7 +45,7 @@ final class QueryTabManager {
     func bindTabSessionRegistry(_ registry: TabSessionRegistry) {
         tabSessionRegistry = registry
         for tab in tabs where registry.session(for: tab.id) == nil {
-            registry.register(TabSession(queryTab: tab))
+            registry.register(TabSession(id: tab.id))
         }
     }
 
@@ -68,7 +68,7 @@ final class QueryTabManager {
         }
         for addedTab in newTabs where !oldIds.contains(addedTab.id) {
             if registry.session(for: addedTab.id) == nil {
-                registry.register(TabSession(queryTab: addedTab))
+                registry.register(TabSession(id: addedTab.id))
             }
         }
     }

--- a/TablePro/Models/Query/TabSession.swift
+++ b/TablePro/Models/Query/TabSession.swift
@@ -2,79 +2,26 @@
 //  TabSession.swift
 //  TablePro
 //
-//  Foundation type for the tab/window subsystem rewrite.
-//  See docs/architecture/tab-subsystem-rewrite.md for the full design.
-//
 
 import Foundation
 import Observation
 
-/// Per-tab state container for the editor tab/window subsystem.
+/// The row buffer for one tab, and nothing else.
 ///
-/// `QueryTab` (struct) is the persistence shape and the canonical source of
-/// truth for per-tab state. `TabSession` (this class) is the @Observable
-/// reference-type mirror that SwiftUI views read from for fine-grained
-/// updates. They are kept in sync by the coordinator helpers in
-/// `MainContentCoordinator+FilterState`, `+ColumnVisibility`, and
-/// `QueryTabManager.tabs.didSet` (which registers a session on tab insert
-/// and unregisters on remove).
+/// `QueryTab` is the whole of a tab's state: title, table context, filters, sort, pagination,
+/// everything that is persisted. This class holds only what `QueryTab` deliberately does not: the
+/// fetched rows. They live here because `QueryTab` is a value type inside an observed array, so
+/// carrying tens of thousands of rows in it would copy them on every unrelated edit and re-render
+/// the whole editor.
 ///
-/// **Invariant**: every `tabManager.tabs[index]` has exactly one `TabSession`
-/// in `TabSessionRegistry`, keyed by the same `id`. Mutations to per-tab
-/// state must go through the coordinator helpers — direct writes to
-/// `tabManager.tabs[index].field = …` will desync the session mirror until
-/// the next coordinator-driven mutation re-syncs.
-///
-/// Class (not struct) because `@Observable` requires a reference type;
-/// SwiftUI's Observation framework tracks property accesses on observed
-/// instances. Session-only fields (`tableRows`, `isEvicted`) are not part
-/// of the `QueryTab` ↔ `TabSession` mirror because they aren't persisted.
+/// It used to mirror most of `QueryTab` as well, on the way to an architecture where views read
+/// the reference type instead of the struct. That migration never happened. Nothing read the
+/// mirrored copies, `QueryTabManager` only reconciled them on tab insert and removal, so pointing
+/// a tab at another table left them describing the old one, and the ones that were kept in sync
+/// were kept in sync for no reader (#2060).
 @Observable @MainActor
 final class TabSession: Identifiable {
-    // MARK: - Identity
-
     let id: UUID
-
-    // MARK: - Tab metadata
-
-    var title: String
-    var tabType: TabType
-    var isPreview: Bool
-
-    // MARK: - Content
-
-    var content: TabQueryContent
-
-    // MARK: - Execution
-
-    var execution: TabExecutionState
-
-    // MARK: - Table context
-
-    var tableContext: TabTableContext
-
-    // MARK: - Display
-
-    var display: TabDisplayState
-
-    // MARK: - Per-tab UI state
-
-    var pendingChanges: TabChangeSnapshot
-    var selectedRowIndices: Set<Int>
-    var sortState: SortState
-    var filterState: TabFilterState
-    var columnLayout: ColumnLayoutState
-    var pagination: PaginationState
-
-    // MARK: - Tracking
-
-    var hasUserInteraction: Bool
-    var schemaVersion: Int
-    var metadataVersion: Int
-    var paginationVersion: Int
-    var loadEpoch: Int
-
-    // MARK: - Session-only state
 
     var tableRows: TableRows
     var isEvicted: Bool
@@ -85,132 +32,10 @@ final class TabSession: Identifiable {
     /// which cannot distinguish two different results of the same size.
     var dataRevision: Int
 
-    // MARK: - Init
-
-    /// Lift a `QueryTab` value into a `TabSession` reference. Used at the
-    /// boundary between legacy code paths (which still pass `QueryTab` by
-    /// value) and the new architecture (which holds `TabSession` references).
-    init(queryTab: QueryTab) {
-        self.id = queryTab.id
-        self.title = queryTab.title
-        self.tabType = queryTab.tabType
-        self.isPreview = queryTab.isPreview
-        self.content = queryTab.content
-        self.execution = queryTab.execution
-        self.tableContext = queryTab.tableContext
-        self.display = queryTab.display
-        self.pendingChanges = queryTab.pendingChanges
-        self.selectedRowIndices = queryTab.selectedRowIndices
-        self.sortState = queryTab.sortState
-        self.filterState = queryTab.filterState
-        self.columnLayout = queryTab.columnLayout
-        self.pagination = queryTab.pagination
-        self.hasUserInteraction = queryTab.hasUserInteraction
-        self.schemaVersion = queryTab.schemaVersion
-        self.metadataVersion = queryTab.metadataVersion
-        self.paginationVersion = queryTab.paginationVersion
-        self.loadEpoch = queryTab.loadEpoch
-        self.tableRows = TableRows()
-        self.isEvicted = false
-        self.dataRevision = 0
-    }
-
-    /// Build a `TabSession` from primitive parameters, mirroring `QueryTab.init`.
-    /// Used by callers that construct sessions directly without an intermediate
-    /// `QueryTab` value.
-    init(
-        id: UUID = UUID(),
-        title: String = "Query",
-        query: String = "",
-        tabType: TabType = .query,
-        tableName: String? = nil
-    ) {
+    init(id: UUID = UUID()) {
         self.id = id
-        self.title = title
-        self.tabType = tabType
-        self.isPreview = false
-        self.content = TabQueryContent(query: query)
-        self.execution = TabExecutionState()
-        self.tableContext = TabTableContext(tableName: tableName, isEditable: tabType == .table)
-        self.display = TabDisplayState()
-        self.pendingChanges = TabChangeSnapshot()
-        self.selectedRowIndices = []
-        self.sortState = SortState()
-        self.filterState = TabFilterState()
-        self.columnLayout = ColumnLayoutState()
-        self.pagination = PaginationState()
-        self.hasUserInteraction = false
-        self.schemaVersion = 0
-        self.metadataVersion = 0
-        self.paginationVersion = 0
-        self.loadEpoch = 0
         self.tableRows = TableRows()
         self.isEvicted = false
         self.dataRevision = 0
-    }
-
-    // MARK: - Conversion
-
-    /// Snapshot the current session state back into a `QueryTab` value. Used
-    /// by code paths that haven't migrated yet (persistence, legacy stores).
-    /// Pure read; callers can mutate the returned struct without affecting
-    /// the session.
-    func snapshot() -> QueryTab {
-        var tab = QueryTab(
-            id: id,
-            title: title,
-            query: content.query,
-            tabType: tabType,
-            tableName: tableContext.tableName
-        )
-        tab.isPreview = isPreview
-        tab.content = content
-        tab.execution = execution
-        tab.tableContext = tableContext
-        tab.display = display
-        tab.pendingChanges = pendingChanges
-        tab.selectedRowIndices = selectedRowIndices
-        tab.sortState = sortState
-        tab.filterState = filterState
-        tab.columnLayout = columnLayout
-        tab.pagination = pagination
-        tab.hasUserInteraction = hasUserInteraction
-        tab.schemaVersion = schemaVersion
-        tab.metadataVersion = metadataVersion
-        tab.paginationVersion = paginationVersion
-        tab.loadEpoch = loadEpoch
-        return tab
-    }
-
-    /// Replace the session's state from a `QueryTab` value, preserving the
-    /// session's identity (`id`). Used when a tab's persisted state is
-    /// reloaded from disk and the existing session must absorb the new state
-    /// without observers losing track of the instance.
-    ///
-    /// Session-only fields (`tableRows`, `isEvicted`) are intentionally NOT
-    /// touched — they aren't part of the `QueryTab` shape and are repopulated
-    /// by the next lazy-load. Callers wanting to discard cached row data
-    /// should set `tabSessionRegistry.session(for: id)?.tableRows = .init()`
-    /// (or call `removeTableRows`) explicitly before `absorb`.
-    func absorb(_ queryTab: QueryTab) {
-        precondition(queryTab.id == id, "TabSession.absorb requires matching ids")
-        self.title = queryTab.title
-        self.tabType = queryTab.tabType
-        self.isPreview = queryTab.isPreview
-        self.content = queryTab.content
-        self.execution = queryTab.execution
-        self.tableContext = queryTab.tableContext
-        self.display = queryTab.display
-        self.pendingChanges = queryTab.pendingChanges
-        self.selectedRowIndices = queryTab.selectedRowIndices
-        self.sortState = queryTab.sortState
-        self.filterState = queryTab.filterState
-        self.columnLayout = queryTab.columnLayout
-        self.pagination = queryTab.pagination
-        self.hasUserInteraction = queryTab.hasUserInteraction
-        self.schemaVersion = queryTab.schemaVersion
-        self.metadataVersion = queryTab.metadataVersion
-        self.paginationVersion = queryTab.paginationVersion
-        self.loadEpoch = queryTab.loadEpoch
     }
 }

--- a/TablePro/Models/Query/TabSessionRegistry.swift
+++ b/TablePro/Models/Query/TabSessionRegistry.swift
@@ -25,10 +25,6 @@ final class TabSessionRegistry {
         sessions.removeAll()
     }
 
-    var allSessions: [TabSession] {
-        Array(sessions.values)
-    }
-
     // MARK: - Row data access
 
     func tableRows(for tabId: UUID) -> TableRows {
@@ -68,23 +64,16 @@ final class TabSessionRegistry {
         sessions[tabId]?.isEvicted ?? false
     }
 
-    /// Evict row data for a tab. Sets `isEvicted = true`, clears rows, and
-    /// bumps the session's `loadEpoch`. Note that SwiftUI's `.task(id:)` keys
-    /// on `QueryTab.loadEpoch` (the value-type tab in `tabManager.tabs`), not
-    /// on `TabSession.loadEpoch` — so callers that need lazy-load to re-fire
-    /// must also bump `tabManager.tabs[i].loadEpoch` separately.
+    /// Drops a tab's rows and marks it evicted. Getting them back is the caller's job: SwiftUI's
+    /// `.task(id:)` keys on `QueryTab.loadEpoch`, so a caller that wants the lazy load to re-fire
+    /// bumps that itself.
     ///
-    /// Returns early if the session has no rows to evict — calling `evict` on
-    /// a tab with empty rows is a no-op (no `isEvicted` change, no epoch bump),
-    /// matching the original `TableRowsStore.evict` semantics. Use
-    /// `tabSessionRegistry.session(for:)?.isEvicted = true` directly if you
-    /// need to mark a fresh-but-empty session as evicted.
+    /// A tab with no rows is left alone, so eviction never marks a tab that has nothing to lose.
     func evict(for tabId: UUID) {
         guard let session = sessions[tabId] else { return }
         guard !session.tableRows.rows.isEmpty else { return }
         session.tableRows.rows = []
         session.isEvicted = true
-        session.loadEpoch &+= 1
         session.dataRevision &+= 1
     }
 
@@ -93,7 +82,6 @@ final class TabSessionRegistry {
             guard !session.tableRows.rows.isEmpty, !session.isEvicted else { continue }
             session.tableRows.rows = []
             session.isEvicted = true
-            session.loadEpoch &+= 1
             session.dataRevision &+= 1
         }
     }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ColumnVisibility.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ColumnVisibility.swift
@@ -62,7 +62,6 @@ extension MainContentCoordinator {
     func applyColumnGeometry(from geometry: ColumnLayoutState, toTabId tabId: UUID) {
         guard let index = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
         tabManager.mutate(at: index) { $0.columnLayout.applyGeometry(from: geometry) }
-        tabSessionRegistry.session(for: tabId)?.columnLayout.applyGeometry(from: geometry)
     }
 
     func clearColumnLayoutForSelectedTable() {
@@ -77,7 +76,6 @@ extension MainContentCoordinator {
             FileColumnLayoutPersister.shared.clear(for: key)
         }
         tabManager.mutate(at: index) { $0.columnLayout = ColumnLayoutState() }
-        tabSessionRegistry.session(for: tab.id)?.columnLayout = ColumnLayoutState()
         requeryWithColumnScope(debounced: false)
     }
 
@@ -108,8 +106,6 @@ extension MainContentCoordinator {
         var hidden = tabManager.tabs[index].columnLayout.hiddenColumns
         mutate(&hidden)
         tabManager.mutate(at: index) { $0.columnLayout.hiddenColumns = hidden }
-        let tabId = tabManager.tabs[index].id
-        tabSessionRegistry.session(for: tabId)?.columnLayout.hiddenColumns = hidden
         if persist {
             persistTabHiddenColumns(tabManager.tabs[index])
         }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TableRowsMutation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TableRowsMutation.swift
@@ -52,7 +52,6 @@ extension MainContentCoordinator {
             guard !tab.selectedRowIndices.isEmpty else { return }
             tab.selectedRowIndices = []
         }
-        tabSessionRegistry.session(for: tabId)?.selectedRowIndices = []
         guard let idx = tabManager.selectedTabIndex,
               idx < tabManager.tabs.count,
               tabManager.tabs[idx].id == tabId else { return }

--- a/TableProTests/Models/Query/TabSessionTests.swift
+++ b/TableProTests/Models/Query/TabSessionTests.swift
@@ -2,6 +2,9 @@
 //  TabSessionTests.swift
 //  TableProTests
 //
+//  TabSession holds a tab's row buffer and nothing else. It used to mirror most of QueryTab too,
+//  which no reader consulted and no retarget updated (#2060).
+//
 
 import Foundation
 import TableProPluginKit
@@ -12,176 +15,97 @@ import Testing
 @Suite("TabSession")
 @MainActor
 struct TabSessionTests {
-    private func makeQueryTab(
-        title: String = "Tab",
-        query: String = "SELECT 1",
-        tabType: TabType = .query,
-        tableName: String? = nil
-    ) -> QueryTab {
-        QueryTab(title: title, query: query, tabType: tabType, tableName: tableName)
+    @Test("A new session starts empty")
+    func newSessionStartsEmpty() {
+        let session = TabSession()
+
+        #expect(session.tableRows.rows.isEmpty)
+        #expect(session.tableRows.columns.isEmpty)
+        #expect(session.isEvicted == false)
+        #expect(session.dataRevision == 0)
     }
 
-    // MARK: - Initialization
-
-    @Test("Init from QueryTab preserves id and all primitive fields")
-    func initFromQueryTabPreservesIdentity() {
-        var tab = makeQueryTab(title: "Users", query: "SELECT * FROM users", tabType: .table, tableName: "users")
-        tab.tableContext.databaseName = "main"
-        tab.tableContext.isEditable = true
-        tab.execution.lastExecutedAt = Date(timeIntervalSince1970: 1_000)
-        tab.schemaVersion = 7
-
-        let session = TabSession(queryTab: tab)
-
-        #expect(session.id == tab.id)
-        #expect(session.title == "Users")
-        #expect(session.tabType == .table)
-        #expect(session.content.query == "SELECT * FROM users")
-        #expect(session.tableContext.tableName == "users")
-        #expect(session.tableContext.databaseName == "main")
-        #expect(session.tableContext.isEditable == true)
-        #expect(session.execution.lastExecutedAt == Date(timeIntervalSince1970: 1_000))
-        #expect(session.schemaVersion == 7)
-    }
-
-    @Test("Init with primitives produces same defaults as QueryTab.init")
-    func initPrimitivesMatchesQueryTabDefaults() {
+    @Test("A session keeps the id it was created with")
+    func sessionKeepsItsId() {
         let id = UUID()
-        let session = TabSession(id: id, title: "Q", query: "x", tabType: .query, tableName: nil)
-        let tab = QueryTab(id: id, title: "Q", query: "x", tabType: .query, tableName: nil)
 
-        #expect(session.id == tab.id)
-        #expect(session.title == tab.title)
-        #expect(session.tabType == tab.tabType)
-        #expect(session.content.query == tab.content.query)
-        #expect(session.isPreview == tab.isPreview)
-        #expect(session.schemaVersion == tab.schemaVersion)
-        #expect(session.hasUserInteraction == tab.hasUserInteraction)
+        #expect(TabSession(id: id).id == id)
     }
 
-    // MARK: - Conversion roundtrip
-
-    @Test("snapshot() returns a QueryTab equal to the source")
-    func snapshotRoundtripEqualsSource() {
-        var original = makeQueryTab(title: "Orders", query: "SELECT * FROM orders", tabType: .table, tableName: "orders")
-        original.tableContext.primaryKeyColumns = ["id"]
-        original.execution.rowsAffected = 42
-        original.pagination.currentPage = 3
-        original.pagination.pageSize = 100
-        original.sortState.columns = [SortColumn(columnIndex: 0, direction: .descending)]
-
-        let session = TabSession(queryTab: original)
-        let roundtrip = session.snapshot()
-
-        #expect(roundtrip == original)
-    }
-
-    @Test("absorb() updates fields and preserves id")
-    func absorbReplacesState() {
-        let id = UUID()
-        let initial = QueryTab(id: id, title: "v1", query: "SELECT 1", tabType: .query)
-        let session = TabSession(queryTab: initial)
-
-        var updated = QueryTab(id: id, title: "v2", query: "SELECT 2", tabType: .table, tableName: "users")
-        updated.schemaVersion = 9
-
-        session.absorb(updated)
-
-        #expect(session.id == id)
-        #expect(session.title == "v2")
-        #expect(session.content.query == "SELECT 2")
-        #expect(session.tabType == .table)
-        #expect(session.tableContext.tableName == "users")
-        #expect(session.schemaVersion == 9)
-    }
-
-    // MARK: - Reference semantics
-
-    @Test("Multiple references see the same mutations (class semantics)")
-    func sharedReferenceSemantics() {
-        let session = TabSession(queryTab: makeQueryTab())
+    /// The row buffer lives here precisely because it is a reference: mutating it must not copy
+    /// the tab or re-render the editor.
+    @Test("Every holder of a session sees the same rows")
+    func sessionIsShared() {
+        let session = TabSession()
         let alias = session
 
-        alias.title = "renamed"
-        alias.schemaVersion = 5
+        alias.tableRows = TableRows(columns: ["id"])
 
-        #expect(session.title == "renamed")
-        #expect(session.schemaVersion == 5)
+        #expect(session.tableRows.columns == ["id"])
+    }
+}
+
+/// The point of #2060: pointing a tab at another table is not an insert or a removal, so the
+/// registry never reconciled the session. Nothing per-table may live in the session for that to
+/// matter, and the tab itself has to be the one thing that describes the table.
+@Suite("Tab retarget leaves no stale per-tab state")
+@MainActor
+struct TabRetargetSessionStateTests {
+    @Test("Retargeting a tab reuses its session rather than replacing it")
+    func retargetKeepsTheSameSession() throws {
+        let (tabManager, registry) = Self.makeManager()
+        let tabId = Self.addTableTab(to: tabManager, tableName: "orders")
+        let before = try #require(registry.session(for: tabId))
+
+        try tabManager.replaceTabContent(tableName: "customers")
+
+        let after = try #require(registry.session(for: tabId))
+        #expect(after === before)
     }
 
-    @Test("Snapshot decouples from the live session (value semantics on the snapshot)")
-    func snapshotIsDecoupled() {
-        let session = TabSession(queryTab: makeQueryTab(title: "live"))
-        var taken = session.snapshot()
+    @Test("Retargeting a tab moves every table-scoped field on the tab itself")
+    func retargetUpdatesTheTab() throws {
+        let (tabManager, _) = Self.makeManager()
+        let tabId = Self.addTableTab(to: tabManager, tableName: "orders")
 
-        taken.title = "snapshot-only"
+        try tabManager.replaceTabContent(tableName: "customers")
 
-        #expect(session.title == "live")
-        #expect(taken.title == "snapshot-only")
+        let tab = try #require(tabManager.tabs.first(where: { $0.id == tabId }))
+        #expect(tab.tableContext.tableName == "customers")
+        #expect(tab.content.query.contains("customers"))
+        #expect(tab.title.contains("customers"))
+        #expect(tab.sortState.isSorting == false)
+        #expect(tab.filterState.hasAppliedFilters == false)
+        #expect(tab.columnLayout.hiddenColumns.isEmpty)
     }
 
-    // MARK: - Session-only state defaults
+    @Test("The row buffer stays reachable through the retarget")
+    func rowBufferSurvivesTheRetarget() throws {
+        let (tabManager, registry) = Self.makeManager()
+        let tabId = Self.addTableTab(to: tabManager, tableName: "orders")
+        registry.setTableRows(TableRows(columns: ["id"]), for: tabId)
 
-    @Test("tableRows defaults to an empty TableRows on primitive init")
-    func tableRowsDefaultsEmptyOnPrimitiveInit() {
-        let session = TabSession()
-        #expect(session.tableRows.rows.isEmpty)
-        #expect(session.tableRows.columns.isEmpty)
+        try tabManager.replaceTabContent(tableName: "customers")
+
+        #expect(registry.tableRows(for: tabId).columns == ["id"])
     }
 
-    @Test("tableRows defaults to an empty TableRows when lifted from QueryTab")
-    func tableRowsDefaultsEmptyFromQueryTab() {
-        let session = TabSession(queryTab: makeQueryTab())
-        #expect(session.tableRows.rows.isEmpty)
-        #expect(session.tableRows.columns.isEmpty)
+    private static func makeManager() -> (QueryTabManager, TabSessionRegistry) {
+        let tabManager = QueryTabManager()
+        let registry = TabSessionRegistry()
+        tabManager.bindTabSessionRegistry(registry)
+        return (tabManager, registry)
     }
 
-    @Test("isEvicted defaults to false")
-    func isEvictedDefaultsFalse() {
-        #expect(TabSession().isEvicted == false)
-        #expect(TabSession(queryTab: makeQueryTab()).isEvicted == false)
-    }
-
-    @Test("loadEpoch defaults to zero")
-    func loadEpochDefaultsZero() {
-        #expect(TabSession().loadEpoch == 0)
-        #expect(TabSession(queryTab: makeQueryTab()).loadEpoch == 0)
-    }
-
-    // MARK: - loadEpoch round-trip
-
-    @Test("loadEpoch round-trips through snapshot()")
-    func loadEpochRoundTripsThroughSnapshot() {
-        let session = TabSession(queryTab: makeQueryTab())
-        session.loadEpoch = 7
-
-        let snapshot = session.snapshot()
-
-        #expect(snapshot.loadEpoch == 7)
-    }
-
-    @Test("loadEpoch round-trips through absorb()")
-    func loadEpochRoundTripsThroughAbsorb() {
-        let id = UUID()
-        let initial = QueryTab(id: id)
-        let session = TabSession(queryTab: initial)
-
-        var updated = QueryTab(id: id)
-        updated.loadEpoch = 12
-        session.absorb(updated)
-
-        #expect(session.loadEpoch == 12)
-    }
-
-    @Test("loadEpoch survives a snapshot/absorb roundtrip across sessions")
-    func loadEpochSurvivesRoundtrip() {
-        let id = UUID()
-        let session1 = TabSession(queryTab: QueryTab(id: id))
-        session1.loadEpoch = 3
-
-        let snapshot = session1.snapshot()
-        let session2 = TabSession(queryTab: snapshot)
-
-        #expect(session2.loadEpoch == 3)
+    private static func addTableTab(to tabManager: QueryTabManager, tableName: String) -> UUID {
+        let tab = QueryTab(
+            title: tableName,
+            query: "SELECT * FROM \(tableName)",
+            tabType: .table,
+            tableName: tableName
+        )
+        tabManager.tabs.append(tab)
+        tabManager.selectedTabId = tab.id
+        return tab.id
     }
 }

--- a/TableProTests/Views/Main/CoordinatorColumnVisibilityTests.swift
+++ b/TableProTests/Views/Main/CoordinatorColumnVisibilityTests.swift
@@ -94,10 +94,6 @@ struct CoordinatorColumnVisibilityTests {
         #expect(layout.hiddenColumns == ["email"])
         #expect(layout.columnWidths == ["id": 80, "name": 220])
         #expect(layout.columnOrder == ["id", "name"])
-
-        let session = coordinator.tabSessionRegistry.session(for: tabId)
-        #expect(session?.columnLayout.hiddenColumns == ["email"])
-        #expect(session?.columnLayout.columnWidths == ["id": 80, "name": 220])
     }
 
     @Test("showColumn removes from the active tab's hidden set")
@@ -166,17 +162,6 @@ struct CoordinatorColumnVisibilityTests {
         coordinator.hideColumn("name")
         coordinator.hideColumn("name")
         #expect(coordinator.selectedTabHiddenColumns == ["name"])
-    }
-
-    @Test("hideColumn mirrors into the corresponding TabSession")
-    func hideColumnMirrorsIntoSession() {
-        let (coordinator, tabManager) = makeCoordinator()
-        let tabId = addTableTab(to: tabManager, tableName: "users")
-
-        coordinator.hideColumn("name")
-
-        let session = coordinator.tabSessionRegistry.session(for: tabId)
-        #expect(session?.columnLayout.hiddenColumns == ["name"])
     }
 
     @Test("Payload-created table tabs rebuild their query after restoring hidden columns")

--- a/TableProTests/Views/Main/MainContentCoordinatorLazyLoadTests.swift
+++ b/TableProTests/Views/Main/MainContentCoordinatorLazyLoadTests.swift
@@ -256,28 +256,33 @@ struct MainContentCoordinatorLazyLoadTests {
 
     // MARK: - loadEpoch bump triggers reload after eviction
 
-    @Test("Eviction bumps the tab's loadEpoch so .task(id:) re-fires")
+    /// `.task(id:)` keys on the tab's own `loadEpoch`, so that is the one the eviction path has to
+    /// move. This used to assert on a copy held by the session that nothing reads, which would
+    /// have stayed green with the reload broken.
+    @Test("Evicting a background tab bumps the tab's loadEpoch so .task(id:) re-fires")
     func evictionBumpsLoadEpoch() {
         let (coordinator, tabManager) = makeCoordinator()
-        let tabId = addTableTab(to: tabManager, tableName: "orders")
-        seedRows(coordinator, for: tabId, rowCount: 7)
-        guard let idx = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
+        let background = addTableTab(to: tabManager, tableName: "orders")
+        seedRows(coordinator, for: background, rowCount: 7)
+        let foreground = addTableTab(to: tabManager, tableName: "customers")
+        tabManager.selectedTabId = foreground
+        guard let idx = tabManager.tabs.firstIndex(where: { $0.id == background }) else {
             Issue.record("expected tab to exist")
             return
         }
         tabManager.tabs[idx].execution.lastExecutedAt = Date()
-        #expect(coordinator.tabSessionRegistry.tableRows(for: tabId).rows.count == 7)
+        let initialEpoch = tabManager.tabs[idx].loadEpoch
+        #expect(coordinator.tabSessionRegistry.tableRows(for: background).rows.count == 7)
 
-        guard let session = coordinator.tabSessionRegistry.session(for: tabId) else {
-            Issue.record("expected session to exist after seedRows")
+        coordinator.evictInactiveRowData()
+
+        guard let evictedTab = tabManager.tabs.first(where: { $0.id == background }) else {
+            Issue.record("expected tab to exist")
             return
         }
-        let initialEpoch = session.loadEpoch
-
-        coordinator.tabSessionRegistry.evict(for: tabId)
-
-        #expect(session.loadEpoch != initialEpoch)
-        #expect(coordinator.tabSessionRegistry.isEvicted(tabId) == true)
+        #expect(evictedTab.loadEpoch != initialEpoch)
+        #expect(coordinator.tabSessionRegistry.isEvicted(background) == true)
+        #expect(coordinator.tabSessionRegistry.isEvicted(foreground) == false)
     }
 
     // MARK: - Regression: handleWindowDidBecomeKey does NOT trigger query work


### PR DESCRIPTION
Closes #2060.

`TabSessionRegistry` kept a `TabSession` per tab that mirrored most of `QueryTab`, and `QueryTabManager.syncTabSessionRegistry` only reconciled it on tab insert and removal. `replaceTabContent` reuses the tab id, so pointing a tab at another table was neither, and the session went on describing the old table.

The issue asked which fix was right: add a retarget branch, or delete the mirror. That depended on whether anything read the stale copies, so I audited every mirrored field.

## The audit

Nothing in the app reads any of them. There are exactly six places outside the registry that touch a `TabSession`:

| Site | Field | Direction |
| --- | --- | --- |
| `MainEditorContentView:561` | `dataRevision` | read (session-only, not a mirror) |
| `MainContentCoordinator+ColumnVisibility` (3 sites) | `columnLayout` | write only |
| `MainContentCoordinator+TableRowsMutation:55` | `selectedRowIndices` | write only |
| `FilterCoordinator:643` | `filterState` | write only |

Every other mirrored field, `title`, `tabType`, `isPreview`, `content`, `execution`, `tableContext`, `display`, `pendingChanges`, `sortState`, `pagination`, `hasUserInteraction`, `schemaVersion`, `metadataVersion`, `paginationVersion`, `loadEpoch`, is written by the initializer and never read again. Every read site in the app goes to `tabManager.tabs[...]` instead. `absorb()` and `snapshot()`, the two methods that move a whole tab in or out, have no production caller at all.

So the stale mirror was latent, not user-visible, and syncing it would have been keeping 15 fields correct for nobody.

## What this changes

`TabSession` keeps only what `QueryTab` deliberately does not carry: `tableRows`, `isEvicted`, `dataRevision`. That is its real job. The rows live in a reference type because `QueryTab` is a value type inside an observed array, so holding tens of thousands of rows in it would copy them on every unrelated edit.

Everything else goes: the 15 mirrored fields, both conversion methods, the `queryTab:` initializer, and the paired writes that kept three of those fields in sync for no reader. `TabSessionRegistry.allSessions` goes too; nothing ever called it. Net 395 lines deleted, 105 added.

One incidental fix. `FilterCoordinator` had an `assertionFailure("registry sync regression")` on the path where the session write was skipped, guarding a mirror that did not matter. It is gone with the write.

## A test that was guarding the wrong value

`MainContentCoordinatorLazyLoadTests.evictionBumpsLoadEpoch` was named "so `.task(id:)` re-fires" but asserted on `TabSession.loadEpoch`. `.task(id:)` keys on `QueryTab.loadEpoch`, which is bumped separately by the two callers of `evict`. The test would have stayed green with the reload broken. It now drives `evictInactiveRowData()` and asserts on the tab's own epoch, and checks the selected tab is spared.

`TabSessionTests` was 187 lines testing the mirror. It is replaced with the defaults and reference semantics that still apply, plus a suite pinning the actual invariant from this issue: after a retarget the session is reused rather than replaced, the tab itself carries the new table, and the row buffer stays reachable.

## Verification

`swiftlint lint --strict` reports 0 violations in 1299 files. No CHANGELOG entry: there is no user-visible behaviour change here, and every entry in that file is meant to be user-facing.

## evictAll(except:) goes too

`TabSessionRegistry.evictAll(except:)` had no production caller either, only its own three tests. I first left it alone as a coherent API, then looked at what it actually does: it drops rows and sets `isEvicted`, but it has no access to the tab manager, so it cannot bump `QueryTab.loadEpoch`. That epoch is what `.task(id:)` keys on. The one real eviction path, `evictInactiveRowData()`, pairs `evict(for:)` with a `loadEpoch` bump for exactly that reason.

So a future caller reaching for `evictAll` would get tabs whose rows were dropped and never reloaded. It is not an API waiting for a caller, it is a trap, and it is gone with its tests.
