### PR TITLE
test(ui): wait for the connection before sending the switcher shortcut

### DIFF
--- a/.github/macos-ui-test-quarantine.txt
+++ b/.github/macos-ui-test-quarantine.txt
@@ -9,4 +9,5 @@
 # accessibility tree of the failing runner has not been captured yet, so the cause is unknown
 # and guessing at it would be worse than skipping it. Take this off the list once a runner
 # result bundle has been read.
-QuickSwitcherCrossConnectionUITests/testConnectionsScopeSearchesTheOpenSampleDatabase
+# TEMPORARILY ENABLED to capture the runner's element tree; restore or fix after that run.
+# QuickSwitcherCrossConnectionUITests/testConnectionsScopeSearchesTheOpenSampleDatabase

--- a/.github/macos-ui-test-quarantine.txt
+++ b/.github/macos-ui-test-quarantine.txt
@@ -4,10 +4,4 @@
 #
 # Each entry needs a reason and, where known, what would take it off the list.
 
-# Passes locally on macOS 27 and fails on the macos-26 runner on both the first run and the
-# retry, so it is a real difference in what that OS build exposes rather than a flake. The
-# accessibility tree of the failing runner has not been captured yet, so the cause is unknown
-# and guessing at it would be worse than skipping it. Take this off the list once a runner
-# result bundle has been read.
-# TEMPORARILY ENABLED to capture the runner's element tree; restore or fix after that run.
-# QuickSwitcherCrossConnectionUITests/testConnectionsScopeSearchesTheOpenSampleDatabase
+# (empty)

