### PR TITLE
refactor(tabs): drop evictAll, which cannot bump the epoch that makes an evicted tab reload

### DIFF
--- a/TablePro/Models/Query/TabSessionRegistry.swift
+++ b/TablePro/Models/Query/TabSessionRegistry.swift
@@ -77,15 +77,6 @@ final class TabSessionRegistry {
         session.dataRevision &+= 1
     }
 
-    func evictAll(except activeTabId: UUID?) {
-        for session in sessions.values where session.id != activeTabId {
-            guard !session.tableRows.rows.isEmpty, !session.isEvicted else { continue }
-            session.tableRows.rows = []
-            session.isEvicted = true
-            session.dataRevision &+= 1
-        }
-    }
-
     private func ensureSession(for tabId: UUID) -> TabSession {
         if let existing = sessions[tabId] {
             return existing

--- a/TableProTests/Core/Services/Query/TabSessionRegistryTableRowsTests.swift
+++ b/TableProTests/Core/Services/Query/TabSessionRegistryTableRowsTests.swift
@@ -101,60 +101,6 @@ struct TabSessionRegistryTableRowsTests {
         store.evict(for: UUID())
     }
 
-    @Test("evictAll(except:) evicts other tabs and spares the active one")
-    func evictAllSparesActive() {
-        let store = TabSessionRegistry()
-        let activeId = UUID()
-        let otherId1 = UUID()
-        let otherId2 = UUID()
-
-        let active = TableRows.from(queryRows: [["a"]], columns: ["c"], columnTypes: [.text(rawType: nil)])
-        let other1 = TableRows.from(queryRows: [["b"]], columns: ["c"], columnTypes: [.text(rawType: nil)])
-        let other2 = TableRows.from(queryRows: [["d"]], columns: ["c"], columnTypes: [.text(rawType: nil)])
-
-        store.setTableRows(active, for: activeId)
-        store.setTableRows(other1, for: otherId1)
-        store.setTableRows(other2, for: otherId2)
-
-        store.evictAll(except: activeId)
-
-        #expect(store.isEvicted(activeId) == false)
-        #expect(store.existingTableRows(for: activeId)?.rows.count == 1)
-        #expect(store.isEvicted(otherId1) == true)
-        #expect(store.existingTableRows(for: otherId1)?.rows.isEmpty == true)
-        #expect(store.isEvicted(otherId2) == true)
-    }
-
-    @Test("evictAll(except: nil) evicts every loaded tab")
-    func evictAllNoActiveEvictsAll() {
-        let store = TabSessionRegistry()
-        let id1 = UUID()
-        let id2 = UUID()
-        store.setTableRows(
-            TableRows.from(queryRows: [["a"]], columns: ["c"], columnTypes: [.text(rawType: nil)]),
-            for: id1
-        )
-        store.setTableRows(
-            TableRows.from(queryRows: [["b"]], columns: ["c"], columnTypes: [.text(rawType: nil)]),
-            for: id2
-        )
-
-        store.evictAll(except: nil)
-
-        #expect(store.isEvicted(id1) == true)
-        #expect(store.isEvicted(id2) == true)
-    }
-
-    @Test("evictAll(except:) skips empty tables")
-    func evictAllSkipsEmpty() {
-        let store = TabSessionRegistry()
-        let tabId = UUID()
-        store.setTableRows(TableRows(), for: tabId)
-
-        store.evictAll(except: nil)
-        #expect(store.isEvicted(tabId) == false)
-    }
-
     @Test("setTableRows clears evicted flag")
     func setClearsEvicted() {
         let store = TabSessionRegistry()


### PR DESCRIPTION
Follow-up to #2064, which flagged this and left it alone.

`TabSessionRegistry.evictAll(except:)` has no production caller. Only its own three tests use it. That alone would be a weak reason to delete a tidy-looking API, so I looked at what it actually does.

It drops a tab's rows and sets `isEvicted`, but it has no access to the tab manager, so it cannot bump `QueryTab.loadEpoch`. That epoch is what SwiftUI's `.task(id:)` keys on, and it is the only thing that makes an evicted tab reload. The one real eviction path pairs the two:

```swift
for (index, tab) in tabManager.tabs.enumerated() where ... {
    tabSessionRegistry.evict(for: tab.id)
    tabManager.mutate(at: index) { $0.loadEpoch &+= 1 }
}
```

`evictInactiveTabs` in the tab-switch path does the same. So anyone reaching for `evictAll` because it looks like the batch version of `evict` would get exactly the wrong result: rows dropped on every background tab, no epoch bumped, and nothing to trigger a refetch. Blank grids that only heal on a manual refresh.

It is not an API waiting for a caller, it is a trap with three tests holding it in place. Removed with them.

## Verification

43 tests pass across `TabSessionRegistryTableRowsTests`, `TabSessionRegistryTests`, `TabSessionTests`, `TabRetargetSessionStateTests` and `MainContentCoordinatorLazyLoadTests`. `swiftlint lint --strict` reports 0 violations in 1300 files.

No CHANGELOG entry: removing an uncalled method changes nothing a user can see.
