### PR TITLE
fix(quick-switcher): select the best match when the query changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Quick Switcher opens what you searched for. Typing a new search kept the row you had highlighted selected whenever it still matched anything, and searching across connections matches the connection path in every row, so almost any row stayed highlighted while the list reordered under it. `Return` then opened something you had stopped searching for.
 - A query that fails shows the database's error again and is recorded in query history. A syntax error, or selecting from a table that does not exist, left the results area blank with no message at all, and opening a table that failed to load was silent the same way. The error also opens the results pane if you had it collapsed. (#2120)
 - Running a query with parameters, or several statements at once, no longer stops the tab from accepting any later run.
 - Query History no longer mixes every connection's queries together with no way to tell them apart. Loading one could put another connection's SQL into the editor in front of you.

--- a/TablePro/ViewModels/QuickSwitcherViewModel.swift
+++ b/TablePro/ViewModels/QuickSwitcherViewModel.swift
@@ -66,6 +66,8 @@ internal final class QuickSwitcherViewModel {
         didSet { scheduleFilter(debounced: false) }
     }
     @ObservationIgnored private var filterTask: Task<Void, Never>?
+    @ObservationIgnored private var selectionQuery: String?
+    @ObservationIgnored private var selectionScope: QuickSwitcherScope?
     @ObservationIgnored private var activeLoadId = UUID()
     @ObservationIgnored private var activeCrossConnectionLoadId = UUID()
     @ObservationIgnored private var activeCrossConnectionQueryLoadId = UUID()
@@ -625,7 +627,7 @@ internal final class QuickSwitcherViewModel {
                 : await Self.filteredGroups(items: items, query: query, frecencyScores: frecencyScores)
             guard !Task.isCancelled, let self else { return }
             self.groups = groups
-            self.reconcileSelection()
+            self.reconcileSelection(query: query, scope: scope)
         }
     }
 
@@ -638,9 +640,18 @@ internal final class QuickSwitcherViewModel {
         await filterTask?.value
     }
 
