### PR TITLE
fix(toolbar): resize hosted items when the window switches connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A failed grid save now records one history entry per statement, the same as a successful one, instead of joining them all into a single unusable entry.
 - Turning off automatic query history cleanup now actually stops it. Entries were still pruned to the limits every hundred queries regardless of the setting.
 - Query parameter values are no longer written to the history database. They were stored in the clear, nothing read them back, and existing ones are deleted on upgrade.
-- Switching connection no longer rebuilds the toolbar. It kept its buttons and status readout but threw them away and made them again on every switch, which cost a frame and reset the titlebar.
+- Switching connection no longer rebuilds the toolbar. It kept its buttons and status readout but threw them away and made them again on every switch, which cost a frame and reset the titlebar. Those items now resize to the connection you switched to instead of holding the previous one's width until you click the toolbar, the Results button tracks the pane you are looking at, and Snowflake's role and warehouse menus reload.
 - Typing in a new query tab now goes into the editor. Cmd+T left the keyboard on the sidebar, so the first characters you typed went to the object list instead.
 - Cmd+W closes the welcome window. The shortcut was bound to Close Tab, which the welcome window has no answer for, so it did nothing there.
 - Customize Toolbar no longer blanks the connection and status controls. Opening it rebuilt those two items and released the ones already on screen, so they shrank to nothing until the window switched connection.

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -370,14 +370,10 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
 
     // MARK: - Toolbar
 
