### PR TITLE
fix(toolbar): stop Customize Toolbar from blanking items and pruning the saved arrangement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Customize Toolbar no longer blanks the connection and status controls. Opening it rebuilt those two items and released the ones already on screen, so they shrank to nothing until the window switched connection.
+- A connection that loses its session no longer puts your toolbar arrangement at risk. The toolbar stayed in place with nothing behind it, and the next time macOS asked it what to show, the items you had customized could be dropped for good.
 - Running EXPLAIN from the toolbar now asks for confirmation when Safe Mode requires it. It previously skipped that check on every database that offers an EXPLAIN variant, even though `EXPLAIN ANALYZE` runs the query.
 - The Stop button can now cancel a running `EXPLAIN ANALYZE`.
 - An EXPLAIN that fails now reports the error in the usual place instead of showing it where the plan should be.

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -461,9 +461,20 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         )
         workspace.rightPanelState?.teardown()
         workspace.rightPanelState = nil
+        /// The toolbar goes with the coordinator it was built for. `MainWindowToolbar.coordinator`
+        /// is weak, so tearing the coordinator down while the toolbar stayed installed left the
+        /// delegate answering nil for every identifier it advertises. `autosavesConfiguration` is
+        /// on, so the next vend AppKit asks for, opening Customize Toolbar or dragging an item,
+        /// would have pruned those items from the user's saved configuration for good. Comparing
+        /// the coordinator itself rather than which workspace is on screen keeps this exact when a
+        /// background workspace loses its session.
+        let releasedCoordinator = workspace.sessionState?.coordinator
         workspace.sessionState?.coordinator.teardown()
         workspace.sessionState = nil
         workspace.session = nil
