### PR TITLE
fix(coordinator): report a failed query instead of settling its claim first (#2120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A query that fails now shows the database's error again and is recorded in query history. A syntax error, or selecting from a table that does not exist, left the results area blank with no message at all, and opening a table that failed to load was silent the same way. The error also opens the results pane if you had it collapsed. (#2120)
+- Running a query with parameters, or several statements at once, no longer stops the tab from accepting any later run.
 - An MCP client could read the query history and schema of a connection whose external access was turned off, or that its token was not allowed to reach, by naming the connection directly. Both now go through the same permission check as every other request.
 - Searching query history for several words now finds entries that contain them all, wherever they appear. It only matched when the words sat next to each other in that order, so `select customers` found nothing.
 - Query History no longer throws away the older entries you loaded when a query finishes while the drawer is open. It also stops refetching once per statement while a large save or import runs.

--- a/TablePro/Core/Coordinators/PaginationCoordinator.swift
+++ b/TablePro/Core/Coordinators/PaginationCoordinator.swift
@@ -264,7 +264,7 @@ final class PaginationCoordinator {
 
         let route = DatabaseManager.shared.executionRoute(for: scope)
 
-        parent.currentQueryTask = Task { [weak self, parent] in
+        let fetchAllTask = Task { [weak self, parent] in
             guard let self, !parent.isTearingDown else { return }
 
             do {
@@ -291,11 +291,11 @@ final class PaginationCoordinator {
                     guard let self, !parent.isTearingDown else { return }
                     guard parent.tabExecution.isSameContent(contentEpoch, for: tabId) else {
                         parent.tabManager.mutate(tabId: tabId) { $0.pagination.isLoadingMore = false }
-                        parent.toolbarState.setExecuting(false)
+                        parent.retireQueryTask(for: nil)
                         return
                     }
                     guard let idx = parent.tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
-                        parent.toolbarState.setExecuting(false)
+                        parent.retireQueryTask(for: nil)
                         return
                     }
 
@@ -309,9 +309,8 @@ final class PaginationCoordinator {
                         tab.display.activeResultSet?.isTruncated = false
                     }
                     parent.dataTabDelegate?.tableViewCoordinator?.applyDelta(replaceDelta)
-                    parent.toolbarState.setExecuting(false)
+                    parent.retireQueryTask(for: nil)
                     parent.toolbarState.lastQueryDuration = result.executionTime
-                    parent.currentQueryTask = nil
 
                     let totalTime = CFAbsoluteTimeGetCurrent() - start
                     progressLog.info("[fetchAll] DONE rows=\(result.rows.count) fetchTime=\(String(format: "%.3f", fetchTime))s totalTime=\(String(format: "%.3f", totalTime))s")
@@ -326,13 +325,11 @@ final class PaginationCoordinator {
                         guard !isStale, !isCancelled else { return }
                         tab.execution.errorMessage = DatabaseWriteRejectionDiagnosis.formatted(error)
                     }
-                    parent.toolbarState.setExecuting(false)
-                    if !isStale {
-                        parent.currentQueryTask = nil
-                    }
+                    parent.retireQueryTask(for: nil)
                     MainContentCoordinator.logger.error("Fetch all failed: \(error.localizedDescription, privacy: .public)")
                 }
             }
         }
+        parent.installQueryTask(fetchAllTask, for: nil)
     }
 }

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
@@ -543,26 +543,37 @@ extension QueryExecutionCoordinator {
         return exceedsThreshold ? .skip : .exactCount(filtered: false)
     }
 
