### PR TITLE
fix(ios): send the Redis ACL username so Valkey and Redis 6 users can sign in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- TablePro Mobile keeps remote connections open when you switch apps, so coming back no longer reconnects and reloads everything.
+- Mobile keeps remote connections open when you switch apps.
 
 ### Fixed
 
-- TablePro Mobile no longer gets killed by iOS when you leave the app with a DuckDB file open.
+- Mobile no longer gets killed by iOS when you leave the app with a DuckDB file open.
+- Redis and Valkey ACL users can sign in on mobile. The username was dropped, so every login was rejected.
+- A rejected Redis login now says what to change.
+- Mobile opens the Redis database index saved on a connection, not always database 0.
 
 ## [0.64.0] - 2026-08-10
 

--- a/Plugins/RedisDriverPlugin/RedisAuthCommand.swift
+++ b/Plugins/RedisDriverPlugin/RedisAuthCommand.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+enum RedisAuthCommand {
+    enum Failure: Equatable, Sendable {
+        case rejectedCredentials
+        case rejectedWithoutUsername
+        case serverHasNoPassword
+        case usernameUnsupported
+        case unrecognized
+    }
+
+    static func arguments(username: String?, password: String?) -> [String]? {
+        guard let password, !password.isEmpty else { return nil }
+        guard let username, !username.isEmpty else { return ["AUTH", password] }
+        return ["AUTH", username, password]
+    }
+
+    static func failure(serverError: String, hadUsername: Bool) -> Failure {
+        let text = serverError.lowercased()
+        if text.contains("wrong number of arguments") { return .usernameUnsupported }
+        if text.contains("without any password configured") || text.contains("no password is set") {
+            return .serverHasNoPassword
+        }
+        if text.contains("invalid password") { return .rejectedCredentials }
+        if text.contains("wrongpass") {
+            return hadUsername ? .rejectedCredentials : .rejectedWithoutUsername
+        }
+        return .unrecognized
+    }
+}

--- a/Plugins/RedisDriverPlugin/RedisDatabaseIndex.swift
+++ b/Plugins/RedisDriverPlugin/RedisDatabaseIndex.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+enum RedisDatabaseIndex {
+    static let fieldName = "redisDatabase"
+
+    static func resolve(additionalFields: [String: String], database: String) -> Int {
+        if let field = additionalFields[fieldName], let index = Int(field) { return index }
+        return Int(database) ?? 0
+    }
+}

