### PR TITLE
ci(macos-tests): scope UI test queries to the switcher panel and give the job room

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -76,10 +76,13 @@ jobs:
       - name: Run editor package tests
         run: swift test --package-path LocalPackages/CodeEditTextView
 
+  # Budget on a macos-26 runner: ~7 min to generate and compile every plugin, ~14 min to build
+  # and run the unit suite, ~17 min for the UI suite. A slow runner stretches all three, and one
+  # UI retry costs another minute or two, so 40 left no headroom and killed the job mid-suite.
   app-tests:
     name: macOS App Tests
     runs-on: macos-26
-    timeout-minutes: 40
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 

--- a/TablePro/Views/QuickSwitcher/QuickSwitcherPanel.swift
+++ b/TablePro/Views/QuickSwitcher/QuickSwitcherPanel.swift
@@ -19,6 +19,11 @@ internal final class QuickSwitcherPanel: NSPanel {
             backing: .buffered,
             defer: false
         )
+        /// Named on the window, the same way the main window is: AppKit publishes `identifier` as
+        /// the window's accessibility identifier, so a client can scope a search to this panel
+        /// instead of walking the whole application. A SwiftUI modifier could not do it, because an
+        /// identifier on the content view overwrites the one every control inside it publishes.
+        identifier = NSUserInterfaceItemIdentifier("quick-switcher-panel")
         isFloatingPanel = true
         level = .floating
         collectionBehavior.insert(.fullScreenAuxiliary)

--- a/TableProUITests/QueryHistoryFocusUITests.swift
+++ b/TableProUITests/QueryHistoryFocusUITests.swift
@@ -13,19 +13,28 @@ final class QueryHistoryFocusUITests: UITestCase {
 
         let list = showHistoryDrawer(in: app)
 
-        /// The drawer animates open, and a row frame read while it is still laying out puts the
-        /// click somewhere the row has left. Both panes existing is what says the drawer is up.
-        let detail = app.windows.firstMatch.descendants(matching: .any)
-            .matching(identifier: "query-history-detail").firstMatch
-        XCTAssertTrue(detail.waitForExistence(timeout: 10))
+        /// The guard here used to be the detail pane existing, which proves nothing: that pane
+        /// publishes its identifier in the empty state too, so it was up before a single row was.
+        /// The list is still filling as the drawer opens, and the entry at a given index changes
+        /// as rows arrive, so a settled row count is what says there is a row worth clicking.
+        let rows = list.tableRows
+        let rowCount = waitForStableCount(of: rows, timeout: 10)
+        XCTAssertGreaterThan(rowCount, 1, "The drawer must list the queries just run")
 
         // Row 0 is the "Today" section header, so the first entry is row 1.
-        let rows = list.tableRows
-        XCTAssertTrue(rows.element(boundBy: 1).waitForExistence(timeout: 10), "The drawer must list the queries just run")
-        rows.element(boundBy: 1).click()
+        let row = rows.element(boundBy: 1)
+        row.click()
+
+        /// The selection is asserted before the preview so a failure says which half broke. The
+        /// preview is the detail pane rendering a selected row, so a missing preview on its own
+        /// cannot tell a click that never landed from a pane that never drew.
+        XCTAssertTrue(
+            waitForPredicate(timeout: 5) { row.isSelected },
+            "Clicking a row must select it"
+        )
 
         let preview = app.textViews["query-history-detail-query"]
-        XCTAssertTrue(preview.waitForExistence(timeout: 5))
+        XCTAssertTrue(preview.waitForExistence(timeout: 10), "A selected row must show in the preview")
         let previewAfterClick = preview.value as? String ?? ""
         XCTAssertFalse(previewAfterClick.isEmpty, "Clicking a row must show that row in the preview")
 
@@ -62,14 +71,5 @@ final class QueryHistoryFocusUITests: UITestCase {
             _ = app.windows.firstMatch.tables.matching(identifier: "data-grid").firstMatch
                 .waitForExistence(timeout: 15)
         }
-    }
-
-    private func waitForPredicate(timeout: TimeInterval, _ condition: () -> Bool) -> Bool {
-        let deadline = Date(timeIntervalSinceNow: timeout)
-        while Date() < deadline {
-            if condition() { return true }
-            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
-        }
-        return condition()
     }
 }

