### PR TITLE
fix(coordinator): stop a stale waiter withdrawal cancelling the fetch that replaced it

### DIFF
--- a/TablePro/Core/Services/Query/SchemaColumnStore.swift
+++ b/TablePro/Core/Services/Query/SchemaColumnStore.swift
@@ -4,17 +4,20 @@ import Foundation
 final class SchemaColumnStore {
     typealias Entry = (columns: [String], primaryKeys: [String])
 
-    /// One fetch shared by every caller asking for the same key while it is in flight. It is only
-    /// cancelled once the last of them has given up, because cancelling on the first departure
-    /// would abandon a fetch the others are still waiting on.
+    /// One fetch shared by every caller asking for the same key while it is in flight.
+    ///
+    /// `id` is what makes the sharing safe. A waiter's cleanup runs on a deferred hop, so by the
+    /// time it lands the key can already belong to a different fetch. Everything that mutates a
+    /// load, or writes the result of one, checks the id it started with first.
     private struct Load {
+        let id: Int
         let task: Task<Void, Never>
         var liveWaiters: Int
     }
 
     private var entries: [String: Entry] = [:]
     private var loads: [String: Load] = [:]
-    private var generation = 0
+    private var lastLoadID = 0
 
     func cached(_ key: String) -> Entry? {
         entries[key]
@@ -35,21 +38,19 @@ final class SchemaColumnStore {
     func load(_ key: String, fetch: @escaping () async -> Entry?) async {
         if entries[key] != nil { return }
 
-        let task = joinLoad(key, fetch: fetch)
-        let startedGeneration = generation
+        let load = joinLoad(key, fetch: fetch)
 
         await withTaskCancellationHandler {
-            await task.value
+            await load.task.value
         } onCancel: {
-            Task { @MainActor [weak self] in self?.withdrawWaiter(from: key) }
+            Task { @MainActor [weak self] in self?.withdrawWaiter(from: key, loadID: load.id) }
         }
 
-        guard generation == startedGeneration else { return }
+        guard loads[key]?.id == load.id else { return }
         loads.removeValue(forKey: key)
     }
 
     func removeAll() {
-        generation += 1
         for load in loads.values { load.task.cancel() }
         loads.removeAll()
         entries.removeAll()
@@ -59,29 +60,45 @@ final class SchemaColumnStore {
     /// the entry there is a window where the task is already cancelled, and a caller that adopted
     /// it would wait for a fetch that is never going to produce anything. Clicking back to a table
     /// just after clicking away from it lands exactly there.
-    private func joinLoad(_ key: String, fetch: @escaping () async -> Entry?) -> Task<Void, Never> {
+    private func joinLoad(_ key: String, fetch: @escaping () async -> Entry?) -> Load {
         if var existing = loads[key], !existing.task.isCancelled {
             existing.liveWaiters += 1
             loads[key] = existing
-            return existing.task
+            return existing
         }
 
+        lastLoadID += 1
+        let id = lastLoadID
         let task = Task { [weak self] in
             guard let entry = await fetch() else { return }
-            self?.entries[key] = entry
+            guard let self, self.loads[key]?.id == id else { return }
+            self.entries[key] = entry
         }
-        loads[key] = Load(task: task, liveWaiters: 1)
-        return task
+        let load = Load(id: id, task: task, liveWaiters: 1)
+        loads[key] = load
+        return load
     }
 
     #if DEBUG
     internal func waiterCount(for key: String) -> Int {
         loads[key]?.liveWaiters ?? 0
     }
+
+    internal func loadID(for key: String) -> Int? {
+        loads[key]?.id
+    }
+
+    internal func withdrawWaiterForTesting(from key: String, loadID: Int) {
+        withdrawWaiter(from: key, loadID: loadID)
+    }
     #endif
 
-    private func withdrawWaiter(from key: String) {
-        guard var load = loads[key] else { return }
+    /// Ignores a withdrawal aimed at a load this key no longer holds. The hop that calls this is
+    /// scheduled when a waiter is cancelled and runs later, by which time its load may have
+    /// finished and a different caller may own the key. Without the id check that late hop
+    /// decrements a stranger's waiter count and cancels a fetch somebody is still waiting on.
+    private func withdrawWaiter(from key: String, loadID: Int) {
+        guard var load = loads[key], load.id == loadID else { return }
         load.liveWaiters -= 1
         loads[key] = load
         guard load.liveWaiters <= 0 else { return }

--- a/TableProTests/Core/Services/Query/SchemaColumnStoreCancellationTests.swift
+++ b/TableProTests/Core/Services/Query/SchemaColumnStoreCancellationTests.swift
@@ -141,6 +141,59 @@ struct SchemaColumnStoreCancellationTests {
         #expect(store.cached("users")?.columns == ["id"])
     }
 
+    /// The defect: a cancelled waiter's cleanup runs on a deferred hop. If its own load finishes
+    /// and a new caller takes the key before that hop lands, the hop used to decrement the new
+    /// load's waiter count to zero and cancel a fetch nobody had abandoned.
+    @Test("A withdrawal aimed at a finished load cannot cancel the one that replaced it")
+    func staleWithdrawalCannotCancelTheNextLoad() async {
+        let store = SchemaColumnStore()
+        let abandonedProbe = FetchProbe()
+
+        let abandoned = Task { await store.load("users", fetch: abandonedProbe.fetch) }
+        #expect(await Self.wait(until: { store.loadID(for: "users") != nil }))
+        let staleLoadID = store.loadID(for: "users")
+        abandoned.cancel()
+        await abandoned.value
+        #expect(store.loadID(for: "users") == nil)
+
+        let liveProbe = FetchProbe()
+        let live = Task { await store.load("users", fetch: liveProbe.fetch) }
+        #expect(await Self.wait(until: { liveProbe.startCount == 1 }))
+        #expect(store.loadID(for: "users") != staleLoadID)
+
+        if let staleLoadID {
+            store.withdrawWaiterForTesting(from: "users", loadID: staleLoadID)
+        }
+
+        #expect(liveProbe.cancelCount == 0)
+
+        liveProbe.release()
+        await live.value
+
+        #expect(liveProbe.finishCount == 1)
+        #expect(store.cached("users")?.columns == ["id", "name"])
+    }
+
+    /// A cancelled fetch that finishes late must not overwrite the result of the fetch that
+    /// replaced it, so the write is gated on still owning the key.
+    @Test("A superseded fetch cannot write its result over a newer one")
+    func supersededFetchCannotOverwriteNewerResult() async {
+        let store = SchemaColumnStore()
+        let stale = FetchProbe()
+        stale.result = (["stale"], [])
+
+        let abandoned = Task { await store.load("users", fetch: stale.fetch) }
+        #expect(await Self.wait(until: { stale.startCount == 1 }))
+        abandoned.cancel()
+        await abandoned.value
+
+        let fresh = FetchProbe()
+        fresh.release()
+        await store.load("users", fetch: fresh.fetch)
+
+        #expect(store.cached("users")?.columns == ["id", "name"])
+    }
+
     private static func wait(
         until condition: () -> Bool,
         within timeout: Duration = .seconds(2)


### PR DESCRIPTION
Found by a review pass over the batch merged in #2062, #2063, #2064 and #2065. This is a defect in #2063, which I wrote.

## The bug

`SchemaColumnStore` shares one fetch between every caller asking for the same key, and counts live waiters so the fetch is only cancelled once the last of them has gone. The cleanup runs from `withTaskCancellationHandler`'s `onCancel`, which is not main actor isolated, so it hops:

```swift
onCancel: { Task { @MainActor [weak self] in self?.withdrawWaiter(from: key) } }
```

That hop is deferred, and `withdrawWaiter` looked up `loads[key]` positionally with no check that the load it finds is the one the cancelled waiter joined. So:

1. W1 loads key `K`. `loads[K]` holds task `T1`, one waiter.
2. W1 is cancelled. The hop is scheduled, not yet run.
3. `T1` finishes on its own, W1 resumes and its own cleanup removes `loads[K]`.
4. A new caller W2 arrives, starts `T2`, `loads[K]` now holds `T2` with one waiter.
5. The hop from step 2 finally runs, decrements W2's count to zero and cancels `T2`.

W2's fetch dies with nobody having abandoned it. In the app that is a table whose column details silently fail to load, so its default sort and hidden columns do not apply.

The same missing identity check let a cancelled-but-still-running fetch write its result over a newer one, because the write to `entries[key]` was unconditional.

## The fix

Every `Load` carries an `id`. The three places that act on a load check it first:

- `withdrawWaiter(from:loadID:)` ignores a withdrawal aimed at a load the key no longer holds.
- `load`'s completion cleanup only removes `loads[key]` if it still owns it.
- The fetch task only writes `entries[key]` if it still owns the key, so a superseded fetch cannot overwrite a newer result, and a fetch outstanding across `removeAll()` can no longer repopulate a cleared cache.

The separate `generation` counter that `removeAll()` used is gone: the per-load id subsumes it and covers the per-key races it never could.

## Tests

Two added, both deterministic rather than timing dependent. The stale-withdrawal test drives the exact interleaving through a `#if DEBUG` seam (`loadID(for:)` and `withdrawWaiterForTesting(from:loadID:)`), which is the same shape as `DatabaseManager.injectSession`. Reproducing it by racing real hops would be flaky in both directions. The second test pins that a superseded fetch cannot overwrite a newer result.

28 tests pass across `SchemaColumnStoreCancellationTests` and `SQLSchemaProviderTests`. `swiftlint lint --strict` reports 0 violations in 1322 files.

No CHANGELOG entry: #2063 has not shipped yet, so per the repo's rule this folds into that entry rather than adding a "Fixed" line for something unreleased.
