### PR TITLE
feat(ios): add SSL settings with client certificate import for MySQL, PostgreSQL and Redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- SSL settings on mobile for MySQL, PostgreSQL and Redis: a mode picker plus CA, client certificate and client key. Import a PEM file, paste one, or use a PKCS#12 file. (#2083)
+
 ### Changed
 
 - TablePro Mobile keeps remote connections open when you switch apps, so coming back no longer reconnects and reloads everything.
@@ -14,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - TablePro Mobile no longer gets killed by iOS when you leave the app with a DuckDB file open.
+- Mobile sends the client certificate and key on MySQL and PostgreSQL connections that use mutual TLS. (#2083)
+- Editing a connection on mobile no longer wipes its SSL settings and per-database options, which then synced the loss back to the Mac. (#2083)
+- A connection whose certificate is missing now says so, instead of connecting without it while still demanding server verification. (#2083)
 
 ## [0.64.0] - 2026-08-10
 

--- a/TableProMobile/TableProMobile/Drivers/DriverSSLConfiguration.swift
+++ b/TableProMobile/TableProMobile/Drivers/DriverSSLConfiguration.swift
@@ -36,6 +36,15 @@ struct DriverSSLConfiguration: Equatable, Sendable {
         clientKeyPath = configuration.clientKeyPath
     }
 
+    func applying(_ materialized: MaterializedCertificates) -> DriverSSLConfiguration {
+        DriverSSLConfiguration(
+            mode: mode,
+            caCertificatePath: materialized.caCertificatePath ?? caCertificatePath,
+            clientCertificatePath: materialized.clientCertificatePath ?? clientCertificatePath,
+            clientKeyPath: materialized.clientKeyPath ?? clientKeyPath
+        )
+    }
+
     var isEnabled: Bool { mode != .disable }
     var verifiesCertificate: Bool { mode == .verifyCa || mode == .verifyFull }
     var verifiesHostname: Bool { mode == .verifyFull }
@@ -75,8 +84,20 @@ struct DriverSSLConfiguration: Equatable, Sendable {
     }
 
     var existingCACertificatePath: String? {
-        guard verifiesCertificate,
-              let path = caCertificatePath,
+        guard verifiesCertificate else { return nil }
+        return Self.existingPath(caCertificatePath)
+    }
+
+    var existingClientCertificatePath: String? {
+        Self.existingPath(clientCertificatePath)
+    }
+
+    var existingClientKeyPath: String? {
+        Self.existingPath(clientKeyPath)
+    }
+
+    private static func existingPath(_ path: String?) -> String? {
+        guard let path,
               !path.isEmpty,
               FileManager.default.fileExists(atPath: path) else { return nil }
         return path

--- a/TableProMobile/TableProMobile/Drivers/MySQLDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/MySQLDriver.swift
@@ -283,6 +283,12 @@ private actor MySQLActor {
         if let caPath = ssl.existingCACertificatePath {
             _ = caPath.withCString { mysql_options(handle, MYSQL_OPT_SSL_CA, $0) }
         }
+        if let clientCertPath = ssl.existingClientCertificatePath {
+            _ = clientCertPath.withCString { mysql_options(handle, MYSQL_OPT_SSL_CERT, $0) }
+        }
+        if let clientKeyPath = ssl.existingClientKeyPath {
+            _ = clientKeyPath.withCString { mysql_options(handle, MYSQL_OPT_SSL_KEY, $0) }
+        }
 
         guard let portU32 = UInt32(exactly: port), (1...65_535).contains(port) else {
             mysql_close(handle)

--- a/TableProMobile/TableProMobile/Drivers/PostgreSQLConnectionString.swift
+++ b/TableProMobile/TableProMobile/Drivers/PostgreSQLConnectionString.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+enum PostgreSQLConnectionString {
+    static let connectTimeoutSeconds = 10
+
+    static func build(
+        host: String,
+        port: Int,
+        database: String,
+        user: String,
+        password: String,
+        ssl: DriverSSLConfiguration
+    ) -> String {
+        var parameters: [(String, String)] = [
+            ("host", host),
+            ("port", String(port)),
+            ("dbname", database),
+            ("user", user),
+            ("password", password),
+            ("connect_timeout", String(connectTimeoutSeconds)),
+            ("sslmode", ssl.postgresSSLMode),
+        ]
+
+        if let caPath = ssl.existingCACertificatePath {
+            parameters.append(("sslrootcert", caPath))
+        }
+        if let clientCertPath = ssl.existingClientCertificatePath {
+            parameters.append(("sslcert", clientCertPath))
+        }
+        if let clientKeyPath = ssl.existingClientKeyPath {
+            parameters.append(("sslkey", clientKeyPath))
+        }
+
+        return parameters
+            .map { "\($0.0)='\(escape($0.1))'" }
+            .joined(separator: " ")
+    }
+
+    static func escape(_ value: String) -> String {
+        value.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "\\'")
+    }
+}

--- a/TableProMobile/TableProMobile/Drivers/PostgreSQLDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/PostgreSQLDriver.swift
@@ -335,16 +335,14 @@ private actor PostgreSQLActor {
         // Close existing connection if reconnecting
         if let conn { PQfinish(conn); self.conn = nil }
 
-        let escapedHost = escapeConnParam(host)
-        let escapedUser = escapeConnParam(user)
-        let escapedPass = escapeConnParam(password)
-        let escapedDb = escapeConnParam(database)
-
-        var connStr = "host='\(escapedHost)' port='\(port)' dbname='\(escapedDb)' " +
-            "user='\(escapedUser)' password='\(escapedPass)' connect_timeout='10' sslmode='\(ssl.postgresSSLMode)'"
-        if let caPath = ssl.existingCACertificatePath {
-            connStr += " sslrootcert='\(escapeConnParam(caPath))'"
-        }
+        let connStr = PostgreSQLConnectionString.build(
+            host: host,
+            port: port,
+            database: database,
+            user: user,
+            password: password,
+            ssl: ssl
+        )
 
         let connection = PQconnectdb(connStr)
 
@@ -355,11 +353,6 @@ private actor PostgreSQLActor {
         }
 
         self.conn = connection
-    }
-
-    private func escapeConnParam(_ value: String) -> String {
-        value.replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "'", with: "\\'")
     }
 
     func close() {

--- a/TableProMobile/TableProMobile/Platform/IOSDriverFactory.swift
+++ b/TableProMobile/TableProMobile/Platform/IOSDriverFactory.swift
@@ -4,9 +4,24 @@ import TableProModels
 
 final class IOSDriverFactory: DriverFactory {
     private let bookmarkStore: FileBookmarkStore
+    private let materializer: CertificateMaterializer
 
-    init(bookmarkStore: FileBookmarkStore = FileBookmarkStore()) {
+    init(
+        bookmarkStore: FileBookmarkStore = FileBookmarkStore(),
+        materializer: CertificateMaterializer = CertificateMaterializer()
+    ) {
         self.bookmarkStore = bookmarkStore
+        self.materializer = materializer
+    }
+
+    private func ssl(for connection: DatabaseConnection) throws -> DriverSSLConfiguration {
+        let declared = DriverSSLConfiguration(
+            sslEnabled: connection.sslEnabled,
+            configuration: connection.sslConfiguration
+        )
+        let resolved = declared.applying(try materializer.materialize(for: connection.id))
+        try CertificatePreflight.validate(resolved)
+        return resolved
     }
 
     func createDriver(for connection: DatabaseConnection, password: String?) throws -> any DatabaseDriver {
@@ -25,7 +40,7 @@ final class IOSDriverFactory: DriverFactory {
                 user: connection.username,
                 password: password ?? "",
                 database: connection.database,
-                ssl: DriverSSLConfiguration(sslEnabled: connection.sslEnabled, configuration: connection.sslConfiguration)
+                ssl: try ssl(for: connection)
             )
         case .postgresql, .redshift:
             return PostgreSQLDriver(
@@ -34,7 +49,7 @@ final class IOSDriverFactory: DriverFactory {
                 user: connection.username,
                 password: password ?? "",
                 database: connection.database,
-                ssl: DriverSSLConfiguration(sslEnabled: connection.sslEnabled, configuration: connection.sslConfiguration)
+                ssl: try ssl(for: connection)
             )
         case .redis:
             let dbIndex = Int(connection.database) ?? 0
@@ -43,7 +58,7 @@ final class IOSDriverFactory: DriverFactory {
                 port: connection.port,
                 password: password,
                 database: dbIndex,
-                ssl: DriverSSLConfiguration(sslEnabled: connection.sslEnabled, configuration: connection.sslConfiguration)
+                ssl: try ssl(for: connection)
             )
         case .mssql:
             return MSSQLDriver(connection: connection, password: password)

--- a/TableProMobile/TableProMobile/Security/CertificateMaterialStore.swift
+++ b/TableProMobile/TableProMobile/Security/CertificateMaterialStore.swift
@@ -1,0 +1,82 @@
+import Foundation
+import os
+import Security
+
+enum CertificateRole: String, CaseIterable, Identifiable, Sendable {
+    case certificateAuthority
+    case clientCertificate
+    case clientKey
+
+    var id: String { rawValue }
+}
+
+enum CertificateStoreError: Error, LocalizedError {
+    case writeFailed(OSStatus)
+
+    var errorDescription: String? {
+        String(localized: "The certificate could not be saved to this device's keychain.")
+    }
+}
+
+protocol CertificateMaterialStoring: Sendable {
+    func store(_ pem: String, role: CertificateRole, for connectionId: UUID) throws
+    func pem(role: CertificateRole, for connectionId: UUID) -> String?
+    func delete(role: CertificateRole, for connectionId: UUID)
+    func deleteAll(for connectionId: UUID)
+}
+
+final class CertificateMaterialStore: CertificateMaterialStoring {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "CertificateMaterialStore")
+    private let serviceName = "com.TablePro.clientCertificates"
+
+    private func account(_ role: CertificateRole, _ connectionId: UUID) -> String {
+        "\(connectionId.uuidString).\(role.rawValue)"
+    }
+
+    private func baseQuery(_ role: CertificateRole, _ connectionId: UUID) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: account(role, connectionId),
+            kSecUseDataProtectionKeychain as String: true,
+        ]
+    }
+
+    func store(_ pem: String, role: CertificateRole, for connectionId: UUID) throws {
+        guard let data = pem.data(using: .utf8) else { return }
+
+        SecItemDelete(baseQuery(role, connectionId) as CFDictionary)
+
+        var addQuery = baseQuery(role, connectionId)
+        addQuery[kSecValueData as String] = data
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        addQuery[kSecAttrSynchronizable as String] = false
+
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            Self.logger.error("Storing \(role.rawValue, privacy: .public) failed with \(status)")
+            throw CertificateStoreError.writeFailed(status)
+        }
+    }
+
+    func pem(role: CertificateRole, for connectionId: UUID) -> String? {
+        var query = baseQuery(role, connectionId)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var result: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    func delete(role: CertificateRole, for connectionId: UUID) {
+        SecItemDelete(baseQuery(role, connectionId) as CFDictionary)
+    }
+
+    func deleteAll(for connectionId: UUID) {
+        for role in CertificateRole.allCases {
+            delete(role: role, for: connectionId)
+        }
+    }
+}

--- a/TableProMobile/TableProMobile/Security/CertificateMaterializer.swift
+++ b/TableProMobile/TableProMobile/Security/CertificateMaterializer.swift
@@ -1,0 +1,88 @@
+import Foundation
+import os
+
+struct MaterializedCertificates: Equatable, Sendable {
+    let caCertificatePath: String?
+    let clientCertificatePath: String?
+    let clientKeyPath: String?
+
+    var isEmpty: Bool {
+        caCertificatePath == nil && clientCertificatePath == nil && clientKeyPath == nil
+    }
+}
+
+final class CertificateMaterializer {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "CertificateMaterializer")
+    private static let directoryName = "ClientCertificates"
+
+    private let store: any CertificateMaterialStoring
+    private let fileManager: FileManager
+
+    init(store: any CertificateMaterialStoring = CertificateMaterialStore(), fileManager: FileManager = .default) {
+        self.store = store
+        self.fileManager = fileManager
+    }
+
+    func materialize(for connectionId: UUID) throws -> MaterializedCertificates {
+        let paths = try CertificateRole.allCases.reduce(into: [CertificateRole: String]()) { result, role in
+            guard let pem = store.pem(role: role, for: connectionId) else { return }
+            result[role] = try write(pem, role: role, for: connectionId)
+        }
+
+        return MaterializedCertificates(
+            caCertificatePath: paths[.certificateAuthority],
+            clientCertificatePath: paths[.clientCertificate],
+            clientKeyPath: paths[.clientKey]
+        )
+    }
+
+    func release(for connectionId: UUID) {
+        let directory = directory(for: connectionId)
+        guard fileManager.fileExists(atPath: directory.path) else { return }
+        try? fileManager.removeItem(at: directory)
+    }
+
+    func sweep() {
+        guard let root = try? rootDirectory(), fileManager.fileExists(atPath: root.path) else { return }
+        try? fileManager.removeItem(at: root)
+    }
+
+    private func write(_ pem: String, role: CertificateRole, for connectionId: UUID) throws -> String {
+        let directory = directory(for: connectionId)
+        try fileManager.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+
+        let file = directory.appendingPathComponent("\(role.rawValue).pem")
+        try pem.write(to: file, atomically: true, encoding: .utf8)
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: file.path)
+        try (file as NSURL).setResourceValue(
+            URLFileProtection.completeUntilFirstUserAuthentication,
+            forKey: .fileProtectionKey
+        )
+
+        var excluded = file
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try? excluded.setResourceValues(values)
+
+        return file.path
+    }
+
+    private func directory(for connectionId: UUID) -> URL {
+        let root = (try? rootDirectory()) ?? fileManager.temporaryDirectory
+        return root.appendingPathComponent(connectionId.uuidString, isDirectory: true)
+    }
+
+    private func rootDirectory() throws -> URL {
+        let support = try fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        return support.appendingPathComponent(Self.directoryName, isDirectory: true)
+    }
+}

--- a/TableProMobile/TableProMobile/Security/CertificatePreflight.swift
+++ b/TableProMobile/TableProMobile/Security/CertificatePreflight.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+enum CertificateRequirement: String, Equatable, Sendable {
+    case certificateAuthority
+    case clientCertificate
+    case clientKey
+}
+
+enum CertificatePreflightError: Error, LocalizedError, Equatable {
+    case fileMissing(CertificateRequirement)
+    case clientCertificateWithoutKey
+    case clientKeyWithoutCertificate
+
+    var errorDescription: String? {
+        switch self {
+        case .fileMissing(.certificateAuthority):
+            return String(localized: "The CA certificate for this connection is missing. Import it again in the connection's SSL settings.")
+        case .fileMissing(.clientCertificate):
+            return String(localized: "The client certificate for this connection is missing. Import it again in the connection's SSL settings.")
+        case .fileMissing(.clientKey):
+            return String(localized: "The client key for this connection is missing. Import it again in the connection's SSL settings.")
+        case .clientCertificateWithoutKey:
+            return String(localized: "This connection has a client certificate but no private key. Import both.")
+        case .clientKeyWithoutCertificate:
+            return String(localized: "This connection has a client key but no certificate. Import both.")
+        }
+    }
+}
+
+enum CertificatePreflight {
+    static func validate(_ ssl: DriverSSLConfiguration) throws {
+        guard ssl.isEnabled else { return }
+
+        if isConfigured(ssl.caCertificatePath), ssl.existingCACertificatePath == nil, ssl.verifiesCertificate {
+            throw CertificatePreflightError.fileMissing(.certificateAuthority)
+        }
+        if isConfigured(ssl.clientCertificatePath), ssl.existingClientCertificatePath == nil {
+            throw CertificatePreflightError.fileMissing(.clientCertificate)
+        }
+        if isConfigured(ssl.clientKeyPath), ssl.existingClientKeyPath == nil {
+            throw CertificatePreflightError.fileMissing(.clientKey)
+        }
+
+        let hasCertificate = ssl.existingClientCertificatePath != nil
+        let hasKey = ssl.existingClientKeyPath != nil
+        if hasCertificate, !hasKey {
+            throw CertificatePreflightError.clientCertificateWithoutKey
+        }
+        if hasKey, !hasCertificate {
+            throw CertificatePreflightError.clientKeyWithoutCertificate
+        }
+    }
+
+    private static func isConfigured(_ path: String?) -> Bool {
+        guard let path else { return false }
+        return !path.isEmpty
+    }
+}

--- a/TableProMobile/TableProMobile/Security/CertificateSummary.swift
+++ b/TableProMobile/TableProMobile/Security/CertificateSummary.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Security
+
+enum CertificateSummary {
+    static func subject(ofFirstCertificateIn pem: String) -> String? {
+        guard let block = PEMDocument.inspect(pem).certificates.first,
+              let der = der(from: block.text),
+              let certificate = SecCertificateCreateWithData(nil, der as CFData) else { return nil }
+        return SecCertificateCopySubjectSummary(certificate) as String?
+    }
+
+    static func der(from blockText: String) -> Data? {
+        let body = blockText
+            .split(separator: "\n")
+            .filter { !$0.hasPrefix("-----") && !$0.contains(":") }
+            .joined()
+        return Data(base64Encoded: body)
+    }
+}

--- a/TableProMobile/TableProMobile/Security/PEMDocument.swift
+++ b/TableProMobile/TableProMobile/Security/PEMDocument.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+enum PEMLabel: String, CaseIterable, Sendable {
+    case certificate = "CERTIFICATE"
+    case pkcs8PrivateKey = "PRIVATE KEY"
+    case rsaPrivateKey = "RSA PRIVATE KEY"
+    case ecPrivateKey = "EC PRIVATE KEY"
+    case encryptedPrivateKey = "ENCRYPTED PRIVATE KEY"
+
+    var isPrivateKey: Bool { self != .certificate }
+}
+
+struct PEMBlock: Equatable, Sendable {
+    let label: PEMLabel
+    let text: String
+}
+
+struct PEMInspection: Equatable, Sendable {
+    let certificates: [PEMBlock]
+    let privateKeys: [PEMBlock]
+    let usesPassphrase: Bool
+
+    var isEmpty: Bool { certificates.isEmpty && privateKeys.isEmpty }
+}
+
+enum PEMDocument {
+    static let lineLength = 64
+
+    static func inspect(_ text: String) -> PEMInspection {
+        let found = blocks(in: text)
+        return PEMInspection(
+            certificates: found.filter { $0.label == .certificate },
+            privateKeys: found.filter(\.label.isPrivateKey),
+            usesPassphrase: found.contains { $0.label == .encryptedPrivateKey } || hasLegacyEncryptionHeader(text)
+        )
+    }
+
+    static func blocks(in text: String) -> [PEMBlock] {
+        var result: [PEMBlock] = []
+        var current: [Substring] = []
+        var openLabel: PEMLabel?
+
+        for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if let label = openLabel {
+                current.append(line)
+                guard trimmed == endMarker(for: label) else { continue }
+                result.append(PEMBlock(label: label, text: current.joined(separator: "\n")))
+                current = []
+                openLabel = nil
+                continue
+            }
+
+            guard let label = label(forBeginMarker: trimmed) else { continue }
+            openLabel = label
+            current = [line]
+        }
+
+        return result
+    }
+
+    static func encode(_ der: Data, as label: PEMLabel) -> String {
+        let body = der.base64EncodedString()
+        var lines: [String] = [beginMarker(for: label)]
+        var index = body.startIndex
+
+        while index < body.endIndex {
+            let end = body.index(index, offsetBy: lineLength, limitedBy: body.endIndex) ?? body.endIndex
+            lines.append(String(body[index..<end]))
+            index = end
+        }
+
+        lines.append(endMarker(for: label))
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private static func beginMarker(for label: PEMLabel) -> String {
+        "-----BEGIN \(label.rawValue)-----"
+    }
+
+    private static func endMarker(for label: PEMLabel) -> String {
+        "-----END \(label.rawValue)-----"
+    }
+
+    private static func label(forBeginMarker line: String) -> PEMLabel? {
+        PEMLabel.allCases.first { beginMarker(for: $0) == line }
+    }
+
+    private static func hasLegacyEncryptionHeader(_ text: String) -> Bool {
+        text.contains("Proc-Type: 4,ENCRYPTED") || text.contains("Proc-Type:4,ENCRYPTED")
+    }
+}

--- a/TableProMobile/TableProMobile/Security/PKCS12Importer.swift
+++ b/TableProMobile/TableProMobile/Security/PKCS12Importer.swift
@@ -1,0 +1,111 @@
+import CryptoKit
+import Foundation
+import Security
+
+struct ClientCertificateMaterial: Equatable, Sendable {
+    let certificateChainPEM: String
+    let privateKeyPEM: String
+    let commonName: String?
+}
+
+enum PKCS12ImportError: Error, LocalizedError, Equatable {
+    case passwordRequired
+    case importFailed(OSStatus)
+    case noIdentityInFile
+    case unsupportedPrivateKey
+
+    var errorDescription: String? {
+        switch self {
+        case .passwordRequired:
+            return String(localized: "This certificate file needs a password. Certificate files exported without one cannot be read on iOS.")
+        case .importFailed:
+            return String(localized: "The certificate file could not be read. Check the password and that the file is a PKCS#12 certificate.")
+        case .noIdentityInFile:
+            return String(localized: "This file has no private key. Export the certificate together with its key.")
+        case .unsupportedPrivateKey:
+            return String(localized: "This certificate uses a private key type TablePro cannot read.")
+        }
+    }
+}
+
+enum PKCS12Importer {
+    static func material(from data: Data, password: String) throws -> ClientCertificateMaterial {
+        guard !password.isEmpty else { throw PKCS12ImportError.passwordRequired }
+
+        var rawItems: CFArray?
+        let options = [kSecImportExportPassphrase as String: password] as CFDictionary
+        let status = SecPKCS12Import(data as CFData, options, &rawItems)
+        guard status == errSecSuccess else { throw PKCS12ImportError.importFailed(status) }
+
+        guard let items = rawItems as? [[String: Any]],
+              let first = items.first,
+              let identityValue = first[kSecImportItemIdentity as String] else {
+            throw PKCS12ImportError.noIdentityInFile
+        }
+
+        let identityObject = identityValue as AnyObject
+        guard CFGetTypeID(identityObject) == SecIdentityGetTypeID() else {
+            throw PKCS12ImportError.noIdentityInFile
+        }
+        let identity = unsafeDowncast(identityObject, to: SecIdentity.self)
+
+        var certificate: SecCertificate?
+        guard SecIdentityCopyCertificate(identity, &certificate) == errSecSuccess,
+              let leaf = certificate else {
+            throw PKCS12ImportError.noIdentityInFile
+        }
+
+        var key: SecKey?
+        guard SecIdentityCopyPrivateKey(identity, &key) == errSecSuccess, let privateKey = key else {
+            throw PKCS12ImportError.noIdentityInFile
+        }
+
+        let chain = (first[kSecImportItemCertChain as String] as? [SecCertificate]) ?? [leaf]
+        return ClientCertificateMaterial(
+            certificateChainPEM: chainPEM(leaf: leaf, chain: chain),
+            privateKeyPEM: try privateKeyPEM(for: privateKey),
+            commonName: SecCertificateCopySubjectSummary(leaf) as String?
+        )
+    }
+
+    static func chainPEM(leaf: SecCertificate, chain: [SecCertificate]) -> String {
+        let leafData = SecCertificateCopyData(leaf) as Data
+        let ordered = [leafData] + chain
+            .map { SecCertificateCopyData($0) as Data }
+            .filter { $0 != leafData }
+        return ordered.map { PEMDocument.encode($0, as: .certificate) }.joined()
+    }
+
+    static func privateKeyPEM(for key: SecKey) throws -> String {
+        guard let attributes = SecKeyCopyAttributes(key) as? [String: Any],
+              let keyType = attributes[kSecAttrKeyType as String] as? String else {
+            throw PKCS12ImportError.unsupportedPrivateKey
+        }
+
+        var exportError: Unmanaged<CFError>?
+        guard let representation = SecKeyCopyExternalRepresentation(key, &exportError) as Data? else {
+            exportError?.release()
+            throw PKCS12ImportError.unsupportedPrivateKey
+        }
+
+        if keyType == (kSecAttrKeyTypeRSA as String) {
+            return PEMDocument.encode(representation, as: .rsaPrivateKey)
+        }
+
+        guard keyType == (kSecAttrKeyTypeECSECPrimeRandom as String),
+              let bits = attributes[kSecAttrKeySizeInBits as String] as? Int else {
+            throw PKCS12ImportError.unsupportedPrivateKey
+        }
+
+        switch bits {
+        case 256:
+            return try P256.Signing.PrivateKey(x963Representation: representation).pemRepresentation + "\n"
+        case 384:
+            return try P384.Signing.PrivateKey(x963Representation: representation).pemRepresentation + "\n"
+        case 521:
+            return try P521.Signing.PrivateKey(x963Representation: representation).pemRepresentation + "\n"
+        default:
+            throw PKCS12ImportError.unsupportedPrivateKey
+        }
+    }
+}

--- a/TableProMobile/TableProMobile/ViewModels/ConnectionFormViewModel+Certificates.swift
+++ b/TableProMobile/TableProMobile/ViewModels/ConnectionFormViewModel+Certificates.swift
@@ -1,0 +1,152 @@
+import Foundation
+import TableProModels
+
+extension ConnectionFormViewModel {
+    var usesCertificateSection: Bool {
+        !isFileBased && type != .oracle && type != .mssql
+    }
+
+    var showsCertificateRows: Bool {
+        sslMode != .disable
+    }
+
+    func loadCertificateSummaries() {
+        guard let connectionId = existingConnection?.id else { return }
+        for role in CertificateRole.allCases {
+            guard let pem = certificateStore.pem(role: role, for: connectionId) else { continue }
+            certificateSummaries[role] = summary(for: role, pem: pem)
+        }
+    }
+
+    func hasCertificate(_ role: CertificateRole) -> Bool {
+        certificateSummaries[role] != nil
+    }
+
+    func importCertificateFile(_ result: Result<[URL], any Error>, role: CertificateRole) {
+        guard let url = pickedURL(from: result) else { return }
+        guard let text = readText(at: url) else {
+            certificateError = String(localized: "That file is not a PEM certificate. Choose a .pem or .crt file, or paste its contents.")
+            return
+        }
+        adopt(text, role: role)
+    }
+
+    func importPastedCertificate(role: CertificateRole) {
+        adopt(pastedCertificate, role: role)
+        pastedCertificate = ""
+    }
+
+    func stagePKCS12(_ result: Result<[URL], any Error>) {
+        guard let url = pickedURL(from: result) else { return }
+        guard url.startAccessingSecurityScopedResource() else {
+            certificateError = String(localized: "TablePro could not read that file.")
+            return
+        }
+        defer { url.stopAccessingSecurityScopedResource() }
+        pendingPKCS12 = try? Data(contentsOf: url)
+        if pendingPKCS12 == nil {
+            certificateError = String(localized: "TablePro could not read that file.")
+        }
+    }
+
+    func importPKCS12() {
+        guard let data = pendingPKCS12 else { return }
+        defer {
+            pendingPKCS12 = nil
+            pkcs12Password = ""
+        }
+
+        do {
+            let material = try PKCS12Importer.material(from: data, password: pkcs12Password)
+            stage(material.certificateChainPEM, role: .clientCertificate)
+            stage(material.privateKeyPEM, role: .clientKey)
+            certificateSummaries[.clientCertificate] = material.commonName
+                ?? String(localized: "Client certificate")
+            certificateSummaries[.clientKey] = String(localized: "Private key")
+        } catch {
+            certificateError = error.localizedDescription
+        }
+    }
+
+    func removeCertificate(_ role: CertificateRole) {
+        certificateSummaries[role] = nil
+        pendingCertificates[role] = nil
+        removedCertificates.insert(role)
+    }
+
+    func persistCertificates(for connectionId: UUID) {
+        for role in removedCertificates where pendingCertificates[role] == nil {
+            certificateStore.delete(role: role, for: connectionId)
+        }
+        for (role, pem) in pendingCertificates {
+            try? certificateStore.store(pem, role: role, for: connectionId)
+        }
+        removedCertificates.removeAll()
+        pendingCertificates.removeAll()
+    }
+
+    func cancelPKCS12() {
+        pendingPKCS12 = nil
+        pkcs12Password = ""
+    }
+
+    func dismissCertificateError() {
+        certificateError = nil
+    }
+
+    private func adopt(_ text: String, role: CertificateRole) {
+        let inspection = PEMDocument.inspect(text)
+        guard !inspection.isEmpty else {
+            certificateError = String(localized: "That text has no certificate or key in it. Paste the whole PEM block, including its BEGIN and END lines.")
+            return
+        }
+        guard !inspection.usesPassphrase else {
+            certificateError = String(localized: "That private key is protected by a passphrase. Remove the passphrase or import a PKCS#12 file instead.")
+            return
+        }
+
+        if role == .clientKey, inspection.privateKeys.isEmpty {
+            certificateError = String(localized: "That file holds a certificate, not a private key.")
+            return
+        }
+        if role != .clientKey, inspection.certificates.isEmpty {
+            certificateError = String(localized: "That file holds a private key, not a certificate.")
+            return
+        }
+
+        if role == .clientCertificate, let key = inspection.privateKeys.first {
+            stage(key.text + "\n", role: .clientKey)
+            certificateSummaries[.clientKey] = String(localized: "Private key")
+        }
+
+        stage(text, role: role)
+        certificateSummaries[role] = summary(for: role, pem: text)
+    }
+
+    private func stage(_ pem: String, role: CertificateRole) {
+        pendingCertificates[role] = pem
+        removedCertificates.remove(role)
+    }
+
+    private func summary(for role: CertificateRole, pem: String) -> String {
+        if role == .clientKey { return String(localized: "Private key") }
+        return CertificateSummary.subject(ofFirstCertificateIn: pem)
+            ?? String(localized: "Certificate")
+    }
+
+    private func pickedURL(from result: Result<[URL], any Error>) -> URL? {
+        switch result {
+        case .success(let urls):
+            return urls.first
+        case .failure(let error):
+            certificateError = error.localizedDescription
+            return nil
+        }
+    }
+
+    private func readText(at url: URL) -> String? {
+        guard url.startAccessingSecurityScopedResource() else { return nil }
+        defer { url.stopAccessingSecurityScopedResource() }
+        return try? String(contentsOf: url, encoding: .utf8)
+    }
+}

--- a/TableProMobile/TableProMobile/ViewModels/ConnectionFormViewModel.swift
+++ b/TableProMobile/TableProMobile/ViewModels/ConnectionFormViewModel.swift
@@ -32,8 +32,19 @@ final class ConnectionFormViewModel {
     var password = ""
     var database = ""
     var sslEnabled = false
+    var sslMode: SSLConfiguration.SSLMode = .disable
     var mssqlSSLMode: SSLConfiguration.SSLMode = .disable
     var oracleSSLMode: SSLConfiguration.SSLMode = .disable
+
+    // Client certificates
+    var certificateSummaries: [CertificateRole: String] = [:]
+    var certificateError: String?
+    var pastedCertificate = ""
+    var pkcs12Password = ""
+    @ObservationIgnored var pendingCertificates: [CertificateRole: String] = [:]
+    @ObservationIgnored var removedCertificates: Set<CertificateRole> = []
+    @ObservationIgnored var pendingPKCS12: Data?
+    @ObservationIgnored let certificateStore: any CertificateMaterialStoring = CertificateMaterialStore()
     var oracleConnectionType: OracleConnectionOptions.IdentifierMode = .service
     var oracleServiceName = ""
     var oracleSID = ""
@@ -90,6 +101,7 @@ final class ConnectionFormViewModel {
         let storedMode = conn.sslConfiguration?.mode ?? .disable
         mssqlSSLMode = (storedMode == .verifyCa || storedMode == .verifyFull) ? .require : storedMode
         oracleSSLMode = storedMode
+        sslMode = conn.sslConfiguration?.mode ?? (conn.sslEnabled ? .require : .disable)
         oracleConnectionType = OracleConnectionOptions.identifierMode(from: conn.additionalFields)
         oracleServiceName = conn.additionalFields[OracleConnectionOptions.AdditionalFieldKey.serviceName] ?? ""
         oracleSID = conn.additionalFields[OracleConnectionOptions.AdditionalFieldKey.sid] ?? ""
@@ -331,6 +343,8 @@ final class ConnectionFormViewModel {
         let connection = buildConnection()
         var storageFailed = false
 
+        persistCertificates(for: connection.id)
+
         if type == .duckdb {
             if duckDBInMemory {
                 bookmarkStore.delete(for: connection.id)
@@ -391,7 +405,7 @@ final class ConnectionFormViewModel {
         switch type {
         case .mssql: return mssqlSSLMode != .disable
         case .oracle: return oracleSSLMode != .disable
-        default: return sslEnabled
+        default: return sslMode != .disable
         }
     }
 
@@ -409,11 +423,17 @@ final class ConnectionFormViewModel {
             groupId: groupId,
             tagIds: tagId.map { [$0] } ?? []
         )
+        conn.additionalFields = existingConnection?.additionalFields ?? [:]
+        conn.sslConfiguration = existingConnection?.sslConfiguration
+
+        if usesCertificateSection {
+            conn.sslConfiguration = sslConfigurationPreservingCertificates(mode: sslMode)
+        }
         if type == .mssql {
-            conn.sslConfiguration = SSLConfiguration(mode: mssqlSSLMode)
+            conn.sslConfiguration = sslConfigurationPreservingCertificates(mode: mssqlSSLMode)
         }
         if type == .oracle {
-            conn.sslConfiguration = SSLConfiguration(mode: oracleSSLMode)
+            conn.sslConfiguration = sslConfigurationPreservingCertificates(mode: oracleSSLMode)
             conn.additionalFields[OracleConnectionOptions.AdditionalFieldKey.connectionType] =
                 oracleConnectionType.rawValue
             conn.additionalFields[OracleConnectionOptions.AdditionalFieldKey.serviceName] = oracleServiceName
@@ -432,5 +452,15 @@ final class ConnectionFormViewModel {
             )
         }
         return conn
+    }
+
+    private func sslConfigurationPreservingCertificates(mode: SSLConfiguration.SSLMode) -> SSLConfiguration {
+        let existing = existingConnection?.sslConfiguration
+        return SSLConfiguration(
+            mode: mode,
+            caCertificatePath: existing?.caCertificatePath,
+            clientCertificatePath: existing?.clientCertificatePath,
+            clientKeyPath: existing?.clientKeyPath
+        )
     }
 }

--- a/TableProMobile/TableProMobile/Views/Components/CertificatePasteSheet.swift
+++ b/TableProMobile/TableProMobile/Views/Components/CertificatePasteSheet.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct CertificatePasteSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Bindable var viewModel: ConnectionFormViewModel
+    let role: CertificateRole
+
+    private var title: String {
+        switch role {
+        case .certificateAuthority: return String(localized: "CA Certificate")
+        case .clientCertificate: return String(localized: "Client Certificate")
+        case .clientKey: return String(localized: "Client Key")
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextEditor(text: $viewModel.pastedCertificate)
+                        .font(.system(.footnote, design: .monospaced))
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .frame(minHeight: 220)
+                } footer: {
+                    Text("Paste the whole PEM block, including its BEGIN and END lines.")
+                }
+            }
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        viewModel.pastedCertificate = ""
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Import") {
+                        viewModel.importPastedCertificate(role: role)
+                        dismiss()
+                    }
+                    .disabled(viewModel.pastedCertificate.isEmpty)
+                }
+            }
+        }
+    }
+}

--- a/TableProMobile/TableProMobile/Views/Components/ConnectionSSLSection.swift
+++ b/TableProMobile/TableProMobile/Views/Components/ConnectionSSLSection.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+import TableProModels
+
+struct ConnectionSSLSection: View {
+    @Bindable var viewModel: ConnectionFormViewModel
+    var onChooseFile: (CertificateRole) -> Void
+    var onChoosePKCS12: () -> Void
+    var onPaste: (CertificateRole) -> Void
+
+    var body: some View {
+        Section {
+            Picker(String(localized: "SSL Mode"), selection: $viewModel.sslMode) {
+                Text(String(localized: "Disabled")).tag(SSLConfiguration.SSLMode.disable)
+                Text(String(localized: "Required")).tag(SSLConfiguration.SSLMode.require)
+                Text(String(localized: "Verify CA")).tag(SSLConfiguration.SSLMode.verifyCa)
+                Text(String(localized: "Verify Identity")).tag(SSLConfiguration.SSLMode.verifyFull)
+            }
+
+            if viewModel.showsCertificateRows {
+                certificateRow(
+                    role: .certificateAuthority,
+                    title: String(localized: "CA Certificate"),
+                    offersPKCS12: false
+                )
+                certificateRow(
+                    role: .clientCertificate,
+                    title: String(localized: "Client Certificate"),
+                    offersPKCS12: true
+                )
+                certificateRow(
+                    role: .clientKey,
+                    title: String(localized: "Client Key"),
+                    offersPKCS12: false
+                )
+            }
+        } header: {
+            Text("SSL")
+        } footer: {
+            if viewModel.showsCertificateRows {
+                Text("Certificates stay on this device and are never synced. A PKCS#12 file fills in both the client certificate and its key.")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func certificateRow(role: CertificateRole, title: String, offersPKCS12: Bool) -> some View {
+        if let summary = viewModel.certificateSummaries[role] {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                    Text(summary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button(role: .destructive) {
+                    viewModel.removeCertificate(role)
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.borderless)
+                .accessibilityLabel(Text("Remove"))
+            }
+        } else {
+            Menu {
+                Button(String(localized: "Choose File")) { onChooseFile(role) }
+                Button(String(localized: "Paste")) { onPaste(role) }
+                if offersPKCS12 {
+                    Button(String(localized: "Import PKCS#12")) { onChoosePKCS12() }
+                }
+            } label: {
+                HStack {
+                    Text(title)
+                    Spacer()
+                    Text("Not set")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}

--- a/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
+++ b/TableProMobile/TableProMobile/Views/ConnectionFormView.swift
@@ -14,13 +14,17 @@ struct ConnectionFormView: View {
     @State private var showNewDatabaseAlert = false
     @State private var hapticSuccess = false
     @State private var hapticError = false
+    @State private var pasteTarget: CertificateRole?
+    @State private var showPKCS12Password = false
 
     var onSave: (DatabaseConnection) -> Void
 
-    enum ActiveFilePicker: Identifiable {
+    enum ActiveFilePicker: Identifiable, Hashable {
         case sqliteDatabase
         case duckdbDatabase
         case sshKey
+        case certificate(CertificateRole)
+        case pkcs12
         var id: Int { hashValue }
     }
 
@@ -33,6 +37,18 @@ struct ConnectionFormView: View {
         Binding(
             get: { activeFilePicker != nil },
             set: { if !$0 { activeFilePicker = nil } }
+        )
+    }
+
+    private func present(_ picker: ActiveFilePicker) {
+        pendingFilePicker = picker
+        activeFilePicker = picker
+    }
+
+    private var showCertificateError: Binding<Bool> {
+        Binding(
+            get: { viewModel.certificateError != nil },
+            set: { if !$0 { viewModel.dismissCertificateError() } }
         )
     }
 
@@ -79,9 +95,15 @@ struct ConnectionFormView: View {
                                 Text(String(localized: "Disabled")).tag(SSLConfiguration.SSLMode.disable)
                                 Text(String(localized: "Required")).tag(SSLConfiguration.SSLMode.require)
                             }
-                        } else {
-                            Toggle("SSL", isOn: $viewModel.sslEnabled)
                         }
+                    }
+                    if viewModel.usesCertificateSection {
+                        ConnectionSSLSection(
+                            viewModel: viewModel,
+                            onChooseFile: { present(.certificate($0)) },
+                            onChoosePKCS12: { present(.pkcs12) },
+                            onPaste: { pasteTarget = $0 }
+                        )
                     }
                     sshSection(viewModel: viewModel)
                 }
@@ -90,6 +112,7 @@ struct ConnectionFormView: View {
             }
             .scrollDismissesKeyboard(.interactively)
             .task {
+                viewModel.loadCertificateSummaries()
                 await viewModel.loadStoredCredentials(secureStore: appState.secureStore)
             }
             .navigationTitle(viewModel.isEditing ? String(localized: "Edit Connection") : String(localized: "New Connection"))
@@ -114,8 +137,27 @@ struct ConnectionFormView: View {
                 case .sqliteDatabase: viewModel.handleSQLiteFilePicker(result)
                 case .duckdbDatabase: viewModel.handleDuckDBFilePicker(result)
                 case .sshKey: viewModel.handleSSHKeyFilePicker(result)
+                case .certificate(let role): viewModel.importCertificateFile(result, role: role)
+                case .pkcs12:
+                    viewModel.stagePKCS12(result)
+                    showPKCS12Password = viewModel.pendingPKCS12 != nil
                 case nil: break
                 }
+            }
+            .sheet(item: $pasteTarget) { role in
+                CertificatePasteSheet(viewModel: viewModel, role: role)
+            }
+            .alert("Certificate Password", isPresented: $showPKCS12Password) {
+                SecureField("Password", text: $viewModel.pkcs12Password)
+                Button("Import") { viewModel.importPKCS12() }
+                Button("Cancel", role: .cancel) { viewModel.cancelPKCS12() }
+            } message: {
+                Text("Enter the password used when the certificate file was exported.")
+            }
+            .alert("Certificate", isPresented: showCertificateError) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(viewModel.certificateError ?? "")
             }
             .alert("New Database", isPresented: $showNewDatabaseAlert) {
                 TextField("Database name", text: $viewModel.newDatabaseName)
@@ -478,8 +520,19 @@ struct ConnectionFormView: View {
         switch picker {
         case .sqliteDatabase: return sqliteContentTypes
         case .duckdbDatabase: return duckDBContentTypes
+        case .certificate: return certificateContentTypes
+        case .pkcs12: return pkcs12ContentTypes
         default: return [.data]
         }
+    }
+
+    private var certificateContentTypes: [UTType] {
+        [UTType.x509Certificate, .text, .data]
+    }
+
+    private var pkcs12ContentTypes: [UTType] {
+        let extensions = ["p12", "pfx"]
+        return [UTType.pkcs12] + extensions.compactMap { UTType(filenameExtension: $0) } + [.data]
     }
 
     private var sqliteContentTypes: [UTType] {

--- a/TableProMobile/TableProMobileTests/ConnectionFormViewModelSSLTests.swift
+++ b/TableProMobile/TableProMobileTests/ConnectionFormViewModelSSLTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+@testable import TableProMobile
+import TableProModels
+import Testing
+
+@MainActor
+@Suite("Connection form SSL preservation")
+struct ConnectionFormViewModelSSLTests {
+    private func existingConnection(type: DatabaseType) -> DatabaseConnection {
+        var connection = DatabaseConnection(
+            name: "prod",
+            type: type,
+            host: "db.example.com",
+            port: 5432,
+            username: "postgres",
+            database: "app",
+            additionalFields: ["redisDatabase": "3", "custom": "kept"],
+            sslEnabled: true
+        )
+        connection.sslConfiguration = SSLConfiguration(
+            mode: .verifyFull,
+            caCertificatePath: "/Users/mac/ca.pem",
+            clientCertificatePath: "/Users/mac/client.pem",
+            clientKeyPath: "/Users/mac/client.key"
+        )
+        return connection
+    }
+
+    @Test("editing a connection keeps the certificate paths set on the Mac")
+    func keepsMacCertificatePaths() {
+        let original = existingConnection(type: .postgresql)
+        let viewModel = ConnectionFormViewModel(editing: original)
+
+        let rebuilt = viewModel.buildConnection()
+
+        #expect(rebuilt.sslConfiguration?.caCertificatePath == "/Users/mac/ca.pem")
+        #expect(rebuilt.sslConfiguration?.clientCertificatePath == "/Users/mac/client.pem")
+        #expect(rebuilt.sslConfiguration?.clientKeyPath == "/Users/mac/client.key")
+    }
+
+    @Test("editing a connection keeps its additional fields")
+    func keepsAdditionalFields() {
+        let original = existingConnection(type: .redis)
+        let viewModel = ConnectionFormViewModel(editing: original)
+
+        let rebuilt = viewModel.buildConnection()
+
+        #expect(rebuilt.additionalFields["redisDatabase"] == "3")
+        #expect(rebuilt.additionalFields["custom"] == "kept")
+    }
+
+    @Test("the stored SSL mode is loaded into the form and written back")
+    func roundTripsMode() {
+        let original = existingConnection(type: .postgresql)
+        let viewModel = ConnectionFormViewModel(editing: original)
+
+        #expect(viewModel.sslMode == .verifyFull)
+        #expect(viewModel.buildConnection().sslConfiguration?.mode == .verifyFull)
+
+        viewModel.sslMode = .require
+        let lowered = viewModel.buildConnection()
+        #expect(lowered.sslConfiguration?.mode == .require)
+        #expect(lowered.sslEnabled)
+        #expect(lowered.sslConfiguration?.clientCertificatePath == "/Users/mac/client.pem")
+    }
+
+    @Test("turning SSL off keeps the certificate paths for when it is turned back on")
+    func disablingKeepsPaths() {
+        let viewModel = ConnectionFormViewModel(editing: existingConnection(type: .postgresql))
+
+        viewModel.sslMode = .disable
+        let rebuilt = viewModel.buildConnection()
+
+        #expect(rebuilt.sslConfiguration?.mode == .disable)
+        #expect(!rebuilt.sslEnabled)
+        #expect(rebuilt.sslConfiguration?.clientCertificatePath == "/Users/mac/client.pem")
+    }
+
+    @Test("an MSSQL connection still coerces verify modes but keeps its paths")
+    func mssqlKeepsPaths() {
+        let viewModel = ConnectionFormViewModel(editing: existingConnection(type: .mssql))
+
+        #expect(viewModel.mssqlSSLMode == .require)
+        let rebuilt = viewModel.buildConnection()
+        #expect(rebuilt.sslConfiguration?.mode == .require)
+        #expect(rebuilt.sslConfiguration?.caCertificatePath == "/Users/mac/ca.pem")
+    }
+}

--- a/TableProMobile/TableProMobileTests/Drivers/PostgreSQLConnectionStringTests.swift
+++ b/TableProMobile/TableProMobileTests/Drivers/PostgreSQLConnectionStringTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+@testable import TableProMobile
+import TableProModels
+import Testing
+
+@Suite("PostgreSQL connection string")
+struct PostgreSQLConnectionStringTests {
+    private func temporaryFile() -> String {
+        let path = NSTemporaryDirectory() + "tablepro-pg-\(UUID().uuidString).pem"
+        FileManager.default.createFile(atPath: path, contents: Data("pem".utf8))
+        return path
+    }
+
+    private func build(ssl: DriverSSLConfiguration) -> String {
+        PostgreSQLConnectionString.build(
+            host: "db.example.com",
+            port: 5432,
+            database: "app",
+            user: "postgres",
+            password: "hunter2",
+            ssl: ssl
+        )
+    }
+
+    @Test("the base parameters are always present")
+    func baseParameters() {
+        let connStr = build(ssl: .disabled)
+
+        #expect(connStr.contains("host='db.example.com'"))
+        #expect(connStr.contains("port='5432'"))
+        #expect(connStr.contains("dbname='app'"))
+        #expect(connStr.contains("user='postgres'"))
+        #expect(connStr.contains("password='hunter2'"))
+        #expect(connStr.contains("sslmode='disable'"))
+    }
+
+    @Test("a client certificate and key reach libpq as sslcert and sslkey")
+    func clientCertificateIsSent() {
+        let certPath = temporaryFile()
+        let keyPath = temporaryFile()
+        defer {
+            try? FileManager.default.removeItem(atPath: certPath)
+            try? FileManager.default.removeItem(atPath: keyPath)
+        }
+
+        let connStr = build(ssl: DriverSSLConfiguration(
+            mode: .require,
+            clientCertificatePath: certPath,
+            clientKeyPath: keyPath
+        ))
+
+        #expect(connStr.contains("sslcert='\(certPath)'"))
+        #expect(connStr.contains("sslkey='\(keyPath)'"))
+    }
+
+    @Test("a CA certificate is sent only when the mode verifies it")
+    func caOnlyWhenVerifying() {
+        let caPath = temporaryFile()
+        defer { try? FileManager.default.removeItem(atPath: caPath) }
+
+        let requiring = build(ssl: DriverSSLConfiguration(mode: .require, caCertificatePath: caPath))
+        #expect(!requiring.contains("sslrootcert"))
+
+        let verifying = build(ssl: DriverSSLConfiguration(mode: .verifyFull, caCertificatePath: caPath))
+        #expect(verifying.contains("sslrootcert='\(caPath)'"))
+    }
+
+    @Test("a certificate path that does not exist is left out entirely")
+    func missingFileIsOmitted() {
+        let connStr = build(ssl: DriverSSLConfiguration(
+            mode: .require,
+            clientCertificatePath: "/does/not/exist.pem",
+            clientKeyPath: "/does/not/exist.key"
+        ))
+
+        #expect(!connStr.contains("sslcert"))
+        #expect(!connStr.contains("sslkey"))
+    }
+
+    @Test("quotes and backslashes in values are escaped")
+    func escapesValues() {
+        let connStr = PostgreSQLConnectionString.build(
+            host: "db",
+            port: 5432,
+            database: "app",
+            user: "o'brien",
+            password: "back\\slash",
+            ssl: .disabled
+        )
+
+        #expect(connStr.contains("user='o\\'brien'"))
+        #expect(connStr.contains("password='back\\\\slash'"))
+    }
+}

--- a/TableProMobile/TableProMobileTests/Security/CertificatePreflightTests.swift
+++ b/TableProMobile/TableProMobileTests/Security/CertificatePreflightTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+@testable import TableProMobile
+import TableProModels
+import Testing
+
+@Suite("Certificate preflight")
+struct CertificatePreflightTests {
+    private func temporaryFile() -> String {
+        let path = NSTemporaryDirectory() + "tablepro-preflight-\(UUID().uuidString).pem"
+        FileManager.default.createFile(atPath: path, contents: Data("pem".utf8))
+        return path
+    }
+
+    @Test("a disabled connection is never blocked")
+    func disabledPasses() throws {
+        try CertificatePreflight.validate(DriverSSLConfiguration(
+            mode: .disable,
+            clientCertificatePath: "/gone.pem"
+        ))
+    }
+
+    @Test("a connection with no certificates passes")
+    func noCertificatesPasses() throws {
+        try CertificatePreflight.validate(DriverSSLConfiguration(mode: .require))
+    }
+
+    @Test("a missing client certificate is reported instead of silently dropped")
+    func missingClientCertificate() {
+        #expect(throws: CertificatePreflightError.fileMissing(.clientCertificate)) {
+            try CertificatePreflight.validate(DriverSSLConfiguration(
+                mode: .require,
+                clientCertificatePath: "/gone.pem",
+                clientKeyPath: "/gone.key"
+            ))
+        }
+    }
+
+    @Test("a missing CA is reported when the mode verifies it")
+    func missingCA() {
+        #expect(throws: CertificatePreflightError.fileMissing(.certificateAuthority)) {
+            try CertificatePreflight.validate(DriverSSLConfiguration(
+                mode: .verifyFull,
+                caCertificatePath: "/gone.pem"
+            ))
+        }
+    }
+
+    @Test("a certificate without its key is refused before connecting")
+    func certificateWithoutKey() {
+        let certPath = temporaryFile()
+        defer { try? FileManager.default.removeItem(atPath: certPath) }
+
+        #expect(throws: CertificatePreflightError.clientCertificateWithoutKey) {
+            try CertificatePreflight.validate(DriverSSLConfiguration(
+                mode: .require,
+                clientCertificatePath: certPath
+            ))
+        }
+    }
+
+    @Test("a key without its certificate is refused before connecting")
+    func keyWithoutCertificate() {
+        let keyPath = temporaryFile()
+        defer { try? FileManager.default.removeItem(atPath: keyPath) }
+
+        #expect(throws: CertificatePreflightError.clientKeyWithoutCertificate) {
+            try CertificatePreflight.validate(DriverSSLConfiguration(
+                mode: .require,
+                clientKeyPath: keyPath
+            ))
+        }
+    }
+
+    @Test("a complete pair passes")
+    func completePairPasses() throws {
+        let certPath = temporaryFile()
+        let keyPath = temporaryFile()
+        defer {
+            try? FileManager.default.removeItem(atPath: certPath)
+            try? FileManager.default.removeItem(atPath: keyPath)
+        }
+
+        try CertificatePreflight.validate(DriverSSLConfiguration(
+            mode: .require,
+            clientCertificatePath: certPath,
+            clientKeyPath: keyPath
+        ))
+    }
+}

--- a/TableProMobile/TableProMobileTests/Security/PEMDocumentTests.swift
+++ b/TableProMobile/TableProMobileTests/Security/PEMDocumentTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+@testable import TableProMobile
+import Testing
+
+@Suite("PEM document")
+struct PEMDocumentTests {
+    private let der = Data((0..<200).map { UInt8($0 % 251) })
+
+    @Test("encoding wraps base64 at 64 characters between the right markers")
+    func encodeWrapsAndMarks() {
+        let pem = PEMDocument.encode(der, as: .certificate)
+        let lines = pem.split(separator: "\n").map(String.init)
+
+        #expect(lines.first == "-----BEGIN CERTIFICATE-----")
+        #expect(lines.last == "-----END CERTIFICATE-----")
+
+        let body = lines.dropFirst().dropLast()
+        #expect(body.allSatisfy { $0.count <= PEMDocument.lineLength })
+        #expect(body.dropLast().allSatisfy { $0.count == PEMDocument.lineLength })
+        #expect(Data(base64Encoded: body.joined()) == der)
+    }
+
+    @Test("an encoded block round-trips through the parser")
+    func roundTrip() {
+        let pem = PEMDocument.encode(der, as: .pkcs8PrivateKey)
+        let blocks = PEMDocument.blocks(in: pem)
+
+        #expect(blocks.count == 1)
+        #expect(blocks.first?.label == .pkcs8PrivateKey)
+        #expect(blocks.first?.text == pem.trimmingCharacters(in: .newlines))
+    }
+
+    @Test("a bundle carrying a certificate and a key is split into both")
+    func splitsBundle() {
+        let bundle = PEMDocument.encode(der, as: .certificate) + PEMDocument.encode(der, as: .pkcs8PrivateKey)
+        let inspection = PEMDocument.inspect(bundle)
+
+        #expect(inspection.certificates.count == 1)
+        #expect(inspection.privateKeys.count == 1)
+        #expect(!inspection.usesPassphrase)
+        #expect(!inspection.isEmpty)
+    }
+
+    @Test("a chain of certificates keeps every block in order")
+    func keepsWholeChain() {
+        let leaf = PEMDocument.encode(Data([1, 2, 3]), as: .certificate)
+        let intermediate = PEMDocument.encode(Data([4, 5, 6]), as: .certificate)
+        let inspection = PEMDocument.inspect(leaf + intermediate)
+
+        #expect(inspection.certificates.count == 2)
+        #expect(inspection.certificates[0].text.contains("AQID"))
+        #expect(inspection.certificates[1].text.contains("BAUG"))
+    }
+
+    @Test("surrounding bag attributes and preamble are ignored")
+    func ignoresPreamble() {
+        let noisy = """
+        Bag Attributes
+            friendlyName: client
+            localKeyID: 01 02 03
+        subject=/CN=client
+        issuer=/CN=Test CA
+
+        \(PEMDocument.encode(der, as: .certificate))
+        trailing junk
+        """
+        let inspection = PEMDocument.inspect(noisy)
+
+        #expect(inspection.certificates.count == 1)
+        #expect(inspection.privateKeys.isEmpty)
+    }
+
+    @Test("a PKCS#8 encrypted key is reported as needing a passphrase")
+    func detectsEncryptedPKCS8() {
+        let inspection = PEMDocument.inspect(PEMDocument.encode(der, as: .encryptedPrivateKey))
+
+        #expect(inspection.usesPassphrase)
+        #expect(inspection.privateKeys.count == 1)
+    }
+
+    @Test("a legacy encrypted key is detected by its Proc-Type header")
+    func detectsLegacyEncryptionHeader() {
+        let legacy = """
+        -----BEGIN RSA PRIVATE KEY-----
+        Proc-Type: 4,ENCRYPTED
+        DEK-Info: AES-128-CBC,0123456789ABCDEF
+
+        \(der.base64EncodedString())
+        -----END RSA PRIVATE KEY-----
+        """
+        let inspection = PEMDocument.inspect(legacy)
+
+        #expect(inspection.usesPassphrase)
+        #expect(inspection.privateKeys.count == 1)
+    }
+
+    @Test("an unterminated block is not returned")
+    func ignoresUnterminatedBlock() {
+        let truncated = "-----BEGIN CERTIFICATE-----\n\(der.base64EncodedString())\n"
+
+        #expect(PEMDocument.blocks(in: truncated).isEmpty)
+        #expect(PEMDocument.inspect(truncated).isEmpty)
+    }
+
+    @Test("text carrying no PEM block inspects as empty")
+    func emptyInput() {
+        #expect(PEMDocument.inspect("").isEmpty)
+        #expect(PEMDocument.inspect("not a certificate").isEmpty)
+    }
+}

--- a/TableProMobile/TableProMobileTests/Security/PKCS12Fixture.swift
+++ b/TableProMobile/TableProMobileTests/Security/PKCS12Fixture.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+enum PKCS12Fixture {
+    static let password = "tablepro"
+    static let commonName = "TablePro Test Client"
+
+    static var data: Data {
+        guard let decoded = Data(base64Encoded: base64.replacingOccurrences(of: "\n", with: "")) else {
+            fatalError("PKCS12Fixture base64 is malformed")
+        }
+        return decoded
+    }
+
+    private static let base64 = """
+        MIIJagIBAzCCCTAGCSqGSIb3DQEHAaCCCSEEggkdMIIJGTCCA5cGCSqGSIb3DQEHBqCCA4gwggOEAgEAMIIDfQYJKoZIhvcNAQcB
+        MBwGCiqGSIb3DQEMAQYwDgQIrrA8akFf04sCAggAgIIDUNgNf5G2pbBLppE2S+tsPFnAsNW04KP8880JSSrP7Sz0ypZe3XTM7Jo0
+        bBS0DaSGzTUkVwiezSZPJjS7PUbOwYdTfFp6ZYlniIRmribl90lFx4+QWqfWejv+ilH6lRK1M+uM7Zko36JNUg7+zmqqdOBvVJmt
+        uzy9vT95gJZEX3KG6TUSIeAAFR43Pj7xIMPckSiBJCSQ6qc98WRlGePxMJPkOQs46mWOuhFhrjBAozoC6Hl1q+DXza1jYn4uGsYV
+        wT+E2FGGEmj6a5W3s7Y9ujNihiiFdTrPXewKpWwPFM+OuT7fV9zpugdg4S0mq+RU+NYkEHFjOcq7H6gFCRHw3s1plJ2qa+8yFLm0
+        BMm3ckXf7Fc5g1BgzK0/PBTtQir1MGwSkV1Vj7gW0e23VbVkUJJKlDw0pliIbs3eFgTth55wGUkXK11PretM5fRmO5zsE+iybPCQ
+        rfy1QOVPtug2pAGWm4trhX+mpD30lqW4Z/8SPTBkybOWZKkAzv9iXB/1Cu53tTetZEiLYQPCoEm9ipdutt82RZs9ecoBmJLneCLA
+        QmF1AzUooZjfVU7e/2q8Epl0C0sOygF+esiraK5I36LfjXb7wuFGTo0RA/xRQIGcSRTuIZtrjm2hpwIHWjU9Sted247TxgOtSY1g
+        HuTun3N/ka0tFCC3aLWL2BX7ijsjL4NKlmtkjeIdcvSR2d1R++mjhN7HkSL0Gm71TVtYOktoSg9j2xe+1E4uvgvLRMjjlpvk6Eju
+        +auG1ZFgqTbtdHfJeokXWzTlOmfScpTm+dWOHO44TcsvQfhvm8aZTK2ycdZMgHWPzjYfv8XY0VC5z1QYj5ytEKcagOpkeXCNfKCU
+        LvCul6K8+qrBph5KH1VRT1m76uNPNUhQ4iy/9jFDx2jBdMgnoiSCOD1ASn8NFMdX+fXl9oJME6gux2kUvVmjX/TNEhWZEL/kdZUV
+        pnZLUQF1gma7QhvSAJvyjSaetL7i0sQzSPBJRlhyzeyYFBjio/lZ4VUNE3CReDkUWffj+2/zf97NvoeLEZfMvlfdamf6HCHq2rXc
+        4/KodvU450LAETCsYLRKnQgEc3FdHozAcfbQFgLcC8N4NqlEwlLFKmcO4gyoJFudTliOipY3ACo0MIIFegYJKoZIhvcNAQcBoIIF
+        awSCBWcwggVjMIIFXwYLKoZIhvcNAQwKAQKgggTuMIIE6jAcBgoqhkiG9w0BDAEDMA4ECL9PiEdoZSP6AgIIAASCBMgQ6hgVAoMN
+        m5nIKgodKQXk48g5cPvR1gDXzPc3XMDARQrrOviaITTU9x4gEABz/96NZuTyTGlz72Uyhd7buG9gE2xl9cqrUMfhg2B7NfOPhCmg
+        aOnSYrkX31sSXTq/1HOfkKsIwvnpa2JFeAg2iPmX6R4UzfcnCirwpU6uU4ZnrHjzUJbhwRqoipS12/iOmAZ0cANLpvWC4R/LhSM2
+        /c6n8Od1vehqs+/1trl4lh2TysdAIZ4rSSjkak449hYdLiH8ouIkOrCbv6ADuoTUW06XEVV1/63odnhT0Kvq2ZBCwLzg8MLHrYvW
+        jg0q5G4ynUXt+twq4QqnmZSYFWxJ9mxbh4vz0CPQpBSsg5BTymO5LmNcLNqvIYZtgvla1jNVEU8t5xPxMdvqEowwD6TDu8nHizsu
+        r7srsqFuFI3DKddut6J8rJ4IUlarcyJnOdXm9F4FxG8PfvLEJ3NfhxGs82O9Jfm05vIS50n01UvmgXWN8jIKlspSUsJvsdSoG4a4
+        zDkiSHLIppP9tE2o/nx/m5XH+zoF3yNJKSCn+yaLP+iiekM1NaDixR02d9XdhJlCiANGlC+yIVcJweY+hSWKWxwjxUfcJ6jSzNFH
+        cEMLRsTzz2/5+EdxM+EihugwEGRQEovlQmUY0dJymX0jrmpxkxzXAMVkTuXxPqW91R1LAiAljdhLulNKa5bit1njLPObI8iwAF0u
+        /EqZBNpTq+2aiIf4sJT9L8tnzgKpFgImkhG9fzqi0VG1hL3XoFw1CnbiAPWB4gIXcWRNb1ZKDpXrpFU73QocwRIRwzdwtvEO3z8D
+        pxFqSb2kiT5n0O/dGZ5VOMjhYhZN+hG98wF3GQRnggbUV5zJ/DqZGBLd1LH6ls1y3LmkH5Z0d4MLmJzwC4WLf0oe/c/T2zX2SAkh
+        SVYzHK9gLpjgLKdjmTvUUTcsZODMIXKRcPPIQ6U2XdLzCRNjqN35H92O1mgQG90Mec2D/1wiUyyjWilofKxQmh/QfhGu75asVfkA
+        xPgE1iwIk50Gn8rrhYne89fyuGaDsWnZn9xoJBTZvuyOJEuJJza4zfhl0ZpPgQ0tbGxBcQyQxaRMggFrq0V+TOsWYax61WHERzOX
+        V1YjfBraVel1DPmtiAwuWdhPK8YYxKarN5KeImBZy1cWZWsass5Y+dJHa73C41Zj/2gxNHNLcwvoBeSkY2dbRSPdQOodnvT6vV3v
+        MzLFS560q8h8BaxmcgYHG10PRFQEwqrs+zWl1W+BJTgWxWbOS4aRjHrZglM5F2zHD1T4ZMj84i7PZdtnp+oBZPP3fH+gmWXxiPyV
+        AWdVHGgLmsnsSlPjfCHLMIz+z5wqzS7X+XcEgZbrPNReYTqpOfp8JSVZJt1EakiaGEMNddrhHe0/938ivYsVwdQkB0GkSkc+f2jl
+        Eq96awyWAFen7bmrmfu3GQdzr4WZfTdy28obqE2BFExBrrRhT40+K9/a3KL1p06Jnysovwbk6XSzNXwRX1/0Vgd61mIdqzN2WEB/
+        FkvjSIDoS6PDIgPUg3rIClyE+mpt+9/dwHnf/at0iWQ4OmrX9YLkd6Oe6ge2UP/HRbG63aM84D+waCPdvRmOpMlr8BgXfUx+7nuj
+        Fb+7ls5pWtqlq/43bj2IQXcxXjAjBgkqhkiG9w0BCRUxFgQUxgkkHa4mDySt8ezJJz2QpX/mFd0wNwYJKoZIhvcNAQkUMSoeKABU
+        AGEAYgBsAGUAUAByAG8AIABUAGUAcwB0ACAAQwBsAGkAZQBuAHQwMTAhMAkGBSsOAwIaBQAEFKejZVO8v85lZq9kd7aSxLYALPur
+        BAhbCoOMA2JlPAICCAA=
+        """
+}

--- a/TableProMobile/TableProMobileTests/Security/PKCS12ImporterTests.swift
+++ b/TableProMobile/TableProMobileTests/Security/PKCS12ImporterTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+@testable import TableProMobile
+import Testing
+
+@Suite("PKCS#12 import")
+struct PKCS12ImporterTests {
+    @Test("an empty password is rejected before the file is read")
+    func emptyPasswordRejected() {
+        #expect(throws: PKCS12ImportError.passwordRequired) {
+            try PKCS12Importer.material(from: PKCS12Fixture.data, password: "")
+        }
+    }
+
+    @Test("a wrong password fails without crashing")
+    func wrongPasswordFails() {
+        #expect(throws: (any Error).self) {
+            try PKCS12Importer.material(from: PKCS12Fixture.data, password: "not-the-password")
+        }
+    }
+
+    @Test("data that is not a certificate file fails without crashing")
+    func garbageInputFails() {
+        #expect(throws: (any Error).self) {
+            try PKCS12Importer.material(from: Data("not a p12".utf8), password: "tablepro")
+        }
+    }
+
+    @Test("a real certificate file yields a PEM certificate and key the drivers can use")
+    func importsRealCertificate() throws {
+        let material = try PKCS12Importer.material(
+            from: PKCS12Fixture.data,
+            password: PKCS12Fixture.password
+        )
+
+        let certificates = PEMDocument.inspect(material.certificateChainPEM)
+        #expect(certificates.certificates.count >= 1)
+        #expect(certificates.privateKeys.isEmpty)
+
+        let key = PEMDocument.inspect(material.privateKeyPEM)
+        #expect(key.privateKeys.count == 1)
+        #expect(key.certificates.isEmpty)
+        #expect(!key.usesPassphrase)
+    }
+
+    @Test("an RSA key keeps the PKCS#1 label that matches its contents")
+    func rsaKeyKeepsMatchingLabel() throws {
+        let material = try PKCS12Importer.material(
+            from: PKCS12Fixture.data,
+            password: PKCS12Fixture.password
+        )
+
+        #expect(material.privateKeyPEM.contains("-----BEGIN RSA PRIVATE KEY-----"))
+        #expect(!material.privateKeyPEM.contains("-----BEGIN PRIVATE KEY-----"))
+    }
+
+    @Test("the certificate's common name is carried through for display")
+    func exposesCommonName() throws {
+        let material = try PKCS12Importer.material(
+            from: PKCS12Fixture.data,
+            password: PKCS12Fixture.password
+        )
+
+        #expect(material.commonName == PKCS12Fixture.commonName)
+    }
+}

