### PR TITLE
fix(sidebar): keep the workspace rail steady when switching tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The workspace rail no longer flickers when you switch tables or focus another window, and no longer disappears for a moment when a table opens in a new window tab.
 - Right-clicking a table that is not part of the current selection now acts on that table. It used to act on the selected tables instead, including for Delete.
 - Database icons and the current-database checkmark stay visible on a selected row in the database switcher. They were drawn in the accent colour, which vanished against the accent-coloured selection.
 - The sidebar drops a database from the tree as soon as you drop it on the server, instead of listing it until you reconnect.

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -183,6 +183,13 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         navigationSidebar.railController.onEntryCountChange = { [weak self] count in
             self?.applyRailVisibility(workspaceCount: count)
         }
+        /// The rail's first reload ran while its view loaded, before this callback existed, so
+        /// its count never reached the window. Waiting for `viewWillAppear` to catch up painted
+        /// a new tab window's first frames with the rail at width 0 and slid it in on
+        /// appearance, which read as the rail vanishing for half a second on every table
+        /// switch. Applied here, with no window yet, the width lands unanimated before the
+        /// first frame.
+        applyRailVisibility(workspaceCount: WorkspaceRailStore.entries.count)
 
         /// The saved layout is restored before any phase-driven collapse, so the user's widths
         /// are already in the live layout. Uncollapsing then returns the pane to the size

--- a/TablePro/Core/Services/Infrastructure/WorkspaceRailStore.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspaceRailStore.swift
@@ -30,6 +30,12 @@ internal struct WorkspaceRailEntry: Identifiable, Equatable {
     internal var container: String { workspace.container }
 }
 