--- a/Plugins/RedisDriverPlugin/RedisPluginConnection.swift
+++ b/Plugins/RedisDriverPlugin/RedisPluginConnection.swift
@@ -447,13 +447,7 @@ private extension RedisPluginConnection {
     }
 
     func authenticateSync() throws {
-        guard let password, !password.isEmpty else { return }
-        let authArgs: [String]
-        if let username, !username.isEmpty {
-            authArgs = ["AUTH", username, password]
-        } else {
-            authArgs = ["AUTH", password]
-        }
+        guard let authArgs = RedisAuthCommand.arguments(username: username, password: password) else { return }
         let reply = try executeCommandSync(authArgs)
         if case .error(let msg) = reply {
             throw RedisPluginError(code: 1, message: "AUTH failed: \(msg)")

--- a/Plugins/RedisDriverPlugin/RedisPluginDriver.swift
+++ b/Plugins/RedisDriverPlugin/RedisPluginDriver.swift
@@ -65,7 +65,7 @@ final class RedisPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func connect(reportingStage report: @escaping ConnectionStageReporter) async throws {
         let sslConfig = config.ssl
-        let redisDb = Int(config.additionalFields["redisDatabase"] ?? "") ?? Int(config.database) ?? 0
+        let redisDb = RedisDatabaseIndex.resolve(additionalFields: config.additionalFields, database: config.database)
 
         let conn = RedisPluginConnection(
             host: config.host,

--- a/TableProMobile/TableProMobile/Drivers/DriverSSLConfiguration.swift
+++ b/TableProMobile/TableProMobile/Drivers/DriverSSLConfiguration.swift
@@ -75,8 +75,20 @@ struct DriverSSLConfiguration: Equatable, Sendable {
     }
 
     var existingCACertificatePath: String? {
-        guard verifiesCertificate,
-              let path = caCertificatePath,
+        guard verifiesCertificate else { return nil }
+        return Self.existingPath(caCertificatePath)
+    }
+
+    var existingClientCertificatePath: String? {
+        Self.existingPath(clientCertificatePath)
+    }
+
+    var existingClientKeyPath: String? {
+        Self.existingPath(clientKeyPath)
+    }
+
+    private static func existingPath(_ path: String?) -> String? {
+        guard let path,
               !path.isEmpty,
               FileManager.default.fileExists(atPath: path) else { return nil }
         return path

--- a/TableProMobile/TableProMobile/Drivers/RedisDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/RedisDriver.swift
@@ -8,6 +8,7 @@ final class RedisDriver: DatabaseDriver, @unchecked Sendable {
     private let actor = RedisActor()
     private let host: String
     private let port: Int
+    private let username: String?
     private let password: String?
     private let database: Int
     let ssl: DriverSSLConfiguration
@@ -19,9 +20,17 @@ final class RedisDriver: DatabaseDriver, @unchecked Sendable {
     // Set once during connect() before the driver is shared — safe for concurrent reads
     nonisolated(unsafe) private(set) var serverVersion: String?
 
-    init(host: String, port: Int, password: String?, database: Int = 0, ssl: DriverSSLConfiguration = .disabled) {
+    init(
+        host: String,
+        port: Int,
+        username: String? = nil,
+        password: String?,
+        database: Int = 0,
+        ssl: DriverSSLConfiguration = .disabled
+    ) {
         self.host = host
         self.port = port
+        self.username = username
         self.password = password
         self.database = database
         self.ssl = ssl
@@ -31,7 +40,14 @@ final class RedisDriver: DatabaseDriver, @unchecked Sendable {
 
     func connect() async throws {
         try await LocalNetworkPermission.shared.ensureAccess(for: host)
-        try await actor.connect(host: host, port: port, password: password, database: database, ssl: ssl)
+        try await actor.connect(
+            host: host,
+            port: port,
+            username: username,
+            password: password,
+            database: database,
+            ssl: ssl
+        )
         serverVersion = try? await actor.fetchServerVersion()
     }
 
@@ -356,7 +372,14 @@ private actor RedisActor {
         }
     }()
 
-    func connect(host: String, port: Int, password: String?, database: Int, ssl: DriverSSLConfiguration) throws {
+    func connect(
+        host: String,
+        port: Int,
+        username: String?,
+        password: String?,
+        database: Int,
+        ssl: DriverSSLConfiguration
+    ) throws {
         // Close existing connection if reconnecting
         close()
 
@@ -382,21 +405,12 @@ private actor RedisActor {
         if ssl.isEnabled {
             _ = Self.initSSL
 
-            let sslCtx: OpaquePointer = try host.withCString { hostCStr in
-                try withOptionalCString(ssl.existingCACertificatePath) { caCStr in
-                    var sslError = redisSSLContextError(0)
-                    var options = redisSSLOptions()
-                    memset(&options, 0, MemoryLayout<redisSSLOptions>.size)
-                    options.server_name = hostCStr
-                    options.cacert_filename = caCStr
-                    options.verify_mode = ssl.verifiesCertificate ? REDIS_SSL_VERIFY_PEER : REDIS_SSL_VERIFY_NONE
-
-                    guard let created = redisCreateSSLContextWithOptions(&options, &sslError) else {
-                        redisFree(context)
-                        throw RedisError.connectionFailed("Failed to create SSL context (error \(sslError.rawValue))")
-                    }
-                    return created
-                }
+            let sslCtx: OpaquePointer
+            do {
+                sslCtx = try Self.makeSSLContext(host: host, ssl: ssl)
+            } catch {
+                redisFree(context)
+                throw error
             }
 
             let result = redisInitiateSSLWithContext(context, sslCtx)
@@ -413,10 +427,16 @@ private actor RedisActor {
         self.ctx = context
 
         do {
-            if let password, !password.isEmpty {
-                let reply = try executeCommand(["AUTH", password])
+            if let authArgs = RedisAuthCommand.arguments(username: username, password: password) {
+                let reply = try executeCommand(authArgs)
                 if case .error(let msg) = reply {
-                    throw RedisError.connectionFailed("Authentication failed: \(msg)")
+                    throw RedisError.authenticationFailed(
+                        serverMessage: msg,
+                        failure: RedisAuthCommand.failure(
+                            serverError: msg,
+                            hadUsername: !(username ?? "").isEmpty
+                        )
+                    )
                 }
             }
 
@@ -429,6 +449,32 @@ private actor RedisActor {
         } catch {
             close()
             throw error
+        }
+    }
+
+    private static func makeSSLContext(host: String, ssl: DriverSSLConfiguration) throws -> OpaquePointer {
+        try host.withCString { hostCStr in
+            try withOptionalCString(ssl.existingCACertificatePath) { caCStr in
+                try withOptionalCString(ssl.existingClientCertificatePath) { certCStr in
+                    try withOptionalCString(ssl.existingClientKeyPath) { keyCStr in
+                        var sslError = redisSSLContextError(0)
+                        var options = redisSSLOptions()
+                        memset(&options, 0, MemoryLayout<redisSSLOptions>.size)
+                        options.server_name = hostCStr
+                        options.cacert_filename = caCStr
+                        options.cert_filename = certCStr
+                        options.private_key_filename = keyCStr
+                        options.verify_mode = ssl.verifiesCertificate ? REDIS_SSL_VERIFY_PEER : REDIS_SSL_VERIFY_NONE
+
+                        guard let created = redisCreateSSLContextWithOptions(&options, &sslError) else {
+                            throw RedisError.connectionFailed(
+                                "Failed to create SSL context (error \(sslError.rawValue))"
+                            )
+                        }
+                        return created
+                    }
+                }
+            }
         }
     }
 
@@ -534,6 +580,7 @@ private actor RedisActor {
 
 enum RedisError: Error, LocalizedError {
     case connectionFailed(String)
+    case authenticationFailed(serverMessage: String, failure: RedisAuthCommand.Failure)
     case notConnected
     case queryFailed(String)
     case unsupported(String)
@@ -541,9 +588,31 @@ enum RedisError: Error, LocalizedError {
     var errorDescription: String? {
         switch self {
         case .connectionFailed(let msg): return "Redis connection failed: \(msg)"
+        case .authenticationFailed(let serverMessage, let failure):
+            guard let hint = Self.hint(for: failure) else {
+                return String(format: String(localized: "Redis authentication failed: %@"), serverMessage)
+            }
+            return String(
+                format: String(localized: "Redis authentication failed: %1$@ %2$@"),
+                serverMessage,
+                hint
+            )
         case .notConnected: return "Not connected to Redis"
         case .queryFailed(let msg): return "Redis command failed: \(msg)"
         case .unsupported(let msg): return msg
+        }
+    }
+
+    private static func hint(for failure: RedisAuthCommand.Failure) -> String? {
+        switch failure {
+        case .rejectedWithoutUsername:
+            return String(localized: "If this server uses Redis 6 or later ACL users, fill in the Username field.")
+        case .serverHasNoPassword:
+            return String(localized: "This server has no password set for the default user. Clear the Password field.")
+        case .usernameUnsupported:
+            return String(localized: "This server predates Redis 6 and takes no username. Clear the Username field.")
+        case .rejectedCredentials, .unrecognized:
+            return nil
         }
     }
 }

--- a/TableProMobile/TableProMobile/Platform/IOSDriverFactory.swift
+++ b/TableProMobile/TableProMobile/Platform/IOSDriverFactory.swift
@@ -37,10 +37,14 @@ final class IOSDriverFactory: DriverFactory {
                 ssl: DriverSSLConfiguration(sslEnabled: connection.sslEnabled, configuration: connection.sslConfiguration)
             )
         case .redis:
-            let dbIndex = Int(connection.database) ?? 0
+            let dbIndex = RedisDatabaseIndex.resolve(
+                additionalFields: connection.additionalFields,
+                database: connection.database
+            )
             return RedisDriver(
                 host: connection.host,
                 port: connection.port,
+                username: connection.username,
                 password: password,
                 database: dbIndex,
                 ssl: DriverSSLConfiguration(sslEnabled: connection.sslEnabled, configuration: connection.sslConfiguration)

--- a/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
@@ -313,7 +313,7 @@ struct ConnectionFormView: View {
     @ViewBuilder
     private func serverSection(viewModel: ConnectionFormViewModel) -> some View {
         @Bindable var viewModel = viewModel
-        Section("Server") {
+        Section {
             TextField("Host", text: $viewModel.host)
                 .textInputAutocapitalization(.never)
                 .keyboardType(.URL)
@@ -321,7 +321,15 @@ struct ConnectionFormView: View {
                 .keyboardType(.numberPad)
             TextField("Username", text: $viewModel.username)
                 .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .keyboardType(.asciiCapable)
             SecureField("Password", text: $viewModel.password)
+        } header: {
+            Text("Server")
+        } footer: {
+            if viewModel.type == .redis {
+                Text("Username is for Redis 6 and later ACL users. Leave it empty for password-only servers.")
+            }
         }
         Section("Database") {
             TextField("Database Name", text: $viewModel.database)

--- a/TableProMobile/TableProMobileTests/Drivers/DriverSSLConfigurationTests.swift
+++ b/TableProMobile/TableProMobileTests/Drivers/DriverSSLConfigurationTests.swift
@@ -83,4 +83,36 @@ struct DriverSSLConfigurationTests {
         let missing = DriverSSLConfiguration(mode: .verifyFull, caCertificatePath: "/does/not/exist.pem")
         #expect(missing.existingCACertificatePath == nil)
     }
+
+    @Test("client certificate and key are used without requiring server verification")
+    func clientCertificateIndependentOfVerification() {
+        let certPath = NSTemporaryDirectory() + "tablepro-cert-\(UUID().uuidString).pem"
+        let keyPath = NSTemporaryDirectory() + "tablepro-key-\(UUID().uuidString).pem"
+        FileManager.default.createFile(atPath: certPath, contents: Data("cert".utf8))
+        FileManager.default.createFile(atPath: keyPath, contents: Data("key".utf8))
+        defer {
+            try? FileManager.default.removeItem(atPath: certPath)
+            try? FileManager.default.removeItem(atPath: keyPath)
+        }
+
+        let ssl = DriverSSLConfiguration(
+            mode: .require,
+            clientCertificatePath: certPath,
+            clientKeyPath: keyPath
+        )
+        #expect(ssl.existingClientCertificatePath == certPath)
+        #expect(ssl.existingClientKeyPath == keyPath)
+    }
+
+    @Test("missing or empty client certificate paths resolve to nil")
+    func clientCertificateMissing() {
+        let absent = DriverSSLConfiguration(
+            mode: .verifyFull,
+            clientCertificatePath: "/does/not/exist.pem",
+            clientKeyPath: ""
+        )
+        #expect(absent.existingClientCertificatePath == nil)
+        #expect(absent.existingClientKeyPath == nil)
+        #expect(DriverSSLConfiguration(mode: .require).existingClientCertificatePath == nil)
+    }
 }

--- a/TableProMobile/project.yml
+++ b/TableProMobile/project.yml
@@ -48,6 +48,9 @@ targets:
       # bundle on iOS, so the driver links into the app.
       - ../Plugins/MSSQLDriverPlugin/FreeTDSConnection.swift
       - ../Plugins/MSSQLDriverPlugin/MSSQLLoginParameters.swift
+      # Redis credential rules the iOS driver shares with the macOS plugin.
+      - ../Plugins/RedisDriverPlugin/RedisAuthCommand.swift
+      - ../Plugins/RedisDriverPlugin/RedisDatabaseIndex.swift
     configFiles:
       Debug: ../Configs/Version-iOS.xcconfig
       Release: ../Configs/Version-iOS.xcconfig

--- a/TableProTests/Plugins/RedisAuthCommandTests.swift
+++ b/TableProTests/Plugins/RedisAuthCommandTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+
+@Suite("Redis AUTH command")
+struct RedisAuthCommandTests {
+    @Test("no password sends no AUTH at all")
+    func noPassword() {
+        #expect(RedisAuthCommand.arguments(username: nil, password: nil) == nil)
+        #expect(RedisAuthCommand.arguments(username: nil, password: "") == nil)
+        #expect(RedisAuthCommand.arguments(username: "acl-user", password: nil) == nil)
+        #expect(RedisAuthCommand.arguments(username: "acl-user", password: "") == nil)
+    }
+
+    @Test("password without a username uses the one-argument form")
+    func passwordOnly() {
+        #expect(RedisAuthCommand.arguments(username: nil, password: "s3cret") == ["AUTH", "s3cret"])
+        #expect(RedisAuthCommand.arguments(username: "", password: "s3cret") == ["AUTH", "s3cret"])
+    }
+
+    @Test("a username sends the ACL form so the server does not fall back to the default user")
+    func usernameAndPassword() {
+        #expect(
+            RedisAuthCommand.arguments(username: "acl-user", password: "s3cret")
+                == ["AUTH", "acl-user", "s3cret"]
+        )
+    }
+
+    @Test("a 64-character hex password is passed through unchanged")
+    func generatedPasswordSurvivesIntact() {
+        let password = String(repeating: "a1b2c3d4", count: 8)
+        #expect(password.count == 64)
+        #expect(
+            RedisAuthCommand.arguments(username: "acl-user", password: password)
+                == ["AUTH", "acl-user", password]
+        )
+    }
+
+    @Test("WRONGPASS without a username points at the missing ACL username")
+    func wrongPassWithoutUsername() {
+        let serverError = "WRONGPASS invalid username-password pair or user is disabled."
+        #expect(
+            RedisAuthCommand.failure(serverError: serverError, hadUsername: false)
+                == .rejectedWithoutUsername
+        )
+    }
+
+    @Test("WRONGPASS with a username stays an ordinary credential rejection")
+    func wrongPassWithUsername() {
+        let serverError = "WRONGPASS invalid username-password pair or user is disabled."
+        #expect(
+            RedisAuthCommand.failure(serverError: serverError, hadUsername: true)
+                == .rejectedCredentials
+        )
+    }
+
+    @Test("a server with no password configured is reported as such")
+    func serverHasNoPassword() {
+        let modern = "ERR AUTH <password> called without any password configured for the default user."
+        #expect(RedisAuthCommand.failure(serverError: modern, hadUsername: false) == .serverHasNoPassword)
+
+        let legacy = "ERR Client sent AUTH, but no password is set"
+        #expect(RedisAuthCommand.failure(serverError: legacy, hadUsername: false) == .serverHasNoPassword)
+    }
+
+    @Test("a pre-ACL server's wrong-password reply never suggests an ACL username")
+    func legacyInvalidPasswordCarriesNoUsernameHint() {
+        let serverError = "ERR invalid password"
+        #expect(RedisAuthCommand.failure(serverError: serverError, hadUsername: false) == .rejectedCredentials)
+        #expect(RedisAuthCommand.failure(serverError: serverError, hadUsername: true) == .rejectedCredentials)
+    }
+
+    @Test("a pre-ACL server rejects the username form with an arity error")
+    func usernameUnsupported() {
+        let serverError = "ERR wrong number of arguments for 'auth' command"
+        #expect(RedisAuthCommand.failure(serverError: serverError, hadUsername: true) == .usernameUnsupported)
+    }
+
+    @Test("an unrelated error carries no hint")
+    func unrecognized() {
+        #expect(RedisAuthCommand.failure(serverError: "LOADING dataset in memory", hadUsername: true) == .unrecognized)
+    }
+}

--- a/TableProTests/Plugins/RedisDatabaseIndexTests.swift
+++ b/TableProTests/Plugins/RedisDatabaseIndexTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+
+@Suite("Redis database index")
+struct RedisDatabaseIndexTests {
+    @Test("the dedicated field wins over the database name")
+    func fieldWins() {
+        let index = RedisDatabaseIndex.resolve(additionalFields: ["redisDatabase": "3"], database: "0")
+        #expect(index == 3)
+    }
+
+    @Test("the database name is used when the field is absent")
+    func fallsBackToDatabase() {
+        #expect(RedisDatabaseIndex.resolve(additionalFields: [:], database: "7") == 7)
+    }
+
+    @Test("a non-numeric field falls back to the database name")
+    func nonNumericField() {
+        #expect(RedisDatabaseIndex.resolve(additionalFields: ["redisDatabase": "db2"], database: "5") == 5)
+    }
+
+    @Test("an unusable value resolves to database zero")
+    func defaultsToZero() {
+        #expect(RedisDatabaseIndex.resolve(additionalFields: [:], database: "") == 0)
+        #expect(RedisDatabaseIndex.resolve(additionalFields: ["redisDatabase": ""], database: "db0") == 0)
+    }
+}

--- a/docs/databases/redis.mdx
+++ b/docs/databases/redis.mdx
@@ -109,6 +109,10 @@ DBSIZE
 
 **Auth failed**: Verify password matches `requirepass` in `redis.conf`. For Redis 6.0+ ACL: `ACL SETUSER myuser on >password ~* +@all`
 
+With the Username field empty, TablePro sends `AUTH password`, which Redis and Valkey always check against the `default` user. An ACL user's password fails that check with `WRONGPASS invalid username-password pair or user is disabled.` Fill in Username to authenticate as that user.
+
+Note that `>password` sets a password and `#hash` sets a SHA-256 hash. A 64-character hex string is valid for both, so `ACL SETUSER myuser on #<64-hex>` is accepted where `>` was meant, and every later login fails with `WRONGPASS`. `ACL LIST` shows stored passwords as hashes, so a value copied from there is a hash, not a password.
+
 **Timeout**: Verify host/port, check network and firewall, whitelist IP for cloud-hosted Redis.
 
 **Slow key list**: `KEYS` blocks the server on a large keyspace. Browse by namespace instead, and use `SCAN` when you need a pattern match in the CLI. Check memory pressure with `INFO memory`.

--- a/project.yml
+++ b/project.yml
@@ -357,7 +357,9 @@ targets:
       - Plugins/PostgreSQLDriverPlugin/RedshiftExternalSchemaQueries.swift
       - Plugins/PostgreSQLDriverPlugin/RedshiftSchemaQueries.swift
       - Plugins/RedisDriverPlugin/RedisArgumentCodec.swift
+      - Plugins/RedisDriverPlugin/RedisAuthCommand.swift
       - Plugins/RedisDriverPlugin/RedisCommandParser.swift
+      - Plugins/RedisDriverPlugin/RedisDatabaseIndex.swift
       - Plugins/RedisDriverPlugin/RedisKeySummary.swift
       - Plugins/RedisDriverPlugin/RedisQueryBuilder.swift
       - Plugins/RedisDriverPlugin/RedisStatementGenerator.swift


### PR DESCRIPTION
A user reported that a Valkey login works in TablePro on macOS but is rejected on iOS and in the mobile app running on a Mac. Their password is 64 hex characters from `openssl rand -hex 32`, which is a red herring: that is exactly what Redis's own `ACL GENPASS` produces, and hiredis sends it with an explicit byte length.

## Root cause

The mobile driver never sends the ACL username.

Redis and Valkey hard-code the one-argument form of `AUTH` to the `default` user. From `authCommand()` in `src/acl.c`, identical in every Redis 6+ and every Valkey:

```c
if (c->argc == 2) {
    username = shared.default_username;   // always
    password = c->argv[1];
} else {
    username = c->argv[1];
    password = c->argv[2];
}
```

So `AUTH <password>` checks the password against `default`, never against an ACL user, and answers `WRONGPASS invalid username-password pair or user is disabled.`

The two code paths had diverged:

- macOS `RedisPluginConnection.swift` sent `["AUTH", username, password]` when a username was set. Works.
- Mobile `RedisDriver.swift` always sent `["AUTH", password]` and had no `username` property, and `IOSDriverFactory` forwarded `connection.username` to MySQL and PostgreSQL but not to Redis.

The iOS form has always shown a Username field for Redis, and it saved and synced. The user filled it in, the app stored it, and the driver threw it away. `docs/databases/redis.mdx` already documented the field as "sent as `AUTH username password`".

## What changed

Rather than adding a username parameter and leaving two hand-written copies of the same logic, the AUTH rules and the Redis database-index resolution moved into two pure files that both platforms call:

- `RedisAuthCommand` decides the AUTH argument shape and classifies the server's rejection.
- `RedisDatabaseIndex` resolves `additionalFields["redisDatabase"]` then `database` then `0`.

Also fixed on mobile, found on the same path:

- The Redis database index was ignored, so a connection configured on the Mac for db 3 opened db 0. That matters here because Valkey's `db=` ACL selectors scope a user to specific databases, and connections always start in db 0.
- The Redis TLS options never set the client certificate or key.

## Error messages

A rejected login now says what to change. When no username was sent, it points at the Username field. Redis's `nopass` reply and a pre-6 server's arity error each get their own message. `WRONGPASS` with a username supplied gets no hint, because the server deliberately does not say which half was wrong.

`ERR invalid password` is a Redis 5 reply and maps to a plain rejection with no hint, since Redis 5 has no ACL users and suggesting a username there would be wrong.

## Testing

13 new unit tests over the two pure helpers, plus 2 for the SSL accessors. macOS `RedisDriver` plugin builds, iOS app builds, `swiftlint --strict` clean.

## Note

`docs/databases/redis.mdx` also documents a related trap: `>password` sets a password and `#hash` sets a SHA-256 hash, and a 64-character hex string is syntactically valid for both. `ACL SETUSER u on #<64-hex>` is accepted where `>` was meant and fails every later login with the same `WRONGPASS`.