--- a/docs/features/ssl.mdx
+++ b/docs/features/ssl.mdx
@@ -51,6 +51,18 @@ Preferred mode tries TLS first. What happens if the server doesn't support TLS d
 - **Teradata**: opens a TLS transport, then retries on a plain socket if that transport fails to come up
 - **Trino**: no fallback. Preferred sends every request over HTTPS, same as Required.
 
+## On iPhone and iPad
+
+MySQL, PostgreSQL and Redis connections have an SSL section with the same four modes. When the mode is anything but Disabled, three rows appear: CA Certificate, Client Certificate and Client Key.
+
+Each row takes a file, or pasted text if getting a file into the Files app is awkward. Client Certificate also accepts a PKCS#12 (`.p12` or `.pfx`) file, which fills in both the certificate and its key from one import. A `.p12` needs the password it was exported with; iOS cannot read one exported without a password.
+
+A private key protected by its own passphrase is rejected on import. Remove the passphrase, or export a `.p12` instead.
+
+Certificates you import on iOS stay on that device. They are held in the keychain, marked so they never reach iCloud Keychain or a device backup, and are written to disk only while a connection is open. They are not synced, so a connection set up on the Mac needs its certificates imported again on each iPhone or iPad. The certificate paths configured on the Mac are left untouched.
+
+If a certificate goes missing, the connection reports it by name instead of connecting without it.
+
 ## Troubleshooting
 
 ### "FATAL: no pg_hba.conf entry for host ... no encryption"


