### PR TITLE
fix(coordinator): stop an unknown row count blanking the estimate already on screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A connection with more than one window open now brings every window's tabs back when it reconnects, instead of leaving them all empty. Each window used to stand down the moment it saw another window on the same connection, so none of them restored anything.
 - Reopening a connection now puts each tab back in the window it was in. A window that held more than one tab came back as one window per tab, and a window that was empty was filled with the next window's tab.
+- The row count under the grid no longer appears and then vanishes a moment later. A count the database could not work out now leaves the estimate on screen instead of blanking it.
 - Table row counts are exact again when the estimate is below your "count rows if estimate less than" setting. Opening a table showed the estimate and never refined it, and a filtered count never updated at all.
 - Closing a window now stops an exact row count that is still running, and pointing a tab at another table stops the count for the table you left. Both used to run to completion against a server nobody was waiting on. (#2059)
 - Clicking quickly through the sidebar no longer keeps loading column details for tables you have already left. Each abandoned table held the connection for another 75-90ms, so every table clicked after it waited that much longer. (#2058)

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
@@ -490,9 +490,8 @@ extension QueryExecutionCoordinator {
             await MainActor.run {
                 guard parent.tabExecution.isSameContent(contentEpoch, for: tabId) else { return }
                 parent.clearRowCountTask(for: tabId, token: token)
-                guard let outcome else { return }
+                guard let applied = outcome?.appliedTotal else { return }
                 parent.tabManager.mutate(tabId: tabId) { tab in
-                    let applied = outcome.appliedTotal
                     tab.pagination.totalRowCount = applied.total
                     tab.pagination.isApproximateRowCount = applied.isApproximate
                 }
@@ -566,9 +565,18 @@ enum RowCountOutcome: Equatable {
 
     /// An estimate of zero or less means "unknown", never "this table is empty": an un-analyzed
     /// table reports 0 or -1 while holding millions of rows. An exact zero is trustworthy.
-    var appliedTotal: (total: Int?, isApproximate: Bool) {
-        guard case let .count(value, isApproximate) = self else { return (nil, false) }
-        guard value > 0 || (value == 0 && !isApproximate) else { return (nil, false) }
-        return (value, isApproximate)
+    ///
+    /// Returns nil for "no answer", which is not the same as an answer of nothing. Phase 1 has
+    /// usually already put an estimate on screen by the time this lands, so an unusable estimate
+    /// must leave that alone rather than blank it. Only `.clear` means the count is genuinely
+    /// gone, which is what a filter change asks for.
+    var appliedTotal: (total: Int?, isApproximate: Bool)? {
+        switch self {
+        case .clear:
+            return (nil, false)
+        case let .count(value, isApproximate):
+            guard value > 0 || (value == 0 && !isApproximate) else { return nil }
+            return (value, isApproximate)
+        }
     }
 }

--- a/TableProTests/Core/Coordinators/RowCountPlanTests.swift
+++ b/TableProTests/Core/Coordinators/RowCountPlanTests.swift
@@ -86,40 +86,41 @@ struct RowCountPlanTests {
 @Suite("RowCountOutcome")
 struct RowCountOutcomeTests {
     @Test("A positive estimate is applied and stays marked approximate")
-    func positiveEstimateApplies() {
-        let applied = RowCountOutcome.count(4_600_000, isApproximate: true).appliedTotal
+    func positiveEstimateApplies() throws {
+        let applied = try #require(RowCountOutcome.count(4_600_000, isApproximate: true).appliedTotal)
         #expect(applied.total == 4_600_000)
         #expect(applied.isApproximate)
     }
 
-    @Test("An estimate of zero means unknown, not an empty table")
-    func zeroEstimateIsUnknown() {
-        let applied = RowCountOutcome.count(0, isApproximate: true).appliedTotal
-        #expect(applied.total == nil)
-        #expect(!applied.isApproximate)
+    /// Phase 1 has usually already put an estimate on screen by the time a phase 2 count lands, so
+    /// "we could not work it out" has to leave that alone. Blanking it made a row count appear and
+    /// then vanish a moment later.
+    @Test("An estimate of zero is no answer, so it applies nothing")
+    func zeroEstimateAppliesNothing() {
+        #expect(RowCountOutcome.count(0, isApproximate: true).appliedTotal == nil)
     }
 
-    @Test("A negative estimate is never shown as a total")
-    func negativeEstimateIsUnknown() {
-        let applied = RowCountOutcome.count(-1, isApproximate: true).appliedTotal
-        #expect(applied.total == nil)
+    @Test("A negative estimate applies nothing")
+    func negativeEstimateAppliesNothing() {
+        #expect(RowCountOutcome.count(-1, isApproximate: true).appliedTotal == nil)
     }
 
     @Test("An exact zero is trustworthy and reported as an empty table")
-    func exactZeroIsApplied() {
-        let applied = RowCountOutcome.count(0, isApproximate: false).appliedTotal
+    func exactZeroIsApplied() throws {
+        let applied = try #require(RowCountOutcome.count(0, isApproximate: false).appliedTotal)
         #expect(applied.total == 0)
         #expect(!applied.isApproximate)
     }
 
-    @Test("A negative exact count is still rejected")
-    func negativeExactIsUnknown() {
-        #expect(RowCountOutcome.count(-5, isApproximate: false).appliedTotal.total == nil)
+    @Test("A negative exact count applies nothing")
+    func negativeExactAppliesNothing() {
+        #expect(RowCountOutcome.count(-5, isApproximate: false).appliedTotal == nil)
     }
 
+    /// A filter change genuinely invalidates the count, so this one still wipes it.
     @Test("Clearing reports an unknown total")
-    func clearIsUnknown() {
-        let applied = RowCountOutcome.clear.appliedTotal
+    func clearIsUnknown() throws {
+        let applied = try #require(RowCountOutcome.clear.appliedTotal)
         #expect(applied.total == nil)
         #expect(!applied.isApproximate)
     }


### PR DESCRIPTION
Fixes the row count appearing under the grid and then vanishing about a second later. Regression from #2068, which revived a guard in `resolveRowCount` that had been dead since #2055, so this code ran for the first time and brought a latent bug with it.

## Cause

`RowCountOutcome.appliedTotal` collapsed two different answers into one value:

```swift
var appliedTotal: (total: Int?, isApproximate: Bool) {
    guard case let .count(value, isApproximate) = self else { return (nil, false) }
    guard value > 0 || (value == 0 && !isApproximate) else { return (nil, false) }
    return (value, isApproximate)
}
```

`(nil, false)` meant both "the count is genuinely gone" and "I could not work it out". The caller wrote it either way.

Those are not the same thing, and the difference is visible. Phase 1 puts an estimate on screen synchronously from inline metadata. Phase 2's driver round trip lands a few hundred milliseconds later. When it comes back with an unusable estimate, which the doc comment on that very function already explains is normal (an un-analyzed table reports 0 or -1 while holding millions of rows), it blanked the number the user was already looking at.

The path needs no filters, which is worth stating because I twice told the user it did. `rowCountPlan` returns `.approximate` for a non-SQL source with no filters, that calls `fetchApproximateRowCount`, and a driver returning 0 or less lands straight on the nil branch.

## Fix

`appliedTotal` becomes optional. `nil` means "no answer", and the caller skips the write entirely, leaving whatever is on screen alone. `.clear` still returns `(nil, false)` and still wipes the count, because a filter change genuinely invalidates it.

That is the whole behavioural change: an absent answer stops overwriting a present one.

## Tests

The six `RowCountOutcomeTests` cases are updated to the new semantics in the same commit, including the two that now assert nothing is applied rather than asserting nil is applied. 36 tests pass across `RowCountOutcomeTests`, `RowCountPlanTests`, `Phase2RowCountGuardTests`, `RowCountTaskLifecycleTests` and `MainContentCoordinatorRefreshTests`. `swiftlint lint --strict` reports 0 violations in 1322 files.

## Still open, not in this PR

Phase 2 has no tracer coverage, which is why this needed a round trip through the user to diagnose. Adding stages is not as cheap as it looks: the trace finishes right after `mainRunLoopIdle`, which is before the phase 2 row count lands, so a stage on a finished token is a no-op. Covering it properly means extending the trace lifetime to wait for phase 2, which risks leaving traces open, and is its own change.

Correction to an earlier claim of mine: I said `StatusBarSnapshot+RowInfo.swift:23` hides the total for a genuinely empty table. It does not. A table with zero rows falls through to `"No rows"`, which is better than `"0-0 of 0 rows"`. There is no bug there.
