### PR TITLE
fix(plugin-duckdb): render timestamp and nested column types the value API cannot decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- DuckDB `TIMESTAMP_S`, `TIMESTAMP_MS` and `TIMESTAMP_NS` columns showed `1970-01-01 00:00:00` on every row instead of the stored value. They now read exactly as the DuckDB CLI prints them, keeping sub-second digits. (#2130)
+- DuckDB `UUID`, `ENUM`, `BIT`, `LIST`, `STRUCT`, `MAP`, `ARRAY` and `UNION` columns showed an empty cell instead of their value. (#2130)
+- Querying two DuckDB tables that share a column name could repeat one table's value in both columns. (#2130)
+
 ## [0.65.0] - 2026-08-16
 
 ### Added

--- a/Plugins/DuckDBDriverPlugin/DuckDBConnection.swift
+++ b/Plugins/DuckDBDriverPlugin/DuckDBConnection.swift
@@ -71,28 +71,9 @@ actor DuckDBConnectionActor {
         }
 
         let startTime = Date()
-        var result = duckdb_result()
-
-        let state = duckdb_query(conn, query, &result)
-
-        if state == DuckDBError {
-            let errorMsg: String
-            if let errPtr = duckdb_result_error(&result) {
-                errorMsg = String(cString: errPtr)
-            } else {
-                errorMsg = "Unknown DuckDB error"
-            }
-            duckdb_destroy_result(&result)
-            throw DuckDBPluginError.queryFailed(errorMsg)
-        }
-
-        defer {
-            duckdb_destroy_result(&result)
-        }
-
-        var raw = Self.extractResult(from: &result, startTime: startTime)
-        Self.patchCastedColumns(&raw, query: query, connection: conn)
-        return raw
+        var resolved = try Self.resolvedResult(query: query, parameters: [], connection: conn)
+        defer { duckdb_destroy_result(&resolved.result) }
+        return Self.extractResult(from: &resolved.result, schema: resolved.schema, startTime: startTime)
     }
 
     func executePrepared(_ query: String, parameters: [PluginCellValue]) throws -> DuckDBRawResult {
@@ -101,70 +82,9 @@ actor DuckDBConnectionActor {
         }
 
         let startTime = Date()
-        var stmtOpt: duckdb_prepared_statement?
-
-        let prepState = duckdb_prepare(conn, query, &stmtOpt)
-        if prepState == DuckDBError {
-            let errorMsg: String
-            if let s = stmtOpt, let errPtr = duckdb_prepare_error(s) {
-                errorMsg = String(cString: errPtr)
-            } else {
-                errorMsg = "Failed to prepare statement"
-            }
-            duckdb_destroy_prepare(&stmtOpt)
-            throw DuckDBPluginError.queryFailed(errorMsg)
-        }
-
-        guard let stmt = stmtOpt else {
-            throw DuckDBPluginError.queryFailed("Failed to prepare statement")
-        }
-
-        defer {
-            duckdb_destroy_prepare(&stmtOpt)
-        }
-
-        for (index, param) in parameters.enumerated() {
-            let paramIdx = idx_t(index + 1)
-            let bindState: duckdb_state
-            switch param {
-            case .null:
-                bindState = duckdb_bind_null(stmt, paramIdx)
-            case .text(let value):
-                bindState = duckdb_bind_varchar(stmt, paramIdx, value)
-            case .bytes(let data):
-                bindState = data.withUnsafeBytes { rawBuffer -> duckdb_state in
-                    guard let baseAddress = rawBuffer.baseAddress else {
-                        return duckdb_bind_null(stmt, paramIdx)
-                    }
-                    return duckdb_bind_blob(stmt, paramIdx, baseAddress, idx_t(data.count))
-                }
-            }
-            if bindState == DuckDBError {
-                throw DuckDBPluginError.queryFailed("Failed to bind parameter at index \(index)")
-            }
-        }
-
-        var result = duckdb_result()
-        let execState = duckdb_execute_prepared(stmt, &result)
-
-        if execState == DuckDBError {
-            let errorMsg: String
-            if let errPtr = duckdb_result_error(&result) {
-                errorMsg = String(cString: errPtr)
-            } else {
-                errorMsg = "Failed to execute prepared statement"
-            }
-            duckdb_destroy_result(&result)
-            throw DuckDBPluginError.queryFailed(errorMsg)
-        }
-
-        defer {
-            duckdb_destroy_result(&result)
-        }
-
-        var raw = Self.extractResult(from: &result, startTime: startTime)
-        Self.patchCastedColumns(&raw, query: query, connection: conn)
-        return raw
+        var resolved = try Self.resolvedResult(query: query, parameters: parameters, connection: conn)
+        defer { duckdb_destroy_result(&resolved.result) }
+        return Self.extractResult(from: &resolved.result, schema: resolved.schema, startTime: startTime)
     }
 
     func streamQuery(
@@ -175,435 +95,372 @@ actor DuckDBConnectionActor {
             throw DuckDBPluginError.notConnected
         }
 
-        var result = duckdb_result()
-        let state = duckdb_query(conn, query, &result)
-
-        if state == DuckDBError {
-            let errorMsg: String
-            if let errPtr = duckdb_result_error(&result) {
-                errorMsg = String(cString: errPtr)
-            } else {
-                errorMsg = "Unknown DuckDB error"
-            }
-            duckdb_destroy_result(&result)
-            throw DuckDBPluginError.queryFailed(errorMsg)
-        }
-
-        let colCount = duckdb_column_count(&result)
-        var columns: [String] = []
-        var columnTypeNames: [String] = []
-        var columnTypes: [duckdb_type] = []
-        for i in 0..<colCount {
-            if let namePtr = duckdb_column_name(&result, i) {
-                columns.append(String(cString: namePtr))
-            } else {
-                columns.append("column_\(i)")
-            }
-            let colType = duckdb_column_type(&result, i)
-            columnTypes.append(colType)
-            columnTypeNames.append(Self.typeName(for: colType))
-        }
-
-        if columnTypes.contains(where: Self.requiresTextCast) {
-            duckdb_destroy_result(&result)
-            try Self.streamWrappedQuery(
-                query: query,
-                columns: columns,
-                columnTypeNames: columnTypeNames,
-                columnTypes: columnTypes,
-                connection: conn,
-                continuation: continuation
-            )
-            return
-        }
-
-        defer { duckdb_destroy_result(&result) }
-        try Self.streamResultRows(
-            &result,
-            columns: columns,
-            columnTypeNames: columnTypeNames,
-            continuation: continuation
-        )
+        var resolved = try Self.resolvedResult(query: query, parameters: [], connection: conn)
+        defer { duckdb_destroy_result(&resolved.result) }
+        try Self.streamResultRows(&resolved.result, schema: resolved.schema, continuation: continuation)
     }
 
-    private static func streamWrappedQuery(
-        query: String,
-        columns: [String],
-        columnTypeNames: [String],
-        columnTypes: [duckdb_type],
-        connection: duckdb_connection,
-        continuation: AsyncThrowingStream<PluginStreamElement, Error>.Continuation
-    ) throws {
-        let castExprs = columns.enumerated().map { i, name in
-            projection(for: columnTypes[i], column: name)
+    // MARK: - Projection planning
+
+    private enum ResultProjection {
+        case unprojected
+        case projected(sql: String, schema: ColumnSchema)
+        case deferred
+    }
+
+    private static func resolvedResult(
+        query: String, parameters: [PluginCellValue], connection: duckdb_connection
+    ) throws -> (result: duckdb_result, schema: ColumnSchema) {
+        var statement: duckdb_prepared_statement?
+        let projection = resolveProjection(query: query, connection: connection, statement: &statement)
+        defer { duckdb_destroy_prepare(&statement) }
+
+        if case .projected(let sql, let schema) = projection,
+           let projected = projectedResult(sql: sql, schema: schema, parameters: parameters, on: connection) {
+            return (projected, schema)
         }
-        let wrappedQuery = buildWrappedQuery(originalQuery: query, castExprs: castExprs)
+
+        var result = try runStatement(statement, query: query, parameters: parameters, on: connection)
+        let schema = self.schema(of: &result)
+
+        guard let sql = deferredProjection(query: query, schema: schema, projection: projection),
+              let projected = projectedResult(sql: sql, schema: schema, parameters: parameters, on: connection)
+        else {
+            return (result, schema)
+        }
+
+        duckdb_destroy_result(&result)
+        return (projected, schema)
+    }
+
+    private static func projectedResult(
+        sql: String, schema: ColumnSchema, parameters: [PluginCellValue], on connection: duckdb_connection
+    ) -> duckdb_result? {
+        guard var projected = try? runPrepared(sql, parameters: parameters, on: connection) else {
+            logger.warning("DuckDB could not read a result through a text projection, using the raw result")
+            return nil
+        }
+        guard duckdb_column_count(&projected) == idx_t(schema.names.count) else {
+            logger.warning("DuckDB text projection returned an unexpected column count, using the raw result")
+            duckdb_destroy_result(&projected)
+            return nil
+        }
+        return projected
+    }
+
+    private static func resolveProjection(
+        query: String, connection: duckdb_connection, statement: inout duckdb_prepared_statement?
+    ) -> ResultProjection {
+        let state = duckdb_prepare(connection, query, &statement)
+
+        guard state != DuckDBError, let stmt = statement else { return .unprojected }
+        guard duckdb_prepared_statement_type(stmt) == DUCKDB_STATEMENT_TYPE_SELECT else { return .unprojected }
+
+        let columnCount = duckdb_prepared_statement_column_count(stmt)
+        guard columnCount > 0 else { return .unprojected }
+
+        var names: [String] = []
+        var logicalTypes: [DuckDBLogicalType?] = []
+        for index in 0..<columnCount {
+            let rawType = duckdb_prepared_statement_column_type(stmt, index)
+            guard rawType != DUCKDB_TYPE_INVALID else { return .deferred }
+            names.append(preparedColumnName(stmt, at: index))
+            logicalTypes.append(logicalType(for: rawType))
+        }
+
+        let schema = ColumnSchema(names: names, logicalTypes: logicalTypes)
+        guard DuckDBLogicalType.requiresTextProjection(anyOf: logicalTypes) else { return .unprojected }
+        guard let sql = DuckDBProjectedQuery.build(originalQuery: query, columns: schema.projectionColumns) else {
+            return .deferred
+        }
+        return .projected(sql: sql, schema: schema)
+    }
+
+    private static func deferredProjection(
+        query: String, schema: ColumnSchema, projection: ResultProjection
+    ) -> String? {
+        guard case .deferred = projection else { return nil }
+        guard DuckDBLogicalType.requiresTextProjection(anyOf: schema.logicalTypes) else { return nil }
+        return DuckDBProjectedQuery.build(originalQuery: query, columns: schema.projectionColumns)
+    }
+
+    private static func preparedColumnName(_ stmt: duckdb_prepared_statement, at index: idx_t) -> String {
+        guard let pointer = duckdb_prepared_statement_column_name(stmt, index) else { return "column_\(index)" }
+        let name = String(cString: pointer)
+        duckdb_free(UnsafeMutableRawPointer(mutating: pointer))
+        return name
+    }
+
+    // MARK: - Execution
+
+    private static func runStatement(
+        _ statement: duckdb_prepared_statement?,
+        query: String,
+        parameters: [PluginCellValue],
+        on connection: duckdb_connection
+    ) throws -> duckdb_result {
+        guard let statement else {
+            guard parameters.isEmpty else { return try runPrepared(query, parameters: parameters, on: connection) }
+            return try runQuery(query, on: connection)
+        }
+
+        try bind(parameters, to: statement)
 
         var result = duckdb_result()
-        let state = duckdb_query(connection, wrappedQuery, &result)
-        if state == DuckDBError {
-            let errorMsg: String
-            if let errPtr = duckdb_result_error(&result) {
-                errorMsg = String(cString: errPtr)
-            } else {
-                errorMsg = "Unknown DuckDB error"
-            }
+        guard duckdb_execute_prepared(statement, &result) != DuckDBError else {
+            let message = errorMessage(from: &result)
             duckdb_destroy_result(&result)
-            throw DuckDBPluginError.queryFailed(errorMsg)
+            throw DuckDBPluginError.queryFailed(message)
         }
-        defer { duckdb_destroy_result(&result) }
+        return result
+    }
 
-        try Self.streamResultRows(
-            &result,
-            columns: columns,
-            columnTypeNames: columnTypeNames,
-            continuation: continuation
+    private static func runQuery(_ sql: String, on connection: duckdb_connection) throws -> duckdb_result {
+        var result = duckdb_result()
+        guard duckdb_query(connection, sql, &result) != DuckDBError else {
+            let message = errorMessage(from: &result)
+            duckdb_destroy_result(&result)
+            throw DuckDBPluginError.queryFailed(message)
+        }
+        return result
+    }
+
+    private static func runPrepared(
+        _ sql: String, parameters: [PluginCellValue], on connection: duckdb_connection
+    ) throws -> duckdb_result {
+        var stmtOpt: duckdb_prepared_statement?
+        let prepareState = duckdb_prepare(connection, sql, &stmtOpt)
+        defer { duckdb_destroy_prepare(&stmtOpt) }
+
+        guard prepareState != DuckDBError, let stmt = stmtOpt else {
+            var message = "Failed to prepare statement"
+            if let failed = stmtOpt, let pointer = duckdb_prepare_error(failed) {
+                message = String(cString: pointer)
+            }
+            throw DuckDBPluginError.queryFailed(message)
+        }
+
+        try bind(parameters, to: stmt)
+
+        var result = duckdb_result()
+        guard duckdb_execute_prepared(stmt, &result) != DuckDBError else {
+            let message = errorMessage(from: &result)
+            duckdb_destroy_result(&result)
+            throw DuckDBPluginError.queryFailed(message)
+        }
+        return result
+    }
+
+    private static func bind(_ parameters: [PluginCellValue], to stmt: duckdb_prepared_statement) throws {
+        for (index, parameter) in parameters.enumerated() {
+            let position = idx_t(index + 1)
+            let state: duckdb_state
+            switch parameter {
+            case .null:
+                state = duckdb_bind_null(stmt, position)
+            case .text(let value):
+                state = duckdb_bind_varchar(stmt, position, value)
+            case .bytes(let data):
+                state = data.withUnsafeBytes { buffer -> duckdb_state in
+                    guard let baseAddress = buffer.baseAddress else {
+                        return duckdb_bind_null(stmt, position)
+                    }
+                    return duckdb_bind_blob(stmt, position, baseAddress, idx_t(data.count))
+                }
+            }
+            if state == DuckDBError {
+                throw DuckDBPluginError.queryFailed("Failed to bind parameter at index \(index)")
+            }
+        }
+    }
+
+    private static func errorMessage(from result: inout duckdb_result) -> String {
+        guard let pointer = duckdb_result_error(&result) else { return "Unknown DuckDB error" }
+        return String(cString: pointer)
+    }
+
+    // MARK: - Extraction
+
+    private struct ColumnSchema {
+        let names: [String]
+        let logicalTypes: [DuckDBLogicalType?]
+
+        var typeNames: [String] {
+            logicalTypes.map { $0?.displayName ?? DuckDBLogicalType.varchar.displayName }
+        }
+
+        var projectionColumns: [(name: String, type: DuckDBLogicalType?)] {
+            Array(zip(names, logicalTypes)).map { (name: $0.0, type: $0.1) }
+        }
+    }
+
+    private static func schema(of result: inout duckdb_result) -> ColumnSchema {
+        let columnCount = duckdb_column_count(&result)
+        var names: [String] = []
+        var logicalTypes: [DuckDBLogicalType?] = []
+
+        for index in 0..<columnCount {
+            if let pointer = duckdb_column_name(&result, index) {
+                names.append(String(cString: pointer))
+            } else {
+                names.append("column_\(index)")
+            }
+            logicalTypes.append(logicalType(for: duckdb_column_type(&result, index)))
+        }
+
+        return ColumnSchema(names: names, logicalTypes: logicalTypes)
+    }
+
+    private static func extractResult(
+        from result: inout duckdb_result,
+        schema: ColumnSchema,
+        startTime: Date
+    ) -> DuckDBRawResult {
+        let rowCount = duckdb_row_count(&result)
+        let rowsChanged = duckdb_rows_changed(&result)
+        let resultTypes = storageTypes(of: &result)
+
+        let maxRows = min(rowCount, UInt64(PluginRowLimits.emergencyMax))
+        var rows: [[PluginCellValue]] = []
+        rows.reserveCapacity(Int(maxRows))
+        var undecodableColumns: Set<idx_t> = []
+
+        for row in 0..<maxRows {
+            rows.append(extractRow(
+                from: &result, row: row, resultTypes: resultTypes, undecodableColumns: &undecodableColumns
+            ))
+        }
+
+        return DuckDBRawResult(
+            columns: schema.names,
+            columnTypeNames: schema.typeNames,
+            rows: rows,
+            rowsAffected: Int(rowsChanged),
+            executionTime: Date().timeIntervalSince(startTime),
+            isTruncated: rowCount > UInt64(PluginRowLimits.emergencyMax)
         )
     }
 
     private static func streamResultRows(
         _ result: inout duckdb_result,
-        columns: [String],
-        columnTypeNames: [String],
+        schema: ColumnSchema,
         continuation: AsyncThrowingStream<PluginStreamElement, Error>.Continuation
     ) throws {
-        let colCount = duckdb_column_count(&result)
         let rowCount = duckdb_row_count(&result)
+        let resultTypes = storageTypes(of: &result)
 
         continuation.yield(.header(PluginStreamHeader(
-            columns: columns,
-            columnTypeNames: columnTypeNames,
+            columns: schema.names,
+            columnTypeNames: schema.typeNames,
             estimatedRowCount: Int(rowCount)
         )))
 
         let maxRows = min(rowCount, UInt64(PluginRowLimits.emergencyMax))
         if rowCount > UInt64(PluginRowLimits.emergencyMax) {
-            Self.logger.warning("streamQuery truncating result from \(rowCount) to \(maxRows) rows")
+            logger.warning("streamQuery truncating result from \(rowCount) to \(maxRows) rows")
         }
 
+        var undecodableColumns: Set<idx_t> = []
         for row in 0..<maxRows {
             if Task.isCancelled {
                 continuation.finish(throwing: CancellationError())
                 return
             }
-
-            var rowData: [PluginCellValue] = []
-            for col in 0..<colCount {
-                let colType = duckdb_column_type(&result, col)
-                if duckdb_value_is_null(&result, col, row) {
-                    rowData.append(.null)
-                } else if colType == DUCKDB_TYPE_BLOB {
-                    let blob = duckdb_value_blob(&result, col, row)
-                    if let ptr = blob.data {
-                        rowData.append(.bytes(Data(bytes: ptr, count: Int(blob.size))))
-                    } else {
-                        rowData.append(.bytes(Data()))
-                    }
-                    duckdb_free(blob.data)
-                } else if let valPtr = duckdb_value_varchar(&result, col, row) {
-                    rowData.append(.text(String(cString: valPtr)))
-                    duckdb_free(valPtr)
-                } else {
-                    rowData.append(PluginCellValue.fromOptional(
-                        Self.extractFallbackValue(&result, col: col, row: row, type: colType)
-                    ))
-                }
-            }
-
-            continuation.yield(.rows([rowData]))
+            continuation.yield(.rows([extractRow(
+                from: &result, row: row, resultTypes: resultTypes, undecodableColumns: &undecodableColumns
+            )]))
         }
 
         continuation.finish()
     }
 
-    private static func extractResult(
+    private static func storageTypes(of result: inout duckdb_result) -> [duckdb_type] {
+        (0..<duckdb_column_count(&result)).map { duckdb_column_type(&result, $0) }
+    }
+
+    private static func extractRow(
         from result: inout duckdb_result,
-        startTime: Date
-    ) -> DuckDBRawResult {
-        let colCount = duckdb_column_count(&result)
-        let rowCount = duckdb_row_count(&result)
-        let rowsChanged = duckdb_rows_changed(&result)
+        row: idx_t,
+        resultTypes: [duckdb_type],
+        undecodableColumns: inout Set<idx_t>
+    ) -> [PluginCellValue] {
+        var rowData: [PluginCellValue] = []
+        rowData.reserveCapacity(resultTypes.count)
 
-        var columns: [String] = []
-        var columnTypeNames: [String] = []
-        var columnTypes: [duckdb_type] = []
-
-        for i in 0..<colCount {
-            if let namePtr = duckdb_column_name(&result, i) {
-                columns.append(String(cString: namePtr))
-            } else {
-                columns.append("column_\(i)")
-            }
-
-            let colType = duckdb_column_type(&result, i)
-            columnTypes.append(colType)
-            columnTypeNames.append(Self.typeName(for: colType))
-        }
-
-        var rows: [[PluginCellValue]] = []
-        var truncated = false
-
-        let maxRows = min(rowCount, UInt64(PluginRowLimits.emergencyMax))
-        if rowCount > UInt64(PluginRowLimits.emergencyMax) {
-            truncated = true
-        }
-
-        for row in 0..<maxRows {
-            var rowData: [PluginCellValue] = []
-
-            for col in 0..<colCount {
-                let colType = columnTypes[Int(col)]
-                if duckdb_value_is_null(&result, col, row) {
-                    rowData.append(.null)
-                } else if colType == DUCKDB_TYPE_BLOB {
-                    let blob = duckdb_value_blob(&result, col, row)
-                    if let ptr = blob.data {
-                        rowData.append(.bytes(Data(bytes: ptr, count: Int(blob.size))))
-                    } else {
-                        rowData.append(.bytes(Data()))
-                    }
-                    duckdb_free(blob.data)
-                } else if let valPtr = duckdb_value_varchar(&result, col, row) {
-                    rowData.append(.text(String(cString: valPtr)))
-                    duckdb_free(valPtr)
+        for (index, columnType) in resultTypes.enumerated() {
+            let column = idx_t(index)
+            if duckdb_value_is_null(&result, column, row) {
+                rowData.append(.null)
+            } else if columnType == DUCKDB_TYPE_BLOB {
+                let blob = duckdb_value_blob(&result, column, row)
+                if let pointer = blob.data {
+                    rowData.append(.bytes(Data(bytes: pointer, count: Int(blob.size))))
                 } else {
-                    rowData.append(PluginCellValue.fromOptional(
-                        Self.extractFallbackValue(&result, col: col, row: row, type: colType)
-                    ))
+                    rowData.append(.bytes(Data()))
                 }
-            }
-
-            rows.append(rowData)
-        }
-
-        let executionTime = Date().timeIntervalSince(startTime)
-
-        return DuckDBRawResult(
-            columns: columns,
-            columnTypeNames: columnTypeNames,
-            columnTypes: columnTypes,
-            rows: rows,
-            rowsAffected: Int(rowsChanged),
-            executionTime: executionTime,
-            isTruncated: truncated
-        )
-    }
-
-    private static func typeName(for type: duckdb_type) -> String {
-        switch type {
-        case DUCKDB_TYPE_BOOLEAN: return "BOOLEAN"
-        case DUCKDB_TYPE_TINYINT: return "TINYINT"
-        case DUCKDB_TYPE_SMALLINT: return "SMALLINT"
-        case DUCKDB_TYPE_INTEGER: return "INTEGER"
-        case DUCKDB_TYPE_BIGINT: return "BIGINT"
-        case DUCKDB_TYPE_UTINYINT: return "UTINYINT"
-        case DUCKDB_TYPE_USMALLINT: return "USMALLINT"
-        case DUCKDB_TYPE_UINTEGER: return "UINTEGER"
-        case DUCKDB_TYPE_UBIGINT: return "UBIGINT"
-        case DUCKDB_TYPE_FLOAT: return "FLOAT"
-        case DUCKDB_TYPE_DOUBLE: return "DOUBLE"
-        case DUCKDB_TYPE_TIMESTAMP: return "TIMESTAMP"
-        case DUCKDB_TYPE_DATE: return "DATE"
-        case DUCKDB_TYPE_TIME: return "TIME"
-        case DUCKDB_TYPE_INTERVAL: return "INTERVAL"
-        case DUCKDB_TYPE_HUGEINT: return "HUGEINT"
-        case DUCKDB_TYPE_VARCHAR: return "VARCHAR"
-        case DUCKDB_TYPE_BLOB: return "BLOB"
-        case DUCKDB_TYPE_DECIMAL: return "DECIMAL"
-        case DUCKDB_TYPE_TIMESTAMP_S: return "TIMESTAMP_S"
-        case DUCKDB_TYPE_TIMESTAMP_MS: return "TIMESTAMP_MS"
-        case DUCKDB_TYPE_TIMESTAMP_NS: return "TIMESTAMP_NS"
-        case DUCKDB_TYPE_ENUM: return "ENUM"
-        case DUCKDB_TYPE_LIST: return "LIST"
-        case DUCKDB_TYPE_STRUCT: return "STRUCT"
-        case DUCKDB_TYPE_MAP: return "MAP"
-        case DUCKDB_TYPE_UUID: return "UUID"
-        case DUCKDB_TYPE_UNION: return "UNION"
-        case DUCKDB_TYPE_BIT: return "BIT"
-        case DUCKDB_TYPE_TIMESTAMP_TZ: return "TIMESTAMPTZ"
-        case DUCKDB_TYPE_TIME_TZ: return "TIMETZ"
-        case DUCKDB_TYPE_TIME_NS: return "TIME_NS"
-        case DUCKDB_TYPE_UHUGEINT: return "UHUGEINT"
-        case DUCKDB_TYPE_ARRAY: return "ARRAY"
-        case DUCKDB_TYPE_GEOMETRY: return "GEOMETRY"
-        default: return "VARCHAR"
-        }
-    }
-
-    private static func extractFallbackValue(
-        _ result: inout duckdb_result, col: idx_t, row: idx_t, type: duckdb_type
-    ) -> String? {
-        switch type {
-        case DUCKDB_TYPE_TIMESTAMP, DUCKDB_TYPE_TIMESTAMP_S, DUCKDB_TYPE_TIMESTAMP_MS, DUCKDB_TYPE_TIMESTAMP_NS:
-            let ts = duckdb_value_timestamp(&result, col, row)
-            return formatTimestamp(ts)
-
-        case DUCKDB_TYPE_DATE:
-            let date = duckdb_value_date(&result, col, row)
-            let d = duckdb_from_date(date)
-            return String(format: "\(formatYearISO(d.year))-%02d-%02d", d.month, d.day)
-
-        case DUCKDB_TYPE_TIME, DUCKDB_TYPE_TIME_NS:
-            let time = duckdb_value_time(&result, col, row)
-            return formatTime(duckdb_from_time(time))
-
-        case DUCKDB_TYPE_BOOLEAN:
-            return duckdb_value_boolean(&result, col, row) ? "true" : "false"
-
-        case DUCKDB_TYPE_TINYINT:
-            return String(duckdb_value_int8(&result, col, row))
-        case DUCKDB_TYPE_SMALLINT:
-            return String(duckdb_value_int16(&result, col, row))
-        case DUCKDB_TYPE_INTEGER:
-            return String(duckdb_value_int32(&result, col, row))
-        case DUCKDB_TYPE_BIGINT:
-            return String(duckdb_value_int64(&result, col, row))
-        case DUCKDB_TYPE_UTINYINT:
-            return String(duckdb_value_uint8(&result, col, row))
-        case DUCKDB_TYPE_USMALLINT:
-            return String(duckdb_value_uint16(&result, col, row))
-        case DUCKDB_TYPE_UINTEGER:
-            return String(duckdb_value_uint32(&result, col, row))
-        case DUCKDB_TYPE_UBIGINT:
-            return String(duckdb_value_uint64(&result, col, row))
-        case DUCKDB_TYPE_FLOAT:
-            return String(duckdb_value_float(&result, col, row))
-        case DUCKDB_TYPE_DOUBLE:
-            return String(duckdb_value_double(&result, col, row))
-
-        case DUCKDB_TYPE_HUGEINT:
-            let h = duckdb_value_hugeint(&result, col, row)
-            return formatHugeInt(upper: h.upper, lower: h.lower)
-
-        case DUCKDB_TYPE_UHUGEINT:
-            let u = duckdb_value_uhugeint(&result, col, row)
-            return formatUHugeInt(upper: u.upper, lower: u.lower)
-
-        default:
-            return nil
-        }
-    }
-
-    static func patchCastedColumns(
-        _ raw: inout DuckDBRawResult, query: String, connection: duckdb_connection
-    ) {
-        let patchedColIndices = raw.columnTypes.enumerated().compactMap { idx, type in
-            requiresTextCast(type) ? idx : nil
-        }
-        guard !patchedColIndices.isEmpty, !raw.rows.isEmpty else { return }
-
-        let castExprs = raw.columns.enumerated().map { i, name in
-            projection(for: raw.columnTypes[i], column: name)
-        }
-        let wrappedQuery = buildWrappedQuery(originalQuery: query, castExprs: castExprs)
-
-        var patchResult = duckdb_result()
-        guard duckdb_query(connection, wrappedQuery, &patchResult) == DuckDBSuccess else { return }
-        defer { duckdb_destroy_result(&patchResult) }
-
-        let patchRowCount = min(duckdb_row_count(&patchResult), UInt64(raw.rows.count))
-        for row in 0..<patchRowCount {
-            for colIdx in patchedColIndices {
-                if duckdb_value_is_null(&patchResult, idx_t(colIdx), row) {
-                    raw.rows[Int(row)][colIdx] = .null
-                } else if let ptr = duckdb_value_varchar(&patchResult, idx_t(colIdx), row) {
-                    raw.rows[Int(row)][colIdx] = .text(String(cString: ptr))
-                    duckdb_free(ptr)
+                duckdb_free(blob.data)
+            } else if let pointer = duckdb_value_varchar(&result, column, row) {
+                rowData.append(.text(String(cString: pointer)))
+                duckdb_free(pointer)
+            } else {
+                if undecodableColumns.insert(column).inserted {
+                    logger.warning(
+                        "DuckDB value API cannot render column \(column) of type id \(columnType.rawValue)"
+                    )
                 }
+                rowData.append(.null)
             }
         }
+
+        return rowData
     }
 
-    static func isNativelyRenderable(_ type: duckdb_type) -> Bool {
+    static func logicalType(for type: duckdb_type) -> DuckDBLogicalType? {
         switch type {
-        case DUCKDB_TYPE_BOOLEAN,
-             DUCKDB_TYPE_TINYINT, DUCKDB_TYPE_SMALLINT, DUCKDB_TYPE_INTEGER, DUCKDB_TYPE_BIGINT, DUCKDB_TYPE_HUGEINT,
-             DUCKDB_TYPE_UTINYINT, DUCKDB_TYPE_USMALLINT, DUCKDB_TYPE_UINTEGER, DUCKDB_TYPE_UBIGINT, DUCKDB_TYPE_UHUGEINT,
-             DUCKDB_TYPE_FLOAT, DUCKDB_TYPE_DOUBLE, DUCKDB_TYPE_DECIMAL,
-             DUCKDB_TYPE_VARCHAR, DUCKDB_TYPE_BLOB, DUCKDB_TYPE_UUID, DUCKDB_TYPE_BIT, DUCKDB_TYPE_ENUM,
-             DUCKDB_TYPE_DATE, DUCKDB_TYPE_TIME, DUCKDB_TYPE_TIME_NS, DUCKDB_TYPE_INTERVAL,
-             DUCKDB_TYPE_TIMESTAMP, DUCKDB_TYPE_TIMESTAMP_S, DUCKDB_TYPE_TIMESTAMP_MS, DUCKDB_TYPE_TIMESTAMP_NS,
-             DUCKDB_TYPE_LIST, DUCKDB_TYPE_STRUCT, DUCKDB_TYPE_MAP, DUCKDB_TYPE_ARRAY, DUCKDB_TYPE_UNION:
-            return true
-        default:
-            return false
+        case DUCKDB_TYPE_BOOLEAN: return .boolean
+        case DUCKDB_TYPE_TINYINT: return .tinyint
+        case DUCKDB_TYPE_SMALLINT: return .smallint
+        case DUCKDB_TYPE_INTEGER: return .integer
+        case DUCKDB_TYPE_BIGINT: return .bigint
+        case DUCKDB_TYPE_UTINYINT: return .utinyint
+        case DUCKDB_TYPE_USMALLINT: return .usmallint
+        case DUCKDB_TYPE_UINTEGER: return .uinteger
+        case DUCKDB_TYPE_UBIGINT: return .ubigint
+        case DUCKDB_TYPE_FLOAT: return .float
+        case DUCKDB_TYPE_DOUBLE: return .double
+        case DUCKDB_TYPE_DECIMAL: return .decimal
+        case DUCKDB_TYPE_HUGEINT: return .hugeint
+        case DUCKDB_TYPE_UHUGEINT: return .uhugeint
+        case DUCKDB_TYPE_VARCHAR: return .varchar
+        case DUCKDB_TYPE_BLOB: return .blob
+        case DUCKDB_TYPE_DATE: return .date
+        case DUCKDB_TYPE_TIME: return .time
+        case DUCKDB_TYPE_TIME_NS: return .timeNs
+        case DUCKDB_TYPE_INTERVAL: return .interval
+        case DUCKDB_TYPE_TIMESTAMP: return .timestamp
+        case DUCKDB_TYPE_TIMESTAMP_S: return .timestampSeconds
+        case DUCKDB_TYPE_TIMESTAMP_MS: return .timestampMilliseconds
+        case DUCKDB_TYPE_TIMESTAMP_NS: return .timestampNanoseconds
+        case DUCKDB_TYPE_TIMESTAMP_TZ: return .timestampTz
+        case DUCKDB_TYPE_TIME_TZ: return .timeTz
+        case DUCKDB_TYPE_BIT: return .bit
+        case DUCKDB_TYPE_UUID: return .uuid
+        case DUCKDB_TYPE_ENUM: return .enumeration
+        case DUCKDB_TYPE_LIST: return .list
+        case DUCKDB_TYPE_ARRAY: return .array
+        case DUCKDB_TYPE_STRUCT: return .structure
+        case DUCKDB_TYPE_MAP: return .map
+        case DUCKDB_TYPE_UNION: return .union
+        case DUCKDB_TYPE_BIGNUM: return .bignum
+        case DUCKDB_TYPE_GEOMETRY: return .geometry
+        default: return nil
         }
-    }
-
-    static func requiresTextCast(_ type: duckdb_type) -> Bool {
-        !isNativelyRenderable(type)
-    }
-
-    static func castExpression(for type: duckdb_type, column: String) -> String {
-        let quoted = quoteIdentifier(column)
-        if type == DUCKDB_TYPE_GEOMETRY {
-            return "CASE WHEN \(quoted) IS NULL THEN NULL ELSE ST_AsText(\(quoted)) END AS \(quoted)"
-        }
-        return "CASE WHEN \(quoted) IS NULL THEN NULL ELSE CAST(\(quoted) AS VARCHAR) END AS \(quoted)"
-    }
-
-    static func projection(for type: duckdb_type, column: String) -> String {
-        requiresTextCast(type) ? castExpression(for: type, column: column) : quoteIdentifier(column)
-    }
-
-    static func buildWrappedQuery(originalQuery: String, castExprs: [String]) -> String {
-        var trimmed = originalQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.hasSuffix(";") {
-            trimmed = String(trimmed.dropLast())
-        }
-        return "SELECT \(castExprs.joined(separator: ", ")) FROM (\(trimmed)) AS _tp_cast"
-    }
-
-    static func quoteIdentifier(_ ident: String) -> String {
-        "\"\(ident.replacingOccurrences(of: "\"", with: "\"\""))\""
-    }
-
-    static func formatTimestamp(_ ts: duckdb_timestamp) -> String {
-        let parts = duckdb_from_timestamp(ts)
-        let d = parts.date
-        let t = parts.time
-        let micros = t.micros % 1_000_000
-        let yearPart = formatYearISO(d.year)
-        if micros == 0 {
-            return String(
-                format: "\(yearPart)-%02d-%02d %02d:%02d:%02d",
-                d.month, d.day, t.hour, t.min, t.sec
-            )
-        }
-        return String(
-            format: "\(yearPart)-%02d-%02d %02d:%02d:%02d.%06d",
-            d.month, d.day, t.hour, t.min, t.sec, micros
-        )
-    }
-
-    static func formatYearISO(_ year: Int32) -> String {
-        if year < 0 {
-            return String(format: "-%04d", -Int(year))
-        }
-        return String(format: "%04d", year)
-    }
-
-    private static func formatTime(_ t: duckdb_time_struct) -> String {
-        let micros = t.micros % 1_000_000
-        if micros == 0 {
-            return String(format: "%02d:%02d:%02d", t.hour, t.min, t.sec)
-        }
-        return String(format: "%02d:%02d:%02d.%06d", t.hour, t.min, t.sec, micros)
-    }
-
-    static func formatHugeInt(upper: Int64, lower: UInt64) -> String {
-        HugeIntFormatter.format(upper: upper, lower: lower)
-    }
-
-    static func formatUHugeInt(upper: UInt64, lower: UInt64) -> String {
-        HugeIntFormatter.formatUnsigned(upper: upper, lower: lower)
     }
 }
 
 struct DuckDBRawResult: @unchecked Sendable {
     let columns: [String]
     let columnTypeNames: [String]
-    let columnTypes: [duckdb_type]
     var rows: [[PluginCellValue]]
     let rowsAffected: Int
     let executionTime: TimeInterval

--- a/Plugins/DuckDBDriverPlugin/DuckDBTypeRendering.swift
+++ b/Plugins/DuckDBDriverPlugin/DuckDBTypeRendering.swift
@@ -1,0 +1,116 @@
+//
+//  DuckDBTypeRendering.swift
+//  DuckDBDriverPlugin
+//
+
+import Foundation
+
+enum DuckDBLogicalType: String, CaseIterable, Sendable {
+    case boolean = "BOOLEAN"
+    case tinyint = "TINYINT"
+    case smallint = "SMALLINT"
+    case integer = "INTEGER"
+    case bigint = "BIGINT"
+    case utinyint = "UTINYINT"
+    case usmallint = "USMALLINT"
+    case uinteger = "UINTEGER"
+    case ubigint = "UBIGINT"
+    case float = "FLOAT"
+    case double = "DOUBLE"
+    case decimal = "DECIMAL"
+    case hugeint = "HUGEINT"
+    case uhugeint = "UHUGEINT"
+    case varchar = "VARCHAR"
+    case blob = "BLOB"
+    case date = "DATE"
+    case time = "TIME"
+    case timeNs = "TIME_NS"
+    case interval = "INTERVAL"
+    case timestamp = "TIMESTAMP"
+    case timestampSeconds = "TIMESTAMP_S"
+    case timestampMilliseconds = "TIMESTAMP_MS"
+    case timestampNanoseconds = "TIMESTAMP_NS"
+    case timestampTz = "TIMESTAMPTZ"
+    case timeTz = "TIMETZ"
+    case bit = "BIT"
+    case uuid = "UUID"
+    case enumeration = "ENUM"
+    case list = "LIST"
+    case array = "ARRAY"
+    case structure = "STRUCT"
+    case map = "MAP"
+    case union = "UNION"
+    case bignum = "BIGNUM"
+    case geometry = "GEOMETRY"
+
+    var displayName: String { rawValue }
+}
+
+extension DuckDBLogicalType {
+    static let typesTheValueAPICannotRender: Set<DuckDBLogicalType> = [
+        .timestampSeconds,
+        .timestampMilliseconds,
+        .timestampNanoseconds,
+        .timestampTz,
+        .timeTz,
+        .bit,
+        .uuid,
+        .enumeration,
+        .list,
+        .array,
+        .structure,
+        .map,
+        .union,
+        .bignum,
+        .geometry,
+    ]
+
+    var isRenderedByValueAPI: Bool {
+        !Self.typesTheValueAPICannotRender.contains(self)
+    }
+
+    static func requiresTextProjection(_ type: DuckDBLogicalType?) -> Bool {
+        guard let type else { return true }
+        return !type.isRenderedByValueAPI
+    }
+
+    static func requiresTextProjection(anyOf types: [DuckDBLogicalType?]) -> Bool {
+        types.contains { requiresTextProjection($0) }
+    }
+}
+
+enum DuckDBProjectedQuery {
+    static let subqueryAlias = "_tp_cast"
+
+    static func sourceAlias(at index: Int) -> String {
+        "c\(index + 1)"
+    }
+
+    static func quoteIdentifier(_ name: String) -> String {
+        "\"\(name.replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
+
+    static func projection(for type: DuckDBLogicalType?, at index: Int, column: String) -> String {
+        let source = sourceAlias(at: index)
+        let alias = quoteIdentifier(column)
+        guard DuckDBLogicalType.requiresTextProjection(type) else {
+            return "\(source) AS \(alias)"
+        }
+        let rendered = type == .geometry ? "ST_AsText(\(source))" : "CAST(\(source) AS VARCHAR)"
+        return "CASE WHEN \(source) IS NULL THEN NULL ELSE \(rendered) END AS \(alias)"
+    }
+
+    static func build(originalQuery: String, columns: [(name: String, type: DuckDBLogicalType?)]) -> String? {
+        guard !columns.isEmpty else { return nil }
+        var inner = originalQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        if inner.hasSuffix(";") {
+            inner = String(inner.dropLast()).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        guard !inner.isEmpty else { return nil }
+        let projections = columns.enumerated()
+            .map { projection(for: $0.element.type, at: $0.offset, column: $0.element.name) }
+            .joined(separator: ", ")
+        let aliases = columns.indices.map(sourceAlias(at:)).joined(separator: ", ")
+        return "SELECT \(projections) FROM (\(inner)\n) AS \(subqueryAlias)(\(aliases))"
+    }
+}

--- a/TableProTests/Plugins/DuckDBTypeRenderingTests.swift
+++ b/TableProTests/Plugins/DuckDBTypeRenderingTests.swift
@@ -1,0 +1,158 @@
+//
+//  DuckDBTypeRenderingTests.swift
+//  TableProTests
+//
+//  The renderability table mirrors what duckdb_value_varchar actually returns for
+//  the linked libduckdb. scripts/check-duckdb-value-api.sh re-measures it.
+//
+
+import Foundation
+import Testing
+
+@Suite("DuckDB type rendering")
+struct DuckDBTypeRenderingTests {
+    @Test("Timestamp flavors the value API cannot decode need a text projection")
+    func undecodableTimestampsRequireProjection() {
+        #expect(DuckDBLogicalType.requiresTextProjection(.timestampSeconds))
+        #expect(DuckDBLogicalType.requiresTextProjection(.timestampMilliseconds))
+        #expect(DuckDBLogicalType.requiresTextProjection(.timestampNanoseconds))
+        #expect(DuckDBLogicalType.requiresTextProjection(.timestampTz))
+        #expect(DuckDBLogicalType.requiresTextProjection(.timeTz))
+    }
+
+    @Test("Types the value API renders directly are left alone")
+    func decodableTypesAreNotProjected() {
+        #expect(!DuckDBLogicalType.requiresTextProjection(.timestamp))
+        #expect(!DuckDBLogicalType.requiresTextProjection(.date))
+        #expect(!DuckDBLogicalType.requiresTextProjection(.time))
+        #expect(!DuckDBLogicalType.requiresTextProjection(.timeNs))
+        #expect(!DuckDBLogicalType.requiresTextProjection(.interval))
+        #expect(!DuckDBLogicalType.requiresTextProjection(.varchar))
+        #expect(!DuckDBLogicalType.requiresTextProjection(.blob))
+        #expect(!DuckDBLogicalType.requiresTextProjection(.decimal))
+        #expect(!DuckDBLogicalType.requiresTextProjection(.hugeint))
+        #expect(!DuckDBLogicalType.requiresTextProjection(.uhugeint))
+    }
+
+    @Test("Nested and extension types the value API cannot decode need a text projection")
+    func undecodableComplexTypesRequireProjection() {
+        #expect(DuckDBLogicalType.requiresTextProjection(.list))
+        #expect(DuckDBLogicalType.requiresTextProjection(.array))
+        #expect(DuckDBLogicalType.requiresTextProjection(.structure))
+        #expect(DuckDBLogicalType.requiresTextProjection(.map))
+        #expect(DuckDBLogicalType.requiresTextProjection(.union))
+        #expect(DuckDBLogicalType.requiresTextProjection(.enumeration))
+        #expect(DuckDBLogicalType.requiresTextProjection(.uuid))
+        #expect(DuckDBLogicalType.requiresTextProjection(.bit))
+        #expect(DuckDBLogicalType.requiresTextProjection(.bignum))
+        #expect(DuckDBLogicalType.requiresTextProjection(.geometry))
+    }
+
+    @Test("An unknown type is projected rather than trusted")
+    func unknownTypeRequiresProjection() {
+        #expect(DuckDBLogicalType.requiresTextProjection(nil))
+    }
+
+    @Test("A result needs projecting when any single column does")
+    func anyColumnDrivesProjection() {
+        #expect(!DuckDBLogicalType.requiresTextProjection(anyOf: [.integer, .varchar, .timestamp]))
+        #expect(DuckDBLogicalType.requiresTextProjection(anyOf: [.integer, .timestampMilliseconds]))
+        #expect(DuckDBLogicalType.requiresTextProjection(anyOf: [.integer, nil]))
+        #expect(!DuckDBLogicalType.requiresTextProjection(anyOf: []))
+    }
+
+    @Test("Display names match the names DuckDB reports for each type")
+    func displayNames() {
+        #expect(DuckDBLogicalType.timestampMilliseconds.displayName == "TIMESTAMP_MS")
+        #expect(DuckDBLogicalType.timestampSeconds.displayName == "TIMESTAMP_S")
+        #expect(DuckDBLogicalType.timestampNanoseconds.displayName == "TIMESTAMP_NS")
+        #expect(DuckDBLogicalType.timestampTz.displayName == "TIMESTAMPTZ")
+        #expect(DuckDBLogicalType.timeTz.displayName == "TIMETZ")
+        #expect(DuckDBLogicalType.structure.displayName == "STRUCT")
+        #expect(DuckDBLogicalType.enumeration.displayName == "ENUM")
+    }
+
+    @Test("Every type name is distinct")
+    func displayNamesAreUnique() {
+        let names = DuckDBLogicalType.allCases.map(\.displayName)
+        #expect(Set(names).count == names.count)
+    }
+
+    @Test("A projected column is read back through DuckDB's own VARCHAR cast")
+    func castProjectionUsesPositionalAlias() {
+        let sql = DuckDBProjectedQuery.projection(for: .timestampMilliseconds, at: 0, column: "open_ts")
+        #expect(sql == "CASE WHEN c1 IS NULL THEN NULL ELSE CAST(c1 AS VARCHAR) END AS \"open_ts\"")
+    }
+
+    @Test("Geometry is projected through ST_AsText rather than a plain cast")
+    func geometryProjection() {
+        let sql = DuckDBProjectedQuery.projection(for: .geometry, at: 2, column: "shape")
+        #expect(sql == "CASE WHEN c3 IS NULL THEN NULL ELSE ST_AsText(c3) END AS \"shape\"")
+    }
+
+    @Test("A directly readable column passes through by position")
+    func passthroughProjection() {
+        #expect(DuckDBProjectedQuery.projection(for: .integer, at: 1, column: "id") == "c2 AS \"id\"")
+    }
+
+    @Test("Column aliases are quoted and embedded quotes escaped")
+    func aliasQuoting() {
+        let sql = DuckDBProjectedQuery.projection(for: .integer, at: 0, column: "we\"ird")
+        #expect(sql == "c1 AS \"we\"\"ird\"")
+    }
+
+    @Test("The wrapper names the subquery's columns by position, so duplicates stay distinct")
+    func wrapperUsesDerivedTableAliasList() {
+        let sql = DuckDBProjectedQuery.build(
+            originalQuery: "SELECT a.ts, b.ts FROM a, b",
+            columns: [("ts", .timestampMilliseconds), ("ts", .timestampMilliseconds)]
+        )
+        #expect(sql == """
+        SELECT CASE WHEN c1 IS NULL THEN NULL ELSE CAST(c1 AS VARCHAR) END AS "ts", \
+        CASE WHEN c2 IS NULL THEN NULL ELSE CAST(c2 AS VARCHAR) END AS "ts" \
+        FROM (SELECT a.ts, b.ts FROM a, b
+        ) AS _tp_cast(c1, c2)
+        """)
+    }
+
+    @Test("The closing parenthesis starts a new line so a trailing comment cannot swallow it")
+    func wrapperTerminatesTrailingComment() {
+        let sql = DuckDBProjectedQuery.build(
+            originalQuery: "SELECT ts FROM bars -- latest",
+            columns: [("ts", .timestampMilliseconds)]
+        )
+        #expect(sql?.contains("-- latest\n) AS _tp_cast(c1)") == true)
+    }
+
+    @Test("A trailing semicolon is dropped before wrapping")
+    func wrapperStripsTrailingSemicolon() {
+        let sql = DuckDBProjectedQuery.build(
+            originalQuery: "SELECT ts FROM bars;  ",
+            columns: [("ts", .timestampMilliseconds)]
+        )
+        #expect(sql?.contains("FROM (SELECT ts FROM bars\n) AS _tp_cast(c1)") == true)
+    }
+
+    @Test("Mixed results only cast the columns that need it")
+    func wrapperMixesCastAndPassthrough() {
+        let sql = DuckDBProjectedQuery.build(
+            originalQuery: "SELECT id, ts FROM bars",
+            columns: [("id", .integer), ("ts", .timestampMilliseconds)]
+        )
+        #expect(sql == """
+        SELECT c1 AS "id", CASE WHEN c2 IS NULL THEN NULL ELSE CAST(c2 AS VARCHAR) END AS "ts" \
+        FROM (SELECT id, ts FROM bars
+        ) AS _tp_cast(c1, c2)
+        """)
+    }
+
+    @Test("A result with no columns cannot be wrapped")
+    func wrapperRejectsEmptyColumns() {
+        #expect(DuckDBProjectedQuery.build(originalQuery: "SELECT 1", columns: []) == nil)
+    }
+
+    @Test("A statement that is only a semicolon cannot be wrapped")
+    func wrapperRejectsEmptyStatement() {
+        #expect(DuckDBProjectedQuery.build(originalQuery: " ; ", columns: [("a", .integer)]) == nil)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -316,6 +316,7 @@ targets:
       - Plugins/ClickHouseDriverPlugin/ClickHouseCredentials.swift
       - Plugins/ClickHouseDriverPlugin/ClickHouseGeneratedColumnClassification.swift
       - Plugins/ClickHouseDriverPlugin/ClickHouseTableOperations.swift
+      - Plugins/DuckDBDriverPlugin/DuckDBTypeRendering.swift
       - Plugins/DuckDBDriverPlugin/QuackConnectBuilder.swift
       - Plugins/DynamoDBDriverPlugin/DynamoDBQueryBuilder.swift
       - Plugins/DynamoDBDriverPlugin/DynamoDBStatementGenerator.swift

--- a/scripts/check-duckdb-value-api.sh
+++ b/scripts/check-duckdb-value-api.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# Measures which DuckDB logical types the deprecated duckdb_value_* row API can
+# render, then checks that DuckDBTypeRendering.swift agrees.
+#
+# The Swift table decides which columns are re-read through CAST(col AS VARCHAR).
+# A type listed as renderable that the C API cannot actually render produces a
+# zero-valued default in the grid instead of the stored value (#2130). Run this
+# after bumping libduckdb.
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HEADERS="$ROOT/Plugins/DuckDBDriverPlugin/CDuckDB/include"
+LIB="$ROOT/Libs/libduckdb.a"
+SWIFT_FILE="$ROOT/Plugins/DuckDBDriverPlugin/DuckDBTypeRendering.swift"
+
+if [ ! -f "$LIB" ]; then
+    echo "error: $LIB is missing. Run scripts/download-libs.sh first." >&2
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/probe.c" <<'PROBE'
+#include <stdio.h>
+#include <string.h>
+#include "duckdb.h"
+
+typedef struct {
+    const char *name;
+    const char *expr;
+    const char *expected;
+} Case;
+
+static const Case cases[] = {
+    {"BOOLEAN", "CAST(true AS BOOLEAN)", "true"},
+    {"TINYINT", "CAST(1 AS TINYINT)", "1"},
+    {"SMALLINT", "CAST(1 AS SMALLINT)", "1"},
+    {"INTEGER", "CAST(1 AS INTEGER)", "1"},
+    {"BIGINT", "CAST(1 AS BIGINT)", "1"},
+    {"UTINYINT", "CAST(1 AS UTINYINT)", "1"},
+    {"USMALLINT", "CAST(1 AS USMALLINT)", "1"},
+    {"UINTEGER", "CAST(1 AS UINTEGER)", "1"},
+    {"UBIGINT", "CAST(1 AS UBIGINT)", "1"},
+    {"FLOAT", "CAST(1.5 AS FLOAT)", "1.5"},
+    {"DOUBLE", "CAST(1.5 AS DOUBLE)", "1.5"},
+    {"DECIMAL", "CAST(1.5 AS DECIMAL(10,2))", "1.50"},
+    {"HUGEINT", "CAST(1 AS HUGEINT)", "1"},
+    {"UHUGEINT", "CAST(1 AS UHUGEINT)", "1"},
+    {"VARCHAR", "CAST('x' AS VARCHAR)", "x"},
+    {"BLOB", "CAST('x' AS BLOB)", "x"},
+    {"DATE", "DATE '2026-08-14'", "2026-08-14"},
+    {"TIME", "TIME '23:59:00.127'", "23:59:00.127"},
+    {"TIME_NS", "CAST('23:59:00.123456789' AS TIME_NS)", "23:59:00.123456789"},
+    {"INTERVAL", "CAST('1 day' AS INTERVAL)", "1 day"},
+    {"TIMESTAMP", "TIMESTAMP '2026-08-14 23:59:00.127'", "2026-08-14 23:59:00.127"},
+    {"TIMESTAMP_S", "CAST('2026-08-14 23:59:00' AS TIMESTAMP_S)", ""},
+    {"TIMESTAMP_MS", "CAST('2026-08-14 23:59:00.127' AS TIMESTAMP_MS)", ""},
+    {"TIMESTAMP_NS", "CAST('2026-08-14 23:59:00.123456789' AS TIMESTAMP_NS)", ""},
+    {"TIMESTAMPTZ", "TIMESTAMPTZ '2026-08-14 23:59:00.127+00'", ""},
+    {"TIMETZ", "TIMETZ '23:59:00.127+02'", ""},
+    {"BIT", "CAST('101' AS BIT)", ""},
+    {"UUID", "CAST('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' AS UUID)", ""},
+    {"ENUM", "CAST('a' AS ENUM('a','b'))", ""},
+    {"LIST", "CAST('[1, 2, 3]' AS INTEGER[])", ""},
+    {"ARRAY", "CAST('[1, 2, 3]' AS INTEGER[3])", ""},
+    {"STRUCT", "CAST('{\"a\": 1}' AS STRUCT(a INTEGER))", ""},
+    {"MAP", "CAST('{a=1}' AS MAP(VARCHAR, INTEGER))", ""},
+    {"UNION", "CAST(1 AS UNION(num INTEGER, str VARCHAR))", ""},
+    {"BIGNUM", "CAST(1 AS BIGNUM)", ""},
+    {"GEOMETRY", "ST_Point(1, 2)", ""},
+};
+
+int main(void) {
+    duckdb_database db;
+    duckdb_connection con;
+    if (duckdb_open(NULL, &db) != DuckDBSuccess) {
+        return 2;
+    }
+    if (duckdb_connect(db, &con) != DuckDBSuccess) {
+        return 2;
+    }
+    fprintf(stderr, "libduckdb %s\n", duckdb_library_version());
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        char sql[512];
+        snprintf(sql, sizeof(sql), "SELECT %s AS v", cases[i].expr);
+        duckdb_result r;
+        if (duckdb_query(con, sql, &r) != DuckDBSuccess) {
+            printf("%s\tSKIP\n", cases[i].name);
+            duckdb_destroy_result(&r);
+            continue;
+        }
+        char *value = duckdb_value_varchar(&r, 0, 0);
+        if (!value) {
+            printf("%s\tNULL\n", cases[i].name);
+        } else if (cases[i].expected[0] != '\0' && strcmp(value, cases[i].expected) != 0) {
+            printf("%s\tWRONG(%s)\n", cases[i].name, value);
+        } else {
+            printf("%s\tRENDERS\n", cases[i].name);
+        }
+        if (value) {
+            duckdb_free(value);
+        }
+        duckdb_destroy_result(&r);
+    }
+
+    duckdb_disconnect(&con);
+    duckdb_close(&db);
+    return 0;
+}
+PROBE
+
+cc -O1 -I "$HEADERS" "$WORK/probe.c" "$LIB" -lc++ -o "$WORK/probe"
+"$WORK/probe" > "$WORK/measured.tsv"
+
+# Swift case identifier -> DuckDB type name, e.g. timestampMilliseconds=TIMESTAMP_MS
+sed -nE 's/^[[:space:]]*case ([a-zA-Z]+) = "([A-Z_0-9]+)"$/\1=\2/p' "$SWIFT_FILE" > "$WORK/raw_values"
+
+# The identifiers Swift declares as unrenderable.
+sed -n '/typesTheValueAPICannotRender/,/^    \]/p' "$SWIFT_FILE" \
+    | sed -nE 's/^[[:space:]]*\.([a-zA-Z]+),$/\1/p' > "$WORK/declared_ids"
+
+while read -r identifier; do
+    grep "^${identifier}=" "$WORK/raw_values" | cut -d= -f2
+done < "$WORK/declared_ids" | sort > "$WORK/declared_all.txt"
+
+if grep -q 'WRONG(' "$WORK/measured.tsv"; then
+    echo "error: the value API rendered the wrong text for a type it claims to support." >&2
+    grep 'WRONG(' "$WORK/measured.tsv" >&2
+    exit 1
+fi
+
+awk -F'\t' '$2 != "SKIP" { print $1 }' "$WORK/measured.tsv" | sort > "$WORK/probed.txt"
+awk -F'\t' '$2 == "NULL" { print $1 }' "$WORK/measured.tsv" | sort > "$WORK/measured.txt"
+awk -F'\t' '$2 == "SKIP" { print "  skipped (needs an extension): " $1 }' "$WORK/measured.tsv" >&2
+
+comm -12 "$WORK/declared_all.txt" "$WORK/probed.txt" > "$WORK/declared.txt"
+
+if diff -u "$WORK/declared.txt" "$WORK/measured.txt" > "$WORK/diff.txt"; then
+    echo "OK: DuckDBTypeRendering.swift matches libduckdb for $(wc -l < "$WORK/measured.tsv" | tr -d ' ') probed types."
+    exit 0
+fi
+
+echo "error: DuckDBTypeRendering.swift disagrees with libduckdb." >&2
+echo "  '-' lines are declared unrenderable but render fine (a needless CAST)." >&2
+echo "  '+' lines render as NULL but are declared renderable (a #2130-class bug)." >&2
+sed '1,2d' "$WORK/diff.txt" >&2
+exit 1


### PR DESCRIPTION
Fixes #2130

## Root cause

Not a unit conversion. DuckDB's deprecated row-value C API has no support for `TIMESTAMP_S`, `TIMESTAMP_MS`, `TIMESTAMP_NS`, `TIMESTAMP_TZ` or `TIME_TZ`: `duckdb_value_varchar` returns `nullptr` and `duckdb_value_timestamp` returns `0`, which the header documents as "0 if the value cannot be converted". Measured against the `libduckdb.a` we ship (v1.5.2):

```
row 0: is_null=0 varchar=(NULL) value_timestamp.micros=0
```

The driver tries `duckdb_value_varchar` first and only falls back to `duckdb_value_timestamp` when it returns nil, so every cell became `duckdb_from_timestamp(0)`, which is `1970-01-01 00:00:00`.

The driver already had the right escape hatch: any type failing `isNativelyRenderable` was re-read through `CAST(col AS VARCHAR)` so DuckDB itself renders it. That is why `TIMESTAMPTZ` was correct. The bug was a wrong entry in that hand-maintained table, held in a second switch that nothing forced to agree with what the extraction code could actually decode.

Probing every type showed the table was wrong for **thirteen** types, not the one reported. `UUID`, `ENUM`, `BIT`, `LIST`, `STRUCT`, `MAP`, `ARRAY` and `UNION` were all claimed as decodable and all return `nullptr`, so those columns had been rendering as empty cells.

## The fix

**One source of truth.** New `DuckDBTypeRendering.swift` holds a pure `DuckDBLogicalType` table with no `import CDuckDB`, so the unit test target compiles it. The two switches in the driver (`typeName(for:)` and `isNativelyRenderable`) collapse into one `logicalType(for:)`, and an unknown or future DuckDB type now defaults to being projected rather than trusted.

**No fabricated values.** The timestamp arm of the fallback is gone; it could not be made correct through this API, and `duckdb_from_timestamp` on a stored `infinity` throws a C++ exception out of a C-linkage function, which is a `SIGABRT` Swift cannot catch. A cell the value API cannot render now logs once per column and reads as NULL instead of inventing a date.

**One execution per query.** `duckdb_prepare` plus `duckdb_prepared_statement_column_type` read a statement's result columns without executing it, so the driver decides on the cast up front and runs the query once. The old path ran it twice and merged the second result into the first by row index, which is not safe for an unordered `LIMIT`/`OFFSET` under a parallel scan. Wrapping is gated on `duckdb_prepared_statement_type` being `SELECT`, so an `UPDATE ... RETURNING` is never re-run or wrapped. Introspection is distrusted when any column type comes back invalid, which the header documents as also collapsing the column count to 1; that case falls back to executing and then projecting.

**The projection can always be abandoned.** Not everything DuckDB types as `SELECT` is valid as a derived table: `PRAGMA storage_info('t')` reports statement type `SELECT` with a `LIST` column, and wrapping it is a parser error. If the projected query fails to run, or comes back with a column count that disagrees with the introspected schema, the driver logs and uses the raw result instead of surfacing an error. Measured across `PRAGMA`, `DESCRIBE`, `CALL`, `RETURNING` and multi-statement input: every one either projects correctly or falls back to the rows it returned before, and the `RETURNING` statement still applies exactly once.

**A safe wrapper.** The cast subquery now names its columns positionally, `FROM (<query>\n) AS _tp_cast(c1, ..., cN)`. This is standard SQL and fixes two verified defects: a query ending in a `--` comment made the wrapper fail to parse, and a join of two tables sharing a column name silently showed one side's value in both columns.

This also fixes `executeParameterized`, which called the patch step with the wrapped SQL and no parameters bound, so any query with a bound value silently kept the wrong cells.

## Why delegate to DuckDB's cast rather than decode the vectors

The non-deprecated vector API would mean reimplementing DuckDB's own rendering: the trailing-zero trim rule (`.100` prints as `.1`), 9-digit nanoseconds, `infinity` literals, `TIME_TZ`'s packed 40+24 bit layout, and overflow-safe scaling. TableProMobile took that route and gets two of those wrong today, printing `.127000` where DuckDB prints `.127`, and trapping on `raw * 1_000` for an `infinity` cell. Delegating is byte-exact by construction, which is what the issue asked for.

## Verified

`scripts/check-duckdb-value-api.sh` is new: it compiles a C probe against `Libs/libduckdb.a`, measures which types `duckdb_value_varchar` can render, checks the rendered text against an expected literal so a wrong-but-non-NULL value also fails, and reports any disagreement with the Swift table. It is the check that would have caught this, and it re-runs on a DuckDB bump instead of trusting a hand-transcribed boolean. It passes for all 35 probed types (`GEOMETRY` needs the spatial extension and is skipped).

Before and after, against a real DuckDB database:

```
BEFORE  row 0: is_null=0 varchar=(NULL) value_timestamp.micros=0     -> 1970-01-01 00:00:00

AFTER   reporter repro          [2026-08-14 23:59:00.127] [2026-08-14 23:59:00.1]
                                [2026-08-14 23:59:00] [<NULL>] [infinity]
        uuid + passthrough      [a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | x]
        duplicate join columns  [2026-01-01 00:00:00.111 | 2020-02-02 00:00:00.222]
        trailing comment        [2026-08-14 23:59:00.127] ...
        seconds / nanos         [2026-08-14 23:59:00 | 2026-08-14 23:59:00.123456789]
        bound parameter         2026-08-14 23:59:00.127
```

- `TablePro` scheme: build succeeded.
- `AllPlugins` scheme: build succeeded. DuckDB is registry-only, so PR CI never compiles it.
- `DuckDBTypeRenderingTests` (16 cases), `DuckDBQuackConnectTests`, `HugeIntFormatterTests`: all passed.
- `swiftlint lint --strict` on the changed files: 0 violations.

No UI automation: the flow needs a DuckDB file and the registry plugin installed, which does not run deterministically under `TableProUITests`.

## Notes

- DuckDB is registry-only, so this reaches users through a plugin release, not the next app release.
- One case still executes twice: a `SELECT` whose result schema cannot be read before execution, which is a `VARIANT` column or an untyped `?` in the select list. That is what the old code did for every cast, so this narrows it rather than introducing it. Removing it entirely would mean decoding vectors, which is the tradeoff described above.
- `CALL` and `RETURNING` statements are never wrapped, so a `LIST` or `MAP` column in one of those still reads as an empty cell, as it does today. The equivalent `SELECT * FROM duckdb_functions()` projects correctly.
- Two things found while investigating and deliberately left alone: TableProMobile's DuckDB decoder has the rendering divergences and the `infinity` overflow trap described above, and `scripts/build-duckdb.sh` names v1.5.3 with a placeholder checksum while the shipped binary is v1.5.2. Both deserve their own issue.