--- a/TableProUITests/QueryHistoryFocusUITests.swift
+++ b/TableProUITests/QueryHistoryFocusUITests.swift
@@ -13,21 +13,21 @@ final class QueryHistoryFocusUITests: UITestCase {
 
         let list = showHistoryDrawer(in: app)
 
-        /// The guard here used to be the detail pane existing, which proves nothing: that pane
-        /// publishes its identifier in the empty state too, so it was up before a single row was.
-        /// The list is still filling as the drawer opens, and the entry at a given index changes
-        /// as rows arrive, so a settled row count is what says there is a row worth clicking.
-        let rows = list.tableRows
-        let rowCount = waitForStableCount(of: rows, timeout: 10)
-        XCTAssertGreaterThan(rowCount, 1, "The drawer must list the queries just run")
-
-        // Row 0 is the "Today" section header, so the first entry is row 1.
-        let row = rows.element(boundBy: 1)
+        /// Row 0 is the "Today" section header, so the first entry is row 1. Waiting for it to be
+        /// hittable rather than merely to exist is what makes the click land: the drawer animates
+        /// open, and a row that is still sliding into place is in the tree a good while before its
+        /// centre hit-tests back to it. The old guard was the detail pane existing, which cannot
+        /// say any of that, because that pane publishes its identifier in the empty state too.
+        let row = list.tableRows.element(boundBy: 1)
+        XCTAssertTrue(
+            waitUntilHittable(row, timeout: 10),
+            "The drawer must list the queries just run and finish opening"
+        )
         row.click()
 
-        /// The selection is asserted before the preview so a failure says which half broke. The
-        /// preview is the detail pane rendering a selected row, so a missing preview on its own
-        /// cannot tell a click that never landed from a pane that never drew.
+        /// The selection is asserted before the preview so a failure says which half broke: the
+        /// preview is the detail pane drawing a selected row, so its absence alone cannot tell a
+        /// click that never landed from a pane that never drew.
         XCTAssertTrue(
             waitForPredicate(timeout: 5) { row.isSelected },
             "Clicking a row must select it"

--- a/TableProUITests/QueryHistoryPanelUITests.swift
+++ b/TableProUITests/QueryHistoryPanelUITests.swift
@@ -98,13 +98,4 @@ final class QueryHistoryPanelUITests: UITestCase {
         }
         return window.textViews.firstMatch
     }
-
-    private func waitForPredicate(timeout: TimeInterval, _ condition: () -> Bool) -> Bool {
-        let deadline = Date(timeIntervalSinceNow: timeout)
-        while Date() < deadline {
-            if condition() { return true }
-            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
-        }
-        return condition()
-    }
 }