-    private func reconcileSelection() {
+    /// A refilter the user did not ask for keeps their selection; a new query moves it to the best
+    /// match. Surviving the refilter is not evidence that the old row is still what the user wants:
+    /// `bestMatch` falls back to the subtitle, and every Connections-scope subtitle carries the
+    /// connection path, so a query matches most of the catalog through that path alone. The old row
+    /// therefore almost always survived, the highlight stayed on it while the ranked list moved
+    /// underneath, and Return opened something the user had stopped searching for.
+    private func reconcileSelection(query: String, scope: QuickSwitcherScope) {
         let items = flatItems
-        if let current = selectedItemId, items.contains(where: { $0.id == current }) {
+        let isSameSearch = query == selectionQuery && scope == selectionScope
+        selectionQuery = query
+        selectionScope = scope
+        if isSameSearch, let current = selectedItemId, items.contains(where: { $0.id == current }) {
             return
         }
         selectedItemId = items.first?.id

--- a/TablePro/Views/Components/HighlightedSQLTextView.swift
+++ b/TablePro/Views/Components/HighlightedSQLTextView.swift
@@ -15,6 +15,9 @@ struct HighlightedSQLTextView: NSViewRepresentable {
     let sql: String
     var fontSize: CGFloat = 13
     var databaseType: DatabaseType = .mysql
+    /// A SwiftUI `.accessibilityIdentifier` lands on the representable's wrapper, not on the text
+    /// view AppKit publishes, so the only way to name this element is to set it on the text view.
+    var accessibilityIdentifier: String?
 
     func makeNSView(context: Context) -> NSScrollView {
         let scrollView = NSTextView.scrollableTextView()
@@ -23,6 +26,8 @@ struct HighlightedSQLTextView: NSViewRepresentable {
             return scrollView
         }
 
+        textView.setAccessibilityIdentifier(accessibilityIdentifier)
+        textView.setAccessibilityLabel(String(localized: "Query preview"))
         textView.isEditable = false
         textView.isSelectable = true
         textView.font = NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)

--- a/TablePro/Views/Editor/History/HistoryDetailPane.swift
+++ b/TablePro/Views/Editor/History/HistoryDetailPane.swift
@@ -24,11 +24,18 @@ struct HistoryDetailPane: View {
         .accessibilityIdentifier("query-history-detail")
     }
 
+    /// The preview is named on the `NSTextView` itself rather than through a SwiftUI modifier, which
+    /// is both because a modifier cannot reach the view behind an `NSViewRepresentable` and because
+    /// the identifier on the enclosing container would overwrite a SwiftUI one.
     private func detail(for entry: QueryHistoryEntry) -> some View {
         VStack(spacing: 0) {
-            HighlightedSQLTextView(sql: entry.query, databaseType: entry.databaseType)
-                .background(Color(nsColor: ThemeEngine.shared.colors.editor.background))
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            HighlightedSQLTextView(
+                sql: entry.query,
+                databaseType: entry.databaseType,
+                accessibilityIdentifier: "query-history-detail-query"
+            )
+            .background(Color(nsColor: ThemeEngine.shared.colors.editor.background))
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             Divider()
 

--- a/TablePro/Views/Main/EditorTabStrip.swift
+++ b/TablePro/Views/Main/EditorTabStrip.swift
@@ -171,6 +171,7 @@ private struct EditorTabStripItem: View {
             Button(String(localized: "Close All Tabs"), action: onCloseAll)
         }
         .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("editor-tab")
         .accessibilityLabel(Text(tab.title))
         .accessibilityValue(Text(positionDescription))
         .accessibilityAddTraits(isSelected ? .isSelected : [])

--- a/TableProTests/ViewModels/QuickSwitcherViewModelTests.swift
+++ b/TableProTests/ViewModels/QuickSwitcherViewModelTests.swift
@@ -456,6 +456,68 @@ struct QuickSwitcherViewModelTests {
         #expect(vm.selectedItem()?.name == "Track")
     }
 
+    /// The previous selection surviving the refilter is not evidence that it is still wanted. Here
+    /// it survives on its own name, and in the Connections scope it survives on the connection path
+    /// every subtitle carries, which is what shipped: the list ranked Invoice first while the
+    /// highlight stayed on the row typed before it, and Return opened that one.
+    @Test("A new query moves the selection off a row that still matches")
+    func newQueryMovesSelectionOffAStillMatchingRow() async throws {
+        let target = QuickSwitcherTarget(
+            connectionId: UUID(),
+            connectionName: "Chinook",
+            databaseName: "sample.sqlite",
+            schemaName: nil
+        )
+        let items = QuickSwitcherViewModel.makeCrossConnectionItems(
+            tables: [
+                TableInfo(name: "Invoice", type: .table, rowCount: nil),
+                TableInfo(name: "InvoiceLine", type: .table, rowCount: nil)
+            ],
+            target: target
+        )
+        let vm = makeViewModel(items: [])
+        vm.crossConnectionItems = items
+        vm.scope = .connections
+        let stale = try #require(items.first { $0.name == "InvoiceLine" })
+        vm.selectedItemId = stale.id
+
+        vm.searchText = "invoice"
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        #expect(vm.flatItems.contains { $0.id == stale.id })
+        #expect(vm.flatItems.first?.name == "Invoice")
+        #expect(vm.selectedItem()?.name == "Invoice")
+    }
+
+    /// The counterpart guard. A catalog that reloads underneath an open panel refilters with the
+    /// same query, and taking the user's arrow keys back to the top of the list on every reload
+    /// would make the panel unusable while connections are still loading.
+    @Test("A refilter with the same query keeps the selection")
+    func refilterWithSameQueryKeepsSelection() async throws {
+        let target = QuickSwitcherTarget(
+            connectionId: UUID(),
+            connectionName: "Chinook",
+            databaseName: "sample.sqlite",
+            schemaName: nil
+        )
+        let tables = [
+            TableInfo(name: "Invoice", type: .table, rowCount: nil),
+            TableInfo(name: "InvoiceLine", type: .table, rowCount: nil)
+        ]
+        let vm = makeViewModel(items: [])
+        vm.crossConnectionItems = QuickSwitcherViewModel.makeCrossConnectionItems(tables: tables, target: target)
+        vm.scope = .connections
+        vm.searchText = "invoice"
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        let chosen = try #require(vm.flatItems.first { $0.name == "InvoiceLine" })
+        vm.selectedItemId = chosen.id
+        vm.crossConnectionItems = QuickSwitcherViewModel.makeCrossConnectionItems(tables: tables, target: target)
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        #expect(vm.selectedItem()?.name == "InvoiceLine")
+    }
+
     @Test("Cross-connection catalog keeps object location")
     func crossConnectionCatalogKeepsLocation() {
         let connectionId = UUID()

--- a/TableProUITests/QueryHistoryFocusUITests.swift
+++ b/TableProUITests/QueryHistoryFocusUITests.swift
@@ -7,20 +7,24 @@ final class QueryHistoryFocusUITests: UITestCase {
         let app = try launchWithSampleDatabase()
         runQueries(in: app, ["SELECT * FROM Genre;", "SELECT * FROM Album;", "SELECT * FROM Artist;"])
 
-        // The editor is the window's first text view; the drawer's preview is added below it.
         let editor = app.windows.firstMatch.textViews.firstMatch
         XCTAssertTrue(editor.waitForExistence(timeout: 10))
         let editorBeforeClick = editor.value as? String ?? ""
 
         let list = showHistoryDrawer(in: app)
 
+        /// The drawer animates open, and a row frame read while it is still laying out puts the
+        /// click somewhere the row has left. Both panes existing is what says the drawer is up.
+        let detail = app.windows.firstMatch.descendants(matching: .any)
+            .matching(identifier: "query-history-detail").firstMatch
+        XCTAssertTrue(detail.waitForExistence(timeout: 10))
+
         // Row 0 is the "Today" section header, so the first entry is row 1.
         let rows = list.tableRows
         XCTAssertTrue(rows.element(boundBy: 1).waitForExistence(timeout: 10), "The drawer must list the queries just run")
         rows.element(boundBy: 1).click()
 
-        // The drawer's preview is the window's second text view, so it reports which row is selected.
-        let preview = app.windows.firstMatch.textViews.element(boundBy: 1)
+        let preview = app.textViews["query-history-detail-query"]
         XCTAssertTrue(preview.waitForExistence(timeout: 5))
         let previewAfterClick = preview.value as? String ?? ""
         XCTAssertFalse(previewAfterClick.isEmpty, "Clicking a row must show that row in the preview")

--- a/TableProUITests/QuickSwitcherCrossConnectionUITests.swift
+++ b/TableProUITests/QuickSwitcherCrossConnectionUITests.swift
@@ -36,17 +36,29 @@ final class QuickSwitcherCrossConnectionUITests: UITestCase {
         searchField.typeText("track")
         searchField.typeKey(.return, modifierFlags: [])
         XCTAssertTrue(searchField.waitForNonExistence(timeout: 5))
+        /// Every open connection lives in one window, so opening an object adds a tab rather than a
+        /// window, and the window retitles to the tab it selected. The strip stays hidden while the
+        /// connection holds a single tab, so the title is all there is to assert on here.
         let trackWindow = app.windows.matching(NSPredicate(format: "title BEGINSWITH %@", "Track")).firstMatch
         XCTAssertTrue(trackWindow.waitForExistence(timeout: 10))
+        XCTAssertEqual(app.windows.count, 1)
 
         app.typeKey("o", modifierFlags: [.command, .shift])
         XCTAssertTrue(searchField.waitForExistence(timeout: 5))
         app.typeKey("5", modifierFlags: .command)
         searchField.typeText("invoice")
+        /// The panel has to have ranked Invoice before Return is sent. A new query used to leave the
+        /// previously highlighted row selected whenever it still matched, and in this scope every
+        /// subtitle carries the connection path, so Return committed the row typed before it.
+        XCTAssertTrue(app.buttons["Invoice"].waitForExistence(timeout: 10))
         searchField.typeKey(.return, modifierFlags: .option)
         XCTAssertTrue(searchField.waitForNonExistence(timeout: 5))
-        let invoiceWindow = app.windows.matching(NSPredicate(format: "title BEGINSWITH %@", "Invoice")).firstMatch
-        XCTAssertTrue(invoiceWindow.waitForExistence(timeout: 10))
+        /// Option+Return opens beside the tab you were on instead of replacing it, which is the one
+        /// thing that separates it from a plain Return. The second tab is also what brings the strip
+        /// out of hiding, so both tabs are assertable from here and neither was before.
+        XCTAssertTrue(tab(in: app, named: "Invoice").waitForExistence(timeout: 10))
+        XCTAssertTrue(tab(in: app, named: "Track").exists)
+        XCTAssertEqual(app.windows.count, 1)
 
         app.typeKey("o", modifierFlags: [.command, .shift])
         XCTAssertTrue(searchField.waitForExistence(timeout: 5))
@@ -58,7 +70,7 @@ final class QuickSwitcherCrossConnectionUITests: UITestCase {
         XCTAssertTrue(searchField.waitForNonExistence(timeout: 5))
     }
 
-    func testQueriesScopeSearchesHistoryAndOpensANewWindowTab() throws {
+    func testQueriesScopeSearchesHistoryAndOpensANewTab() throws {
         let app = try launchWithSampleDatabase()
 
         app.typeKey("t", modifierFlags: .command)
@@ -96,6 +108,12 @@ final class QuickSwitcherCrossConnectionUITests: UITestCase {
             .matching(NSPredicate(format: "value CONTAINS %@", "cross_connection_probe"))
             .firstMatch
         XCTAssertTrue(openedEditor.waitForExistence(timeout: 10))
+    }
+
+    private func tab(in app: XCUIApplication, named name: String) -> XCUIElement {
+        app.buttons.matching(
+            NSPredicate(format: "identifier == %@ AND label BEGINSWITH %@", "editor-tab", name)
+        ).firstMatch
     }
 
     private func editorTextView(in app: XCUIApplication) -> XCUIElement {

--- a/TableProUITests/Support/UITestCase.swift
+++ b/TableProUITests/Support/UITestCase.swift
@@ -14,10 +14,12 @@ import XCTest
 internal class UITestCase: XCTestCase {
     private var sandboxRoot: URL?
     private var launchedApps: [XCUIApplication] = []
+    private var privacyAlertMonitor: (any NSObjectProtocol)?
 
     override internal func setUpWithError() throws {
         try super.setUpWithError()
         continueAfterFailure = false
+        privacyAlertMonitor = addPrivacyAlertMonitor()
 
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("TableProUITests", isDirectory: true)
@@ -43,7 +45,27 @@ internal class UITestCase: XCTestCase {
             removeDefaultsSuite(forSandboxAt: sandboxRoot)
         }
         sandboxRoot = nil
+        if let privacyAlertMonitor {
+            removeUIInterruptionMonitor(privacyAlertMonitor)
+        }
+        privacyAlertMonitor = nil
         try super.tearDownWithError()
+    }
+
+    /// macOS raises its local-network privacy alert over the app under test, and XCTest's built-in
+    /// handler misses it: that matcher keys on the wording "would like to find", which macOS 26
+    /// rewrote to "Allow ... to find devices on local networks?". Nothing dismissed it, so every
+    /// element lookup for the rest of the test paid a full interruption sweep, which cost one suite
+    /// ten minutes of a forty minute job. Matching on the buttons rather than the title keeps this
+    /// working through the next rewording. Nothing under test needs the local network.
+    private func addPrivacyAlertMonitor() -> any NSObjectProtocol {
+        addUIInterruptionMonitor(withDescription: "System privacy alert") { alert in
+            for label in ["Don't Allow", "Deny", "Allow"] where alert.buttons[label].exists {
+                alert.buttons[label].click()
+                return true
+            }
+            return false
+        }
     }
 
     /// A UI test that fails only on CI is undiagnosable from a log line: the assertion says what
@@ -72,14 +94,18 @@ internal class UITestCase: XCTestCase {
 
     /// The sample database is opened from the Help menu. Three suites used to reach for File, which
     /// has never carried this item, so they failed on any machine rather than flakily.
+    ///
+    /// Never click the parent menu first. `click()` on a menu item runs its own menu traversal and
+    /// opens the parent as part of it, so an already-open menu makes that traversal fail with "open
+    /// menu during menu traversal"; XCUITest then falls back to hovering and resolves the item to an
+    /// unhittable zero-size frame. That failed every suite this helper serves.
     @discardableResult
     internal func launchWithSampleDatabase() throws -> XCUIApplication {
         let app = try launchApp()
         let menuBar = app.menuBars.firstMatch
         XCTAssertTrue(menuBar.waitForExistence(timeout: 10))
-        menuBar.menuBarItems["Help"].click()
         let openSample = menuBar.menuItems["Open Sample Database"]
-        XCTAssertTrue(openSample.waitForExistence(timeout: 5))
+        XCTAssertTrue(openSample.waitForExistence(timeout: 10))
         openSample.click()
         return app
     }


### PR DESCRIPTION
Fixes the two UI tests that have been failing deterministically on CI. One of them was red because of a real app bug; the other because its premise died with #2097.

## The app bug: the Quick Switcher opened the wrong thing

`QuickSwitcherViewModel.reconcileSelection()` kept `selectedItemId` whenever the selected item survived the refilter, with no check that the query had changed. `bestMatch` falls back to the subtitle, and every Connections-scope subtitle carries the connection path, so a query matches most of the catalog through that path alone. The previously highlighted row therefore almost always survived: the ranked list reordered underneath it while the highlight stayed put, and `Return` committed a row the user had stopped searching for.

That is what the CI failure was. In the recording, the field reads `invoice`, the list ranks Invoice then InvoiceLine then Track, and the highlight is still on Track from the empty-query Recent section. Option+Return opened Track.

Reconciliation is now query-aware: a new query or scope moves the selection to the best match, an unprompted refilter keeps it. The second half matters as much as the first, since the catalog reloads underneath an open panel while connections are still connecting, and taking the user's arrow keys back to the top on every reload would make the panel unusable.

Two unit tests cover both directions. `newQueryMovesSelectionOffAStillMatchingRow` fails on the previous code, verified by reverting the fix and re-running. The existing `changingQuerySelectsBestMatch` passed vacuously: its fixture subtitle is short enough that the stale row drops out of the list, so reconciliation was never asked the hard question.

## The dead premise: tables no longer open in their own window

`testConnectionsScopeSearchesTheOpenSampleDatabase` asserted that opening an object produces a window titled after it. #2097 put every open connection in one window, and editor tabs are not windows. The element tree at failure shows exactly one window, titled `Track`, with no Invoice anywhere.

The surviving Track assertion had been passing for the wrong reason: the single window retitles itself to the selected tab, so a window-title check cannot tell "opened a tab" from "retitled the window we already had". That is precisely the Return versus Option+Return difference the test exists to cover.

Re-expressed against the editor tab strip, which needed an `editor-tab` accessibility identifier in source. The strip is deliberately hidden while a connection holds a single tab, so the tab assertions sit after Option+Return, where the second tab brings the strip out of hiding. Asserting that the Track tab survives alongside the new Invoice tab is strictly stronger than the old check.

## The other test: an untargetable locator

`QueryHistoryFocusUITests` addressed the drawer preview as `textViews.element(boundBy: 1)`. The preview is a real `NSTextView`, but a positional locator is not a contract, and on CI the element tree contained exactly one text view at the moment of failure.

`HighlightedSQLTextView` now names its text view. A SwiftUI `.accessibilityIdentifier` cannot reach the view behind an `NSViewRepresentable`, so it is set on the `NSTextView` through AppKit, the pattern `FieldDrivenList` already uses. That also means it does not collide with the `query-history-detail` identifier on the enclosing container, which stays exactly as it was.

## Harness

`launchWithSampleDatabase` clicked the Help menu open and then clicked the item inside it. `click()` on a menu item runs its own traversal and opens the parent as part of it, so the already-open menu made that traversal fail with "open menu during menu traversal"; XCUITest then fell back to hovering and resolved the item to an unhittable zero-size frame. That failed locally for every suite the helper serves.

Also added an interruption monitor for the macOS local-network privacy alert. XCTest's built-in handler misses it: that matcher keys on "would like to find", which macOS 26 rewrote to "Allow ... to find devices on local networks?". Nothing dismissed it, so every element lookup for the rest of the test paid a full interruption sweep, which cost one suite about ten minutes of a forty minute job. It caused neither failure, only time. Matching on the buttons rather than the title keeps it working through the next rewording.

## Verification

Unit tests, build and `swiftlint lint --strict` (0 violations) are green locally. Both target UI tests passed locally when run individually before local UI testing became unavailable: this machine now raises a LocalAuthentication prompt (`Failed to initialize for UI testing ... Authentication canceled`) that has to be approved interactively, so the CI run on this PR is the authoritative check for the UI suite.

A full local suite run earlier is not evidence of anything: it collapsed partway through with "Not authorized for performing UI testing actions", including in suites that touch none of this.

## Found but deliberately not fixed here

- Every history row reports the `Selected` accessibility trait, selected or not, so VoiceOver announces them all as selected. It comes from the SwiftUI-hosted row publishing a selection state it does not own. Fixing it touches `FieldDrivenList`, which the data grid also uses, and that is a bigger blast radius than this PR should carry.
- `Cmd+Y` reveals a list that declares `acceptsFocus: true` but never receives focus, which is the only reason the test needs a synthesized mouse click before it can arrow. Routing first responder into an AppKit table buried in SwiftUI is a real change, not a test fix.
- Option+Return does not force a new tab for a table that is already open: `EditorTabPayload` carries no force-new-tab field and `QueryTabManager.addTableTab` dedupes and reselects, which makes the documented behaviour false in that case. It does not affect this test, and changing the dedup also affects the sidebar's Open in New Tab.
- A "Publishing changes from within view updates" SwiftUI warning fires once per run under the first Cmd+T. Reproduces locally, cause not identified; two candidates were ruled out by measurement.
