### PR TITLE
feat(plugin-beancount): project the remaining directives, metadata, and diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropping a SQL file on a connection window opens it. (#2104)
 - The Settings window can be resized.
 - SSL settings on mobile for MySQL, PostgreSQL and Redis: a mode picker plus CA, client certificate and client key. Import a PEM file, paste one, or use a PKCS#12 file. (#2083)
-- A Beancount ledger projects the directives it used to leave in the source file: commodities, documents, notes, events and closes, plus transaction and posting metadata, tags and links. Transactions and postings carry the file and line they were read from.
-- A Beancount ledger opened through `rledger` lists what validation found in a `diagnostics` table, with the severity, phase, code and source location of each problem.
+- A Beancount ledger projects the directives it used to leave in the source file: commodities, documents, notes, events and closes, plus transaction and posting metadata, tags and links. Transactions remain visible with these details when they have no postings. Transactions and postings carry the file and line they were read from.
+- A Beancount ledger opened through `rledger` lists what validation found in a `diagnostics` table, with the severity, phase, code and source location of each problem. Document diagnostics refresh when a referenced file is created or removed.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropping a SQL file on a connection window opens it. (#2104)
 - The Settings window can be resized.
 - SSL settings on mobile for MySQL, PostgreSQL and Redis: a mode picker plus CA, client certificate and client key. Import a PEM file, paste one, or use a PKCS#12 file. (#2083)
+- A Beancount ledger projects the directives it used to leave in the source file: commodities, documents, notes, events and closes, plus transaction and posting metadata, tags and links. Transactions and postings carry the file and line they were read from.
+- A Beancount ledger opened through `rledger` lists what validation found in a `diagnostics` table, with the severity, phase, code and source location of each problem.
 
 ### Changed
 

--- a/Plugins/BeancountDriverPlugin/BeancountIncludeResolver.swift
+++ b/Plugins/BeancountDriverPlugin/BeancountIncludeResolver.swift
@@ -8,6 +8,7 @@ import Foundation
 struct BeancountSourceGraph: Sendable {
     let sourceFiles: [URL]
     let watchedDirectories: [URL]
+    let reloadDependencies: [URL]
 }
 
 enum BeancountResolverError: LocalizedError {
@@ -24,23 +25,44 @@ enum BeancountResolverError: LocalizedError {
     }
 }
 
+private struct BeancountDocumentDeclaration {
+    let path: String
+    let sourceDirectory: URL
+}
+
 final class BeancountIncludeResolver {
+    private static let maximumSymbolicLinkDepth = 32
+
     private var visited: Set<URL> = []
     private var activeStack: Set<URL> = []
     private var sourceFiles: [URL] = []
     private var watchedDirectories: Set<URL> = []
+    private var documentDeclarations: [BeancountDocumentDeclaration] = []
+    private var documentRootPaths: [String] = []
+    private var mainDirectory = URL(fileURLWithPath: "/")
 
     func resolve(fileURL: URL) throws -> BeancountSourceGraph {
         visited.removeAll()
         activeStack.removeAll()
         sourceFiles.removeAll()
         watchedDirectories.removeAll()
+        documentDeclarations.removeAll()
+        documentRootPaths.removeAll()
 
-        try resolveFile(fileURL.standardizedFileURL)
+        let mainFile = fileURL.standardizedFileURL
+        mainDirectory = mainFile.deletingLastPathComponent()
+        try resolveFile(mainFile)
+
+        let documentRoots = resolvedDocumentRoots()
+        let documentFiles = resolvedDocumentFiles(documentRoots: documentRoots)
+        let dependencies = Set(sourceFiles)
+            .union(watchedDirectories)
+            .union(documentFiles)
 
         return BeancountSourceGraph(
             sourceFiles: sourceFiles,
-            watchedDirectories: watchedDirectories.sorted { $0.path < $1.path }
+            watchedDirectories: watchedDirectories.sorted { $0.path < $1.path },
+            reloadDependencies: dependencies.sorted { $0.path < $1.path }
         )
     }
 
@@ -65,24 +87,109 @@ final class BeancountIncludeResolver {
         sourceFiles.append(normalized)
 
         for rawLine in contents.components(separatedBy: .newlines) {
-            let trimmed = stripComment(rawLine).trimmingCharacters(in: .whitespaces)
-            guard trimmed.hasPrefix("include "), let includePath = quotedString(in: trimmed) else { continue }
-            let includeURLs = try resolveIncludeURLs(
-                includePath,
-                relativeTo: normalized.deletingLastPathComponent()
-            )
-            for includeURL in includeURLs {
-                try resolveFile(includeURL)
+            let line = stripComment(rawLine).trimmingCharacters(in: .whitespaces)
+            let quotedValues = quotedStrings(in: line)
+            let directive = line.split(maxSplits: 1, whereSeparator: { $0.isWhitespace }).first
+
+            if directive == "include", let includePath = quotedValues.first {
+                let includeURLs = try resolveIncludeURLs(
+                    includePath,
+                    relativeTo: normalized.deletingLastPathComponent()
+                )
+                for includeURL in includeURLs {
+                    try resolveFile(includeURL)
+                }
+            } else if directive == "option",
+                      quotedValues.count >= 2,
+                      quotedValues[0] == "documents" {
+                documentRootPaths.append(quotedValues[1])
+            } else if isDocumentDirective(line), let documentPath = quotedValues.first {
+                documentDeclarations.append(
+                    BeancountDocumentDeclaration(
+                        path: documentPath,
+                        sourceDirectory: normalized.deletingLastPathComponent()
+                    )
+                )
             }
         }
     }
 
-    private func resolveIncludeURLs(_ includePath: String, relativeTo directory: URL) throws -> [URL] {
-        guard containsGlobPattern(includePath) else {
-            return [resolveIncludeURL(includePath, relativeTo: directory)]
+    private func resolvedDocumentRoots() -> [URL] {
+        Set(documentRootPaths.map { path in
+            resolvePath(path, relativeTo: mainDirectory)
+        }).sorted { $0.path < $1.path }
+    }
+
+    private func resolvedDocumentFiles(documentRoots: [URL]) -> Set<URL> {
+        documentDeclarations.reduce(into: Set<URL>()) { files, declaration in
+            if NSString(string: declaration.path).isAbsolutePath {
+                files.formUnion(
+                    documentFileDependencies(
+                        for: URL(fileURLWithPath: declaration.path).standardizedFileURL
+                    )
+                )
+            } else {
+                files.formUnion(
+                    documentFileDependencies(
+                        for: resolvePath(declaration.path, relativeTo: declaration.sourceDirectory)
+                    )
+                )
+                for root in documentRoots {
+                    files.formUnion(
+                        documentFileDependencies(for: resolvePath(declaration.path, relativeTo: root))
+                    )
+                }
+            }
+        }
+    }
+
+    private func documentFileDependencies(for file: URL) -> Set<URL> {
+        var dependencies: Set<URL> = [file.standardizedFileURL]
+        var candidate = file.standardizedFileURL
+
+        for _ in 0..<Self.maximumSymbolicLinkDepth {
+            guard let destination = try? FileManager.default.destinationOfSymbolicLink(atPath: candidate.path) else {
+                break
+            }
+            let destinationURL: URL
+            if NSString(string: destination).isAbsolutePath {
+                destinationURL = URL(fileURLWithPath: destination).standardizedFileURL
+            } else {
+                destinationURL = candidate.deletingLastPathComponent()
+                    .appendingPathComponent(destination)
+                    .standardizedFileURL
+            }
+            guard dependencies.insert(destinationURL).inserted else { break }
+            candidate = destinationURL
         }
 
-        let patternURL = resolveIncludeURL(includePath, relativeTo: directory)
+        dependencies.insert(file.resolvingSymlinksInPath().standardizedFileURL)
+        return dependencies
+    }
+
+    private func isDocumentDirective(_ line: String) -> Bool {
+        let fields = line.split(maxSplits: 2, whereSeparator: { $0.isWhitespace })
+        guard fields.count >= 2, fields[1] == "document" else { return false }
+
+        let dateParts = fields[0].split(
+            omittingEmptySubsequences: false,
+            whereSeparator: { $0 == "-" || $0 == "/" }
+        )
+        guard dateParts.count == 3,
+              dateParts[0].count == 4,
+              (1...2).contains(dateParts[1].count),
+              (1...2).contains(dateParts[2].count) else {
+            return false
+        }
+        return dateParts.allSatisfy { !$0.isEmpty && $0.allSatisfy(\.isNumber) }
+    }
+
+    private func resolveIncludeURLs(_ includePath: String, relativeTo directory: URL) throws -> [URL] {
+        guard containsGlobPattern(includePath) else {
+            return [resolvePath(includePath, relativeTo: directory)]
+        }
+
+        let patternURL = resolvePath(includePath, relativeTo: directory)
         let patternPath = patternURL.path
         let searchRoot = globSearchRoot(for: patternPath)
         guard searchRoot.path != "/" else { return [] }
@@ -120,11 +227,11 @@ final class BeancountIncludeResolver {
         return matches.sorted { $0.path < $1.path }
     }
 
-    private func resolveIncludeURL(_ includePath: String, relativeTo directory: URL) -> URL {
-        if includePath.hasPrefix("/") {
-            return URL(fileURLWithPath: includePath).standardizedFileURL
+    private func resolvePath(_ path: String, relativeTo directory: URL) -> URL {
+        if NSString(string: path).isAbsolutePath {
+            return URL(fileURLWithPath: path).standardizedFileURL
         }
-        return directory.appendingPathComponent(includePath).standardizedFileURL
+        return directory.appendingPathComponent(path).standardizedFileURL
     }
 
     private func containsGlobPattern(_ path: String) -> Bool {
@@ -198,14 +305,22 @@ final class BeancountIncludeResolver {
         return regex + "$"
     }
 
-    private func quotedString(in line: String) -> String? {
+    private func quotedStrings(in line: String) -> [String] {
+        var values: [String] = []
         var inQuote = false
         var isEscaped = false
         var current = ""
 
         for character in line {
             if isEscaped {
-                current.append(character)
+                switch character {
+                case "b": current.append("\u{08}")
+                case "f": current.append("\u{0C}")
+                case "n": current.append("\n")
+                case "r": current.append("\r")
+                case "t": current.append("\t")
+                default: current.append(character)
+                }
                 isEscaped = false
                 continue
             }
@@ -215,9 +330,10 @@ final class BeancountIncludeResolver {
             }
             if character == "\"" {
                 if inQuote {
-                    return current
+                    values.append(current)
+                    current = ""
                 }
-                inQuote = true
+                inQuote.toggle()
                 continue
             }
             if inQuote {
@@ -225,7 +341,7 @@ final class BeancountIncludeResolver {
             }
         }
 
-        return nil
+        return values
     }
 
     private func stripComment(_ line: String) -> String {

--- a/Plugins/BeancountDriverPlugin/BeancountPluginDriver+Projection.swift
+++ b/Plugins/BeancountDriverPlugin/BeancountPluginDriver+Projection.swift
@@ -1,0 +1,613 @@
+//
+//  BeancountPluginDriver+Projection.swift
+//  BeancountDriverPlugin
+//
+
+import Foundation
+import SQLite3
+
+private struct BeancountSourcePosition {
+    let file: String?
+    let line: Int?
+    let formatted: String?
+}
+
+private final class BeancountProjectionWriter {
+    private let db: OpaquePointer
+    private var statements: [String: OpaquePointer] = [:]
+
+    init(db: OpaquePointer) {
+        self.db = db
+    }
+
+    deinit {
+        for statement in statements.values {
+            sqlite3_finalize(statement)
+        }
+    }
+
+    func insert(sql: String, values: [String?]) throws {
+        let statement = try preparedStatement(sql)
+        sqlite3_reset(statement)
+        sqlite3_clear_bindings(statement)
+
+        for (index, value) in values.enumerated() {
+            let position = Int32(index + 1)
+            if let value {
+                sqlite3_bind_text(statement, position, value, -1, projectionSQLiteTransient)
+            } else {
+                sqlite3_bind_null(statement, position)
+            }
+        }
+
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw BeancountDriverError.queryFailed(String(cString: sqlite3_errmsg(db)))
+        }
+    }
+
+    private func preparedStatement(_ sql: String) throws -> OpaquePointer {
+        if let cached = statements[sql] {
+            return cached
+        }
+        var prepared: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &prepared, nil) == SQLITE_OK, let prepared else {
+            throw BeancountDriverError.queryFailed(String(cString: sqlite3_errmsg(db)))
+        }
+        statements[sql] = prepared
+        return prepared
+    }
+}
+
+struct BeancountProjectionRows {
+    var transactions: [[String: Any]] = []
+    var postings: [[String: Any]] = []
+    var accounts: [[String: Any]] = []
+    var prices: [[String: Any]] = []
+    var balances: [[String: Any]] = []
+    var balanceAssertions: [[String: Any]] = []
+    var commodities: [[String: Any]] = []
+    var documents: [[String: Any]] = []
+    var notes: [[String: Any]] = []
+    var events: [[String: Any]] = []
+    var closes: [[String: Any]] = []
+    var diagnostics: [[String: Any]] = []
+}
+
+extension BeancountPluginDriver {
+    static func loadProjection(rows: BeancountProjectionRows, sourceFiles: [URL]) throws -> OpaquePointer {
+        var handle: OpaquePointer?
+        let openResult = sqlite3_open(":memory:", &handle)
+        guard openResult == SQLITE_OK, let handle else {
+            if let handle {
+                sqlite3_close(handle)
+            }
+            throw BeancountDriverError.connectionFailed(
+                String(localized: "Could not initialize SQL projection")
+            )
+        }
+
+        do {
+            try createSchema(handle)
+            let writer = BeancountProjectionWriter(db: handle)
+            let transactionIDs = try loadTransactions(rows.transactions, into: writer)
+            try loadPostings(rows.postings, transactionIDs: transactionIDs, into: writer)
+            try loadAccounts(rows.accounts, into: writer)
+            try loadPrices(rows.prices, into: writer)
+            try loadBalances(rows.balances, into: writer)
+            try loadBalanceAssertions(rows.balanceAssertions, into: writer)
+            try loadCommodities(rows.commodities, into: writer)
+            try loadDocuments(rows.documents, into: writer)
+            try loadNotes(rows.notes, into: writer)
+            try loadEvents(rows.events, into: writer)
+            try loadCloses(rows.closes, into: writer)
+            try loadDiagnostics(rows.diagnostics, into: writer)
+            try loadSourceFiles(sourceFiles, into: writer)
+            try exec(handle, "PRAGMA query_only = ON")
+        } catch {
+            sqlite3_close(handle)
+            throw error
+        }
+
+        return handle
+    }
+
+    private static func createSchema(_ db: OpaquePointer) throws {
+        try exec(db, """
+            CREATE TABLE transactions (
+                id INTEGER PRIMARY KEY,
+                date DATE NOT NULL,
+                flag TEXT NOT NULL,
+                payee TEXT,
+                narration TEXT,
+                source_file TEXT,
+                line INTEGER,
+                source_location TEXT
+            );
+            CREATE TABLE postings (
+                id INTEGER PRIMARY KEY,
+                transaction_id INTEGER NOT NULL,
+                date DATE NOT NULL,
+                account TEXT NOT NULL,
+                amount TEXT,
+                commodity TEXT,
+                cost_number TEXT,
+                cost_currency TEXT,
+                source_file TEXT,
+                line INTEGER,
+                source_location TEXT
+            );
+            CREATE TABLE accounts (
+                name TEXT PRIMARY KEY,
+                open_date DATE,
+                currencies TEXT
+            );
+            CREATE TABLE prices (
+                id INTEGER PRIMARY KEY,
+                date DATE NOT NULL,
+                commodity TEXT NOT NULL,
+                amount TEXT NOT NULL,
+                currency TEXT NOT NULL
+            );
+            CREATE TABLE balances (
+                id INTEGER PRIMARY KEY,
+                account TEXT NOT NULL,
+                amount TEXT NOT NULL,
+                commodity TEXT NOT NULL
+            );
+            CREATE TABLE balance_assertions (
+                id INTEGER PRIMARY KEY,
+                date DATE NOT NULL,
+                account TEXT NOT NULL,
+                amount TEXT NOT NULL,
+                commodity TEXT NOT NULL
+            );
+            CREATE TABLE commodities (
+                id INTEGER PRIMARY KEY,
+                date DATE NOT NULL,
+                commodity TEXT NOT NULL
+            );
+            CREATE TABLE documents (
+                id INTEGER PRIMARY KEY,
+                date DATE NOT NULL,
+                account TEXT NOT NULL,
+                path TEXT NOT NULL,
+                tags TEXT,
+                links TEXT
+            );
+            CREATE TABLE notes (
+                id INTEGER PRIMARY KEY,
+                date DATE NOT NULL,
+                account TEXT NOT NULL,
+                comment TEXT
+            );
+            CREATE TABLE events (
+                id INTEGER PRIMARY KEY,
+                date DATE NOT NULL,
+                type TEXT NOT NULL,
+                description TEXT
+            );
+            CREATE TABLE closes (
+                id INTEGER PRIMARY KEY,
+                date DATE NOT NULL,
+                account TEXT NOT NULL
+            );
+            CREATE TABLE transaction_metadata (
+                id INTEGER PRIMARY KEY,
+                transaction_id INTEGER NOT NULL,
+                key TEXT NOT NULL,
+                value TEXT
+            );
+            CREATE TABLE posting_metadata (
+                id INTEGER PRIMARY KEY,
+                posting_id INTEGER NOT NULL,
+                key TEXT NOT NULL,
+                value TEXT
+            );
+            CREATE TABLE transaction_tags (
+                id INTEGER PRIMARY KEY,
+                transaction_id INTEGER NOT NULL,
+                tag TEXT NOT NULL
+            );
+            CREATE TABLE transaction_links (
+                id INTEGER PRIMARY KEY,
+                transaction_id INTEGER NOT NULL,
+                link TEXT NOT NULL
+            );
+            CREATE TABLE diagnostics (
+                id INTEGER PRIMARY KEY,
+                source_file TEXT,
+                line INTEGER,
+                source_location TEXT,
+                column_number INTEGER,
+                end_line INTEGER,
+                end_column INTEGER,
+                severity TEXT,
+                phase TEXT,
+                code TEXT,
+                message TEXT
+            );
+            CREATE TABLE source_files (
+                path TEXT PRIMARY KEY
+            );
+            """)
+    }
+
+    private static func loadTransactions(
+        _ rows: [[String: Any]],
+        into writer: BeancountProjectionWriter
+    ) throws -> Set<Int> {
+        var transactionIDs: Set<Int> = []
+        var metadataID = 0
+        var tagID = 0
+        var linkID = 0
+
+        for row in rows {
+            guard let transactionID = intValue(row["id"]),
+                  let date = stringValue(row["date"]),
+                  transactionIDs.insert(transactionID).inserted else {
+                continue
+            }
+
+            let position = sourcePosition(
+                file: row["filename"],
+                line: row["lineno"],
+                formatted: row["location"]
+            )
+            try writer.insert(sql: """
+                INSERT INTO transactions (id, date, flag, payee, narration, source_file, line, source_location)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """, values: [
+                    String(transactionID),
+                    date,
+                    stringValue(row["flag"]) ?? "*",
+                    stringValue(row["payee"]),
+                    stringValue(row["narration"]),
+                    position?.file,
+                    position?.line.map(String.init),
+                    position?.formatted
+                ])
+
+            for entry in metadataPairs(row["_entry_meta"]) {
+                metadataID += 1
+                try writer.insert(sql: """
+                    INSERT INTO transaction_metadata (id, transaction_id, key, value)
+                    VALUES (?, ?, ?, ?)
+                    """, values: [String(metadataID), String(transactionID), entry.key, entry.value])
+            }
+
+            for tag in stringList(row["tags"]) {
+                tagID += 1
+                try writer.insert(sql: """
+                    INSERT INTO transaction_tags (id, transaction_id, tag) VALUES (?, ?, ?)
+                    """, values: [String(tagID), String(transactionID), tag])
+            }
+
+            for link in stringList(row["links"]) {
+                linkID += 1
+                try writer.insert(sql: """
+                    INSERT INTO transaction_links (id, transaction_id, link) VALUES (?, ?, ?)
+                    """, values: [String(linkID), String(transactionID), link])
+            }
+        }
+
+        return transactionIDs
+    }
+
+    private static func loadPostings(
+        _ rows: [[String: Any]],
+        transactionIDs: Set<Int>,
+        into writer: BeancountProjectionWriter
+    ) throws {
+        var postingID = 0
+        var metadataID = 0
+
+        for row in rows {
+            guard let transactionID = intValue(row["transaction_id"]),
+                  let date = stringValue(row["date"]),
+                  let account = stringValue(row["account"]) else {
+                continue
+            }
+            guard transactionIDs.contains(transactionID) else {
+                throw BeancountDriverError.queryFailed(
+                    String(
+                        format: String(localized: "Beancount posting references missing transaction ID %@"),
+                        String(transactionID)
+                    )
+                )
+            }
+
+            postingID += 1
+            let position = sourcePosition(
+                file: row["filename"],
+                line: row["lineno"],
+                formatted: row["location"]
+            )
+            try writer.insert(sql: """
+                INSERT INTO postings
+                (id, transaction_id, date, account, amount, commodity, cost_number, cost_currency,
+                 source_file, line, source_location)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """, values: [
+                    String(postingID),
+                    String(transactionID),
+                    date,
+                    account,
+                    stringValue(row["number"]),
+                    stringValue(row["currency"]),
+                    stringValue(row["cost_number"]),
+                    stringValue(row["cost_currency"]),
+                    position?.file,
+                    position?.line.map(String.init),
+                    position?.formatted
+                ])
+
+            for entry in metadataPairs(row["_posting_meta"]) {
+                metadataID += 1
+                try writer.insert(sql: """
+                    INSERT INTO posting_metadata (id, posting_id, key, value)
+                    VALUES (?, ?, ?, ?)
+                    """, values: [String(metadataID), String(postingID), entry.key, entry.value])
+            }
+        }
+    }
+
+    private static func loadCommodities(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
+        var commodityId = 0
+        for row in rows {
+            guard let date = stringValue(row["date"]),
+                  let commodity = stringValue(row["name"]) ?? stringValue(row["commodity"]) else {
+                continue
+            }
+            commodityId += 1
+            try writer.insert(sql: """
+                INSERT INTO commodities (id, date, commodity) VALUES (?, ?, ?)
+                """, values: [String(commodityId), date, commodity])
+        }
+    }
+
+    private static func loadDocuments(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
+        var documentId = 0
+        for row in rows {
+            guard let date = stringValue(row["date"]),
+                  let account = stringValue(row["account"]),
+                  let path = stringValue(row["filename"]) ?? stringValue(row["path"]) else {
+                continue
+            }
+            documentId += 1
+            try writer.insert(sql: """
+                INSERT INTO documents (id, date, account, path, tags, links) VALUES (?, ?, ?, ?, ?, ?)
+                """, values: [
+                    String(documentId),
+                    date,
+                    account,
+                    path,
+                    joinedList(row["tags"]),
+                    joinedList(row["links"])
+                ])
+        }
+    }
+
+    private static func loadNotes(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
+        var noteId = 0
+        for row in rows {
+            guard let date = stringValue(row["date"]),
+                  let account = stringValue(row["account"]) else { continue }
+            noteId += 1
+            try writer.insert(sql: """
+                INSERT INTO notes (id, date, account, comment) VALUES (?, ?, ?, ?)
+                """, values: [String(noteId), date, account, stringValue(row["comment"])])
+        }
+    }
+
+    private static func loadEvents(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
+        var eventId = 0
+        for row in rows {
+            guard let date = stringValue(row["date"]),
+                  let type = stringValue(row["type"]) else { continue }
+            eventId += 1
+            try writer.insert(sql: """
+                INSERT INTO events (id, date, type, description) VALUES (?, ?, ?, ?)
+                """, values: [String(eventId), date, type, stringValue(row["description"])])
+        }
+    }
+
+    private static func loadCloses(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
+        var closeId = 0
+        for row in rows {
+            guard let account = stringValue(row["account"]),
+                  let date = stringValue(row["close"]) ?? stringValue(row["date"]) else { continue }
+            closeId += 1
+            try writer.insert(sql: """
+                INSERT INTO closes (id, date, account) VALUES (?, ?, ?)
+                """, values: [String(closeId), date, account])
+        }
+    }
+
+    private static func loadDiagnostics(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
+        var diagnosticId = 0
+        for row in rows {
+            diagnosticId += 1
+            let position = sourcePosition(file: row["file"], line: row["line"], formatted: nil)
+            try writer.insert(sql: """
+                INSERT INTO diagnostics
+                (id, source_file, line, source_location, column_number, end_line, end_column,
+                 severity, phase, code, message)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """, values: [
+                    String(diagnosticId),
+                    position?.file,
+                    position?.line.map(String.init),
+                    position?.formatted,
+                    intValue(row["column"]).map(String.init),
+                    intValue(row["end_line"]).map(String.init),
+                    intValue(row["end_column"]).map(String.init),
+                    stringValue(row["severity"]),
+                    stringValue(row["phase"]),
+                    stringValue(row["code"]),
+                    stringValue(row["message"])
+                ])
+        }
+    }
+
+    private static func loadAccounts(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
+        for row in rows {
+            guard let name = stringValue(row["account"]) else { continue }
+            try writer.insert(sql: """
+                INSERT OR REPLACE INTO accounts (name, open_date, currencies)
+                VALUES (?, ?, ?)
+                """, values: [
+                    name,
+                    stringValue(row["open"]),
+                    joinedList(row["currencies"])
+                ])
+        }
+    }
+
+    private static func loadPrices(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
+        var priceId = 0
+        for row in rows {
+            guard let commodity = stringValue(row["currency"]),
+                  let date = stringValue(row["date"]) else {
+                continue
+            }
+            let amount = amountFields(row["amount"])
+            guard let number = amount.number, let currency = amount.currency else { continue }
+            priceId += 1
+            try writer.insert(sql: """
+                INSERT INTO prices (id, date, commodity, amount, currency)
+                VALUES (?, ?, ?, ?, ?)
+                """, values: [String(priceId), date, commodity, number, currency])
+        }
+    }
+
+    private static func loadBalances(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
+        var balanceId = 0
+        for row in rows {
+            guard let account = stringValue(row["account"]) else { continue }
+            for position in inventoryPositions(row["balance"]) {
+                balanceId += 1
+                try writer.insert(sql: """
+                    INSERT INTO balances (id, account, amount, commodity)
+                    VALUES (?, ?, ?, ?)
+                    """, values: [String(balanceId), account, position.number, position.currency])
+            }
+        }
+    }
+
+    private static func loadBalanceAssertions(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
+        var balanceId = 0
+        for row in rows {
+            guard let account = stringValue(row["account"]),
+                  let date = stringValue(row["date"]) else { continue }
+            let amount = amountFields(row["amount"])
+            guard let number = amount.number, let commodity = amount.currency else { continue }
+            balanceId += 1
+            try writer.insert(sql: """
+                INSERT INTO balance_assertions (id, date, account, amount, commodity)
+                VALUES (?, ?, ?, ?, ?)
+                """, values: [String(balanceId), date, account, number, commodity])
+        }
+    }
+
+    private static func loadSourceFiles(_ files: [URL], into writer: BeancountProjectionWriter) throws {
+        for file in files {
+            try writer.insert(sql: "INSERT OR IGNORE INTO source_files (path) VALUES (?)", values: [file.path])
+        }
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        switch value {
+        case let string as String:
+            return string
+        case let number as NSNumber:
+            return number.stringValue
+        default:
+            return nil
+        }
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        switch value {
+        case let number as NSNumber:
+            return number.intValue
+        case let string as String:
+            return Int(string)
+        default:
+            return nil
+        }
+    }
+
+    private static func amountFields(_ value: Any?) -> (number: String?, currency: String?) {
+        guard let dictionary = value as? [String: Any] else { return (nil, nil) }
+        return (stringValue(dictionary["number"]), stringValue(dictionary["currency"]))
+    }
+
+    private static func inventoryPositions(_ value: Any?) -> [(number: String, currency: String)] {
+        guard let dictionary = value as? [String: Any],
+              let positions = dictionary["positions"] as? [[String: Any]] else {
+            return []
+        }
+        return positions.compactMap { position in
+            guard let number = stringValue(position["number"]),
+                  let currency = stringValue(position["currency"]) else {
+                return nil
+            }
+            return (number: number, currency: currency)
+        }
+    }
+
+    private static func joinedList(_ value: Any?) -> String? {
+        guard let array = value as? [Any] else { return stringValue(value) }
+        let items = array.compactMap { $0 as? String }
+        return items.isEmpty ? nil : items.joined(separator: " ")
+    }
+
+    private static func stringList(_ value: Any?) -> [String] {
+        guard let array = value as? [Any] else {
+            guard let joined = stringValue(value) else { return [] }
+            return joined
+                .split(whereSeparator: { $0 == "," || $0.isWhitespace })
+                .map(String.init)
+        }
+        return array.compactMap { $0 as? String }
+    }
+
+    private static func metadataPairs(_ value: Any?) -> [(key: String, value: String?)] {
+        guard let dictionary = value as? [String: Any] else { return [] }
+        return dictionary.keys.sorted().map { key in
+            guard let raw = dictionary[key], !(raw is NSNull) else {
+                return (key: key, value: nil)
+            }
+            return (key: key, value: metadataValue(raw))
+        }
+    }
+
+    private static func metadataValue(_ raw: Any) -> String? {
+        if let number = raw as? NSNumber, CFGetTypeID(number) == CFBooleanGetTypeID() {
+            return number.boolValue ? "TRUE" : "FALSE"
+        }
+        return stringValue(raw) ?? BeancountPluginDriver.rustledgerCellValue(raw)
+    }
+
+    private static func sourcePosition(file: Any?, line: Any?, formatted: Any?) -> BeancountSourcePosition? {
+        let path = stringValue(file).flatMap { $0.isEmpty ? nil : $0 }
+        let lineNumber = intValue(line).flatMap { $0 > 0 ? $0 : nil }
+        guard path != nil || lineNumber != nil else { return nil }
+        let rendered = stringValue(formatted).flatMap { $0.isEmpty ? nil : $0 }
+            ?? path.flatMap { path in lineNumber.map { "\(path):\($0)" } }
+        return BeancountSourcePosition(file: path, line: lineNumber, formatted: rendered)
+    }
+
+    private static func exec(_ db: OpaquePointer, _ sql: String) throws {
+        var error: UnsafeMutablePointer<CChar>?
+        guard sqlite3_exec(db, sql, nil, nil, &error) == SQLITE_OK else {
+            let message = error.map { String(cString: $0) } ?? String(cString: sqlite3_errmsg(db))
+            if error != nil {
+                sqlite3_free(error)
+            }
+            throw BeancountDriverError.queryFailed(message)
+        }
+    }
+}
+
+private let projectionSQLiteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)

--- a/Plugins/BeancountDriverPlugin/BeancountPluginDriver+PythonScript.swift
+++ b/Plugins/BeancountDriverPlugin/BeancountPluginDriver+PythonScript.swift
@@ -8,9 +8,15 @@ import Foundation
 extension BeancountPluginDriver {
     static let pythonProjectionScript = """
 import json
+import os
 import sys
+import tempfile
 from collections import defaultdict
 from decimal import Decimal
+
+cache_directory = tempfile.TemporaryDirectory(prefix="tablepro-beancount-")
+os.environ["BEANCOUNT_DISABLE_LOAD_CACHE"] = "1"
+os.environ["BEANCOUNT_LOAD_CACHE_FILENAME"] = os.path.join(cache_directory.name, "disabled.picklecache")
 
 from beancount import loader
 
@@ -76,12 +82,12 @@ if errors:
     sys.exit(1)
 
 rows = {
-    "transactions_and_postings": [],
+    "transactions": [],
+    "postings": [],
     "accounts": [],
     "prices": [],
     "balances": [],
     "balance_assertions": [],
-    "transaction_locations": [],
     "commodities": [],
     "documents": [],
     "notes": [],
@@ -98,11 +104,18 @@ for entry in entries:
         entry_meta = user_meta(entry.meta)
         tags = name_list(entry.tags)
         links = name_list(entry.links)
-        rows["transaction_locations"].append({
+        rows["transactions"].append({
             "id": transaction_id,
+            "date": date_value(entry.date),
+            "flag": str(entry.flag),
+            "payee": entry.payee,
+            "narration": entry.narration,
             "filename": source_file(entry.meta),
             "lineno": source_line(entry.meta),
             "location": source_location(entry.meta),
+            "tags": tags,
+            "links": links,
+            "_entry_meta": entry_meta,
         })
         for posting in entry.postings:
             units = getattr(posting, "units", None)
@@ -110,12 +123,9 @@ for entry in entries:
             posting_meta = getattr(posting, "meta", None)
             if units is not None and getattr(units, "number", None) is not None and getattr(units, "currency", None):
                 balances[(posting.account, units.currency)] += units.number
-            rows["transactions_and_postings"].append({
-                "id": transaction_id,
+            rows["postings"].append({
+                "transaction_id": transaction_id,
                 "date": date_value(entry.date),
-                "flag": str(entry.flag),
-                "payee": entry.payee,
-                "narration": entry.narration,
                 "account": posting.account,
                 "number": decimal_value(getattr(units, "number", None)) if units is not None else None,
                 "currency": getattr(units, "currency", None) if units is not None else None,
@@ -124,9 +134,6 @@ for entry in entries:
                 "filename": source_file(posting_meta) or source_file(entry.meta),
                 "lineno": source_line(posting_meta) or source_line(entry.meta),
                 "location": source_location(posting_meta) or source_location(entry.meta),
-                "tags": tags,
-                "links": links,
-                "_entry_meta": entry_meta,
                 "_posting_meta": user_meta(posting_meta),
             })
     elif entry_type == "Commodity":

--- a/Plugins/BeancountDriverPlugin/BeancountPluginDriver+PythonScript.swift
+++ b/Plugins/BeancountDriverPlugin/BeancountPluginDriver+PythonScript.swift
@@ -28,6 +28,47 @@ def amount_value(amount):
         "currency": getattr(amount, "currency", None),
     }
 
+META_INTERNAL_KEYS = ("filename", "lineno", "__automatic__", "__residual__", "__tolerances__")
+
+def source_file(meta):
+    if not meta:
+        return None
+    value = meta.get("filename")
+    return str(value) if value is not None else None
+
+def source_line(meta):
+    if not meta:
+        return None
+    value = meta.get("lineno")
+    return int(value) if value is not None else None
+
+def source_location(meta):
+    path = source_file(meta)
+    line = source_line(meta)
+    if path is None or line is None:
+        return None
+    return path + ":" + str(line)
+
+def user_meta(meta):
+    if not meta:
+        return None
+    pairs = {}
+    for key, value in meta.items():
+        if key in META_INTERNAL_KEYS or key.startswith("__"):
+            continue
+        if value is None:
+            pairs[key] = None
+        elif isinstance(value, (str, bool, int, float)):
+            pairs[key] = value
+        elif isinstance(value, Decimal):
+            pairs[key] = decimal_value(value)
+        else:
+            pairs[key] = str(value)
+    return pairs or None
+
+def name_list(values):
+    return sorted(str(value) for value in (values or []))
+
 entries, errors, options_map = loader.load_file(sys.argv[1])
 if errors:
     for error in errors:
@@ -40,6 +81,12 @@ rows = {
     "prices": [],
     "balances": [],
     "balance_assertions": [],
+    "transaction_locations": [],
+    "commodities": [],
+    "documents": [],
+    "notes": [],
+    "events": [],
+    "closes": [],
 }
 balances = defaultdict(Decimal)
 transaction_id = 0
@@ -48,9 +95,19 @@ for entry in entries:
     entry_type = type(entry).__name__
     if entry_type == "Transaction":
         transaction_id += 1
+        entry_meta = user_meta(entry.meta)
+        tags = name_list(entry.tags)
+        links = name_list(entry.links)
+        rows["transaction_locations"].append({
+            "id": transaction_id,
+            "filename": source_file(entry.meta),
+            "lineno": source_line(entry.meta),
+            "location": source_location(entry.meta),
+        })
         for posting in entry.postings:
             units = getattr(posting, "units", None)
             cost = getattr(posting, "cost", None)
+            posting_meta = getattr(posting, "meta", None)
             if units is not None and getattr(units, "number", None) is not None and getattr(units, "currency", None):
                 balances[(posting.account, units.currency)] += units.number
             rows["transactions_and_postings"].append({
@@ -64,7 +121,44 @@ for entry in entries:
                 "currency": getattr(units, "currency", None) if units is not None else None,
                 "cost_number": decimal_value(getattr(cost, "number", None)) if cost is not None else None,
                 "cost_currency": getattr(cost, "currency", None) if cost is not None else None,
+                "filename": source_file(posting_meta) or source_file(entry.meta),
+                "lineno": source_line(posting_meta) or source_line(entry.meta),
+                "location": source_location(posting_meta) or source_location(entry.meta),
+                "tags": tags,
+                "links": links,
+                "_entry_meta": entry_meta,
+                "_posting_meta": user_meta(posting_meta),
             })
+    elif entry_type == "Commodity":
+        rows["commodities"].append({
+            "date": date_value(entry.date),
+            "name": entry.currency,
+        })
+    elif entry_type == "Document":
+        rows["documents"].append({
+            "date": date_value(entry.date),
+            "account": entry.account,
+            "filename": entry.filename,
+            "tags": name_list(getattr(entry, "tags", None)),
+            "links": name_list(getattr(entry, "links", None)),
+        })
+    elif entry_type == "Note":
+        rows["notes"].append({
+            "date": date_value(entry.date),
+            "account": entry.account,
+            "comment": entry.comment,
+        })
+    elif entry_type == "Event":
+        rows["events"].append({
+            "date": date_value(entry.date),
+            "type": entry.type,
+            "description": entry.description,
+        })
+    elif entry_type == "Close":
+        rows["closes"].append({
+            "account": entry.account,
+            "close": date_value(entry.date),
+        })
     elif entry_type == "Open":
         rows["accounts"].append({
             "account": entry.account,

--- a/Plugins/BeancountDriverPlugin/BeancountPluginDriver.swift
+++ b/Plugins/BeancountDriverPlugin/BeancountPluginDriver.swift
@@ -48,73 +48,6 @@ private struct BeancountProjection {
     let signatures: [String: BeancountSourceSignature]
 }
 
-private struct BeancountSourcePosition {
-    let file: String?
-    let line: Int?
-    let formatted: String?
-}
-
-private final class BeancountProjectionWriter {
-    private let db: OpaquePointer
-    private var statements: [String: OpaquePointer] = [:]
-
-    init(db: OpaquePointer) {
-        self.db = db
-    }
-
-    deinit {
-        for statement in statements.values {
-            sqlite3_finalize(statement)
-        }
-    }
-
-    func insert(sql: String, values: [String?]) throws {
-        let statement = try preparedStatement(sql)
-        sqlite3_reset(statement)
-        sqlite3_clear_bindings(statement)
-
-        for (index, value) in values.enumerated() {
-            let position = Int32(index + 1)
-            if let value {
-                sqlite3_bind_text(statement, position, value, -1, SQLITE_TRANSIENT)
-            } else {
-                sqlite3_bind_null(statement, position)
-            }
-        }
-
-        guard sqlite3_step(statement) == SQLITE_DONE else {
-            throw BeancountDriverError.queryFailed(String(cString: sqlite3_errmsg(db)))
-        }
-    }
-
-    private func preparedStatement(_ sql: String) throws -> OpaquePointer {
-        if let cached = statements[sql] {
-            return cached
-        }
-        var prepared: OpaquePointer?
-        guard sqlite3_prepare_v2(db, sql, -1, &prepared, nil) == SQLITE_OK, let prepared else {
-            throw BeancountDriverError.queryFailed(String(cString: sqlite3_errmsg(db)))
-        }
-        statements[sql] = prepared
-        return prepared
-    }
-}
-
-struct BeancountProjectionRows {
-    var transactionsAndPostings: [[String: Any]] = []
-    var accounts: [[String: Any]] = []
-    var prices: [[String: Any]] = []
-    var balances: [[String: Any]] = []
-    var balanceAssertions: [[String: Any]] = []
-    var transactionLocations: [[String: Any]] = []
-    var commodities: [[String: Any]] = []
-    var documents: [[String: Any]] = []
-    var notes: [[String: Any]] = []
-    var events: [[String: Any]] = []
-    var closes: [[String: Any]] = []
-    var diagnostics: [[String: Any]] = []
-}
-
 private enum BeancountBackend {
     case rledger
     case python(String)
@@ -127,6 +60,17 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     private var ledgerURL: URL?
     private var watchedURLs: [URL] = []
     private var sourceSignatures: [String: BeancountSourceSignature] = [:]
+    private var projectionGeneration: UInt64 = 0
+    private var pendingConnectionGeneration: UInt64?
+
+    private static let transactionsCoreColumns =
+        "id, date, flag, payee, narration, filename, lineno"
+    private static let transactionsDetailColumns = "tags, links, _entry_meta"
+    private static let transactionsQuery =
+        "SELECT \(transactionsCoreColumns), \(transactionsDetailColumns) "
+            + "FROM #entries WHERE type = 'transaction' ORDER BY id"
+    private static let transactionsCoreQuery =
+        "SELECT \(transactionsCoreColumns) FROM #entries WHERE type = 'transaction' ORDER BY id"
 
     private static let postingsCoreColumns =
         "id, date, flag, payee, narration, account, number, currency, cost_number, cost_currency"
@@ -140,8 +84,6 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     private static let balancesQuery =
         "SELECT account, sum(position) AS balance FROM #postings GROUP BY account ORDER BY account"
     private static let balanceAssertionsQuery = "SELECT date, account, amount FROM #balances ORDER BY date, account"
-    private static let transactionLocationsQuery =
-        "SELECT id, filename, lineno FROM #entries WHERE type = 'transaction' ORDER BY id"
     private static let commoditiesQuery = "SELECT date, name FROM #commodities ORDER BY date, name"
     private static let documentsQuery =
         "SELECT date, account, filename, tags, links FROM #documents ORDER BY date, account"
@@ -186,18 +128,46 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             )
         }
 
-        let projection = try await perform { try Self.buildProjection(ledgerURL: fileURL) }
+        let generation = lock.withLock { () -> UInt64 in
+            projectionGeneration &+= 1
+            pendingConnectionGeneration = projectionGeneration
+            return projectionGeneration
+        }
+        let projection: BeancountProjection
+        do {
+            projection = try await perform { try Self.buildProjection(ledgerURL: fileURL) }
+        } catch {
+            lock.withLock {
+                if pendingConnectionGeneration == generation {
+                    pendingConnectionGeneration = nil
+                }
+            }
+            throw error
+        }
 
-        lock.withLock {
+        let installed = lock.withLock { () -> Bool in
+            guard projectionGeneration == generation,
+                  pendingConnectionGeneration == generation else {
+                sqlite3_close(projection.handle)
+                return false
+            }
+            pendingConnectionGeneration = nil
+            if let db {
+                sqlite3_close(db)
+            }
             db = projection.handle
             ledgerURL = fileURL
             watchedURLs = projection.watchedURLs
             sourceSignatures = projection.signatures
+            return true
         }
+        guard installed else { throw CancellationError() }
     }
 
     func installProjection(_ handle: OpaquePointer, ledgerURL: URL) {
         lock.withLock {
+            projectionGeneration &+= 1
+            pendingConnectionGeneration = nil
             if let db {
                 sqlite3_close(db)
             }
@@ -210,6 +180,8 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func disconnect() {
         lock.withLock {
+            projectionGeneration &+= 1
+            pendingConnectionGeneration = nil
             if db != nil {
                 sqlite3_close(db)
                 db = nil
@@ -490,9 +462,14 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     private func reloadProjectionIfNeeded() throws {
-        let snapshot: (url: URL, watched: [URL], signatures: [String: BeancountSourceSignature])? = lock.withLock {
-            guard let ledgerURL else { return nil }
-            return (ledgerURL, watchedURLs, sourceSignatures)
+        let snapshot: (
+            url: URL,
+            watched: [URL],
+            signatures: [String: BeancountSourceSignature],
+            generation: UInt64
+        )? = lock.withLock {
+            guard pendingConnectionGeneration == nil, let ledgerURL else { return nil }
+            return (ledgerURL, watchedURLs, sourceSignatures, projectionGeneration)
         }
         guard let snapshot else { return }
 
@@ -502,7 +479,8 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         let projection = try Self.buildProjection(ledgerURL: snapshot.url)
 
         lock.withLock {
-            guard ledgerURL == snapshot.url else {
+            guard ledgerURL == snapshot.url,
+                  projectionGeneration == snapshot.generation else {
                 sqlite3_close(projection.handle)
                 return
             }
@@ -512,6 +490,7 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             db = projection.handle
             watchedURLs = projection.watchedURLs
             sourceSignatures = projection.signatures
+            projectionGeneration &+= 1
         }
     }
 
@@ -531,28 +510,48 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     private static func buildProjection(ledgerURL: URL) throws -> BeancountProjection {
-        let graph = try BeancountIncludeResolver().resolve(fileURL: ledgerURL)
-        let watched = Array(Set(graph.sourceFiles + graph.watchedDirectories)).sorted { $0.path < $1.path }
-        let fileSignatures = signatures(for: watched)
+        for _ in 0..<2 {
+            let initialGraph = try BeancountIncludeResolver().resolve(fileURL: ledgerURL)
+            let initialSignatures = signatures(for: initialGraph.reloadDependencies)
+            let rows = try projectionRows(ledgerPath: ledgerURL.path)
+            let finalGraph = try BeancountIncludeResolver().resolve(fileURL: ledgerURL)
+            guard initialGraph.sourceFiles == finalGraph.sourceFiles,
+                  initialGraph.reloadDependencies == finalGraph.reloadDependencies else {
+                continue
+            }
 
-        let rows = try projectionRows(ledgerPath: ledgerURL.path)
-        let handle = try loadProjection(rows: rows, sourceFiles: graph.sourceFiles)
+            let finalSignatures = signatures(for: finalGraph.reloadDependencies)
+            guard initialSignatures == finalSignatures else { continue }
 
-        return BeancountProjection(handle: handle, watchedURLs: watched, signatures: fileSignatures)
+            let handle = try loadProjection(rows: rows, sourceFiles: finalGraph.sourceFiles)
+            guard signatures(for: finalGraph.reloadDependencies) == finalSignatures else {
+                sqlite3_close(handle)
+                continue
+            }
+            return BeancountProjection(
+                handle: handle,
+                watchedURLs: finalGraph.reloadDependencies,
+                signatures: finalSignatures
+            )
+        }
+
+        throw BeancountDriverError.connectionFailed(
+            String(localized: "Beancount ledger changed while building its SQL projection")
+        )
     }
 
     private static func projectionRows(ledgerPath: String) throws -> BeancountProjectionRows {
         switch try resolveProjectionBackend() {
         case .rledger:
+            let transactions = try transactionRows(ledgerPath: ledgerPath)
+            let postings = try postingRows(ledgerPath: ledgerPath)
             return BeancountProjectionRows(
-                transactionsAndPostings: try postingRows(ledgerPath: ledgerPath),
+                transactions: transactionRowsByAddingPostingDetails(transactions, postings: postings),
+                postings: postings,
                 accounts: try query(ledgerPath: ledgerPath, bql: accountsQuery),
                 prices: try query(ledgerPath: ledgerPath, bql: pricesQuery),
                 balances: try query(ledgerPath: ledgerPath, bql: balancesQuery),
                 balanceAssertions: try query(ledgerPath: ledgerPath, bql: balanceAssertionsQuery),
-                transactionLocations: directiveRows(
-                    ledgerPath: ledgerPath, bql: transactionLocationsQuery, table: "transaction locations"
-                ),
                 commodities: directiveRows(ledgerPath: ledgerPath, bql: commoditiesQuery, table: "commodities"),
                 documents: directiveRows(ledgerPath: ledgerPath, bql: documentsQuery, table: "documents"),
                 notes: directiveRows(ledgerPath: ledgerPath, bql: notesQuery, table: "notes"),
@@ -563,12 +562,12 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         case .python(let executablePath):
             let rows = try pythonProjectionRows(ledgerPath: ledgerPath, executablePath: executablePath)
             return BeancountProjectionRows(
-                transactionsAndPostings: rows["transactions_and_postings"] ?? [],
+                transactions: rows["transactions"] ?? [],
+                postings: rows["postings"] ?? [],
                 accounts: rows["accounts"] ?? [],
                 prices: rows["prices"] ?? [],
                 balances: rows["balances"] ?? [],
                 balanceAssertions: rows["balance_assertions"] ?? [],
-                transactionLocations: rows["transaction_locations"] ?? [],
                 commodities: rows["commodities"] ?? [],
                 documents: rows["documents"] ?? [],
                 notes: rows["notes"] ?? [],
@@ -578,54 +577,65 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         }
     }
 
-    static func loadProjection(rows: BeancountProjectionRows, sourceFiles: [URL]) throws -> OpaquePointer {
-        var handle: OpaquePointer?
-        guard sqlite3_open(":memory:", &handle) == SQLITE_OK, let handle else {
-            throw BeancountDriverError.connectionFailed(
-                String(localized: "Could not initialize SQL projection")
-            )
-        }
-
-        do {
-            try createSchema(handle)
-            let writer = BeancountProjectionWriter(db: handle)
-            try loadTransactionsAndPostings(
-                rows.transactionsAndPostings,
-                locations: transactionLocations(rows.transactionLocations),
-                into: writer
-            )
-            try loadAccounts(rows.accounts, into: writer)
-            try loadPrices(rows.prices, into: writer)
-            try loadBalances(rows.balances, into: writer)
-            try loadBalanceAssertions(rows.balanceAssertions, into: writer)
-            try loadCommodities(rows.commodities, into: writer)
-            try loadDocuments(rows.documents, into: writer)
-            try loadNotes(rows.notes, into: writer)
-            try loadEvents(rows.events, into: writer)
-            try loadCloses(rows.closes, into: writer)
-            try loadDiagnostics(rows.diagnostics, into: writer)
-            try loadSourceFiles(sourceFiles, into: writer)
-            try exec(handle, "PRAGMA query_only = ON")
-        } catch {
-            sqlite3_close(handle)
-            throw error
-        }
-
-        return handle
-    }
-
     private static func query(ledgerPath: String, bql: String) throws -> [[String: Any]] {
         let data = try runRledger(arguments: rledgerQueryArguments(ledgerPath: ledgerPath, query: bql))
         return try decodeRledgerRows(data)
     }
 
-    private static func postingRows(ledgerPath: String) throws -> [[String: Any]] {
+    private static func transactionRows(ledgerPath: String) throws -> [[String: Any]] {
         do {
-            return try query(ledgerPath: ledgerPath, bql: postingsQuery)
+            return try query(ledgerPath: ledgerPath, bql: transactionsQuery)
+        } catch {
+            logger.warning("Beancount transaction details unavailable, projecting core columns: \(error)")
+            return try query(ledgerPath: ledgerPath, bql: transactionsCoreQuery)
+        }
+    }
+
+    private static func postingRows(ledgerPath: String) throws -> [[String: Any]] {
+        let rows: [[String: Any]]
+        do {
+            rows = try query(ledgerPath: ledgerPath, bql: postingsQuery)
         } catch {
             logger.warning("Beancount postings detail unavailable, projecting core columns: \(error)")
-            return try query(ledgerPath: ledgerPath, bql: postingsCoreQuery)
+            rows = try query(ledgerPath: ledgerPath, bql: postingsCoreQuery)
         }
+        return rows.map { row in
+            var normalized = row
+            normalized["transaction_id"] = row["id"]
+            return normalized
+        }
+    }
+
+    static func transactionRowsByAddingPostingDetails(
+        _ transactions: [[String: Any]],
+        postings: [[String: Any]]
+    ) -> [[String: Any]] {
+        let detailKeys = ["tags", "links", "_entry_meta"]
+        let postingDetails = Dictionary(postings.compactMap { posting -> (String, [String: Any])? in
+            guard let identifier = rowIdentifier(posting["transaction_id"]) else { return nil }
+            return (identifier, posting)
+        }, uniquingKeysWith: { first, _ in first })
+
+        return transactions.map { transaction in
+            guard let identifier = rowIdentifier(transaction["id"]),
+                  let details = postingDetails[identifier] else {
+                return transaction
+            }
+            var enriched = transaction
+            for key in detailKeys where enriched[key] == nil || enriched[key] is NSNull {
+                if let value = details[key] {
+                    enriched[key] = value
+                }
+            }
+            return enriched
+        }
+    }
+
+    private static func rowIdentifier(_ value: Any?) -> String? {
+        if let number = value as? NSNumber {
+            return number.stringValue
+        }
+        return value as? String
     }
 
     private static func directiveRows(ledgerPath: String, bql: String, table: String) -> [[String: Any]] {
@@ -641,7 +651,7 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         do {
             let data = try runProcess(
                 executablePath: try rustledgerExecutablePath(),
-                arguments: ["check", "-f", "json", ledgerPath],
+                arguments: ["check", "--no-cache", "-f", "json", ledgerPath],
                 failureMessage: String(localized: "rustledger validation failed"),
                 allowsNonZeroExit: true
             )
@@ -654,381 +664,6 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         } catch {
             logger.warning("Beancount validation did not run, leaving the diagnostics table empty: \(error)")
             return []
-        }
-    }
-
-    private static func createSchema(_ db: OpaquePointer) throws {
-        try exec(db, """
-            CREATE TABLE transactions (
-                id INTEGER PRIMARY KEY,
-                date DATE NOT NULL,
-                flag TEXT NOT NULL,
-                payee TEXT,
-                narration TEXT,
-                source_file TEXT,
-                line INTEGER,
-                source_location TEXT
-            );
-            CREATE TABLE postings (
-                id INTEGER PRIMARY KEY,
-                transaction_id INTEGER NOT NULL,
-                date DATE NOT NULL,
-                account TEXT NOT NULL,
-                amount TEXT,
-                commodity TEXT,
-                cost_number TEXT,
-                cost_currency TEXT,
-                source_file TEXT,
-                line INTEGER,
-                source_location TEXT
-            );
-            CREATE TABLE accounts (
-                name TEXT PRIMARY KEY,
-                open_date DATE,
-                currencies TEXT
-            );
-            CREATE TABLE prices (
-                id INTEGER PRIMARY KEY,
-                date DATE NOT NULL,
-                commodity TEXT NOT NULL,
-                amount TEXT NOT NULL,
-                currency TEXT NOT NULL
-            );
-            CREATE TABLE balances (
-                id INTEGER PRIMARY KEY,
-                account TEXT NOT NULL,
-                amount TEXT NOT NULL,
-                commodity TEXT NOT NULL
-            );
-            CREATE TABLE balance_assertions (
-                id INTEGER PRIMARY KEY,
-                date DATE NOT NULL,
-                account TEXT NOT NULL,
-                amount TEXT NOT NULL,
-                commodity TEXT NOT NULL
-            );
-            CREATE TABLE commodities (
-                id INTEGER PRIMARY KEY,
-                date DATE NOT NULL,
-                commodity TEXT NOT NULL
-            );
-            CREATE TABLE documents (
-                id INTEGER PRIMARY KEY,
-                date DATE NOT NULL,
-                account TEXT NOT NULL,
-                path TEXT NOT NULL,
-                tags TEXT,
-                links TEXT
-            );
-            CREATE TABLE notes (
-                id INTEGER PRIMARY KEY,
-                date DATE NOT NULL,
-                account TEXT NOT NULL,
-                comment TEXT
-            );
-            CREATE TABLE events (
-                id INTEGER PRIMARY KEY,
-                date DATE NOT NULL,
-                type TEXT NOT NULL,
-                description TEXT
-            );
-            CREATE TABLE closes (
-                id INTEGER PRIMARY KEY,
-                date DATE NOT NULL,
-                account TEXT NOT NULL
-            );
-            CREATE TABLE transaction_metadata (
-                id INTEGER PRIMARY KEY,
-                transaction_id INTEGER NOT NULL,
-                key TEXT NOT NULL,
-                value TEXT
-            );
-            CREATE TABLE posting_metadata (
-                id INTEGER PRIMARY KEY,
-                posting_id INTEGER NOT NULL,
-                key TEXT NOT NULL,
-                value TEXT
-            );
-            CREATE TABLE transaction_tags (
-                id INTEGER PRIMARY KEY,
-                transaction_id INTEGER NOT NULL,
-                tag TEXT NOT NULL
-            );
-            CREATE TABLE transaction_links (
-                id INTEGER PRIMARY KEY,
-                transaction_id INTEGER NOT NULL,
-                link TEXT NOT NULL
-            );
-            CREATE TABLE diagnostics (
-                id INTEGER PRIMARY KEY,
-                source_file TEXT,
-                line INTEGER,
-                source_location TEXT,
-                column_number INTEGER,
-                end_line INTEGER,
-                end_column INTEGER,
-                severity TEXT,
-                phase TEXT,
-                code TEXT,
-                message TEXT
-            );
-            CREATE TABLE source_files (
-                path TEXT PRIMARY KEY
-            );
-            """)
-    }
-
-    private static func loadTransactionsAndPostings(
-        _ rows: [[String: Any]],
-        locations: [Int: BeancountSourcePosition],
-        into writer: BeancountProjectionWriter
-    ) throws {
-        var seenTransactions: Set<Int> = []
-        var postingId = 0
-        var metadataId = 0
-        var postingMetadataId = 0
-        var tagId = 0
-        var linkId = 0
-
-        for row in rows {
-            guard let transactionId = intValue(row["id"]),
-                  let date = stringValue(row["date"]) else {
-                continue
-            }
-            let flag = stringValue(row["flag"]) ?? "*"
-
-            if seenTransactions.insert(transactionId).inserted {
-                let location = locations[transactionId]
-                try writer.insert(sql: """
-                    INSERT INTO transactions (id, date, flag, payee, narration, source_file, line, source_location)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                    """, values: [
-                        String(transactionId),
-                        date,
-                        flag,
-                        stringValue(row["payee"]),
-                        stringValue(row["narration"]),
-                        location?.file,
-                        location?.line.map(String.init),
-                        location?.formatted
-                    ])
-
-                for entry in metadataPairs(row["_entry_meta"]) {
-                    metadataId += 1
-                    try writer.insert(sql: """
-                        INSERT INTO transaction_metadata (id, transaction_id, key, value)
-                        VALUES (?, ?, ?, ?)
-                        """, values: [String(metadataId), String(transactionId), entry.key, entry.value])
-                }
-
-                for tag in stringList(row["tags"]) {
-                    tagId += 1
-                    try writer.insert(sql: """
-                        INSERT INTO transaction_tags (id, transaction_id, tag) VALUES (?, ?, ?)
-                        """, values: [String(tagId), String(transactionId), tag])
-                }
-
-                for link in stringList(row["links"]) {
-                    linkId += 1
-                    try writer.insert(sql: """
-                        INSERT INTO transaction_links (id, transaction_id, link) VALUES (?, ?, ?)
-                        """, values: [String(linkId), String(transactionId), link])
-                }
-            }
-
-            guard let account = stringValue(row["account"]) else { continue }
-            postingId += 1
-            let position = sourcePosition(file: row["filename"], line: row["lineno"], formatted: row["location"])
-            try writer.insert(sql: """
-                INSERT INTO postings
-                (id, transaction_id, date, account, amount, commodity, cost_number, cost_currency,
-                 source_file, line, source_location)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """, values: [
-                    String(postingId),
-                    String(transactionId),
-                    date,
-                    account,
-                    stringValue(row["number"]),
-                    stringValue(row["currency"]),
-                    stringValue(row["cost_number"]),
-                    stringValue(row["cost_currency"]),
-                    position?.file,
-                    position?.line.map(String.init),
-                    position?.formatted
-                ])
-
-            for entry in metadataPairs(row["_posting_meta"]) {
-                postingMetadataId += 1
-                try writer.insert(sql: """
-                    INSERT INTO posting_metadata (id, posting_id, key, value)
-                    VALUES (?, ?, ?, ?)
-                    """, values: [String(postingMetadataId), String(postingId), entry.key, entry.value])
-            }
-        }
-    }
-
-    private static func loadCommodities(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
-        var commodityId = 0
-        for row in rows {
-            guard let date = stringValue(row["date"]),
-                  let commodity = stringValue(row["name"]) ?? stringValue(row["commodity"]) else {
-                continue
-            }
-            commodityId += 1
-            try writer.insert(sql: """
-                INSERT INTO commodities (id, date, commodity) VALUES (?, ?, ?)
-                """, values: [String(commodityId), date, commodity])
-        }
-    }
-
-    private static func loadDocuments(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
-        var documentId = 0
-        for row in rows {
-            guard let date = stringValue(row["date"]),
-                  let account = stringValue(row["account"]),
-                  let path = stringValue(row["filename"]) ?? stringValue(row["path"]) else {
-                continue
-            }
-            documentId += 1
-            try writer.insert(sql: """
-                INSERT INTO documents (id, date, account, path, tags, links) VALUES (?, ?, ?, ?, ?, ?)
-                """, values: [
-                    String(documentId),
-                    date,
-                    account,
-                    path,
-                    joinedList(row["tags"]),
-                    joinedList(row["links"])
-                ])
-        }
-    }
-
-    private static func loadNotes(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
-        var noteId = 0
-        for row in rows {
-            guard let date = stringValue(row["date"]),
-                  let account = stringValue(row["account"]) else { continue }
-            noteId += 1
-            try writer.insert(sql: """
-                INSERT INTO notes (id, date, account, comment) VALUES (?, ?, ?, ?)
-                """, values: [String(noteId), date, account, stringValue(row["comment"])])
-        }
-    }
-
-    private static func loadEvents(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
-        var eventId = 0
-        for row in rows {
-            guard let date = stringValue(row["date"]),
-                  let type = stringValue(row["type"]) else { continue }
-            eventId += 1
-            try writer.insert(sql: """
-                INSERT INTO events (id, date, type, description) VALUES (?, ?, ?, ?)
-                """, values: [String(eventId), date, type, stringValue(row["description"])])
-        }
-    }
-
-    private static func loadCloses(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
-        var closeId = 0
-        for row in rows {
-            guard let account = stringValue(row["account"]),
-                  let date = stringValue(row["close"]) ?? stringValue(row["date"]) else { continue }
-            closeId += 1
-            try writer.insert(sql: """
-                INSERT INTO closes (id, date, account) VALUES (?, ?, ?)
-                """, values: [String(closeId), date, account])
-        }
-    }
-
-    private static func loadDiagnostics(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
-        var diagnosticId = 0
-        for row in rows {
-            diagnosticId += 1
-            let position = sourcePosition(file: row["file"], line: row["line"], formatted: nil)
-            try writer.insert(sql: """
-                INSERT INTO diagnostics
-                (id, source_file, line, source_location, column_number, end_line, end_column,
-                 severity, phase, code, message)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """, values: [
-                    String(diagnosticId),
-                    position?.file,
-                    position?.line.map(String.init),
-                    position?.formatted,
-                    intValue(row["column"]).map(String.init),
-                    intValue(row["end_line"]).map(String.init),
-                    intValue(row["end_column"]).map(String.init),
-                    stringValue(row["severity"]),
-                    stringValue(row["phase"]),
-                    stringValue(row["code"]),
-                    stringValue(row["message"])
-                ])
-        }
-    }
-
-    private static func loadAccounts(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
-        for row in rows {
-            guard let name = stringValue(row["account"]) else { continue }
-            try writer.insert(sql: """
-                INSERT OR REPLACE INTO accounts (name, open_date, currencies)
-                VALUES (?, ?, ?)
-                """, values: [
-                    name,
-                    stringValue(row["open"]),
-                    joinedList(row["currencies"])
-                ])
-        }
-    }
-
-    private static func loadPrices(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
-        var priceId = 0
-        for row in rows {
-            guard let commodity = stringValue(row["currency"]),
-                  let date = stringValue(row["date"]) else {
-                continue
-            }
-            let amount = amountFields(row["amount"])
-            guard let number = amount.number, let currency = amount.currency else { continue }
-            priceId += 1
-            try writer.insert(sql: """
-                INSERT INTO prices (id, date, commodity, amount, currency)
-                VALUES (?, ?, ?, ?, ?)
-                """, values: [String(priceId), date, commodity, number, currency])
-        }
-    }
-
-    private static func loadBalances(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
-        var balanceId = 0
-        for row in rows {
-            guard let account = stringValue(row["account"]) else { continue }
-            for position in inventoryPositions(row["balance"]) {
-                balanceId += 1
-                try writer.insert(sql: """
-                    INSERT INTO balances (id, account, amount, commodity)
-                    VALUES (?, ?, ?, ?)
-                    """, values: [String(balanceId), account, position.number, position.currency])
-            }
-        }
-    }
-
-    private static func loadBalanceAssertions(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
-        var balanceId = 0
-        for row in rows {
-            guard let account = stringValue(row["account"]),
-                  let date = stringValue(row["date"]) else { continue }
-            let amount = amountFields(row["amount"])
-            guard let number = amount.number, let commodity = amount.currency else { continue }
-            balanceId += 1
-            try writer.insert(sql: """
-                INSERT INTO balance_assertions (id, date, account, amount, commodity)
-                VALUES (?, ?, ?, ?, ?)
-                """, values: [String(balanceId), date, account, number, commodity])
-        }
-    }
-
-    private static func loadSourceFiles(_ files: [URL], into writer: BeancountProjectionWriter) throws {
-        for file in files {
-            try writer.insert(sql: "INSERT OR IGNORE INTO source_files (path) VALUES (?)", values: [file.path])
         }
     }
 
@@ -1305,7 +940,7 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         )
     }
 
-    private static func rustledgerCellValue(_ value: Any) -> String {
+    static func rustledgerCellValue(_ value: Any) -> String {
         if let string = value as? String {
             return string
         }
@@ -1333,105 +968,6 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             return string
         }
         return String(describing: value)
-    }
-
-    // MARK: - Value Decoding
-
-    private static func stringValue(_ value: Any?) -> String? {
-        switch value {
-        case let string as String:
-            return string
-        case let number as NSNumber:
-            return number.stringValue
-        default:
-            return nil
-        }
-    }
-
-    private static func intValue(_ value: Any?) -> Int? {
-        switch value {
-        case let number as NSNumber:
-            return number.intValue
-        case let string as String:
-            return Int(string)
-        default:
-            return nil
-        }
-    }
-
-    private static func amountFields(_ value: Any?) -> (number: String?, currency: String?) {
-        guard let dictionary = value as? [String: Any] else { return (nil, nil) }
-        return (stringValue(dictionary["number"]), stringValue(dictionary["currency"]))
-    }
-
-    private static func inventoryPositions(_ value: Any?) -> [(number: String, currency: String)] {
-        guard let dictionary = value as? [String: Any],
-              let positions = dictionary["positions"] as? [[String: Any]] else {
-            return []
-        }
-        return positions.compactMap { position in
-            guard let number = stringValue(position["number"]),
-                  let currency = stringValue(position["currency"]) else {
-                return nil
-            }
-            return (number: number, currency: currency)
-        }
-    }
-
-    private static func joinedList(_ value: Any?) -> String? {
-        guard let array = value as? [Any] else { return stringValue(value) }
-        let items = array.compactMap { $0 as? String }
-        return items.isEmpty ? nil : items.joined(separator: " ")
-    }
-
-    private static func stringList(_ value: Any?) -> [String] {
-        guard let array = value as? [Any] else {
-            guard let joined = stringValue(value) else { return [] }
-            return joined
-                .split(whereSeparator: { $0 == "," || $0.isWhitespace })
-                .map(String.init)
-        }
-        return array.compactMap { $0 as? String }
-    }
-
-    private static func metadataPairs(_ value: Any?) -> [(key: String, value: String?)] {
-        guard let dictionary = value as? [String: Any] else { return [] }
-        return dictionary.keys.sorted().map { key in
-            guard let raw = dictionary[key], !(raw is NSNull) else {
-                return (key: key, value: nil)
-            }
-            return (key: key, value: metadataValue(raw))
-        }
-    }
-
-    private static func metadataValue(_ raw: Any) -> String? {
-        if let number = raw as? NSNumber, CFGetTypeID(number) == CFBooleanGetTypeID() {
-            return number.boolValue ? "TRUE" : "FALSE"
-        }
-        return stringValue(raw) ?? rustledgerCellValue(raw)
-    }
-
-    private static func sourcePosition(file: Any?, line: Any?, formatted: Any?) -> BeancountSourcePosition? {
-        let path = stringValue(file).flatMap { $0.isEmpty ? nil : $0 }
-        let lineNumber = intValue(line).flatMap { $0 > 0 ? $0 : nil }
-        guard path != nil || lineNumber != nil else { return nil }
-        let rendered = stringValue(formatted).flatMap { $0.isEmpty ? nil : $0 }
-            ?? path.flatMap { path in lineNumber.map { "\(path):\($0)" } }
-        return BeancountSourcePosition(file: path, line: lineNumber, formatted: rendered)
-    }
-
-    private static func transactionLocations(_ rows: [[String: Any]]) -> [Int: BeancountSourcePosition] {
-        rows.reduce(into: [:]) { locations, row in
-            guard let id = intValue(row["id"]),
-                  let position = sourcePosition(
-                      file: row["filename"],
-                      line: row["lineno"],
-                      formatted: row["location"]
-                  ) else {
-                return
-            }
-            locations[id] = position
-        }
     }
 
     // MARK: - SQLite Helpers
@@ -1471,18 +1007,6 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         guard lowercased.hasPrefix("bql:") || lowercased.hasPrefix("bql ") else { return nil }
         return String(trimmed.dropFirst(4)).trimmingCharacters(in: .whitespacesAndNewlines)
     }
-
-    private static func exec(_ db: OpaquePointer, _ sql: String) throws {
-        var error: UnsafeMutablePointer<CChar>?
-        guard sqlite3_exec(db, sql, nil, nil, &error) == SQLITE_OK else {
-            let message = error.map { String(cString: $0) } ?? String(cString: sqlite3_errmsg(db))
-            if error != nil {
-                sqlite3_free(error)
-            }
-            throw BeancountDriverError.queryFailed(message)
-        }
-    }
-
 
     private static func signatures(for sourceFiles: [URL]) -> [String: BeancountSourceSignature] {
         sourceFiles.reduce(into: [:]) { signatures, fileURL in

--- a/Plugins/BeancountDriverPlugin/BeancountPluginDriver.swift
+++ b/Plugins/BeancountDriverPlugin/BeancountPluginDriver.swift
@@ -5,6 +5,7 @@
 
 import Dispatch
 import Foundation
+import OSLog
 import SQLite3
 import TableProPluginKit
 
@@ -47,12 +48,71 @@ private struct BeancountProjection {
     let signatures: [String: BeancountSourceSignature]
 }
 
+private struct BeancountSourcePosition {
+    let file: String?
+    let line: Int?
+    let formatted: String?
+}
+
+private final class BeancountProjectionWriter {
+    private let db: OpaquePointer
+    private var statements: [String: OpaquePointer] = [:]
+
+    init(db: OpaquePointer) {
+        self.db = db
+    }
+
+    deinit {
+        for statement in statements.values {
+            sqlite3_finalize(statement)
+        }
+    }
+
+    func insert(sql: String, values: [String?]) throws {
+        let statement = try preparedStatement(sql)
+        sqlite3_reset(statement)
+        sqlite3_clear_bindings(statement)
+
+        for (index, value) in values.enumerated() {
+            let position = Int32(index + 1)
+            if let value {
+                sqlite3_bind_text(statement, position, value, -1, SQLITE_TRANSIENT)
+            } else {
+                sqlite3_bind_null(statement, position)
+            }
+        }
+
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw BeancountDriverError.queryFailed(String(cString: sqlite3_errmsg(db)))
+        }
+    }
+
+    private func preparedStatement(_ sql: String) throws -> OpaquePointer {
+        if let cached = statements[sql] {
+            return cached
+        }
+        var prepared: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &prepared, nil) == SQLITE_OK, let prepared else {
+            throw BeancountDriverError.queryFailed(String(cString: sqlite3_errmsg(db)))
+        }
+        statements[sql] = prepared
+        return prepared
+    }
+}
+
 struct BeancountProjectionRows {
     var transactionsAndPostings: [[String: Any]] = []
     var accounts: [[String: Any]] = []
     var prices: [[String: Any]] = []
     var balances: [[String: Any]] = []
     var balanceAssertions: [[String: Any]] = []
+    var transactionLocations: [[String: Any]] = []
+    var commodities: [[String: Any]] = []
+    var documents: [[String: Any]] = []
+    var notes: [[String: Any]] = []
+    var events: [[String: Any]] = []
+    var closes: [[String: Any]] = []
+    var diagnostics: [[String: Any]] = []
 }
 
 private enum BeancountBackend {
@@ -68,14 +128,28 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     private var watchedURLs: [URL] = []
     private var sourceSignatures: [String: BeancountSourceSignature] = [:]
 
+    private static let postingsCoreColumns =
+        "id, date, flag, payee, narration, account, number, currency, cost_number, cost_currency"
+    private static let postingsDetailColumns =
+        "filename, lineno, location, tags, links, _entry_meta, _posting_meta"
     private static let postingsQuery =
-        "SELECT id, date, flag, payee, narration, account, number, currency, cost_number, cost_currency "
-        + "FROM #postings ORDER BY id"
+        "SELECT \(postingsCoreColumns), \(postingsDetailColumns) FROM #postings ORDER BY id"
+    private static let postingsCoreQuery = "SELECT \(postingsCoreColumns) FROM #postings ORDER BY id"
     private static let accountsQuery = "SELECT account, open, currencies FROM #accounts ORDER BY account"
     private static let pricesQuery = "SELECT date, currency, amount FROM #prices ORDER BY date, currency"
     private static let balancesQuery =
         "SELECT account, sum(position) AS balance FROM #postings GROUP BY account ORDER BY account"
     private static let balanceAssertionsQuery = "SELECT date, account, amount FROM #balances ORDER BY date, account"
+    private static let transactionLocationsQuery =
+        "SELECT id, filename, lineno FROM #entries WHERE type = 'transaction' ORDER BY id"
+    private static let commoditiesQuery = "SELECT date, name FROM #commodities ORDER BY date, name"
+    private static let documentsQuery =
+        "SELECT date, account, filename, tags, links FROM #documents ORDER BY date, account"
+    private static let notesQuery = "SELECT date, account, comment FROM #notes ORDER BY date, account"
+    private static let eventsQuery = "SELECT date, type, description FROM #events ORDER BY date, type"
+    private static let closesQuery =
+        "SELECT account, close FROM #accounts WHERE close IS NOT NULL ORDER BY close, account"
+    private static let logger = Logger(subsystem: "com.TablePro", category: "BeancountPluginDriver")
     private static let rledgerCapabilityLock = NSLock()
     private static var rledgerNoCacheSupport: [String: Bool] = [:]
 
@@ -471,11 +545,20 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         switch try resolveProjectionBackend() {
         case .rledger:
             return BeancountProjectionRows(
-                transactionsAndPostings: try query(ledgerPath: ledgerPath, bql: postingsQuery),
+                transactionsAndPostings: try postingRows(ledgerPath: ledgerPath),
                 accounts: try query(ledgerPath: ledgerPath, bql: accountsQuery),
                 prices: try query(ledgerPath: ledgerPath, bql: pricesQuery),
                 balances: try query(ledgerPath: ledgerPath, bql: balancesQuery),
-                balanceAssertions: try query(ledgerPath: ledgerPath, bql: balanceAssertionsQuery)
+                balanceAssertions: try query(ledgerPath: ledgerPath, bql: balanceAssertionsQuery),
+                transactionLocations: directiveRows(
+                    ledgerPath: ledgerPath, bql: transactionLocationsQuery, table: "transaction locations"
+                ),
+                commodities: directiveRows(ledgerPath: ledgerPath, bql: commoditiesQuery, table: "commodities"),
+                documents: directiveRows(ledgerPath: ledgerPath, bql: documentsQuery, table: "documents"),
+                notes: directiveRows(ledgerPath: ledgerPath, bql: notesQuery, table: "notes"),
+                events: directiveRows(ledgerPath: ledgerPath, bql: eventsQuery, table: "events"),
+                closes: directiveRows(ledgerPath: ledgerPath, bql: closesQuery, table: "closes"),
+                diagnostics: validationDiagnostics(ledgerPath: ledgerPath)
             )
         case .python(let executablePath):
             let rows = try pythonProjectionRows(ledgerPath: ledgerPath, executablePath: executablePath)
@@ -484,7 +567,13 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 accounts: rows["accounts"] ?? [],
                 prices: rows["prices"] ?? [],
                 balances: rows["balances"] ?? [],
-                balanceAssertions: rows["balance_assertions"] ?? []
+                balanceAssertions: rows["balance_assertions"] ?? [],
+                transactionLocations: rows["transaction_locations"] ?? [],
+                commodities: rows["commodities"] ?? [],
+                documents: rows["documents"] ?? [],
+                notes: rows["notes"] ?? [],
+                events: rows["events"] ?? [],
+                closes: rows["closes"] ?? []
             )
         }
     }
@@ -499,12 +588,23 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
         do {
             try createSchema(handle)
-            try loadTransactionsAndPostings(rows.transactionsAndPostings, into: handle)
-            try loadAccounts(rows.accounts, into: handle)
-            try loadPrices(rows.prices, into: handle)
-            try loadBalances(rows.balances, into: handle)
-            try loadBalanceAssertions(rows.balanceAssertions, into: handle)
-            try loadSourceFiles(sourceFiles, into: handle)
+            let writer = BeancountProjectionWriter(db: handle)
+            try loadTransactionsAndPostings(
+                rows.transactionsAndPostings,
+                locations: transactionLocations(rows.transactionLocations),
+                into: writer
+            )
+            try loadAccounts(rows.accounts, into: writer)
+            try loadPrices(rows.prices, into: writer)
+            try loadBalances(rows.balances, into: writer)
+            try loadBalanceAssertions(rows.balanceAssertions, into: writer)
+            try loadCommodities(rows.commodities, into: writer)
+            try loadDocuments(rows.documents, into: writer)
+            try loadNotes(rows.notes, into: writer)
+            try loadEvents(rows.events, into: writer)
+            try loadCloses(rows.closes, into: writer)
+            try loadDiagnostics(rows.diagnostics, into: writer)
+            try loadSourceFiles(sourceFiles, into: writer)
             try exec(handle, "PRAGMA query_only = ON")
         } catch {
             sqlite3_close(handle)
@@ -519,6 +619,44 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         return try decodeRledgerRows(data)
     }
 
+    private static func postingRows(ledgerPath: String) throws -> [[String: Any]] {
+        do {
+            return try query(ledgerPath: ledgerPath, bql: postingsQuery)
+        } catch {
+            logger.warning("Beancount postings detail unavailable, projecting core columns: \(error)")
+            return try query(ledgerPath: ledgerPath, bql: postingsCoreQuery)
+        }
+    }
+
+    private static func directiveRows(ledgerPath: String, bql: String, table: String) -> [[String: Any]] {
+        do {
+            return try query(ledgerPath: ledgerPath, bql: bql)
+        } catch {
+            logger.warning("Beancount projection left \(table, privacy: .public) empty: \(error)")
+            return []
+        }
+    }
+
+    private static func validationDiagnostics(ledgerPath: String) -> [[String: Any]] {
+        do {
+            let data = try runProcess(
+                executablePath: try rustledgerExecutablePath(),
+                arguments: ["check", "-f", "json", ledgerPath],
+                failureMessage: String(localized: "rustledger validation failed"),
+                allowsNonZeroExit: true
+            )
+            guard let dictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let diagnostics = dictionary["diagnostics"] as? [[String: Any]] else {
+                logger.warning("Beancount validation produced no diagnostics field, leaving the table empty")
+                return []
+            }
+            return diagnostics
+        } catch {
+            logger.warning("Beancount validation did not run, leaving the diagnostics table empty: \(error)")
+            return []
+        }
+    }
+
     private static func createSchema(_ db: OpaquePointer) throws {
         try exec(db, """
             CREATE TABLE transactions (
@@ -526,7 +664,10 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 date DATE NOT NULL,
                 flag TEXT NOT NULL,
                 payee TEXT,
-                narration TEXT
+                narration TEXT,
+                source_file TEXT,
+                line INTEGER,
+                source_location TEXT
             );
             CREATE TABLE postings (
                 id INTEGER PRIMARY KEY,
@@ -536,7 +677,10 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 amount TEXT,
                 commodity TEXT,
                 cost_number TEXT,
-                cost_currency TEXT
+                cost_currency TEXT,
+                source_file TEXT,
+                line INTEGER,
+                source_location TEXT
             );
             CREATE TABLE accounts (
                 name TEXT PRIMARY KEY,
@@ -563,15 +707,88 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 amount TEXT NOT NULL,
                 commodity TEXT NOT NULL
             );
+            CREATE TABLE commodities (
+                id INTEGER PRIMARY KEY,
+                date DATE NOT NULL,
+                commodity TEXT NOT NULL
+            );
+            CREATE TABLE documents (
+                id INTEGER PRIMARY KEY,
+                date DATE NOT NULL,
+                account TEXT NOT NULL,
+                path TEXT NOT NULL,
+                tags TEXT,
+                links TEXT
+            );
+            CREATE TABLE notes (
+                id INTEGER PRIMARY KEY,
+                date DATE NOT NULL,
+                account TEXT NOT NULL,
+                comment TEXT
+            );
+            CREATE TABLE events (
+                id INTEGER PRIMARY KEY,
+                date DATE NOT NULL,
+                type TEXT NOT NULL,
+                description TEXT
+            );
+            CREATE TABLE closes (
+                id INTEGER PRIMARY KEY,
+                date DATE NOT NULL,
+                account TEXT NOT NULL
+            );
+            CREATE TABLE transaction_metadata (
+                id INTEGER PRIMARY KEY,
+                transaction_id INTEGER NOT NULL,
+                key TEXT NOT NULL,
+                value TEXT
+            );
+            CREATE TABLE posting_metadata (
+                id INTEGER PRIMARY KEY,
+                posting_id INTEGER NOT NULL,
+                key TEXT NOT NULL,
+                value TEXT
+            );
+            CREATE TABLE transaction_tags (
+                id INTEGER PRIMARY KEY,
+                transaction_id INTEGER NOT NULL,
+                tag TEXT NOT NULL
+            );
+            CREATE TABLE transaction_links (
+                id INTEGER PRIMARY KEY,
+                transaction_id INTEGER NOT NULL,
+                link TEXT NOT NULL
+            );
+            CREATE TABLE diagnostics (
+                id INTEGER PRIMARY KEY,
+                source_file TEXT,
+                line INTEGER,
+                source_location TEXT,
+                column_number INTEGER,
+                end_line INTEGER,
+                end_column INTEGER,
+                severity TEXT,
+                phase TEXT,
+                code TEXT,
+                message TEXT
+            );
             CREATE TABLE source_files (
                 path TEXT PRIMARY KEY
             );
             """)
     }
 
-    private static func loadTransactionsAndPostings(_ rows: [[String: Any]], into db: OpaquePointer) throws {
+    private static func loadTransactionsAndPostings(
+        _ rows: [[String: Any]],
+        locations: [Int: BeancountSourcePosition],
+        into writer: BeancountProjectionWriter
+    ) throws {
         var seenTransactions: Set<Int> = []
         var postingId = 0
+        var metadataId = 0
+        var postingMetadataId = 0
+        var tagId = 0
+        var linkId = 0
 
         for row in rows {
             guard let transactionId = intValue(row["id"]),
@@ -581,24 +798,52 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             let flag = stringValue(row["flag"]) ?? "*"
 
             if seenTransactions.insert(transactionId).inserted {
-                try insert(db, sql: """
-                    INSERT INTO transactions (id, date, flag, payee, narration)
-                    VALUES (?, ?, ?, ?, ?)
+                let location = locations[transactionId]
+                try writer.insert(sql: """
+                    INSERT INTO transactions (id, date, flag, payee, narration, source_file, line, source_location)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                     """, values: [
                         String(transactionId),
                         date,
                         flag,
                         stringValue(row["payee"]),
-                        stringValue(row["narration"])
+                        stringValue(row["narration"]),
+                        location?.file,
+                        location?.line.map(String.init),
+                        location?.formatted
                     ])
+
+                for entry in metadataPairs(row["_entry_meta"]) {
+                    metadataId += 1
+                    try writer.insert(sql: """
+                        INSERT INTO transaction_metadata (id, transaction_id, key, value)
+                        VALUES (?, ?, ?, ?)
+                        """, values: [String(metadataId), String(transactionId), entry.key, entry.value])
+                }
+
+                for tag in stringList(row["tags"]) {
+                    tagId += 1
+                    try writer.insert(sql: """
+                        INSERT INTO transaction_tags (id, transaction_id, tag) VALUES (?, ?, ?)
+                        """, values: [String(tagId), String(transactionId), tag])
+                }
+
+                for link in stringList(row["links"]) {
+                    linkId += 1
+                    try writer.insert(sql: """
+                        INSERT INTO transaction_links (id, transaction_id, link) VALUES (?, ?, ?)
+                        """, values: [String(linkId), String(transactionId), link])
+                }
             }
 
             guard let account = stringValue(row["account"]) else { continue }
             postingId += 1
-            try insert(db, sql: """
+            let position = sourcePosition(file: row["filename"], line: row["lineno"], formatted: row["location"])
+            try writer.insert(sql: """
                 INSERT INTO postings
-                (id, transaction_id, date, account, amount, commodity, cost_number, cost_currency)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                (id, transaction_id, date, account, amount, commodity, cost_number, cost_currency,
+                 source_file, line, source_location)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """, values: [
                     String(postingId),
                     String(transactionId),
@@ -607,26 +852,135 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                     stringValue(row["number"]),
                     stringValue(row["currency"]),
                     stringValue(row["cost_number"]),
-                    stringValue(row["cost_currency"])
+                    stringValue(row["cost_currency"]),
+                    position?.file,
+                    position?.line.map(String.init),
+                    position?.formatted
+                ])
+
+            for entry in metadataPairs(row["_posting_meta"]) {
+                postingMetadataId += 1
+                try writer.insert(sql: """
+                    INSERT INTO posting_metadata (id, posting_id, key, value)
+                    VALUES (?, ?, ?, ?)
+                    """, values: [String(postingMetadataId), String(postingId), entry.key, entry.value])
+            }
+        }
+    }
+
+    private static func loadCommodities(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
+        var commodityId = 0
+        for row in rows {
+            guard let date = stringValue(row["date"]),
+                  let commodity = stringValue(row["name"]) ?? stringValue(row["commodity"]) else {
+                continue
+            }
+            commodityId += 1
+            try writer.insert(sql: """
+                INSERT INTO commodities (id, date, commodity) VALUES (?, ?, ?)
+                """, values: [String(commodityId), date, commodity])
+        }
+    }
+
+    private static func loadDocuments(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
+        var documentId = 0
+        for row in rows {
+            guard let date = stringValue(row["date"]),
+                  let account = stringValue(row["account"]),
+                  let path = stringValue(row["filename"]) ?? stringValue(row["path"]) else {
+                continue
+            }
+            documentId += 1
+            try writer.insert(sql: """
+                INSERT INTO documents (id, date, account, path, tags, links) VALUES (?, ?, ?, ?, ?, ?)
+                """, values: [
+                    String(documentId),
+                    date,
+                    account,
+                    path,
+                    joinedList(row["tags"]),
+                    joinedList(row["links"])
                 ])
         }
     }
 
-    private static func loadAccounts(_ rows: [[String: Any]], into db: OpaquePointer) throws {
+    private static func loadNotes(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
+        var noteId = 0
+        for row in rows {
+            guard let date = stringValue(row["date"]),
+                  let account = stringValue(row["account"]) else { continue }
+            noteId += 1
+            try writer.insert(sql: """
+                INSERT INTO notes (id, date, account, comment) VALUES (?, ?, ?, ?)
+                """, values: [String(noteId), date, account, stringValue(row["comment"])])
+        }
+    }
+
+    private static func loadEvents(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
+        var eventId = 0
+        for row in rows {
+            guard let date = stringValue(row["date"]),
+                  let type = stringValue(row["type"]) else { continue }
+            eventId += 1
+            try writer.insert(sql: """
+                INSERT INTO events (id, date, type, description) VALUES (?, ?, ?, ?)
+                """, values: [String(eventId), date, type, stringValue(row["description"])])
+        }
+    }
+
+    private static func loadCloses(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
+        var closeId = 0
+        for row in rows {
+            guard let account = stringValue(row["account"]),
+                  let date = stringValue(row["close"]) ?? stringValue(row["date"]) else { continue }
+            closeId += 1
+            try writer.insert(sql: """
+                INSERT INTO closes (id, date, account) VALUES (?, ?, ?)
+                """, values: [String(closeId), date, account])
+        }
+    }
+
+    private static func loadDiagnostics(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
+        var diagnosticId = 0
+        for row in rows {
+            diagnosticId += 1
+            let position = sourcePosition(file: row["file"], line: row["line"], formatted: nil)
+            try writer.insert(sql: """
+                INSERT INTO diagnostics
+                (id, source_file, line, source_location, column_number, end_line, end_column,
+                 severity, phase, code, message)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """, values: [
+                    String(diagnosticId),
+                    position?.file,
+                    position?.line.map(String.init),
+                    position?.formatted,
+                    intValue(row["column"]).map(String.init),
+                    intValue(row["end_line"]).map(String.init),
+                    intValue(row["end_column"]).map(String.init),
+                    stringValue(row["severity"]),
+                    stringValue(row["phase"]),
+                    stringValue(row["code"]),
+                    stringValue(row["message"])
+                ])
+        }
+    }
+
+    private static func loadAccounts(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
         for row in rows {
             guard let name = stringValue(row["account"]) else { continue }
-            try insert(db, sql: """
+            try writer.insert(sql: """
                 INSERT OR REPLACE INTO accounts (name, open_date, currencies)
                 VALUES (?, ?, ?)
                 """, values: [
                     name,
                     stringValue(row["open"]),
-                    currencyList(row["currencies"])
+                    joinedList(row["currencies"])
                 ])
         }
     }
 
-    private static func loadPrices(_ rows: [[String: Any]], into db: OpaquePointer) throws {
+    private static func loadPrices(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
         var priceId = 0
         for row in rows {
             guard let commodity = stringValue(row["currency"]),
@@ -636,20 +990,20 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             let amount = amountFields(row["amount"])
             guard let number = amount.number, let currency = amount.currency else { continue }
             priceId += 1
-            try insert(db, sql: """
+            try writer.insert(sql: """
                 INSERT INTO prices (id, date, commodity, amount, currency)
                 VALUES (?, ?, ?, ?, ?)
                 """, values: [String(priceId), date, commodity, number, currency])
         }
     }
 
-    private static func loadBalances(_ rows: [[String: Any]], into db: OpaquePointer) throws {
+    private static func loadBalances(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
         var balanceId = 0
         for row in rows {
             guard let account = stringValue(row["account"]) else { continue }
             for position in inventoryPositions(row["balance"]) {
                 balanceId += 1
-                try insert(db, sql: """
+                try writer.insert(sql: """
                     INSERT INTO balances (id, account, amount, commodity)
                     VALUES (?, ?, ?, ?)
                     """, values: [String(balanceId), account, position.number, position.currency])
@@ -657,7 +1011,7 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         }
     }
 
-    private static func loadBalanceAssertions(_ rows: [[String: Any]], into db: OpaquePointer) throws {
+    private static func loadBalanceAssertions(_ rows: [[String: Any]], into writer: BeancountProjectionWriter) throws {
         var balanceId = 0
         for row in rows {
             guard let account = stringValue(row["account"]),
@@ -665,16 +1019,16 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             let amount = amountFields(row["amount"])
             guard let number = amount.number, let commodity = amount.currency else { continue }
             balanceId += 1
-            try insert(db, sql: """
+            try writer.insert(sql: """
                 INSERT INTO balance_assertions (id, date, account, amount, commodity)
                 VALUES (?, ?, ?, ?, ?)
                 """, values: [String(balanceId), date, account, number, commodity])
         }
     }
 
-    private static func loadSourceFiles(_ files: [URL], into db: OpaquePointer) throws {
+    private static func loadSourceFiles(_ files: [URL], into writer: BeancountProjectionWriter) throws {
         for file in files {
-            try insert(db, sql: "INSERT OR IGNORE INTO source_files (path) VALUES (?)", values: [file.path])
+            try writer.insert(sql: "INSERT OR IGNORE INTO source_files (path) VALUES (?)", values: [file.path])
         }
     }
 
@@ -723,7 +1077,8 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     private static func runProcess(
         executablePath: String,
         arguments: [String],
-        failureMessage: String
+        failureMessage: String,
+        allowsNonZeroExit: Bool = false
     ) throws -> Data {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executablePath)
@@ -752,7 +1107,7 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         readers.wait()
         process.waitUntilExit()
 
-        guard process.terminationStatus == 0 else {
+        guard process.terminationStatus == 0 || allowsNonZeroExit else {
             let message = String(data: errorCollector.data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             if let message, !message.isEmpty {
@@ -1023,10 +1378,60 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         }
     }
 
-    private static func currencyList(_ value: Any?) -> String? {
+    private static func joinedList(_ value: Any?) -> String? {
         guard let array = value as? [Any] else { return stringValue(value) }
         let items = array.compactMap { $0 as? String }
         return items.isEmpty ? nil : items.joined(separator: " ")
+    }
+
+    private static func stringList(_ value: Any?) -> [String] {
+        guard let array = value as? [Any] else {
+            guard let joined = stringValue(value) else { return [] }
+            return joined
+                .split(whereSeparator: { $0 == "," || $0.isWhitespace })
+                .map(String.init)
+        }
+        return array.compactMap { $0 as? String }
+    }
+
+    private static func metadataPairs(_ value: Any?) -> [(key: String, value: String?)] {
+        guard let dictionary = value as? [String: Any] else { return [] }
+        return dictionary.keys.sorted().map { key in
+            guard let raw = dictionary[key], !(raw is NSNull) else {
+                return (key: key, value: nil)
+            }
+            return (key: key, value: metadataValue(raw))
+        }
+    }
+
+    private static func metadataValue(_ raw: Any) -> String? {
+        if let number = raw as? NSNumber, CFGetTypeID(number) == CFBooleanGetTypeID() {
+            return number.boolValue ? "TRUE" : "FALSE"
+        }
+        return stringValue(raw) ?? rustledgerCellValue(raw)
+    }
+
+    private static func sourcePosition(file: Any?, line: Any?, formatted: Any?) -> BeancountSourcePosition? {
+        let path = stringValue(file).flatMap { $0.isEmpty ? nil : $0 }
+        let lineNumber = intValue(line).flatMap { $0 > 0 ? $0 : nil }
+        guard path != nil || lineNumber != nil else { return nil }
+        let rendered = stringValue(formatted).flatMap { $0.isEmpty ? nil : $0 }
+            ?? path.flatMap { path in lineNumber.map { "\(path):\($0)" } }
+        return BeancountSourcePosition(file: path, line: lineNumber, formatted: rendered)
+    }
+
+    private static func transactionLocations(_ rows: [[String: Any]]) -> [Int: BeancountSourcePosition] {
+        rows.reduce(into: [:]) { locations, row in
+            guard let id = intValue(row["id"]),
+                  let position = sourcePosition(
+                      file: row["filename"],
+                      line: row["lineno"],
+                      formatted: row["location"]
+                  ) else {
+                return
+            }
+            locations[id] = position
+        }
     }
 
     // MARK: - SQLite Helpers
@@ -1078,26 +1483,6 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         }
     }
 
-    private static func insert(_ db: OpaquePointer, sql: String, values: [String?]) throws {
-        var statement: OpaquePointer?
-        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
-            throw BeancountDriverError.queryFailed(String(cString: sqlite3_errmsg(db)))
-        }
-        defer { sqlite3_finalize(statement) }
-
-        for (index, value) in values.enumerated() {
-            let position = Int32(index + 1)
-            if let value {
-                sqlite3_bind_text(statement, position, value, -1, SQLITE_TRANSIENT)
-            } else {
-                sqlite3_bind_null(statement, position)
-            }
-        }
-
-        guard sqlite3_step(statement) == SQLITE_DONE else {
-            throw BeancountDriverError.queryFailed(String(cString: sqlite3_errmsg(db)))
-        }
-    }
 
     private static func signatures(for sourceFiles: [URL]) -> [String: BeancountSourceSignature] {
         sourceFiles.reduce(into: [:]) { signatures, fileURL in

--- a/TableProTests/Plugins/BeancountIncludeResolverTests.swift
+++ b/TableProTests/Plugins/BeancountIncludeResolverTests.swift
@@ -28,6 +28,121 @@ struct BeancountIncludeResolverTests {
         #expect(graph.sourceFiles.map(\.lastPathComponent).sorted() == ["main.beancount", "prices.beancount"])
     }
 
+    @Test("tracks missing documents relative to their declaring source")
+    func resolvesIncludedDocumentDependencies() throws {
+        let directory = try Self.makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let parts = directory.appendingPathComponent("parts", isDirectory: true)
+        try FileManager.default.createDirectory(at: parts, withIntermediateDirectories: true)
+
+        let absoluteDocument = directory.appendingPathComponent("absolute.pdf").standardizedFileURL
+        let linkedDocument = parts.appendingPathComponent("linked.pdf").standardizedFileURL
+        let linkedTarget = directory.appendingPathComponent("external.pdf").standardizedFileURL
+        try FileManager.default.createSymbolicLink(
+            atPath: linkedDocument.path,
+            withDestinationPath: linkedTarget.path
+        )
+        let included = parts.appendingPathComponent("entries.beancount")
+        try """
+        2024/1/2 document Assets:Cash "receipt.pdf"
+        2024-01-03 document Assets:Cash "\(absoluteDocument.path)"
+        2024-01-04 document Assets:Cash "tab\\treceipt.pdf"
+        2024-01-05 document Assets:Cash "linked.pdf"
+        """.write(to: included, atomically: true, encoding: .utf8)
+
+        let ledger = directory.appendingPathComponent("main.beancount")
+        try """
+        include\t"parts/entries.beancount"
+
+        2024-01-01 open Assets:Cash USD
+        """.write(to: ledger, atomically: true, encoding: .utf8)
+
+        let graph = try BeancountIncludeResolver().resolve(fileURL: ledger)
+        let relativeDocument = parts.appendingPathComponent("receipt.pdf").standardizedFileURL
+        let escapedDocument = parts.appendingPathComponent("tab\treceipt.pdf").standardizedFileURL
+
+        #expect(graph.reloadDependencies.contains(relativeDocument))
+        #expect(graph.reloadDependencies.contains(absoluteDocument))
+        #expect(graph.reloadDependencies.contains(escapedDocument))
+        #expect(graph.reloadDependencies.contains(linkedDocument))
+        #expect(graph.reloadDependencies.contains(linkedTarget))
+        #expect(!graph.sourceFiles.contains(relativeDocument))
+        #expect(!graph.sourceFiles.contains(absoluteDocument))
+    }
+
+    @Test("bounds document symlink dependency resolution")
+    func boundsDocumentSymlinkDependencies() throws {
+        let directory = try Self.makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        for index in 0..<40 {
+            try FileManager.default.createSymbolicLink(
+                atPath: directory.appendingPathComponent("link-\(index).pdf").path,
+                withDestinationPath: "link-\(index + 1).pdf"
+            )
+        }
+
+        let ledger = directory.appendingPathComponent("main.beancount")
+        try "2024-01-01 document Assets:Cash \"link-0.pdf\"\n"
+            .write(to: ledger, atomically: true, encoding: .utf8)
+
+        let graph = try BeancountIncludeResolver().resolve(fileURL: ledger)
+        let linkedDependencies = graph.reloadDependencies.filter {
+            $0.deletingLastPathComponent() == directory.standardizedFileURL
+                && $0.lastPathComponent.hasPrefix("link-")
+        }
+
+        #expect(linkedDependencies.count <= 34)
+        #expect(graph.reloadDependencies.contains(directory.appendingPathComponent("link-32.pdf")))
+        #expect(!graph.reloadDependencies.contains(directory.appendingPathComponent("link-33.pdf")))
+    }
+
+    @Test("applies document roots after traversing every include")
+    func resolvesDocumentRootDependencies() throws {
+        let directory = try Self.makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let parts = directory.appendingPathComponent("parts", isDirectory: true)
+        let relativeRoot = directory.appendingPathComponent("archive", isDirectory: true)
+        let nestedRoot = relativeRoot.appendingPathComponent("account/nested", isDirectory: true)
+        let absoluteRoot = directory.appendingPathComponent("absolute-archive", isDirectory: true)
+        try FileManager.default.createDirectory(at: parts, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: nestedRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: absoluteRoot, withIntermediateDirectories: true)
+
+        try "2024-01-02 document Assets:Cash \"receipt.pdf\"\n"
+            .write(to: parts.appendingPathComponent("entries.beancount"), atomically: true, encoding: .utf8)
+        try """
+        option\t"documents"\t"archive"
+        option "documents" "\(absoluteRoot.path)"
+        """.write(
+            to: parts.appendingPathComponent("options.beancount"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let ledger = directory.appendingPathComponent("main.beancount")
+        try """
+        include "parts/entries.beancount"
+        include "parts/options.beancount"
+        """.write(to: ledger, atomically: true, encoding: .utf8)
+
+        let graph = try BeancountIncludeResolver().resolve(fileURL: ledger)
+        let candidates = [
+            relativeRoot.appendingPathComponent("receipt.pdf").standardizedFileURL,
+            absoluteRoot.appendingPathComponent("receipt.pdf").standardizedFileURL
+        ]
+
+        for candidate in candidates {
+            #expect(graph.reloadDependencies.contains(candidate))
+            #expect(!graph.sourceFiles.contains(candidate))
+        }
+        #expect(graph.reloadDependencies.contains(parts.appendingPathComponent("receipt.pdf").standardizedFileURL))
+        #expect(!graph.reloadDependencies.contains(relativeRoot.standardizedFileURL))
+        #expect(!graph.reloadDependencies.contains(nestedRoot.standardizedFileURL))
+    }
+
     @Test("expands glob includes and watches their directories")
     func resolvesGlobIncludes() throws {
         let directory = try Self.makeTempDirectory()

--- a/TableProTests/Plugins/BeancountPluginDriverTests.swift
+++ b/TableProTests/Plugins/BeancountPluginDriverTests.swift
@@ -428,6 +428,156 @@ struct BeancountPluginDriverTests {
 
     // MARK: - Helpers
 
+    @Test(
+        "projects rich directives, metadata, and source locations through rledger",
+        .enabled(if: RustledgerLocator.path != nil, "rledger executable unavailable")
+    )
+    func projectsRichDirectivesThroughRustledger() async throws {
+        try await Self.withRustledger {
+            try await Self.withRichDirectiveLedger { driver, ledger in
+                try await Self.expectRichDirectives(driver, ledger: ledger)
+            }
+        }
+    }
+
+    @Test(
+        "projects rich directives, metadata, and source locations through Python Beancount",
+        .enabled(if: PythonBeancountLocator.path != nil, "Python Beancount unavailable")
+    )
+    func projectsRichDirectivesThroughPythonBeancount() async throws {
+        let python = try #require(PythonBeancountLocator.path)
+        try await Self.withEnvironment([
+            "TABLEPRO_BEANCOUNT_BACKEND": "python",
+            "TABLEPRO_BEANCOUNT_PYTHON": python
+        ]) {
+            try await Self.withRichDirectiveLedger { driver, ledger in
+                try await Self.expectRichDirectives(driver, ledger: ledger)
+            }
+        }
+    }
+
+    @Test(
+        "projects validation diagnostics and still opens an invalid ledger",
+        .enabled(if: RustledgerLocator.path != nil, "rledger executable unavailable")
+    )
+    func projectsValidationDiagnostics() async throws {
+        try await Self.withRustledger {
+            let directory = try Self.makeTempDirectory()
+            defer { try? FileManager.default.removeItem(at: directory) }
+
+            let ledger = directory.appendingPathComponent("main.beancount")
+            try """
+            2024-01-01 open Assets:Cash USD
+
+            2024-01-04 document Assets:Cash "missing.pdf"
+            """.write(to: ledger, atomically: true, encoding: .utf8)
+
+            let driver = BeancountPluginDriver(config: Self.config(ledger))
+            try await driver.connect()
+            defer { driver.disconnect() }
+
+            let accounts = try await driver.execute(query: "SELECT name FROM accounts")
+            #expect(accounts.rows.map { $0[0].asText } == ["Assets:Cash"])
+
+            let diagnostics = try await driver.execute(query: """
+                SELECT severity, phase, code, line, source_location FROM diagnostics ORDER BY id
+                """)
+            #expect(diagnostics.rows.count == 1)
+            let diagnostic = try #require(diagnostics.rows.first)
+            #expect(diagnostic[0].asText == "error")
+            #expect(diagnostic[1].asText == "validate")
+            #expect(diagnostic[2].asText == "E8001")
+            #expect(diagnostic[3].asText == "3")
+            #expect(diagnostic[4].asText?.hasSuffix("\(ledger.lastPathComponent):3") == true)
+        }
+    }
+
+    private static func withRichDirectiveLedger(
+        _ body: (BeancountPluginDriver, URL) async throws -> Void
+    ) async throws {
+        let directory = try Self.makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try Data("pdf".utf8).write(to: directory.appendingPathComponent("receipt.pdf"))
+
+        let ledger = directory.appendingPathComponent("main.beancount")
+        try """
+        2024-01-01 commodity USD
+          name: "US Dollar"
+
+        2024-01-01 open Assets:Cash USD
+        2024-01-01 open Expenses:Food USD
+
+        2024-01-02 event "location" "Taipei"
+
+        2024-01-03 note Assets:Cash "called the bank"
+
+        2024-01-04 document Assets:Cash "receipt.pdf"
+
+        2024-01-05 * "Cafe" "Coffee" #coffee #daily ^receipt-123
+          invoice: "INV-9"
+          verified: TRUE
+          Expenses:Food   3.00 USD
+            method: "card"
+          Assets:Cash
+
+        2024-06-30 close Expenses:Food
+        """.write(to: ledger, atomically: true, encoding: .utf8)
+
+        let driver = BeancountPluginDriver(config: Self.config(ledger))
+        try await driver.connect()
+        defer { driver.disconnect() }
+
+        try await body(driver, ledger)
+    }
+
+    private static func expectRichDirectives(_ driver: BeancountPluginDriver, ledger: URL) async throws {
+        let commodities = try await driver.execute(query: "SELECT date, commodity FROM commodities")
+        #expect(commodities.rows.map { $0.map(\.asText) } == [["2024-01-01", "USD"]])
+
+        let events = try await driver.execute(query: "SELECT date, type, description FROM events")
+        #expect(events.rows.map { $0.map(\.asText) } == [["2024-01-02", "location", "Taipei"]])
+
+        let notes = try await driver.execute(query: "SELECT date, account, comment FROM notes")
+        #expect(notes.rows.map { $0.map(\.asText) } == [["2024-01-03", "Assets:Cash", "called the bank"]])
+
+        let closes = try await driver.execute(query: "SELECT date, account FROM closes")
+        #expect(closes.rows.map { $0.map(\.asText) } == [["2024-06-30", "Expenses:Food"]])
+
+        let documents = try await driver.execute(query: "SELECT date, account, path FROM documents")
+        #expect(documents.rows.count == 1)
+        let document = try #require(documents.rows.first)
+        #expect(document[0].asText == "2024-01-04")
+        #expect(document[1].asText == "Assets:Cash")
+        #expect(document[2].asText?.hasSuffix("receipt.pdf") == true)
+
+        let metadata = try await driver.execute(query: """
+            SELECT key, value FROM transaction_metadata ORDER BY key
+            """)
+        #expect(metadata.rows.map { $0.map(\.asText) } == [["invoice", "INV-9"], ["verified", "TRUE"]])
+
+        let postingMetadata = try await driver.execute(query: "SELECT key, value FROM posting_metadata")
+        #expect(postingMetadata.rows.map { $0.map(\.asText) } == [["method", "card"]])
+
+        let tags = try await driver.execute(query: "SELECT tag FROM transaction_tags ORDER BY tag")
+        #expect(tags.rows.map { $0[0].asText } == ["coffee", "daily"])
+
+        let links = try await driver.execute(query: "SELECT link FROM transaction_links")
+        #expect(links.rows.map { $0[0].asText } == ["receipt-123"])
+
+        let transactions = try await driver.execute(query: """
+            SELECT source_file, line, source_location FROM transactions
+            """)
+        #expect(transactions.rows.count == 1)
+        let transaction = try #require(transactions.rows.first)
+        #expect(transaction[0].asText?.hasSuffix(ledger.lastPathComponent) == true)
+        #expect(transaction[1].asText == "13")
+        #expect(transaction[2].asText?.hasSuffix("\(ledger.lastPathComponent):13") == true)
+
+        let postings = try await driver.execute(query: "SELECT line FROM postings ORDER BY id")
+        #expect(postings.rows.map { $0[0].asText } == ["16", "18"])
+    }
+
     private static func withRustledger(_ body: () async throws -> Void) async throws {
         let rledger = try #require(RustledgerLocator.path)
         try await withRustledgerEnvironment(rledger, body)

--- a/TableProTests/Plugins/BeancountPluginDriverTests.swift
+++ b/TableProTests/Plugins/BeancountPluginDriverTests.swift
@@ -3,6 +3,7 @@
 //  TableProTests
 //
 
+import Darwin
 import Foundation
 import TableProPluginKit
 import Testing
@@ -429,7 +430,7 @@ struct BeancountPluginDriverTests {
     // MARK: - Helpers
 
     @Test(
-        "projects rich directives, metadata, and source locations through rledger",
+        "projects rich directives and posting-free transactions through rledger",
         .enabled(if: RustledgerLocator.path != nil, "rledger executable unavailable")
     )
     func projectsRichDirectivesThroughRustledger() async throws {
@@ -441,7 +442,7 @@ struct BeancountPluginDriverTests {
     }
 
     @Test(
-        "projects rich directives, metadata, and source locations through Python Beancount",
+        "projects rich directives and posting-free transactions through Python Beancount",
         .enabled(if: PythonBeancountLocator.path != nil, "Python Beancount unavailable")
     )
     func projectsRichDirectivesThroughPythonBeancount() async throws {
@@ -457,20 +458,26 @@ struct BeancountPluginDriverTests {
     }
 
     @Test(
-        "projects validation diagnostics and still opens an invalid ledger",
+        "refreshes document diagnostics when an included document target changes",
         .enabled(if: RustledgerLocator.path != nil, "rledger executable unavailable")
     )
-    func projectsValidationDiagnostics() async throws {
+    func refreshesDocumentDiagnostics() async throws {
         try await Self.withRustledger {
             let directory = try Self.makeTempDirectory()
             defer { try? FileManager.default.removeItem(at: directory) }
 
-            let ledger = directory.appendingPathComponent("main.beancount")
+            let subdirectory = directory.appendingPathComponent("sub", isDirectory: true)
+            try FileManager.default.createDirectory(at: subdirectory, withIntermediateDirectories: true)
+            let included = subdirectory.appendingPathComponent("entries.beancount")
             try """
             2024-01-01 open Assets:Cash USD
 
-            2024-01-04 document Assets:Cash "missing.pdf"
-            """.write(to: ledger, atomically: true, encoding: .utf8)
+            2024-01-04 document Assets:Cash "receipt.pdf"
+            """.write(to: included, atomically: true, encoding: .utf8)
+
+            let ledger = directory.appendingPathComponent("main.beancount")
+            try "include \"sub/entries.beancount\"\n"
+                .write(to: ledger, atomically: true, encoding: .utf8)
 
             let driver = BeancountPluginDriver(config: Self.config(ledger))
             try await driver.connect()
@@ -479,16 +486,38 @@ struct BeancountPluginDriverTests {
             let accounts = try await driver.execute(query: "SELECT name FROM accounts")
             #expect(accounts.rows.map { $0[0].asText } == ["Assets:Cash"])
 
-            let diagnostics = try await driver.execute(query: """
-                SELECT severity, phase, code, line, source_location FROM diagnostics ORDER BY id
+            var diagnostics = try await driver.execute(query: """
+                SELECT source_file, line, source_location FROM diagnostics
+                WHERE code = 'E8001' ORDER BY id
                 """)
             #expect(diagnostics.rows.count == 1)
             let diagnostic = try #require(diagnostics.rows.first)
-            #expect(diagnostic[0].asText == "error")
-            #expect(diagnostic[1].asText == "validate")
-            #expect(diagnostic[2].asText == "E8001")
-            #expect(diagnostic[3].asText == "3")
-            #expect(diagnostic[4].asText?.hasSuffix("\(ledger.lastPathComponent):3") == true)
+            let sourceFile = try #require(diagnostic[0].asText)
+            #expect(Self.canonicalPath(URL(fileURLWithPath: sourceFile)) == Self.canonicalPath(included))
+            #expect(diagnostic[1].asText == "3")
+            #expect(diagnostic[2].asText == "\(sourceFile):3")
+
+            let document = subdirectory.appendingPathComponent("receipt.pdf")
+            try Data("pdf".utf8).write(to: document)
+
+            diagnostics = try await driver.execute(query: """
+                SELECT source_file, line, source_location FROM diagnostics
+                WHERE code = 'E8001' ORDER BY id
+                """)
+            #expect(diagnostics.rows.isEmpty)
+
+            try FileManager.default.removeItem(at: document)
+
+            diagnostics = try await driver.execute(query: """
+                SELECT source_file, line, source_location FROM diagnostics
+                WHERE code = 'E8001' ORDER BY id
+                """)
+            #expect(diagnostics.rows.count == 1)
+            let returned = try #require(diagnostics.rows.first)
+            let returnedSourceFile = try #require(returned[0].asText)
+            #expect(Self.canonicalPath(URL(fileURLWithPath: returnedSourceFile)) == Self.canonicalPath(included))
+            #expect(returned[1].asText == "3")
+            #expect(returned[2].asText == "\(returnedSourceFile):3")
         }
     }
 
@@ -521,6 +550,9 @@ struct BeancountPluginDriverTests {
             method: "card"
           Assets:Cash
 
+        2024-01-06 * "Archive" "No postings" #empty ^standalone
+          reason: "record only"
+
         2024-06-30 close Expenses:Food
         """.write(to: ledger, atomically: true, encoding: .utf8)
 
@@ -552,21 +584,42 @@ struct BeancountPluginDriverTests {
         #expect(document[2].asText?.hasSuffix("receipt.pdf") == true)
 
         let metadata = try await driver.execute(query: """
-            SELECT key, value FROM transaction_metadata ORDER BY key
+            SELECT metadata.key, metadata.value
+            FROM transaction_metadata AS metadata
+            JOIN transactions ON transactions.id = metadata.transaction_id
+            WHERE transactions.narration = 'Coffee'
+            ORDER BY metadata.key
             """)
         #expect(metadata.rows.map { $0.map(\.asText) } == [["invoice", "INV-9"], ["verified", "TRUE"]])
 
-        let postingMetadata = try await driver.execute(query: "SELECT key, value FROM posting_metadata")
+        let postingMetadata = try await driver.execute(query: """
+            SELECT metadata.key, metadata.value
+            FROM posting_metadata AS metadata
+            JOIN postings ON postings.id = metadata.posting_id
+            JOIN transactions ON transactions.id = postings.transaction_id
+            WHERE transactions.narration = 'Coffee'
+            """)
         #expect(postingMetadata.rows.map { $0.map(\.asText) } == [["method", "card"]])
 
-        let tags = try await driver.execute(query: "SELECT tag FROM transaction_tags ORDER BY tag")
+        let tags = try await driver.execute(query: """
+            SELECT tags.tag
+            FROM transaction_tags AS tags
+            JOIN transactions ON transactions.id = tags.transaction_id
+            WHERE transactions.narration = 'Coffee'
+            ORDER BY tags.tag
+            """)
         #expect(tags.rows.map { $0[0].asText } == ["coffee", "daily"])
 
-        let links = try await driver.execute(query: "SELECT link FROM transaction_links")
+        let links = try await driver.execute(query: """
+            SELECT links.link
+            FROM transaction_links AS links
+            JOIN transactions ON transactions.id = links.transaction_id
+            WHERE transactions.narration = 'Coffee'
+            """)
         #expect(links.rows.map { $0[0].asText } == ["receipt-123"])
 
         let transactions = try await driver.execute(query: """
-            SELECT source_file, line, source_location FROM transactions
+            SELECT source_file, line, source_location FROM transactions WHERE narration = 'Coffee'
             """)
         #expect(transactions.rows.count == 1)
         let transaction = try #require(transactions.rows.first)
@@ -574,8 +627,68 @@ struct BeancountPluginDriverTests {
         #expect(transaction[1].asText == "13")
         #expect(transaction[2].asText?.hasSuffix("\(ledger.lastPathComponent):13") == true)
 
-        let postings = try await driver.execute(query: "SELECT line FROM postings ORDER BY id")
+        let postings = try await driver.execute(query: """
+            SELECT postings.line
+            FROM postings
+            JOIN transactions ON transactions.id = postings.transaction_id
+            WHERE transactions.narration = 'Coffee'
+            ORDER BY postings.id
+            """)
         #expect(postings.rows.map { $0[0].asText } == ["16", "18"])
+
+        let postingFree = try await driver.execute(query: """
+            SELECT id, date, flag, payee, narration, source_file, line, source_location
+            FROM transactions WHERE narration = 'No postings'
+            """)
+        #expect(postingFree.rows.count == 1)
+        let transactionWithoutPostings = try #require(postingFree.rows.first)
+        #expect(transactionWithoutPostings[0].asText != nil)
+        #expect(transactionWithoutPostings.dropFirst().prefix(4).map(\.asText) == [
+            "2024-01-06",
+            "*",
+            "Archive",
+            "No postings"
+        ])
+        let sourceFile = try #require(transactionWithoutPostings[5].asText)
+        #expect(Self.canonicalPath(URL(fileURLWithPath: sourceFile)) == Self.canonicalPath(ledger))
+        #expect(transactionWithoutPostings[6].asText == "20")
+        #expect(transactionWithoutPostings[7].asText == "\(sourceFile):20")
+
+        let postingFreeMetadata = try await driver.execute(query: """
+            SELECT metadata.key, metadata.value
+            FROM transaction_metadata AS metadata
+            JOIN transactions ON transactions.id = metadata.transaction_id
+            WHERE transactions.narration = 'No postings'
+            ORDER BY metadata.key
+            """)
+        #expect(postingFreeMetadata.rows.map { $0.map(\.asText) } == [["reason", "record only"]])
+
+        let postingFreeTags = try await driver.execute(query: """
+            SELECT tags.tag
+            FROM transaction_tags AS tags
+            JOIN transactions ON transactions.id = tags.transaction_id
+            WHERE transactions.narration = 'No postings'
+            ORDER BY tags.tag
+            """)
+        #expect(postingFreeTags.rows.map { $0[0].asText } == ["empty"])
+
+        let postingFreeLinks = try await driver.execute(query: """
+            SELECT links.link
+            FROM transaction_links AS links
+            JOIN transactions ON transactions.id = links.transaction_id
+            WHERE transactions.narration = 'No postings'
+            ORDER BY links.link
+            """)
+        #expect(postingFreeLinks.rows.map { $0[0].asText } == ["standalone"])
+
+        let postingFreeCount = try await driver.execute(query: """
+            SELECT COUNT(postings.id)
+            FROM transactions
+            LEFT JOIN postings ON postings.transaction_id = transactions.id
+            WHERE transactions.narration = 'No postings'
+            GROUP BY transactions.id
+            """)
+        #expect(postingFreeCount.rows.first?.first?.asText == "0")
     }
 
     private static func withRustledger(_ body: () async throws -> Void) async throws {
@@ -584,7 +697,10 @@ struct BeancountPluginDriverTests {
     }
 
     private static func withRustledgerEnvironment(_ path: String, _ body: () async throws -> Void) async throws {
-        try await withEnvironment(["TABLEPRO_RUSTLEDGER_BINARY": path], body)
+        try await withEnvironment([
+            "TABLEPRO_BEANCOUNT_BACKEND": "rledger",
+            "TABLEPRO_RUSTLEDGER_BINARY": path
+        ], body)
     }
 
     private static func withEnvironment(
@@ -609,6 +725,16 @@ struct BeancountPluginDriverTests {
 
     private static func config(_ ledger: URL) -> DriverConnectionConfig {
         DriverConnectionConfig(host: "", port: 0, username: "", password: "", database: ledger.path)
+    }
+
+    private static func canonicalPath(_ url: URL) -> String {
+        url.withUnsafeFileSystemRepresentation { fileSystemPath in
+            guard let fileSystemPath, let resolvedPath = realpath(fileSystemPath, nil) else {
+                return url.standardizedFileURL.path
+            }
+            defer { free(resolvedPath) }
+            return String(cString: resolvedPath)
+        }
     }
 
     private static func makeTempDirectory() throws -> URL {

--- a/TableProTests/Plugins/BeancountProjectionTests.swift
+++ b/TableProTests/Plugins/BeancountProjectionTests.swift
@@ -17,7 +17,8 @@ struct BeancountProjectionTests {
         let transactions = try await driver.execute(query: "SELECT id, payee, narration FROM transactions ORDER BY id")
         #expect(transactions.rows.map { $0.map(\.asText) } == [
             ["1", "Cafe", "Coffee"],
-            ["2", "Broker", "Buy stock"]
+            ["2", "Broker", "Buy stock"],
+            ["3", "Archive", "No postings"]
         ])
 
         let postings = try await driver.execute(query: """
@@ -30,6 +31,11 @@ struct BeancountProjectionTests {
             ["2", "Assets:Stock", "10", "HOOL", "100.00", "USD"],
             ["2", "Assets:Cash", "-1000.00", "USD", nil, nil]
         ])
+
+        let postingFreeCount = try await driver.execute(query: """
+            SELECT COUNT(*) FROM postings WHERE transaction_id = 3
+            """)
+        #expect(postingFreeCount.rows.first?.first?.asText == "0")
     }
 
     @Test("projects computed balances, assertions, accounts, and prices")
@@ -103,11 +109,12 @@ struct BeancountProjectionTests {
         defer { driver.disconnect() }
 
         let metadata = try await driver.execute(query: """
-            SELECT transaction_id, key, value FROM transaction_metadata ORDER BY id
+            SELECT transaction_id, key, value FROM transaction_metadata ORDER BY transaction_id, key
             """)
         #expect(metadata.rows.map { $0.map(\.asText) } == [
             ["1", "invoice", "INV-9"],
-            ["1", "reviewed", "TRUE"]
+            ["1", "reviewed", "TRUE"],
+            ["3", "reason", "record only"]
         ])
 
         let postingMetadata = try await driver.execute(query: """
@@ -115,11 +122,17 @@ struct BeancountProjectionTests {
             """)
         #expect(postingMetadata.rows.map { $0.map(\.asText) } == [["1", "method", "card"]])
 
-        let tags = try await driver.execute(query: "SELECT transaction_id, tag FROM transaction_tags ORDER BY id")
-        #expect(tags.rows.map { $0.map(\.asText) } == [["1", "coffee"], ["1", "daily"]])
+        let tags = try await driver.execute(query: """
+            SELECT transaction_id, tag FROM transaction_tags ORDER BY transaction_id, tag
+            """)
+        #expect(tags.rows.map { $0.map(\.asText) } == [
+            ["1", "coffee"], ["1", "daily"], ["3", "empty"]
+        ])
 
-        let links = try await driver.execute(query: "SELECT transaction_id, link FROM transaction_links ORDER BY id")
-        #expect(links.rows.map { $0.map(\.asText) } == [["1", "receipt-123"]])
+        let links = try await driver.execute(query: """
+            SELECT transaction_id, link FROM transaction_links ORDER BY transaction_id, link
+            """)
+        #expect(links.rows.map { $0.map(\.asText) } == [["1", "receipt-123"], ["3", "standalone"]])
     }
 
     @Test("projects source locations for transactions and postings")
@@ -132,7 +145,8 @@ struct BeancountProjectionTests {
             """)
         #expect(transactions.rows.map { $0.map(\.asText) } == [
             ["1", "/ledger/main.beancount", "10", "/ledger/main.beancount:10"],
-            ["2", nil, nil, nil]
+            ["2", nil, nil, nil],
+            ["3", "/ledger/main.beancount", "30", "/ledger/main.beancount:30"]
         ])
 
         let postings = try await driver.execute(query: """
@@ -175,6 +189,67 @@ struct BeancountProjectionTests {
         #expect(none.rows.first?.first?.asText == "0")
     }
 
+    @Test("rejects postings whose transaction is missing")
+    func rejectsOrphanPostings() {
+        let rows = BeancountProjectionRows(
+            postings: [
+                Self.postingRow(
+                    transactionID: 99,
+                    account: "Assets:Cash",
+                    number: "1.00",
+                    currency: "USD"
+                )
+            ]
+        )
+
+        #expect(throws: BeancountDriverError.self) {
+            _ = try BeancountPluginDriver.loadProjection(rows: rows, sourceFiles: [])
+        }
+    }
+
+    @Test("backfills legacy transaction details without using posting locations")
+    func backfillsLegacyTransactionDetails() {
+        let transactions: [[String: Any]] = [
+            [
+                "id": 1,
+                "tags": ["entry"],
+                "links": ["entry-link"],
+                "_entry_meta": ["source": "entry"]
+            ],
+            ["id": 2]
+        ]
+        let postings: [[String: Any]] = [
+            [
+                "transaction_id": 1,
+                "tags": ["posting"],
+                "links": ["posting-link"],
+                "_entry_meta": ["source": "posting"]
+            ],
+            [
+                "transaction_id": 2,
+                "tags": ["legacy"],
+                "links": ["legacy-link"],
+                "_entry_meta": ["source": "legacy"],
+                "filename": "/ledger/posting.beancount",
+                "lineno": 22
+            ]
+        ]
+
+        let enriched = BeancountPluginDriver.transactionRowsByAddingPostingDetails(
+            transactions,
+            postings: postings
+        )
+
+        #expect(enriched[0]["tags"] as? [String] == ["entry"])
+        #expect(enriched[0]["links"] as? [String] == ["entry-link"])
+        #expect((enriched[0]["_entry_meta"] as? [String: String])?["source"] == "entry")
+        #expect(enriched[1]["tags"] as? [String] == ["legacy"])
+        #expect(enriched[1]["links"] as? [String] == ["legacy-link"])
+        #expect((enriched[1]["_entry_meta"] as? [String: String])?["source"] == "legacy")
+        #expect(enriched[1]["filename"] == nil)
+        #expect(enriched[1]["lineno"] == nil)
+    }
+
     // MARK: - Fixtures
 
     private static let ledgerURL = URL(fileURLWithPath: "/tmp/tablepro-beancount-fixture/main.beancount")
@@ -189,22 +264,46 @@ struct BeancountProjectionTests {
     }
 
     private static let cannedRows = BeancountProjectionRows(
-        transactionsAndPostings: [
-            row(
-                id: 1, payee: "Cafe", narration: "Coffee", account: "Expenses:Food", number: "4.00", currency: "USD",
-                line: 11, entryMeta: ["invoice": "INV-9", "reviewed": true], postingMeta: ["method": "card"],
-                tags: ["coffee", "daily"], links: ["receipt-123"]
+        transactions: [
+            transactionRow(
+                id: 1,
+                payee: "Cafe",
+                narration: "Coffee",
+                line: 10,
+                metadata: ["invoice": "INV-9", "reviewed": true],
+                tags: ["coffee", "daily"],
+                links: ["receipt-123"]
             ),
-            row(
-                id: 1, payee: "Cafe", narration: "Coffee", account: "Assets:Cash", number: "-4.00", currency: "USD",
-                line: 12, entryMeta: ["invoice": "INV-9", "reviewed": true],
-                tags: ["coffee", "daily"], links: ["receipt-123"]
+            transactionRow(id: 2, payee: "Broker", narration: "Buy stock"),
+            transactionRow(
+                id: 3,
+                payee: "Archive",
+                narration: "No postings",
+                line: 30,
+                metadata: ["reason": "record only"],
+                tags: ["empty"],
+                links: ["standalone"]
+            )
+        ],
+        postings: [
+            postingRow(
+                transactionID: 1,
+                account: "Expenses:Food",
+                number: "4.00",
+                currency: "USD",
+                line: 11,
+                metadata: ["method": "card"]
             ),
-            row(
-                id: 2, payee: "Broker", narration: "Buy stock", account: "Assets:Stock",
-                number: "10", currency: "HOOL", costNumber: "100.00", costCurrency: "USD"
+            postingRow(transactionID: 1, account: "Assets:Cash", number: "-4.00", currency: "USD", line: 12),
+            postingRow(
+                transactionID: 2,
+                account: "Assets:Stock",
+                number: "10",
+                currency: "HOOL",
+                costNumber: "100.00",
+                costCurrency: "USD"
             ),
-            row(id: 2, payee: "Broker", narration: "Buy stock", account: "Assets:Cash", number: "-1000.00", currency: "USD")
+            postingRow(transactionID: 2, account: "Assets:Cash", number: "-1000.00", currency: "USD")
         ],
         accounts: [
             ["account": "Assets:Cash", "open": "2024-01-01", "currencies": ["USD"]],
@@ -221,9 +320,6 @@ struct BeancountProjectionTests {
         ],
         balanceAssertions: [
             ["date": "2024-01-31", "account": "Assets:Cash", "amount": ["number": "-1004.00", "currency": "USD"]]
-        ],
-        transactionLocations: [
-            ["id": 1, "filename": "/ledger/main.beancount", "lineno": 10, "location": "/ledger/main.beancount:10"]
         ],
         commodities: [
             ["date": "2024-01-01", "name": "USD"],
@@ -253,24 +349,49 @@ struct BeancountProjectionTests {
         ]
     )
 
-    private static func row(
+    private static func transactionRow(
         id: Int,
         payee: String,
         narration: String,
+        line: Int? = nil,
+        metadata: [String: Any]? = nil,
+        tags: [String]? = nil,
+        links: [String]? = nil
+    ) -> [String: Any] {
+        var row: [String: Any] = [
+            "id": id,
+            "date": "2024-01-05",
+            "flag": "*",
+            "payee": payee,
+            "narration": narration
+        ]
+        if let line {
+            row["filename"] = "/ledger/main.beancount"
+            row["lineno"] = line
+            row["location"] = "/ledger/main.beancount:\(line)"
+        }
+        row["_entry_meta"] = metadata
+        row["tags"] = tags
+        row["links"] = links
+        return row
+    }
+
+    private static func postingRow(
+        transactionID: Int,
         account: String,
         number: String,
         currency: String,
         costNumber: String? = nil,
         costCurrency: String? = nil,
         line: Int? = nil,
-        entryMeta: [String: Any]? = nil,
-        postingMeta: [String: Any]? = nil,
-        tags: [String]? = nil,
-        links: [String]? = nil
+        metadata: [String: Any]? = nil
     ) -> [String: Any] {
         var row: [String: Any] = [
-            "id": id, "date": "2024-01-05", "flag": "*", "payee": payee, "narration": narration,
-            "account": account, "number": number, "currency": currency
+            "transaction_id": transactionID,
+            "date": "2024-01-05",
+            "account": account,
+            "number": number,
+            "currency": currency
         ]
         row["cost_number"] = costNumber
         row["cost_currency"] = costCurrency
@@ -279,10 +400,7 @@ struct BeancountProjectionTests {
             row["lineno"] = line
             row["location"] = "/ledger/main.beancount:\(line)"
         }
-        row["_entry_meta"] = entryMeta
-        row["_posting_meta"] = postingMeta
-        row["tags"] = tags
-        row["links"] = links
+        row["_posting_meta"] = metadata
         return row
     }
 

--- a/TableProTests/Plugins/BeancountProjectionTests.swift
+++ b/TableProTests/Plugins/BeancountProjectionTests.swift
@@ -71,6 +71,110 @@ struct BeancountProjectionTests {
         }
     }
 
+    @Test("projects commodity, document, note, event, and close directives")
+    func projectsRichDirectives() async throws {
+        let driver = try Self.makeDriver()
+        defer { driver.disconnect() }
+
+        let commodities = try await driver.execute(query: "SELECT date, commodity FROM commodities ORDER BY commodity")
+        #expect(commodities.rows.map { $0.map(\.asText) } == [
+            ["2024-01-01", "HOOL"],
+            ["2024-01-01", "USD"]
+        ])
+
+        let documents = try await driver.execute(query: "SELECT date, account, path, tags, links FROM documents")
+        #expect(documents.rows.map { $0.map(\.asText) } == [
+            ["2024-01-03", "Assets:Cash", "/receipts/jan.pdf", "scanned", "batch-1"]
+        ])
+
+        let notes = try await driver.execute(query: "SELECT date, account, comment FROM notes")
+        #expect(notes.rows.map { $0.map(\.asText) } == [["2024-01-04", "Assets:Cash", "called the bank"]])
+
+        let events = try await driver.execute(query: "SELECT date, type, description FROM events")
+        #expect(events.rows.map { $0.map(\.asText) } == [["2024-01-01", "location", "Taipei"]])
+
+        let closes = try await driver.execute(query: "SELECT date, account FROM closes")
+        #expect(closes.rows.map { $0.map(\.asText) } == [["2024-06-30", "Expenses:Food"]])
+    }
+
+    @Test("projects transaction metadata, posting metadata, tags, and links")
+    func projectsMetadataTagsAndLinks() async throws {
+        let driver = try Self.makeDriver()
+        defer { driver.disconnect() }
+
+        let metadata = try await driver.execute(query: """
+            SELECT transaction_id, key, value FROM transaction_metadata ORDER BY id
+            """)
+        #expect(metadata.rows.map { $0.map(\.asText) } == [
+            ["1", "invoice", "INV-9"],
+            ["1", "reviewed", "TRUE"]
+        ])
+
+        let postingMetadata = try await driver.execute(query: """
+            SELECT posting_id, key, value FROM posting_metadata ORDER BY id
+            """)
+        #expect(postingMetadata.rows.map { $0.map(\.asText) } == [["1", "method", "card"]])
+
+        let tags = try await driver.execute(query: "SELECT transaction_id, tag FROM transaction_tags ORDER BY id")
+        #expect(tags.rows.map { $0.map(\.asText) } == [["1", "coffee"], ["1", "daily"]])
+
+        let links = try await driver.execute(query: "SELECT transaction_id, link FROM transaction_links ORDER BY id")
+        #expect(links.rows.map { $0.map(\.asText) } == [["1", "receipt-123"]])
+    }
+
+    @Test("projects source locations for transactions and postings")
+    func projectsSourceLocations() async throws {
+        let driver = try Self.makeDriver()
+        defer { driver.disconnect() }
+
+        let transactions = try await driver.execute(query: """
+            SELECT id, source_file, line, source_location FROM transactions ORDER BY id
+            """)
+        #expect(transactions.rows.map { $0.map(\.asText) } == [
+            ["1", "/ledger/main.beancount", "10", "/ledger/main.beancount:10"],
+            ["2", nil, nil, nil]
+        ])
+
+        let postings = try await driver.execute(query: """
+            SELECT id, source_location FROM postings ORDER BY id LIMIT 2
+            """)
+        #expect(postings.rows.map { $0.map(\.asText) } == [
+            ["1", "/ledger/main.beancount:11"],
+            ["2", "/ledger/main.beancount:12"]
+        ])
+    }
+
+    @Test("projects validation diagnostics and stays empty without a validator")
+    func projectsDiagnostics() async throws {
+        let driver = try Self.makeDriver()
+        defer { driver.disconnect() }
+
+        let diagnostics = try await driver.execute(query: """
+            SELECT source_file, line, source_location, column_number, end_line, end_column,
+                   severity, phase, code, message
+            FROM diagnostics ORDER BY id
+            """)
+        #expect(diagnostics.rows.map { $0.map(\.asText) } == [
+            [
+                "/ledger/main.beancount", "20", "/ledger/main.beancount:20", "1", "22", "1",
+                "error", "validate", "E8001", "Document file not found: /receipts/jan.pdf"
+            ]
+        ])
+
+        let handle = try BeancountPluginDriver.loadProjection(
+            rows: BeancountProjectionRows(),
+            sourceFiles: [Self.ledgerURL]
+        )
+        let empty = BeancountPluginDriver(
+            config: DriverConnectionConfig(host: "", port: 0, username: "", password: "", database: Self.ledgerURL.path)
+        )
+        empty.installProjection(handle, ledgerURL: Self.ledgerURL)
+        defer { empty.disconnect() }
+
+        let none = try await empty.execute(query: "SELECT COUNT(*) FROM diagnostics")
+        #expect(none.rows.first?.first?.asText == "0")
+    }
+
     // MARK: - Fixtures
 
     private static let ledgerURL = URL(fileURLWithPath: "/tmp/tablepro-beancount-fixture/main.beancount")
@@ -86,8 +190,16 @@ struct BeancountProjectionTests {
 
     private static let cannedRows = BeancountProjectionRows(
         transactionsAndPostings: [
-            row(id: 1, payee: "Cafe", narration: "Coffee", account: "Expenses:Food", number: "4.00", currency: "USD"),
-            row(id: 1, payee: "Cafe", narration: "Coffee", account: "Assets:Cash", number: "-4.00", currency: "USD"),
+            row(
+                id: 1, payee: "Cafe", narration: "Coffee", account: "Expenses:Food", number: "4.00", currency: "USD",
+                line: 11, entryMeta: ["invoice": "INV-9", "reviewed": true], postingMeta: ["method": "card"],
+                tags: ["coffee", "daily"], links: ["receipt-123"]
+            ),
+            row(
+                id: 1, payee: "Cafe", narration: "Coffee", account: "Assets:Cash", number: "-4.00", currency: "USD",
+                line: 12, entryMeta: ["invoice": "INV-9", "reviewed": true],
+                tags: ["coffee", "daily"], links: ["receipt-123"]
+            ),
             row(
                 id: 2, payee: "Broker", narration: "Buy stock", account: "Assets:Stock",
                 number: "10", currency: "HOOL", costNumber: "100.00", costCurrency: "USD"
@@ -109,6 +221,35 @@ struct BeancountProjectionTests {
         ],
         balanceAssertions: [
             ["date": "2024-01-31", "account": "Assets:Cash", "amount": ["number": "-1004.00", "currency": "USD"]]
+        ],
+        transactionLocations: [
+            ["id": 1, "filename": "/ledger/main.beancount", "lineno": 10, "location": "/ledger/main.beancount:10"]
+        ],
+        commodities: [
+            ["date": "2024-01-01", "name": "USD"],
+            ["date": "2024-01-01", "name": "HOOL"]
+        ],
+        documents: [
+            [
+                "date": "2024-01-03", "account": "Assets:Cash", "filename": "/receipts/jan.pdf",
+                "tags": ["scanned"], "links": ["batch-1"]
+            ]
+        ],
+        notes: [
+            ["date": "2024-01-04", "account": "Assets:Cash", "comment": "called the bank"]
+        ],
+        events: [
+            ["date": "2024-01-01", "type": "location", "description": "Taipei"]
+        ],
+        closes: [
+            ["account": "Expenses:Food", "close": "2024-06-30"]
+        ],
+        diagnostics: [
+            [
+                "file": "/ledger/main.beancount", "line": 20, "column": 1, "end_line": 22, "end_column": 1,
+                "severity": "error", "phase": "validate", "code": "E8001",
+                "message": "Document file not found: /receipts/jan.pdf"
+            ]
         ]
     )
 
@@ -120,7 +261,12 @@ struct BeancountProjectionTests {
         number: String,
         currency: String,
         costNumber: String? = nil,
-        costCurrency: String? = nil
+        costCurrency: String? = nil,
+        line: Int? = nil,
+        entryMeta: [String: Any]? = nil,
+        postingMeta: [String: Any]? = nil,
+        tags: [String]? = nil,
+        links: [String]? = nil
     ) -> [String: Any] {
         var row: [String: Any] = [
             "id": id, "date": "2024-01-05", "flag": "*", "payee": payee, "narration": narration,
@@ -128,6 +274,15 @@ struct BeancountProjectionTests {
         ]
         row["cost_number"] = costNumber
         row["cost_currency"] = costCurrency
+        if let line {
+            row["filename"] = "/ledger/main.beancount"
+            row["lineno"] = line
+            row["location"] = "/ledger/main.beancount:\(line)"
+        }
+        row["_entry_meta"] = entryMeta
+        row["_posting_meta"] = postingMeta
+        row["tags"] = tags
+        row["links"] = links
         return row
     }
 

--- a/docs/databases/beancount.mdx
+++ b/docs/databases/beancount.mdx
@@ -85,7 +85,7 @@ See [Connection URL Reference](/databases/connection-urls) for all parameters.
 
 | Table | Contents |
 |-------|----------|
-| `transactions` | Transaction date, flag, payee, narration, and source location |
+| `transactions` | Transaction date, flag, payee, narration, and source location, including transactions with no postings |
 | `postings` | Posting account, amount, commodity, resolved cost basis (`cost_number`, `cost_currency`), and source location |
 | `accounts` | Opened accounts and declared currencies |
 | `prices` | Price directives |
@@ -111,6 +111,8 @@ Metadata values are projected as text. Booleans keep their Beancount spelling, `
 
 `transactions` and `postings` carry `source_file`, `line`, and `source_location`. `source_location` is formatted as `path:line`, so it can be copied, filtered, or exported directly. A posting points at its own line rather than the line of the transaction that contains it.
 
+Valid transactions with no postings remain in `transactions` with their metadata, tags, links, and source location.
+
 A transaction the backend generates rather than reads, such as the one inserted for a `pad`, has whatever location that backend gives it. `rledger` leaves these columns empty; Python Beancount points them at the `pad` directive.
 
 ## Diagnostics
@@ -118,6 +120,8 @@ A transaction the backend generates rather than reads, such as the one inserted 
 The `diagnostics` table holds structured validation output: `source_file`, `line`, `source_location`, `column_number`, `end_line`, `end_column`, `severity`, `phase`, `code`, and `message`.
 
 The table is populated by `rledger check`. A ledger opened through `rledger` is projected even when it fails validation, so the entries the projection skipped are readable here rather than only on the command line. Ledgers opened on the Python Beancount backend leave the table empty.
+
+TablePro refreshes the projection when a referenced document file is created or removed, so document existence diagnostics stay current without editing the ledger.
 
 ## Includes
 

--- a/docs/databases/beancount.mdx
+++ b/docs/databases/beancount.mdx
@@ -3,7 +3,7 @@ title: Beancount
 description: Open Beancount ledgers with TablePro
 ---
 
-TablePro opens `.beancount` ledgers as read-only, file-based connections. If the Beancount plugin is not installed yet, TablePro prompts you to download it before opening the ledger. The driver projects transactions, postings, accounts, prices, computed balances, balance assertions, and source files into SQL tables for browsing and exports.
+TablePro opens `.beancount` ledgers as read-only, file-based connections. If the Beancount plugin is not installed yet, TablePro prompts you to download it before opening the ledger. The driver projects transactions, postings, accounts, prices, computed balances, balance assertions, the remaining directives, metadata, and source files into SQL tables for browsing and exports.
 
 The plugin uses either `rledger` (the rustledger project) or Python Beancount to parse ledgers. TablePro does not bundle either one, so install one yourself before opening a ledger. When both are available, TablePro uses `rledger`; Python Beancount is the fallback for browsing projected SQL tables.
 
@@ -85,15 +85,39 @@ See [Connection URL Reference](/databases/connection-urls) for all parameters.
 
 | Table | Contents |
 |-------|----------|
-| `transactions` | Transaction date, flag, payee, and narration |
-| `postings` | Posting account, amount, commodity, and resolved cost basis (`cost_number`, `cost_currency`) |
+| `transactions` | Transaction date, flag, payee, narration, and source location |
+| `postings` | Posting account, amount, commodity, resolved cost basis (`cost_number`, `cost_currency`), and source location |
 | `accounts` | Opened accounts and declared currencies |
 | `prices` | Price directives |
 | `balances` | Computed account balances by commodity |
 | `balance_assertions` | Beancount balance directives |
+| `commodities` | Commodity directives |
+| `documents` | Document directives, their attached paths, tags, and links |
+| `notes` | Account notes |
+| `events` | Event type and description directives |
+| `closes` | Close directives |
+| `transaction_metadata` | Transaction metadata key/value pairs |
+| `posting_metadata` | Posting metadata key/value pairs |
+| `transaction_tags` | Transaction tags |
+| `transaction_links` | Transaction links |
+| `diagnostics` | Validation diagnostics from `rledger check` |
 | `source_files` | Parsed ledger and include files |
 
 Amounts come from whichever backend parsed the ledger, so thousands separators, arithmetic, cost (`{}`), and price (`@`/`@@`) annotations arrive already resolved to their booked values.
+
+Metadata values are projected as text. Booleans keep their Beancount spelling, `TRUE` and `FALSE`.
+
+## Source locations
+
+`transactions` and `postings` carry `source_file`, `line`, and `source_location`. `source_location` is formatted as `path:line`, so it can be copied, filtered, or exported directly. A posting points at its own line rather than the line of the transaction that contains it.
+
+A transaction the backend generates rather than reads, such as the one inserted for a `pad`, has whatever location that backend gives it. `rledger` leaves these columns empty; Python Beancount points them at the `pad` directive.
+
+## Diagnostics
+
+The `diagnostics` table holds structured validation output: `source_file`, `line`, `source_location`, `column_number`, `end_line`, `end_column`, `severity`, `phase`, `code`, and `message`.
+
+The table is populated by `rledger check`. A ledger opened through `rledger` is projected even when it fails validation, so the entries the projection skipped are readable here rather than only on the command line. Ledgers opened on the Python Beancount backend leave the table empty.
 
 ## Includes
 
@@ -125,4 +149,5 @@ Table browsing, row counts, and pagination work for BQL results. BQL queries do 
 
 - Beancount connections are read-only.
 - Schema editing, imports, SSH, SSL, and database switching are not available for ledgers.
+- `pad` directives are not projected as their own table. `rledger` does not expose the padded and source accounts, so the directive is only visible through the balancing transaction it inserts. The directive itself remains in the original source files.
 - The SQL projection covers common ledger directives; unsupported directives remain available in the original source files.

--- a/project.yml
+++ b/project.yml
@@ -299,6 +299,7 @@ targets:
       # Plugin logic under test. Plugin bundles load at runtime, so the test bundle
       # compiles the pure-logic files its suites cover.
       - Plugins/BeancountDriverPlugin/BeancountIncludeResolver.swift
+      - Plugins/BeancountDriverPlugin/BeancountPluginDriver+Projection.swift
       - Plugins/BeancountDriverPlugin/BeancountPluginDriver+PythonScript.swift
       - Plugins/BeancountDriverPlugin/BeancountPluginDriver.swift
       - Plugins/BigQueryDriverPlugin/BigQueryAuth.swift


### PR DESCRIPTION
## Summary

The Beancount SQL projection covered transactions, postings, accounts, prices and balances. Commodity, document, note, event and close directives, along with metadata, tags and links, were only reachable by opening the ledger file. This projects them as tables.

New tables:

| Table | Contents |
|-------|----------|
| `commodities` | Commodity directives |
| `documents` | Document directives, paths, tags, links |
| `notes` | Account notes |
| `events` | Event type and description |
| `closes` | Close directives |
| `transaction_metadata` | Transaction metadata key/value pairs |
| `posting_metadata` | Posting metadata key/value pairs |
| `transaction_tags` | Transaction tags |
| `transaction_links` | Transaction links |
| `diagnostics` | Structured `rledger check` output |

`transactions` and `postings` also gain `source_file`, `line` and `source_location`, so a row can be traced back to the line it came from. A posting points at its own line, not the line of its transaction.

Both backends produce the same shapes. `rledger` reads `#commodities`, `#documents`, `#notes`, `#events`, the `close` column on `#accounts`, and `#entries` for transaction locations; the Python script projects the same directives from `loader.load_file`.

## Notes for review

**`pad` is deliberately not projected.** `rledger` has no `#pads` table, and `#entries` returns an empty `accounts` array for pad directives, so neither the padded nor the source account is reachable. A `pads` table would be date-and-line only on the default backend. This is called out under Limitations in the docs rather than shipped half-populated.

**`rledger check` exits non-zero whenever it emits diagnostics**, while still writing valid JSON to stdout. `runProcess` gained an `allowsNonZeroExit` parameter for that one call, otherwise the diagnostics table would be empty in exactly the case it matters.

**Unsupported columns degrade instead of failing the connection.** Each new directive query is optional: if a backend version does not expose one, that table is empty and the reason is logged, rather than the ledger failing to open. The widened `#postings` query falls back to the previous column list the same way. This matters because the projection is all-or-nothing at connect time.

**Metadata booleans** are projected as `TRUE`/`FALSE` rather than `1`/`0`, matching Beancount's own spelling.

**Backend differences worth knowing:** `documents.path` is the literal path from `rledger` and the resolved absolute path from Python Beancount. `rledger` canonicalises `source_file` (`/private/var/...`) while Python does not (`/var/...`). The tests assert on suffixes for that reason. The transaction generated for a `pad` has no location under `rledger` and points at the pad directive under Python; both are documented.

## Performance

This adds six `rledger` invocations plus one `rledger check` per projection build, and each invocation re-parses the ledger. Measured on a synthetic 20,000-transaction, 2 MB ledger, interleaved against `main` under equal load:

| | connect |
|---|---|
| `main` | ~3.9 s |
| this branch | ~6.7 s |

Widening the `#postings` query is free (1.08 s to 1.10 s); the cost is the extra parses and the extra rows. The projection loader now caches prepared statements instead of preparing one per row, which took this from ~9.7 s to ~6.7 s and speeds up the existing tables too.

If ~1.7x on a large ledger is not acceptable, the next step is projecting directive tables lazily on first read rather than at connect. That is an architectural change, so I have left it out of this PR. Happy to follow up.

## Verification

- `commodities`, `documents`, `notes`, `events`, `closes`, metadata, tags, links, source locations and diagnostics asserted end to end against a real `rledger` (0.21.0) and real Python Beancount (3.2.3), through `connect()`, using the existing `RustledgerLocator` / `PythonBeancountLocator` gates in `BeancountPluginDriverTests`.
- Projection mapping covered by canned-row tests in `BeancountProjectionTests`.
- A ledger that fails validation still opens and reports the problem as a `diagnostics` row.

I could not run `xcodebuild test` or SwiftLint locally: this machine has Command Line Tools only, and both need a full Xcode. The driver, the plugin sources and all Beancount test files compile clean via SwiftPM in Swift 5 language mode, and the behaviour above was verified by driving `BeancountPluginDriver.connect()` against real ledgers. CI should be treated as the authority on lint and on the test run itself.

## Checklist

- [x] Tests added or updated
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated in `docs/`
- [x] User-facing strings localized
- [ ] No SwiftLint/SwiftFormat violations (not runnable locally, see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
