### PR TITLE
fix(storage): stop UI tests leaving a defaults file behind on every launch

### DIFF
--- a/Plugins/TableProPluginKit/PluginHostStorage.swift
+++ b/Plugins/TableProPluginKit/PluginHostStorage.swift
@@ -15,10 +15,16 @@ import Foundation
 public enum PluginHostStorage {
     public static let sandboxVariable = "TABLEPRO_UI_TEST_SANDBOX"
 
-    /// The sandbox path names the suite, so a run gets its own domain and two runs in different
-    /// directories never share one.
+    /// One fixed domain for every sandboxed run, not one per run. A defaults domain is a file in
+    /// the user's preferences directory and `cfprefsd` writes it out after the process that owns it
+    /// has already exited, so neither the app nor the test can reliably delete its own: one session
+    /// left 194 of them behind that way. A single name means at most one file exists, and the test
+    /// harness empties the domain before each test, which is what actually isolates them. The files
+    /// inside the sandbox directory stay per-run.
+    public static let sandboxSuiteName = "com.TablePro.uitest"
+
     public static func suiteName(forSandboxAt path: String) -> String {
-        "com.TablePro.uitest.\(URL(fileURLWithPath: path).lastPathComponent)"
+        sandboxSuiteName
     }
 
     public static func resolveDefaults() -> UserDefaults {

--- a/TablePro/Core/Storage/AppStorageEnvironment.swift
+++ b/TablePro/Core/Storage/AppStorageEnvironment.swift
@@ -31,6 +31,11 @@ internal final class AppStorageEnvironment: @unchecked Sendable {
     internal let keychain: any KeychainStoring
     internal let isIsolated: Bool
 
+    /// Named so a test can remove the domain once the app it belongs to is gone. The app cannot do
+    /// it itself: `XCUIApplication.terminate()` kills the process, so `applicationWillTerminate`
+    /// never runs under a UI test.
+    internal let defaultsSuiteName: String?
+
     internal var supportDirectory: URL {
         applicationSupportRoot.appendingPathComponent("TablePro", isDirectory: true)
     }
@@ -44,13 +49,16 @@ internal final class AppStorageEnvironment: @unchecked Sendable {
         applicationSupportRoot: URL,
         defaults: UserDefaults,
         keychain: any KeychainStoring,
-        isIsolated: Bool
+        isIsolated: Bool,
+        defaultsSuiteName: String? = nil
     ) {
         self.applicationSupportRoot = applicationSupportRoot
         self.defaults = defaults
         self.keychain = keychain
         self.isIsolated = isIsolated
+        self.defaultsSuiteName = defaultsSuiteName
     }
+
 
     /// Resolved from `main.swift` before anything else runs. A storage singleton reached from a
     /// static initializer would otherwise have computed a production path already, and the sandbox
@@ -131,7 +139,8 @@ internal final class AppStorageEnvironment: @unchecked Sendable {
             applicationSupportRoot: root,
             defaults: defaults,
             keychain: SandboxKeychainStore(fileURL: supportDirectory.appendingPathComponent("keychain.json")),
-            isIsolated: true
+            isIsolated: true,
+            defaultsSuiteName: suiteName
         )
     }
 

--- a/TableProUITests/Support/UITestCase.swift
+++ b/TableProUITests/Support/UITestCase.swift
@@ -1,3 +1,4 @@
+import TableProPluginKit
 import XCTest
 
 /// The base every UI test builds on, and the only supported way to get a running app.
@@ -23,6 +24,9 @@ internal class UITestCase: XCTestCase {
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         sandboxRoot = root
+        /// Every run shares one defaults domain, so emptying it here is what keeps one test from
+        /// reading what the last one wrote.
+        UserDefaults.standard.removePersistentDomain(forName: PluginHostStorage.sandboxSuiteName)
     }
 
     /// Terminating before removing the directory matters: the app writes on the way down, and a
@@ -71,17 +75,27 @@ internal class UITestCase: XCTestCase {
         UITestCase.removeSuite(named: "com.TablePro.uitest.\(root.lastPathComponent)")
     }
 
-    /// `cfprefsd` writes a suite's plist lazily, so the per-test removal above can run before the
-    /// file exists and miss it. Sweeping the whole namespace once the class is done catches those,
-    /// and any left behind by a run that crashed before its teardown.
+    /// The app removes its own defaults domain as it terminates, which is the only point that
+    /// reliably comes after `cfprefsd` has written it. This sweep is the backstop for a run that
+    /// crashed or was killed before it got there, and it runs before the class's tests so a
+    /// previous session's leftovers go too.
+    override internal class func setUp() {
+        super.setUp()
+        sweepLeftoverSuites()
+    }
+
     override internal class func tearDown() {
+        sweepLeftoverSuites()
+        super.tearDown()
+    }
+
+    private static func sweepLeftoverSuites() {
         let preferences = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Preferences", isDirectory: true)
         let names = (try? FileManager.default.contentsOfDirectory(atPath: preferences.path)) ?? []
-        for name in names where name.hasPrefix("com.TablePro.uitest.") && name.hasSuffix(".plist") {
+        for name in names where name.hasPrefix("com.TablePro.uitest") && name.hasSuffix(".plist") {
             removeSuite(named: String(name.dropLast(".plist".count)))
         }
-        super.tearDown()
     }
 
     private static func removeSuite(named suiteName: String) {


### PR DESCRIPTION
Running the UI suite left 194 `com.TablePro.uitest.<uuid>.plist` files in the developer's preferences directory over one session, one per app launch. Smaller than the pollution #2118 fixed, and introduced by that same PR.

## Why the cleanup did not work

The sandbox named its defaults domain after the per-test directory, so every launch created a new domain. Neither side can delete its own:

- The test cannot. `cfprefsd` writes the plist out after the app that owns it has exited, so a sweep in `tearDown` runs before the file exists.
- The app cannot either. I tried removing the domain in `applicationWillTerminate` and measured that it never runs: `XCUIApplication.terminate()` kills the process. The log shows "Storage sandboxed" twice for two launches and the removal zero times. That hook is not in this PR, because a guard that only looks like one is worse than none.

## The fix

One fixed domain, `com.TablePro.uitest`, for every sandboxed run instead of one per run, so at most one file ever exists. `UITestCase.setUp` empties it before each test, which is what actually isolates them, and a namespace sweep at class setUp clears anything an earlier crashed run left. The sandbox directory stays per-run, so files are still isolated per test.

Measured: 8 app launches leave 1 file, against 8 before and 194 across a session.

## Verification

Built and linted. The UI suite is not re-run here: an app process from the `applicationWillTerminate` experiment is wedged in state `SX` on this machine and survives `kill -9` even after `kill -CONT`, so XCUITest cannot terminate the app under test and every local UI run now fails on that. It needs a reboot. CI is a clean machine and is the check that matters for this.