-    /// Only ever called with a live coordinator. The toolbar's delegate builds no item without
-    /// one, and `NSToolbar` asks it once, so a toolbar created early is permanently empty: a
-    /// later coordinator cannot refill it, and validation only speaks to items that already
-    /// exist. A window with no session shows a plain titlebar instead.
-    /// `NSToolbar` asks its delegate for an item once and keeps what it returns, and every item
-    /// view captures the coordinator it was built with. Reassigning the owner's coordinator
-    /// therefore repoints nothing: the toolbar goes on naming, and acting on, the connection it
-    /// was built for. Switching connection rebuilds it instead.
+    /// Only ever called with a live coordinator. The window keeps one toolbar for its whole life
+    /// and points it at whichever connection it is showing, so this builds the owner once and
+    /// repoints it afterwards. `NSWindow.toolbar` is assigned only when it differs, because
+    /// assigning an already-built toolbar still makes AppKit rebuild the titlebar hierarchy.
     func installToolbar(coordinator: MainContentCoordinator) {
         guard let window = view.window else { return }
         let owner = toolbarOwner ?? MainWindowToolbar()

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Buttons.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Buttons.swift
@@ -85,13 +85,17 @@ struct SessionContextToolbarButton: View {
 }
 
 /// Thin wrappers so the toolbar's hosted content follows the window's subject instead of capturing
-/// one connection. Reading `subject.coordinator` inside `body` is what registers the observation.
+/// one connection. Reading `subject.coordinator` inside `body` is what registers the observation,
+/// and the `id` is what makes the connection's identity the view's identity. The `if let` alone
+/// keeps one branch across a repoint, so SwiftUI carried the outgoing connection's `@State` over
+/// and left its `task(id:)` running instead of restarting it for the connection that arrived.
 internal struct ConnectionToolbarSubjectButton: View {
     internal let subject: ToolbarSubject
 
     internal var body: some View {
         if let coordinator = subject.coordinator {
             ConnectionToolbarButton(coordinator: coordinator)
+                .id(coordinator.connectionId)
         }
     }
 }
@@ -102,6 +106,7 @@ internal struct DatabaseToolbarSubjectButton: View {
     internal var body: some View {
         if let coordinator = subject.coordinator {
             DatabaseToolbarButton(coordinator: coordinator)
+                .id(coordinator.connectionId)
         }
     }
 }
@@ -112,6 +117,7 @@ internal struct SessionContextToolbarSubjectButton: View {
     internal var body: some View {
         if let coordinator = subject.coordinator {
             SessionContextToolbarButton(coordinator: coordinator)
+                .id(coordinator.connectionId)
         }
     }
 }
@@ -130,6 +136,7 @@ internal struct ToolbarPrincipalSubjectContent: View {
                 onCancelQuery: { [weak coordinator] in coordinator?.cancelCurrentQuery() },
                 onSafeModeChange: { [weak coordinator] level in coordinator?.setSafeModeLevel(level) }
             )
+            .id(coordinator.connectionId)
         }
     }
 }

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Delegate.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Delegate.swift
@@ -89,8 +89,8 @@ extension MainWindowToolbar {
                 modifiers: [.command, .option],
                 shortcut: .toggleResults,
                 description: String(localized: "Toggle Results"),
-                symbolProvider: { [weak coordinator] in
-                    coordinator?.toolbarState.isResultsCollapsed == false
+                symbolProvider: { [weak self] in
+                    self?.coordinator?.toolbarState.isResultsCollapsed == false
                         ? "rectangle.inset.filled"
                         : "rectangle.bottomhalf.inset.filled"
                 }

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Items.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Items.swift
@@ -150,7 +150,7 @@ extension MainWindowToolbar {
         // Controller must outlive the item; AppKit doesn't retain it and the view orphans otherwise.
         // focusable(false) stops SwiftUI from claiming scene focus on click, which would break menu shortcuts.
         let controller = NSHostingController(rootView: AnyView(content.focusable(false)))
-        controller.sizingOptions = .intrinsicContentSize
+        controller.sizingOptions = MainWindowToolbar.hostedItemSizingOptions
         retain(controller, for: id, when: retainsController)
         item.view = controller.view
 
@@ -237,7 +237,7 @@ extension MainWindowToolbar {
 
         // Same retention requirement as hostingItem: group.view comes from this controller.
         let controller = NSHostingController(rootView: AnyView(content.focusable(false)))
-        controller.sizingOptions = .intrinsicContentSize
+        controller.sizingOptions = MainWindowToolbar.hostedItemSizingOptions
         retain(controller, for: id, when: retainsController)
         group.view = controller.view
 

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -24,6 +24,14 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
 
     internal let managedToolbar: NSToolbar
 
+    /// How a hosted item answers "how wide are you". `.intrinsicContentSize` only overrides the
+    /// hosting view's `intrinsicContentSize`, and AppKit measures a view-backed item when it is
+    /// inserted and never reads that value again. Repointing the subject then left the item at the
+    /// width of the connection that had gone: the content redrew correctly inside a container
+    /// measured for the other engine, and only a click on the toolbar resized it. Under
+    /// `.preferredContentSize` the hosting view resizes itself, which is what AppKit follows.
+    internal static let hostedItemSizingOptions: NSHostingSizingOptions = .preferredContentSize
+
     /// Retain hosting controllers per item identifier. NSHostingController is not retained by NSToolbarItem,
     /// so without this its view orphans and the toolbar item collapses to zero width.
     internal var hostingControllers: [NSToolbarItem.Identifier: NSHostingController<AnyView>] = [:]

--- a/TableProTests/Services/MainWindowToolbarLayoutTests.swift
+++ b/TableProTests/Services/MainWindowToolbarLayoutTests.swift
@@ -5,6 +5,7 @@
 
 import AppKit
 import Foundation
+import SwiftUI
 @testable import TablePro
 import Testing
 
@@ -49,5 +50,57 @@ struct MainWindowToolbarCustomizationTests {
     @Test("The toolbar identifier is stable")
     func identifierIsStable() {
         #expect(MainWindowToolbar.toolbarIdentifier == "com.TablePro.main.toolbar.v2")
+    }
+}
+
+@MainActor
+struct MainWindowToolbarHostedSizingTests {
+    private static let hostedIdentifiers: [NSToolbarItem.Identifier] = [
+        MainWindowToolbar.connectionGroup,
+        MainWindowToolbar.principal,
+    ]
+
+    private func vendHostedItems() -> MainWindowToolbar {
+        let owner = MainWindowToolbar()
+        for identifier in Self.hostedIdentifiers {
+            _ = owner.toolbar(
+                owner.managedToolbar,
+                itemForItemIdentifier: identifier,
+                willBeInsertedIntoToolbar: true
+            )
+        }
+        return owner
+    }
+
+    /// AppKit measures a view-backed item when it is inserted and never reads that size again, so
+    /// the hosting view has to resize itself. Under `.intrinsicContentSize` it does not, and the
+    /// leading group kept the width of the connection the window had switched away from until the
+    /// user clicked the toolbar.
+    @Test("Hosted toolbar items size themselves from the preferred content size")
+    func hostedItemsSizeFromPreferredContentSize() throws {
+        let owner = vendHostedItems()
+        for identifier in Self.hostedIdentifiers {
+            let controller = try #require(owner.hostingControllers[identifier])
+            #expect(controller.sizingOptions == .preferredContentSize, "\(identifier.rawValue)")
+        }
+    }
+
+    /// Measured on macOS 27: `[.minSize, .intrinsicContentSize, .maxSize]` shrinks the hosted
+    /// content but leaves AppKit's item container at the old width, drawing the new content
+    /// centred inside the old box. That is the artifact this suite exists to keep out.
+    @Test("Hosted toolbar items never size from the intrinsic content size")
+    func hostedItemsNeverSizeFromIntrinsicContentSize() throws {
+        let owner = vendHostedItems()
+        for identifier in Self.hostedIdentifiers {
+            let controller = try #require(owner.hostingControllers[identifier])
+            #expect(!controller.sizingOptions.contains(.intrinsicContentSize), "\(identifier.rawValue)")
+        }
+    }
+
+    /// Both hosted items are built through the same two helpers, so the contract belongs to the
+    /// helpers rather than to either call site.
+    @Test("Every hosted item shares one sizing contract")
+    func hostedItemsShareOneSizingContract() {
+        #expect(MainWindowToolbar.hostedItemSizingOptions == .preferredContentSize)
     }
 }

--- a/TableProTests/Services/MainWindowToolbarValidationTests.swift
+++ b/TableProTests/Services/MainWindowToolbarValidationTests.swift
@@ -310,6 +310,40 @@ struct MainWindowToolbarRepointTests {
         #expect(owner.subject.coordinator === subjectBefore)
     }
 
+    /// The item is built once and outlives every connection the window shows, so anything it reads
+    /// has to be resolved when it is asked, not when it was vended. Capturing the coordinator left
+    /// the glyph reporting the results pane of the connection the user had switched away from, and
+    /// pinned it to the collapsed glyph for good once that coordinator went away.
+    @Test("The Results glyph follows the repointed connection")
+    func resultsSymbolFollowsTheRepointedConnection() throws {
+        let collapsed = makeCoordinator()
+        let expanded = makeCoordinator()
+        defer {
+            collapsed.teardown()
+            expanded.teardown()
+        }
+        collapsed.toolbarState.isResultsCollapsed = true
+        expanded.toolbarState.isResultsCollapsed = false
+
+        let owner = MainWindowToolbar()
+        owner.repoint(to: collapsed)
+        let item = try #require(
+            owner.toolbar(
+                owner.managedToolbar,
+                itemForItemIdentifier: MainWindowToolbar.results,
+                willBeInsertedIntoToolbar: true
+            ) as? StatefulToolbarItem
+        )
+        let provider = try #require(item.symbolProvider)
+        #expect(provider() == "rectangle.bottomhalf.inset.filled")
+
+        owner.repoint(to: expanded)
+        #expect(provider() == "rectangle.inset.filled")
+
+        owner.repoint(to: nil)
+        #expect(provider() == "rectangle.bottomhalf.inset.filled")
+    }
+
     /// The delegate used to answer nil for every identifier when it had no coordinator. With
     /// `autosavesConfiguration` on, a vend in that state pruned the user's saved arrangement for
     /// good, which this project has already paid for once.


### PR DESCRIPTION
Fixes the stale toolbar geometry reported after #2121: with several connections open in one window, the leading connection group and the centred status item kept the width of the connection you switched away from until you clicked the toolbar. PostgreSQL shows a database switcher next to the connection switcher and SQLite does not, so switching between them left one real button inside a two-button box.

## Root cause

`hostingItem()` and `makeGroup()` both set `NSHostingController.sizingOptions = .intrinsicContentSize`. That option only overrides the hosting view's `intrinsicContentSize`; the view never resizes itself. AppKit measures a view-backed toolbar item when the item is inserted and does not read that value again, so nothing re-measured the item after a repoint.

Before #2121 a connection switch tore the toolbar off the window and built a new one, which re-measured every item from scratch, so the wrong sizing contract never showed. After #2121 the window keeps one `NSToolbar` and two `NSHostingController`s for its whole life, and `repoint(to:)` writes the observable subject, pushes three text properties and calls `validateVisibleItems()`. None of those is a sizing signal: validation drives `isEnabled` and, through `StatefulToolbarItem.validate()`, the glyph.

Only two of the eleven vendable identifiers are view-backed (`connectionGroup`, `principal`), which is exactly the set that misbehaves.

## Measurement

Reproduced in a standalone AppKit harness mirroring the real shape (weak `@Observable` subject, `@Bindable`, `.popover`, a conditional button, a group carrying both `.view` and `.subitems`, `isNavigational`, `centeredItemIdentifiers`, a split-view content with sidebar and inspector tracking separators).

With `.intrinsicContentSize`, after the repoint SwiftUI re-renders correctly (`fittingSize` and `intrinsicContentSize` both go 74.0 to 35.0) while `view.frame` stays 74.0 and AppKit's item container stays 82.0, still stale at 850ms. With `.preferredContentSize` the hosted view itself resizes, the container follows 82.0 to 44.0, and the centred item re-centres from x=466.0 to x=479.5. Baseline widths are byte-identical to today, and the reverse switch restores 74.0/82.0.

Two combinations were measured and rejected. `[.minSize, .intrinsicContentSize, .maxSize]` produces the exact reported artifact: the content shrinks to 35.0 but the container stays 82.0 and the content centres inside it at x=23.5. `[.minSize, .maxSize]` corrupts the principal item at baseline (234.0 instead of 259.5).

`NSHostingSizingOptions.preferredContentSize` is macOS 13.0+, below the 14.0 floor, so no availability gate and no deprecated API.

## Also fixed

Three defects with the same shape, all reachable only once the toolbar outlives a connection:

- **Results glyph.** `symbolProvider` captured `[weak coordinator]`, resolving the subject once at vend time, so after a switch it reported the previous connection's results pane and pinned to the collapsed glyph once that coordinator went away. It now reads through the subject at validation time. Covered by a regression test that fails on the previous code.
- **Session contexts.** `SessionContextToolbarButton` is the only caller of `loadSessionContexts()` and runs it from `.task(id:)` keyed on connection state. The `if let` in the subject wrapper kept one SwiftUI identity across a coordinator swap, so between two already-connected coordinators the id never changed and the task was never restarted. Snowflake's role and warehouse menus stayed empty for any connection you switched to.
- **Tag popover.** `ToolbarPrincipalContent`'s `@State` survived the swap for the same reason, so a popover opened on one connection could carry over to another.

All three are one rule: a wrapper that follows a subject makes the subject's identity the view's identity. `.id(coordinator.connectionId)` on the four wrappers states that once. Verified in the harness that `.id()` and `.preferredContentSize` compose with no change to any measurement.

The `installToolbar` doc comment still described the pre-#2121 world and contradicted its own body; it is rewritten.

## Rejected

- Rebuilding the toolbar per connection. #2121's premise holds: assigning an already-built `NSToolbar` still makes AppKit rebuild the titlebar hierarchy. What was missing was a sizing contract, not an architecture.
- Inserting and removing item identifiers per driver. With `autosavesConfiguration` on, `removeItem` writes to the saved arrangement and `insertItem` appends rather than restoring the slot, so switching engines would permanently reorder a customized toolbar. Both APIs are also macOS 15+.
- Deferring `invalidateIntrinsicContentSize()` a runloop turn. It works, but only deferred (measured stale 3/3 when called synchronously inside `repoint`, because SwiftUI has not re-rendered yet), which makes it a scheduled nudge that is silently wrong if anyone later inlines it.
- `validateVisibleItems()`, reassigning `item.view`, and `NSToolbarItem.isHidden` on the group's subitems. All measured ineffective. The last cannot work: a group carrying a `.view` is sized by that view, so its subitems exist only for the overflow menu, the palette and validation.

## Follow-up worth its own PR

The leading group carries both a hosted `.view` and real subitems, so the subitems are inert: they never draw, and AppKit never sends them `validate()`, which makes the `database` rule in `MainWindowToolbar+Validation.swift` dead for the visible UI. Rebuilding that group as a pure native `NSToolbarItemGroup`, with the database item dimmed rather than absent on SQLite, would revive the overflow menu, the customization palette, display-mode support and that validation rule. It costs rebuilding two SwiftUI popover anchors on AppKit buttons, and it does not remove the need for a correct hosted sizing contract, because the centred status item stays SwiftUI.

## Tests

- `MainWindowToolbarHostedSizingTests`: both hosted items vend with `.preferredContentSize`, neither contains `.intrinsicContentSize`, and the contract lives in one place.
- `MainWindowToolbarRepointTests.resultsSymbolFollowsTheRepointedConnection`: fails on the previous code, verified by reverting the fix and re-running.
- Full toolbar, window-phase and menu suites pass. `swiftlint lint --strict`: 0 violations.

Toolbar geometry cannot be asserted headlessly, so please sanity check in the app: open a PostgreSQL and a SQLite connection in one window, switch back and forth on the rail, and confirm the leading group narrows and widens with no click and the status item re-centres. Worth a look at Customize Toolbar and a display-mode toggle too, since the palette copies deliberately do not retain their controller.