+    /// Reports a failure that belongs to this tab. Ownership of the window's task handle and the
+    /// spinner is settled by the caller before this runs, so nothing here touches them.
     func handleQueryExecutionError(
         _ error: Error,
         sql: String,
         tabId: UUID,
         connection conn: DatabaseConnection
     ) {
-        parent.currentQueryTask = nil
-        guard !DatabaseCancellationDiagnosis.isCancellation(error) else {
-            parent.tabManager.mutate(tabId: tabId) { tab in
-                tab.pagination.isLoadingMore = false
-            }
-            parent.toolbarState.setExecuting(false)
-            return
-        }
+        let message = DatabaseWriteRejectionDiagnosis.formatted(error)
+        helpersLogger.error(
+            "Query failed on tab \(tabId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+        )
         parent.tabManager.mutate(tabId: tabId) { tab in
-            tab.execution.errorMessage = DatabaseWriteRejectionDiagnosis.formatted(error)
+            tab.execution.errorMessage = message
             tab.execution.errorQuery = sql
             tab.execution.lastExecutedAt = Date()
+            tab.execution.executionTime = nil
+
+            // The banner lives at the top of the results pane, so a collapsed pane hides the only
+            // thing telling the user their query failed. Every success path opens it the same way.
+            if tab.display.isResultsCollapsed {
+                tab.display.isResultsCollapsed = false
+            }
         }
-        parent.toolbarState.setExecuting(false)
+        // The toolbar mirrors the selected tab, so a failure on a tab in the background describes
+        // itself on its own tab and leaves the window chrome to whatever is actually on screen.
+        if parent.tabManager.selectedTabId == tabId {
+            parent.toolbarState.isResultsCollapsed = false
+            parent.toolbarState.lastQueryDuration = nil
+            parent.announceQueryError(message)
+        }
 
         recordHistory(
             QueryHistoryRecordRequest(

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+MultiStatement.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+MultiStatement.swift
@@ -83,13 +83,10 @@ extension QueryExecutionCoordinator {
         lastSelectSQL: String?,
         newResultSets: [ResultSet]
     ) {
-        parent.currentQueryTask = nil
-        parent.toolbarState.setExecuting(false)
+        guard parent.tabExecution.settle(claim) else { return }
+        parent.retireQueryTask(for: claim)
         parent.toolbarState.lastQueryDuration = cumulativeTime
 
-        if !parent.tabExecution.isCurrent(claim) {
-            return
-        }
         guard let idx = parent.tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
             return
         }

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+Parameters.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+Parameters.swift
@@ -121,7 +121,7 @@ extension QueryExecutionCoordinator {
             needsMetadataFetch = false
         }
 
-        parent.currentQueryTask = Task { [weak self, parent] in
+        let parameterizedTask = Task { [weak self, parent] in
             guard let self else { return }
 
             let schemaTask: Task<FetchedTableSchema, Error>?
@@ -147,7 +147,7 @@ extension QueryExecutionCoordinator {
 
                 guard !Task.isCancelled else {
                     schemaTask?.cancel()
-                    await parent.resetExecutionState(tabId: tabId, executionTime: fetchResult.executionTime)
+                    await parent.resetExecutionState(claim: claim, executionTime: fetchResult.executionTime)
                     return
                 }
 
@@ -185,28 +185,25 @@ extension QueryExecutionCoordinator {
                         )
                     }
                 } else if !isEditable || tableName == nil {
-                    await MainActor.run { [weak self] in
-                        guard let self else { return }
-                        guard parent.tabExecution.isCurrent(claim) else { return }
-                        guard !Task.isCancelled else { return }
-                        parent.changeManager.clearChangesAndUndoHistory()
+                    await MainActor.run { [parent] in
+                        parent.clearChangesIfCurrent(claim: claim)
                     }
                 }
             } catch {
                 schemaTask?.cancel()
                 await MainActor.run { [weak self] in
                     guard let self else { return }
+                    guard parent.tabExecution.settle(claim) else { return }
                     parent.tabManager.mutate(tabId: tabId) { tab in
                         tab.pagination.isLoadingMore = false
                     }
-                    parent.currentQueryTask = nil
-                    parent.toolbarState.setExecuting(false)
+                    parent.retireQueryTask(for: claim)
                     if DatabaseCancellationDiagnosis.isCancellation(error) || Task.isCancelled { return }
-                    guard parent.tabExecution.isCurrent(claim) else { return }
                     handleQueryExecutionError(error, sql: sql, tabId: tabId, connection: conn)
                 }
             }
         }
+        parent.installQueryTask(parameterizedTask, for: claim)
     }
 
     /// Every statement of the run shares one lease on the tab's database, so the
@@ -269,7 +266,7 @@ extension QueryExecutionCoordinator {
             )
         }
 
-        parent.currentQueryTask = Task { [weak self, parent] in
+        let multiStatementTask = Task { [weak self, parent] in
             guard let self else { return }
 
             let outcome = await runMultiStatementTransaction(
@@ -281,8 +278,8 @@ extension QueryExecutionCoordinator {
 
             switch outcome {
             case .cancelled:
-                parent.currentQueryTask = nil
-                parent.toolbarState.setExecuting(false)
+                guard parent.tabExecution.settle(claim) else { return }
+                parent.retireQueryTask(for: claim)
             case .completed(let results):
                 let resultSets = applyExecutedStatements(
                     prepared: prepared,
@@ -323,6 +320,7 @@ extension QueryExecutionCoordinator {
                 )
             }
         }
+        parent.installQueryTask(multiStatementTask, for: claim)
     }
 
     private func prepareStatement(
@@ -473,16 +471,13 @@ extension QueryExecutionCoordinator {
     ) async {
         await MainActor.run { [weak self] in
             guard let self else { return }
-            parent.currentQueryTask = nil
+            guard parent.tabExecution.settle(claim) else { return }
+            parent.retireQueryTask(for: claim)
+            guard !Task.isCancelled else { return }
             if PluginManager.shared.supportsQueryProgress(for: parent.connection.type) {
                 parent.clearClickHouseProgress()
             }
-            parent.toolbarState.setExecuting(false)
             parent.toolbarState.lastQueryDuration = fetchResult.executionTime
-
-            if !parent.tabExecution.isCurrent(claim) || Task.isCancelled {
-                return
-            }
 
             applyPhase1Result(
                 tabId: tabId,
@@ -525,15 +520,6 @@ extension QueryExecutionCoordinator {
         failedSQL: String?,
         resultSets: inout [ResultSet]
     ) async {
-        if !parent.tabExecution.isCurrent(claim) {
-            await MainActor.run { [weak self] in
-                guard let self else { return }
-                parent.currentQueryTask = nil
-                parent.toolbarState.setExecuting(false)
-            }
-            return
-        }
-
         let failedStmtIndex = executedCount + 1
         let contextMsg = "Statement \(failedStmtIndex)/\(totalCount) failed: " + errorDescription
 
@@ -545,15 +531,24 @@ extension QueryExecutionCoordinator {
         let capturedResultSets = resultSets
         await MainActor.run { [weak self] in
             guard let self else { return }
-            parent.currentQueryTask = nil
-            parent.toolbarState.setExecuting(false)
+            guard parent.tabExecution.settle(claim) else { return }
+            parent.retireQueryTask(for: claim)
 
             parent.tabManager.mutate(tabId: tabId) { tab in
                 tab.execution.errorMessage = contextMsg
                 tab.execution.errorQuery = failedStatement
                 tab.execution.executionTime = cumulativeTime
+                tab.execution.lastExecutedAt = Date()
 
                 tab.display.replaceUnpinnedResults(with: capturedResultSets)
+                if tab.display.isResultsCollapsed {
+                    tab.display.isResultsCollapsed = false
+                }
+            }
+            if parent.tabManager.selectedTabId == tabId {
+                parent.toolbarState.isResultsCollapsed = false
+                parent.toolbarState.lastQueryDuration = cumulativeTime
+                parent.announceQueryError(contextMsg)
             }
 
             let rawSQL = failedStatement

--- a/TablePro/Core/Database/ConnectionAttemptRegistry.swift
+++ b/TablePro/Core/Database/ConnectionAttemptRegistry.swift
@@ -23,6 +23,9 @@ struct ConnectionAttemptRegistry {
         generations.removeValue(forKey: connectionId)
     }
 
+    /// Safe to return nothing only because every caller runs it last, after validating through
+    /// `isCurrent`. `TabExecutionRegistry.settle` is the same operation one level down and returns
+    /// the answer instead, because its completion sites validate after releasing and cannot.
     mutating func finish(_ generation: Int, for connectionId: UUID) {
         guard generations[connectionId] == generation else { return }
         generations.removeValue(forKey: connectionId)

--- a/TablePro/Core/Execution/TabExecutionRegistry.swift
+++ b/TablePro/Core/Execution/TabExecutionRegistry.swift
@@ -54,8 +54,19 @@ internal struct TabExecutionRegistry {
         contentEpoch(for: tabId) == epoch
     }
 
+    /// Only for an execution that is still in flight and has more work to do. An execution that has
+    /// finished asks `settle` instead, which answers the same question and releases the tab in one
+    /// step: `settle` removes the entry, so `isCurrent` after it is false whether or not the claim
+    /// owned anything, and a guard written that way rejects every result it was meant to admit.
     internal func isCurrent(_ claim: TabExecutionClaim) -> Bool {
         entries[claim.tabId]?.epoch == claim.epoch
+    }
+
+    /// Identity of what the tab is showing, asked on behalf of the claim that produced it. Work
+    /// that outlives its own claim (phase 2, clearing pending edits) has to ask this, because its
+    /// claim was settled the moment the result was applied.
+    internal func ownsContent(_ claim: TabExecutionClaim) -> Bool {
+        isSameContent(claim.epoch, for: claim.tabId)
     }
 
     /// Retarget, explicit cancel, tab close, teardown. Removing the entry rather than bumping a
@@ -76,11 +87,22 @@ internal struct TabExecutionRegistry {
         }
     }
 
-    /// Ends a claim that ran to completion. A claim that is no longer current settles nothing, so a
-    /// late result cannot clear the busy state of the navigation that superseded it.
-    internal mutating func settle(_ claim: TabExecutionClaim) {
-        guard isCurrent(claim) else { return }
+    /// Ends a claim that ran to completion and reports whether it still owned the tab. A claim that
+    /// is no longer current settles nothing, so a late result cannot clear the busy state of the
+    /// navigation that superseded it.
+    ///
+    /// The answer and the release are one call on purpose. Asking them separately is
+    /// order-dependent, and releasing first makes the check that follows answer "no" forever, which
+    /// is how a failed query stopped reporting its error (#2120). The returned value is the
+    /// caller's authority to write: `guard settle(claim) else { return }`, with every write below
+    /// the guard. It is deliberately not `@discardableResult`.
+    ///
+    /// `ConnectionAttemptRegistry.finish` is the same idea for connections and keeps the older
+    /// void shape, because its completion sites call it last, after validating through a pure read.
+    internal mutating func settle(_ claim: TabExecutionClaim) -> Bool {
+        guard isCurrent(claim) else { return false }
         entries.removeValue(forKey: claim.tabId)
+        return true
     }
 
     internal func isExecuting(_ tabId: UUID) -> Bool {

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Alerts.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Alerts.swift
@@ -46,18 +46,6 @@ extension MainContentCoordinator {
 
     // MARK: - Error Alerts
 
-    /// Show query execution error as a sheet
-    /// - Parameters:
-    ///   - error: The error that occurred
-    ///   - window: Parent window (optional)
-    func showQueryError(_ error: Error, window: NSWindow?) {
-        AlertHelper.showErrorSheet(
-            title: String(localized: "Query Execution Failed"),
-            message: error.localizedDescription,
-            window: window
-        )
-    }
-
     /// Show save changes error as a sheet
     /// - Parameters:
     ///   - error: The error that occurred

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Explain.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Explain.swift
@@ -123,7 +123,7 @@ extension MainContentCoordinator {
         tabManager.mutate(at: index) { $0.execution.errorMessage = nil }
         toolbarState.setExecuting(true)
 
-        currentQueryTask = Task { [weak self] in
+        let explainTask = Task { [weak self] in
             guard let self else { return }
             do {
                 let fetchResult = try await services.databaseManager.withScopedDriver(
@@ -144,9 +144,9 @@ extension MainContentCoordinator {
                     // Every write below belongs to whoever owns the tab now. A superseded plan
                     // that cleared the spinner or nilled the task handle would be reporting on a
                     // query that is still running, so the gate comes before all of them.
-                    guard tabExecution.isCurrent(claim), !Task.isCancelled else { return }
-                    currentQueryTask = nil
-                    toolbarState.setExecuting(false)
+                    guard tabExecution.settle(claim) else { return }
+                    retireQueryTask(for: claim)
+                    guard !Task.isCancelled else { return }
 
                     tabManager.mutate(tabId: tabId) { tab in
                         tab.execution.executionTime = fetchResult.executionTime
@@ -165,7 +165,6 @@ extension MainContentCoordinator {
                         }
                     }
                     toolbarState.isResultsCollapsed = false
-                    tabExecution.settle(claim)
 
                     recordHistory(
                         QueryHistoryRecordRequest(
@@ -184,17 +183,23 @@ extension MainContentCoordinator {
             } catch {
                 await MainActor.run { [weak self] in
                     guard let self else { return }
-                    tabExecution.settle(claim)
-                    currentQueryTask = nil
-                    toolbarState.setExecuting(false)
+                    guard tabExecution.settle(claim) else { return }
+                    retireQueryTask(for: claim)
 
                     // A cancelled EXPLAIN is not a failure the user needs told about, and it does
                     // not belong in history either.
                     if DatabaseCancellationDiagnosis.isCancellation(error) || Task.isCancelled { return }
-                    guard tabExecution.isCurrent(claim) else { return }
 
                     tabManager.mutate(tabId: tabId) { tab in
                         tab.execution.errorMessage = error.localizedDescription
+                        tab.execution.lastExecutedAt = Date()
+                        if tab.display.isResultsCollapsed {
+                            tab.display.isResultsCollapsed = false
+                        }
+                    }
+                    if tabManager.selectedTabId == tabId {
+                        toolbarState.isResultsCollapsed = false
+                        announceQueryError(error.localizedDescription)
                     }
 
                     recordHistory(
@@ -214,5 +219,6 @@ extension MainContentCoordinator {
                 }
             }
         }
+        installQueryTask(explainTask, for: claim)
     }
 }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryHelpers.swift
@@ -3,6 +3,7 @@
 //  TablePro
 //
 
+import AppKit
 import Foundation
 import os
 import TableProPluginKit
@@ -11,6 +12,17 @@ extension MainContentCoordinator {
     func fixErrorWithAI(query: String, error: String) {
         showAIChatPanel()
         aiViewModel?.handleFixError(query: query, error: error)
+    }
+
+    /// The banner appears without the user doing anything, and macOS has no live region to mark it
+    /// with, so an announcement is the only way VoiceOver hears about it. Announcements are
+    /// app-scoped rather than window-scoped, so a background window has to stay quiet instead of
+    /// talking over whatever the front one is doing.
+    func announceQueryError(_ message: String) {
+        guard contentWindow?.isKeyWindow == true else { return }
+        AccessibilityNotification.Announcement(
+            String(format: String(localized: "Query failed. %@"), message)
+        ).post()
     }
 
     func finishFailedQuery(
@@ -23,15 +35,16 @@ extension MainContentCoordinator {
         trigger: TableLoadTrigger,
         traceToken: TableLoadTraceToken?
     ) {
+        guard tabExecution.settle(claim) else {
+            traceStaleResultDropped(traceToken)
+            return
+        }
         tabManager.mutate(tabId: tabId) { tab in
             tab.pagination.isLoadingMore = false
         }
-        tabExecution.settle(claim)
-        currentQueryTask = nil
-        toolbarState.setExecuting(false)
+        retireQueryTask(for: claim)
         traceExecutionFailed(traceToken, error: error)
         if DatabaseCancellationDiagnosis.isCancellation(error) || Task.isCancelled { return }
-        guard tabExecution.isCurrent(claim) else { return }
         if isAutoLoad, services.databaseManager.driver(for: connectionId)?.status != .connected {
             pendingLoadTrigger = trigger
             return
@@ -39,8 +52,12 @@ extension MainContentCoordinator {
         handleQueryExecutionError(error, sql: sql, tabId: tabId, connection: conn)
     }
 
+    /// The change manager is one per window and holds whichever tab is selected, so a result that
+    /// still owns its own tab may not own the edits on screen. Clearing without the selection check
+    /// throws away another tab's uncommitted cells and its undo history.
     func clearChangesIfCurrent(claim: TabExecutionClaim) {
-        guard tabExecution.isCurrent(claim), !Task.isCancelled else { return }
+        guard tabExecution.ownsContent(claim), !Task.isCancelled else { return }
+        guard tabManager.selectedTabId == claim.tabId else { return }
         changeManager.clearChangesAndUndoHistory()
     }
 

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -210,6 +210,12 @@ final class MainContentCoordinator {
     /// property and invalidates its readers.
     internal var tabExecution = TabExecutionRegistry()
     @ObservationIgnored internal var currentQueryTask: Task<Void, Never>?
+
+    /// Which claim installed `currentQueryTask`. The handle is one per window while claims are one
+    /// per tab, so owning your own tab is not the same as owning the query the window is running:
+    /// superseding tab B cancels tab A's task, and A's completion would otherwise nil out B's
+    /// handle and leave B's query with no spinner and no way to stop it.
+    @ObservationIgnored internal var currentQueryTaskOwner: TabExecutionClaim?
     @ObservationIgnored internal var rowCountTasks: [UUID: (token: UUID, task: Task<Void, Never>)] = [:]
     @ObservationIgnored internal var tableLoadTasks: [UUID: (token: UUID, task: Task<Void, Never>)] = [:]
     @ObservationIgnored internal var redisDatabaseSwitchTask: Task<Void, Never>?
@@ -1067,7 +1073,7 @@ final class MainContentCoordinator {
             )
         }
         guard let scope = scope(for: tab) else {
-            tabExecution.settle(claim)
+            guard tabExecution.settle(claim) else { return }
             tabManager.mutate(at: index) { tab in
                 tab.execution.errorMessage = String(localized: "Not connected to database")
             }
@@ -1075,7 +1081,7 @@ final class MainContentCoordinator {
             return
         }
 
-        currentQueryTask = Task { [weak self] in
+        let queryTask = Task { [weak self] in
             guard let self else { return }
 
             if isAutoLoad {
@@ -1085,9 +1091,8 @@ final class MainContentCoordinator {
                     await MainActor.run { [weak self] in
                         guard let self else { return }
                         traceConnectUnavailable(traceToken)
-                        tabExecution.settle(claim)
-                        currentQueryTask = nil
-                        toolbarState.setExecuting(false)
+                        guard tabExecution.settle(claim) else { return }
+                        retireQueryTask(for: claim)
                         pendingLoadTrigger = trigger
                     }
                     return
@@ -1120,7 +1125,7 @@ final class MainContentCoordinator {
                 guard !Task.isCancelled else {
                     schemaTask?.cancel()
                     traceFetchCancelled(traceToken, began: fetchBeganAt, ended: fetchEndedAt)
-                    await resetExecutionState(tabId: tabId, executionTime: fetchResult.executionTime)
+                    await resetExecutionState(claim: claim, executionTime: fetchResult.executionTime)
                     return
                 }
 
@@ -1134,16 +1139,22 @@ final class MainContentCoordinator {
 
                     // Every write below belongs to whoever owns the tab now. A superseded result
                     // that cleared the spinner or nilled the task handle would be reporting on a
-                    // query that is still running, so the gate comes before all of them.
-                    guard tabExecution.isCurrent(claim), !Task.isCancelled else {
+                    // query that is still running, so the gate comes before all of them. Settling
+                    // is that gate: it answers and releases in one step, and it comes before the
+                    // cancellation check rather than sharing a guard with it, because a short
+                    // circuit there would leave the tab claimed forever and refusing later runs.
+                    guard tabExecution.settle(claim) else {
                         traceStaleResultDropped(traceToken)
                         return
                     }
-                    currentQueryTask = nil
+                    retireQueryTask(for: claim)
+                    guard !Task.isCancelled else {
+                        traceStaleResultDropped(traceToken)
+                        return
+                    }
                     if services.pluginManager.supportsQueryProgress(for: self.connection.type) {
                         self.clearClickHouseProgress()
                     }
-                    toolbarState.setExecuting(false)
                     toolbarState.lastQueryDuration = fetchResult.executionTime
 
                     traceApplyingResult(traceToken, tabId: tabId)
@@ -1165,7 +1176,6 @@ final class MainContentCoordinator {
                         isTruncated: fetchResult.isTruncated
                     )
 
-                    tabExecution.settle(claim)
                     scheduleTraceCompletion(traceToken, outcome: "completed")
                 }
 
@@ -1194,6 +1204,24 @@ final class MainContentCoordinator {
                 )
             }
         }
+        installQueryTask(queryTask, for: claim)
+    }
+
+    /// A nil claim means work that runs against a tab without claiming it, which is Fetch All. It
+    /// still owns the handle for as long as it runs; it just cannot be retired by any claim.
+    internal func installQueryTask(_ task: Task<Void, Never>, for claim: TabExecutionClaim?) {
+        currentQueryTask = task
+        currentQueryTaskOwner = claim
+    }
+
+    /// Retires the window's task handle and the spinner it drives, but only for the execution that
+    /// installed them. A completion that owns its own tab can still be a stranger to the query the
+    /// window is running, and clearing that one's spinner reports on work still in flight.
+    internal func retireQueryTask(for claim: TabExecutionClaim?) {
+        guard currentQueryTaskOwner == claim else { return }
+        currentQueryTask = nil
+        currentQueryTaskOwner = nil
+        toolbarState.setExecuting(false)
     }
 
     internal func cancelInFlightQueryTask(reach: DriverCancellationReach = .userStop) {
@@ -1205,24 +1233,36 @@ final class MainContentCoordinator {
             Self.logger.warning("cancelQuery failed: \(error.localizedDescription, privacy: .public)")
         }
         currentQueryTask = nil
+        currentQueryTaskOwner = nil
     }
 
     /// Ends whatever the tab was doing so a new navigation owns it outright. Invalidating before the
     /// new claim is minted is what makes "the user navigated away and no successor ever ran" still
     /// discard the old result, which a counter that only moved on a successful start could not do.
+    ///
+    /// Clearing the spinner here is what makes the cancelled execution's own completion free to stay
+    /// silent. A retarget need not be followed by a successor, so nothing else would put the
+    /// titlebar back to idle, and a stuck spinner keeps Stop enabled and makes Disconnect warn about
+    /// a query that is not running.
     internal func supersedeExecution(for tabId: UUID) {
         tabExecution.invalidate(tabId)
         cancelTableLoad(for: tabId)
         cancelRowCountTask(for: tabId)
+        let hadInFlightQuery = currentQueryTask != nil
         cancelInFlightQueryTask(reach: .supersededNavigation)
+        if hadInFlightQuery {
+            toolbarState.setExecuting(false)
+        }
     }
 
-    /// Reset execution state when a query is cancelled
+    /// Reset execution state when a query is cancelled. The task handle is retired through the same
+    /// ownership check as any other completion: a cancelled attempt that has already been replaced
+    /// would otherwise take its successor's handle and spinner down with it.
     @MainActor
-    internal func resetExecutionState(tabId: UUID, executionTime: TimeInterval) {
-        tabExecution.invalidate(tabId)
-        currentQueryTask = nil
-        toolbarState.setExecuting(false)
+    internal func resetExecutionState(claim: TabExecutionClaim, executionTime: TimeInterval) {
+        tabExecution.invalidate(claim.tabId)
+        guard currentQueryTaskOwner == claim else { return }
+        retireQueryTask(for: claim)
         toolbarState.lastQueryDuration = executionTime
     }
 

--- a/TablePro/Views/Results/InlineErrorBanner.swift
+++ b/TablePro/Views/Results/InlineErrorBanner.swift
@@ -27,6 +27,7 @@ struct InlineErrorBanner: View {
                     .font(.subheadline)
                     .textSelection(.enabled)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .accessibilityIdentifier("query-error-message")
                     .onGeometryChange(for: CGFloat.self) { proxy in
                         proxy.size.height
                     } action: { height in

--- a/TableProTests/Core/Execution/TabExecutionRegistryTests.swift
+++ b/TableProTests/Core/Execution/TabExecutionRegistryTests.swift
@@ -66,7 +66,8 @@ struct TabExecutionRegistryTests {
         #expect(registry.isExecuting(tabId))
         #expect(registry.isAnyExecuting)
 
-        registry.settle(claim)
+        let settled = registry.settle(claim)
+        #expect(settled)
         #expect(registry.isExecuting(tabId) == false)
         #expect(registry.isAnyExecuting == false)
     }
@@ -80,10 +81,52 @@ struct TabExecutionRegistryTests {
         let stale = registry.claim(tabId)
         let live = registry.claim(tabId)
 
-        registry.settle(stale)
+        let settledStale = registry.settle(stale)
+        #expect(settledStale == false)
 
         #expect(registry.isExecuting(tabId))
         #expect(registry.isCurrent(live))
+    }
+
+    /// The whole point of the return value. A completing execution has one question, "may I write
+    /// this?", and settling has to answer it, because asking `isCurrent` afterwards is always false
+    /// and asking it beforehand is a separate call someone will eventually put in the wrong order.
+    /// That is what silently swallowed every query error in 0.64.0 (#2120).
+    @Test("Settling answers whether the claim owned the tab")
+    func settleReportsOwnership() {
+        var registry = TabExecutionRegistry()
+        let tabId = UUID()
+        let claim = registry.claim(tabId)
+
+        let firstSettle = registry.settle(claim)
+        #expect(firstSettle)
+        let secondSettle = registry.settle(claim)
+        #expect(secondSettle == false)
+
+        let superseded = registry.claim(tabId)
+        registry.invalidate(tabId)
+        let settledSuperseded = registry.settle(superseded)
+        #expect(settledSuperseded == false)
+    }
+
+    /// Work that outlives its own claim, phase 2 and clearing pending edits, asks about content
+    /// instead. Content identity is what survives the settle and dies on a retarget.
+    @Test("Content ownership survives a settle but not a retarget or a reclaim")
+    func ownsContentOutlivesTheClaim() {
+        var registry = TabExecutionRegistry()
+        let tabId = UUID()
+        let claim = registry.claim(tabId)
+
+        let settled = registry.settle(claim)
+        #expect(settled)
+        #expect(registry.ownsContent(claim))
+
+        registry.invalidate(tabId)
+        #expect(registry.ownsContent(claim) == false)
+
+        let reclaimed = registry.claim(tabId)
+        _ = registry.claim(tabId)
+        #expect(registry.ownsContent(reclaimed) == false)
     }
 
 

--- a/TableProTests/Core/Execution/TabExecutionSettleGuardTests.swift
+++ b/TableProTests/Core/Execution/TabExecutionSettleGuardTests.swift
@@ -1,0 +1,80 @@
+//
+//  TabExecutionSettleGuardTests.swift
+//  TableProTests
+//
+//  `settle` answers whether the claim still owned the tab, and the answer is the caller's authority
+//  to write. Discarding it is the whole bug: the callers that did went on to ask `isCurrent`, which
+//  settling had already made false, so their writes never ran. The compiler only warns about an
+//  unused result, and this trap has been walked into three times (#2055, #2068, #2120), so it is
+//  worth failing the build over.
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Execution claim settle guard")
+struct TabExecutionSettleGuardTests {
+    @Test("Every settle call consumes the ownership answer it returns")
+    func noSettleCallDiscardsItsAnswer() throws {
+        let offenders = try Self.settleCallSites().filter { !$0.consumesResult }
+        #expect(
+            offenders.isEmpty,
+            """
+            Settling reports whether the claim still owned the tab. Write \
+            `guard tabExecution.settle(claim) else { return }` and put every write below it: \
+            \(offenders.map(\.description).sorted())
+            """
+        )
+    }
+
+    private struct CallSite {
+        let file: String
+        let line: Int
+        let text: String
+
+        /// A consumed answer decides something: a condition, or a binding the code goes on to read.
+        /// `_ =` is not consumption, it is the discard this guard exists to catch, and a bare call
+        /// is the same thing with a compiler warning nobody has to act on.
+        var consumesResult: Bool {
+            let trimmed = text.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.hasPrefix("_ ="), !trimmed.hasPrefix("_=") else { return false }
+            return trimmed.hasPrefix("guard ")
+                || trimmed.hasPrefix("if ")
+                || trimmed.hasPrefix("return ")
+                || trimmed.hasPrefix("while ")
+                || trimmed.contains(" = ")
+        }
+
+        var description: String { "\(file):\(line)" }
+    }
+
+    private static func settleCallSites() throws -> [CallSite] {
+        let sourceRoot = try repoRoot().appendingPathComponent("TablePro")
+        guard let enumerator = FileManager.default.enumerator(
+            at: sourceRoot,
+            includingPropertiesForKeys: [.isRegularFileKey]
+        ) else { return [] }
+
+        var sites: [CallSite] = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            let text = try String(contentsOf: url, encoding: .utf8)
+            for (offset, line) in text.components(separatedBy: .newlines).enumerated()
+                where line.contains(".settle(") {
+                sites.append(CallSite(file: url.lastPathComponent, line: offset + 1, text: line))
+            }
+        }
+        return sites
+    }
+
+    private static func repoRoot() throws -> URL {
+        var directory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        for _ in 0 ..< 12 {
+            if FileManager.default.fileExists(atPath: directory.appendingPathComponent("TablePro.xcodeproj").path) {
+                return directory
+            }
+            directory = directory.deletingLastPathComponent()
+        }
+        throw CocoaError(.fileNoSuchFile)
+    }
+}

--- a/TableProTests/Core/Execution/TabRetargetInvalidationTests.swift
+++ b/TableProTests/Core/Execution/TabRetargetInvalidationTests.swift
@@ -63,7 +63,8 @@ struct TabRetargetInvalidationTests {
         registry.invalidate(tabId)
         let tableB = registry.claim(tabId)
 
-        registry.settle(tableA)
+        let settled = registry.settle(tableA)
+        #expect(settled == false)
 
         #expect(registry.isCurrent(tableB))
         #expect(registry.isExecuting(tabId))
@@ -76,7 +77,8 @@ struct TabRetargetInvalidationTests {
         var registry = TabExecutionRegistry()
         let tabId = UUID()
         let claim = registry.claim(tabId)
-        registry.settle(claim)
+        let settled = registry.settle(claim)
+        #expect(settled)
 
         let captured = registry.contentEpoch(for: tabId)
         #expect(registry.isSameContent(captured, for: tabId))
@@ -93,7 +95,8 @@ struct TabRetargetInvalidationTests {
         let claim = registry.claim(tabId)
         let captured = registry.contentEpoch(for: tabId)
 
-        registry.settle(claim)
+        let settled = registry.settle(claim)
+        #expect(settled)
 
         #expect(registry.isSameContent(captured, for: tabId))
     }

--- a/TableProTests/Views/Main/Phase2RowCountGuardTests.swift
+++ b/TableProTests/Views/Main/Phase2RowCountGuardTests.swift
@@ -23,7 +23,8 @@ struct Phase2RowCountGuardTests {
         let claim = registry.claim(tabId)
         let contentEpoch = registry.contentEpoch(for: tabId)
 
-        registry.settle(claim)
+        let settled = registry.settle(claim)
+        #expect(settled)
 
         #expect(registry.isCurrent(claim) == false)
         #expect(registry.isSameContent(contentEpoch, for: tabId))
@@ -37,7 +38,8 @@ struct Phase2RowCountGuardTests {
         let (coordinator, tabManager) = Self.makeCoordinator()
         let tabId = Self.addTableTab(to: tabManager)
         let claim = coordinator.tabExecution.claim(tabId)
-        coordinator.tabExecution.settle(claim)
+        let settled = coordinator.tabExecution.settle(claim)
+        #expect(settled)
         #expect(coordinator.tabExecution.isCurrent(claim) == false)
 
         coordinator.launchPhase2Count(tableName: "users", tabId: tabId, connectionType: .mysql)
@@ -53,7 +55,8 @@ struct Phase2RowCountGuardTests {
         let tabId = UUID()
         let claim = registry.claim(tabId)
         let contentEpoch = registry.contentEpoch(for: tabId)
-        registry.settle(claim)
+        let settled = registry.settle(claim)
+        #expect(settled)
 
         registry.invalidate(tabId)
 

--- a/TableProTests/Views/Main/QueryFailureReportingTests.swift
+++ b/TableProTests/Views/Main/QueryFailureReportingTests.swift
@@ -1,0 +1,235 @@
+//
+//  QueryFailureReportingTests.swift
+//  TableProTests
+//
+//  A failed query has one job: say so. The 0.64.0 execution-ownership refactor released the tab's
+//  claim before asking whether the claim still owned the tab, and that question is always answered
+//  no once the claim is released, so every failure returned before it could report anything (#2120).
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("Query failure reporting", .serialized)
+@MainActor
+struct QueryFailureReportingTests {
+    private struct DriverFailure: LocalizedError {
+        let errorDescription: String? = "relation \"stu\" does not exist"
+    }
+
+    @Test("A failed query reports the database's error on the tab")
+    func failureSetsTheErrorMessage() {
+        let (coordinator, tabManager) = Self.makeCoordinator()
+        let tabId = Self.addQueryTab(to: tabManager)
+        let claim = coordinator.tabExecution.claim(tabId)
+
+        Self.finishFailure(on: coordinator, tabId: tabId, claim: claim)
+
+        let tab = try? #require(tabManager.tabs.first)
+        #expect(tab?.execution.errorMessage == "relation \"stu\" does not exist")
+        #expect(tab?.execution.errorQuery == "select * from stu")
+        #expect(tab?.execution.lastExecutedAt != nil)
+    }
+
+    /// The banner is drawn at the top of the results pane, so a collapsed pane hides the only thing
+    /// that says the query failed. Every success path opens it; the failure paths did not.
+    @Test("A failure opens a collapsed results pane")
+    func failureOpensCollapsedResults() {
+        let (coordinator, tabManager) = Self.makeCoordinator()
+        let tabId = Self.addQueryTab(to: tabManager)
+        tabManager.mutate(tabId: tabId) { $0.display.isResultsCollapsed = true }
+        let claim = coordinator.tabExecution.claim(tabId)
+
+        Self.finishFailure(on: coordinator, tabId: tabId, claim: claim)
+
+        #expect(tabManager.tabs.first?.display.isResultsCollapsed == false)
+        #expect(coordinator.toolbarState.isResultsCollapsed == false)
+    }
+
+    /// The toolbar's duration readout is only written on success, so a failure that left it alone
+    /// showed the previous run's timing beside a red banner.
+    @Test("A failure clears the duration left over from the last successful run")
+    func failureClearsTheStaleDuration() {
+        let (coordinator, tabManager) = Self.makeCoordinator()
+        let tabId = Self.addQueryTab(to: tabManager)
+        coordinator.toolbarState.lastQueryDuration = 1.5
+        let claim = coordinator.tabExecution.claim(tabId)
+
+        Self.finishFailure(on: coordinator, tabId: tabId, claim: claim)
+
+        #expect(coordinator.toolbarState.lastQueryDuration == nil)
+        #expect(tabManager.tabs.first?.execution.executionTime == nil)
+    }
+
+    @Test("Reporting a failure releases the tab so the next run is not blocked")
+    func failureReleasesTheTab() {
+        let (coordinator, tabManager) = Self.makeCoordinator()
+        let tabId = Self.addQueryTab(to: tabManager)
+        let claim = coordinator.tabExecution.claim(tabId)
+        #expect(coordinator.tabExecution.isExecuting(tabId))
+
+        Self.finishFailure(on: coordinator, tabId: tabId, claim: claim)
+
+        #expect(coordinator.tabExecution.isExecuting(tabId) == false)
+    }
+
+    @Test("A cancelled query is not reported as an error")
+    func cancellationIsNotAnError() {
+        let (coordinator, tabManager) = Self.makeCoordinator()
+        let tabId = Self.addQueryTab(to: tabManager)
+        let claim = coordinator.tabExecution.claim(tabId)
+
+        Self.finishFailure(on: coordinator, tabId: tabId, claim: claim, error: CancellationError())
+
+        #expect(tabManager.tabs.first?.execution.errorMessage == nil)
+    }
+
+    /// The other half of the gate. A result that lost the tab must not report into it, and must not
+    /// clear the spinner belonging to the navigation that replaced it.
+    @Test("A superseded failure writes nothing and leaves the successor's spinner alone")
+    func supersededFailureIsSilent() {
+        let (coordinator, tabManager) = Self.makeCoordinator()
+        let tabId = Self.addQueryTab(to: tabManager)
+        let stale = coordinator.tabExecution.claim(tabId)
+        _ = coordinator.tabExecution.claim(tabId)
+        coordinator.toolbarState.setExecuting(true)
+
+        Self.finishFailure(on: coordinator, tabId: tabId, claim: stale)
+
+        #expect(tabManager.tabs.first?.execution.errorMessage == nil)
+        #expect(coordinator.toolbarState.isExecuting)
+        #expect(coordinator.tabExecution.isExecuting(tabId))
+    }
+
+    /// The window's task handle is one per window while claims are one per tab, so owning your own
+    /// tab is not owning the query the window is running.
+    @Test("Retiring the task handle only works for the execution that installed it")
+    func onlyTheInstallerRetiresTheTaskHandle() {
+        let (coordinator, tabManager) = Self.makeCoordinator()
+        let tabId = Self.addQueryTab(to: tabManager)
+        let otherTabId = Self.addQueryTab(to: tabManager, title: "Query 2")
+        let running = coordinator.tabExecution.claim(otherTabId)
+        let stranger = coordinator.tabExecution.claim(tabId)
+
+        let task = Task<Void, Never> {}
+        coordinator.installQueryTask(task, for: running)
+        coordinator.toolbarState.setExecuting(true)
+
+        coordinator.retireQueryTask(for: stranger)
+        #expect(coordinator.currentQueryTask != nil)
+        #expect(coordinator.toolbarState.isExecuting)
+
+        coordinator.retireQueryTask(for: running)
+        #expect(coordinator.currentQueryTask == nil)
+        #expect(coordinator.toolbarState.isExecuting == false)
+        task.cancel()
+    }
+
+    /// Cancelling goes through the same ownership check as any other completion. A cancelled attempt
+    /// that has already been replaced would otherwise take its successor's handle and spinner down
+    /// with it, leaving a running query with no spinner and nothing for Stop to reach.
+    @Test("Resetting after a cancel leaves a successor's task handle alone")
+    func cancelResetRespectsTheHandleOwner() {
+        let (coordinator, tabManager) = Self.makeCoordinator()
+        let tabId = Self.addQueryTab(to: tabManager)
+        let otherTabId = Self.addQueryTab(to: tabManager, title: "Query 2")
+        let cancelled = coordinator.tabExecution.claim(tabId)
+        let successor = coordinator.tabExecution.claim(otherTabId)
+
+        let task = Task<Void, Never> {}
+        coordinator.installQueryTask(task, for: successor)
+        coordinator.toolbarState.setExecuting(true)
+
+        coordinator.resetExecutionState(claim: cancelled, executionTime: 0.5)
+
+        #expect(coordinator.currentQueryTask != nil)
+        #expect(coordinator.toolbarState.isExecuting)
+        #expect(coordinator.tabExecution.isExecuting(tabId) == false)
+        #expect(coordinator.tabExecution.isCurrent(successor))
+        task.cancel()
+    }
+
+    /// The toolbar mirrors the selected tab, so a failure on a background tab must not repaint the
+    /// window chrome around whatever the user is actually looking at.
+    @Test("A background tab's failure leaves the toolbar describing the selected tab")
+    func backgroundFailureLeavesTheToolbarAlone() {
+        let (coordinator, tabManager) = Self.makeCoordinator()
+        let backgroundTabId = Self.addQueryTab(to: tabManager)
+        let selectedTabId = Self.addQueryTab(to: tabManager, title: "Query 2")
+        tabManager.selectedTabId = selectedTabId
+        coordinator.toolbarState.lastQueryDuration = 1.5
+        coordinator.toolbarState.isResultsCollapsed = true
+        let claim = coordinator.tabExecution.claim(backgroundTabId)
+
+        Self.finishFailure(on: coordinator, tabId: backgroundTabId, claim: claim)
+
+        #expect(tabManager.tabs.first?.execution.errorMessage != nil)
+        #expect(coordinator.toolbarState.lastQueryDuration == 1.5)
+        #expect(coordinator.toolbarState.isResultsCollapsed)
+    }
+
+    /// The change manager is one per window and holds whichever tab is selected. Clearing it from a
+    /// completion on a different tab throws away edits and undo history the user can never get back.
+    @Test("Clearing pending changes never reaches a tab the user has switched to")
+    func pendingChangesOfAnotherTabSurvive() {
+        let (coordinator, tabManager) = Self.makeCoordinator()
+        let backgroundTabId = Self.addQueryTab(to: tabManager)
+        let selectedTabId = Self.addQueryTab(to: tabManager, title: "Query 2")
+        let claim = coordinator.tabExecution.claim(backgroundTabId)
+        let settled = coordinator.tabExecution.settle(claim)
+        #expect(settled)
+
+        tabManager.selectedTabId = selectedTabId
+        coordinator.changeManager.recordCellChange(
+            rowIndex: 0,
+            columnIndex: 1,
+            columnName: "name",
+            oldValue: nil,
+            newValue: "edited"
+        )
+        #expect(coordinator.changeManager.hasChanges)
+
+        coordinator.clearChangesIfCurrent(claim: claim)
+
+        #expect(coordinator.changeManager.hasChanges)
+    }
+
+    private static func finishFailure(
+        on coordinator: MainContentCoordinator,
+        tabId: UUID,
+        claim: TabExecutionClaim,
+        error: Error = DriverFailure()
+    ) {
+        coordinator.finishFailedQuery(
+            error,
+            tabId: tabId,
+            sql: "select * from stu",
+            connection: TestFixtures.makeConnection(),
+            claim: claim,
+            isAutoLoad: false,
+            trigger: .userInitiated,
+            traceToken: nil
+        )
+    }
+
+    private static func makeCoordinator() -> (MainContentCoordinator, QueryTabManager) {
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: TestFixtures.makeConnection(),
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        return (coordinator, tabManager)
+    }
+
+    @discardableResult
+    private static func addQueryTab(to tabManager: QueryTabManager, title: String = "Query") -> UUID {
+        let tab = QueryTab(title: title, query: "select * from stu", tabType: .query)
+        tabManager.tabs.append(tab)
+        tabManager.selectedTabId = tab.id
+        return tab.id
+    }
+}

--- a/TableProUITests/QueryErrorBannerUITests.swift
+++ b/TableProUITests/QueryErrorBannerUITests.swift
@@ -1,0 +1,68 @@
+//
+//  QueryErrorBannerUITests.swift
+//  TableProUITests
+//
+//  The sample SQLite database makes a failing query deterministic, with no server to reach: a
+//  missing table is always "no such table". The app shipped a release where a failed query wrote
+//  nothing at all, so the banner never appeared (#2120).
+//
+
+import XCTest
+
+final class QueryErrorBannerUITests: UITestCase {
+    func testAFailedQueryShowsTheDatabaseError() throws {
+        let app = try launchWithSampleDatabase()
+        runQuery("SELECT * FROM nope;", in: app)
+
+        let banner = app.windows.firstMatch.staticTexts["query-error-message"].firstMatch
+        XCTAssertTrue(
+            banner.waitForExistence(timeout: 20),
+            "A query the database rejects must show its error, not an empty result area"
+        )
+        XCTAssertTrue(
+            (banner.value as? String ?? banner.label).localizedCaseInsensitiveContains("no such table"),
+            "The banner must carry the database's own message, not a generic failure"
+        )
+    }
+
+    func testTheBannerCanBeDismissed() throws {
+        let app = try launchWithSampleDatabase()
+        runQuery("SELECT * FROM nope;", in: app)
+
+        let banner = app.windows.firstMatch.staticTexts["query-error-message"].firstMatch
+        XCTAssertTrue(banner.waitForExistence(timeout: 20))
+
+        app.windows.firstMatch.buttons["Dismiss error"].firstMatch.click()
+        XCTAssertTrue(
+            waitForDisappearance(of: banner, timeout: 10),
+            "Dismissing the banner must remove it"
+        )
+    }
+
+    private func runQuery(_ sql: String, in app: XCUIApplication) {
+        app.typeKey("t", modifierFlags: .command)
+        let queryEditor = editorTextView(in: app)
+        XCTAssertTrue(queryEditor.waitForExistence(timeout: 10))
+        queryEditor.click()
+        app.typeText(sql)
+        app.typeKey(.return, modifierFlags: .command)
+    }
+
+    private func editorTextView(in app: XCUIApplication) -> XCUIElement {
+        let window = app.windows.firstMatch
+        let identified = window.textViews.matching(identifier: "sql-editor-textview").firstMatch
+        if identified.exists {
+            return identified
+        }
+        return window.textViews.firstMatch
+    }
+
+    private func waitForDisappearance(of element: XCUIElement, timeout: TimeInterval) -> Bool {
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        while Date() < deadline {
+            if !element.exists { return true }
+            usleep(200_000)
+        }
+        return !element.exists
+    }
+}


### PR DESCRIPTION
Fixes #2120.

## Root cause

`TabExecutionRegistry` splits execution ownership into `isCurrent(claim)`, which reads
`entries[tabId]?.epoch == claim.epoch`, and `settle(claim)`, which removes the entry. Because
settling removes the entry, `isCurrent` afterwards is false in both branches: the entry is gone if
the claim owned the tab, and the comparison already failed if it did not.

`finishFailedQuery` settled first and asked second:

```swift
tabExecution.settle(claim)                          // releases the tab
guard tabExecution.isCurrent(claim) else { return } // can never pass
handleQueryExecutionError(...)                      // never runs
```

`handleQueryExecutionError` is the only writer of `tab.execution.errorMessage`, which is what
`InlineErrorBanner` renders, and the only thing that records the failure in query history. Both were
skipped, so a failed query produced no banner, no message, no history entry and no log. Introduced
by d99458bb4 (#2055) and shipped in 0.64.0.

It was never limited to syntax errors. `executeQueryInternal` is the single-statement editor path
and the table-tab load path, so a failed table open was equally silent. Multi-statement runs still
reported errors, through a different path, which is why running two failing statements told you and
running one did not.

The same inversion was in three more places, and two paths had the opposite problem:

- A failing EXPLAIN reported nothing, for the same reason (unreleased, so it folds into the existing
  Unreleased changelog line rather than getting its own).
- `clearChangesIfCurrent` validated a claim the success path had already settled, so it never ran.
- The parameterized and multi-statement paths never settled at all. The refactor removed every
  `isExecuting = false` from them without replacement, so the claim leaked, `isExecuting(tabId)`
  stayed true, and `runQuery`, `runAllStatements`, `runExplain` and `fetchAllRows` all refused to run
  again on that tab until a retarget or Stop.

## The fix

`settle` now returns whether the claim still owned the tab, so validating and releasing are one call
that cannot be sequenced wrongly. Every completion site is `guard tabExecution.settle(claim) else
{ return }` with the writes below the guard, and `isCurrent` survives at exactly one caller, the
in-flight check inside a multi-statement transaction. Work that legitimately outlives its own claim
asks `ownsContent`, the claim-shaped form of the content-identity check #2068 introduced for phase 2.

Gating the shared writes on ownership needed two supporting changes to be true rather than
aspirational:

- `currentQueryTask` is one handle per window while claims are per tab, so a completion could own its
  own tab and still clear another tab's task handle and spinner, leaving that query unstoppable.
  The handle is now paired with the claim that installed it, and every path that installs or retires
  it goes through that pairing, including `resetExecutionState` and Fetch All (which claims no tab,
  so it installs with no owner and no claim can retire it out from under it).
- `supersedeExecution` now clears the spinner it orphans, mirroring `resetExecutionState`. A retarget
  need not have a successor, and the ungated failure handler used to clean that up by accident.
- Settling happens before the cancellation check rather than sharing a guard with it. Swift
  short-circuits `guard !Task.isCancelled, settle(claim)`, so a cancelled success path would skip the
  settle and leave the tab claimed forever, which is the second bug over again.

The toolbar is window-scoped while the failure belongs to a tab, so the collapse toggle, the duration
readout and the VoiceOver announcement only fire when the failing tab is the selected one. A
background tab's failure still writes its own banner and opens its own pane.

`handleQueryExecutionError` also picked up three things it was missing: it opens the results pane if
you had it collapsed (the banner lives inside that pane, so a collapsed pane hid the only feedback
there was), it clears the duration left over from the last successful run instead of showing it next
to a red banner, and it logs the failure through OSLog.

`clearChangesIfCurrent` gained a selected-tab guard along with the ownership fix. The change manager
is one per window and holds whichever tab is selected, so turning the dead path back on without it
would have let one tab's completion silently wipe another tab's uncommitted cell edits and undo
history. The sibling multi-statement path already guarded that way.

Also removed `showQueryError`, a modal query-error alert helper with no callers since #1815 moved
errors inline.

## Presentation

Not redesigned. `InlineErrorBanner` already does what the HIG asks for an error caused by the user's
own action: inline and non-modal, symbol plus text rather than colour alone, selectable with a copy
button, and a recovery action. It is what `docs/features/sql-editor.mdx` already documents, so no
docs change was needed; the code was the thing out of step. Two additions in that area: an
accessibility identifier on the message text so the UI test can see it, and a VoiceOver announcement
when an error arrives, posted from the coordinator and gated on the key window because announcements
are app-scoped and a background window would otherwise talk over the front one.

## Tested

- `TabExecutionRegistryTests`: the new settle contract and `ownsContent` across settle, invalidate
  and reclaim.
- `QueryFailureReportingTests` (new, 10 cases): a failed query sets the message, query and timestamp;
  it opens a collapsed pane; it clears the stale duration; it releases the tab; a cancellation is not
  an error; a superseded failure writes nothing and leaves the successor's spinner alone; only the
  installer retires the task handle; a cancel reset respects that owner too; a background tab's
  failure leaves the toolbar alone; another tab's pending edits survive.
- `TabExecutionSettleGuardTests` (new): source guard failing the build if any `settle` call discards
  its answer, which is the mistake itself and something the compiler only warns about. This trap has
  now been walked into three times (#2055, #2068, #2120).
- `QueryErrorBannerUITests` (new): runs `SELECT * FROM nope;` against the bundled SQLite sample and
  asserts the banner appears carrying "no such table", and that it dismisses.
- Verified the regression tests genuinely catch it: restoring the settle-then-check ordering fails
  `failureSetsTheErrorMessage`, `failureOpensCollapsedResults`, `failureClearsTheStaleDuration` and
  the source guard; restoring the fix passes all 30.
- Build, `Phase2RowCountGuardTests`, `TabRetargetInvalidationTests`,
  `MainContentCoordinatorLazyLoadTests`, `MainContentCoordinatorRefreshTests` and
  `swiftlint lint --strict` on every changed file all green.
