### PR TITLE
fix(ios): release database file locks before suspension instead of closing every session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- TablePro Mobile keeps remote connections open when you switch apps, so coming back no longer reconnects and reloads everything.
+
+### Fixed
+
+- TablePro Mobile no longer gets killed by iOS when you leave the app with a DuckDB file open.
+
 ## [0.64.0] - 2026-08-10
 
 ### Added

--- a/Packages/TableProCore/Sources/TableProDatabase/ConnectionManager.swift
+++ b/Packages/TableProCore/Sources/TableProDatabase/ConnectionManager.swift
@@ -8,6 +8,8 @@ public final class ConnectionManager: @unchecked Sendable {
 
     private let lock = NSLock()
     private var sessions: [UUID: ConnectionSession] = [:]
+    private var teardowns: [UUID: Task<Void, Never>] = [:]
+    private var blockingTeardowns: Set<UUID> = []
 
     public init(
         driverFactory: DriverFactory,
@@ -75,25 +77,58 @@ public final class ConnectionManager: @unchecked Sendable {
     }
 
     public func disconnect(_ connectionId: UUID) async {
-        let session = removeSession(for: connectionId)
-        guard let session else { return }
-        try? await session.driver.disconnect()
-        if let sshProvider {
-            try? await sshProvider.closeTunnel(for: connectionId)
+        guard let teardown = claimTeardown(for: connectionId) else { return }
+        await teardown.value
+        finishTeardown(teardown, for: connectionId)
+    }
+
+    public var hasSuspensionBlockingResources: Bool {
+        !suspensionBlockingIds().isEmpty
+    }
+
+    public func releaseSuspensionBlockingResources() async {
+        let ids = suspensionBlockingIds()
+        guard !ids.isEmpty else { return }
+        await withTaskGroup(of: Void.self) { group in
+            for id in ids {
+                group.addTask { await self.disconnect(id) }
+            }
         }
     }
 
-    public func disconnectAll() async {
-        let ids = allSessionIds()
-        for id in ids {
-            await disconnect(id)
-        }
-    }
-
-    private func allSessionIds() -> [UUID] {
+    private func suspensionBlockingIds() -> [UUID] {
         lock.lock()
         defer { lock.unlock() }
-        return Array(sessions.keys)
+        let connected = sessions.filter { $0.value.driver.holdsSuspensionBlockingResource }.map(\.key)
+        return Array(blockingTeardowns.union(connected))
+    }
+
+    private func claimTeardown(for connectionId: UUID) -> Task<Void, Never>? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let session = sessions.removeValue(forKey: connectionId) else {
+            return teardowns[connectionId]
+        }
+        let sshProvider = sshProvider
+        let teardown = Task {
+            try? await session.driver.disconnect()
+            if let sshProvider {
+                try? await sshProvider.closeTunnel(for: connectionId)
+            }
+        }
+        teardowns[connectionId] = teardown
+        if session.driver.holdsSuspensionBlockingResource {
+            blockingTeardowns.insert(connectionId)
+        }
+        return teardown
+    }
+
+    private func finishTeardown(_ teardown: Task<Void, Never>, for connectionId: UUID) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard teardowns[connectionId] == teardown else { return }
+        teardowns.removeValue(forKey: connectionId)
+        blockingTeardowns.remove(connectionId)
     }
 
     public func updateSession(_ connectionId: UUID, _ mutation: (inout ConnectionSession) -> Void) {
@@ -122,12 +157,5 @@ public final class ConnectionManager: @unchecked Sendable {
         lock.lock()
         sessions[id] = session
         lock.unlock()
-    }
-
-    private func removeSession(for id: UUID) -> ConnectionSession? {
-        lock.lock()
-        let session = sessions.removeValue(forKey: id)
-        lock.unlock()
-        return session
     }
 }

--- a/Packages/TableProCore/Sources/TableProDatabase/DatabaseDriver.swift
+++ b/Packages/TableProCore/Sources/TableProDatabase/DatabaseDriver.swift
@@ -5,6 +5,7 @@ public protocol DatabaseDriver: AnyObject, Sendable {
     func connect() async throws
     func disconnect() async throws
     func ping() async throws -> Bool
+    var holdsSuspensionBlockingResource: Bool { get }
 
     func execute(query: String) async throws -> QueryResult
     func executeStreaming(query: String, options: StreamOptions) -> AsyncThrowingStream<StreamElement, Error>
@@ -31,6 +32,8 @@ public protocol DatabaseDriver: AnyObject, Sendable {
 }
 
 public extension DatabaseDriver {
+    var holdsSuspensionBlockingResource: Bool { false }
+
     func executeStreaming(query: String, options: StreamOptions = .default) -> AsyncThrowingStream<StreamElement, Error> {
         AsyncThrowingStream { continuation in
             let task = Task {

--- a/Packages/TableProCore/Tests/TableProDatabaseTests/ConnectionManagerTests.swift
+++ b/Packages/TableProCore/Tests/TableProDatabaseTests/ConnectionManagerTests.swift
@@ -8,14 +8,19 @@ import Foundation
 private final class MockDatabaseDriver: DatabaseDriver, @unchecked Sendable {
     var isConnected = false
     var shouldFailConnect = false
+    var holdsSuspensionBlockingResource = false
+    var onConnect: (@Sendable () -> Void)?
+    var beforeDisconnect: (@Sendable () async -> Void)?
     private(set) var disconnectCount = 0
 
     func connect() async throws {
         if shouldFailConnect { throw NSError(domain: "test", code: 1) }
+        onConnect?()
         isConnected = true
     }
 
     func disconnect() async throws {
+        await beforeDisconnect?()
         isConnected = false
         disconnectCount += 1
     }
@@ -70,6 +75,58 @@ private final class MockSecureStore: SecureStore, Sendable {
     }
 
     func delete(forKey key: String) throws {}
+}
+
+// MARK: - Synchronisation Helpers
+
+private actor Gate {
+    private var isOpen = false
+    private var hasEntered = false
+    private var blocked: [CheckedContinuation<Void, Never>] = []
+    private var observers: [CheckedContinuation<Void, Never>] = []
+
+    func enter() async {
+        hasEntered = true
+        for observer in observers { observer.resume() }
+        observers.removeAll()
+        guard !isOpen else { return }
+        await withCheckedContinuation { blocked.append($0) }
+    }
+
+    func open() {
+        isOpen = true
+        for waiter in blocked { waiter.resume() }
+        blocked.removeAll()
+    }
+
+    func waitUntilEntered() async {
+        guard !hasEntered else { return }
+        await withCheckedContinuation { observers.append($0) }
+    }
+}
+
+private actor Barrier {
+    private static let pollInterval: UInt64 = 20_000_000
+    private static let maxPolls = 250
+
+    private let expected: Int
+    private var arrived = 0
+    private(set) var overlapped = 0
+
+    init(expected: Int) {
+        self.expected = expected
+    }
+
+    func arriveAndWait() async {
+        arrived += 1
+        var polls = 0
+        while arrived < expected, polls < Self.maxPolls {
+            try? await Task.sleep(nanoseconds: Self.pollInterval)
+            polls += 1
+        }
+        guard arrived >= expected else { return }
+        overlapped += 1
+    }
 }
 
 @Suite("ConnectionManager Tests")
@@ -197,6 +254,117 @@ struct ConnectionManagerTests {
         }
 
         #expect(sshProvider.closedTunnels.contains(connection.id))
+    }
+
+    @Test("Only sessions holding a suspension blocking resource are released")
+    func releaseOnlyTouchesBlockingSessions() async throws {
+        let factory = MockDriverFactory()
+        let store = MockSecureStore()
+        let manager = ConnectionManager(driverFactory: factory, secureStore: store)
+
+        let blockingDriver = MockDatabaseDriver()
+        blockingDriver.holdsSuspensionBlockingResource = true
+        factory.drivers["blocking"] = blockingDriver
+        let blocking = DatabaseConnection(name: "File", type: DatabaseType(rawValue: "blocking"))
+        _ = try await manager.connect(blocking)
+
+        let remoteDriver = MockDatabaseDriver()
+        factory.drivers["remote"] = remoteDriver
+        let remote = DatabaseConnection(name: "Remote", type: DatabaseType(rawValue: "remote"))
+        _ = try await manager.connect(remote)
+
+        #expect(manager.hasSuspensionBlockingResources)
+
+        await manager.releaseSuspensionBlockingResources()
+
+        #expect(blockingDriver.disconnectCount == 1)
+        #expect(remoteDriver.disconnectCount == 0)
+        #expect(manager.session(for: blocking.id) == nil)
+        #expect(manager.session(for: remote.id) != nil)
+        #expect(!manager.hasSuspensionBlockingResources)
+    }
+
+    @Test("Releasing several blocking sessions runs them concurrently")
+    func releaseRunsConcurrently() async throws {
+        let factory = MockDriverFactory()
+        let store = MockSecureStore()
+        let manager = ConnectionManager(driverFactory: factory, secureStore: store)
+        let barrier = Barrier(expected: 2)
+
+        let firstDriver = MockDatabaseDriver()
+        firstDriver.holdsSuspensionBlockingResource = true
+        firstDriver.beforeDisconnect = { await barrier.arriveAndWait() }
+        factory.drivers["first"] = firstDriver
+        _ = try await manager.connect(DatabaseConnection(name: "First", type: DatabaseType(rawValue: "first")))
+
+        let secondDriver = MockDatabaseDriver()
+        secondDriver.holdsSuspensionBlockingResource = true
+        secondDriver.beforeDisconnect = { await barrier.arriveAndWait() }
+        factory.drivers["second"] = secondDriver
+        _ = try await manager.connect(DatabaseConnection(name: "Second", type: DatabaseType(rawValue: "second")))
+
+        await manager.releaseSuspensionBlockingResources()
+
+        #expect(await barrier.overlapped == 2)
+        #expect(firstDriver.disconnectCount == 1)
+        #expect(secondDriver.disconnectCount == 1)
+    }
+
+    @Test("A teardown still in flight keeps counting as a blocking resource")
+    func inFlightTeardownStillBlocks() async throws {
+        let factory = MockDriverFactory()
+        let store = MockSecureStore()
+        let manager = ConnectionManager(driverFactory: factory, secureStore: store)
+        let connection = DatabaseConnection(name: "File", type: DatabaseType(rawValue: "mock"))
+        let gate = Gate()
+
+        let driver = MockDatabaseDriver()
+        driver.holdsSuspensionBlockingResource = true
+        driver.beforeDisconnect = { await gate.enter() }
+        factory.drivers["mock"] = driver
+        _ = try await manager.connect(connection)
+
+        let teardown = Task { await manager.disconnect(connection.id) }
+        await gate.waitUntilEntered()
+
+        #expect(manager.session(for: connection.id) == nil)
+        #expect(manager.hasSuspensionBlockingResources)
+
+        await gate.open()
+        await teardown.value
+
+        #expect(!manager.hasSuspensionBlockingResources)
+    }
+
+    @Test("Connecting waits for an in-flight teardown of the same connection")
+    func connectWaitsForInFlightTeardown() async throws {
+        let factory = MockDriverFactory()
+        let store = MockSecureStore()
+        let manager = ConnectionManager(driverFactory: factory, secureStore: store)
+        let connection = DatabaseConnection(name: "Test", type: DatabaseType(rawValue: "mock"))
+        let gate = Gate()
+
+        let first = MockDatabaseDriver()
+        first.beforeDisconnect = { await gate.enter() }
+        factory.drivers["mock"] = first
+        _ = try await manager.connect(connection)
+
+        let teardown = Task { await manager.disconnect(connection.id) }
+        await gate.waitUntilEntered()
+
+        let second = MockDatabaseDriver()
+        factory.drivers["mock"] = second
+        let reconnect = Task { try await manager.connect(connection) }
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(!second.isConnected)
+
+        await gate.open()
+        _ = try await reconnect.value
+        await teardown.value
+
+        #expect(first.disconnectCount == 1)
+        #expect(second.isConnected)
     }
 }
 

--- a/TableProMobile/TableProMobile/AppState.swift
+++ b/TableProMobile/TableProMobile/AppState.swift
@@ -32,6 +32,7 @@ final class AppState {
     var pendingTableName: String?
     var pendingImportURL: URL?
     let connectionManager: ConnectionManager
+    let backgroundRelease: BackgroundReleaseCoordinator
     let syncCoordinator = IOSSyncCoordinator()
     let sshProvider: IOSSSHProvider
     let secureStore: KeychainSecureStore
@@ -46,11 +47,13 @@ final class AppState {
         self.secureStore = secureStore
         let sshProvider = IOSSSHProvider(secureStore: secureStore)
         self.sshProvider = sshProvider
-        self.connectionManager = ConnectionManager(
+        let connectionManager = ConnectionManager(
             driverFactory: driverFactory,
             secureStore: secureStore,
             sshProvider: sshProvider
         )
+        self.connectionManager = connectionManager
+        self.backgroundRelease = BackgroundReleaseCoordinator(connectionManager: connectionManager)
         loadPersistedData()
 
         guard !TestRuntime.isActive else { return }

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
@@ -1,4 +1,5 @@
 import CDuckDB
+import Dispatch
 import Foundation
 import TableProDatabase
 import TableProModels
@@ -17,6 +18,7 @@ final class DuckDBDriver: DatabaseDriver, @unchecked Sendable {
     var supportsSchemas: Bool { true }
     var supportsTransactions: Bool { true }
     var serverVersion: String? { String(cString: duckdb_library_version()) }
+    var holdsSuspensionBlockingResource: Bool { dbPath != Self.inMemoryPath }
 
     var currentSchema: String? {
         stateLock.lock()
@@ -164,6 +166,10 @@ final class DuckDBDriver: DatabaseDriver, @unchecked Sendable {
 
 actor DuckDBActor {
     static let maxRows = 100_000
+
+    private let queue = DispatchSerialQueue(label: "com.TablePro.duckdb")
+
+    nonisolated var unownedExecutor: UnownedSerialExecutor { queue.asUnownedSerialExecutor() }
 
     private var database: duckdb_database?
     var connection: duckdb_connection?

--- a/TableProMobile/TableProMobile/Platform/BackgroundReleaseCoordinator.swift
+++ b/TableProMobile/TableProMobile/Platform/BackgroundReleaseCoordinator.swift
@@ -1,0 +1,84 @@
+import os
+import TableProDatabase
+import UIKit
+
+@MainActor
+protocol BackgroundTaskAsserting {
+    func beginBackgroundTask(name: String, expirationHandler: @escaping () -> Void) -> UIBackgroundTaskIdentifier
+    func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier)
+}
+
+extension UIApplication: BackgroundTaskAsserting {
+    func beginBackgroundTask(name: String, expirationHandler: @escaping () -> Void) -> UIBackgroundTaskIdentifier {
+        beginBackgroundTask(withName: name, expirationHandler: expirationHandler)
+    }
+}
+
+@MainActor
+final class BackgroundReleaseCoordinator {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "BackgroundRelease")
+    private static let taskName = "Release database files"
+
+    private let connectionManager: ConnectionManager
+    private let asserter: BackgroundTaskAsserting
+    private var taskIdentifier: UIBackgroundTaskIdentifier = .invalid
+    private var isPreparedForSuspension = false
+    private var releasesInFlight = 0
+
+    init(connectionManager: ConnectionManager, asserter: BackgroundTaskAsserting = UIApplication.shared) {
+        self.connectionManager = connectionManager
+        self.asserter = asserter
+    }
+
+    func prepareForSuspension() {
+        isPreparedForSuspension = true
+        syncAssertion()
+    }
+
+    func cancelPreparation() {
+        isPreparedForSuspension = false
+        syncAssertion()
+    }
+
+    func releaseForSuspension() async {
+        isPreparedForSuspension = false
+        guard connectionManager.hasSuspensionBlockingResources else {
+            syncAssertion()
+            return
+        }
+        beginAssertion()
+        releasesInFlight += 1
+        await connectionManager.releaseSuspensionBlockingResources()
+        releasesInFlight -= 1
+        syncAssertion()
+    }
+
+    private var needsAssertion: Bool {
+        if releasesInFlight > 0 { return true }
+        return isPreparedForSuspension && connectionManager.hasSuspensionBlockingResources
+    }
+
+    private func syncAssertion() {
+        guard needsAssertion else {
+            endAssertion(expired: false)
+            return
+        }
+        beginAssertion()
+    }
+
+    private func beginAssertion() {
+        guard taskIdentifier == .invalid else { return }
+        taskIdentifier = asserter.beginBackgroundTask(name: Self.taskName) { [weak self] in
+            self?.endAssertion(expired: true)
+        }
+    }
+
+    private func endAssertion(expired: Bool) {
+        guard taskIdentifier != .invalid else { return }
+        if expired {
+            Self.logger.warning("Background time expired before database files were released")
+        }
+        asserter.endBackgroundTask(taskIdentifier)
+        taskIdentifier = .invalid
+    }
+}

--- a/TableProMobile/TableProMobile/TableProMobileApp.swift
+++ b/TableProMobile/TableProMobile/TableProMobileApp.swift
@@ -75,6 +75,7 @@ struct TableProMobileApp: App {
             lockState.handleScenePhase(phase)
             switch phase {
             case .active:
+                appState.backgroundRelease.cancelPreparation()
                 MemoryPressureMonitor.shared.start()
                 appState.retryLoadIfFailed()
                 if AppPreferences.isCloudSyncEnabled && appState.loadStatus == .ready {
@@ -94,13 +95,15 @@ struct TableProMobileApp: App {
                     heartbeatService = service
                     heartbeatTask = service.startPeriodicHeartbeat()
                 }
+            case .inactive:
+                appState.backgroundRelease.prepareForSuspension()
             case .background:
                 syncTask?.cancel()
                 syncTask = nil
                 heartbeatTask?.cancel()
                 heartbeatTask = nil
                 heartbeatService = nil
-                Task { await appState.connectionManager.disconnectAll() }
+                Task { await appState.backgroundRelease.releaseForSuspension() }
                 scheduleBackgroundSync()
             default:
                 break

--- a/TableProMobile/TableProMobileTests/BackgroundReleaseCoordinatorTests.swift
+++ b/TableProMobile/TableProMobileTests/BackgroundReleaseCoordinatorTests.swift
@@ -1,0 +1,217 @@
+import Testing
+import UIKit
+import TableProDatabase
+import TableProModels
+@testable import TableProMobile
+
+@MainActor
+private final class SpyBackgroundTaskAsserter: BackgroundTaskAsserting {
+    let identifier = UIBackgroundTaskIdentifier(rawValue: 7)
+    private(set) var beginCount = 0
+    private(set) var endedIdentifiers: [UIBackgroundTaskIdentifier] = []
+    private var expirationHandler: (() -> Void)?
+
+    func beginBackgroundTask(name: String, expirationHandler: @escaping () -> Void) -> UIBackgroundTaskIdentifier {
+        beginCount += 1
+        self.expirationHandler = expirationHandler
+        return identifier
+    }
+
+    func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier) {
+        endedIdentifiers.append(identifier)
+    }
+
+    func fireExpiration() {
+        expirationHandler?()
+    }
+}
+
+private final class StubDriverFactory: DriverFactory, @unchecked Sendable {
+    var drivers: [String: any DatabaseDriver] = [:]
+
+    func createDriver(for connection: DatabaseConnection, password: String?) throws -> any DatabaseDriver {
+        guard let driver = drivers[connection.type.rawValue] else {
+            throw ConnectionError.driverNotFound(connection.type.rawValue)
+        }
+        return driver
+    }
+
+    func supportedTypes() -> [DatabaseType] { [] }
+}
+
+private func makeConnection(_ type: String) -> DatabaseConnection {
+    DatabaseConnection(name: "Test", type: DatabaseType(rawValue: type))
+}
+
+private func makeManager(_ factory: StubDriverFactory) -> ConnectionManager {
+    ConnectionManager(driverFactory: factory, secureStore: MockSecureStore())
+}
+
+private actor Gate {
+    private var isOpen = false
+    private var hasEntered = false
+    private var blocked: [CheckedContinuation<Void, Never>] = []
+    private var observers: [CheckedContinuation<Void, Never>] = []
+
+    func enter() async {
+        hasEntered = true
+        for observer in observers { observer.resume() }
+        observers.removeAll()
+        guard !isOpen else { return }
+        await withCheckedContinuation { blocked.append($0) }
+    }
+
+    func open() {
+        isOpen = true
+        for waiter in blocked { waiter.resume() }
+        blocked.removeAll()
+    }
+
+    func waitUntilEntered() async {
+        guard !hasEntered else { return }
+        await withCheckedContinuation { observers.append($0) }
+    }
+}
+
+private func makeBlockingDriver() -> MockDatabaseDriver {
+    let driver = MockDatabaseDriver()
+    driver.holdsSuspensionBlockingResource = true
+    return driver
+}
+
+@Suite("BackgroundReleaseCoordinator Tests")
+@MainActor
+struct BackgroundReleaseCoordinatorTests {
+    @Test("No assertion is taken when no session holds a resource")
+    func noAssertionWithoutBlockingSession() async throws {
+        let factory = StubDriverFactory()
+        factory.drivers["remote"] = MockDatabaseDriver()
+        let manager = makeManager(factory)
+        _ = try await manager.connect(makeConnection("remote"))
+
+        let asserter = SpyBackgroundTaskAsserter()
+        let coordinator = BackgroundReleaseCoordinator(connectionManager: manager, asserter: asserter)
+
+        coordinator.prepareForSuspension()
+
+        #expect(asserter.beginCount == 0)
+    }
+
+    @Test("Preparing takes one assertion and cancelling ends it")
+    func assertionTakenOnceAndEndedOnCancel() async throws {
+        let factory = StubDriverFactory()
+        factory.drivers["file"] = makeBlockingDriver()
+        let manager = makeManager(factory)
+        _ = try await manager.connect(makeConnection("file"))
+
+        let asserter = SpyBackgroundTaskAsserter()
+        let coordinator = BackgroundReleaseCoordinator(connectionManager: manager, asserter: asserter)
+
+        coordinator.prepareForSuspension()
+        coordinator.prepareForSuspension()
+        #expect(asserter.beginCount == 1)
+
+        coordinator.cancelPreparation()
+        #expect(asserter.endedIdentifiers == [asserter.identifier])
+    }
+
+    @Test("Returning to the foreground leaves the session connected")
+    func cancelledPreparationKeepsSession() async throws {
+        let factory = StubDriverFactory()
+        factory.drivers["file"] = makeBlockingDriver()
+        let manager = makeManager(factory)
+        let connection = makeConnection("file")
+        _ = try await manager.connect(connection)
+
+        let asserter = SpyBackgroundTaskAsserter()
+        let coordinator = BackgroundReleaseCoordinator(connectionManager: manager, asserter: asserter)
+
+        coordinator.prepareForSuspension()
+        coordinator.cancelPreparation()
+
+        #expect(manager.session(for: connection.id) != nil)
+    }
+
+    @Test("Releasing disconnects only the blocking session and ends the assertion")
+    func releaseDisconnectsBlockingSession() async throws {
+        let factory = StubDriverFactory()
+        factory.drivers["file"] = makeBlockingDriver()
+        factory.drivers["remote"] = MockDatabaseDriver()
+        let manager = makeManager(factory)
+        let fileConnection = makeConnection("file")
+        let remoteConnection = makeConnection("remote")
+        _ = try await manager.connect(fileConnection)
+        _ = try await manager.connect(remoteConnection)
+
+        let asserter = SpyBackgroundTaskAsserter()
+        let coordinator = BackgroundReleaseCoordinator(connectionManager: manager, asserter: asserter)
+
+        coordinator.prepareForSuspension()
+        await coordinator.releaseForSuspension()
+
+        #expect(manager.session(for: fileConnection.id) == nil)
+        #expect(manager.session(for: remoteConnection.id) != nil)
+        #expect(asserter.beginCount == 1)
+        #expect(asserter.endedIdentifiers == [asserter.identifier])
+    }
+
+    @Test("Releasing takes an assertion when preparation was skipped")
+    func releaseTakesAssertionWithoutPreparation() async throws {
+        let factory = StubDriverFactory()
+        factory.drivers["file"] = makeBlockingDriver()
+        let manager = makeManager(factory)
+        _ = try await manager.connect(makeConnection("file"))
+
+        let asserter = SpyBackgroundTaskAsserter()
+        let coordinator = BackgroundReleaseCoordinator(connectionManager: manager, asserter: asserter)
+
+        await coordinator.releaseForSuspension()
+
+        #expect(asserter.beginCount == 1)
+        #expect(asserter.endedIdentifiers == [asserter.identifier])
+    }
+
+    @Test("Returning to the foreground keeps the assertion while a release is still in flight")
+    func inFlightReleaseSurvivesForegroundBounce() async throws {
+        let factory = StubDriverFactory()
+        let driver = makeBlockingDriver()
+        let gate = Gate()
+        driver.beforeDisconnect = { await gate.enter() }
+        factory.drivers["file"] = driver
+        let manager = makeManager(factory)
+        _ = try await manager.connect(makeConnection("file"))
+
+        let asserter = SpyBackgroundTaskAsserter()
+        let coordinator = BackgroundReleaseCoordinator(connectionManager: manager, asserter: asserter)
+
+        coordinator.prepareForSuspension()
+        let release = Task { await coordinator.releaseForSuspension() }
+        await gate.waitUntilEntered()
+
+        coordinator.cancelPreparation()
+        #expect(asserter.endedIdentifiers.isEmpty)
+
+        await gate.open()
+        await release.value
+
+        #expect(asserter.beginCount == 1)
+        #expect(asserter.endedIdentifiers == [asserter.identifier])
+    }
+
+    @Test("Expiring ends the assertion without ending it twice")
+    func expirationEndsAssertionOnce() async throws {
+        let factory = StubDriverFactory()
+        factory.drivers["file"] = makeBlockingDriver()
+        let manager = makeManager(factory)
+        _ = try await manager.connect(makeConnection("file"))
+
+        let asserter = SpyBackgroundTaskAsserter()
+        let coordinator = BackgroundReleaseCoordinator(connectionManager: manager, asserter: asserter)
+
+        coordinator.prepareForSuspension()
+        asserter.fireExpiration()
+        coordinator.cancelPreparation()
+
+        #expect(asserter.endedIdentifiers == [asserter.identifier])
+    }
+}

--- a/TableProMobile/TableProMobileTests/Drivers/DuckDBDriverSuspensionTests.swift
+++ b/TableProMobile/TableProMobileTests/Drivers/DuckDBDriverSuspensionTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import TableProMobile
+
+final class DuckDBDriverSuspensionTests: XCTestCase {
+    func testInMemoryDatabaseHoldsNoSuspensionBlockingResource() {
+        let driver = DuckDBDriver(path: DuckDBDriver.inMemoryPath, bookmark: nil)
+
+        XCTAssertFalse(driver.holdsSuspensionBlockingResource)
+    }
+
+    func testFileBackedDatabaseHoldsSuspensionBlockingResource() {
+        let driver = DuckDBDriver(path: "/tmp/analytics.duckdb", bookmark: nil)
+
+        XCTAssertTrue(driver.holdsSuspensionBlockingResource)
+    }
+}

--- a/TableProMobile/TableProMobileTests/Mocks/MockDatabaseDriver.swift
+++ b/TableProMobile/TableProMobileTests/Mocks/MockDatabaseDriver.swift
@@ -23,9 +23,14 @@ final class MockDatabaseDriver: DatabaseDriver, @unchecked Sendable {
     var currentSchema: String? = nil
     var supportsTransactions: Bool = true
     var serverVersion: String? = "Mock 1.0"
+    var holdsSuspensionBlockingResource: Bool = false
+
+    var beforeDisconnect: (@Sendable () async -> Void)?
 
     func connect() async throws {}
-    func disconnect() async throws {}
+    func disconnect() async throws {
+        await beforeDisconnect?()
+    }
     func ping() async throws -> Bool { true }
     func cancelCurrentQuery() async throws {}
 


### PR DESCRIPTION
Fixes a `RUNNINGBOARD 0xdead10cc` SIGKILL in TablePro Mobile, reproduced in three TestFlight crash reports (1.0 build 19, iOS 27.0, iPhone 14,5).

## Root cause

Xcode names the crash point `SwiftUI: specialized UnsafeMutablePointer<>.withMemoryRebound`, but that is just the main thread parked in `UIApplicationMain`'s runloop. The real signal is the termination reason: the app was killed for holding a file lock across suspension. Every report has a thread doing exactly that:

```
duckdb_close -> DatabaseInstance::~DatabaseInstance -> ResetDatabases
  -> AttachedDatabase::Close -> DuckCatalog::~DuckCatalog
  -> RowGroup::~RowGroup -> BlockHandle::~BlockHandle -> FileBuffer::~FileBuffer -> madvise
DuckDBActor.close()               DuckDBDriver.swift:217
DuckDBDriver.disconnect()         DuckDBDriver.swift:44
ConnectionManager.disconnectAll() ConnectionManager.swift:80
```

Two defects compounded.

**Wrong policy.** `scenePhase == .background` ran `disconnectAll()`, closing every session. For the six network drivers that is pure cost: iOS drops sockets at suspension anyway, the resume path already pings and reconnects, and closing a live session deliberately destroys server-side state (temp tables, `search_path`, `SET` variables, open transactions). For DuckDB it meant a multi-second `duckdb_close()` holding the database file lock. Unlike SQLite, which the picker copies into the app container, DuckDB keeps a security-scoped bookmark and opens the user's file in place, so that file can live in iCloud Drive or another Files provider.

**Wrong mechanics.** No background task assertion existed anywhere in the repo. The work started at `.background`, which is the point Apple's documentation explicitly warns against because the assertion is granted asynchronously, and it ran a blocking C call on the Swift cooperative thread pool.

The background disconnect landed in `dbaeea3d2`, when every iOS driver was a network socket where close is instant. DuckDB arrived later in `c01361f45` and invalidated that premise.

## The change

Backgrounding is no longer "close everything". It is "release the OS resources that block suspension", which in practice is DuckDB's file lock and nothing else. This also matches every comparable client: no database client on any platform drops connections on backgrounding, and Postico shipped this exact behaviour in 1.0 and removed it by 1.2.

- `DatabaseDriver` gains `holdsSuspensionBlockingResource`, defaulted `false` in the protocol extension. Only `DuckDBDriver` overrides it, and only when file-backed.
- `ConnectionManager` gains `hasSuspensionBlockingResources` and `releaseSuspensionBlockingResources()`, which releases just those sessions and does so concurrently. `disconnectAll()` is removed; it had one caller.
- `ConnectionManager.disconnect(_:)` tracks in-flight teardowns, so `connect()` for the same id awaits one instead of racing it. Previously a resumed app could start a second `duckdb_open_ext` on the same file while the first close was still running.
- `DuckDBActor` runs on its own `DispatchSerialQueue` executor (SE-0392), taking `duckdb_close` and every blocking `duckdb_query` off the cooperative pool. `Task.detached` would not have done this.
- New `BackgroundReleaseCoordinator` owns the `UIApplication` assertion: taken at `.inactive`, consumed at `.background`, released on `.active`. Splitting prepare from release is the point, since the grant is asynchronous and `.inactive` is where Apple's *Preparing your UI to run in the background* puts "close any open files". Doing no work at `.inactive` avoids tearing down connections on every notification banner.

## Behaviour change

Remote connections now survive an app switch instead of being dropped and rebuilt. Returning to the app no longer reconnects and reloads everything.

## Tests

- `ConnectionManagerTests`: release touches only blocking sessions, releases run concurrently (proved by a rendezvous, not by timing), an in-flight teardown still counts as a blocking resource, and `connect()` waits for an in-flight teardown.
- `BackgroundReleaseCoordinatorTests`: no assertion when nothing needs releasing, assertion taken once and ended on cancel, release ends it, release takes one when preparation was skipped, expiry does not double-end, and an in-flight release keeps the assertion alive across a foreground bounce.
- `DuckDBDriverSuspensionTests`: in-memory opts out, file-backed opts in.

Each load-bearing test was checked against the pre-fix code and confirmed to fail there.

| Check | Result |
| --- | --- |
| TableProCore suite | 181 tests, 0 failures |
| iOS test target (simulator) | `TEST SUCCEEDED`, 0 failures |
| SwiftLint `--strict` on changed app sources | clean |

## Verifying by hand

`0xdead10cc` terminations do not occur in the Simulator or on device with the debugger attached, so this needs a detached device build: open a file-backed DuckDB connection from Files, background the app, and confirm no crash report appears.