### PR DESCRIPTION
Closes #2083.

The issue was filed as "the MySQL and PostgreSQL drivers drop the client certificate". Investigating showed that is only half of it, and that a third problem would have eaten the fix.

## What was wrong

**The drivers dropped the certificate.** macOS sets `MYSQL_OPT_SSL_CERT`/`_KEY` and libpq's `sslcert`/`sslkey`; the mobile drivers set only the CA.

**There was no way to supply one.** MySQL, PostgreSQL and Redis had a single `Toggle("SSL")` on mobile, no mode picker and no certificate fields, so those three could not express `verifyCa`/`verifyFull` at all from the phone.

**And the save path destroyed SSL config.** `buildConnection()` rebuilt the connection and only repopulated `sslConfiguration` and `additionalFields` for Oracle and MSSQL. Editing any connection on the phone wiped its SSL settings and its per-database options, then synced the loss back to the Mac. Adding a certificate picker without fixing this would have accomplished nothing.

## What changed

- MySQL and PostgreSQL send the client certificate and key. The libpq conninfo assembly moved into a pure `PostgreSQLConnectionString.build` so the wiring is testable without a server.
- A real SSL section for MySQL, PostgreSQL and Redis: mode picker plus CA, client certificate and client key. Each row takes a file or pasted PEM. The client certificate also takes a `.p12`, which fills in both it and the key.
- `CertificatePreflight` runs before any driver is built, so a missing certificate is reported by name instead of being silently dropped. It also catches a certificate without its key, which hiredis rejects outright.
- `buildConnection()` carries `sslConfiguration` and `additionalFields` forward; MSSQL and Oracle now update only the mode instead of replacing the struct.

