### PR TITLE
refactor(launch): register each window presenter independently

### DIFF
--- a/TablePro/Core/Services/Infrastructure/WindowOpener.swift
+++ b/TablePro/Core/Services/Infrastructure/WindowOpener.swift
@@ -20,14 +20,17 @@ internal final class WindowOpener {
     @ObservationIgnored private var openSettingsAction: (() -> Void)?
     @ObservationIgnored private var stagedDraftId: UUID?
     @ObservationIgnored private var pendingCalls: [() -> Void] = []
-    @ObservationIgnored private var isWired = false
 
-    private init() {}
+    /// Not private so a test can exercise the queue on an instance with no presenters
+    /// registered. Production code uses `shared`.
+    internal init() {}
 
     internal func openWelcome() {
-        run {
-            $0.openWelcomeAction?()
+        perform { opener in
+            guard let present = opener.openWelcomeAction else { return false }
+            present()
             NSApp.activate()
+            return true
         }
     }
 
@@ -35,7 +38,11 @@ internal final class WindowOpener {
         if let tab {
             UserDefaults.standard.set(tab.rawValue, forKey: PreferenceKeys.selectedSettingsPane.name)
         }
-        run { $0.openSettingsAction?() }
+        perform { opener in
+            guard let present = opener.openSettingsAction else { return false }
+            present()
+            return true
+        }
     }
 
     internal func closeWelcome() {
@@ -45,7 +52,11 @@ internal final class WindowOpener {
     }
 
     internal func openConnectionForm(editing connectionId: UUID) {
-        run { $0.openConnectionFormAction?(.edit(connectionId: connectionId)) }
+        perform { opener in
+            guard let present = opener.openConnectionFormAction else { return false }
+            present(.edit(connectionId: connectionId))
+            return true
+        }
     }
 
     internal func openConnectionForm() {
@@ -64,7 +75,11 @@ internal final class WindowOpener {
     internal func openStagedConnectionForm() {
         guard let draftId = stagedDraftId else { return }
         stagedDraftId = nil
-        run { $0.openConnectionFormAction?(.create(draftId: draftId)) }
+        perform { opener in
+            guard let present = opener.openConnectionFormAction else { return false }
+            present(.create(draftId: draftId))
+            return true
+        }
     }
 
     private func discardStagedDraft() {
@@ -82,36 +97,49 @@ internal final class WindowOpener {
     }
 
     internal func openIntegrationsActivity() {
-        run { $0.openIntegrationsActivityAction?() }
+        perform { opener in
+            guard let present = opener.openIntegrationsActivityAction else { return false }
+            present()
+            return true
+        }
     }
 
-    internal func wire(
-        openWelcome: @escaping () -> Void,
-        openConnectionForm: @escaping (ConnectionFormRequest) -> Void,
-        openIntegrationsActivity: @escaping () -> Void,
-        openSettings: @escaping () -> Void
-    ) {
-        openWelcomeAction = openWelcome
-        openConnectionFormAction = openConnectionForm
-        openIntegrationsActivityAction = openIntegrationsActivity
-        openSettingsAction = openSettings
-        isWired = true
+    internal func setWelcomePresenter(_ present: @escaping () -> Void) {
+        openWelcomeAction = present
+        drainPendingCalls()
+    }
+
+    internal func setConnectionFormPresenter(_ present: @escaping (ConnectionFormRequest) -> Void) {
+        openConnectionFormAction = present
+        drainPendingCalls()
+    }
+
+    internal func setIntegrationsActivityPresenter(_ present: @escaping () -> Void) {
+        openIntegrationsActivityAction = present
+        drainPendingCalls()
+    }
+
+    internal func setSettingsPresenter(_ present: @escaping () -> Void) {
+        openSettingsAction = present
+        drainPendingCalls()
+    }
+
+    /// Returns false when the presenter for that window has not been registered yet, which
+    /// queues the call. Each window registers independently, so one that has already migrated
+    /// to AppKit never waits on one that has not.
+    private func perform(_ block: @escaping (WindowOpener) -> Bool) {
+        guard !block(self) else { return }
+        Self.logger.notice("WindowOpener call queued; presenter not registered yet")
+        pendingCalls.append { [weak self] in
+            self?.perform(block)
+        }
+    }
+
+    private func drainPendingCalls() {
         let drained = pendingCalls
         pendingCalls.removeAll()
         for call in drained {
             call()
-        }
-    }
-
-    private func run(_ block: @escaping (WindowOpener) -> Void) {
-        if isWired {
-            block(self)
-            return
-        }
-        Self.logger.notice("WindowOpener call queued; bridge not yet wired")
-        pendingCalls.append { [weak self] in
-            guard let self else { return }
-            block(self)
         }
     }
 }

--- a/TablePro/Views/Infrastructure/WindowOpenerBridge.swift
+++ b/TablePro/Views/Infrastructure/WindowOpenerBridge.swift
@@ -16,11 +16,11 @@ internal struct WindowOpenerBridge: View {
     }
 
     private func wireUp() {
-        WindowOpener.shared.wire(
-            openWelcome: { openWindow(id: SceneId.welcome) },
-            openConnectionForm: { request in openWindow(id: SceneId.connectionForm, value: request) },
-            openIntegrationsActivity: { openWindow(id: SceneId.integrationsActivity) },
-            openSettings: { openSettings() }
-        )
+        WindowOpener.shared.setWelcomePresenter { openWindow(id: SceneId.welcome) }
+        WindowOpener.shared.setConnectionFormPresenter { request in
+            openWindow(id: SceneId.connectionForm, value: request)
+        }
+        WindowOpener.shared.setIntegrationsActivityPresenter { openWindow(id: SceneId.integrationsActivity) }
+        WindowOpener.shared.setSettingsPresenter { openSettings() }
     }
 }

--- a/TableProTests/Core/Services/Infrastructure/WindowOpenerTests.swift
+++ b/TableProTests/Core/Services/Infrastructure/WindowOpenerTests.swift
@@ -14,14 +14,12 @@ final class WindowOpenerTests: XCTestCase {
         super.setUp()
         _ = WelcomeRouter.shared.consumePendingRequest()
         openedRequests = []
-        WindowOpener.shared.wire(
-            openWelcome: {},
-            openConnectionForm: { [weak self] request in
-                self?.openedRequests.append(request)
-            },
-            openIntegrationsActivity: {},
-            openSettings: {}
-        )
+        WindowOpener.shared.setWelcomePresenter {}
+        WindowOpener.shared.setConnectionFormPresenter { [weak self] request in
+            self?.openedRequests.append(request)
+        }
+        WindowOpener.shared.setIntegrationsActivityPresenter {}
+        WindowOpener.shared.setSettingsPresenter {}
     }
 
     override func tearDown() {
@@ -126,6 +124,35 @@ final class WindowOpenerTests: XCTestCase {
         WindowOpener.shared.openConnectionForm(editing: connectionId)
 
         XCTAssertEqual(openedRequests, [.edit(connectionId: connectionId)])
+    }
+
+    func testACallMadeBeforeItsPresenterIsRegisteredRunsOnceItArrives() {
+        let opener = WindowOpener()
+        var opened: [ConnectionFormRequest] = []
+        let connectionId = UUID()
+
+        opener.openConnectionForm(editing: connectionId)
+        XCTAssertTrue(opened.isEmpty, "No presenter yet, so the call has to wait")
+
+        opener.setConnectionFormPresenter { opened.append($0) }
+
+        XCTAssertEqual(opened, [.edit(connectionId: connectionId)])
+    }
+
+    /// Registering one window's presenter must not drop another window's queued call, which is
+    /// what lets the windows migrate to AppKit one at a time.
+    func testRegisteringOneWindowDoesNotDiscardAnotherWindowsQueuedCall() {
+        let opener = WindowOpener()
+        var opened: [ConnectionFormRequest] = []
+        let connectionId = UUID()
+
+        opener.openConnectionForm(editing: connectionId)
+        opener.setWelcomePresenter {}
+        XCTAssertTrue(opened.isEmpty, "The connection form still has no presenter")
+
+        opener.setConnectionFormPresenter { opened.append($0) }
+
+        XCTAssertEqual(opened, [.edit(connectionId: connectionId)])
     }
 
     func testEditingTheSameConnectionTwiceRequestsTheSameWindow() {


### PR DESCRIPTION
First step toward owning the main menu in AppKit. No user-visible change.

`WindowOpener.wire(...)` took all four window presenters in one call, so no window could move to AppKit until all four did. This splits it into four independent registrations.

- `setWelcomePresenter`, `setConnectionFormPresenter`, `setIntegrationsActivityPresenter`, `setSettingsPresenter`
- A call made before its own presenter exists is still queued, and now re-queues itself if a different window registers first, so registering one window can no longer drop another window's pending call
- `init` is no longer private, so a test can exercise the queue on an instance with nothing registered instead of the process-wide singleton

Two tests cover the new behaviour: a queued call runs when its presenter arrives, and registering one window does not discard another's queued call.

Build succeeds, `swiftlint --strict` clean, `WindowOpenerTests` passes.

## Why

#2057 rewrote the menu bar on AppKit and had to be reverted (#2071): SwiftUI reconciles `NSApp.mainMenu` once shortly after launch and discards it. Under the SwiftUI App lifecycle there is no supported way to keep it, so the app moves to the AppKit lifecycle, where the menu bar has a single owner. The four SwiftUI scenes become `NSWindowController`s one at a time; this PR makes that possible.
