### PR TITLE
refactor(launch): host Integrations Activity in an AppKit window

### DIFF
--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -61,6 +61,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         )
 
         NSWindow.allowsAutomaticWindowTabbing = true
+        WindowOpener.shared.setIntegrationsActivityPresenter {
+            IntegrationsActivityWindowController.present()
+        }
         KeyRepeatFilter.shared.install()
         let syncSettings = AppSettingsStorage.shared.loadSync()
         let passwordSyncExpected = syncSettings.enabled && syncSettings.syncConnections && syncSettings.syncPasswords

--- a/TablePro/TableProApp.swift
+++ b/TablePro/TableProApp.swift
@@ -1005,13 +1005,6 @@ struct TableProApp: App {
         .defaultSize(width: 820, height: 600)
         .commandsRemoved()
 
-        Window("Integrations Activity", id: SceneId.integrationsActivity) {
-            IntegrationsActivityView()
-                .background(WindowOpenerBridge())
-                .environment(\.appServices, .live)
-        }
-        .windowResizability(.contentMinSize)
-        .defaultSize(width: 960, height: 600)
         .commands {
             AppMenuCommands(
                 settingsManager: AppSettingsManager.shared,

--- a/TablePro/Views/Infrastructure/WindowOpenerBridge.swift
+++ b/TablePro/Views/Infrastructure/WindowOpenerBridge.swift
@@ -20,7 +20,6 @@ internal struct WindowOpenerBridge: View {
         WindowOpener.shared.setConnectionFormPresenter { request in
             openWindow(id: SceneId.connectionForm, value: request)
         }
-        WindowOpener.shared.setIntegrationsActivityPresenter { openWindow(id: SceneId.integrationsActivity) }
         WindowOpener.shared.setSettingsPresenter { openSettings() }
     }
 }

--- a/TablePro/Views/Integrations/IntegrationsActivityWindowController.swift
+++ b/TablePro/Views/Integrations/IntegrationsActivityWindowController.swift
@@ -1,0 +1,40 @@
+//
+//  IntegrationsActivityWindowController.swift
+//  TablePro
+//
+
+import AppKit
+import SwiftUI
+
+/// Hosts `IntegrationsActivityView` in an AppKit window so the app no longer needs a SwiftUI
+/// scene for it. One instance is kept for the app's lifetime, matching the single-window scene
+/// it replaces.
+@MainActor
+internal final class IntegrationsActivityWindowController: NSWindowController {
+    private static var shared: IntegrationsActivityWindowController?
+
+    internal static func present() {
+        let controller = shared ?? IntegrationsActivityWindowController()
+        shared = controller
+        controller.showWindow(nil)
+        controller.window?.makeKeyAndOrderFront(nil)
+        NSApp.activate()
+    }
+
+    private convenience init() {
+        let content = IntegrationsActivityView()
+            .environment(\.appServices, .live)
+        let hosting = NSHostingController(rootView: content)
+        /// A standalone window wants the content's minimum to become the window's, unlike a
+        /// split pane's host, where the same minimum would pin the window's dividers.
+        hosting.sizingOptions = [.minSize]
+
+        let window = NSWindow(contentViewController: hosting)
+        window.title = String(localized: "Integrations Activity")
+        window.identifier = NSUserInterfaceItemIdentifier(SceneId.integrationsActivity)
+        window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
+        window.setContentSize(NSSize(width: 960, height: 600))
+        window.setFrameAutosaveName(SceneId.integrationsActivity)
+        self.init(window: window)
+    }
+}


### PR DESCRIPTION
Second step toward owning the main menu in AppKit. Stacked on #2073.

Integrations Activity was a SwiftUI `Window` scene. It is now an `NSWindowController` hosting the same unchanged `IntegrationsActivityView`.

- New `Views/Integrations/IntegrationsActivityWindowController.swift`, one instance kept for the app's lifetime, matching the single-window scene it replaces
- `AppDelegate` registers the presenter, so `WindowOpener.openIntegrationsActivity()` no longer depends on a SwiftUI scene being alive
- The scene and its bridge registration are deleted

`NSHostingController.sizingOptions` is `[.minSize]` here on purpose. The `sizingOptions = []` rule in CLAUDE.md exists to stop a split pane's minimums pinning the window's dividers; this is a standalone window, where the content's minimum should become the window's `contentMinSize`.

The window also gets an explicit `identifier` and `setFrameAutosaveName`, which the SwiftUI scene provided implicitly.

Build succeeds, `swiftlint --strict` clean, `WindowOpenerTests` passes.

## Why

Under the SwiftUI App lifecycle there is no supported way to own `NSApp.mainMenu`: SwiftUI reconciles it once shortly after launch and discards anything it did not create. That is what forced the revert in #2071. Moving to the AppKit lifecycle gives the menu bar a single owner. Each of the four SwiftUI scenes becomes an `NSWindowController` first, one per PR, so the entry-point flip at the end is a small diff.