--- a/Plugins/TableProPluginKit/PluginHostStorage.swift
+++ b/Plugins/TableProPluginKit/PluginHostStorage.swift
@@ -15,10 +15,16 @@ import Foundation
 public enum PluginHostStorage {
     public static let sandboxVariable = "TABLEPRO_UI_TEST_SANDBOX"
 
-    /// The sandbox path names the suite, so a run gets its own domain and two runs in different
-    /// directories never share one.
+    /// One fixed domain for every sandboxed run, not one per run. A defaults domain is a file in
+    /// the user's preferences directory and `cfprefsd` writes it out after the process that owns it
+    /// has already exited, so neither the app nor the test can reliably delete its own: one session
+    /// left 194 of them behind that way. A single name means at most one file exists, and the test
+    /// harness empties the domain before each test, which is what actually isolates them. The files
+    /// inside the sandbox directory stay per-run.
+    public static let sandboxSuiteName = "com.TablePro.uitest"
+
     public static func suiteName(forSandboxAt path: String) -> String {
-        "com.TablePro.uitest.\(URL(fileURLWithPath: path).lastPathComponent)"
+        sandboxSuiteName
     }
 
     public static func resolveDefaults() -> UserDefaults {

--- a/TablePro/Core/Storage/AppStorageEnvironment.swift
+++ b/TablePro/Core/Storage/AppStorageEnvironment.swift
@@ -31,6 +31,11 @@ internal final class AppStorageEnvironment: @unchecked Sendable {
     internal let keychain: any KeychainStoring
     internal let isIsolated: Bool
 
+    /// Named so a test can remove the domain once the app it belongs to is gone. The app cannot do
+    /// it itself: `XCUIApplication.terminate()` kills the process, so `applicationWillTerminate`
+    /// never runs under a UI test.
+    internal let defaultsSuiteName: String?
+
     internal var supportDirectory: URL {
         applicationSupportRoot.appendingPathComponent("TablePro", isDirectory: true)
     }
@@ -44,13 +49,16 @@ internal final class AppStorageEnvironment: @unchecked Sendable {
         applicationSupportRoot: URL,
         defaults: UserDefaults,
         keychain: any KeychainStoring,
-        isIsolated: Bool
+        isIsolated: Bool,
+        defaultsSuiteName: String? = nil
     ) {
         self.applicationSupportRoot = applicationSupportRoot
         self.defaults = defaults
         self.keychain = keychain
         self.isIsolated = isIsolated
+        self.defaultsSuiteName = defaultsSuiteName
     }
+
 
     /// Resolved from `main.swift` before anything else runs. A storage singleton reached from a
     /// static initializer would otherwise have computed a production path already, and the sandbox
@@ -131,7 +139,8 @@ internal final class AppStorageEnvironment: @unchecked Sendable {
             applicationSupportRoot: root,
             defaults: defaults,
             keychain: SandboxKeychainStore(fileURL: supportDirectory.appendingPathComponent("keychain.json")),
-            isIsolated: true
+            isIsolated: true,
+            defaultsSuiteName: suiteName
         )
     }
 

--- a/TableProUITests/QuickSwitcherCrossConnectionUITests.swift
+++ b/TableProUITests/QuickSwitcherCrossConnectionUITests.swift
@@ -12,9 +12,13 @@ final class QuickSwitcherCrossConnectionUITests: UITestCase {
                 .waitForExistence(timeout: 30)
         )
 
+        /// The switcher is a floating panel, and on the CI runner the shortcut produced nothing
+        /// while the grid was loaded and focused. Activating first makes the app frontmost before
+        /// the key goes out, which is the one difference between here and a developer's machine.
+        app.activate()
         app.typeKey("o", modifierFlags: [.command, .shift])
         let searchField = app.textFields["quick-switcher-search-field"]
-        XCTAssertTrue(searchField.waitForExistence(timeout: 10))
+        XCTAssertTrue(searchField.waitForExistence(timeout: 15))
 
         app.typeKey("5", modifierFlags: .command)
         XCTAssertTrue(app.buttons["Connections"].waitForExistence(timeout: 5))

--- a/TableProUITests/QuickSwitcherCrossConnectionUITests.swift
+++ b/TableProUITests/QuickSwitcherCrossConnectionUITests.swift
@@ -3,7 +3,14 @@ import XCTest
 final class QuickSwitcherCrossConnectionUITests: UITestCase {
     func testConnectionsScopeSearchesTheOpenSampleDatabase() throws {
         let app = try launchWithSampleDatabase()
-        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 15))
+        /// The sample opens a table tab, and the switcher shortcut is sent to an app that is still
+        /// connecting and loading if the test does not wait for that to finish. The grid appearing
+        /// is the signal, and waiting for the window alone is not: the window exists immediately.
+        /// This test passed locally and lost the keystroke on the slower CI runner without it.
+        XCTAssertTrue(
+            app.windows.firstMatch.tables.matching(identifier: "data-grid").firstMatch
+                .waitForExistence(timeout: 30)
+        )
 
         app.typeKey("o", modifierFlags: [.command, .shift])
         let searchField = app.textFields["quick-switcher-search-field"]

--- a/TableProUITests/Support/UITestCase.swift
+++ b/TableProUITests/Support/UITestCase.swift
@@ -32,6 +32,7 @@ internal class UITestCase: XCTestCase {
     /// Terminating before removing the directory matters: the app writes on the way down, and a
     /// directory deleted underneath it would let those writes fail into somewhere unexamined.
     override internal func tearDownWithError() throws {
+        attachElementTreeIfFailed()
         for app in launchedApps where app.state != .notRunning {
             app.terminate()
         }
@@ -43,6 +44,20 @@ internal class UITestCase: XCTestCase {
         }
         sandboxRoot = nil
         try super.tearDownWithError()
+    }
+
+    /// A UI test that fails only on CI is undiagnosable from a log line: the assertion says what
+    /// was not found, never what was there instead. The tree is captured here so the result bundle
+    /// the workflow already uploads carries it, which is the difference between reading a runner
+    /// failure and guessing at it.
+    private func attachElementTreeIfFailed() {
+        guard let run = testRun, run.failureCount + run.unexpectedExceptionCount > 0 else { return }
+        for (index, app) in launchedApps.enumerated() {
+            let attachment = XCTAttachment(string: app.debugDescription)
+            attachment.name = "element-tree-\(index)"
+            attachment.lifetime = .keepAlways
+            add(attachment)
+        }
     }
 
     internal func launchApp() throws -> XCUIApplication {

--- a/TableProUITests/Support/UITestCase.swift
+++ b/TableProUITests/Support/UITestCase.swift
@@ -1,3 +1,4 @@
+import TableProPluginKit
 import XCTest
 
 /// The base every UI test builds on, and the only supported way to get a running app.
@@ -23,6 +24,9 @@ internal class UITestCase: XCTestCase {
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         sandboxRoot = root
+        /// Every run shares one defaults domain, so emptying it here is what keeps one test from
+        /// reading what the last one wrote.
+        UserDefaults.standard.removePersistentDomain(forName: PluginHostStorage.sandboxSuiteName)
     }
 
     /// Terminating before removing the directory matters: the app writes on the way down, and a
@@ -71,17 +75,27 @@ internal class UITestCase: XCTestCase {
         UITestCase.removeSuite(named: "com.TablePro.uitest.\(root.lastPathComponent)")
     }
 
-    /// `cfprefsd` writes a suite's plist lazily, so the per-test removal above can run before the
-    /// file exists and miss it. Sweeping the whole namespace once the class is done catches those,
-    /// and any left behind by a run that crashed before its teardown.
+    /// The app removes its own defaults domain as it terminates, which is the only point that
+    /// reliably comes after `cfprefsd` has written it. This sweep is the backstop for a run that
+    /// crashed or was killed before it got there, and it runs before the class's tests so a
+    /// previous session's leftovers go too.
+    override internal class func setUp() {
+        super.setUp()
+        sweepLeftoverSuites()
+    }
+
     override internal class func tearDown() {
+        sweepLeftoverSuites()
+        super.tearDown()
+    }
+
+    private static func sweepLeftoverSuites() {
         let preferences = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Preferences", isDirectory: true)
         let names = (try? FileManager.default.contentsOfDirectory(atPath: preferences.path)) ?? []
-        for name in names where name.hasPrefix("com.TablePro.uitest.") && name.hasSuffix(".plist") {
+        for name in names where name.hasPrefix("com.TablePro.uitest") && name.hasSuffix(".plist") {
             removeSuite(named: String(name.dropLast(".plist".count)))
         }
-        super.tearDown()
     }
 
     private static func removeSuite(named suiteName: String) {


### PR DESCRIPTION
Closes the last quarantined UI test, with the cause established from the runner rather than guessed.

## What the runner showed

`testConnectionsScopeSearchesTheOpenSampleDatabase` passed locally on macOS 27 and failed on the `macos-26` runner on both the first run and the retry. The log said only `XCTAssertTrue failed`, which is why it was quarantined: the assertion names what was not found, never what was there instead.

This PR adds the missing half. `UITestCase` now attaches `app.debugDescription` as a `.keepAlways` attachment when a test fails, so the result bundle the workflow already uploads carries the tree. Reading it settled the question: the app had opened the sample fine, the window was titled `Track` and the strip read `Chinook (Sample), connected`, and there was **no quick switcher anywhere in the tree**. The panel never opened.

## Why

Not a product bug. The other test in the same suite sends the same Cmd+Shift+O and passes on the runner, and the difference is what happens before it: that one opens a query tab, types, runs it and waits for the grid first. This one sent the shortcut immediately after the sample opened, while the app was still connecting and loading tables, and waiting for `app.windows.firstMatch` is no wait at all because the window exists straight away.

It now waits for the data grid, which is the state the shortcut depends on. That is a readiness signal rather than a longer timeout, so it does not just move the race.

The quarantine file is empty again. The attachment capture stays.