+        if let releasedCoordinator, toolbarOwner?.coordinator === releasedCoordinator {
+            invalidateToolbar()
+        }
         /// The panes are rebuilt rather than dropped: the workspace stays in the registry so it can
         /// render its own phase, and its content view is now the not-connected pane. Leaving the
         /// old tree mounted would keep the torn-down coordinator alive through it.

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Delegate.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Delegate.swift
@@ -26,6 +26,7 @@ extension MainWindowToolbar {
                 id: itemIdentifier,
                 label: String(localized: "Connection"),
                 subitems: [subitemConnection(), subitemDatabase()],
+                retainsController: Self.retainsHostingController(willBeInsertedIntoToolbar: flag),
                 content: HStack(spacing: 4) {
                     ConnectionToolbarButton(coordinator: coordinator)
                     DatabaseToolbarButton(coordinator: coordinator)
@@ -42,6 +43,7 @@ extension MainWindowToolbar {
                 action: nil,
                 keyEquivalent: "",
                 modifiers: [],
+                retainsController: Self.retainsHostingController(willBeInsertedIntoToolbar: flag),
                 content: ToolbarPrincipalContent(
                     state: coordinator.toolbarState,
                     onSwitchDatabase: { [weak coordinator] in coordinator?.commandActions?.openDatabaseSwitcher() },

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Items.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Items.swift
@@ -134,6 +134,7 @@ extension MainWindowToolbar {
         action: Selector?,
         keyEquivalent: String,
         modifiers: NSEvent.ModifierFlags,
+        retainsController: Bool = true,
         content: Content
     ) -> NSToolbarItem {
         let item = NSToolbarItem(itemIdentifier: id)
@@ -144,7 +145,7 @@ extension MainWindowToolbar {
         // focusable(false) stops SwiftUI from claiming scene focus on click, which would break menu shortcuts.
         let controller = NSHostingController(rootView: AnyView(content.focusable(false)))
         controller.sizingOptions = .intrinsicContentSize
-        hostingControllers[id] = controller
+        retain(controller, for: id, when: retainsController)
         item.view = controller.view
 
         if let symbol {
@@ -221,6 +222,7 @@ extension MainWindowToolbar {
         id: NSToolbarItem.Identifier,
         label: String,
         subitems: [NSToolbarItem],
+        retainsController: Bool = true,
         content: Content
     ) -> NSToolbarItemGroup {
         let group = NSToolbarItemGroup(itemIdentifier: id)
@@ -230,10 +232,28 @@ extension MainWindowToolbar {
         // Same retention requirement as hostingItem: group.view comes from this controller.
         let controller = NSHostingController(rootView: AnyView(content.focusable(false)))
         controller.sizingOptions = .intrinsicContentSize
-        hostingControllers[id] = controller
+        retain(controller, for: id, when: retainsController)
         group.view = controller.view
 
         group.subitems = subitems
         return group
+    }
+
+    /// One slot per identifier, and the slot belongs to the item that is actually in the toolbar.
+    /// AppKit asks the delegate again with `willBeInsertedIntoToolbar: false` to build the palette
+    /// copies shown by Customize Toolbar, and letting those overwrite the slot released the
+    /// controllers whose views were on screen. `NSToolbarItem` does not retain its controller, so
+    /// the live items collapsed to zero width the moment the panel opened.
+    static func retainsHostingController(willBeInsertedIntoToolbar: Bool) -> Bool {
+        willBeInsertedIntoToolbar
+    }
+
+    private func retain(
+        _ controller: NSHostingController<AnyView>,
+        for id: NSToolbarItem.Identifier,
+        when retains: Bool
+    ) {
+        guard retains else { return }
+        hostingControllers[id] = controller
     }
 }

--- a/TableProTests/Services/MainWindowToolbarLayoutTests.swift
+++ b/TableProTests/Services/MainWindowToolbarLayoutTests.swift
@@ -32,3 +32,22 @@ struct MainWindowToolbarLayoutTests {
         #expect(group.subitems.count == 2)
     }
 }
+
+@MainActor
+struct MainWindowToolbarCustomizationTests {
+    /// Opening Customize Toolbar makes AppKit ask the delegate again, with the flag off, for the
+    /// palette copies. Those used to overwrite the retained hosting controllers, releasing the ones
+    /// whose views were on screen, and the connection group and status item collapsed to nothing.
+    @Test("Only the item going into the toolbar claims the retained controller")
+    func paletteCopiesDoNotClaimTheSlot() {
+        #expect(MainWindowToolbar.retainsHostingController(willBeInsertedIntoToolbar: true))
+        #expect(!MainWindowToolbar.retainsHostingController(willBeInsertedIntoToolbar: false))
+    }
+
+    /// The identifier is the autosave name. Changing it silently discards every user's arrangement,
+    /// which is what the v1 to v2 move already cost once.
+    @Test("The toolbar identifier is stable")
+    func identifierIsStable() {
+        #expect(MainWindowToolbar.toolbarIdentifier == "com.TablePro.main.toolbar.v2")
+    }
+}


### PR DESCRIPTION
Two defects a user can hit today. They surfaced while investigating why switching connection rebuilds the toolbar; the rebuild itself is a separate change and is not in this PR.

## Customize Toolbar blanked the connection and status controls

`hostingControllers` holds one `NSHostingController` per identifier, and the file says why: "NSHostingController is not retained by NSToolbarItem, so without this its view orphans and the toolbar item collapses to zero width."

`allowsUserCustomization` is true, and opening Customize Toolbar makes AppKit ask the delegate for each item again with `willBeInsertedIntoToolbar: false`, to build the palette copies shown in the panel. Both builders wrote `hostingControllers[id] = controller` unconditionally, so those palette copies took the slot, the controllers behind the on-screen items were released, and `connectionGroup` and the centered status item collapsed.

It has been masked so far: switching connection rebuilds the toolbar and puts the controllers back. Anything that stops rebuilding on every switch turns it permanent.

Only the item actually going into the toolbar claims the slot now.

## A dead session could prune the saved arrangement for good

`MainWindowToolbar.coordinator` is weak, and the delegate opens with `guard let coordinator else { return nil }`, returning nil for every identifier it advertises.

`releaseSession` tore the coordinator down, cleared `sessionState` and `session`, rebuilt the panes, and never touched the toolbar. `MainContentCoordinator.teardown()` removes the last strong reference, so the weak one went nil under a toolbar still installed on the window. Any vend after that, opening Customize Toolbar or dragging an item, hit the nil path.

With `autosavesConfiguration` true, AppKit persists what it is told the toolbar contains, so those items were dropped from the user's saved arrangement permanently. There is no repair code for this. The only remedy on record is bumping the toolbar identifier and discarding everyone's customization, which is what `com.TablePro.main.toolbar` to `.v2` did in #1549, and why the CHANGELOG for that release says "Customized toolbars reset once."

The toolbar now goes when the coordinator it was built for goes. The check compares the coordinator identity rather than which workspace is on screen, so a background workspace losing its session is handled the same way.

## Tests

`MainWindowToolbarCustomizationTests` locks the palette rule and the identifier. The identifier test exists because changing that string discards every user's arrangement, and it has already happened once.

The two fixes themselves sit on AppKit integration that this repo's test harness cannot reach: constructing a `MainWindowToolbar` needs a live `MainContentCoordinator`, which no existing test builds. The rule each fix turns on is extracted and asserted instead.

Full unit suite passes.

## Not in this PR

The rebuild on every connection switch, measured at 12-24ms. Repointing one window-owned toolbar through an observable subject is the direction the evidence supports: a rebuild measured 10.2ms on this machine against 0.002ms for in-place validation, and Xcode, Finder and Mail all keep one toolbar per window type and update its items rather than swapping toolbars. That refactor should land on top of these fixes, not with them, because removing the rebuild is what makes the first bug permanent if it were still there.
