### PR TITLE
feat(datagrid): edit PostgreSQL array columns element by element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- PostgreSQL array columns of a simple type, including arrays of an enum, get a list editor in the data grid. One row per element, with reordering, add and remove, and NULL per element. An empty array and a NULL column stay separate values. Enum arrays pick from the labels the type declares. Arrays of `jsonb`, `bytea` or composite types, and multi-dimensional values, keep the plain text editor.
+
+### Fixed
+
+- PostgreSQL enum columns whose type lives in another schema now show their values instead of a plain text box.
+
 - Select several databases or schemas in the sidebar tree and act on them at once: drop, refresh, copy names, or export. Shift-click and Cmd-click extend the selection.
 - The database switcher takes a multiple selection too, with the same actions on the right-click menu.
 - Drop Schema for PostgreSQL, SQL Server and SurrealDB.

--- a/Plugins/PostgreSQLDriverPlugin/LibPQDriverCore.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQDriverCore.swift
@@ -141,6 +141,10 @@ final class LibPQDriverCore: @unchecked Sendable {
         libpqConnection?.setPostgisOidMap(map)
     }
 
+    func setEnumOidMap(_ map: [UInt32: String]) {
+        libpqConnection?.setEnumOidMap(map)
+    }
+
     func applyQueryTimeout(_ seconds: Int) async throws {
         let ms = seconds * 1_000
         _ = try await execute(query: "SET statement_timeout = '\(ms)'")

--- a/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
@@ -69,6 +69,26 @@ private func pgOidToTypeName(_ oid: UInt32) -> String {
     case 829: return "macaddr"
     case 869: return "inet"
     case 1_009: return "text[]"
+    case 1_000: return "boolean[]"
+    case 1_001: return "bytea[]"
+    case 1_005: return "smallint[]"
+    case 1_007: return "integer[]"
+    case 1_014: return "char[]"
+    case 1_015: return "varchar[]"
+    case 1_016: return "bigint[]"
+    case 1_021: return "real[]"
+    case 1_022: return "double precision[]"
+    case 1_115: return "timestamp[]"
+    case 1_182: return "date[]"
+    case 1_183: return "time[]"
+    case 1_185: return "timestamptz[]"
+    case 1_187: return "interval[]"
+    case 1_231: return "numeric[]"
+    case 1_270: return "timetz[]"
+    case 199: return "json[]"
+    case 3_807: return "jsonb[]"
+    case 2_951: return "uuid[]"
+    case 1_041: return "inet[]"
     case 1_042: return "char"
     case 1_043: return "varchar"
     case 1_082: return "date"
@@ -109,6 +129,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
     private var _cachedServerVersionNumber: Int32 = 0
     private var _isConnectCancelled: Bool = false
     private var _postgisOidMap: [UInt32: String] = [:]
+    private var _enumOidMap: [UInt32: String] = [:]
 
     var isConnected: Bool {
         stateLock.lock()
@@ -378,6 +399,19 @@ final class LibPQPluginConnection: @unchecked Sendable {
         stateLock.lock()
         defer { stateLock.unlock() }
         return _postgisOidMap
+    }
+
+    func setEnumOidMap(_ map: [UInt32: String]) {
+        stateLock.lock()
+        _enumOidMap = map
+        stateLock.unlock()
+    }
+
+    private func resolveTypeName(_ oid: UInt32) -> String {
+        stateLock.lock()
+        let mapped = _enumOidMap[oid]
+        stateLock.unlock()
+        return mapped ?? pgOidToTypeName(oid)
     }
 
     // MARK: - Query Cancellation
@@ -698,7 +732,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
                                 }
                                 let oid = UInt32(PQftype(result, Int32(i)))
                                 columnOids.append(oid)
-                                columnTypeNames.append(pgOidToTypeName(oid))
+                                columnTypeNames.append(resolveTypeName(oid))
                             }
 
                             continuation.yield(.header(PluginStreamHeader(
@@ -821,7 +855,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
             }
             let oid = UInt32(PQftype(result, Int32(i)))
             columnOids.append(oid)
-            columnTypeNames.append(pgOidToTypeName(oid))
+            columnTypeNames.append(resolveTypeName(oid))
         }
         return ColumnMetadata(columns: columns, columnOids: columnOids, columnTypeNames: columnTypeNames)
     }

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Columns.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Columns.swift
@@ -10,7 +10,7 @@ extension PostgreSQLPluginDriver {
     func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] {
         let safeSchema = escapeStringLiteral(schema ?? core.currentSchema)
         let safeTable = escapeStringLiteral(table)
-        let enumMap = try await fetchEnumLabelMap(schema: safeSchema)
+        let catalog = try await fetchTypeCatalog()
         let projections = columnProjections()
         let query = PostgreSQLSchemaQueries.columnsQuery(
             schemaLiteral: safeSchema,
@@ -21,13 +21,13 @@ extension PostgreSQLPluginDriver {
         )
         let result = try await execute(query: query)
         return result.rows.compactMap { row in
-            mapPgColumnRow(row, tableNameOffset: 0, enumLabelsByType: enumMap)
+            mapPgColumnRow(row, tableNameOffset: 0, catalog: catalog)
         }
     }
 
     func fetchAllColumns(schema: String?) async throws -> [String: [PluginColumnInfo]] {
         let safeSchema = escapeStringLiteral(schema ?? core.currentSchema)
-        let enumMap = try await fetchEnumLabelMap(schema: safeSchema)
+        let catalog = try await fetchTypeCatalog()
         let projections = columnProjections()
         let query = PostgreSQLSchemaQueries.columnsQuery(
             schemaLiteral: safeSchema,
@@ -40,7 +40,7 @@ extension PostgreSQLPluginDriver {
         var allColumns: [String: [PluginColumnInfo]] = [:]
         for row in result.rows {
             guard row.count >= 5, let tableName = row[0].asText else { continue }
-            if let column = mapPgColumnRow(row, tableNameOffset: 1, enumLabelsByType: enumMap) {
+            if let column = mapPgColumnRow(row, tableNameOffset: 1, catalog: catalog) {
                 allColumns[tableName, default: []].append(column)
             }
         }
@@ -60,29 +60,43 @@ extension PostgreSQLPluginDriver {
         return (identity, generated, attributeJoin)
     }
 
-    fileprivate func fetchEnumLabelMap(schema: String) async throws -> [String: [String]] {
-        let query = """
-            SELECT t.typname, e.enumlabel
-            FROM pg_catalog.pg_type t
-            JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
-            JOIN pg_catalog.pg_enum e ON e.enumtypid = t.oid
-            WHERE n.nspname = '\(schema)'
-            ORDER BY t.typname, e.enumsortorder
-            """
-        let result = try await execute(query: query)
+    fileprivate func fetchEnumLabelMap() async throws -> [String: [String]] {
+        let result = try await execute(query: PostgreSQLSchemaQueries.enumLabelQuery)
         var map: [String: [String]] = [:]
         for row in result.rows {
-            guard let typeName = row[safe: 0]?.asText,
-                  let label = row[safe: 1]?.asText else { continue }
-            map[typeName, default: []].append(label)
+            guard let schemaName = row[safe: 0]?.asText,
+                  let typeName = row[safe: 1]?.asText,
+                  let label = row[safe: 2]?.asText else { continue }
+            let key = PostgresColumnTypeResolver.qualifiedName(schema: schemaName, name: typeName)
+            map[key, default: []].append(label)
         }
         return map
+    }
+
+    fileprivate func fetchArrayTypeMap() async throws -> [String: PostgresArrayTypeInfo] {
+        let result = try await execute(query: PostgreSQLSchemaQueries.arrayTypeQuery)
+        var map: [String: PostgresArrayTypeInfo] = [:]
+        for row in result.rows {
+            guard let schemaName = row[safe: 0]?.asText,
+                  let arrayTypeName = row[safe: 1]?.asText,
+                  let elementTypeName = row[safe: 2]?.asText,
+                  let elementKind = row[safe: 3]?.asText?.first else { continue }
+            let key = PostgresColumnTypeResolver.qualifiedName(schema: schemaName, name: arrayTypeName)
+            map[key] = PostgresArrayTypeInfo(elementTypeName: elementTypeName, elementTypeKind: elementKind)
+        }
+        return map
+    }
+
+    fileprivate func fetchTypeCatalog() async throws -> PostgresTypeCatalog {
+        let enumLabels = try await fetchEnumLabelMap()
+        let arrayTypes = try await fetchArrayTypeMap()
+        return PostgresTypeCatalog(enumLabels: enumLabels, arrayTypes: arrayTypes)
     }
 
     fileprivate func mapPgColumnRow(
         _ row: [PluginCellValue],
         tableNameOffset: Int,
-        enumLabelsByType: [String: [String]]
+        catalog: PostgresTypeCatalog
     ) -> PluginColumnInfo? {
         let nameIdx = tableNameOffset
         let typeIdx = tableNameOffset + 1
@@ -94,6 +108,7 @@ extension PostgreSQLPluginDriver {
         let pkIdx = tableNameOffset + 7
         let identityIdx = tableNameOffset + 8
         let generatedIdx = tableNameOffset + 9
+        let udtSchemaIdx = tableNameOffset + 10
 
         guard row.count > typeIdx,
               let name = row[nameIdx].asText,
@@ -101,20 +116,16 @@ extension PostgreSQLPluginDriver {
         else { return nil }
 
         let udtName = row.count > udtIdx ? row[udtIdx].asText : nil
-        let allowedValues: [String]?
-        let dataType: String
-        if rawDataType.uppercased() == "USER-DEFINED", let udt = udtName {
-            if let labels = enumLabelsByType[udt] {
-                allowedValues = labels
-                dataType = "ENUM"
-            } else {
-                allowedValues = nil
-                dataType = "ENUM(\(udt))"
-            }
-        } else {
-            allowedValues = nil
-            dataType = rawDataType.uppercased()
-        }
+        let udtSchema = row.count > udtSchemaIdx ? row[udtSchemaIdx].asText : nil
+        let resolution = PostgresColumnTypeResolver.resolve(
+            rawDataType: rawDataType,
+            udtSchema: udtSchema,
+            udtName: udtName,
+            enumLabelsByQualifiedName: catalog.enumLabels,
+            arrayTypesByQualifiedName: catalog.arrayTypes
+        )
+        let allowedValues = resolution.allowedValues
+        let dataType = resolution.dataType
 
         let isNullable = row.count > nullableIdx && row[nullableIdx].asText == "YES"
         let defaultValue = row.count > defaultIdx ? row[defaultIdx].asText : nil

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+EnumTypes.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+EnumTypes.swift
@@ -1,0 +1,36 @@
+//
+//  PostgreSQLPluginDriver+EnumTypes.swift
+//  PostgreSQLDriver
+//
+
+import Foundation
+import OSLog
+import TableProPluginKit
+
+private let enumProbeLogger = Logger(
+    subsystem: "com.TablePro.PostgreSQLDriver",
+    category: "EnumTypeProbe"
+)
+
+extension PostgreSQLPluginDriver {
+    func probeEnumOids() async {
+        do {
+            let result = try await core.execute(query: PostgreSQLSchemaQueries.enumTypeOidQuery)
+            var map: [UInt32: String] = [:]
+            for row in result.rows {
+                guard row.count >= 3,
+                      let typeName = row[2].asText,
+                      let scalarOid = row[0].asText.flatMap({ UInt32($0) }) else { continue }
+                map[scalarOid] = "ENUM(\(typeName))"
+                if let arrayOid = row[1].asText.flatMap({ UInt32($0) }), arrayOid != 0 {
+                    map[arrayOid] = "ENUM[](\(typeName))"
+                }
+            }
+            core.setEnumOidMap(map)
+        } catch {
+            enumProbeLogger.debug(
+                "Enum OID probe failed; enum columns fall back to text for this session: \(error.localizedDescription)"
+            )
+        }
+    }
+}

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
@@ -51,6 +51,7 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
         core.onPostConnect = { [weak self] in
             await self?.probeCatalogPresence()
             await self?.probePostgisOids()
+            await self?.probeEnumOids()
         }
         try await core.connect()
     }

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLSchemaQueries.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLSchemaQueries.swift
@@ -195,6 +195,28 @@ enum PostgreSQLSchemaQueries {
     /// then current schema) before escaping and passing it here. The identity,
     /// generated, and attribute-join fragments come from the connected server's
     /// versioned capabilities.
+    static let enumTypeOidQuery = """
+        SELECT t.oid::text, t.typarray::text, t.typname
+        FROM pg_catalog.pg_type t
+        WHERE t.typtype = 'e'
+        """
+
+    static let enumLabelQuery = """
+        SELECT n.nspname, t.typname, e.enumlabel
+        FROM pg_catalog.pg_type t
+        JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+        JOIN pg_catalog.pg_enum e ON e.enumtypid = t.oid
+        ORDER BY n.nspname, t.typname, e.enumsortorder
+        """
+
+    static let arrayTypeQuery = """
+        SELECT n.nspname, arr.typname, el.typname, el.typtype
+        FROM pg_catalog.pg_type arr
+        JOIN pg_catalog.pg_type el ON el.oid = arr.typelem
+        JOIN pg_catalog.pg_namespace n ON n.oid = arr.typnamespace
+        WHERE arr.typelem <> 0 AND el.typarray = arr.oid
+        """
+
     static func columnsQuery(
         schemaLiteral: String,
         tableLiteral: String?,
@@ -214,7 +236,8 @@ enum PostgreSQLSchemaQueries {
                 c.udt_name,
                 CASE WHEN pk.column_name IS NOT NULL THEN 'YES' ELSE 'NO' END AS is_pk,
                 \(identityProjection),
-                \(generatedProjection)
+                \(generatedProjection),
+                c.udt_schema
             FROM information_schema.columns c
             LEFT JOIN pg_catalog.pg_statio_all_tables st
                 ON st.schemaname = c.table_schema

--- a/Plugins/TableProPluginKit/PostgresArrayLiteralCodec.swift
+++ b/Plugins/TableProPluginKit/PostgresArrayLiteralCodec.swift
@@ -1,0 +1,179 @@
+import Foundation
+
+public enum PostgresArrayElement: Hashable, Sendable {
+    case value(String)
+    case null
+}
+
+public enum PostgresArrayLiteralCodec {
+    public static let defaultDelimiter: Character = ","
+
+    public static func parse(_ text: String, delimiter: Character = defaultDelimiter) -> [PostgresArrayElement]? {
+        let characters = Array(text)
+        var index = 0
+        skipWhitespace(characters, &index)
+        guard index < characters.count, characters[index] == "{" else { return nil }
+        index += 1
+        skipWhitespace(characters, &index)
+
+        if index < characters.count, characters[index] == "}" {
+            index += 1
+            return isExhausted(characters, from: index) ? [] : nil
+        }
+
+        var elements: [PostgresArrayElement] = []
+        while true {
+            skipWhitespace(characters, &index)
+            guard index < characters.count, characters[index] != "{" else { return nil }
+            guard let element = parseElement(characters, &index, delimiter: delimiter) else { return nil }
+            elements.append(element)
+            skipWhitespace(characters, &index)
+            guard index < characters.count else { return nil }
+            if characters[index] == delimiter {
+                index += 1
+                continue
+            }
+            guard characters[index] == "}" else { return nil }
+            index += 1
+            break
+        }
+        return isExhausted(characters, from: index) ? elements : nil
+    }
+
+    public static func serialize(
+        _ elements: [PostgresArrayElement],
+        delimiter: Character = defaultDelimiter
+    ) -> String {
+        let body = elements
+            .map { serializeElement($0, delimiter: delimiter) }
+            .joined(separator: String(delimiter))
+        return "{\(body)}"
+    }
+
+    private static func isExhausted(_ characters: [Character], from index: Int) -> Bool {
+        var cursor = index
+        skipWhitespace(characters, &cursor)
+        return cursor == characters.count
+    }
+
+    private static func skipWhitespace(_ characters: [Character], _ index: inout Int) {
+        while index < characters.count, characters[index].isWhitespace {
+            index += 1
+        }
+    }
+
+    private static func parseElement(
+        _ characters: [Character],
+        _ index: inout Int,
+        delimiter: Character
+    ) -> PostgresArrayElement? {
+        if characters[index] == "\"" {
+            index += 1
+            return parseQuotedElement(characters, &index)
+        }
+        return parseUnquotedElement(characters, &index, delimiter: delimiter)
+    }
+
+    private static func parseQuotedElement(
+        _ characters: [Character],
+        _ index: inout Int
+    ) -> PostgresArrayElement? {
+        var value: [Character] = []
+        while index < characters.count {
+            let character = characters[index]
+            if character == "\\" {
+                guard index + 1 < characters.count else { return nil }
+                value.append(characters[index + 1])
+                index += 2
+                continue
+            }
+            if character == "\"" {
+                index += 1
+                return .value(String(value))
+            }
+            value.append(character)
+            index += 1
+        }
+        return nil
+    }
+
+    private static func parseUnquotedElement(
+        _ characters: [Character],
+        _ index: inout Int,
+        delimiter: Character
+    ) -> PostgresArrayElement? {
+        var value: [Character] = []
+        var significantCount = 0
+        var containsEscape = false
+        var startedContent = false
+
+        while index < characters.count {
+            let character = characters[index]
+            if character == "\\" {
+                guard index + 1 < characters.count else { return nil }
+                value.append(characters[index + 1])
+                containsEscape = true
+                startedContent = true
+                index += 2
+                significantCount = value.count
+                continue
+            }
+            if character == delimiter || character == "}" {
+                break
+            }
+            guard character != "{", character != "\"" else { return nil }
+            if !startedContent, character.isWhitespace {
+                index += 1
+                continue
+            }
+            startedContent = true
+            value.append(character)
+            index += 1
+            if !character.isWhitespace {
+                significantCount = value.count
+            }
+        }
+
+        guard startedContent else { return nil }
+        let text = String(value.prefix(significantCount))
+        if !containsEscape, isUnquotedNullKeyword(text) {
+            return .null
+        }
+        return .value(text)
+    }
+
+    private static func isUnquotedNullKeyword(_ text: String) -> Bool {
+        text.count == 4 && text.lowercased() == "null"
+    }
+
+    private static func serializeElement(_ element: PostgresArrayElement, delimiter: Character) -> String {
+        switch element {
+        case .null:
+            return "NULL"
+        case .value(let value):
+            guard needsQuoting(value, delimiter: delimiter) else { return value }
+            var quoted: [Character] = ["\""]
+            for character in value {
+                if character == "\\" || character == "\"" {
+                    quoted.append("\\")
+                }
+                quoted.append(character)
+            }
+            quoted.append("\"")
+            return String(quoted)
+        }
+    }
+
+    private static func needsQuoting(_ value: String, delimiter: Character) -> Bool {
+        if value.isEmpty { return true }
+        if isUnquotedNullKeyword(value) { return true }
+        return value.contains { character in
+            character == delimiter
+                || character == "\""
+                || character == "\\"
+                || character == "{"
+                || character == "}"
+                || character.isWhitespace
+        }
+    }
+}

--- a/Plugins/TableProPluginKit/PostgresColumnTypeResolver.swift
+++ b/Plugins/TableProPluginKit/PostgresColumnTypeResolver.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+public struct PostgresArrayTypeInfo: Equatable, Sendable {
+    public let elementTypeName: String
+    public let elementTypeKind: Character
+
+    public init(elementTypeName: String, elementTypeKind: Character) {
+        self.elementTypeName = elementTypeName
+        self.elementTypeKind = elementTypeKind
+    }
+
+    public var elementIsEnum: Bool { elementTypeKind == "e" }
+    public var elementIsBaseType: Bool { elementTypeKind == "b" }
+}
+
+public struct PostgresTypeCatalog: Equatable, Sendable {
+    public let enumLabels: [String: [String]]
+    public let arrayTypes: [String: PostgresArrayTypeInfo]
+
+    public init(enumLabels: [String: [String]], arrayTypes: [String: PostgresArrayTypeInfo]) {
+        self.enumLabels = enumLabels
+        self.arrayTypes = arrayTypes
+    }
+}
+
+public enum PostgresColumnTypeResolver {
+    public struct Resolution: Equatable, Sendable {
+        public let dataType: String
+        public let allowedValues: [String]?
+
+        public init(dataType: String, allowedValues: [String]?) {
+            self.dataType = dataType
+            self.allowedValues = allowedValues
+        }
+    }
+
+    public static func qualifiedName(schema: String?, name: String) -> String {
+        guard let schema, !schema.isEmpty else { return name }
+        return "\(schema).\(name)"
+    }
+
+    public static func resolve(
+        rawDataType: String,
+        udtSchema: String?,
+        udtName: String?,
+        enumLabelsByQualifiedName: [String: [String]],
+        arrayTypesByQualifiedName: [String: PostgresArrayTypeInfo]
+    ) -> Resolution {
+        let upper = rawDataType.uppercased()
+        guard let udtName, !udtName.isEmpty else {
+            return Resolution(dataType: upper, allowedValues: nil)
+        }
+        let key = qualifiedName(schema: udtSchema, name: udtName)
+
+        if upper == "USER-DEFINED" {
+            guard let labels = enumLabelsByQualifiedName[key] else {
+                return Resolution(dataType: "ENUM(\(udtName))", allowedValues: nil)
+            }
+            return Resolution(dataType: "ENUM", allowedValues: labels)
+        }
+
+        guard upper == "ARRAY", let arrayType = arrayTypesByQualifiedName[key] else {
+            return Resolution(dataType: upper, allowedValues: nil)
+        }
+
+        if arrayType.elementIsEnum {
+            let elementKey = qualifiedName(schema: udtSchema, name: arrayType.elementTypeName)
+            guard let labels = enumLabelsByQualifiedName[elementKey] else {
+                return Resolution(dataType: "ENUM[](\(arrayType.elementTypeName))", allowedValues: nil)
+            }
+            return Resolution(dataType: "ENUM[]", allowedValues: labels)
+        }
+
+        guard arrayType.elementIsBaseType else {
+            return Resolution(dataType: upper, allowedValues: nil)
+        }
+        return Resolution(dataType: "\(arrayType.elementTypeName)[]", allowedValues: nil)
+    }
+}

--- a/TablePro/Core/Services/ColumnType+PluginColumnKind.swift
+++ b/TablePro/Core/Services/ColumnType+PluginColumnKind.swift
@@ -9,7 +9,7 @@ import TableProPluginKit
 extension ColumnType {
     var pluginColumnKind: PluginColumnKind {
         switch self {
-        case .text, .enumType, .set:
+        case .text, .enumType, .set, .array:
             return .text
         case .integer:
             return .integer

--- a/TablePro/Core/Services/ColumnType.swift
+++ b/TablePro/Core/Services/ColumnType.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Represents the semantic type of a database column
-enum ColumnType: Equatable {
+enum ColumnType: Equatable, Sendable {
     case text(rawType: String?)
     case integer(rawType: String?)
     case decimal(rawType: String?)
@@ -22,6 +22,7 @@ enum ColumnType: Equatable {
     case enumType(rawType: String?, values: [String]?)
     case set(rawType: String?, values: [String]?)
     case spatial(rawType: String?)
+    indirect case array(rawType: String?, element: ColumnType)
 
     /// Raw database type name (e.g., "LONGTEXT", "VARCHAR(255)", "CLOB")
     var rawType: String? {
@@ -29,7 +30,7 @@ enum ColumnType: Equatable {
         case .text(let raw), .integer(let raw), .decimal(let raw),
              .date(let raw), .timestamp(let raw), .datetime(let raw),
              .boolean(let raw), .blob(let raw), .json(let raw),
-             .spatial(let raw):
+             .spatial(let raw), .array(let raw, _):
             return raw
         case .enumType(let raw, _), .set(let raw, _):
             return raw
@@ -53,6 +54,7 @@ enum ColumnType: Equatable {
         case .enumType: return "Enum"
         case .set: return "Set"
         case .spatial: return "Spatial"
+        case .array(_, let element): return "\(element.displayName) Array"
         }
     }
 
@@ -146,6 +148,25 @@ enum ColumnType: Equatable {
         }
     }
 
+    /// The element type of an array column, if this is one
+    var arrayElement: ColumnType? {
+        switch self {
+        case .array(_, let element): return element
+        default: return nil
+        }
+    }
+
+    /// Whether this array's elements can be edited one at a time
+    var supportsElementEditing: Bool {
+        guard let element = arrayElement else { return false }
+        switch element {
+        case .text, .integer, .decimal, .date, .timestamp, .datetime, .boolean, .enumType, .set:
+            return true
+        case .json, .blob, .spatial, .array:
+            return false
+        }
+    }
+
     /// Compact lowercase badge label for sidebar
     var badgeLabel: String {
         switch self {
@@ -162,6 +183,7 @@ enum ColumnType: Equatable {
         case .text(let rawType):
             return rawType == "RedisRaw" ? "raw" : "string"
         case .spatial: return "spatial"
+        case .array(_, let element): return "\(element.badgeLabel)[]"
         }
     }
 
@@ -170,6 +192,8 @@ enum ColumnType: Equatable {
         switch self {
         case .enumType(_, let values), .set(_, let values):
             return values
+        case .array(_, let element):
+            return element.enumValues
         default:
             return nil
         }

--- a/TablePro/Core/Services/ColumnTypeClassifier.swift
+++ b/TablePro/Core/Services/ColumnTypeClassifier.swift
@@ -13,6 +13,14 @@ struct ColumnTypeClassifier {
     func classify(rawTypeName: String) -> ColumnType {
         let stripped = stripWrappers(rawTypeName)
         let (base, params) = extractBaseAndParams(stripped)
+
+        if base.hasSuffix("[]") {
+            let elementBase = String(base.dropLast(2))
+            guard !elementBase.isEmpty else { return .text(rawType: rawTypeName) }
+            let elementRaw = params.map { "\(elementBase)(\($0))" } ?? elementBase
+            return .array(rawType: rawTypeName, element: classify(rawTypeName: elementRaw))
+        }
+
         let upper = base.uppercased()
 
         // MySQL convention: TINYINT(1) means boolean

--- a/TablePro/Core/Utilities/SQL/ColumnTypeSQLQuoting.swift
+++ b/TablePro/Core/Utilities/SQL/ColumnTypeSQLQuoting.swift
@@ -20,7 +20,7 @@ internal enum ColumnTypeSQLQuoting {
             return RowValueCopyFormatter.isIntegerLiteral(value)
         case .decimal:
             return PluginNumericLiteral.isValid(value)
-        case .text, .date, .timestamp, .datetime, .boolean, .blob, .json, .enumType, .set, .spatial:
+        case .text, .date, .timestamp, .datetime, .boolean, .blob, .json, .enumType, .set, .spatial, .array:
             return false
         }
     }
@@ -28,7 +28,7 @@ internal enum ColumnTypeSQLQuoting {
     static func isKnownTextLike(_ type: ColumnType?) -> Bool {
         guard let type else { return false }
         switch type {
-        case .text, .enumType, .set:
+        case .text, .enumType, .set, .array:
             return true
         case .integer, .decimal, .date, .timestamp, .datetime, .boolean, .blob, .json, .spatial:
             return false

--- a/TablePro/Core/Utilities/SQL/JsonRowConverter.swift
+++ b/TablePro/Core/Utilities/SQL/JsonRowConverter.swift
@@ -91,7 +91,7 @@ internal struct JsonRowConverter {
             return formatBoolean(value)
         case .json:
             return formatJson(value)
-        case .blob, .text, .date, .timestamp, .datetime, .enumType, .set, .spatial:
+        case .blob, .text, .date, .timestamp, .datetime, .enumType, .set, .spatial, .array:
             return quotedEscaped(value)
         }
     }

--- a/TablePro/Views/Components/PopoverPresenter.swift
+++ b/TablePro/Views/Components/PopoverPresenter.swift
@@ -18,13 +18,14 @@ enum PopoverPresenter {
         of view: NSView,
         preferredEdge: NSRectEdge = .maxY,
         contentSize: NSSize? = nil,
+        behavior: NSPopover.Behavior = .semitransient,
         @ViewBuilder content: (_ dismiss: @escaping () -> Void) -> Content
     ) -> NSPopover {
         let popover = NSPopover()
         let dismiss: () -> Void = { [weak popover] in popover?.close() }
         let hostingController = NSHostingController(rootView: content(dismiss))
         popover.contentViewController = hostingController
-        popover.behavior = .semitransient
+        popover.behavior = behavior
         if let size = contentSize {
             popover.contentSize = size
         }

--- a/TablePro/Views/Results/ArrayValueEditorModel.swift
+++ b/TablePro/Views/Results/ArrayValueEditorModel.swift
@@ -1,0 +1,66 @@
+//
+//  ArrayValueEditorModel.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+struct ArrayEditorRow: Identifiable, Equatable {
+    let id: UUID
+    var element: PostgresArrayElement
+
+    init(id: UUID = UUID(), element: PostgresArrayElement) {
+        self.id = id
+        self.element = element
+    }
+}
+
+enum ArrayValueEditorModel {
+    static func rows(from elements: [PostgresArrayElement]) -> [ArrayEditorRow] {
+        elements.map { ArrayEditorRow(element: $0) }
+    }
+
+    static func literal(from rows: [ArrayEditorRow], delimiter: Character) -> String {
+        PostgresArrayLiteralCodec.serialize(rows.map(\.element), delimiter: delimiter)
+    }
+
+    static func pickerOptions(for element: PostgresArrayElement, allowedValues: [String]) -> [String] {
+        guard case .value(let value) = element, !allowedValues.contains(value) else {
+            return allowedValues
+        }
+        return allowedValues + [value]
+    }
+
+    static func selectionIndex(for element: PostgresArrayElement, in options: [String]) -> Int {
+        guard case .value(let value) = element else { return options.count }
+        return options.firstIndex(of: value) ?? options.count
+    }
+
+    static func element(atSelectionIndex index: Int, in options: [String]) -> PostgresArrayElement {
+        guard options.indices.contains(index) else { return .null }
+        return .value(options[index])
+    }
+
+    static func moved(_ rows: [ArrayEditorRow], from index: Int, by offset: Int) -> [ArrayEditorRow] {
+        let target = index + offset
+        guard rows.indices.contains(index), rows.indices.contains(target) else { return rows }
+        var updated = rows
+        updated.swapAt(index, target)
+        return updated
+    }
+
+    static func moved(_ rows: [ArrayEditorRow], id: UUID, by offset: Int) -> [ArrayEditorRow] {
+        guard let index = rows.firstIndex(where: { $0.id == id }) else { return rows }
+        return moved(rows, from: index, by: offset)
+    }
+
+    static func removing(_ rows: [ArrayEditorRow], id: UUID) -> [ArrayEditorRow] {
+        rows.filter { $0.id != id }
+    }
+
+    static func isDriftedValue(_ element: PostgresArrayElement, allowedValues: [String]) -> Bool {
+        guard !allowedValues.isEmpty, case .value(let value) = element else { return false }
+        return !allowedValues.contains(value)
+    }
+}

--- a/TablePro/Views/Results/ArrayValueEditorView.swift
+++ b/TablePro/Views/Results/ArrayValueEditorView.swift
@@ -1,0 +1,281 @@
+//
+//  ArrayValueEditorView.swift
+//  TablePro
+//
+//  Ordered per-element editor for PostgreSQL array columns.
+//
+
+import SwiftUI
+import TableProPluginKit
+
+struct ArrayValueEditorView: View {
+    let allowedValues: [String]
+    let isNullable: Bool
+    let delimiter: Character
+    let onCommit: (String?) -> Void
+    let onDismiss: () -> Void
+
+    @State private var rows: [ArrayEditorRow]
+    @State private var isNull: Bool
+    @State private var isEditingRawText: Bool
+    @State private var rawText: String
+
+    init(
+        initialElements: [PostgresArrayElement]?,
+        allowedValues: [String],
+        isNullable: Bool,
+        delimiter: Character = PostgresArrayLiteralCodec.defaultDelimiter,
+        onCommit: @escaping (String?) -> Void,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.allowedValues = allowedValues
+        self.isNullable = isNullable
+        self.delimiter = delimiter
+        self.onCommit = onCommit
+        self.onDismiss = onDismiss
+        let elements = initialElements ?? []
+        _rows = State(initialValue: ArrayValueEditorModel.rows(from: elements))
+        _isNull = State(initialValue: initialElements == nil)
+        _isEditingRawText = State(initialValue: false)
+        _rawText = State(initialValue: PostgresArrayLiteralCodec.serialize(elements, delimiter: delimiter))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            if isEditingRawText {
+                rawTextEditor
+            } else {
+                elementList
+            }
+            Divider()
+            footer
+        }
+        .frame(width: 320)
+        .frame(maxHeight: 420)
+        .fixedSize(horizontal: false, vertical: true)
+        .onExitCommand(perform: onDismiss)
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            if isNullable {
+                Toggle("NULL", isOn: $isNull)
+                    .toggleStyle(.checkbox)
+            }
+            Text(elementCountLabel)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Button(isEditingRawText ? "Edit as List" : "Edit as Text") {
+                toggleRawTextEditing()
+            }
+            .buttonStyle(.link)
+            .font(.caption)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private var elementList: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(rows) { row in
+                    elementRow(for: row)
+                }
+                if rows.isEmpty {
+                    Text("Empty array")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .padding(.vertical, 4)
+                }
+            }
+            .padding(12)
+        }
+        .disabled(isNull)
+        .opacity(isNull ? 0.4 : 1)
+    }
+
+    @ViewBuilder
+    private func elementRow(for row: ArrayEditorRow) -> some View {
+        HStack(spacing: 6) {
+            if allowedValues.isEmpty {
+                scalarField(for: row)
+            } else {
+                labelPicker(for: row)
+            }
+            reorderButtons(for: row)
+            Button {
+                rows = ArrayValueEditorModel.removing(rows, id: row.id)
+            } label: {
+                Image(systemName: "minus.circle")
+            }
+            .buttonStyle(.borderless)
+            .help(Text("Remove Element"))
+        }
+    }
+
+    @ViewBuilder
+    private func scalarField(for row: ArrayEditorRow) -> some View {
+        let element = binding(for: row.id)
+        TextField(
+            "",
+            text: Binding(
+                get: {
+                    guard case .value(let value) = element.wrappedValue else { return "" }
+                    return value
+                },
+                set: { element.wrappedValue = .value($0) }
+            )
+        )
+        .textFieldStyle(.roundedBorder)
+        .font(.system(.callout, design: .monospaced))
+        .disabled(element.wrappedValue == .null)
+        Toggle("NULL", isOn: Binding(
+            get: { element.wrappedValue == .null },
+            set: { element.wrappedValue = $0 ? .null : .value("") }
+        ))
+        .toggleStyle(.checkbox)
+        .font(.caption)
+    }
+
+    @ViewBuilder
+    private func labelPicker(for row: ArrayEditorRow) -> some View {
+        let element = binding(for: row.id)
+        let options = ArrayValueEditorModel.pickerOptions(for: row.element, allowedValues: allowedValues)
+        Picker(
+            "",
+            selection: Binding(
+                get: { ArrayValueEditorModel.selectionIndex(for: element.wrappedValue, in: options) },
+                set: { element.wrappedValue = ArrayValueEditorModel.element(atSelectionIndex: $0, in: options) }
+            )
+        ) {
+            ForEach(Array(options.enumerated()), id: \.offset) { optionIndex, option in
+                Text(option)
+                    .font(.system(.callout, design: .monospaced))
+                    .tag(optionIndex)
+            }
+            Text("NULL").italic().tag(options.count)
+        }
+        .labelsHidden()
+        .pickerStyle(.menu)
+        if ArrayValueEditorModel.isDriftedValue(row.element, allowedValues: allowedValues) {
+            Image(systemName: "exclamationmark.triangle")
+                .foregroundStyle(.orange)
+                .help(Text("This value is not one of the type's current labels"))
+        }
+    }
+
+    private func reorderButtons(for row: ArrayEditorRow) -> some View {
+        HStack(spacing: 2) {
+            Button {
+                rows = ArrayValueEditorModel.moved(rows, id: row.id, by: -1)
+            } label: {
+                Image(systemName: "chevron.up")
+            }
+            .buttonStyle(.borderless)
+            .disabled(rows.first?.id == row.id)
+            .help(Text("Move Up"))
+
+            Button {
+                rows = ArrayValueEditorModel.moved(rows, id: row.id, by: 1)
+            } label: {
+                Image(systemName: "chevron.down")
+            }
+            .buttonStyle(.borderless)
+            .disabled(rows.last?.id == row.id)
+            .help(Text("Move Down"))
+        }
+    }
+
+    private func binding(for id: UUID) -> Binding<PostgresArrayElement> {
+        Binding(
+            get: { rows.first(where: { $0.id == id })?.element ?? .null },
+            set: { newValue in
+                guard let index = rows.firstIndex(where: { $0.id == id }) else { return }
+                rows[index].element = newValue
+            }
+        )
+    }
+
+    private var rawTextEditor: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            TextEditor(text: $rawText)
+                .font(.system(.callout, design: .monospaced))
+                .frame(minHeight: 90)
+            if PostgresArrayLiteralCodec.parse(rawText, delimiter: delimiter) == nil {
+                Label {
+                    Text("This is not a value the list editor can read back.")
+                } icon: {
+                    Image(systemName: "exclamationmark.triangle")
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+        }
+        .padding(12)
+        .disabled(isNull)
+        .opacity(isNull ? 0.4 : 1)
+    }
+
+    private var footer: some View {
+        HStack {
+            if !isEditingRawText {
+                Button {
+                    rows.append(ArrayEditorRow(element: defaultNewElement))
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .buttonStyle(.borderless)
+                .disabled(isNull)
+                .help(Text("Add Element"))
+            }
+            Spacer()
+            Button("Cancel") { onDismiss() }
+                .keyboardShortcut(.cancelAction)
+            Button("OK") { commitAndDismiss() }
+                .keyboardShortcut(.defaultAction)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private var defaultNewElement: PostgresArrayElement {
+        guard let first = allowedValues.first else { return .value("") }
+        return .value(first)
+    }
+
+    private var elementCountLabel: String {
+        guard !isNull else { return String(localized: "NULL") }
+        let count = isEditingRawText
+            ? (PostgresArrayLiteralCodec.parse(rawText, delimiter: delimiter)?.count ?? rows.count)
+            : rows.count
+        guard count > 0 else { return String(localized: "Empty array") }
+        return String(format: String(localized: "%d elements"), count)
+    }
+
+    private func toggleRawTextEditing() {
+        if isEditingRawText {
+            guard let parsed = PostgresArrayLiteralCodec.parse(rawText, delimiter: delimiter) else { return }
+            rows = ArrayValueEditorModel.rows(from: parsed)
+            isEditingRawText = false
+            return
+        }
+        rawText = ArrayValueEditorModel.literal(from: rows, delimiter: delimiter)
+        isEditingRawText = true
+    }
+
+    private func commitAndDismiss() {
+        guard !isNull else {
+            onCommit(nil)
+            onDismiss()
+            return
+        }
+        let value = isEditingRawText
+            ? rawText
+            : ArrayValueEditorModel.literal(from: rows, delimiter: delimiter)
+        onCommit(value)
+        onDismiss()
+    }
+}

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -31,6 +31,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     private let displayCache = RowDisplayCache()
     weak var delegate: (any DataGridViewDelegate)?
     weak var activeFKPreviewPopover: NSPopover?
+    weak var activeArrayEditorPopover: NSPopover?
     weak var activeValueFilterPopover: NSPopover?
     var activeFKPreviewModel: FKPreviewModel?
     var activeFKPreviewColumnIndex: Int?
@@ -306,6 +307,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         activeFKPreviewPopover?.close()
         activeValueFilterPopover?.close()
         activeValueFilterPopover = nil
+        dismissActiveArrayEditorPopover()
         clearFKPreviewState()
     }
 
@@ -783,9 +785,13 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
 
         for i in 0..<columns.count {
             let name = columns[i]
-            if let values = enumValues[name], !values.isEmpty {
-                let ct = i < types.count ? types[i] : nil
-                let isExcluded = ct?.isJsonType == true || ct?.isBlobType == true || ct?.isBooleanType == true
+            let columnType = i < types.count ? types[i] : nil
+            if columnType?.supportsElementEditing == true {
+                enumSet.insert(i)
+            } else if let values = enumValues[name], !values.isEmpty {
+                let isExcluded = columnType?.isJsonType == true
+                    || columnType?.isBlobType == true
+                    || columnType?.isBooleanType == true
                 if !isExcluded {
                     enumSet.insert(i)
                 }

--- a/TablePro/Views/Results/Extensions/DataGridView+Click.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Click.swift
@@ -86,6 +86,8 @@ extension TableViewCoordinator {
 
         if columnType.isBooleanType {
             showDropdownMenu(tableView: tableView, row: row, column: column, columnIndex: columnIndex)
+        } else if columnType.supportsElementEditing {
+            showArrayEditorPopover(tableView: tableView, row: row, column: column, columnIndex: columnIndex)
         } else if let values = tableRows.columnEnumValues[columnName], !values.isEmpty {
             if columnType.isSetType {
                 showSetPopover(tableView: tableView, row: row, column: column, columnIndex: columnIndex)

--- a/TablePro/Views/Results/Extensions/DataGridView+Popovers.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Popovers.swift
@@ -245,6 +245,54 @@ extension TableViewCoordinator {
         }
     }
 
+    func showArrayEditorPopover(tableView: NSTableView, row: Int, column: Int, columnIndex: Int) {
+        guard tableView.view(atColumn: column, row: row, makeIfNecessary: false) != nil else { return }
+        let tableRows = tableRowsProvider()
+        guard columnIndex >= 0, columnIndex < tableRows.columns.count else { return }
+        let columnName = tableRows.columns[columnIndex]
+
+        let typedValue = cellTypedValue(at: row, column: columnIndex)
+        let elements: [PostgresArrayElement]?
+        if typedValue.isNull {
+            elements = nil
+        } else {
+            guard let parsed = PostgresArrayLiteralCodec.parse(typedValue.asText ?? "") else {
+                beginCellEdit(row: row, tableColumnIndex: column)
+                return
+            }
+            elements = parsed
+        }
+
+        let allowedValues = tableRows.columnEnumValues[columnName] ?? []
+        let isNullable = tableRows.columnNullable[columnName] ?? true
+        let cellRect = tableView.rect(ofRow: row).intersection(tableView.rect(ofColumn: column))
+
+        activeArrayEditorPopover = PopoverPresenter.show(
+            relativeTo: cellRect,
+            of: tableView,
+            behavior: .applicationDefined
+        ) { [weak self] dismiss in
+            ArrayValueEditorView(
+                initialElements: elements,
+                allowedValues: allowedValues,
+                isNullable: isNullable,
+                onCommit: { newValue in
+                    self?.commitPopoverEdit(row: row, columnIndex: columnIndex, newValue: newValue)
+                },
+                onDismiss: {
+                    dismiss()
+                    self?.activeArrayEditorPopover = nil
+                }
+            )
+        }
+    }
+
+    func dismissActiveArrayEditorPopover() {
+        guard let popover = activeArrayEditorPopover else { return }
+        activeArrayEditorPopover = nil
+        popover.close()
+    }
+
     func showDropdownMenu(tableView: NSTableView, row: Int, column: Int, columnIndex: Int) {
         guard tableView.view(atColumn: column, row: row, makeIfNecessary: false) != nil else { return }
         let tableRows = tableRowsProvider()

--- a/TableProTests/Core/Services/ColumnTypeClassifierTests.swift
+++ b/TableProTests/Core/Services/ColumnTypeClassifierTests.swift
@@ -932,4 +932,62 @@ struct ColumnTypeClassifierTests {
             #expect(isText(classifier.classify(rawTypeName: "varchar(255)")))
         }
     }
+
+    @Suite("Array Types")
+    struct ArrayTypes {
+        private let classifier = ColumnTypeClassifier()
+
+        private func element(_ rawTypeName: String) -> ColumnType? {
+            classifier.classify(rawTypeName: rawTypeName).arrayElement
+        }
+
+        @Test("A bracket suffix classifies the element type")
+        func classifiesElementType() {
+            #expect(element("text[]") == .text(rawType: "text"))
+            #expect(element("integer[]") == .integer(rawType: "integer"))
+            #expect(element("numeric[]") == .decimal(rawType: "numeric"))
+            #expect(element("boolean[]") == .boolean(rawType: "boolean"))
+            #expect(element("timestamptz[]") == .timestamp(rawType: "timestamptz"))
+            #expect(element("uuid[]") == .text(rawType: "uuid"))
+        }
+
+        @Test("An enum array keeps the element's enum classification")
+        func classifiesEnumArray() {
+            #expect(element("ENUM[]")?.isEnumType == true)
+            #expect(element("ENUM[](mood)")?.isEnumType == true)
+        }
+
+        @Test("The raw type name survives classification")
+        func preservesRawTypeName() {
+            #expect(classifier.classify(rawTypeName: "ENUM[](mood)").rawType == "ENUM[](mood)")
+            #expect(classifier.classify(rawTypeName: "text[]").rawType == "text[]")
+        }
+
+        @Test("Element editing is offered for scalar elements only")
+        func gatesElementEditing() {
+            #expect(classifier.classify(rawTypeName: "ENUM[]").supportsElementEditing)
+            #expect(classifier.classify(rawTypeName: "text[]").supportsElementEditing)
+            #expect(classifier.classify(rawTypeName: "integer[]").supportsElementEditing)
+            #expect(!classifier.classify(rawTypeName: "jsonb[]").supportsElementEditing)
+            #expect(!classifier.classify(rawTypeName: "bytea[]").supportsElementEditing)
+            #expect(!classifier.classify(rawTypeName: "text").supportsElementEditing)
+        }
+
+        @Test("Array badges and display names name the element")
+        func describesElement() {
+            #expect(classifier.classify(rawTypeName: "text[]").badgeLabel == "string[]")
+            #expect(classifier.classify(rawTypeName: "ENUM[]").badgeLabel == "enum[]")
+            #expect(classifier.classify(rawTypeName: "text[]").displayName == "Text Array")
+        }
+
+        @Test("Types that are not bracket arrays keep their existing classification")
+        func leavesOtherTypesAlone() {
+            #expect(classifier.classify(rawTypeName: "ARRAY").isJsonType)
+            #expect(classifier.classify(rawTypeName: "Array(String)").isJsonType)
+            #expect(classifier.classify(rawTypeName: "ENUM").isEnumType)
+            #expect(classifier.classify(rawTypeName: "ENUM(mood)").isEnumType)
+            #expect(classifier.classify(rawTypeName: "SET('a','b')").isSetType)
+            #expect(classifier.classify(rawTypeName: "[]").arrayElement == nil)
+        }
+    }
 }

--- a/TableProTests/Plugins/PostgresArrayLiteralCodecTests.swift
+++ b/TableProTests/Plugins/PostgresArrayLiteralCodecTests.swift
@@ -1,0 +1,123 @@
+//
+//  PostgresArrayLiteralCodecTests.swift
+//  TableProTests
+//
+//  Tests for parsing and serializing PostgreSQL array literals.
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@Suite("Postgres Array Literal Codec")
+struct PostgresArrayLiteralCodecTests {
+    private let hostileLiteral =
+        #"{"a,b","has \"quote\"","back\\slash"," lead","trail ","","NULL","null","{brace}",NULL}"#
+
+    private var hostileElements: [PostgresArrayElement] {
+        [
+            .value("a,b"),
+            .value("has \"quote\""),
+            .value("back\\slash"),
+            .value(" lead"),
+            .value("trail "),
+            .value(""),
+            .value("NULL"),
+            .value("null"),
+            .value("{brace}"),
+            .null
+        ]
+    }
+
+    @Test("Parses every hostile element form PostgreSQL emits")
+    func parsesHostileLiteral() throws {
+        let parsed = try #require(PostgresArrayLiteralCodec.parse(hostileLiteral))
+        #expect(parsed == hostileElements)
+    }
+
+    @Test("Serializes back to the exact literal PostgreSQL produced")
+    func serializesHostileLiteral() {
+        #expect(PostgresArrayLiteralCodec.serialize(hostileElements) == hostileLiteral)
+    }
+
+    @Test("Round-trips without drift")
+    func roundTripsHostileLiteral() throws {
+        let parsed = try #require(PostgresArrayLiteralCodec.parse(hostileLiteral))
+        let serialized = PostgresArrayLiteralCodec.serialize(parsed)
+        let reparsed = try #require(PostgresArrayLiteralCodec.parse(serialized))
+        #expect(reparsed == hostileElements)
+    }
+
+    @Test("Empty array is distinct from a null element")
+    func parsesEmptyArray() {
+        #expect(PostgresArrayLiteralCodec.parse("{}")?.isEmpty == true)
+        #expect(PostgresArrayLiteralCodec.parse("{ }")?.isEmpty == true)
+        #expect(PostgresArrayLiteralCodec.parse("{NULL}") == [.null])
+        #expect(PostgresArrayLiteralCodec.serialize([]) == "{}")
+    }
+
+    @Test("Bare NULL is SQL NULL in any case, quoted NULL is the four-character string")
+    func distinguishesNullForms() {
+        #expect(PostgresArrayLiteralCodec.parse("{NULL}") == [.null])
+        #expect(PostgresArrayLiteralCodec.parse("{null}") == [.null])
+        #expect(PostgresArrayLiteralCodec.parse("{NuLl}") == [.null])
+        #expect(PostgresArrayLiteralCodec.parse(#"{"NULL"}"#) == [.value("NULL")])
+        #expect(PostgresArrayLiteralCodec.parse(#"{\N\U\L\L}"#) == [.value("NULL")])
+    }
+
+    @Test("Unquoted whitespace is trimmed, quoted whitespace is kept")
+    func handlesWhitespace() {
+        #expect(PostgresArrayLiteralCodec.parse("{  a ,  b  }") == [.value("a"), .value("b")])
+        #expect(PostgresArrayLiteralCodec.parse(#"{ "  a  " }"#) == [.value("  a  ")])
+        #expect(PostgresArrayLiteralCodec.parse(#"{\ }"#) == [.value(" ")])
+    }
+
+    @Test("Backslash escaping is accepted as an alternative to quoting")
+    func acceptsBackslashEscaping() {
+        #expect(PostgresArrayLiteralCodec.parse(#"{a\,b," x "}"#) == [.value("a,b"), .value(" x ")])
+    }
+
+    @Test("Order and duplicate elements survive a round trip")
+    func preservesOrderAndDuplicates() {
+        let elements: [PostgresArrayElement] = [.value("b"), .value("a"), .value("b")]
+        let serialized = PostgresArrayLiteralCodec.serialize(elements)
+        #expect(serialized == "{b,a,b}")
+        #expect(PostgresArrayLiteralCodec.parse(serialized) == elements)
+    }
+
+    @Test("Shapes the element editor cannot represent are rejected")
+    func rejectsUnsupportedShapes() {
+        #expect(PostgresArrayLiteralCodec.parse("[0:2]={a,b,c}") == nil)
+        #expect(PostgresArrayLiteralCodec.parse("{{1,2},{3,4}}") == nil)
+    }
+
+    @Test("Malformed literals are rejected rather than silently accepted")
+    func rejectsMalformedLiterals() {
+        #expect(PostgresArrayLiteralCodec.parse("{,}") == nil)
+        #expect(PostgresArrayLiteralCodec.parse("{a,  ,b}") == nil)
+        #expect(PostgresArrayLiteralCodec.parse("{a, }") == nil)
+        #expect(PostgresArrayLiteralCodec.parse("{a,b") == nil)
+        #expect(PostgresArrayLiteralCodec.parse("{a,b} trailing") == nil)
+        #expect(PostgresArrayLiteralCodec.parse("hello") == nil)
+        #expect(PostgresArrayLiteralCodec.parse("") == nil)
+    }
+
+    @Test("An empty string element must stay quoted")
+    func keepsEmptyStringElementQuoted() {
+        #expect(PostgresArrayLiteralCodec.parse(#"{""}"#) == [.value("")])
+        #expect(PostgresArrayLiteralCodec.serialize([.value("")]) == #"{""}"#)
+    }
+
+    @Test("The delimiter comes from the element type, not a hardcoded comma")
+    func honoursElementDelimiter() {
+        let boxes = "{(1,1),(0,0);(3,3),(2,2)}"
+        let parsed = PostgresArrayLiteralCodec.parse(boxes, delimiter: ";")
+        #expect(parsed == [.value("(1,1),(0,0)"), .value("(3,3),(2,2)")])
+    }
+
+    @Test("A value needing quotes under one delimiter may not need them under another")
+    func quotesAccordingToDelimiter() {
+        #expect(PostgresArrayLiteralCodec.serialize([.value("a,b")], delimiter: ";") == "{a,b}")
+        #expect(PostgresArrayLiteralCodec.serialize([.value("a,b")]) == #"{"a,b"}"#)
+    }
+}

--- a/TableProTests/Plugins/PostgresColumnTypeResolverTests.swift
+++ b/TableProTests/Plugins/PostgresColumnTypeResolverTests.swift
@@ -1,0 +1,97 @@
+//
+//  PostgresColumnTypeResolverTests.swift
+//  TableProTests
+//
+//  Tests for resolving PostgreSQL column types to enum and array metadata.
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@Suite("Postgres Column Type Resolver")
+struct PostgresColumnTypeResolverTests {
+    private let enumLabels = [
+        "app.mood": ["sad", "ok", "happy"],
+        "public.status": ["on", "off"]
+    ]
+
+    private let arrayTypes: [String: PostgresArrayTypeInfo] = [
+        "app._mood": PostgresArrayTypeInfo(elementTypeName: "mood", elementTypeKind: "e"),
+        "pg_catalog._text": PostgresArrayTypeInfo(elementTypeName: "text", elementTypeKind: "b"),
+        "pg_catalog._int4": PostgresArrayTypeInfo(elementTypeName: "int4", elementTypeKind: "b"),
+        "public._pair": PostgresArrayTypeInfo(elementTypeName: "pair", elementTypeKind: "c")
+    ]
+
+    private func resolve(
+        _ rawDataType: String,
+        schema: String?,
+        udt: String?
+    ) -> PostgresColumnTypeResolver.Resolution {
+        PostgresColumnTypeResolver.resolve(
+            rawDataType: rawDataType,
+            udtSchema: schema,
+            udtName: udt,
+            enumLabelsByQualifiedName: enumLabels,
+            arrayTypesByQualifiedName: arrayTypes
+        )
+    }
+
+    @Test("A scalar enum column carries its labels in declaration order")
+    func resolvesScalarEnum() {
+        let resolution = resolve("USER-DEFINED", schema: "app", udt: "mood")
+        #expect(resolution.dataType == "ENUM")
+        #expect(resolution.allowedValues == ["sad", "ok", "happy"])
+    }
+
+    @Test("An enum defined outside the table's schema still resolves")
+    func resolvesEnumFromAnotherSchema() {
+        let resolution = resolve("USER-DEFINED", schema: "public", udt: "status")
+        #expect(resolution.dataType == "ENUM")
+        #expect(resolution.allowedValues == ["on", "off"])
+    }
+
+    @Test("An array of an enum reports the element's labels")
+    func resolvesEnumArray() {
+        let resolution = resolve("ARRAY", schema: "app", udt: "_mood")
+        #expect(resolution.dataType == "ENUM[]")
+        #expect(resolution.allowedValues == ["sad", "ok", "happy"])
+    }
+
+    @Test("An array of a base type reports the element type name")
+    func resolvesScalarArray() {
+        #expect(resolve("ARRAY", schema: "pg_catalog", udt: "_text").dataType == "text[]")
+        #expect(resolve("ARRAY", schema: "pg_catalog", udt: "_text").allowedValues == nil)
+        #expect(resolve("ARRAY", schema: "pg_catalog", udt: "_int4").dataType == "int4[]")
+    }
+
+    @Test("An array the editor cannot represent falls back to today's behaviour")
+    func leavesUnsupportedArraysAlone() {
+        #expect(resolve("ARRAY", schema: "public", udt: "_pair").dataType == "ARRAY")
+        #expect(resolve("ARRAY", schema: "public", udt: "_mystery").dataType == "ARRAY")
+        #expect(resolve("ARRAY", schema: "public", udt: "_pair").allowedValues == nil)
+    }
+
+    @Test("An enum with no catalog entry keeps the existing named fallback")
+    func fallsBackForUnknownEnum() {
+        let resolution = resolve("USER-DEFINED", schema: "app", udt: "nope")
+        #expect(resolution.dataType == "ENUM(nope)")
+        #expect(resolution.allowedValues == nil)
+    }
+
+    @Test("Ordinary columns pass through unchanged")
+    func passesThroughOrdinaryTypes() {
+        #expect(resolve("text", schema: "pg_catalog", udt: "text").dataType == "TEXT")
+        #expect(resolve("integer", schema: "pg_catalog", udt: "int4").dataType == "INTEGER")
+        #expect(resolve("timestamp without time zone", schema: nil, udt: nil).dataType
+            == "TIMESTAMP WITHOUT TIME ZONE")
+        #expect(resolve("text", schema: "pg_catalog", udt: "text").allowedValues == nil)
+    }
+
+    @Test("Qualified names join schema and type, and tolerate a missing schema")
+    func buildsQualifiedNames() {
+        #expect(PostgresColumnTypeResolver.qualifiedName(schema: "app", name: "mood") == "app.mood")
+        #expect(PostgresColumnTypeResolver.qualifiedName(schema: nil, name: "mood") == "mood")
+        #expect(PostgresColumnTypeResolver.qualifiedName(schema: "", name: "mood") == "mood")
+    }
+}

--- a/TableProTests/Views/ArrayValueEditorModelTests.swift
+++ b/TableProTests/Views/ArrayValueEditorModelTests.swift
@@ -1,0 +1,89 @@
+//
+//  ArrayValueEditorModelTests.swift
+//  TableProTests
+//
+//  Tests for the array cell editor's row model.
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("Array Value Editor Model")
+struct ArrayValueEditorModelTests {
+    private let labels = ["sad", "ok", "happy"]
+
+    @Test("Rows keep duplicate elements distinct")
+    func rowsKeepDuplicatesDistinct() {
+        let rows = ArrayValueEditorModel.rows(from: [.value("sad"), .value("sad")])
+        #expect(rows.count == 2)
+        #expect(rows[0].id != rows[1].id)
+        #expect(rows[0].element == rows[1].element)
+    }
+
+    @Test("A value the type no longer declares stays selectable")
+    func keepsDriftedValueSelectable() {
+        let options = ArrayValueEditorModel.pickerOptions(for: .value("retired"), allowedValues: labels)
+        #expect(options == ["sad", "ok", "happy", "retired"])
+        #expect(ArrayValueEditorModel.selectionIndex(for: .value("retired"), in: options) == 3)
+        #expect(ArrayValueEditorModel.isDriftedValue(.value("retired"), allowedValues: labels))
+        #expect(!ArrayValueEditorModel.isDriftedValue(.value("sad"), allowedValues: labels))
+        #expect(!ArrayValueEditorModel.isDriftedValue(.null, allowedValues: labels))
+    }
+
+    @Test("A known value does not widen the option list")
+    func doesNotWidenOptionsForKnownValue() {
+        #expect(ArrayValueEditorModel.pickerOptions(for: .value("ok"), allowedValues: labels) == labels)
+        #expect(ArrayValueEditorModel.pickerOptions(for: .null, allowedValues: labels) == labels)
+    }
+
+    @Test("The index past the last label selects NULL")
+    func mapsTrailingIndexToNull() {
+        #expect(ArrayValueEditorModel.selectionIndex(for: .null, in: labels) == labels.count)
+        #expect(ArrayValueEditorModel.element(atSelectionIndex: labels.count, in: labels) == .null)
+        #expect(ArrayValueEditorModel.element(atSelectionIndex: 1, in: labels) == .value("ok"))
+        #expect(ArrayValueEditorModel.element(atSelectionIndex: 99, in: labels) == .null)
+    }
+
+    @Test("Reordering swaps neighbours and ignores moves off the ends")
+    func reordersWithinBounds() {
+        let rows = ArrayValueEditorModel.rows(from: [.value("a"), .value("b"), .value("c")])
+        let movedDown = ArrayValueEditorModel.moved(rows, from: 0, by: 1)
+        #expect(movedDown.map(\.element) == [.value("b"), .value("a"), .value("c")])
+
+        let movedUp = ArrayValueEditorModel.moved(rows, from: 2, by: -1)
+        #expect(movedUp.map(\.element) == [.value("a"), .value("c"), .value("b")])
+
+        #expect(ArrayValueEditorModel.moved(rows, from: 0, by: -1).map(\.element) == rows.map(\.element))
+        #expect(ArrayValueEditorModel.moved(rows, from: 2, by: 1).map(\.element) == rows.map(\.element))
+    }
+
+    @Test("Rows are removed and reordered by identity, so duplicates stay independent")
+    func mutatesByIdentity() {
+        let rows = ArrayValueEditorModel.rows(from: [.value("a"), .value("b"), .value("a")])
+        let removedFirst = ArrayValueEditorModel.removing(rows, id: rows[0].id)
+        #expect(removedFirst.map(\.element) == [.value("b"), .value("a")])
+        #expect(removedFirst.count == 2)
+
+        let movedLastUp = ArrayValueEditorModel.moved(rows, id: rows[2].id, by: -1)
+        #expect(movedLastUp.map(\.id) == [rows[0].id, rows[2].id, rows[1].id])
+
+        #expect(ArrayValueEditorModel.moved(rows, id: rows[0].id, by: -1).map(\.id) == rows.map(\.id))
+        #expect(ArrayValueEditorModel.moved(rows, id: UUID(), by: 1).map(\.id) == rows.map(\.id))
+        #expect(ArrayValueEditorModel.removing(rows, id: UUID()).count == 3)
+    }
+
+    @Test("The committed literal preserves order and quotes hostile labels")
+    func buildsLiteralFromRows() {
+        let rows = ArrayValueEditorModel.rows(from: [.value("happy"), .null, .value("a,b")])
+        let literal = ArrayValueEditorModel.literal(from: rows, delimiter: ",")
+        #expect(literal == #"{happy,NULL,"a,b"}"#)
+        #expect(PostgresArrayLiteralCodec.parse(literal) == rows.map(\.element))
+    }
+
+    @Test("An empty row list commits an empty array, not NULL")
+    func buildsEmptyArrayLiteral() {
+        #expect(ArrayValueEditorModel.literal(from: [], delimiter: ",") == "{}")
+    }
+}

--- a/docs/databases/postgresql.mdx
+++ b/docs/databases/postgresql.mdx
@@ -41,7 +41,9 @@ Connect to RDS or Aurora with your AWS identity instead of a static password: se
 
 **Partitioned tables**: A partitioned table is listed once, under its own icon. Its partitions are not listed beside it; expand the table in the sidebar to see them, and expand a partition again if it is subpartitioned. Opening a partition works like opening any other table. Tables that use the older `INHERITS` inheritance are listed normally, since a child there is a table in its own right. Requires PostgreSQL 10 or later, which is where declarative partitioning was added.
 
-**Types**: `jsonb` renders as formatted JSON. `array`, `uuid`, `inet`, `timestamp with time zone`, `interval`, and `bytea` display natively.
+**Types**: `jsonb` renders as formatted JSON. `uuid`, `inet`, `timestamp with time zone`, `interval`, and `bytea` display natively.
+
+**Arrays**: An array column whose elements are a simple type (`text[]`, `integer[]`, `uuid[]`, `timestamptz[]`, and enum arrays such as `mood[]`) opens a list editor, one row per element. Reorder rows with the arrows, add and remove elements, and set any single element to NULL. An empty array and a NULL column are separate values and the editor keeps them apart. Elements of an enum array pick from the labels the type declares, in declaration order; a value the type no longer lists stays selectable and is flagged. Switch to **Edit as Text** for the raw `{...}` literal. Arrays of `jsonb`, `bytea`, or composite types, and multi-dimensional values, keep the plain text editor, since their quoting cannot round-trip through a per-element list.
 
 **EXPLAIN**: `EXPLAIN` and `EXPLAIN ANALYZE` run with `FORMAT JSON` and render as a plan diagram or tree. See [EXPLAIN Visualization](/features/explain-visualization).
 

--- a/docs/features/data-grid.mdx
+++ b/docs/features/data-grid.mdx
@@ -71,6 +71,7 @@ Double-click a cell to edit it. Press `Enter` to confirm or `Escape` to cancel. 
 | Boolean, `BIT`, `TINYINT(1)` | Checkbox, with a third state for nullable columns |
 | `ENUM` | Searchable value list |
 | `SET` (MySQL/MariaDB) | Multi-select checkboxes |
+| Array of a simple type (PostgreSQL) | Ordered list, one row per element |
 | `JSON`, `JSONB`, `BLOB`, binary | [Cell viewers](/features/json-viewer); hex editor is read-only over 10 KB |
 
 <Frame caption="Type-specific cell editor">


### PR DESCRIPTION
PostgreSQL array columns rendered as a plain text field showing the raw `{happy,sad}` literal, with no picker and no per-element awareness. A user asked whether `enum[]` had a dedicated editor. It did not, and it never reached the enum path at all.

## Root cause

Three separate gaps, not one bug.

**The element type was never resolved.** `mapPgColumnRow` only special-cased `data_type == 'USER-DEFINED'`. An `enum[]` column reports `data_type = 'ARRAY'` with `udt_name = '_mood'`, so it fell into the `else` branch and `allowedValues` stayed nil.

**Enum labels were scoped to the table's schema.** `fetchEnumLabelMap` filtered `WHERE n.nspname = <table's schema>` and keyed by `typname` alone, so an enum defined in `public` and used by a table in another schema found no labels. That affected scalar enum columns too, and is a shipped bug independent of arrays.

**`ColumnType` could not express an array.** The grid's type comes from `pgOidToTypeName`, a hardcoded OID switch whose `default` returns `"unknown"`. Even with the data in hand there was no case to route on, so the chevron dispatch had nowhere to branch.

## Approach

`ColumnType` gains `indirect case array(rawType:element:)` carrying the classified element type. `supportsElementEditing` gates which element types get a structured editor. A `[]` suffix in a type name classifies the element and wraps it, so `text[]`, `integer[]` and `ENUM[](mood)` all flow through one path.

Detection follows the PostGIS precedent already in this plugin: a connect-time catalog probe installs an OID map, the same shape as `probePostgisOids` / `setPostgisOidMap`. Built-in array OIDs are static; only user-defined enum arrays need the probe. The schema-browse path resolves arrays through `pg_type.typarray` rather than stripping the leading underscore off `udt_name`.

The editor is an ordered per-element list in a popover: enum elements pick from the declared labels in `enumsortorder`, scalar elements get a text field with a per-element NULL toggle. That shape matches Mail rules and Finder Smart Folder criteria, which is what macOS ships when order and duplicates matter. Apple's token and tag pickers model an unordered set with no duplicates, which is the wrong data model for a SQL array. `NSTokenField` was rejected for a specific reason: an Apple-acknowledged macOS 26 crash (FB18088608, closed "Works as currently designed") whose prescribed fix is implementing `isEqual`/`hash`, which would make two identical enum labels indistinguishable.

The popover is `.applicationDefined` rather than `.transient`, so clicking the next cell cannot silently discard uncommitted edits, and Escape is wired through `onExitCommand`. Reordering offers arrows as well as position, per the HIG rule against drag-only interactions.

## Array literal handling

This is the part that looks trivial and is not. Enum labels can legally contain commas, double quotes, backslashes, braces, leading and trailing whitespace, and the empty string. MySQL's `SET` approach of comma-joining selected values would silently write a two-element array for a label `a,b`.

The codec round-trips this vector, verified against a live PostgreSQL 17.10 server:

```
{"a,b","has \"quote\"","back\\slash"," lead","trail ","","NULL","null","{brace}",NULL}
```

Ten elements: `a,b` / `has "quote"` / `back\slash` / ` lead` / `trail ` / empty string / `NULL` / `null` / `{brace}` / SQL NULL. Bare `NULL` is SQL NULL, quoted `"NULL"` is the four-character string, and `{}` is an empty array which is not NULL. The delimiter comes from the element type, so `box[]` and its `;` separator parse correctly.

Values are bound as parameters with `paramTypes: nil`, so PostgreSQL infers the type from the target column. No changes to `SQLStatementGenerator`. BigQuery's WHERE-anchor exclusion for complex types does not transfer, since PostgreSQL arrays are natively `=`-comparable.

## Plugin ABI

No change. `PluginColumnInfo.dataType` and `allowedValues` already existed and carry everything needed. Only new public types were added, no initializer signature moved. No `currentPluginKitVersion` bump and no re-release of the 16 registry plugins.

## Scope

In: PostgreSQL one-dimensional arrays whose elements are a simple type, including enum arrays. The cross-schema enum label fix is folded in, since the same catalog query replacement fixes both.

Out, degrading to the current plain-text behaviour rather than anything worse:

- Arrays of `jsonb`, `bytea`, or composite types. Their element text carries a second escaping layer that cannot round-trip through a per-element list.
- Multi-dimensional values and dimension-prefixed literals such as `[0:2]={a,b,c}`. The codec returns nil and the chevron falls back to inline text editing.
- Domain-wrapped arrays, which report the domain name and miss the catalog lookup.
- CockroachDB. It shares the plugin bundle but has its own column mapping and does not resolve scalar enum labels today, so array support would need that built first.

## Testing

36 new tests. The codec covers the full hostile vector plus the malformed cases PostgreSQL rejects (`{,}`, whitespace-only elements, unterminated literals). The resolver covers the cross-schema fix, enum arrays, scalar arrays, and the safe degrade for composite and unknown arrays. The classifier suite adds array cases with regression guards confirming ClickHouse `Array(String)` still maps to JSON and scalar `ENUM`/`SET` are unchanged.

314 tests pass across the touched areas. Suites were confirmed to have actually executed rather than trusting `TEST SUCCEEDED`, since a filter matching nothing still reports success.

`swiftlint --strict` is clean. All 30 plugins compile via the `AllPlugins` scheme, since PR CI only builds the bundled ones.

## Not covered

No live-database verification. The catalog SQL and connect-time probe are validated by shape and unit tests, not against a running server. Worth a manual pass on a table carrying a `mood[]`, a `text[]`, and an enum type defined in a schema other than the table's.

No UI automation for the popover, since its presentation timing is not deterministic.
