### PR TITLE
refactor(toolbar): point one toolbar at the selected connection instead of rebuilding it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Switching connection no longer rebuilds the toolbar. It kept its buttons and status readout but threw them away and made them again on every switch, which cost a frame and reset the titlebar.
 - Typing in a new query tab now goes into the editor. Cmd+T left the keyboard on the sidebar, so the first characters you typed went to the object list instead.
 - Cmd+W closes the welcome window. The shortcut was bound to Close Tab, which the welcome window has no answer for, so it did nothing there.
 - Customize Toolbar no longer blanks the connection and status controls. Opening it rebuilt those two items and released the ones already on screen, so they shrank to nothing until the window switched connection.

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -371,13 +371,12 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     /// was built for. Switching connection rebuilds it instead.
     func installToolbar(coordinator: MainContentCoordinator) {
         guard let window = view.window else { return }
-        if let owner = toolbarOwner, owner.coordinator !== coordinator {
-            invalidateToolbar()
-        }
-        if toolbarOwner == nil {
-            toolbarOwner = MainWindowToolbar(coordinator: coordinator)
-        }
-        if let owner = toolbarOwner, window.toolbar !== owner.managedToolbar {
+        let owner = toolbarOwner ?? MainWindowToolbar()
+        toolbarOwner = owner
+        /// Pointed at the connection before the toolbar reaches the window, so the delegate builds
+        /// its items with a subject already in place and nothing has to be rebuilt afterwards.
+        owner.repoint(to: coordinator)
+        if window.toolbar !== owner.managedToolbar {
             window.toolbar = owner.managedToolbar
         }
     }
@@ -473,7 +472,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         workspace.sessionState = nil
         workspace.session = nil
         if let releasedCoordinator, toolbarOwner?.coordinator === releasedCoordinator {
-            invalidateToolbar()
+            toolbarOwner?.repoint(to: nil)
         }
         /// The panes are rebuilt rather than dropped: the workspace stays in the registry so it can
         /// render its own phase, and its content view is now the not-connected pane. Leaving the
@@ -508,7 +507,10 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
             coordinator.splitViewController = self
             installToolbar(coordinator: coordinator)
         } else {
-            invalidateToolbar()
+            /// Pointed at nothing rather than torn off the window. Every item validates to disabled
+            /// with no subject, and leaving the toolbar in place keeps AppKit from rebuilding the
+            /// titlebar twice for a switch the user experiences as one.
+            toolbarOwner?.repoint(to: nil)
         }
 
         showSelectedPanes()

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Buttons.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Buttons.swift
@@ -83,3 +83,52 @@ struct SessionContextToolbarButton: View {
         }
     }
 }
