### PR TITLE
fix(coordinator): validate phase 2 against content identity, not a claim already settled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A connection with more than one window open now brings every window's tabs back when it reconnects, instead of leaving them all empty. Each window used to stand down the moment it saw another window on the same connection, so none of them restored anything.
 - Reopening a connection now puts each tab back in the window it was in. A window that held more than one tab came back as one window per tab, and a window that was empty was filled with the next window's tab.
+- Table row counts are exact again when the estimate is below your "count rows if estimate less than" setting. Opening a table showed the estimate and never refined it, and a filtered count never updated at all.
 - Closing a window now stops an exact row count that is still running, and pointing a tab at another table stops the count for the table you left. Both used to run to completion against a server nobody was waiting on. (#2059)
 - Clicking quickly through the sidebar no longer keeps loading column details for tables you have already left. Each abandoned table held the connection for another 75-90ms, so every table clicked after it waited that much longer. (#2058)
 - Clicking a table while another one is still loading now loads the table you clicked. The tab used to fill with the previous table's rows under the new table's name, and the table you clicked never loaded at all.

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
@@ -269,11 +269,11 @@ extension QueryExecutionCoordinator {
     func launchPhase2Work(
         tableName: String,
         tabId: UUID,
-        claim: TabExecutionClaim,
         connectionType: DatabaseType,
         schemaTask: Task<FetchedTableSchema, Error>?
     ) {
         let isNonSQL = PluginManager.shared.editorLanguage(for: connectionType) != .sql
+        let contentEpoch = parent.tabExecution.contentEpoch(for: tabId)
         Task(priority: .utility) { [weak self, parent] in
             guard let self else { return }
             guard !parent.isTearingDown else { return }
@@ -288,11 +288,10 @@ extension QueryExecutionCoordinator {
                 if let schema {
                     applySchemaMetadata(schema, tabId: tabId, tableName: tableName)
                 }
-                if parent.tabExecution.isCurrent(claim) {
+                if parent.tabExecution.isSameContent(contentEpoch, for: tabId) {
                     resolveRowCount(
                         tableName: tableName,
                         tabId: tabId,
-                        claim: claim,
                         connectionType: connectionType
                     )
                 }
@@ -396,24 +395,25 @@ extension QueryExecutionCoordinator {
     func launchPhase2Count(
         tableName: String,
         tabId: UUID,
-        claim: TabExecutionClaim,
         connectionType: DatabaseType
     ) {
         resolveRowCount(
             tableName: tableName,
             tabId: tabId,
-            claim: claim,
             connectionType: connectionType
         )
     }
 
+    /// Validates against the tab's content identity, not the execution claim. The claim is settled
+    /// the moment phase 1 is applied, which happens before phase 2 is even dispatched, so a claim
+    /// check here is false on every run and the count never lands.
     func resolveRowCount(
         tableName: String,
         tabId: UUID,
-        claim: TabExecutionClaim,
         connectionType: DatabaseType
     ) {
         let isNonSQL = PluginManager.shared.editorLanguage(for: connectionType) != .sql
+        let contentEpoch = parent.tabExecution.contentEpoch(for: tabId)
 
         let task = Task(priority: .utility) { [weak self, parent] in
             guard let self else { return }
@@ -487,7 +487,7 @@ extension QueryExecutionCoordinator {
             }
 
             await MainActor.run {
-                guard parent.tabExecution.isCurrent(claim) else { return }
+                guard parent.tabExecution.isSameContent(contentEpoch, for: tabId) else { return }
                 parent.clearRowCountTask(for: tabId)
                 guard let outcome else { return }
                 parent.tabManager.mutate(tabId: tabId) { tab in

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+Parameters.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+Parameters.swift
@@ -176,7 +176,6 @@ extension QueryExecutionCoordinator {
                         launchPhase2Work(
                             tableName: tableName,
                             tabId: tabId,
-                            claim: claim,
                             connectionType: conn.type,
                             schemaTask: schemaTask
                         )
@@ -184,7 +183,6 @@ extension QueryExecutionCoordinator {
                         launchPhase2Count(
                             tableName: tableName,
                             tabId: tabId,
-                            claim: claim,
                             connectionType: conn.type
                         )
                     }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
@@ -95,7 +95,6 @@ extension MainContentCoordinator {
     func launchPhase2(
         tableName: String,
         tabId: UUID,
-        claim: TabExecutionClaim,
         connectionType: DatabaseType,
         needsMetadataFetch: Bool,
         schemaTask: Task<FetchedTableSchema, Error>?
@@ -104,7 +103,6 @@ extension MainContentCoordinator {
             launchPhase2Count(
                 tableName: tableName,
                 tabId: tabId,
-                claim: claim,
                 connectionType: connectionType
             )
             return
@@ -112,7 +110,6 @@ extension MainContentCoordinator {
         launchPhase2Work(
             tableName: tableName,
             tabId: tabId,
-            claim: claim,
             connectionType: connectionType,
             schemaTask: schemaTask
         )
@@ -121,14 +118,12 @@ extension MainContentCoordinator {
     func launchPhase2Work(
         tableName: String,
         tabId: UUID,
-        claim: TabExecutionClaim,
         connectionType: DatabaseType,
         schemaTask: Task<FetchedTableSchema, Error>?
     ) {
         queryExecutionCoordinator.launchPhase2Work(
             tableName: tableName,
             tabId: tabId,
-            claim: claim,
             connectionType: connectionType,
             schemaTask: schemaTask
         )
@@ -137,13 +132,11 @@ extension MainContentCoordinator {
     func launchPhase2Count(
         tableName: String,
         tabId: UUID,
-        claim: TabExecutionClaim,
         connectionType: DatabaseType
     ) {
         queryExecutionCoordinator.launchPhase2Count(
             tableName: tableName,
             tabId: tabId,
-            claim: claim,
             connectionType: connectionType
         )
     }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -1291,7 +1291,6 @@ final class MainContentCoordinator {
                     launchPhase2(
                         tableName: tableName,
                         tabId: tabId,
-                        claim: claim,
                         connectionType: conn.type,
                         needsMetadataFetch: needsMetadataFetch,
                         schemaTask: schemaTask

--- a/TableProTests/Views/Main/Phase2RowCountGuardTests.swift
+++ b/TableProTests/Views/Main/Phase2RowCountGuardTests.swift
@@ -1,0 +1,85 @@
+//
+//  Phase2RowCountGuardTests.swift
+//  TableProTests
+//
+//  Phase 1 settles the execution claim before phase 2 is dispatched, so a phase-2 validity check
+//  written against the claim is false on every run and the row count never lands. Phase 2 has to
+//  validate against the tab's content identity, which survives a settled claim on purpose.
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Phase 2 row count guard", .serialized)
+@MainActor
+struct Phase2RowCountGuardTests {
+    /// The registry contract phase 2 depends on. A claim is dead the moment phase 1 settles it, so
+    /// anything that runs afterwards and still belongs to the same content must ask about content.
+    @Test("A settled claim is no longer current but its content identity holds")
+    func settledClaimKeepsContentIdentity() {
+        var registry = TabExecutionRegistry()
+        let tabId = UUID()
+        let claim = registry.claim(tabId)
+        let contentEpoch = registry.contentEpoch(for: tabId)
+
+        registry.settle(claim)
+
+        #expect(registry.isCurrent(claim) == false)
+        #expect(registry.isSameContent(contentEpoch, for: tabId))
+    }
+
+    /// The bug: phase 2 gated the row count on `isCurrent(claim)`, which `settle` had already made
+    /// false, so the count was never requested. `launchPhase2Count` reaches `resolveRowCount`
+    /// synchronously, so the handle it registers is observable without waiting on anything.
+    @Test("Phase 2 still requests a row count after phase 1 has settled the claim")
+    func phase2RequestsRowCountAfterSettle() {
+        let (coordinator, tabManager) = Self.makeCoordinator()
+        let tabId = Self.addTableTab(to: tabManager)
+        let claim = coordinator.tabExecution.claim(tabId)
+        coordinator.tabExecution.settle(claim)
+        #expect(coordinator.tabExecution.isCurrent(claim) == false)
+
+        coordinator.launchPhase2Count(tableName: "users", tabId: tabId, connectionType: .mysql)
+
+        #expect(coordinator.rowCountTasks[tabId] != nil)
+        coordinator.cancelAllRowCountTasks()
+    }
+
+    /// A retarget bumps content identity, and that is what has to stop a late phase 2 instead.
+    @Test("A retarget makes the phase 2 content check fail")
+    func retargetFailsTheContentCheck() {
+        var registry = TabExecutionRegistry()
+        let tabId = UUID()
+        let claim = registry.claim(tabId)
+        let contentEpoch = registry.contentEpoch(for: tabId)
+        registry.settle(claim)
+
+        registry.invalidate(tabId)
+
+        #expect(registry.isSameContent(contentEpoch, for: tabId) == false)
+    }
+
+    private static func makeCoordinator() -> (MainContentCoordinator, QueryTabManager) {
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: TestFixtures.makeConnection(),
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        return (coordinator, tabManager)
+    }
+
+    private static func addTableTab(to tabManager: QueryTabManager, tableName: String = "users") -> UUID {
+        let tab = QueryTab(
+            title: tableName,
+            query: "SELECT * FROM \(tableName)",
+            tabType: .table,
+            tableName: tableName
+        )
+        tabManager.tabs.append(tab)
+        tabManager.selectedTabId = tab.id
+        return tab.id
+    }
+}


### PR DESCRIPTION
Found by a review pass over the batch merged in #2062, #2063, #2064 and #2065. This is a regression from #2055, not from any of those.

## The bug

`executeQueryInternal` settles the execution claim as the last step of applying phase 1:

```swift
applyPhase1Result(...)
tabExecution.settle(claim)          // MainContentCoordinator.swift:1286
...
launchPhase2(... claim: claim ...)  // dispatched after
```

`settle` removes the tab's entry from `TabExecutionRegistry`, so `isCurrent(claim)` is false from that instant. Phase 2 then validated against that same dead claim in two places:

- `launchPhase2Work` gated the row count on `if parent.tabExecution.isCurrent(claim)`, so on a first table open the count was never requested at all.
- `resolveRowCount`'s write-back began `guard parent.tabExecution.isCurrent(claim) else { return }`, so on the already-cached path the count was computed and then thrown away.

Both are false on every run, not just after a supersede.

## Why it was not obvious

The estimate still appears, because `applyPhase1Result` seeds `totalRowCount` from inline metadata before settle. What silently stopped working is the refinement: the exact `COUNT` that should replace the estimate when it falls under the "count rows if estimate less than" setting, and the recount after a filter changes.

Two things point straight at it. The parameterized-query path does not settle before dispatching phase 2, so the same code works there, and that asymmetry is the tell. And `TabExecutionRegistry`'s own doc comment says background work that augments an applied result must validate against `contentEpoch`, giving an exact row count as its example. `PaginationCoordinator.requestExactRowCount` does exactly that. `resolveRowCount` did not.

## The fix

Phase 2 validates content identity instead of the claim. `contentEpoch` is set by `claim()` and moved by `invalidate()`, and deliberately survives `settle()`, so it stays true for the content phase 1 just applied and goes false the moment the tab is retargeted, which is the behaviour phase 2 actually wants.

`claim` is no longer used anywhere in the phase-2 chain, so the parameter is dropped from `launchPhase2`, `launchPhase2Work`, `launchPhase2Count` and `resolveRowCount`, with all callers updated in this commit.

## Tests

`Phase2RowCountGuardTests` pins the registry contract phase 2 depends on (a settled claim is not current, its content identity holds, a retarget breaks it) and that `launchPhase2Count` still registers a row count task after the claim is settled.

Note on coverage: I first wrote the positive test against `launchPhase2Work` and it failed, because the handle is registered and cleared inside a single main actor turn, so polling never observes it. That is the fix working, but it is not a usable signal, so the test drives `launchPhase2Count`, which reaches `resolveRowCount` synchronously. The `launchPhase2Work` gate itself is covered by the predicate test rather than end to end.

28 tests pass across `Phase2RowCountGuardTests`, `TabRetargetInvalidationTests`, `RowCountTaskLifecycleTests` and `MainContentCoordinatorRefreshTests`. `swiftlint lint --strict` reports 0 violations in 1322 files.