--- a/TableProUITests/QuickSwitcherCrossConnectionUITests.swift
+++ b/TableProUITests/QuickSwitcherCrossConnectionUITests.swift
@@ -17,20 +17,21 @@ final class QuickSwitcherCrossConnectionUITests: UITestCase {
         /// the key goes out, which is the one difference between here and a developer's machine.
         app.activate()
         app.typeKey("o", modifierFlags: [.command, .shift])
-        let searchField = app.textFields["quick-switcher-search-field"]
+        let panel = switcherPanel(in: app)
+        let searchField = panel.textFields["quick-switcher-search-field"]
         XCTAssertTrue(searchField.waitForExistence(timeout: 15))
 
         app.typeKey("5", modifierFlags: .command)
-        XCTAssertTrue(app.buttons["Connections"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.staticTexts["Chinook (Sample)"].waitForExistence(timeout: 15))
-        XCTAssertTrue(app.buttons["Track"].waitForExistence(timeout: 5))
+        XCTAssertTrue(panel.buttons["Connections"].waitForExistence(timeout: 5))
+        XCTAssertTrue(panel.staticTexts["Chinook (Sample)"].waitForExistence(timeout: 15))
+        XCTAssertTrue(panel.buttons["Track"].waitForExistence(timeout: 5))
 
         searchField.typeText("track")
-        XCTAssertTrue(app.buttons["Track"].waitForExistence(timeout: 5))
+        XCTAssertTrue(panel.buttons["Track"].waitForExistence(timeout: 5))
 
         searchField.typeKey("a", modifierFlags: .command)
         searchField.typeText("missing-object-name")
-        XCTAssertTrue(app.staticTexts["No results for \"missing-object-name\""].waitForExistence(timeout: 5))
+        XCTAssertTrue(panel.staticTexts["No results for \"missing-object-name\""].waitForExistence(timeout: 5))
 
         searchField.typeKey("a", modifierFlags: .command)
         searchField.typeText("track")
@@ -39,9 +40,10 @@ final class QuickSwitcherCrossConnectionUITests: UITestCase {
         /// Every open connection lives in one window, so opening an object adds a tab rather than a
         /// window, and the window retitles to the tab it selected. The strip stays hidden while the
         /// connection holds a single tab, so the title is all there is to assert on here.
-        let trackWindow = app.windows.matching(NSPredicate(format: "title BEGINSWITH %@", "Track")).firstMatch
+        let trackWindow = app.children(matching: .window)
+            .matching(NSPredicate(format: "title BEGINSWITH %@", "Track")).firstMatch
         XCTAssertTrue(trackWindow.waitForExistence(timeout: 10))
-        XCTAssertEqual(app.windows.count, 1)
+        XCTAssertEqual(app.children(matching: .window).count, 1)
 
         app.typeKey("o", modifierFlags: [.command, .shift])
         XCTAssertTrue(searchField.waitForExistence(timeout: 5))
@@ -50,7 +52,7 @@ final class QuickSwitcherCrossConnectionUITests: UITestCase {
         /// The panel has to have ranked Invoice before Return is sent. A new query used to leave the
         /// previously highlighted row selected whenever it still matched, and in this scope every
         /// subtitle carries the connection path, so Return committed the row typed before it.
-        XCTAssertTrue(app.buttons["Invoice"].waitForExistence(timeout: 10))
+        XCTAssertTrue(panel.buttons["Invoice"].waitForExistence(timeout: 10))
         searchField.typeKey(.return, modifierFlags: .option)
         XCTAssertTrue(searchField.waitForNonExistence(timeout: 5))
         /// Option+Return opens beside the tab you were on instead of replacing it, which is the one
@@ -58,7 +60,7 @@ final class QuickSwitcherCrossConnectionUITests: UITestCase {
         /// out of hiding, so both tabs are assertable from here and neither was before.
         XCTAssertTrue(tab(in: app, named: "Invoice").waitForExistence(timeout: 10))
         XCTAssertTrue(tab(in: app, named: "Track").exists)
-        XCTAssertEqual(app.windows.count, 1)
+        XCTAssertEqual(app.children(matching: .window).count, 1)
 
         app.typeKey("o", modifierFlags: [.command, .shift])
         XCTAssertTrue(searchField.waitForExistence(timeout: 5))
@@ -89,13 +91,14 @@ final class QuickSwitcherCrossConnectionUITests: UITestCase {
         queryEditor.typeText("SELECT 0;")
 
         app.typeKey("o", modifierFlags: [.command, .shift])
-        let searchField = app.textFields["quick-switcher-search-field"]
+        let panel = switcherPanel(in: app)
+        let searchField = panel.textFields["quick-switcher-search-field"]
         XCTAssertTrue(searchField.waitForExistence(timeout: 10))
         app.typeKey("4", modifierFlags: .command)
-        XCTAssertTrue(app.buttons["Queries"].waitForExistence(timeout: 5))
+        XCTAssertTrue(panel.buttons["Queries"].waitForExistence(timeout: 5))
 
         searchField.typeText("cross_connection_probe")
-        let historyResult = app.buttons.matching(
+        let historyResult = panel.buttons.matching(
             NSPredicate(format: "label CONTAINS %@", "cross_connection_probe")
         ).firstMatch
         XCTAssertTrue(historyResult.waitForExistence(timeout: 10))
@@ -108,6 +111,16 @@ final class QuickSwitcherCrossConnectionUITests: UITestCase {
             .matching(NSPredicate(format: "value CONTAINS %@", "cross_connection_probe"))
             .firstMatch
         XCTAssertTrue(openedEditor.waitForExistence(timeout: 10))
+    }
+
+    /// Every lookup inside the switcher goes through here. Rooted at the application the same
+    /// queries walk the whole accessibility tree, and with a data grid loaded in the main window
+    /// one existence check overran XCTest's own four second evaluation watchdog and had to be
+    /// retried: this test alone spent seven minutes of the job's budget on that. `children` rather
+    /// than `descendants` keeps resolving the panel shallow, because a window is a direct child of
+    /// the application element and searching the descendants for one costs the walk all over again.
+    private func switcherPanel(in app: XCUIApplication) -> XCUIElement {
+        app.children(matching: .window).matching(identifier: "quick-switcher-panel").firstMatch
     }
 
     private func tab(in app: XCUIApplication, named name: String) -> XCUIElement {

--- a/TableProUITests/QuickSwitcherCrossConnectionUITests.swift
+++ b/TableProUITests/QuickSwitcherCrossConnectionUITests.swift
@@ -116,11 +116,14 @@ final class QuickSwitcherCrossConnectionUITests: UITestCase {
     /// Every lookup inside the switcher goes through here. Rooted at the application the same
     /// queries walk the whole accessibility tree, and with a data grid loaded in the main window
     /// one existence check overran XCTest's own four second evaluation watchdog and had to be
-    /// retried: this test alone spent seven minutes of the job's budget on that. `children` rather
-    /// than `descendants` keeps resolving the panel shallow, because a window is a direct child of
-    /// the application element and searching the descendants for one costs the walk all over again.
+    /// retried: this test alone spent seven minutes of the job's budget on that.
+    ///
+    /// `children` rather than `descendants` keeps resolving the panel shallow, because the panel is
+    /// a direct child of the application element and searching the descendants for it costs the
+    /// walk all over again. The type stays `.any` because AppKit gives a floating panel the
+    /// `AXDialog` subrole, which XCUITest reports as `Dialog` and not as `Window`.
     private func switcherPanel(in app: XCUIApplication) -> XCUIElement {
-        app.children(matching: .window).matching(identifier: "quick-switcher-panel").firstMatch
+        app.children(matching: .any).matching(identifier: "quick-switcher-panel").firstMatch
     }
 
     private func tab(in app: XCUIApplication, named name: String) -> XCUIElement {

--- a/TableProUITests/Support/UITestCase.swift
+++ b/TableProUITests/Support/UITestCase.swift
@@ -119,19 +119,14 @@ internal class UITestCase: XCTestCase {
         return condition()
     }
 
-    /// A list that is still filling holds a different entry at a given index before and after the
-    /// last row arrives, so `waitForExistence` on one row proves nothing: the row is there either
-    /// way. The count holding across two samples is what says the list is done arriving.
-    internal func waitForStableCount(of query: XCUIElementQuery, timeout: TimeInterval) -> Int {
-        let deadline = Date(timeIntervalSinceNow: timeout)
-        var previous = query.count
-        while Date() < deadline {
-            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.5))
-            let current = query.count
-            if current > 0, current == previous { return current }
-            previous = current
-        }
-        return previous
+    /// The precondition a click actually has. `waitForExistence` only says the element is in the
+    /// tree, which a row inside a pane that is still animating open already is; the click then
+    /// lands on a moving target, the app hit-tests the point to nothing, and the event goes
+    /// nowhere with no failure of its own. `isHittable` is the question AppKit can answer: does
+    /// this point come back to this element. Nothing in the app can defend against the early
+    /// click, because animating a pane into place is what AppKit does.
+    internal func waitUntilHittable(_ element: XCUIElement, timeout: TimeInterval) -> Bool {
+        waitForPredicate(timeout: timeout) { element.exists && element.isHittable }
     }
 
     /// A defaults suite is a file in the user's preferences directory, so removing the sandbox

--- a/TableProUITests/Support/UITestCase.swift
+++ b/TableProUITests/Support/UITestCase.swift
@@ -110,6 +110,30 @@ internal class UITestCase: XCTestCase {
         return app
     }
 
+    internal func waitForPredicate(timeout: TimeInterval, _ condition: () -> Bool) -> Bool {
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
+        }
+        return condition()
+    }
+
+    /// A list that is still filling holds a different entry at a given index before and after the
+    /// last row arrives, so `waitForExistence` on one row proves nothing: the row is there either
+    /// way. The count holding across two samples is what says the list is done arriving.
+    internal func waitForStableCount(of query: XCUIElementQuery, timeout: TimeInterval) -> Int {
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        var previous = query.count
+        while Date() < deadline {
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.5))
+            let current = query.count
+            if current > 0, current == previous { return current }
+            previous = current
+        }
+        return previous
+    }
+
     /// A defaults suite is a file in the user's preferences directory, so removing the sandbox
     /// directory alone would leave one behind for every test that ever ran.
     private func removeDefaultsSuite(forSandboxAt root: URL) {


### PR DESCRIPTION
The `macOS App Tests` job was dying at its 40 minute cap, so runs reported `cancelled` rather than a test failure. Run [31925210948](https://github.com/TableProApp/TablePro/actions/runs/31925210948) was killed at exactly 40:13, two suites from the end; the `release: v0.65.0` push to main went the same way at 41:17. Underneath that were two real defects, both in the tests.

## One test spent seven minutes on accessibility queries

`testConnectionsScopeSearchesTheOpenSampleDatabase` took 440s on that run and 262s on the one before. The session log says why: every lookup was rooted at the application, so `Descendants matching type Button` walked the whole tree, and with a Chinook data grid loaded the app-side evaluation overran XCTest's own four second watchdog and was retried.

```
Waiting 5.0s for "Track" Button to exist (25.3437s)
  Checking existence of `"Track" Button` (20.0804s)
    Remote query evaluation failed with error: ... Interrupted by waiter.
```

Every switcher lookup now scopes to the panel. AppKit already publishes the panel as a child of the application element; it just had no identifier, so the panel sets `identifier`, which is the same mechanism that gives the main window its `identifier: 'main'`. Resolving the scope uses `children` rather than `descendants`, because the panel is a direct child and searching the descendants for it costs the same walk again, and the type stays `.any` because AppKit gives a floating panel the `AXDialog` subrole, which XCUITest reports as `Dialog` and not `Window`.

## The history row click was landing on a moving target

`testArrowKeysKeepMovingThroughTheListAfterClickingARow` failed both iterations. The old guard waited for `query-history-detail` before clicking a row, but `HistoryDetailPane` publishes that identifier in the empty state too, so the wait was satisfied before a single row existed.

The failure diagnostics ruled out the obvious readings. The element tree shows a settled list of four rows with none selected and the pane still reading "No Query Selected"; the synthesized event record shows a proper move to (410, 628), the row's centre, then down and up; the screen recording shows the pointer sitting on the row with nothing happening.

Reproduced offline, in a harness built from the shipping `FieldDrivenList`, `AutosavingSplitView` and `VerticalCollapsibleSplitView` sources in the same nesting the drawer uses:

| scenario | selection |
|---|---|
| 2.4s after opening the drawer, then click | `[1]` |
| 0.2s after opening, then click | `[]` |
| 0.2s after opening, wait until hittable (50ms), then click | `[1]` |
| immediately after opening, wait until hittable (250ms), then click | `[1]` |

The row is in the tree while the drawer is still animating open, but its centre hit-tests to nothing, so AppKit routes the click nowhere and no failure is raised anywhere. That is what an animating pane is supposed to do, so there is no app defect to fix and nothing the app could defend against. `waitForExistence` was never the precondition for a click; `isHittable` is, and it is what the test now waits for. The click's result is also asserted separately from the preview, so a future failure names the click rather than the pane.

A `FieldDrivenList` reload clearing the model's selection was the first suspect. A test against a real `NSTableView` disproved it: `reloadData()` keeps the selection when the list grows. Nothing in the app changed for it.

## The job has no headroom

Budget on a macos-26 runner: ~7 min to generate and compile every plugin, ~14 to 17 min to build and run the unit suite, ~15 min for the UI suite. One UI retry costs another minute or two. Raised to 60.

## Testing

- `xcodebuild build-for-testing` clean, `swiftlint lint --strict` 0 violations in 1424 files.
- The UI suites cannot run on this machine (the local XCTest host wedges, and a run would terminate the developer's own TablePro), so the click behaviour was proven in the offline harness above and the timings come from the CI runs.