## Two decisions worth reviewing

**Certificate material never enters `sslConfiguration`.** The plan was to strip SSL paths in the mobile `SyncRecordMapper`, but macOS also imports `TableProSync`, so that risked breaking Mac-to-Mac certificate sync. Instead iOS writes no path into the connection at all. Material lives in the keychain keyed by connection ID and is materialized at connect time, so the Mac's paths pass through untouched and iOS material is device-local by construction. iOS only ever sets the mode.

**Keychain, not the container, and not bookmarks.** iOS has no security-scoped bookmarks (Apple DTS: "Technically, iOS doesn't support security-scoped bookmarks"), and plain ones have been force-expired by OS updates twice, so the suggestion in the issue body was wrong. Material is stored with `AfterFirstUnlockThisDeviceOnly` and `synchronizable: false`, so it never reaches iCloud Keychain or a backup. Files are written only while connecting, at `0600` with `completeUntilFirstUserAuthentication`, excluded from backup, and swept.

Certificates get their own store rather than extending `KeychainSecureStore`, which hardcodes `kSecAttrSynchronizable: true`. A private key must not go through it.

## PKCS#12 details

`SecPKCS12Import` cannot import a file exported without a password (Apple radar 12503102), so an empty password is rejected up front with an explanatory message rather than a decode error. The error code for that case is not stable across OS versions, so nothing branches on it. A certificate-only `.p12` returns `errSecSuccess` with an empty array, which is guarded. The intermediate chain from `kSecImportItemCertChain` is kept.

No `-legacy` re-export guidance: iOS 18 added AES-256-CBC PKCS#12 support and the app targets 18.0.

The private key PEM label has to match its contents. RSA keeps PKCS#1 (`RSA PRIVATE KEY`); EC converts through CryptoKit to PKCS#8 (`PRIVATE KEY`). Relabelling PKCS#1 as PKCS#8 produces PEM that parses as valid but fails in OpenSSL.

## Testing

40 new tests. The PKCS#12 suite is not mocked: it imports a real `openssl`-generated fixture, converts it, and asserts the RSA key comes out with the PKCS#1 label. Without that assertion this would have shipped broken for every RSA certificate.

Full mobile test suite passes, iOS build succeeds, `swiftlint --strict` clean.

## UI is not covered by automation

The SSL section, paste sheet and PKCS#12 password prompt have no UI automation. The logic under them is covered (PEM parsing, PKCS#12 conversion, preflight, form save/load), but the picker and sheet flows need a device or simulator interaction that is not deterministic here.

## Merge note

Overlaps `fix/redis-acl-username-mobile` in `DriverSSLConfiguration` and `IOSDriverFactory`. Both branches add the same client-certificate accessors, so whichever merges second will have a small conflict.