+
+/// Thin wrappers so the toolbar's hosted content follows the window's subject instead of capturing
+/// one connection. Reading `subject.coordinator` inside `body` is what registers the observation.
+internal struct ConnectionToolbarSubjectButton: View {
+    internal let subject: ToolbarSubject
+
+    internal var body: some View {
+        if let coordinator = subject.coordinator {
+            ConnectionToolbarButton(coordinator: coordinator)
+        }
+    }
+}
+
+internal struct DatabaseToolbarSubjectButton: View {
+    internal let subject: ToolbarSubject
+
+    internal var body: some View {
+        if let coordinator = subject.coordinator {
+            DatabaseToolbarButton(coordinator: coordinator)
+        }
+    }
+}
+
+internal struct SessionContextToolbarSubjectButton: View {
+    internal let subject: ToolbarSubject
+
+    internal var body: some View {
+        if let coordinator = subject.coordinator {
+            SessionContextToolbarButton(coordinator: coordinator)
+        }
+    }
+}
+
+/// The centred status item. `ConnectionToolbarState` is a reference type, so this reads it from the
+/// subject each time rather than being handed one connection's instance at build time.
+internal struct ToolbarPrincipalSubjectContent: View {
+    internal let subject: ToolbarSubject
+
+    internal var body: some View {
+        if let coordinator = subject.coordinator {
+            ToolbarPrincipalContent(
+                state: coordinator.toolbarState,
+                onSwitchDatabase: { [weak coordinator] in coordinator?.commandActions?.openDatabaseSwitcher() },
+                onCancelQuery: { [weak coordinator] in coordinator?.cancelCurrentQuery() },
+                onSafeModeChange: { [weak coordinator] level in coordinator?.setSafeModeLevel(level) }
+            )
+        }
+    }
+}

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Delegate.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Delegate.swift
@@ -16,8 +16,6 @@ extension MainWindowToolbar {
         Self.lifecycleLogger.info(
             "[open] toolbar delegate buildItem id=\(itemIdentifier.rawValue, privacy: .public) hasCoordinator=\(self.coordinator != nil)"
         )
-        guard let coordinator else { return nil }
-
         switch itemIdentifier {
         case Self.sidebarToggle:
             return makeSidebarToggleItem()
@@ -28,9 +26,9 @@ extension MainWindowToolbar {
                 subitems: [subitemConnection(), subitemDatabase()],
                 retainsController: Self.retainsHostingController(willBeInsertedIntoToolbar: flag),
                 content: HStack(spacing: 4) {
-                    ConnectionToolbarButton(coordinator: coordinator)
-                    DatabaseToolbarButton(coordinator: coordinator)
-                    SessionContextToolbarButton(coordinator: coordinator)
+                    ConnectionToolbarSubjectButton(subject: subject)
+                    DatabaseToolbarSubjectButton(subject: subject)
+                    SessionContextToolbarSubjectButton(subject: subject)
                 }
             )
             group.isNavigational = true
@@ -44,12 +42,7 @@ extension MainWindowToolbar {
                 keyEquivalent: "",
                 modifiers: [],
                 retainsController: Self.retainsHostingController(willBeInsertedIntoToolbar: flag),
-                content: ToolbarPrincipalContent(
-                    state: coordinator.toolbarState,
-                    onSwitchDatabase: { [weak coordinator] in coordinator?.commandActions?.openDatabaseSwitcher() },
-                    onCancelQuery: { [weak coordinator] in coordinator?.cancelCurrentQuery() },
-                    onSafeModeChange: { [weak coordinator] level in coordinator?.setSafeModeLevel(level) }
-                )
+                content: ToolbarPrincipalSubjectContent(subject: subject)
             )
             item.visibilityPriority = .high
             item.toolTip = String(localized: "Connection status")

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Items.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Items.swift
@@ -31,10 +31,16 @@ extension MainWindowToolbar {
         )
     }
 
-    func subitemDatabase() -> NSToolbarItem {
-        let containerName = coordinator.map {
+    /// What this driver calls the thing a connection browses, so the item reads "Open Keyspace" on
+    /// Cassandra rather than a word that does not exist there.
+    var containerEntityName: String {
+        coordinator.map {
             PluginManager.shared.containerEntityName(for: $0.toolbarState.databaseType)
         } ?? String(localized: "Database")
+    }
+
+    func subitemDatabase() -> NSToolbarItem {
+        let containerName = containerEntityName
         return menuOnlyItem(
             id: Self.database,
             label: containerName,
@@ -109,7 +115,7 @@ extension MainWindowToolbar {
         return item
     }
 
-    private func buildImportSubmenu() -> NSMenu {
+    func buildImportSubmenu() -> NSMenu {
         let menu = NSMenu()
         guard let databaseType = coordinator?.connection.type else { return menu }
         for format in PluginManager.shared.importFormatOptions(for: databaseType) {

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -15,7 +15,12 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
 
     internal static let toolbarIdentifier = NSToolbar.Identifier("com.TablePro.main.toolbar.v2")
 
-    weak var coordinator: MainContentCoordinator?
+    /// Which connection the toolbar is about. Every item reads through this rather than capturing
+    /// a coordinator, so a switch repoints one reference instead of rebuilding eight items, two
+    /// `NSHostingController`s and the window's whole titlebar.
+    internal let subject = ToolbarSubject()
+
+    internal var coordinator: MainContentCoordinator? { subject.coordinator }
 
     internal let managedToolbar: NSToolbar
 
@@ -24,8 +29,7 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
     internal var hostingControllers: [NSToolbarItem.Identifier: NSHostingController<AnyView>] = [:]
     private(set) var sidebarGroup: NSToolbarItemGroup?
 
-    internal init(coordinator: MainContentCoordinator) {
-        self.coordinator = coordinator
+    override internal init() {
         self.managedToolbar = NSToolbar(identifier: Self.toolbarIdentifier)
         super.init()
         self.managedToolbar.delegate = self
@@ -35,10 +39,55 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
         self.managedToolbar.centeredItemIdentifiers = [Self.principal]
     }
 
+    /// `@Observable` generates no equality check, so assigning the same coordinator still fires
+    /// every observer. `windowDidBecomeKey` runs on activation with the connection unchanged, so
+    /// without this guard the window would pay for a switch every time it came forward.
+    internal func repoint(to coordinator: MainContentCoordinator?) {
+        guard subject.coordinator !== coordinator else { return }
+        subject.coordinator = coordinator
+        refreshConnectionScopedItems()
+        syncSidebarSelection()
+        managedToolbar.validateVisibleItems()
+    }
+
     func invalidate() {
         sidebarGroup = nil
         hostingControllers.removeAll()
-        coordinator = nil
+        subject.coordinator = nil
+    }
+
+    /// Three items carry text derived from the connection's database type, and none of them can be
+    /// repointed by validation: a subitem of a view-backed group is never sent `validate()`, and a
+    /// menu built at construction keeps whatever it was built with. They are pushed here instead.
+    private func refreshConnectionScopedItems() {
+        for item in allItems() {
+            switch item.itemIdentifier {
+            case Self.database:
+                apply(label: containerEntityName, to: item)
+                item.toolTip = String(format: String(localized: "Open %@"), containerEntityName)
+            case Self.previewSQL:
+                item.toolTip = previewDescription
+            case Self.importTables:
+                (item as? NSMenuToolbarItem)?.menu = buildImportSubmenu()
+                item.menuFormRepresentation?.submenu = buildImportSubmenu()
+            default:
+                continue
+            }
+        }
+    }
+
+    /// The overflow menu keeps the title it was built with, so a label change has to reach it too.
+    private func apply(label: String, to item: NSToolbarItem) {
+        item.label = label
+        item.paletteLabel = label
+        item.menuFormRepresentation?.title = label
+    }
+
+    private func allItems() -> [NSToolbarItem] {
+        managedToolbar.items.flatMap { item -> [NSToolbarItem] in
+            guard let group = item as? NSToolbarItemGroup else { return [item] }
+            return [item] + group.subitems
+        }
     }
 
     // MARK: - Identifiers

--- a/TablePro/Core/Services/Infrastructure/ToolbarSubject.swift
+++ b/TablePro/Core/Services/Infrastructure/ToolbarSubject.swift
@@ -1,0 +1,31 @@
+//
+//  ToolbarSubject.swift
+//  TablePro
+//
+
+import Foundation
+import Observation
+
+/// Which connection the window's toolbar is about. The toolbar belongs to the window; its subject
+/// is whichever connection the window is showing, and that changes.
+///
+/// Items used to capture the coordinator they were built with, so a switch could only be expressed
+/// by throwing the whole toolbar away and building another. Reading the subject inside a SwiftUI
+/// body is what registers observation, so pointing it somewhere else invalidates the two hosted
+/// item trees and nothing else. `NSWindow.toolbar` is never reassigned, which is worth as much as
+/// the rebuild itself: assigning an already-built toolbar still costs several milliseconds because
+/// AppKit rebuilds the titlebar hierarchy for it.
+///
+/// The reference is weak on purpose. The coordinator is owned by `ConnectionWorkspace.sessionState`
+/// and leaves `MainContentCoordinator.activeCoordinators` only on deinit, so a toolbar that held it
+/// strongly would keep a torn-down connection alive and voting in every aggregate that walks that
+/// registry.
+@MainActor
+@Observable
+internal final class ToolbarSubject {
+    internal weak var coordinator: MainContentCoordinator?
+
+    internal init(coordinator: MainContentCoordinator? = nil) {
+        self.coordinator = coordinator
+    }
+}

--- a/TableProTests/Services/MainWindowToolbarValidationTests.swift
+++ b/TableProTests/Services/MainWindowToolbarValidationTests.swift
@@ -209,7 +209,8 @@ struct MainWindowToolbarValidationTests {
     func validateToolbarItemFollowsLiveSession() {
         let coordinator = makeCoordinator()
         defer { coordinator.teardown() }
-        let owner = MainWindowToolbar(coordinator: coordinator)
+        let owner = MainWindowToolbar()
+        owner.repoint(to: coordinator)
         let refresh = NSToolbarItem(itemIdentifier: MainWindowToolbar.refresh)
 
         coordinator.toolbarState.connectionState = .connected
@@ -232,7 +233,8 @@ struct MainWindowToolbarValidationTests {
     func toolbarConfigurationEnablesAutosave() {
         let coordinator = makeCoordinator()
         defer { coordinator.teardown() }
-        let owner = MainWindowToolbar(coordinator: coordinator)
+        let owner = MainWindowToolbar()
+        owner.repoint(to: coordinator)
         #expect(owner.managedToolbar.identifier == MainWindowToolbar.toolbarIdentifier)
         #expect(owner.managedToolbar.allowsUserCustomization == true)
         #expect(owner.managedToolbar.autosavesConfiguration == true)
@@ -242,7 +244,8 @@ struct MainWindowToolbarValidationTests {
     func allowedItemIdentifiersAreSupersetOfDefaults() {
         let coordinator = makeCoordinator()
         defer { coordinator.teardown() }
-        let owner = MainWindowToolbar(coordinator: coordinator)
+        let owner = MainWindowToolbar()
+        owner.repoint(to: coordinator)
         let toolbar = owner.managedToolbar
         let defaults = Set(owner.toolbarDefaultItemIdentifiers(toolbar))
         let allowed = Set(owner.toolbarAllowedItemIdentifiers(toolbar))
@@ -256,5 +259,72 @@ struct MainWindowToolbarValidationTests {
             changeManager: DataChangeManager(),
             toolbarState: ConnectionToolbarState()
         )
+    }
+}
+
+@MainActor
+struct MainWindowToolbarRepointTests {
+    private func makeCoordinator() -> MainContentCoordinator {
+        MainContentCoordinator(
+            connection: TestFixtures.makeConnection(database: "db_a"),
+            tabManager: QueryTabManager(),
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+    }
+
+    /// The window keeps one toolbar and points it at whichever connection it is showing, so a
+    /// switch has to change what the items are about without rebuilding them.
+    @Test("Repointing changes the subject the items read")
+    func repointChangesTheSubject() {
+        let first = makeCoordinator()
+        let second = makeCoordinator()
+        defer {
+            first.teardown()
+            second.teardown()
+        }
+        let owner = MainWindowToolbar()
+
+        owner.repoint(to: first)
+        #expect(owner.coordinator === first)
+
+        owner.repoint(to: second)
+        #expect(owner.coordinator === second)
+
+        owner.repoint(to: nil)
+        #expect(owner.coordinator == nil)
+    }
+
+    /// `windowDidBecomeKey` runs on every activation with the connection unchanged, and
+    /// `@Observable` generates no equality check, so a repoint to the same coordinator would
+    /// otherwise invalidate the hosted items every time the window came forward.
+    @Test("Repointing to the same coordinator is a no-op")
+    func repointToSameCoordinatorIsIgnored() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+        let owner = MainWindowToolbar()
+
+        owner.repoint(to: coordinator)
+        let subjectBefore = owner.subject.coordinator
+        owner.repoint(to: coordinator)
+        #expect(owner.subject.coordinator === subjectBefore)
+    }
+
+    /// The delegate used to answer nil for every identifier when it had no coordinator. With
+    /// `autosavesConfiguration` on, a vend in that state pruned the user's saved arrangement for
+    /// good, which this project has already paid for once.
+    @Test("The delegate builds every advertised item with no subject")
+    func delegateNeverAnswersNil() {
+        let owner = MainWindowToolbar()
+        let buildable = MainWindowToolbar.allowedItemIdentifiers.filter { !$0.rawValue.hasPrefix("NSToolbar") }
+
+        for identifier in buildable {
+            let item = owner.toolbar(
+                owner.managedToolbar,
+                itemForItemIdentifier: identifier,
+                willBeInsertedIntoToolbar: true
+            )
+            #expect(item != nil, "\(identifier.rawValue) must still build with no connection")
+        }
     }
 }


### PR DESCRIPTION
Follow-up to #2119, which is merged. That order mattered: removing the rebuild is exactly what would have made the Customize Toolbar blanking permanent, so the retention fix had to land first.

Switching connection rebuilt the whole toolbar because its items captured the coordinator they were built with. The rebuild was the largest remaining synchronous cost of a switch, 12-24ms measured in the app.

## What changed

`ToolbarSubject` is a small `@Observable` holding a weak coordinator. The toolbar owns one and every item reads through it, so a switch repoints one reference. `NSWindow.toolbar` is never reassigned.

Five things captured a coordinator and now do not:

- the connection group's hosted SwiftUI tree, through three thin wrappers that read `subject.coordinator` inside `body`, which is what registers the observation
- the centered status item, the same way
- the database subitem's label and tooltip
- the Preview tooltip, which names the driver's query language
- the Import submenu, built from the connection's type

The last three carry text derived from the database type and cannot be repointed by validation: a subitem of a view-backed group is never sent `validate()`, and a menu built at construction keeps what it was built with. `refreshConnectionScopedItems()` pushes them, including `menuFormRepresentation.title`, which the overflow menu reads and a plain `label` assignment would leave stale.

`repoint(to:)` guards on identity. `@Observable` generates no equality check and `windowDidBecomeKey` fires on every activation with the connection unchanged, so without the guard a window would pay for a switch each time it came forward.

The delegate no longer opens with `guard let coordinator else { return nil }`. Items build unconditionally and validation decides what is usable. A sessionless workspace now repoints the toolbar to nil instead of detaching it, which also stops AppKit rebuilding the titlebar twice for one switch.

## Why this shape and not per-connection toolbars

Measured on this machine with a 14-item toolbar of hosted views, 12 iterations each: building a toolbar and assigning it, 10.2ms median; assigning an already-built toolbar, 4.2ms; `validateVisibleItems` on the installed one, 0.002ms. `NSWindow.toolbar =` is itself expensive, so pre-building one toolbar per connection recovers only about 60% of the cost while keeping N live instances.

It is also the wrong model. `NSToolbar.h` is explicit that toolbars sharing an identifier are implicitly synchronized and that changes propagate to all of them, so N instances would share one saved configuration anyway. Giving each a distinct identifier is the alternative, and it would mean a user's arrangement on one connection silently not applying to another. No Apple app does this: scanning every defaults domain on this machine, only Xcode persists more than one toolbar configuration, and its two belong to two window types. Xcode is the closest analogue, with workspace tabs holding independent editor state and toolbar items that hold a workspace window controller, and it repoints rather than swapping.

The toolbar holds no user-visible state that a switch would lose, so unlike the pane refactor in #2116 this is a cost change, not a state-preservation change.

## Tests

`MainWindowToolbarRepointTests` covers the subject changing, the identity guard, and that the delegate builds every advertised identifier with no subject at all. That last one is the regression guard for the pruning incident.

Existing toolbar suites updated to the new initializer and pass. Full unit suite: 834 cases, 0 failures.

## Correction to #2119

That PR's description says constructing a `MainWindowToolbar` needs a live `MainContentCoordinator` that no existing test builds. That is wrong: `MainWindowToolbarValidationTests` has built one all along. The repoint behaviour is directly tested here because of it.
