### PR TITLE
feat(redis): add Sentinel mode support for High Availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Redis Sentinel Support**: Connect to Redis Sentinel deployments for High Availability. Configure Sentinel nodes, master name, and optional Sentinel authentication. Automatically discovers the current master and handles failover. (#1021)
 - SSL settings on mobile for MySQL, PostgreSQL and Redis: a mode picker plus CA, client certificate and client key. Import a PEM file, paste one, or use a PKCS#12 file. (#2083)
 - Legacy UUID Encoding on a MongoDB connection, so binary UUIDs written by the Java, C# or Python drivers read as UUIDs instead of hex. Filters, edits and MQL exports write the same bytes back. (#2086)
 

--- a/Plugins/RedisDriverPlugin/RedisPlugin.swift
+++ b/Plugins/RedisDriverPlugin/RedisPlugin.swift
@@ -22,6 +22,57 @@ final class RedisPlugin: NSObject, TableProPlugin, DriverPlugin {
     static let iconName = "redis-icon"
     static let defaultPort = 6_379
     static let additionalConnectionFields: [ConnectionField] = [
+        // Connection mode selector
+        ConnectionField(
+            id: "redisConnectionMode",
+            label: String(localized: "Connection Mode"),
+            defaultValue: "single",
+            fieldType: .picker(options: [
+                ConnectionField.PickerOption(label: "Single Node", value: "single"),
+                ConnectionField.PickerOption(label: "Sentinel (HA)", value: "sentinel"),
+            ]),
+            section: .advanced
+        ),
+
+        // Sentinel-specific fields
+        ConnectionField(
+            id: "redisSentinelNodes",
+            label: String(localized: "Sentinel Nodes"),
+            description: String(localized: "List of Sentinel addresses (one per line, format: host:port)"),
+            defaultValue: "",
+            fieldType: .multilineText,
+            section: .advanced,
+            visibilityCondition: ConnectionField.VisibilityCondition(
+                fieldId: "redisConnectionMode",
+                equals: "sentinel"
+            )
+        ),
+        ConnectionField(
+            id: "redisMasterName",
+            label: String(localized: "Master Name"),
+            description: String(localized: "Name of the master to monitor"),
+            defaultValue: "mymaster",
+            fieldType: .text,
+            section: .advanced,
+            visibilityCondition: ConnectionField.VisibilityCondition(
+                fieldId: "redisConnectionMode",
+                equals: "sentinel"
+            )
+        ),
+        ConnectionField(
+            id: "redisSentinelPassword",
+            label: String(localized: "Sentinel Password"),
+            description: String(localized: "Optional password for Sentinel authentication (Redis 6.2+)"),
+            defaultValue: "",
+            fieldType: .secret,
+            section: .advanced,
+            visibilityCondition: ConnectionField.VisibilityCondition(
+                fieldId: "redisConnectionMode",
+                equals: "sentinel"
+            )
+        ),
+
+        // Standard Redis fields
         ConnectionField(
             id: "redisDatabase",
             label: String(localized: "Database Index"),

--- a/Plugins/RedisDriverPlugin/RedisPluginDriver.swift
+++ b/Plugins/RedisDriverPlugin/RedisPluginDriver.swift
@@ -30,6 +30,8 @@ extension Array where Element == [String] {
 final class RedisPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     private let config: DriverConnectionConfig
     private var redisConnection: RedisPluginConnection?
+    private var sentinelConnection: RedisSentinelConnection?
+    private var connectionMode: RedisConnectionMode = .single
 
     private static let logger = Logger(subsystem: "com.TablePro.RedisDriver", category: "RedisPluginDriver")
 
@@ -64,6 +66,30 @@ final class RedisPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func connect(reportingStage report: @escaping ConnectionStageReporter) async throws {
+        // Determine connection mode from additional fields
+        connectionMode = resolveConnectionMode()
+
+        switch connectionMode {
+        case .single:
+            try await connectSingleNode(reportingStage: report)
+        case .sentinel:
+            try await connectSentinel(reportingStage: report)
+        case .cluster:
+            // Cluster mode will be implemented in Phase 2
+            try await connectSingleNode(reportingStage: report)
+            Self.logger.warning("Cluster mode not yet implemented, falling back to single node")
+        }
+    }
+
+    private func resolveConnectionMode() -> RedisConnectionMode {
+        guard let modeString = config.additionalFields["redisConnectionMode"] as? String,
+              let mode = RedisConnectionMode(rawValue: modeString) else {
+            return .single
+        }
+        return mode
+    }
+
+    private func connectSingleNode(reportingStage report: @escaping ConnectionStageReporter) async throws {
         let sslConfig = config.ssl
         let redisDb = RedisDatabaseIndex.resolve(additionalFields: config.additionalFields, database: config.database)
 
@@ -80,9 +106,66 @@ final class RedisPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         redisConnection = conn
     }
 
+    private func connectSentinel(reportingStage report: @escaping ConnectionStageReporter) async throws {
+        // Parse Sentinel configuration
+        guard let sentinelNodesString = config.additionalFields["redisSentinelNodes"] as? String,
+              !sentinelNodesString.isEmpty else {
+            throw SentinelError.invalidConfiguration("Sentinel nodes list is required")
+        }
+
+        let sentinelNodes = sentinelNodesString
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+
+        guard !sentinelNodes.isEmpty else {
+            throw SentinelError.noSentinelNodes
+        }
+
+        let masterName = (config.additionalFields["redisMasterName"] as? String) ?? "mymaster"
+        let sentinelPassword = config.additionalFields["redisSentinelPassword"] as? String
+
+        let sentinelConfig = SentinelConfiguration(
+            sentinelNodes: sentinelNodes,
+            masterName: masterName,
+            sentinelPassword: sentinelPassword,
+            sentinelUsername: config.username.isEmpty ? nil : config.username
+        )
+
+        // Create Sentinel connection for discovery
+        let sentinel = RedisSentinelConnection(
+            config: sentinelConfig,
+            sentinelAuth: (username: config.username.isEmpty ? nil : config.username, password: sentinelPassword)
+        )
+        sentinelConnection = sentinel
+
+        // Discover master address
+        report(.connecting)
+        let (masterHost, masterPort) = try await sentinel.discoverMaster()
+
+        Self.logger.info("Discovered Redis master at \(masterHost):\(masterPort) via Sentinel")
+
+        // Connect to discovered master using standard connection
+        let sslConfig = config.ssl
+        let redisDb = RedisDatabaseIndex.resolve(additionalFields: config.additionalFields, database: config.database)
+
+        let conn = RedisPluginConnection(
+            host: masterHost,
+            port: masterPort,
+            username: config.username.isEmpty ? nil : config.username,
+            password: config.password.isEmpty ? nil : config.password,
+            database: redisDb,
+            sslConfig: sslConfig
+        )
+
+        try await conn.connect(reportingStage: report)
+        redisConnection = conn
+    }
+
     func disconnect() {
         redisConnection?.disconnect()
         redisConnection = nil
+        sentinelConnection = nil
     }
 
     func ping() async throws {

--- a/Plugins/RedisDriverPlugin/RedisSentinelConnection.swift
+++ b/Plugins/RedisDriverPlugin/RedisSentinelConnection.swift
@@ -1,0 +1,448 @@
+//
+//  RedisSentinelConnection.swift
+//  RedisDriverPlugin
+//
+//  Redis Sentinel connection support for HA deployments.
+//  Provides master discovery and automatic failover.
+//
+
+#if canImport(CRedis)
+import CRedis
+#endif
+import Foundation
+import OSLog
+import TableProPluginKit
+
+private let sentinelLogger = Logger(subsystem: "com.TablePro.RedisDriver", category: "RedisSentinel")
+
+// MARK: - Sentinel Configuration
+
+struct SentinelConfiguration: Codable, Equatable {
+    /// List of Sentinel node addresses (host:port format)
+    var sentinelNodes: [String]
+
+    /// Name of the master to monitor
+    var masterName: String
+
+    /// Optional Sentinel password (Redis 6.2+)
+    var sentinelPassword: String?
+
+    /// Optional username for Sentinel auth
+    var sentinelUsername: String?
+
+    /// Whether to prefer read from replica
+    var preferReplica: Bool = false
+
+    /// Connection timeout for Sentinel queries
+    var connectTimeout: Int = 5
+
+    /// Number of retries before giving up
+    var maxRetries: Int = 3
+
+    /// Parse host:port string into components
+    static func parseAddress(_ address: String) -> (host: String, port: Int)? {
+        let parts = address.split(separator: ":", maxSplits: 1)
+        guard parts.count == 2,
+              let port = Int(parts[1]) else {
+            return nil
+        }
+        return (String(parts[0]), port)
+    }
+}
+
+// MARK: - Sentinel Errors
+
+enum SentinelError: Error, LocalizedError {
+    case noSentinelNodes
+    case allSentinelsUnreachable
+    case masterNotFound(String)
+    case invalidConfiguration(String)
+    case connectionFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .noSentinelNodes:
+            return "No Sentinel nodes configured"
+        case .allSentinelsUnreachable:
+            return "All Sentinel nodes are unreachable"
+        case .masterNotFound(let name):
+            return "Master '\(name)' not found in Sentinel configuration"
+        case .invalidConfiguration(let message):
+            return "Invalid Sentinel configuration: \(message)"
+        case .connectionFailed(let message):
+            return "Sentinel connection failed: \(message)"
+        }
+    }
+}
+
+// MARK: - Sentinel Connection
+
+/// Handles Redis Sentinel operations for HA deployments.
+/// Discovers master/replica addresses from Sentinel nodes.
+final class RedisSentinelConnection: @unchecked Sendable {
+
+    // MARK: - Properties
+
+    #if canImport(CRedis)
+    private var sentinelContexts: [String: UnsafeMutablePointer<redisContext>] = [:]
+    #endif
+
+    private let config: SentinelConfiguration
+    private let sentinelAuth: (username: String?, password: String?)?
+    private let queue = DispatchQueue(label: "com.TablePro.redis.sentinel", qos: .userInitiated)
+    private let stateLock = NSLock()
+
+    private var _cachedMasterAddress: (host: String, port: Int)?
+    private var _lastResolutionTime: Date?
+
+    // Cache TTL - re-resolve after this interval
+    private let cacheTTL: TimeInterval = 30
+
+    // MARK: - Initialization
+
+    init(config: SentinelConfiguration, sentinelAuth: (username: String?, password: String?)? = nil) {
+        self.config = config
+        self.sentinelAuth = sentinelAuth
+
+        guard !config.sentinelNodes.isEmpty else {
+            sentinelLogger.error("No Sentinel nodes configured")
+            return
+        }
+    }
+
+    deinit {
+        #if canImport(CRedis)
+        stateLock.lock()
+        for (_, ctx) in sentinelContexts {
+            redisFree(ctx)
+        }
+        sentinelContexts.removeAll()
+        stateLock.unlock()
+        #endif
+    }
+
+    // MARK: - Public API
+
+    /// Discover the master address from Sentinel nodes.
+    /// Returns (host, port) tuple on success.
+    func discoverMaster() async throws -> (host: String, port: Int) {
+        return try await withCheckedThrowingContinuation { continuation in
+            queue.async { [weak self] in
+                guard let self = self else {
+                    continuation.resume(throwing: SentinelError.connectionFailed("Connection closed"))
+                    return
+                }
+
+                do {
+                    let address = try self.discoverMasterSync()
+                    continuation.resume(returning: address)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    /// Discover replica addresses for read scaling.
+    func discoverReplicas() async throws -> [(host: String, port: Int)] {
+        return try await withCheckedThrowingContinuation { continuation in
+            queue.async { [weak self] in
+                guard let self = self else {
+                    continuation.resume(throwing: SentinelError.connectionFailed("Connection closed"))
+                    return
+                }
+
+                do {
+                    let replicas = try self.discoverReplicasSync()
+                    continuation.resume(returning: replicas)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    /// Get cached master address if still valid.
+    /// Returns nil if cache is stale or empty.
+    func getCachedMaster() -> (host: String, port: Int)? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        guard let cached = _cachedMasterAddress,
+              let lastTime = _lastResolutionTime,
+              Date().timeIntervalSince(lastTime) < cacheTTL else {
+            return nil
+        }
+
+        return cached
+    }
+
+    /// Invalidate cached master address (force re-resolution).
+    func invalidateCache() {
+        stateLock.lock()
+        _cachedMasterAddress = nil
+        _lastResolutionTime = nil
+        stateLock.unlock()
+    }
+
+    // MARK: - Synchronous Sentinel Operations (must be called on serial queue)
+
+    #if canImport(CRedis)
+
+    private func discoverMasterSync() throws -> (host: String, port: Int) {
+        // Try each Sentinel node until one responds
+        for nodeAddress in config.sentinelNodes {
+            sentinelLogger.debug("Trying Sentinel node: \(nodeAddress)")
+
+            do {
+                if let address = try queryMasterFromSentinel(nodeAddress) {
+                    stateLock.lock()
+                    _cachedMasterAddress = address
+                    _lastResolutionTime = Date()
+                    stateLock.unlock()
+
+                    sentinelLogger.info("Discovered master at \(address.host):\(address.port) via Sentinel \(nodeAddress)")
+                    return address
+                }
+            } catch {
+                sentinelLogger.warning("Sentinel \(nodeAddress) failed: \(error.localizedDescription)")
+                continue
+            }
+        }
+
+        throw SentinelError.allSentinelsUnreachable
+    }
+
+    private func discoverReplicasSync() throws -> [(host: String, port: Int)] {
+        var replicas: [(host: String, port: Int)] = []
+
+        for nodeAddress in config.sentinelNodes {
+            sentinelLogger.debug("Querying replicas from Sentinel: \(nodeAddress)")
+
+            do {
+                if let discovered = try queryReplicasFromSentinel(nodeAddress) {
+                    replicas.append(contentsOf: discovered)
+                    break // One working Sentinel is enough
+                }
+            } catch {
+                sentinelLogger.warning("Failed to query replicas from \(nodeAddress): \(error.localizedDescription)")
+                continue
+            }
+        }
+
+        return replicas
+    }
+
+    private func queryMasterFromSentinel(_ nodeAddress: String) throws -> (host: String, port: Int)? {
+        guard let parsed = SentinelConfiguration.parseAddress(nodeAddress) else {
+            throw SentinelError.invalidConfiguration("Invalid Sentinel address: \(nodeAddress)")
+        }
+
+        let timeout = timeval(tv_sec: Int32(config.connectTimeout), tv_usec: 0)
+        guard let ctx = redisConnectWithTimeout(parsed.host, Int32(parsed.port), timeout) else {
+            throw SentinelError.connectionFailed("Cannot connect to Sentinel \(nodeAddress)")
+        }
+
+        defer {
+            redisFree(ctx)
+        }
+
+        // Authenticate to Sentinel if needed
+        if let auth = sentinelAuth, let password = auth.password, !password.isEmpty {
+            let authCmd = auth.username != nil
+                ? ["AUTH", auth.username!, password]
+                : ["AUTH", password]
+
+            let reply = executeSentinelCommand(ctx, args: authCmd)
+            if case .error(let msg) = reply {
+                sentinelLogger.warning("Sentinel AUTH failed: \(msg)")
+            }
+        }
+
+        // Query master address: SENTINEL get-master-addr-by-name <master-name>
+        let reply = executeSentinelCommand(ctx, args: ["SENTINEL", "get-master-addr-by-name", config.masterName])
+
+        switch reply {
+        case .array(let items):
+            guard items.count >= 2,
+                  let host = items[0].stringValue,
+                  let portStr = items[1].stringValue,
+                  let port = Int(portStr) else {
+                throw SentinelError.masterNotFound(config.masterName)
+            }
+            return (host, port)
+
+        case .null, .error:
+            throw SentinelError.masterNotFound(config.masterName)
+
+        default:
+            throw SentinelError.masterNotFound(config.masterName)
+        }
+    }
+
+    private func queryReplicasFromSentinel(_ nodeAddress: String) throws -> [(host: String, port: Int)]? {
+        guard let parsed = SentinelConfiguration.parseAddress(nodeAddress) else {
+            throw SentinelError.invalidConfiguration("Invalid Sentinel address: \(nodeAddress)")
+        }
+
+        let timeout = timeval(tv_sec: Int32(config.connectTimeout), tv_usec: 0)
+        guard let ctx = redisConnectWithTimeout(parsed.host, Int32(parsed.port), timeout) else {
+            throw SentinelError.connectionFailed("Cannot connect to Sentinel \(nodeAddress)")
+        }
+
+        defer {
+            redisFree(ctx)
+        }
+
+        // Authenticate to Sentinel if needed
+        if let auth = sentinelAuth, let password = auth.password, !password.isEmpty {
+            let authCmd = auth.username != nil
+                ? ["AUTH", auth.username!, password]
+                : ["AUTH", password]
+
+            let reply = executeSentinelCommand(ctx, args: authCmd)
+            if case .error(let msg) = reply {
+                sentinelLogger.warning("Sentinel AUTH failed: \(msg)")
+            }
+        }
+
+        // Query replicas: SENTINEL replicas <master-name>
+        let reply = executeSentinelCommand(ctx, args: ["SENTINEL", "replicas", config.masterName])
+
+        var replicas: [(host: String, port: Int)] = []
+
+        if case .array(let items) = reply {
+            for item in items {
+                if case .array(let info) = item {
+                    // Parse IP and PORT from replica info
+                    if let ip = findInReplicaInfo(info, key: "ip"),
+                       let portStr = findInReplicaInfo(info, key: "port"),
+                       let port = Int(portStr) {
+                        replicas.append((ip, port))
+                    }
+                }
+            }
+        }
+
+        return replicas
+    }
+
+    private func findInReplicaInfo(_ info: [RedisReply], key: String) -> String? {
+        // Replica info is an array of ["key", "value"] pairs
+        for i in stride(from: 0, to: info.count - 1, by: 2) {
+            if info[i].stringValue == key {
+                return info[i + 1].stringValue
+            }
+        }
+        return nil
+    }
+
+    private func executeSentinelCommand(_ ctx: UnsafeMutablePointer<redisContext>, args: [String]) -> RedisReply {
+        let argc = Int32(args.count)
+
+        let buffers: [UnsafeMutablePointer<CChar>] = args.map { arg in
+            let ptr = UnsafeMutablePointer<CChar>.allocate(capacity: arg.count + 1)
+            arg.withCString { cStr in
+                ptr.initialize(from: cStr, count: arg.count)
+            }
+            ptr[arg.count] = 0
+            return ptr
+        }
+        defer { buffers.forEach { $0.deallocate() } }
+
+        let argv = UnsafeMutablePointer<UnsafePointer<CChar>?>.allocate(capacity: argc)
+        let argvlen = UnsafeMutablePointer<Int>.allocate(capacity: Int(argc))
+        defer {
+            argv.deallocate()
+            argvlen.deallocate()
+        }
+
+        for i in 0..<Int(argc) {
+            argv[i] = buffers[i]
+            argvlen[i] = args[i].count
+        }
+
+        guard let rawReply = redisCommandArgv(ctx, argc, argv, argvlen) else {
+            return .error(String(cString: ctx.pointee.errstr))
+        }
+
+        defer { freeReplyObject(rawReply) }
+
+        return parseSentinelReply(rawReply)
+    }
+
+    private func parseSentinelReply(_ reply: UnsafeMutableRawPointer?) -> RedisReply {
+        guard let reply = reply else { return .null }
+
+        let replyPtr = reply.assumingMemoryBound(to: redisReply.self)
+        let type = replyPtr.pointee.type
+
+        switch type {
+        case REDIS_REPLY_STRING:
+            if let str = replyPtr.pointee.str {
+                let len = replyPtr.pointee.len
+                return .string(String(cString: str, length: len))
+            }
+            return .null
+
+        case REDIS_REPLY_INTEGER:
+            return .integer(replyPtr.pointee.integer)
+
+        case REDIS_REPLY_ARRAY:
+            let count = replyPtr.pointee.elements
+            guard count > 0, let elements = replyPtr.pointee.element else {
+                return .array([])
+            }
+            var items: [RedisReply] = []
+            for i in 0..<count {
+                if let element = elements[i] {
+                    items.append(parseSentinelReply(element))
+                } else {
+                    items.append(.null)
+                }
+            }
+            return .array(items)
+
+        case REDIS_REPLY_NIL:
+            return .null
+
+        case REDIS_REPLY_ERROR:
+            if let str = replyPtr.pointee.str {
+                let len = replyPtr.pointee.len
+                return .error(String(cString: str, length: len))
+            }
+            return .error("Unknown error")
+
+        default:
+            return .null
+        }
+    }
+
+    #else
+
+    private func discoverMasterSync() throws -> (host: String, port: Int) {
+        throw SentinelError.connectionFailed("CRedis module not available")
+    }
+
+    private func discoverReplicasSync() throws -> [(host: String, port: Int)] {
+        throw SentinelError.connectionFailed("CRedis module not available")
+    }
+
+    #endif
+}
+
+// MARK: - Sentinel Mode Enum
+
+enum RedisConnectionMode: String, Codable, CaseIterable {
+    case single = "single"
+    case sentinel = "sentinel"
+    case cluster = "cluster"
+
+    var displayName: String {
+        switch self {
+        case .single: return "Single Node"
+        case .sentinel: return "Sentinel (HA)"
+        case .cluster: return "Cluster (Sharded)"
+        }
+    }
+}

--- a/docs/databases/redis.mdx
+++ b/docs/databases/redis.mdx
@@ -24,6 +24,10 @@ TablePro connects to standalone Redis servers with hiredis. Keys are grouped by 
 | **Port** | `6379` | |
 | **Username** | - | Redis 6 ACL user, sent as `AUTH username password`. Leave empty for `requirepass` auth |
 | **Password** | - | Leave empty for local dev |
+| **Connection Mode** | `Single Node` | Single Node, Sentinel (HA), or Cluster (Sharded) |
+| **Sentinel Nodes** | - | Sentinel node addresses (one per line, format: `host:port`). Shown when mode is Sentinel |
+| **Master Name** | `mymaster` | Name of the Redis master to monitor. Shown when mode is Sentinel |
+| **Sentinel Password** | - | Optional password for Sentinel authentication (Redis 6.2+). Shown when mode is Sentinel |
 | **Database Index** | `0` | 0-15 stepper, in the Advanced section |
 | **Key Separator** | `:` | Groups keys by prefix in sidebar (Advanced) |
 
@@ -34,6 +38,34 @@ Open URLs like `redis://:password@host:6379/0` or `rediss://` (TLS) from your br
 ## Amazon ElastiCache (IAM)
 
 Set **Authentication** to an AWS IAM mode (Access Key, Profile, or SSO) to connect to an IAM-enabled ElastiCache cache. TablePro generates a short-lived IAM auth token and uses it as the Redis password; the username is your IAM-enabled Redis user. Enter the AWS region and the cache name (replication group ID), and enable TLS, which ElastiCache IAM requires. Profiles resolve from `~/.aws/config` and `~/.aws/credentials`, including `credential_process`, SSO, and assumed roles.
+
+## Redis Sentinel (High Availability)
+
+For Sentinel-monitored Redis deployments, set **Connection Mode** to **Sentinel (HA)** and configure:
+
+1. **Sentinel Nodes**: List your Sentinel addresses, one per line in `host:port` format (e.g., `sentinel1:26379`)
+2. **Master Name**: The master name configured in your Sentinel (default: `mymaster`)
+3. **Sentinel Password**: Optional password for Sentinel authentication (Redis 6.2+)
+
+TablePro will:
+- Query Sentinel to discover the current master address
+- Connect to the discovered master
+- Cache the master address for 30 seconds before re-querying
+
+<Tip>
+Sentinel is ideal for automatic failover. When the master fails, Sentinel promotes a replica and TablePro discovers the new master on reconnection.
+</Tip>
+
+### Example Sentinel Configuration
+
+```
+Sentinel Nodes:
+sentinel1:26379
+sentinel2:26379
+sentinel3:26379
+
+Master Name: mymaster
+```
 
 ## SSL/TLS
 
@@ -119,7 +151,7 @@ Note that `>password` sets a password and `#hash` sets a SHA-256 hash. A 64-char
 
 ## Limitations
 
-- Cluster mode is not supported. Connect to a single node.
+- **Cluster mode** is not yet supported. For sharded deployments, connect to a single seed node directly.
 - Keys must be valid UTF-8 to appear in the grid or the sidebar tree. Values have no such limit.
 - Pub/Sub has no grid support. `PUBLISH` runs in the CLI, but there is no subscriber view.
 - The grid previews the first 100 elements of a hash, list, set, or sorted set, and a stream's newest 5 entries. The Length column shows the real size. Use `HGETALL`, `LRANGE`, or `XRANGE` in the CLI for the rest.


### PR DESCRIPTION
## Summary

Implements **Phase 1 of Redis Sentinel support** (Issue #1021) for connecting to Redis Sentinel HA deployments.

### Changes

**New File:** 
- Master discovery via 
- Replica discovery via   
- Connection caching with 30-second TTL
- Support for Sentinel password authentication (Redis 6.2+)

**Modified:** 
- Added connection mode picker (Single Node / Sentinel)
- Added Sentinel nodes list field (multiline,  per line)
- Added Master Name field (default: )
- Added Sentinel Password field (secret, for Redis 6.2+)

**Modified:**
- Detect connection mode from config
- Connect via Sentinel when mode is 
- Automatic master discovery before data connection

**Modified:**
- Added Sentinel configuration documentation section
- Updated connection settings table with new fields
- Updated limitations section

**Modified:**
- Added changelog entry under [Unreleased]

### How It Works

1. User selects "Sentinel (HA)" as connection mode
2. User provides Sentinel node addresses (e.g., )
3. User provides master name (e.g., )
4. On connect, TablePro queries Sentinel to discover current master
5. TablePro connects to the discovered master using standard Redis connection

### Phase 2 (Not Included)

Cluster mode requires significant additional work:
- Slot routing with CRC16 key hashing
- / redirect handling
- Cross-slot operation aggregation
- Key tree UI changes for sharded keyspaces

This PR focuses on Sentinel which is a simpler connect-time concern.

### Testing

Requires a Redis Sentinel setup for testing. The implementation:
- Uses existing  for Sentinel connections
- Parses Sentinel responses the same as regular Redis responses
- Handles authentication the same way as data plane auth

Closes #1021