### PR TITLE
fix(tabs): give every window of a connection its own tabs back on reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A connection with more than one window open now brings every window's tabs back when it reconnects, instead of leaving them all empty. Each window used to stand down the moment it saw another window on the same connection, so none of them restored anything.
+- Reopening a connection now puts each tab back in the window it was in. A window that held more than one tab came back as one window per tab, and a window that was empty was filled with the next window's tab.
 - Clicking a table while another one is still loading now loads the table you clicked. The tab used to fill with the previous table's rows under the new table's name, and the table you clicked never loaded at all.
 - Stop no longer aborts a save, a discard, or a schema change. It cancels reads only, so a write can no longer be cut off half way.
 - Ending a session while its window stayed open could lose that window's tabs. Tabs are now written to disk before the session goes away, which also covers the disconnect tool used by AI clients and Reset Sample Database.

--- a/TablePro/Core/Services/Infrastructure/RestoreWindowPlan.swift
+++ b/TablePro/Core/Services/Infrastructure/RestoreWindowPlan.swift
@@ -5,11 +5,25 @@
 
 import Foundation
 
+/// Which restored group ends up in front. A group rather than a tab, because a window that held more
+/// than one tab restores them all into itself, so the tab the user left selected identifies a window
+/// to raise, not a tab to single out.
 enum RestoreWindowPlan {
-    static func resolveFrontTabId(remainingTabIds: [UUID], firstTabId: UUID, selectedId: UUID?) -> UUID {
-        guard let selectedId else { return firstTabId }
-        if selectedId == firstTabId { return firstTabId }
-        if remainingTabIds.contains(selectedId) { return selectedId }
-        return firstTabId
+    enum FrontGroup: Equatable {
+        case own
+        case orphaned(windowGroupIndex: Int)
+    }
+
+    static func resolveFrontGroup(
+        ownTabIds: [UUID],
+        orphanedGroups: [(windowGroupIndex: Int, tabIds: [UUID])],
+        selectedId: UUID?
+    ) -> FrontGroup {
+        guard let selectedId else { return .own }
+        if ownTabIds.contains(selectedId) { return .own }
+        if let match = orphanedGroups.first(where: { $0.tabIds.contains(selectedId) }) {
+            return .orphaned(windowGroupIndex: match.windowGroupIndex)
+        }
+        return .own
     }
 }

--- a/TablePro/Core/Services/Infrastructure/TabPersistenceCoordinator.swift
+++ b/TablePro/Core/Services/Infrastructure/TabPersistenceCoordinator.swift
@@ -13,6 +13,10 @@ internal struct RestoreResult {
     let source: RestoreSource
     var lastActiveDatabase: String?
     var lastActiveSchema: String?
+    /// Which window each tab belongs to, by tab id. Kept beside the tabs rather than on `QueryTab`,
+    /// because it describes where a tab was rather than anything about the tab, and it is read once
+    /// while a window works out which tabs are its own.
+    var windowGroupIndexByTabId: [UUID: Int] = [:]
 
     enum RestoreSource {
         case disk
@@ -173,7 +177,8 @@ internal final class TabPersistenceCoordinator {
             selectedTabId: state.selectedTabId,
             source: .disk,
             lastActiveDatabase: state.lastActiveDatabase,
-            lastActiveSchema: state.lastActiveSchema
+            lastActiveSchema: state.lastActiveSchema,
+            windowGroupIndexByTabId: WindowGroupAssignment.normalizedGroupIndices(for: state.tabs)
         )
     }
 }

--- a/TablePro/Core/Services/Infrastructure/WindowGroupAssignment.swift
+++ b/TablePro/Core/Services/Infrastructure/WindowGroupAssignment.swift
@@ -1,0 +1,71 @@
+//
+//  WindowGroupAssignment.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Which saved tabs a restoring window claims, and which saved groups have no window left to claim
+/// them. Every window of a connection asks this independently: the answer depends only on the window's
+/// own position and on what is on disk, never on which window got here first. That is what lets a
+/// connection with several windows restore without any of them arbitrating, since the windows all
+/// react to one session-return broadcast in no defined order.
+internal enum WindowGroupAssignment {
+    internal struct Group: Equatable {
+        internal let windowGroupIndex: Int
+        internal let tabs: [QueryTab]
+        internal let selectedTabId: UUID?
+    }
+
+    internal struct Plan: Equatable {
+        internal let ownTabs: [QueryTab]
+        internal let ownSelectedTabId: UUID?
+        /// Groups whose window is gone, for the leftmost window to reopen. Empty for every other
+        /// window, which is what keeps exactly one window fanning out without a claim protocol.
+        internal let orphanedGroups: [Group]
+    }
+
+    internal static func resolve(
+        windowIndex: Int,
+        openWindowCount: Int,
+        tabs: [QueryTab],
+        windowGroupIndexByTabId: [UUID: Int],
+        selectedTabId: UUID?
+    ) -> Plan {
+        let grouped = Dictionary(grouping: tabs) { windowGroupIndexByTabId[$0.id] ?? 0 }
+        let ownTabs = grouped[windowIndex] ?? []
+        let ownSelectedTabId = selectedTabId.flatMap { id in
+            ownTabs.contains { $0.id == id } ? id : nil
+        }
+
+        guard windowIndex == 0 else {
+            return Plan(ownTabs: ownTabs, ownSelectedTabId: ownSelectedTabId, orphanedGroups: [])
+        }
+
+        let orphanedGroups = grouped.keys
+            .filter { $0 >= openWindowCount }
+            .sorted()
+            .map { index in
+                let groupTabs = grouped[index] ?? []
+                return Group(
+                    windowGroupIndex: index,
+                    tabs: groupTabs,
+                    selectedTabId: selectedTabId.flatMap { id in
+                        groupTabs.contains { $0.id == id } ? id : nil
+                    }
+                )
+            }
+
+        return Plan(ownTabs: ownTabs, ownSelectedTabId: ownSelectedTabId, orphanedGroups: orphanedGroups)
+    }
+
+    /// A file saved before tabs recorded their window carries no grouping at all. Reading every tab
+    /// as group zero would pile them into one window, and with no in-window tab bar all but one would
+    /// be invisible, so each tab keeps its own window the way it always has: its position is its group.
+    internal static func normalizedGroupIndices(for tabs: [PersistedTab]) -> [UUID: Int] {
+        guard tabs.contains(where: { $0.windowGroupIndex != nil }) else {
+            return Dictionary(uniqueKeysWithValues: tabs.enumerated().map { ($0.element.id, $0.offset) })
+        }
+        return Dictionary(uniqueKeysWithValues: tabs.map { ($0.id, $0.windowGroupIndex ?? 0) })
+    }
+}

--- a/TablePro/Core/Services/Infrastructure/WindowLifecycleMonitor.swift
+++ b/TablePro/Core/Services/Infrastructure/WindowLifecycleMonitor.swift
@@ -48,8 +48,8 @@ internal final class WindowLifecycleMonitor {
         )
         /// A window id belongs to the SwiftUI content mounted in the window, not to the window, so a
         /// window whose content is rebuilt registers again under a new id. Reconnecting rebuilds it.
-        /// Leaving the superseded entry behind makes one window count as two, which is what stopped a
-        /// reconnected window from restoring its tabs: the restore stands down when it sees a sibling.
+        /// Leaving the superseded entry behind makes one window count as two, and everything asking
+        /// this registry how many windows a connection has would believe it.
         let supersededIds = entries.compactMap { key, value -> UUID? in
             key != windowId && value.window === window ? key : nil
         }
@@ -122,13 +122,6 @@ internal final class WindowLifecycleMonitor {
             .compactMap(\.window)
     }
 
-    /// Check if other live windows exist for a connection, excluding a specific windowId.
-    internal func hasOtherWindows(for connectionId: UUID, excluding windowId: UUID) -> Bool {
-        purgeStaleEntries()
-        return entries.contains { key, value in
-            key != windowId && value.connectionId == connectionId
-        }
-    }
 
     /// All connection IDs that currently have registered windows.
     internal func allConnectionIds() -> Set<UUID> {

--- a/TablePro/Core/Services/Infrastructure/WindowTabGroupOrder.swift
+++ b/TablePro/Core/Services/Infrastructure/WindowTabGroupOrder.swift
@@ -1,0 +1,36 @@
+//
+//  WindowTabGroupOrder.swift
+//  TablePro
+//
+
+import AppKit
+import Foundation
+
+/// Where a window sits in its native tab group, left to right. This is the one definition of window
+/// order that both halves of tab persistence use: the save side stamps each tab with its window's
+/// position, and a restoring window claims the position it occupies. Deriving the two from different
+/// sets would silently misfile tabs, because a window with no live session has no coordinator to be
+/// counted among but still occupies a tab.
+///
+/// It reads `NSWindow.tabbedWindows` rather than any of TablePro's own registries because AppKit
+/// populates that at window creation and a lost session never touches it, while `WindowLifecycleMonitor`
+/// only learns about a window once its SwiftUI content mounts, which is mid-flight during a reconnect.
+internal enum WindowTabGroupOrder {
+    internal static func windows(containing window: NSWindow) -> [NSWindow] {
+        window.tabbedWindows ?? [window]
+    }
+
+    /// Position of `window` among the windows sharing its tab group. A window that reports no tab
+    /// group is alone, which is position zero: the same answer as the only window of a connection.
+    internal static func index(of window: NSWindow) -> Int {
+        position(of: ObjectIdentifier(window), in: windows(containing: window).map(ObjectIdentifier.init))
+    }
+
+    internal static func size(containing window: NSWindow) -> Int {
+        windows(containing: window).count
+    }
+
+    internal static func position(of window: ObjectIdentifier, in group: [ObjectIdentifier]) -> Int {
+        group.firstIndex(of: window) ?? 0
+    }
+}

--- a/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
@@ -94,17 +94,21 @@ extension MainContentView {
             return
         }
 
-        if WindowLifecycleMonitor.shared.hasOtherWindows(for: connection.id, excluding: windowId) {
-            MainContentView.lifecycleLogger.info(
-                "[open] handleRestoreOrDefault short-circuit (other windows exist) windowId=\(windowId, privacy: .public)"
+        /// The split view controller owns the window and is wired up before this view is built, unlike
+        /// `viewWindow`, which arrives from `configureWindow` and can still be nil here.
+        guard let window = coordinator.splitViewController?.view.window else {
+            MainContentView.lifecycleLogger.error(
+                "[open] handleRestoreOrDefault has no window windowId=\(windowId, privacy: .public)"
             )
             return
         }
+        let windowIndex = WindowTabGroupOrder.index(of: window)
+        let openWindowCount = WindowTabGroupOrder.size(containing: window)
 
         let restoreStart = Date()
         let result = await coordinator.persistence.restoreFromDisk()
         MainContentView.lifecycleLogger.info(
-            "[open] restoreFromDisk done windowId=\(windowId, privacy: .public) tabsRestored=\(result.tabs.count) source=\(String(describing: result.source), privacy: .public) elapsedMs=\(Int(Date().timeIntervalSince(restoreStart) * 1_000))"
+            "[open] restoreFromDisk done windowId=\(windowId, privacy: .public) tabsRestored=\(result.tabs.count) windowIndex=\(windowIndex) openWindowCount=\(openWindowCount) source=\(String(describing: result.source), privacy: .public) elapsedMs=\(Int(Date().timeIntervalSince(restoreStart) * 1_000))"
         )
         guard !result.tabs.isEmpty else { return }
 
@@ -125,37 +129,72 @@ extension MainContentView {
             }
         }
 
-        let selectedId = result.selectedTabId
+        let plan = WindowGroupAssignment.resolve(
+            windowIndex: windowIndex,
+            openWindowCount: openWindowCount,
+            tabs: restoredTabs,
+            windowGroupIndexByTabId: result.windowGroupIndexByTabId,
+            selectedTabId: result.selectedTabId
+        )
 
-        // First tab gets the current window to preserve order; the rest open as
-        // native window tabs, each carrying its full restored state via the registry.
-        // Only the frontmost restored tab loads its data immediately; the others
-        // load the first time the user switches to them.
-        let firstTab = restoredTabs[0]
-        let remainingTabs = Array(restoredTabs.dropFirst())
-        let frontTabId = RestoreWindowPlan.resolveFrontTabId(
-            remainingTabIds: remainingTabs.map(\.id),
-            firstTabId: firstTab.id,
-            selectedId: selectedId
+        if openWindowCount == 1 {
+            restoreAsOnlyWindow(plan, result: result)
+        } else {
+            claimOwnTabs(plan, result: result, window: window)
+        }
+    }
+
+    /// The connection has one window, so this window restores what it kept and opens a window for every
+    /// other group. Nothing has focus yet, so the tab the user left selected is brought to the front.
+    private func restoreAsOnlyWindow(_ plan: WindowGroupAssignment.Plan, result: RestoreResult) {
+        let frontGroup = RestoreWindowPlan.resolveFrontGroup(
+            ownTabIds: plan.ownTabs.map(\.id),
+            orphanedGroups: plan.orphanedGroups.map { ($0.windowGroupIndex, $0.tabs.map(\.id)) },
+            selectedId: result.selectedTabId
         )
 
         applyRestoredGroup(
-            [firstTab],
-            selectedTabId: firstTab.id,
+            plan.ownTabs,
+            selectedTabId: plan.ownSelectedTabId ?? plan.ownTabs.first?.id,
             activeDatabase: result.lastActiveDatabase,
             activeSchema: result.lastActiveSchema,
-            loadTiming: frontTabId == firstTab.id ? .immediate : .deferred
+            loadTiming: frontGroup == .own ? .immediate : .deferred
         )
 
-        for tab in remainingTabs {
+        for group in plan.orphanedGroups {
+            let isFront = frontGroup == .orphaned(windowGroupIndex: group.windowGroupIndex)
             openRestoredTabWindow(
-                tab,
-                activate: tab.id == frontTabId,
-                loadTiming: tab.id == frontTabId ? .immediate : .deferred
+                group.tabs,
+                selectedTabId: group.selectedTabId,
+                activate: isFront,
+                loadTiming: isFront ? .immediate : .deferred
             )
         }
-        if frontTabId == firstTab.id, !remainingTabs.isEmpty {
+        if frontGroup == .own, !plan.orphanedGroups.isEmpty {
             viewWindow?.makeKeyAndOrderFront(nil)
+        }
+    }
+
+    /// Other windows of this connection are already open and every one of them is restoring its own
+    /// tabs right now, so this window takes only what was its own and never raises itself: the user is
+    /// already looking at one of these windows. Only the window the user can see loads its data now,
+    /// which also keeps a reconnect from firing one query per window.
+    private func claimOwnTabs(_ plan: WindowGroupAssignment.Plan, result: RestoreResult, window: NSWindow) {
+        applyRestoredGroup(
+            plan.ownTabs,
+            selectedTabId: plan.ownSelectedTabId ?? plan.ownTabs.first?.id,
+            activeDatabase: result.lastActiveDatabase,
+            activeSchema: result.lastActiveSchema,
+            loadTiming: window.isKeyWindow ? .immediate : .deferred
+        )
+
+        for group in plan.orphanedGroups {
+            openRestoredTabWindow(
+                group.tabs,
+                selectedTabId: group.selectedTabId,
+                activate: false,
+                loadTiming: .deferred
+            )
         }
     }
 
@@ -237,21 +276,30 @@ extension MainContentView {
         }
     }
 
-    private func openRestoredTabWindow(_ tab: QueryTab, activate: Bool, loadTiming: RestoreLoadTiming) {
+    /// Opens one window for a whole saved group. The payload describes the tab the window opens on so
+    /// its native label reads right from creation; the group itself travels through the registry, which
+    /// is what carries the state a payload cannot express.
+    private func openRestoredTabWindow(
+        _ tabs: [QueryTab],
+        selectedTabId: UUID?,
+        activate: Bool,
+        loadTiming: RestoreLoadTiming
+    ) {
+        guard let leadTab = tabs.first(where: { $0.id == selectedTabId }) ?? tabs.first else { return }
         let restorePayload = EditorTabPayload(
             connectionId: connection.id,
-            tabType: tab.tabType,
-            tableName: tab.tableContext.tableName,
-            databaseName: tab.tableContext.databaseName,
-            schemaName: tab.tableContext.schemaName,
-            isView: tab.tableContext.isView,
+            tabType: leadTab.tabType,
+            tableName: leadTab.tableContext.tableName,
+            databaseName: leadTab.tableContext.databaseName,
+            schemaName: leadTab.tableContext.schemaName,
+            isView: leadTab.tableContext.isView,
             skipAutoExecute: true,
-            erDiagramSchemaKey: tab.display.erDiagramSchemaKey,
-            tabTitle: tab.title,
+            erDiagramSchemaKey: leadTab.display.erDiagramSchemaKey,
+            tabTitle: leadTab.title,
             intent: .restoreOrDefault
         )
         RestorationGroupRegistry.register(
-            .init(tabs: [tab], selectedTabId: tab.id, loadTiming: loadTiming),
+            .init(tabs: tabs, selectedTabId: selectedTabId ?? leadTab.id, loadTiming: loadTiming),
             for: restorePayload.id
         )
         WindowManager.shared.openTab(payload: restorePayload, activate: activate)

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -313,30 +313,39 @@ final class MainContentCoordinator {
 
     /// Collect tabs across all of a connection's windows for persistence, tagged with
     /// the index of the native window group they belong to so tab order restores intact.
+    /// Tabs stamped with the position of the window holding them, so a window can claim its own back.
+    /// The position is the window's place in the native tab group, not its rank among the windows that
+    /// happen to have a coordinator: a window whose session went away has no coordinator but still
+    /// occupies a tab, and numbering around it would hand every later window the wrong tabs.
     static func aggregatedTabs(for connectionId: UUID) -> [(tab: QueryTab, windowGroupIndex: Int)] {
         let coordinators = activeCoordinators.values
             .filter { $0.connectionId == connectionId }
 
-        // Sort by native window tab order to preserve left-to-right position
-        let orderedCoordinators: [MainContentCoordinator]
-        if let firstWindow = coordinators.compactMap({ $0.contentWindow }).first,
-           let tabbedWindows = firstWindow.tabbedWindows {
-            let windowOrder = Dictionary(uniqueKeysWithValues:
-                tabbedWindows.enumerated().map { (ObjectIdentifier($0.element), $0.offset) }
-            )
-            orderedCoordinators = coordinators.sorted { a, b in
-                let aIdx = a.contentWindow.flatMap { windowOrder[ObjectIdentifier($0)] } ?? Int.max
-                let bIdx = b.contentWindow.flatMap { windowOrder[ObjectIdentifier($0)] } ?? Int.max
-                return aIdx < bIdx
+        guard let anyWindow = coordinators.compactMap({ $0.contentWindow }).first else {
+            return coordinators.enumerated().flatMap { groupIndex, coordinator in
+                coordinator.tabManager.tabs
+                    .map { (tab: coordinator.enrichedForPersistence($0), windowGroupIndex: groupIndex) }
             }
-        } else {
-            orderedCoordinators = Array(coordinators)
         }
 
-        return orderedCoordinators.enumerated().flatMap { groupIndex, coordinator in
-            coordinator.tabManager.tabs
-                .map { (tab: coordinator.enrichedForPersistence($0), windowGroupIndex: groupIndex) }
-        }
+        let groupOrder = Dictionary(uniqueKeysWithValues:
+            WindowTabGroupOrder.windows(containing: anyWindow)
+                .enumerated()
+                .map { (ObjectIdentifier($0.element), $0.offset) }
+        )
+        return coordinators
+            .sorted { lhs, rhs in
+                lhs.tabGroupPosition(in: groupOrder) < rhs.tabGroupPosition(in: groupOrder)
+            }
+            .flatMap { coordinator in
+                let groupIndex = coordinator.tabGroupPosition(in: groupOrder)
+                return coordinator.tabManager.tabs
+                    .map { (tab: coordinator.enrichedForPersistence($0), windowGroupIndex: groupIndex) }
+            }
+    }
+
+    private func tabGroupPosition(in groupOrder: [ObjectIdentifier: Int]) -> Int {
+        contentWindow.flatMap { groupOrder[ObjectIdentifier($0)] } ?? Int.max
     }
 
     /// Resolve transient view state that only the live coordinator knows about

--- a/TableProTests/Core/Services/RestoreWindowPlanTests.swift
+++ b/TableProTests/Core/Services/RestoreWindowPlanTests.swift
@@ -10,43 +10,48 @@ import Testing
 
 @Suite("RestoreWindowPlan")
 struct RestoreWindowPlanTests {
-    @Test("Selected tab is the first tab: front is the first tab")
-    func selectedIsFirst() {
-        let first = UUID()
-        let remaining = [UUID(), UUID()]
-        let front = RestoreWindowPlan.resolveFrontTabId(
-            remainingTabIds: remaining, firstTabId: first, selectedId: first
+    @Test("Selected tab is one this window kept: this window comes to the front")
+    func selectedIsOwn() {
+        let own = UUID()
+        let front = RestoreWindowPlan.resolveFrontGroup(
+            ownTabIds: [own],
+            orphanedGroups: [(windowGroupIndex: 1, tabIds: [UUID()])],
+            selectedId: own
         )
-        #expect(front == first)
+        #expect(front == .own)
     }
 
-    @Test("Selected tab is one of the remaining tabs: front is that tab")
-    func selectedIsRemaining() {
-        let first = UUID()
+    @Test("Selected tab belongs to a reopened group: that group comes to the front")
+    func selectedIsOrphaned() {
         let target = UUID()
-        let remaining = [UUID(), target, UUID()]
-        let front = RestoreWindowPlan.resolveFrontTabId(
-            remainingTabIds: remaining, firstTabId: first, selectedId: target
+        let front = RestoreWindowPlan.resolveFrontGroup(
+            ownTabIds: [UUID()],
+            orphanedGroups: [
+                (windowGroupIndex: 1, tabIds: [UUID()]),
+                (windowGroupIndex: 2, tabIds: [UUID(), target]),
+            ],
+            selectedId: target
         )
-        #expect(front == target)
+        #expect(front == .orphaned(windowGroupIndex: 2))
     }
 
-    @Test("Selected id matches neither: falls back to the first tab")
+    @Test("Selected id matches nothing being restored: this window comes to the front")
     func selectedMatchesNeither() {
-        let first = UUID()
-        let remaining = [UUID()]
-        let front = RestoreWindowPlan.resolveFrontTabId(
-            remainingTabIds: remaining, firstTabId: first, selectedId: UUID()
+        let front = RestoreWindowPlan.resolveFrontGroup(
+            ownTabIds: [UUID()],
+            orphanedGroups: [(windowGroupIndex: 1, tabIds: [UUID()])],
+            selectedId: UUID()
         )
-        #expect(front == first)
+        #expect(front == .own)
     }
 
-    @Test("Nil selected id: falls back to the first tab")
+    @Test("Nothing was selected: this window comes to the front")
     func selectedNil() {
-        let first = UUID()
-        let front = RestoreWindowPlan.resolveFrontTabId(
-            remainingTabIds: [UUID()], firstTabId: first, selectedId: nil
+        let front = RestoreWindowPlan.resolveFrontGroup(
+            ownTabIds: [UUID()],
+            orphanedGroups: [(windowGroupIndex: 1, tabIds: [UUID()])],
+            selectedId: nil
         )
-        #expect(front == first)
+        #expect(front == .own)
     }
 }

--- a/TableProTests/Core/Services/TabPersistenceCoordinatorTests.swift
+++ b/TableProTests/Core/Services/TabPersistenceCoordinatorTests.swift
@@ -379,4 +379,22 @@ struct TabPersistenceCoordinatorTests {
         #expect(result.tabs.isEmpty)
         #expect(result.source == .none)
     }
+
+    /// Which window a tab belonged to has to survive the round trip, or a reconnecting window cannot
+    /// tell its own tabs from a sibling's.
+    @Test("Window positions survive a save and restore")
+    func windowGroupIndexRoundTrip() async {
+        let coordinator = makeCoordinator()
+        let tabs = makeTabs(count: 3)
+        coordinator.saveNowSync(
+            windowedTabs: [(tabs[0], 0), (tabs[1], 1), (tabs[2], 1)],
+            selectedTabId: tabs[1].id
+        )
+
+        let result = await coordinator.restoreFromDisk()
+
+        #expect(result.windowGroupIndexByTabId[tabs[0].id] == 0)
+        #expect(result.windowGroupIndexByTabId[tabs[1].id] == 1)
+        #expect(result.windowGroupIndexByTabId[tabs[2].id] == 1)
+    }
 }

--- a/TableProTests/Core/Services/WindowGroupAssignmentTests.swift
+++ b/TableProTests/Core/Services/WindowGroupAssignmentTests.swift
@@ -1,0 +1,186 @@
+//
+//  WindowGroupAssignmentTests.swift
+//  TableProTests
+//
+//  Every window of a connection restores at the same time, in no defined order, so the rule deciding
+//  which tabs are whose has to depend only on the window's own position. A connection with more than
+//  one window open used to come back with every window empty, because each one stood down on seeing a
+//  sibling and none of them claimed the tabs.
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Window group assignment")
+struct WindowGroupAssignmentTests {
+    private func tab(_ title: String) -> QueryTab {
+        QueryTab(id: UUID(), title: title, query: "SELECT 1", tabType: .table)
+    }
+
+    private func indices(_ pairs: [(QueryTab, Int)]) -> [UUID: Int] {
+        Dictionary(uniqueKeysWithValues: pairs.map { ($0.0.id, $0.1) })
+    }
+
+    @Test("A window claims the group saved at its own position")
+    func claimsOwnGroup() {
+        let first = tab("First")
+        let second = tab("Second")
+        let third = tab("Third")
+
+        let plan = WindowGroupAssignment.resolve(
+            windowIndex: 1,
+            openWindowCount: 3,
+            tabs: [first, second, third],
+            windowGroupIndexByTabId: indices([(first, 0), (second, 1), (third, 2)]),
+            selectedTabId: nil
+        )
+
+        #expect(plan.ownTabs == [second])
+        #expect(plan.orphanedGroups.isEmpty)
+    }
+
+    /// The property that lets every window decide alone: only the leftmost one reopens anything, so
+    /// two windows can never both restore the same saved group into a window of their own.
+    @Test("Only the leftmost window reports orphaned groups")
+    func onlyLeftmostWindowFansOut() {
+        let kept = tab("Kept")
+        let orphaned = tab("Orphaned")
+        let byId = indices([(kept, 0), (orphaned, 4)])
+
+        let leftmost = WindowGroupAssignment.resolve(
+            windowIndex: 0,
+            openWindowCount: 2,
+            tabs: [kept, orphaned],
+            windowGroupIndexByTabId: byId,
+            selectedTabId: nil
+        )
+        let other = WindowGroupAssignment.resolve(
+            windowIndex: 1,
+            openWindowCount: 2,
+            tabs: [kept, orphaned],
+            windowGroupIndexByTabId: byId,
+            selectedTabId: nil
+        )
+
+        #expect(leftmost.orphanedGroups.map(\.windowGroupIndex) == [4])
+        #expect(other.orphanedGroups.isEmpty)
+    }
+
+    @Test("A group that still has a window is never reopened")
+    func liveWindowsAreNotFannedOut() {
+        let first = tab("First")
+        let second = tab("Second")
+        let third = tab("Third")
+
+        let plan = WindowGroupAssignment.resolve(
+            windowIndex: 0,
+            openWindowCount: 3,
+            tabs: [first, second, third],
+            windowGroupIndexByTabId: indices([(first, 0), (second, 1), (third, 2)]),
+            selectedTabId: nil
+        )
+
+        #expect(plan.ownTabs == [first])
+        #expect(plan.orphanedGroups.isEmpty)
+    }
+
+    @Test("Orphaned groups come back in saved order")
+    func orphanedGroupsAreOrdered() {
+        let kept = tab("Kept")
+        let later = tab("Later")
+        let earlier = tab("Earlier")
+
+        let plan = WindowGroupAssignment.resolve(
+            windowIndex: 0,
+            openWindowCount: 1,
+            tabs: [kept, later, earlier],
+            windowGroupIndexByTabId: indices([(kept, 0), (later, 3), (earlier, 1)]),
+            selectedTabId: nil
+        )
+
+        #expect(plan.orphanedGroups.map(\.windowGroupIndex) == [1, 3])
+    }
+
+    /// A window that was blank when the session ended comes back blank, rather than being handed
+    /// somebody else's tab.
+    @Test("A window with nothing saved at its position stays empty")
+    func windowWithoutSavedGroupStaysEmpty() {
+        let first = tab("First")
+        let third = tab("Third")
+
+        let plan = WindowGroupAssignment.resolve(
+            windowIndex: 1,
+            openWindowCount: 3,
+            tabs: [first, third],
+            windowGroupIndexByTabId: indices([(first, 0), (third, 2)]),
+            selectedTabId: nil
+        )
+
+        #expect(plan.ownTabs.isEmpty)
+        #expect(plan.orphanedGroups.isEmpty)
+    }
+
+    @Test("A window that held several tabs gets all of them back")
+    func multipleTabsInOneWindow() {
+        let left = tab("Left")
+        let right = tab("Right")
+
+        let plan = WindowGroupAssignment.resolve(
+            windowIndex: 0,
+            openWindowCount: 1,
+            tabs: [left, right],
+            windowGroupIndexByTabId: indices([(left, 0), (right, 0)]),
+            selectedTabId: right.id
+        )
+
+        #expect(plan.ownTabs == [left, right])
+        #expect(plan.ownSelectedTabId == right.id)
+    }
+
+    @Test("The selected tab is only reported by the group that holds it")
+    func selectionBelongsToOneGroup() {
+        let kept = tab("Kept")
+        let orphaned = tab("Orphaned")
+
+        let plan = WindowGroupAssignment.resolve(
+            windowIndex: 0,
+            openWindowCount: 1,
+            tabs: [kept, orphaned],
+            windowGroupIndexByTabId: indices([(kept, 0), (orphaned, 1)]),
+            selectedTabId: orphaned.id
+        )
+
+        #expect(plan.ownSelectedTabId == nil)
+        #expect(plan.orphanedGroups.first?.selectedTabId == orphaned.id)
+    }
+
+    /// A file written before tabs recorded their window has no grouping at all. Reading every tab as
+    /// window zero would pile them into one window, and with no in-window tab bar all but one would be
+    /// invisible, so each tab keeps a window of its own exactly as it always has.
+    @Test("A file saved without window positions gives each tab its own window")
+    func legacyFileKeepsOneTabPerWindow() {
+        let first = PersistedTab(id: UUID(), title: "First", query: "SELECT 1", tabType: .table, tableName: nil)
+        let second = PersistedTab(id: UUID(), title: "Second", query: "SELECT 2", tabType: .table, tableName: nil)
+
+        let normalized = WindowGroupAssignment.normalizedGroupIndices(for: [first, second])
+
+        #expect(normalized[first.id] == 0)
+        #expect(normalized[second.id] == 1)
+    }
+
+    @Test("A file that records window positions keeps them")
+    func recordedPositionsAreKept() {
+        let first = PersistedTab(
+            id: UUID(), title: "First", query: "SELECT 1", tabType: .table, tableName: nil, windowGroupIndex: 2
+        )
+        let second = PersistedTab(
+            id: UUID(), title: "Second", query: "SELECT 2", tabType: .table, tableName: nil, windowGroupIndex: 0
+        )
+
+        let normalized = WindowGroupAssignment.normalizedGroupIndices(for: [first, second])
+
+        #expect(normalized[first.id] == 2)
+        #expect(normalized[second.id] == 0)
+    }
+}

--- a/TableProTests/Core/Services/WindowLifecycleMonitorRegistrationTests.swift
+++ b/TableProTests/Core/Services/WindowLifecycleMonitorRegistrationTests.swift
@@ -39,7 +39,7 @@ struct WindowLifecycleMonitorRegistrationTests {
         monitor.register(window: window, connectionId: connectionId, windowId: firstId)
         monitor.register(window: window, connectionId: connectionId, windowId: secondId)
 
-        #expect(!monitor.hasOtherWindows(for: connectionId, excluding: secondId))
+        #expect(monitor.windows(for: connectionId).count == 1)
         #expect(monitor.window(for: secondId) === window)
         #expect(monitor.window(for: firstId) == nil)
     }
@@ -60,7 +60,8 @@ struct WindowLifecycleMonitorRegistrationTests {
         monitor.register(window: first, connectionId: connectionId, windowId: firstId)
         monitor.register(window: second, connectionId: connectionId, windowId: secondId)
 
-        #expect(monitor.hasOtherWindows(for: connectionId, excluding: secondId))
-        #expect(monitor.hasOtherWindows(for: connectionId, excluding: firstId))
+        #expect(monitor.windows(for: connectionId).count == 2)
+        #expect(monitor.window(for: firstId) === first)
+        #expect(monitor.window(for: secondId) === second)
     }
 }

--- a/TableProTests/Core/Services/WindowLifecycleMonitorTests.swift
+++ b/TableProTests/Core/Services/WindowLifecycleMonitorTests.swift
@@ -80,38 +80,6 @@ struct WindowLifecycleMonitorTests {
         monitor.unregisterWindow(for: UUID())
     }
 
-    // MARK: - hasOtherWindows
-
-    @Test("hasOtherWindows — returns true when other windows exist for same connection")
-    func hasOtherWindowsTrueWhenOthersExist() {
-        let windowId1 = UUID()
-        let windowId2 = UUID()
-        let connectionId = UUID()
-
-        monitor.register(window: NSWindow(), connectionId: connectionId, windowId: windowId1)
-        monitor.register(window: NSWindow(), connectionId: connectionId, windowId: windowId2)
-        defer { cleanup(windowId1, windowId2) }
-
-        #expect(monitor.hasOtherWindows(for: connectionId, excluding: windowId1))
-        #expect(monitor.hasOtherWindows(for: connectionId, excluding: windowId2))
-    }
-
-    @Test("hasOtherWindows — returns false when only the excluded window exists")
-    func hasOtherWindowsFalseWhenOnlySelf() {
-        let windowId = UUID()
-        let connectionId = UUID()
-
-        monitor.register(window: NSWindow(), connectionId: connectionId, windowId: windowId)
-        defer { cleanup(windowId) }
-
-        #expect(!monitor.hasOtherWindows(for: connectionId, excluding: windowId))
-    }
-
-    @Test("hasOtherWindows — returns false when no windows exist")
-    func hasOtherWindowsFalseWhenEmpty() {
-        #expect(!monitor.hasOtherWindows(for: UUID(), excluding: UUID()))
-    }
-
     // MARK: - Multiple connections
 
     @Test("Multiple connections — windows are independent")

--- a/TableProTests/Core/Services/WindowTabGroupOrderTests.swift
+++ b/TableProTests/Core/Services/WindowTabGroupOrderTests.swift
@@ -1,0 +1,61 @@
+//
+//  WindowTabGroupOrderTests.swift
+//  TableProTests
+//
+//  Saving and restoring tabs both describe a window by its place in the native tab group. They have to
+//  agree: a window with no live session has no coordinator to be counted among, but it still occupies a
+//  tab, and numbering around it would hand every window after it somebody else's tabs.
+//
+
+import AppKit
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Window tab group order")
+@MainActor
+struct WindowTabGroupOrderTests {
+    private func makeWindow() -> NSWindow {
+        NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: true
+        )
+    }
+
+    @Test("A window with no tab group is alone at the first position")
+    func windowWithoutTabGroupIsFirst() {
+        let window = makeWindow()
+
+        #expect(WindowTabGroupOrder.index(of: window) == 0)
+        #expect(WindowTabGroupOrder.size(containing: window) == 1)
+        #expect(WindowTabGroupOrder.windows(containing: window) == [window])
+    }
+
+    @Test("A window reports its position in the group it belongs to")
+    func positionWithinGroup() {
+        /// Held in bindings on purpose: an `ObjectIdentifier` taken from a temporary is only unique
+        /// while that object is alive, and the next allocation can land on the same address.
+        let firstWindow = makeWindow()
+        let secondWindow = makeWindow()
+        let thirdWindow = makeWindow()
+        let group = [firstWindow, secondWindow, thirdWindow].map(ObjectIdentifier.init)
+
+        #expect(WindowTabGroupOrder.position(of: ObjectIdentifier(firstWindow), in: group) == 0)
+        #expect(WindowTabGroupOrder.position(of: ObjectIdentifier(secondWindow), in: group) == 1)
+        #expect(WindowTabGroupOrder.position(of: ObjectIdentifier(thirdWindow), in: group) == 2)
+    }
+
+    /// A window absent from the list it was asked about is treated as the only one there is, which is
+    /// the same answer a connection's single window gets.
+    @Test("A window missing from its group falls back to the first position")
+    func missingWindowFallsBackToFirst() {
+        let absentWindow = makeWindow()
+        let presentWindow = makeWindow()
+        let absent = ObjectIdentifier(absentWindow)
+
+        #expect(WindowTabGroupOrder.position(of: absent, in: [ObjectIdentifier(presentWindow)]) == 0)
+        #expect(WindowTabGroupOrder.position(of: absent, in: []) == 0)
+    }
+}

--- a/docs/features/tabs.mdx
+++ b/docs/features/tabs.mdx
@@ -78,7 +78,7 @@ To move between open connections, use the [workspace rail](/features/workspace-r
 
 **Connection > Disconnect** ends the session without closing the window. The window shows a Reconnect screen in place of its tabs, and the tabs are saved before the session ends. Use **Connection > Reconnect**, or the Reconnect button on the screen itself.
 
-A connection with one window open restores its tabs as soon as you reconnect. A connection with several windows open restores them the next time you open the connection instead.
+Reconnecting puts the tabs back as they were, however many windows the connection has open. Each window takes back the tabs that were its own, and a window whose tabs you had closed stays empty.
 
 Disconnecting asks first only when a window has unsaved changes or a query still running. It applies to the whole connection, so every window and workspace on it shows the same Reconnect screen. Nothing reconnects on its own afterwards: a connection you disconnected is not reopened at the next launch, and clicking back into its window leaves it disconnected until you ask.
 


### PR DESCRIPTION
Follow-up to #2056, which shipped Disconnect with a documented caveat: a connection with several windows open came back with every window empty. This removes the caveat, and in doing so makes the window position saved with every tab actually mean something.

## Why every window came back empty

Restore was "one window fans out into N": the window that claimed it kept persisted tab 0 and opened a brand-new window for every other tab. To stop two windows both doing that, `handleRestoreOrDefault` stood down whenever `hasOtherWindows` was true. On a reconnect that guard is true for all of them, because the windows never closed, so every window stood down and nobody restored.

The data needed to do better was already on disk and already ignored. `aggregatedTabs` stamps each tab with `windowGroupIndex` on every save, but `QueryTab` has no such field, `QueryTab.init(from:)` drops it, and `restoreFromDisk` returns a flat array. Nothing had ever read it back. So restore also flattened a window that held two tabs into two windows, and filled a window that was empty with the next window's tab, at launch as well as on reconnect.

## The rule

Each window asks where it sits in its own native tab group and claims the saved group at that position. Nothing arbitrates. That matters because the N windows all react to one session-return broadcast, each subscribed with `.receive(on: RunLoop.main)`, and their SwiftUI `.task` bodies contain awaits and interleave in no defined order. Any design where one window has to act before another would be racing. Here each window's answer depends only on its own position and on immutable file content, so order stops mattering.

Only the window at position 0 opens windows, and only for groups whose position is past the last open window. That is a structural property rather than a protocol: exactly one window computes position 0, so two windows cannot both reopen the same saved group. `WindowGroupAssignmentTests.onlyLeftmostWindowFansOut` is the test that pins it.

With one window the rule reduces to what launch already did: position 0 keeps group 0 and everything past the only window is reopened. Launch and reconnect are now the same code path.

## Save and restore had to agree, and did not

Both halves describe a window by its position, so they have to count the same windows. They did not. `aggregatedTabs` numbered coordinators, ordered by window position but skipping any window without one, while the restore side would number positions in `tabbedWindows`, which counts every window. A window with no live session has no coordinator and still occupies a tab, so with three windows whose middle one had lost its session, save wrote positions 0 and 1 while restore read 0 and 2: the third window's tabs would land in the second window and the third would get nothing.

`WindowTabGroupOrder` is now the single definition both use, and `aggregatedTabs` stamps the window's real position in the tab group rather than its rank among coordinators. This was the reason to share the primitive; tidiness was not.

## Files saved before tabs recorded their window

Those carry no grouping at all. Reading every tab as position 0 would pile them into one window, and since there is no in-window tab bar, all but one would be invisible: tabs the user could no longer reach. Instead `normalizedGroupIndices` gives each tab its array position when no tab records one, so an old file restores exactly the way it always has, through the same single code path rather than a second algorithm kept alongside.

## Focus

A window being created by this restore pass can be brought to the front, because nothing has focus yet: that is launch, and `RestoreWindowPlan` still decides which group wins, now per group rather than per tab, since a group can hold several tabs.

Once siblings already exist, restore never moves focus. The user is looking at one of these windows and a reconnect must not pull the key window out from under them. Each window decides its own eager load from its own `isKeyWindow` instead, which also stops a reconnect firing one query per window: only the visible one loads now, the rest defer and load when the user switches to them, through the `windowDidBecomeKey` path that already exists.

## Other changes

- `RestoreWindowPlan.resolveFrontTabId` becomes `resolveFrontGroup`. Keeping a tab-based front decision while groups can hold several tabs would have been a latent inconsistency. Its four tests are updated in the same commit.
- `WindowLifecycleMonitor.hasOtherWindows` is deleted; the guard it existed for is gone. `WindowLifecycleMonitorRegistrationTests` asserted the supersede fix from #2056 through it, so those assertions now go through `windows(for:)`, which states the invariant more directly: one entry per physical window.
- The window resolved for the index comes from `coordinator.splitViewController?.view.window`, not `viewWindow`. The split view controller is wired up in `adoptSession` before this view is built, while `viewWindow` arrives from `configureWindow` and can still be nil at `.task` time.

## Known limitation

Closing a window while the connection is disconnected renumbers the positions of the windows that remain, so their tabs shift by one and the last group opens as a new window. Every tab still comes back and nothing is lost, but they can be distributed differently than they were. Position is the only window identity persisted; fixing it properly means giving windows a stable identity on disk, which is its own change.

## Testing

Build succeeds. `swiftlint lint --strict` clean across 1301 files. 108 tests pass across 9 suites, including the pre-existing persistence, restore-plan, window-monitor and multi-window suites.

Newly covered, none of which had any coverage before:

- `WindowGroupAssignmentTests`: a window claims the group at its position; only the leftmost reports orphans; a group that still has a window is never reopened; orphans come back in saved order; a window with nothing saved at its position stays empty; a window that held several tabs gets all of them; the selection is reported only by the group holding it; and both legacy-file cases.
- `WindowTabGroupOrderTests`: position within a group, the fallback for a window absent from its group, and a window with no tab group.
- `TabPersistenceCoordinatorTests`: one added case proving window positions survive the round trip.

Not automated: the real multi-window check needs several `NSWindow`s joined with `addTabbedWindow`, which depends on window-server state and is not exercised anywhere in this repo's tests today. Manual pass for review: open a connection, open three native tabs on it, Disconnect, Reconnect, and confirm each window shows the tab it had, none are blank, and focus does not jump.
