### PR TITLE
fix(plugin-mongodb): export ObjectId and dates as mongosh constructors, and compile every plugin in CI

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -120,6 +120,20 @@ jobs:
             -scheme "$XCODE_SCHEME" \
             -skipPackagePluginValidation
 
+      # The TablePro scheme only builds the 14 bundled plugins, so a change confined to one
+      # of the 16 registry-only plugins compiles nowhere else in CI. AllPlugins is the only
+      # target that covers them, and build-plugin.yml does not run until a release tag.
+      - name: Compile every plugin
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -project "$XCODE_PROJECT" \
+            -scheme AllPlugins \
+            -destination "$TEST_DESTINATION" \
+            -skipPackagePluginValidation \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcbeautify --renderer github-actions
+
       # Quarantined suites (driver-loading, env-coupled, or hanging headless) are listed
       # in .github/macos-test-quarantine.txt. Burn that list down over time.
       - name: Run unit tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- MQL export writes a MongoDB `_id` as `ObjectId("...")` and a date as `ISODate("...")`, so running the script inserts the same types back instead of strings. A value nested inside a subdocument is still exported as a string.
 - MQL export keeps a binary value's BSON subtype and writes it as a `BinData(...)` constructor, so running the script inserts the same bytes back. It wrote Extended JSON that mongosh reads as a plain object, and stamped every value as subtype 0. (#2086)
 - MongoDB no longer prints a binary field nested inside a document as a UUID when it is not one, or labels a UUID with the wrong byte order. (#2086)
 - Deleting a MongoDB document with a binary `_id` deletes that document. It used to match on the other fields and could remove the wrong one.

--- a/Plugins/MQLExportPlugin/MQLExportHelpers.swift
+++ b/Plugins/MQLExportPlugin/MQLExportHelpers.swift
@@ -28,6 +28,31 @@ enum MQLExportHelpers {
         MongoDBUuidCodec.binaryText(for: MongoDBBinaryValue(data: data, subtype: subtype))
     }
 
+    /// A mongosh script inserts a string wherever it sees one, so a typed scalar has to be
+    /// written as its constructor. The column type is the only surviving record of the type.
+    static func mqlTextValue(for value: String, columnTypeName: String) -> String {
+        switch columnTypeName {
+        case "ObjectId":
+            let objectId = MongoDBObjectId(hex: value)
+            guard objectId.isValid else { break }
+            return "ObjectId(\"\(PluginExportUtilities.escapeJSONString(value))\")"
+        case "TIMESTAMP":
+            guard isIso8601(value) else { break }
+            return "ISODate(\"\(PluginExportUtilities.escapeJSONString(value))\")"
+        default:
+            break
+        }
+        return mqlJsonValue(for: value)
+    }
+
+    private static func isIso8601(_ value: String) -> Bool {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if formatter.date(from: value) != nil { return true }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: value) != nil
+    }
+
     static func mqlJsonValue(for value: String) -> String {
         if value == "true" || value == "false" {
             return value

--- a/Plugins/MQLExportPlugin/MQLExportPlugin.swift
+++ b/Plugins/MQLExportPlugin/MQLExportPlugin.swift
@@ -111,18 +111,20 @@ final class MQLExportPlugin: ExportFormatPlugin, SettablePlugin {
                             for (colIndex, column) in columns.enumerated() {
                                 guard colIndex < row.count else { continue }
                                 let cell = row[colIndex]
+                                let typeName = colIndex < columnTypeNames.count ? columnTypeNames[colIndex] : ""
                                 let jsonValue: String
                                 switch cell {
                                 case .null:
                                     continue
                                 case .bytes(let data):
-                                    let typeName = colIndex < columnTypeNames.count ? columnTypeNames[colIndex] : ""
                                     jsonValue = MQLExportHelpers.mqlBinaryValue(
                                         for: data,
                                         subtype: MongoDBUuidCodec.binarySubtype(fromColumnTypeName: typeName)
                                     )
                                 case .text(let value):
-                                    jsonValue = MQLExportHelpers.mqlJsonValue(for: value)
+                                    jsonValue = MQLExportHelpers.mqlTextValue(
+                                        for: value, columnTypeName: typeName
+                                    )
                                 }
                                 fields.append("\"\(PluginExportUtilities.escapeJSONString(column))\": \(jsonValue)")
                             }

--- a/Plugins/MongoDBDriverPlugin/BsonDocumentFlattener.swift
+++ b/Plugins/MongoDBDriverPlugin/BsonDocumentFlattener.swift
@@ -20,6 +20,7 @@ enum BsonValueKind: Hashable {
     case null
     case int32
     case int64
+    case objectId
     case uuid
     case legacyUuid
 
@@ -118,6 +119,7 @@ struct BsonDocumentFlattener {
         case .date: return "TIMESTAMP"
         case .int32: return "INTEGER"
         case .int64: return "BIGINT"
+        case .objectId: return "ObjectId"
         case .uuid:
             return MongoDBUuidCodec.wrapperTag(
                 forSubtype: MongoDBUuidCodec.standardUuidSubtype, representation: representation
@@ -144,6 +146,8 @@ struct BsonDocumentFlattener {
             return displayString(for: num)
         case let date as Date:
             return iso8601Formatter.string(from: date)
+        case let objectId as MongoDBObjectId:
+            return objectId.hex
         case let binary as MongoDBBinaryValue:
             return binaryString(for: binary, representation: representation)
         case let data as Data:
@@ -204,6 +208,8 @@ struct BsonDocumentFlattener {
             return dict.mapValues { sanitizeForJson($0, representation: representation) }
         case let array as [Any]:
             return array.map { sanitizeForJson($0, representation: representation) }
+        case let objectId as MongoDBObjectId:
+            return objectId.hex
         case let binary as MongoDBBinaryValue:
             return binaryString(for: binary, representation: representation)
         case let data as Data:
@@ -286,6 +292,8 @@ struct BsonDocumentFlattener {
             return objCType == "q" || objCType == "l" ? .int64 : .int32
         case is String:
             return .string
+        case is MongoDBObjectId:
+            return .objectId
         case is Date:
             return .date
         case let binary as MongoDBBinaryValue:

--- a/Plugins/MongoDBDriverPlugin/MongoDBConnection.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBConnection.swift
@@ -941,7 +941,7 @@ extension MongoDBConnection {
     static func unwrapExtendedJson(_ value: Any) -> Any {
         if let dict = value as? [String: Any] {
             if dict.count == 1 {
-                if let oid = dict["$oid"] as? String { return oid }
+                if let oid = dict["$oid"] as? String { return MongoDBObjectId(hex: oid) }
                 if let s = dict["$numberInt"] as? String, let n = Int32(s) { return n }
                 if let s = dict["$numberLong"] as? String, let n = Int64(s) { return n }
                 if let s = dict["$numberDouble"] as? String, let n = Double(s) { return n }

--- a/Plugins/TableProPluginKit/MongoDBUuidCodec.swift
+++ b/Plugins/TableProPluginKit/MongoDBUuidCodec.swift
@@ -1,5 +1,19 @@
 import Foundation
 
+public struct MongoDBObjectId: Sendable, Hashable, CustomStringConvertible {
+    public let hex: String
+
+    public init(hex: String) {
+        self.hex = hex
+    }
+
+    public var description: String { hex }
+
+    public var isValid: Bool {
+        hex.count == 24 && hex.allSatisfy { $0.isHexDigit && $0.isASCII }
+    }
+}
+
 public struct MongoDBBinaryValue: Sendable, Hashable {
     public let data: Data
     public let subtype: UInt8

--- a/TableProTests/Plugins/MQLExportHelpersTests.swift
+++ b/TableProTests/Plugins/MQLExportHelpersTests.swift
@@ -54,4 +54,46 @@ struct MQLExportHelpersTests {
     func ordinaryValuesUnchanged(input: String, expected: String) {
         #expect(MQLExportHelpers.mqlJsonValue(for: input) == expected)
     }
+
+    @Test("An ObjectId column exports as an ObjectId constructor")
+    func objectIdExportsAsConstructor() {
+        let value = MQLExportHelpers.mqlTextValue(
+            for: "507f1f77bcf86cd799439011", columnTypeName: "ObjectId"
+        )
+        #expect(value == "ObjectId(\"507f1f77bcf86cd799439011\")")
+    }
+
+    @Test("A value that is not a valid ObjectId falls back to a quoted string")
+    func invalidObjectIdFallsBack() {
+        #expect(MQLExportHelpers.mqlTextValue(for: "nope", columnTypeName: "ObjectId") == "\"nope\"")
+    }
+
+    @Test("A timestamp column exports as an ISODate constructor")
+    func timestampExportsAsIsoDate() {
+        let value = MQLExportHelpers.mqlTextValue(
+            for: "2026-01-01T00:00:00Z", columnTypeName: "TIMESTAMP"
+        )
+        #expect(value == "ISODate(\"2026-01-01T00:00:00Z\")")
+
+        let fractional = MQLExportHelpers.mqlTextValue(
+            for: "2026-01-01T00:00:00.123Z", columnTypeName: "TIMESTAMP"
+        )
+        #expect(fractional == "ISODate(\"2026-01-01T00:00:00.123Z\")")
+    }
+
+    @Test("A non-date in a timestamp column falls back to a quoted string")
+    func invalidTimestampFallsBack() {
+        #expect(MQLExportHelpers.mqlTextValue(for: "later", columnTypeName: "TIMESTAMP") == "\"later\"")
+    }
+
+    @Test("An ordinary column is unaffected by the typed-scalar path")
+    func ordinaryColumnUnaffected() {
+        #expect(MQLExportHelpers.mqlTextValue(for: "Alice", columnTypeName: "VARCHAR") == "\"Alice\"")
+        #expect(MQLExportHelpers.mqlTextValue(for: "42", columnTypeName: "INTEGER") == "42")
+        #expect(
+            MQLExportHelpers.mqlTextValue(for: "507f1f77bcf86cd799439011", columnTypeName: "VARCHAR")
+                == "\"507f1f77bcf86cd799439011\""
+        )
+    }
+
 }

--- a/docs/features/import-export.mdx
+++ b/docs/features/import-export.mdx
@@ -16,6 +16,8 @@ TablePro remembers the last format and options you exported with. Option changes
 
 <Note>
 **MongoDB**: SQL export is not available. Use MQL, which generates `db.collection.insertMany([...])` scripts for `mongosh`. **Redis**: SQL and MQL exports are not available.
+
+MQL writes top-level typed values as the constructors mongosh understands, so `_id` comes back as an `ObjectId`, a date as an `ISODate`, and binary as `BinData` with its real subtype. A typed value **nested inside a subdocument or array** is written as a string, because the parent is serialized to JSON before the exporter sees it. Re-importing such a script gives you a string where the original held an ObjectId, date, or binary. Export those collections as JSON, or use `mongodump`.
 </Note>
 
 <Frame caption="Export dialog">


### PR DESCRIPTION
Two commits. Follows #2090.

## 1. CI never compiled the registry plugins

`macos-tests.yml` builds `-scheme TablePro`, whose dependencies are the 14 bundled plugins. The 16 registry-only plugins (MongoDB, Oracle, DuckDB, MSSQL and the rest) are compiled only by the `AllPlugins` aggregate, and nothing in PR CI ran it. `build-plugin.yml` does not fire until a release tag.

I hit this while writing #2090: a hard compile error in the MongoDB plugin still produced `** BUILD SUCCEEDED **`. It surfaced only because that one file happens to be in the test target's source list. The rest of the plugin was never compiled by CI at all, so a plugin-only change could go green and be broken.

Adds an `AllPlugins` build step before the test step.

## 2. ObjectId and dates did not survive MQL export

The dump is a mongosh script, so a bare string in it inserts a string. `_id` was written as `"507f1f77bcf86cd799439011"` and a date as `"2026-01-01T00:00:00Z"`, so re-running the script replaced every ObjectId and every date with a string. Same defect class as the binary subtype in #2090, and the same root cause: the type was gone before the exporter saw the value.

`unwrapExtendedJson` mapped `{"$oid": ...}` straight to `String`, so nothing downstream could tell an ObjectId from an ordinary string. It now returns a `MongoDBObjectId` box, which is `CustomStringConvertible` over the hex so the one site that interpolates `bsonToDict(doc)["_id"]` keeps working. `BsonValueKind` gains `.objectId`, and `typeName` reports `ObjectId`, the spelling `fetchColumns` already used for an empty collection.

MQL export then writes `ObjectId("...")` for an `ObjectId` column and `ISODate("...")` for a `TIMESTAMP` column, validating the value first and falling back to a quoted string if it does not parse. Cell display is unchanged: the grid still shows the bare hex, and the column still classifies as text, so no edit guard or formatter moves.

## Deliberately not fixed: values nested in a subdocument

A typed value inside a subdocument or array still exports as a string, and the docs now say so.

I stopped short of fixing it because the only contained fix is a bad one. The export data source is format-agnostic: the same `PluginCellValue` stream feeds MQL, CSV, JSON and XLSX, and a nested document has already been serialized to a JSON string by the time any exporter sees it. MQL export could re-parse that JSON and rewrite any string matching `BinData(...)` or `ObjectId(...)` back into a constructor, but that is reconstructing a type by pattern-matching a display string, and it would silently convert a genuine user string that happens to look like one.

The clean fix is a driver-owned export hook, so MongoDB serializes its own literals per format rather than the exporter guessing from text. That is an additive PluginKit protocol change affecting every driver and every format, and it deserves its own design rather than being tacked on here.

## Verification

- 8628 tests in 1052 suites pass, full `TableProTests` with CI's own quarantine skip list.
- `AllPlugins` builds.
- PluginKit ABI diff additive, zero removed symbols.

https://claude.ai/code/session_01628orR3jwc3ATfcFCLVUMB
