### PR TITLE
fix(coordinator): token a row count handle so a superseded task cannot clear its successor

### DIFF
--- a/TablePro/Core/Coordinators/PaginationCoordinator.swift
+++ b/TablePro/Core/Coordinators/PaginationCoordinator.swift
@@ -166,6 +166,7 @@ final class PaginationCoordinator {
         parent.tabManager.mutate(at: index) { $0.pagination.isCountingExact = true }
 
         let contentEpoch = parent.tabExecution.contentEpoch(for: tabId)
+        let token = UUID()
         let task = Task(priority: .userInitiated) { [parent] in
             let count = await Self.exactRowCount(
                 scope: scope,
@@ -177,7 +178,7 @@ final class PaginationCoordinator {
 
             guard !Task.isCancelled else { return }
             guard parent.tabExecution.isSameContent(contentEpoch, for: tabId) else { return }
-            parent.clearRowCountTask(for: tabId)
+            parent.clearRowCountTask(for: tabId, token: token)
             parent.tabManager.mutate(tabId: tabId) { tab in
                 tab.pagination.isCountingExact = false
                 guard let count, count >= 0 else { return }
@@ -185,7 +186,7 @@ final class PaginationCoordinator {
                 tab.pagination.isApproximateRowCount = false
             }
         }
-        parent.setRowCountTask(task, for: tabId)
+        parent.setRowCountTask(task, token: token, for: tabId)
     }
 
     private static func exactRowCount(

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
@@ -414,6 +414,7 @@ extension QueryExecutionCoordinator {
     ) {
         let isNonSQL = PluginManager.shared.editorLanguage(for: connectionType) != .sql
         let contentEpoch = parent.tabExecution.contentEpoch(for: tabId)
+        let token = UUID()
 
         let task = Task(priority: .utility) { [weak self, parent] in
             guard let self else { return }
@@ -488,7 +489,7 @@ extension QueryExecutionCoordinator {
 
             await MainActor.run {
                 guard parent.tabExecution.isSameContent(contentEpoch, for: tabId) else { return }
-                parent.clearRowCountTask(for: tabId)
+                parent.clearRowCountTask(for: tabId, token: token)
                 guard let outcome else { return }
                 parent.tabManager.mutate(tabId: tabId) { tab in
                     let applied = outcome.appliedTotal
@@ -497,7 +498,7 @@ extension QueryExecutionCoordinator {
                 }
             }
         }
-        parent.setRowCountTask(task, for: tabId)
+        parent.setRowCountTask(task, token: token, for: tabId)
     }
 
     static func rowCountPlan(

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+RowCountTasks.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+RowCountTasks.swift
@@ -2,31 +2,34 @@
 //  MainContentCoordinator+RowCountTasks.swift
 //  TablePro
 //
-//  A row count belongs to the tab that asked for it. One shared handle per window meant the
-//  second tab to ask dropped the only reference to the first tab's task, leaving it running with
-//  nothing able to cancel it, not even teardown, while it held the coordinator alive.
+//  A row count belongs to the tab that asked for it, so its handle is keyed by tab. The token
+//  carried alongside is what stops a task that is finishing from clearing the slot a successor
+//  has already taken, the same discipline `tableLoadTasks` uses.
 //
 
 import Foundation
 
 extension MainContentCoordinator {
     /// Cancels whatever this tab had running first, because a tab only ever wants its newest count.
-    internal func setRowCountTask(_ task: Task<Void, Never>, for tabId: UUID) {
-        rowCountTasks[tabId]?.cancel()
-        rowCountTasks[tabId] = task
+    internal func setRowCountTask(_ task: Task<Void, Never>, token: UUID, for tabId: UUID) {
+        rowCountTasks[tabId]?.task.cancel()
+        rowCountTasks[tabId] = (token, task)
     }
 
-    /// Drops a finished task's handle. The task is already done, so there is nothing to cancel.
-    internal func clearRowCountTask(for tabId: UUID) {
-        rowCountTasks.removeValue(forKey: tabId)
+    /// Drops a finished task's handle, and only its own. A superseded task still reaches its
+    /// completion path, so without the token it would clear the successor that replaced it and
+    /// leave that successor with nothing able to cancel it.
+    internal func clearRowCountTask(for tabId: UUID, token: UUID) {
+        guard rowCountTasks[tabId]?.token == token else { return }
+        rowCountTasks[tabId] = nil
     }
 
     internal func cancelRowCountTask(for tabId: UUID) {
-        rowCountTasks.removeValue(forKey: tabId)?.cancel()
+        rowCountTasks.removeValue(forKey: tabId)?.task.cancel()
     }
 
     internal func cancelAllRowCountTasks() {
-        for task in rowCountTasks.values { task.cancel() }
+        for entry in rowCountTasks.values { entry.task.cancel() }
         rowCountTasks.removeAll()
     }
 }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -210,7 +210,7 @@ final class MainContentCoordinator {
     /// property and invalidates its readers.
     internal var tabExecution = TabExecutionRegistry()
     @ObservationIgnored internal var currentQueryTask: Task<Void, Never>?
-    @ObservationIgnored internal var rowCountTasks: [UUID: Task<Void, Never>] = [:]
+    @ObservationIgnored internal var rowCountTasks: [UUID: (token: UUID, task: Task<Void, Never>)] = [:]
     @ObservationIgnored internal var tableLoadTasks: [UUID: (token: UUID, task: Task<Void, Never>)] = [:]
     @ObservationIgnored internal var redisDatabaseSwitchTask: Task<Void, Never>?
     @ObservationIgnored private var periodicSaveTask: Task<Void, Never>?

--- a/TableProTests/Views/Main/MainContentCoordinatorRefreshTests.swift
+++ b/TableProTests/Views/Main/MainContentCoordinatorRefreshTests.swift
@@ -199,7 +199,7 @@ struct MainContentCoordinatorRefreshTests {
         withInjectedDriver { connection, driver in
             let (coordinator, tabManager) = makeCoordinator(connection: connection)
             let tabId = addTableTab(to: tabManager)
-            coordinator.setRowCountTask(Task<Void, Never> {}, for: tabId)
+            coordinator.setRowCountTask(Task<Void, Never> {}, token: UUID(), for: tabId)
 
             coordinator.cancelCurrentQuery()
 
@@ -220,7 +220,7 @@ struct MainContentCoordinatorRefreshTests {
             tabManager.tabs[idx].execution.lastExecutedAt = Date()
 
             for _ in 0..<4 {
-                coordinator.setRowCountTask(Task<Void, Never> {}, for: tabId)
+                coordinator.setRowCountTask(Task<Void, Never> {}, token: UUID(), for: tabId)
                 coordinator.handleRefresh(hasPendingTableOps: false, onDiscard: {})
                 coordinator.currentQueryTask?.cancel()
                 coordinator.currentQueryTask = nil

--- a/TableProTests/Views/Main/RowCountTaskLifecycleTests.swift
+++ b/TableProTests/Views/Main/RowCountTaskLifecycleTests.swift
@@ -20,8 +20,8 @@ struct RowCountTaskLifecycleTests {
         let first = Self.neverEndingTask()
         defer { first.cancel() }
 
-        coordinator.setRowCountTask(first, for: tabId)
-        coordinator.setRowCountTask(Self.neverEndingTask(), for: tabId)
+        coordinator.setRowCountTask(first, token: UUID(), for: tabId)
+        coordinator.setRowCountTask(Self.neverEndingTask(), token: UUID(), for: tabId)
 
         #expect(first.isCancelled)
         #expect(coordinator.rowCountTasks.count == 1)
@@ -41,8 +41,8 @@ struct RowCountTaskLifecycleTests {
             countB.cancel()
         }
 
-        coordinator.setRowCountTask(countA, for: tabA)
-        coordinator.setRowCountTask(countB, for: tabB)
+        coordinator.setRowCountTask(countA, token: UUID(), for: tabA)
+        coordinator.setRowCountTask(countB, token: UUID(), for: tabB)
 
         #expect(countA.isCancelled == false)
         #expect(coordinator.rowCountTasks.count == 2)
@@ -59,8 +59,8 @@ struct RowCountTaskLifecycleTests {
             countA.cancel()
             countB.cancel()
         }
-        coordinator.setRowCountTask(countA, for: tabA)
-        coordinator.setRowCountTask(countB, for: tabB)
+        coordinator.setRowCountTask(countA, token: UUID(), for: tabA)
+        coordinator.setRowCountTask(countB, token: UUID(), for: tabB)
 
         coordinator.supersedeExecution(for: tabA)
 
@@ -78,8 +78,8 @@ struct RowCountTaskLifecycleTests {
         let tabB = Self.addTableTab(to: tabManager, tableName: "customers")
         let countA = Self.neverEndingTask()
         let countB = Self.neverEndingTask()
-        coordinator.setRowCountTask(countA, for: tabA)
-        coordinator.setRowCountTask(countB, for: tabB)
+        coordinator.setRowCountTask(countA, token: UUID(), for: tabA)
+        coordinator.setRowCountTask(countB, token: UUID(), for: tabB)
 
         coordinator.teardown()
 
@@ -95,8 +95,8 @@ struct RowCountTaskLifecycleTests {
         let tabB = Self.addTableTab(to: tabManager, tableName: "customers")
         let countA = Self.neverEndingTask()
         let countB = Self.neverEndingTask()
-        coordinator.setRowCountTask(countA, for: tabA)
-        coordinator.setRowCountTask(countB, for: tabB)
+        coordinator.setRowCountTask(countA, token: UUID(), for: tabA)
+        coordinator.setRowCountTask(countB, token: UUID(), for: tabB)
 
         coordinator.cancelCurrentQuery()
 
@@ -113,12 +113,36 @@ struct RowCountTaskLifecycleTests {
         let tabId = Self.addTableTab(to: tabManager)
         let count = Self.neverEndingTask()
         defer { count.cancel() }
-        coordinator.setRowCountTask(count, for: tabId)
+        let token = UUID()
+        coordinator.setRowCountTask(count, token: token, for: tabId)
 
-        coordinator.clearRowCountTask(for: tabId)
+        coordinator.clearRowCountTask(for: tabId, token: token)
 
         #expect(count.isCancelled == false)
         #expect(coordinator.rowCountTasks.isEmpty)
+    }
+
+    /// A superseded task still runs its completion path. Once phase 2 validates content identity
+    /// rather than a claim that is already settled, that path is reached, so without the token the
+    /// finishing task clears the successor that replaced it and leaves it uncancellable.
+    @Test("A superseded task cannot clear the handle of the one that replaced it")
+    func supersededTaskCannotClearItsSuccessor() {
+        let (coordinator, tabManager) = Self.makeCoordinator()
+        let tabId = Self.addTableTab(to: tabManager)
+        let firstToken = UUID()
+        let first = Self.neverEndingTask()
+        let second = Self.neverEndingTask()
+        defer {
+            first.cancel()
+            second.cancel()
+        }
+        coordinator.setRowCountTask(first, token: firstToken, for: tabId)
+        coordinator.setRowCountTask(second, token: UUID(), for: tabId)
+
+        coordinator.clearRowCountTask(for: tabId, token: firstToken)
+
+        #expect(coordinator.rowCountTasks[tabId] != nil)
+        #expect(second.isCancelled == false)
     }
 
     private static func makeCoordinator() -> (MainContentCoordinator, QueryTabManager) {


### PR DESCRIPTION
Follow-up to #2068, which made this reachable.

Before #2068, `resolveRowCount`'s write-back guard was `isCurrent(claim)`, which was false on every run, so the code below it never executed. #2068 fixed that guard to use content identity, which means the completion path now actually runs, including `clearRowCountTask(for:)`.

That exposes a gap. A tab's auto count can be superseded by the exact-count button, which cancels it and installs a new handle. The superseded task still reaches its completion path, its content check still passes (content did not change, only the task did), and it clears the slot its successor now owns. The successor is then orphaned: not cancellable by Stop, by a retarget, or by teardown, which is the exact class of bug #2059 set out to remove.

`tableLoadTasks` has carried a token for this since before any of this work: its `defer` only clears the entry `if tableLoadTasks[tabId]?.token == token`. This gives `rowCountTasks` the same discipline rather than inventing a different one.

`RowCountTaskLifecycleTests` gains a test that registers two handles for one tab and clears with the first token, asserting the successor survives. 23 tests pass across `RowCountTaskLifecycleTests`, `MainContentCoordinatorRefreshTests` and `Phase2RowCountGuardTests`. `swiftlint lint --strict` reports 0 violations.

No CHANGELOG entry: #2068 has not shipped, so this folds into that entry.