+internal enum WorkspaceRailReloadPlan: Equatable {
+    case unchanged
+    case refreshRows
+    case rebuild
+}
+
 @MainActor
 internal enum WorkspaceRailStore {
     /// Derived live from the open windows, their sessions and their tabs rather than
@@ -140,6 +146,20 @@ internal enum WorkspaceRailStore {
     internal static func shouldRestoreSelection(after target: WorkspaceID, railConnectionId: UUID?) -> Bool {
         guard let railConnectionId else { return false }
         return target.connectionId != railConnectionId
+    }
+
+    /// How much of the table an event actually requires. Most events the rail listens to,
+    /// a table switch above all, resolve to the same entries it already shows; rebuilding
+    /// the rows for those recreates every cell and blinks the selection. Rows are torn down
+    /// only when the set of workspaces itself changed; a row whose entry changed in place
+    /// keeps its cell and is reconfigured.
+    internal static func reloadPlan(
+        from current: [WorkspaceRailEntry],
+        to resolved: [WorkspaceRailEntry]
+    ) -> WorkspaceRailReloadPlan {
+        guard resolved != current else { return .unchanged }
+        guard resolved.map(\.id) == current.map(\.id) else { return .rebuild }
+        return .refreshRows
     }
 
     internal static var changes: AnyPublisher<Void, Never> {

--- a/TablePro/Core/Services/Infrastructure/WorkspaceRailViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspaceRailViewController.swift
@@ -141,18 +141,38 @@ internal final class WorkspaceRailViewController: NSViewController {
 
     // MARK: - Data
 
+    /// Selection still re-resolves on an unchanged list: a browse-cursor move keeps the
+    /// entries identical and changes only which row is the window's own.
     private func reload() {
-        entries = WorkspaceRailStore.entries
+        let resolved = WorkspaceRailStore.entries
+        let plan = WorkspaceRailStore.reloadPlan(from: entries, to: resolved)
+        entries = resolved
         Self.logger.debug(
             """
             reload rail=\(self.railName, privacy: .public) \
+            plan=\(String(describing: plan), privacy: .public) \
             entries=\(self.entries.count, privacy: .public) \
             [\(self.entries.map(\.workspace).map(Self.describe).joined(separator: " "), privacy: .public)]
             """
         )
-        tableView.reloadData()
+        switch plan {
+        case .unchanged:
+            break
+        case .refreshRows:
+            reconfigureRows()
+        case .rebuild:
+            tableView.reloadData()
+        }
         applySelection()
         onEntryCountChange?(entries.count)
+    }
+
+    private func reconfigureRows() {
+        for row in entries.indices {
+            guard let cell = tableView.view(atColumn: 0, row: row, makeIfNecessary: false)
+                as? WorkspaceRailCellView else { continue }
+            cell.configure(entry: entries[row], layout: layout)
+        }
     }
 
     private static func describe(_ workspace: WorkspaceID) -> String {

--- a/TableProTests/Core/Services/WorkspaceRailStoreTests.swift
+++ b/TableProTests/Core/Services/WorkspaceRailStoreTests.swift
@@ -231,6 +231,55 @@ struct WorkspaceRailStoreTests {
     }
 }
 
+@Suite("Workspace rail reload plan")
+@MainActor
+struct WorkspaceRailReloadPlanTests {
+    private func makeEntry(
+        connection: DatabaseConnection,
+        container: String,
+        status: ConnectionStatus = .connected
+    ) -> WorkspaceRailEntry {
+        WorkspaceRailEntry(
+            workspace: WorkspaceID(connectionId: connection.id, container: container),
+            connection: connection,
+            status: status
+        )
+    }
+
+    @Test("An event that resolves to the same entries rebuilds nothing")
+    func identicalEntriesAreUnchanged() {
+        let connection = TestFixtures.makeConnection(database: "app")
+        let entries = [makeEntry(connection: connection, container: "app")]
+        #expect(WorkspaceRailStore.reloadPlan(from: entries, to: entries) == .unchanged)
+    }
+
+    @Test("A row whose entry changed in place keeps its cell and is reconfigured")
+    func changedEntryOnSameRowRefreshes() {
+        let connection = TestFixtures.makeConnection(database: "app")
+        let current = [makeEntry(connection: connection, container: "app", status: .connected)]
+        let resolved = [makeEntry(connection: connection, container: "app", status: .disconnected)]
+        #expect(WorkspaceRailStore.reloadPlan(from: current, to: resolved) == .refreshRows)
+    }
+
+    @Test("A workspace appearing rebuilds the rows")
+    func addedWorkspaceRebuilds() {
+        let connection = TestFixtures.makeConnection(database: "app")
+        let current = [makeEntry(connection: connection, container: "app")]
+        let resolved = current + [makeEntry(connection: connection, container: "logs")]
+        #expect(WorkspaceRailStore.reloadPlan(from: current, to: resolved) == .rebuild)
+    }
+
+    @Test("A reorder rebuilds the rows")
+    func reorderedWorkspacesRebuild() {
+        let connection = TestFixtures.makeConnection(database: "app")
+        let current = [
+            makeEntry(connection: connection, container: "app"),
+            makeEntry(connection: connection, container: "logs"),
+        ]
+        #expect(WorkspaceRailStore.reloadPlan(from: current, to: current.reversed()) == .rebuild)
+    }
+}
+
 @Suite("Workspace rail cell text")
 @MainActor
 struct WorkspaceRailCellTextTests {


### PR DESCRIPTION
## Environment

- macOS: 26.5.1
- TablePro: 0.64.0
- Databases: MySQL 8 and Redis (the bug is UI-level, not database-specific)

## Reproduction steps

1. Open two or more connections or databases so the workspace rail is visible.
2. Open a table and apply a filter or sort, so the current tab holds active work.
3. Click other tables in the sidebar.

## Expected

The rail stays in place while tables change.

## Actual

Two problems on every table switch:

1. The rail flickers: every store event rebuilt all rail cells with `reloadData()`, which blinked the selection even when the entries had not changed.
2. The rail disappears for about half a second, then slides back in. With active work on the current tab, each table click opens a new native window tab. The new window's rail starts at width 0, and its first reload runs while the sidebar view loads, before the window has assigned the entry-count callback. Visibility is only applied at `viewWillAppear`, at which point the window exists, so the width animates in. The first frames of the new tab paint without the rail.

## Fix

- Diff the old and new entries before reloading: unchanged entries touch nothing, in-place changes reconfigure the existing cells, and `reloadData()` runs only when the set of workspaces itself changed.
- Apply rail visibility synchronously in `viewDidLoad` after the split items are added. The window is nil at that point, so the width lands unanimated before the first frame.
