### PR TITLE
fix(plugin-duckdb): browse schemas and attached databases in the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The sidebar tree opens on the database and schema you are connected to the first time you see it, instead of every container being closed. After that it remembers what you left open.
+- A connection you open in Tree layout for the first time shows its current database and schema already expanded, instead of every container being closed. Connections that already remember what you left open are untouched.
 - DuckDB connections reset their saved column widths, per-table filters, favourites and recent tables once, because those are stored per database and DuckDB connections now report a database name.
 
 ## [0.65.0] - 2026-08-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DuckDB `TIMESTAMP_S`, `TIMESTAMP_MS` and `TIMESTAMP_NS` columns showed `1970-01-01 00:00:00` on every row instead of the stored value. They now read exactly as the DuckDB CLI prints them, keeping sub-second digits. (#2130)
 - DuckDB `UUID`, `ENUM`, `BIT`, `LIST`, `STRUCT`, `MAP`, `ARRAY` and `UNION` columns showed an empty cell instead of their value. (#2130)
 - Querying two DuckDB tables that share a column name could repeat one table's value in both columns. (#2130)
+- DuckDB tables outside the `main` schema are visible again. The sidebar lists every schema of the connected database, Tree layout shows database, schema and tables, and `ATTACH`ed databases appear alongside the one you opened. (#2131)
+- DuckDB metadata no longer mixes up databases that share a schema name, so an `ATTACH`ed file's tables stay out of the database you opened.
+- A DuckDB table in the default schema is titled `orders` again rather than `main.orders`, and exports preselect the schema you are browsing.
+
+### Changed
+
+- The sidebar tree opens on the database and schema you are connected to the first time you see it, instead of every container being closed. After that it remembers what you left open.
+- DuckDB connections reset their saved column widths, per-table filters, favourites and recent tables once, because those are stored per database and DuckDB connections now report a database name.
 
 ## [0.65.0] - 2026-08-16
 

--- a/Plugins/DuckDBDriverPlugin/DuckDBPlugin.swift
+++ b/Plugins/DuckDBDriverPlugin/DuckDBPlugin.swift
@@ -10,7 +10,7 @@ import TableProPluginKit
 
 final class DuckDBPlugin: NSObject, TableProPlugin, DriverPlugin {
     static let pluginName = "DuckDB Driver"
-    static let pluginVersion = "1.0.0"
+    static let pluginVersion = "1.1.0"
     static let pluginDescription = "DuckDB analytical database support"
     static let capabilities: [PluginCapability] = [.databaseDriver]
 
@@ -83,10 +83,14 @@ final class DuckDBPlugin: NSObject, TableProPlugin, DriverPlugin {
     ]
     static let fileExtensions: [String] = ["duckdb", "ddb"]
     static let brandColorHex = "#FFD900"
-    static let supportsDatabaseSwitching = false
     static let parameterStyle: ParameterStyle = .dollar
-    static let systemDatabaseNames: [String] = ["information_schema", "pg_catalog"]
-    static let databaseGroupingStrategy: GroupingStrategy = .flat
+
+    static let supportsDatabaseSwitching = true
+    static let supportsSchemaSwitching = true
+    static let databaseGroupingStrategy: GroupingStrategy = .bySchema
+    static let defaultSchemaName = "main"
+    static let systemDatabaseNames: [String] = ["system", "temp"]
+    static let postConnectActions: [PostConnectAction] = [.selectSchemaFromLastSession]
     static let columnTypesByCategory: [String: [String]] = [
         "Integer": ["TINYINT", "SMALLINT", "INTEGER", "BIGINT", "HUGEINT", "UTINYINT", "USMALLINT", "UINTEGER", "UBIGINT"],
         "Float": ["FLOAT", "DOUBLE", "DECIMAL", "NUMERIC"],
@@ -167,6 +171,7 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     private let stateLock = NSLock()
     nonisolated(unsafe) private var _connectionForInterrupt: duckdb_connection?
     nonisolated(unsafe) private var _currentSchema: String = "main"
+    nonisolated(unsafe) private var _currentDatabase: String?
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "DuckDBPluginDriver")
 
@@ -174,6 +179,12 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         stateLock.lock()
         defer { stateLock.unlock() }
         return _currentSchema
+    }
+
+    var currentDatabase: String? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return _currentDatabase
     }
     var serverVersion: String? { String(cString: duckdb_library_version()) }
     var supportsSchemas: Bool { true }
@@ -237,6 +248,7 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
         try await connectionActor.open(path: path)
         await enableExtensionAutoloading()
+        await refreshCurrentCatalog()
         await captureInterruptHandle()
     }
 
@@ -271,9 +283,26 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
         stateLock.lock()
         _currentSchema = "main"
+        _currentDatabase = alias
         stateLock.unlock()
 
         await captureInterruptHandle()
+    }
+
+    /// Every metadata query is anchored to `current_database()`, and the app seeds the
+    /// browsed database from `currentDatabase`, so the driver has to know which catalog
+    /// the file opened as. DuckDB names it after the file stem, which is not derivable
+    /// from the path alone once an alias or a URL is involved.
+    private func refreshCurrentCatalog() async {
+        do {
+            let result = try await connectionActor.executeQuery(DuckDBSchemaQueries.currentCatalog)
+            guard let name = result.rows.first?[safe: 0]?.asText, !name.isEmpty else { return }
+            stateLock.lock()
+            _currentDatabase = name
+            stateLock.unlock()
+        } catch {
+            Self.logger.warning("Failed to resolve the current DuckDB catalog: \(error.localizedDescription)")
+        }
     }
 
     private func enableExtensionAutoloading() async {
@@ -374,13 +403,9 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func fetchTables(schema: String?) async throws -> [PluginTableInfo] {
         let schemaName = resolveSchema(schema)
-        let query = """
-            SELECT table_name, table_type
-            FROM information_schema.tables
-            WHERE table_schema = $1
-            ORDER BY table_name
-        """
-        let result = try await executeParameterized(query: query, parameters: [.text(schemaName)])
+        let result = try await executeParameterized(
+            query: DuckDBSchemaQueries.listTables, parameters: [.text(schemaName)]
+        )
         return result.rows.compactMap { row in
             guard let name = row[safe: 0]?.asText else { return nil }
             let typeString = (row[safe: 1]?.asText) ?? "BASE TABLE"
@@ -391,14 +416,9 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] {
         let schemaName = resolveSchema(schema)
-        let query = """
-            SELECT column_name, data_type, is_nullable, column_default, ordinal_position
-            FROM information_schema.columns
-            WHERE table_schema = $1
-              AND table_name = $2
-            ORDER BY ordinal_position
-        """
-        let result = try await executeParameterized(query: query, parameters: [.text(schemaName), .text(table)])
+        let result = try await executeParameterized(
+            query: DuckDBSchemaQueries.columnsForTable, parameters: [.text(schemaName), .text(table)]
+        )
 
         let pkColumns = try await fetchPrimaryKeyColumns(table: table, schema: schemaName)
         let enumMap = try await fetchEnumLabelMap(schema: schemaName)
@@ -426,24 +446,13 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func fetchAllColumns(schema: String?) async throws -> [String: [PluginColumnInfo]] {
         let schemaName = resolveSchema(schema)
-        let query = """
-            SELECT table_name, column_name, data_type, is_nullable, column_default, ordinal_position
-            FROM information_schema.columns
-            WHERE table_schema = $1
-            ORDER BY table_name, ordinal_position
-        """
-        let result = try await executeParameterized(query: query, parameters: [.text(schemaName)])
+        let result = try await executeParameterized(
+            query: DuckDBSchemaQueries.columnsForSchema, parameters: [.text(schemaName)]
+        )
 
-        let pkQuery = """
-            SELECT tc.table_name, kcu.column_name
-            FROM information_schema.table_constraints tc
-            JOIN information_schema.key_column_usage kcu
-              ON tc.constraint_name = kcu.constraint_name
-              AND tc.table_schema = kcu.table_schema
-            WHERE tc.constraint_type = 'PRIMARY KEY'
-              AND tc.table_schema = $1
-        """
-        let pkResult = try await executeParameterized(query: pkQuery, parameters: [.text(schemaName)])
+        let pkResult = try await executeParameterized(
+            query: DuckDBSchemaQueries.primaryKeyColumnsForSchema, parameters: [.text(schemaName)]
+        )
         var pkMap: [String: Set<String>] = [:]
         for row in pkResult.rows {
             if let tableName = row[safe: 0]?.asText, let colName = row[safe: 1]?.asText {
@@ -481,28 +490,24 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     private func fetchEnumLabelMap(schema: String) async throws -> [String: [String]] {
-        let typeNamesQuery = """
-            SELECT type_name
-            FROM duckdb_types()
-            WHERE schema_name = $1 AND type_category = 'ENUM'
-        """
         let typeResult: PluginQueryResult
         do {
-            typeResult = try await executeParameterized(query: typeNamesQuery, parameters: [.text(schema)])
+            typeResult = try await executeParameterized(
+                query: DuckDBSchemaQueries.enumTypeNamesForSchema, parameters: [.text(schema)]
+            )
         } catch {
             return [:]
         }
         let typeNames = typeResult.rows.compactMap { $0[safe: 0]?.asText }
         guard !typeNames.isEmpty else { return [:] }
 
-        let quotedSchema = quoteIdentifier(schema)
         var map: [String: [String]] = [:]
         for typeName in typeNames {
-            let quoted = quoteIdentifier(typeName)
-            let valuesQuery = "SELECT UNNEST(enum_range(NULL::\(quotedSchema).\(quoted)))::VARCHAR AS value"
             let valuesResult: PluginQueryResult
             do {
-                valuesResult = try await execute(query: valuesQuery)
+                valuesResult = try await execute(
+                    query: DuckDBSchemaQueries.enumLabels(schema: schema, typeName: typeName)
+                )
             } catch {
                 continue
             }
@@ -523,16 +528,9 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func fetchIndexes(table: String, schema: String?) async throws -> [PluginIndexInfo] {
         let schemaName = resolveSchema(schema)
-        let query = """
-            SELECT index_name, is_unique, sql, index_oid
-            FROM duckdb_indexes()
-            WHERE schema_name = $1
-              AND table_name = $2
-        """
-
         do {
             let result = try await executeParameterized(
-                query: query, parameters: [.text(schemaName), .text(table)]
+                query: DuckDBSchemaQueries.indexesForTable, parameters: [.text(schemaName), .text(table)]
             )
             return result.rows.compactMap { row in
                 guard let name = row[safe: 0]?.asText else { return nil }
@@ -558,29 +556,9 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] {
         let schemaName = resolveSchema(schema)
-        let query = """
-            SELECT
-                rc.constraint_name,
-                kcu.column_name,
-                kcu2.table_name AS referenced_table,
-                kcu2.column_name AS referenced_column,
-                rc.delete_rule,
-                rc.update_rule
-            FROM information_schema.referential_constraints rc
-            JOIN information_schema.key_column_usage kcu
-                ON rc.constraint_name = kcu.constraint_name
-                AND rc.constraint_schema = kcu.constraint_schema
-            JOIN information_schema.key_column_usage kcu2
-                ON rc.unique_constraint_name = kcu2.constraint_name
-                AND rc.unique_constraint_schema = kcu2.constraint_schema
-                AND kcu.ordinal_position = kcu2.ordinal_position
-            WHERE kcu.table_schema = $1
-              AND kcu.table_name = $2
-        """
-
         do {
             let result = try await executeParameterized(
-                query: query, parameters: [.text(schemaName), .text(table)]
+                query: DuckDBSchemaQueries.foreignKeysForTable, parameters: [.text(schemaName), .text(table)]
             )
             return result.rows.compactMap { row in
                 guard let name = row[safe: 0]?.asText,
@@ -611,8 +589,9 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         let schemaName = resolveSchema(schema)
 
         // Try native DDL from duckdb_tables() first (preserves complex types like LIST, STRUCT, MAP)
-        let nativeQuery = "SELECT sql FROM duckdb_tables() WHERE schema_name = $1 AND table_name = $2"
-        let nativeResult = try await executeParameterized(query: nativeQuery, parameters: [.text(schemaName), .text(table)])
+        let nativeResult = try await executeParameterized(
+            query: DuckDBSchemaQueries.tableDDL, parameters: [.text(schemaName), .text(table)]
+        )
 
         if let firstRow = nativeResult.rows.first, let sql = firstRow[0].asText {
             var ddl = sql.hasSuffix(";") ? sql : sql + ";"
@@ -676,13 +655,9 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func fetchViewDefinition(view: String, schema: String?) async throws -> String {
         let schemaName = resolveSchema(schema)
-        let query = """
-            SELECT view_definition
-            FROM information_schema.views
-            WHERE table_schema = $1
-              AND table_name = $2
-        """
-        let result = try await executeParameterized(query: query, parameters: [.text(schemaName), .text(view)])
+        let result = try await executeParameterized(
+            query: DuckDBSchemaQueries.viewDefinition, parameters: [.text(schemaName), .text(view)]
+        )
 
         guard let firstRow = result.rows.first,
               let definition = firstRow[0].asText else {
@@ -696,11 +671,9 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func fetchTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata {
         let schemaName = resolveSchema(schema)
-        let safeTable = escapeIdentifier(table)
-        let safeSchema = escapeIdentifier(schemaName)
-        let countQuery =
-            "SELECT COUNT(*) FROM (SELECT 1 FROM \"\(safeSchema)\".\"\(safeTable)\" LIMIT 100001) AS _t"
-        let countResult = try await execute(query: countQuery)
+        let countResult = try await execute(
+            query: DuckDBSchemaQueries.rowCountProbe(schema: schemaName, table: table, limit: 100_001)
+        )
         let rowCount: Int64? = {
             guard let row = countResult.rows.first, let firstCell = row.first else { return nil }
             return Int64(firstCell.asText ?? "0")
@@ -716,8 +689,8 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     // MARK: - Schema Navigation
 
     func fetchSchemas() async throws -> [String] {
-        let query = "SELECT schema_name FROM information_schema.schemata ORDER BY schema_name"
-        if let remoteAlias {
+        let query = DuckDBSchemaQueries.listSchemas
+        if remoteAlias != nil {
             let schemas = (try? await execute(query: query))?.rows.compactMap { $0[safe: 0]?.asText } ?? []
             return schemas.isEmpty ? ["main"] : schemas
         }
@@ -726,8 +699,7 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func switchSchema(to schema: String) async throws {
-        let safeSchema = escapeIdentifier(schema)
-        _ = try await execute(query: "SET schema = \"\(safeSchema)\"")
+        _ = try await execute(query: DuckDBSchemaQueries.useSchema(schema, in: currentDatabase))
         stateLock.lock()
         _currentSchema = schema
         stateLock.unlock()
@@ -735,12 +707,21 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     // MARK: - Database Operations
 
+    /// `USE` on a catalog also moves the connection onto that catalog's default schema,
+    /// so the tracked schema follows or the next `pin` would skip a switch it still needs.
+    func switchDatabase(to database: String) async throws {
+        _ = try await execute(query: DuckDBSchemaQueries.useDatabase(database))
+        stateLock.lock()
+        _currentDatabase = database
+        _currentSchema = "main"
+        stateLock.unlock()
+    }
+
     func fetchDatabases() async throws -> [String] {
         if let remoteAlias {
             return [remoteAlias]
         }
-        let query = "SELECT database_name FROM duckdb_databases() ORDER BY database_name"
-        let result = try await execute(query: query)
+        let result = try await execute(query: DuckDBSchemaQueries.listDatabases)
         return result.rows.compactMap { row in
             row[safe: 0]?.asText
         }
@@ -770,16 +751,7 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     // MARK: - All Tables Metadata
 
     func allTablesMetadataSQL(schema: String?) -> String? {
-        let s = (schema ?? currentSchema ?? "main").replacingOccurrences(of: "'", with: "''")
-        return """
-        SELECT
-            table_schema as schema_name,
-            table_name as name,
-            table_type as kind
-        FROM information_schema.tables
-        WHERE table_schema = '\(s)'
-        ORDER BY table_name
-        """
+        DuckDBSchemaQueries.allTablesMetadata(schema: schema ?? currentSchema ?? "main")
     }
 
     // MARK: - Private Helpers
@@ -805,17 +777,9 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         table: String,
         schema: String
     ) async throws -> Set<String> {
-        let query = """
-            SELECT kcu.column_name
-            FROM information_schema.table_constraints tc
-            JOIN information_schema.key_column_usage kcu
-              ON tc.constraint_name = kcu.constraint_name
-              AND tc.table_schema = kcu.table_schema
-            WHERE tc.constraint_type = 'PRIMARY KEY'
-              AND tc.table_schema = $1
-              AND tc.table_name = $2
-        """
-        let result = try await executeParameterized(query: query, parameters: [.text(schema), .text(table)])
+        let result = try await executeParameterized(
+            query: DuckDBSchemaQueries.primaryKeyColumnsForTable, parameters: [.text(schema), .text(table)]
+        )
         return Set(result.rows.compactMap { $0[safe: 0]?.asText })
     }
 

--- a/Plugins/DuckDBDriverPlugin/DuckDBPlugin.swift
+++ b/Plugins/DuckDBDriverPlugin/DuckDBPlugin.swift
@@ -707,13 +707,16 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     // MARK: - Database Operations
 
-    /// `USE` on a catalog also moves the connection onto that catalog's default schema,
-    /// so the tracked schema follows or the next `pin` would skip a switch it still needs.
+    /// `USE` on a catalog also moves the connection onto that catalog's default schema, so
+    /// the tracked schema has to follow or the next `pin` skips a switch it still needs.
+    /// The new schema is read back rather than assumed to be `main`: a catalog attached
+    /// through the postgres or mysql scanner defaults to that engine's own schema.
     func switchDatabase(to database: String) async throws {
         _ = try await execute(query: DuckDBSchemaQueries.useDatabase(database))
+        let landedSchema = try? await execute(query: DuckDBSchemaQueries.currentSchema)
         stateLock.lock()
         _currentDatabase = database
-        _currentSchema = "main"
+        _currentSchema = landedSchema?.rows.first?[safe: 0]?.asText?.nilIfEmpty ?? "main"
         stateLock.unlock()
     }
 

--- a/Plugins/DuckDBDriverPlugin/DuckDBSchemaQueries.swift
+++ b/Plugins/DuckDBDriverPlugin/DuckDBSchemaQueries.swift
@@ -65,7 +65,9 @@ enum DuckDBSchemaQueries {
         FROM information_schema.table_constraints tc
         JOIN information_schema.key_column_usage kcu
           ON tc.constraint_name = kcu.constraint_name
+          AND tc.table_catalog = kcu.table_catalog
           AND tc.table_schema = kcu.table_schema
+          AND tc.table_name = kcu.table_name
         WHERE tc.constraint_type = 'PRIMARY KEY'
           AND tc.table_catalog = current_database()
           AND tc.table_schema = $1
@@ -76,7 +78,9 @@ enum DuckDBSchemaQueries {
         FROM information_schema.table_constraints tc
         JOIN information_schema.key_column_usage kcu
           ON tc.constraint_name = kcu.constraint_name
+          AND tc.table_catalog = kcu.table_catalog
           AND tc.table_schema = kcu.table_schema
+          AND tc.table_name = kcu.table_name
         WHERE tc.constraint_type = 'PRIMARY KEY'
           AND tc.table_catalog = current_database()
           AND tc.table_schema = $1
@@ -102,12 +106,16 @@ enum DuckDBSchemaQueries {
         FROM information_schema.referential_constraints rc
         JOIN information_schema.key_column_usage kcu
             ON rc.constraint_name = kcu.constraint_name
+            AND rc.constraint_catalog = kcu.constraint_catalog
             AND rc.constraint_schema = kcu.constraint_schema
         JOIN information_schema.key_column_usage kcu2
             ON rc.unique_constraint_name = kcu2.constraint_name
+            AND rc.unique_constraint_catalog = kcu2.constraint_catalog
             AND rc.unique_constraint_schema = kcu2.constraint_schema
             AND kcu.ordinal_position = kcu2.ordinal_position
-        WHERE kcu.table_catalog = current_database()
+        WHERE rc.constraint_catalog = current_database()
+          AND kcu.table_catalog = current_database()
+          AND kcu2.table_catalog = current_database()
           AND kcu.table_schema = $1
           AND kcu.table_name = $2
         """
@@ -137,6 +145,8 @@ enum DuckDBSchemaQueries {
         """
 
     static let currentCatalog = "SELECT current_database()"
+
+    static let currentSchema = "SELECT current_schema()"
 
     static func allTablesMetadata(schema: String) -> String {
         """

--- a/Plugins/DuckDBDriverPlugin/DuckDBSchemaQueries.swift
+++ b/Plugins/DuckDBDriverPlugin/DuckDBSchemaQueries.swift
@@ -1,0 +1,190 @@
+//
+//  DuckDBSchemaQueries.swift
+//  DuckDBDriverPlugin
+//
+//  Static SQL used to enumerate catalogs, schemas and objects. Extracted so the
+//  queries can be exercised by unit tests via TableProTests, which never loads
+//  the plugin bundle.
+//
+
+import Foundation
+
+/// DuckDB's namespace is `catalog.schema.table`, and both `information_schema` and the
+/// `duckdb_*` table functions span every attached catalog. A predicate on the schema
+/// alone therefore matches same-named schemas in other catalogs: with a second database
+/// attached, `WHERE table_schema = 'main'` returns both catalogs' `main` tables. Every
+/// query here is anchored to `current_database()` for that reason, and the driver's
+/// `switchDatabase` is what moves it.
+enum DuckDBSchemaQueries {
+    /// `system` and `temp` are DuckDB's built-in catalogs; `internal` marks them and
+    /// nothing else. Filtering catalogs is also what keeps `information_schema` and
+    /// `pg_catalog` out of the schema list, because they are schemas of `system`.
+    static let listDatabases = """
+        SELECT database_name
+        FROM duckdb_databases()
+        WHERE internal = false
+        ORDER BY database_name
+        """
+
+    /// Never filters on the schema's own `internal` flag: DuckDB marks the auto-created
+    /// `main` internal in every catalog, so that predicate hides the default schema.
+    static let listSchemas = """
+        SELECT schema_name
+        FROM duckdb_schemas()
+        WHERE database_name = current_database()
+        ORDER BY schema_name
+        """
+
+    static let listTables = """
+        SELECT table_name, table_type
+        FROM information_schema.tables
+        WHERE table_catalog = current_database()
+          AND table_schema = $1
+        ORDER BY table_name
+        """
+
+    static let columnsForTable = """
+        SELECT column_name, data_type, is_nullable, column_default, ordinal_position
+        FROM information_schema.columns
+        WHERE table_catalog = current_database()
+          AND table_schema = $1
+          AND table_name = $2
+        ORDER BY ordinal_position
+        """
+
+    static let columnsForSchema = """
+        SELECT table_name, column_name, data_type, is_nullable, column_default, ordinal_position
+        FROM information_schema.columns
+        WHERE table_catalog = current_database()
+          AND table_schema = $1
+        ORDER BY table_name, ordinal_position
+        """
+
+    static let primaryKeyColumnsForSchema = """
+        SELECT tc.table_name, kcu.column_name
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+          ON tc.constraint_name = kcu.constraint_name
+          AND tc.table_schema = kcu.table_schema
+        WHERE tc.constraint_type = 'PRIMARY KEY'
+          AND tc.table_catalog = current_database()
+          AND tc.table_schema = $1
+        """
+
+    static let primaryKeyColumnsForTable = """
+        SELECT kcu.column_name
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+          ON tc.constraint_name = kcu.constraint_name
+          AND tc.table_schema = kcu.table_schema
+        WHERE tc.constraint_type = 'PRIMARY KEY'
+          AND tc.table_catalog = current_database()
+          AND tc.table_schema = $1
+          AND tc.table_name = $2
+        """
+
+    static let indexesForTable = """
+        SELECT index_name, is_unique, sql, index_oid
+        FROM duckdb_indexes()
+        WHERE database_name = current_database()
+          AND schema_name = $1
+          AND table_name = $2
+        """
+
+    static let foreignKeysForTable = """
+        SELECT
+            rc.constraint_name,
+            kcu.column_name,
+            kcu2.table_name AS referenced_table,
+            kcu2.column_name AS referenced_column,
+            rc.delete_rule,
+            rc.update_rule
+        FROM information_schema.referential_constraints rc
+        JOIN information_schema.key_column_usage kcu
+            ON rc.constraint_name = kcu.constraint_name
+            AND rc.constraint_schema = kcu.constraint_schema
+        JOIN information_schema.key_column_usage kcu2
+            ON rc.unique_constraint_name = kcu2.constraint_name
+            AND rc.unique_constraint_schema = kcu2.constraint_schema
+            AND kcu.ordinal_position = kcu2.ordinal_position
+        WHERE kcu.table_catalog = current_database()
+          AND kcu.table_schema = $1
+          AND kcu.table_name = $2
+        """
+
+    static let tableDDL = """
+        SELECT sql
+        FROM duckdb_tables()
+        WHERE database_name = current_database()
+          AND schema_name = $1
+          AND table_name = $2
+        """
+
+    static let viewDefinition = """
+        SELECT view_definition
+        FROM information_schema.views
+        WHERE table_catalog = current_database()
+          AND table_schema = $1
+          AND table_name = $2
+        """
+
+    static let enumTypeNamesForSchema = """
+        SELECT type_name
+        FROM duckdb_types()
+        WHERE database_name = current_database()
+          AND schema_name = $1
+          AND type_category = 'ENUM'
+        """
+
+    static let currentCatalog = "SELECT current_database()"
+
+    static func allTablesMetadata(schema: String) -> String {
+        """
+        SELECT
+            table_schema as schema_name,
+            table_name as name,
+            table_type as kind
+        FROM information_schema.tables
+        WHERE table_catalog = current_database()
+          AND table_schema = '\(escapeLiteral(schema))'
+        ORDER BY table_name
+        """
+    }
+
+    static func enumLabels(schema: String, typeName: String) -> String {
+        "SELECT UNNEST(enum_range(NULL::\(quoteIdentifier(schema)).\(quoteIdentifier(typeName))))::VARCHAR AS value"
+    }
+
+    static func rowCountProbe(schema: String, table: String, limit: Int) -> String {
+        let target = "\(quoteIdentifier(schema)).\(quoteIdentifier(table))"
+        return "SELECT COUNT(*) FROM (SELECT 1 FROM \(target) LIMIT \(limit)) AS _t"
+    }
+
+    static func useDatabase(_ database: String) -> String {
+        "USE \(quoteIdentifier(database))"
+    }
+
+    /// `SET schema` splits its value on `.`, so it cannot address a schema whose name
+    /// contains one, and it cannot say which catalog it means. The two-part `USE` form
+    /// is unambiguous for both.
+    static func useSchema(_ schema: String, in database: String?) -> String {
+        guard let database, !database.isEmpty else {
+            return "USE \(quoteIdentifier(schema))"
+        }
+        return "USE \(quoteIdentifier(database)).\(quoteIdentifier(schema))"
+    }
+
+    static func quoteIdentifier(_ name: String) -> String {
+        "\"\(escapeIdentifier(name))\""
+    }
+
+    static func escapeIdentifier(_ name: String) -> String {
+        name.replacingOccurrences(of: "\"", with: "\"\"")
+    }
+
+    private static func escapeLiteral(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\0", with: "")
+            .replacingOccurrences(of: "'", with: "''")
+    }
+}

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -150,6 +150,12 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
     // Database switching (SQL Server USE, ClickHouse database switch, etc.)
     func switchDatabase(to database: String) async throws
 
+    /// The database the connection is currently on, when the driver rather than the
+    /// connection definition is the authority on that. An embedded engine names its
+    /// database from the file it opened, so nothing outside the driver can derive it.
+    /// Drivers whose database comes from the connection definition return nil.
+    var currentDatabase: String? { get }
+
     // DDL schema generation (optional, plugins return nil to use default fallback)
     func generateAddColumnSQL(table: String, column: PluginColumnDefinition) -> String?
     func generateModifyColumnSQL(table: String, oldColumn: PluginColumnDefinition, newColumn: PluginColumnDefinition) -> String?
@@ -348,6 +354,8 @@ public extension PluginDatabaseDriver {
             userInfo: [NSLocalizedDescriptionKey: "This driver does not support database switching"]
         )
     }
+
+    var currentDatabase: String? { nil }
 
     func buildBrowseQuery(table: String, sortColumns: [(columnIndex: Int, ascending: Bool)], columns: [String], limit: Int, offset: Int) -> String? { nil }
     func buildFilteredQuery(table: String, filters: [(column: String, op: String, value: String)], logicMode: String, sortColumns: [(columnIndex: Int, ascending: Bool)], columns: [String], limit: Int, offset: Int) -> String? { nil }

--- a/TablePro/Core/Database/DatabaseDriver.swift
+++ b/TablePro/Core/Database/DatabaseDriver.swift
@@ -243,6 +243,13 @@ protocol SchemaSwitchable: DatabaseDriver {
     func switchSchema(to schema: String) async throws
 }
 
+/// Protocol for drivers that know which database they are on. An embedded engine names
+/// its database from the file it opened, so the session cannot derive it from the
+/// connection definition the way a networked engine can.
+protocol DatabaseReporting: DatabaseDriver {
+    var currentDatabase: String? { get }
+}
+
 /// Default implementation for common operations
 extension DatabaseDriver {
     /// Default implementation returns nil

--- a/TablePro/Core/Database/DatabaseManager+Scope.swift
+++ b/TablePro/Core/Database/DatabaseManager+Scope.swift
@@ -21,16 +21,23 @@ extension DatabaseManager {
     /// tier down: an explicit database passes through untouched, and only a missing one
     /// falls back to where the user happens to be browsing. Re-deriving it later is what
     /// lets a tab drift onto another database.
+    ///
+    /// A schema name only means something inside the database that holds it, so the
+    /// browsing fallback stops at a database boundary: a caller naming another database
+    /// and no schema gets no schema, not the one the user happens to be on here. Carrying
+    /// it across made the sidebar ask a newly attached database for a schema that lives in
+    /// a different one, and the engine rejected the whole read.
     func resolvedScope(database: String?, schema: String?, for connectionId: UUID) -> DatabaseScope? {
-        let resolvedSchema = resolvedSchemaName(schema, for: connectionId)
         if let database, !database.isEmpty {
-            return DatabaseScope(connectionId: connectionId, database: database, schema: resolvedSchema)
+            let isBrowsedDatabase = activeSessions[connectionId]?.resolvedBrowseDatabase == database
+            let inheritedSchema = isBrowsedDatabase ? resolvedSchemaName(schema, for: connectionId) : schema
+            return DatabaseScope(connectionId: connectionId, database: database, schema: inheritedSchema)
         }
         guard let session = activeSessions[connectionId] else { return nil }
         return DatabaseScope(
             connectionId: connectionId,
             database: session.resolvedBrowseDatabase,
-            schema: resolvedSchema
+            schema: resolvedSchemaName(schema, for: connectionId)
         )
     }
 }

--- a/TablePro/Core/Database/DatabaseManager+Sessions.swift
+++ b/TablePro/Core/Database/DatabaseManager+Sessions.swift
@@ -134,6 +134,10 @@ extension DatabaseManager {
             if let schemaDriver = driver as? SchemaSwitchable {
                 activeSessions[connection.id]?.browseSchema = schemaDriver.currentSchema
             }
+            if let reportingDriver = driver as? DatabaseReporting,
+               let openedDatabase = reportingDriver.currentDatabase, !openedDatabase.isEmpty {
+                activeSessions[connection.id]?.browseDatabase = openedDatabase
+            }
 
             await executePostConnectActions(
                 for: connection, resolvedConnection: resolvedConnection, driver: driver

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -7,7 +7,7 @@ import Foundation
 import os
 import TableProPluginKit
 
-final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable {
+final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable, DatabaseReporting {
     private struct State {
         var status: ConnectionStatus = .disconnected
         var columnTypeCache: [String: ColumnType] = [:]
@@ -557,6 +557,10 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable {
 
     func switchDatabase(to database: String) async throws {
         try await pluginDriver.switchDatabase(to: database)
+    }
+
+    var currentDatabase: String? {
+        pluginDriver.currentDatabase
     }
 
     // MARK: - DDL Schema Generation

--- a/TablePro/Core/Plugins/PluginManager+Registration.swift
+++ b/TablePro/Core/Plugins/PluginManager+Registration.swift
@@ -527,14 +527,30 @@ extension PluginManager {
 
     /// A file holds exactly one database, so a file-based engine never has a tree to draw.
     /// Every other mode can: a server hosts several databases, and an embedded engine can
-    /// attach them. `supportsDatabaseSwitching` defaults to true on `DriverPlugin`, so the
-    /// grouping strategy is what keeps an engine that never declared one out of the tree.
+    /// attach them.
+    ///
+    /// Both remaining terms are permissive by default (`supportsDatabaseSwitching` is true
+    /// and the grouping strategy is `.byDatabase` on `DriverPlugin`), so a plugin that
+    /// declares neither gets a tree its default `fetchDatabases()` returns nothing for.
+    /// That was true of networked plugins before this guard was widened and is why the
+    /// list stays a declaration rather than an inference; `DatabaseTreeCapabilityTests`
+    /// pins it for both modes.
     func supportsDatabaseTree(for databaseType: DatabaseType) -> Bool {
-        guard connectionMode(for: databaseType) != .fileBased,
-              supportsDatabaseSwitching(for: databaseType) else {
-            return false
-        }
-        let grouping = databaseGroupingStrategy(for: databaseType)
+        Self.supportsDatabaseTree(
+            connectionMode: connectionMode(for: databaseType),
+            supportsDatabaseSwitching: supportsDatabaseSwitching(for: databaseType),
+            grouping: databaseGroupingStrategy(for: databaseType)
+        )
+    }
+
+    /// The rule itself, as a pure function of the three inputs, so it can be exercised for
+    /// combinations no registered type declares today.
+    static func supportsDatabaseTree(
+        connectionMode: ConnectionMode,
+        supportsDatabaseSwitching: Bool,
+        grouping: GroupingStrategy
+    ) -> Bool {
+        guard connectionMode != .fileBased, supportsDatabaseSwitching else { return false }
         return grouping == .byDatabase || grouping == .bySchema
     }
 

--- a/TablePro/Core/Plugins/PluginManager+Registration.swift
+++ b/TablePro/Core/Plugins/PluginManager+Registration.swift
@@ -525,8 +525,12 @@ extension PluginManager {
             .schema.databaseGroupingStrategy ?? .byDatabase
     }
 
+    /// A file holds exactly one database, so a file-based engine never has a tree to draw.
+    /// Every other mode can: a server hosts several databases, and an embedded engine can
+    /// attach them. `supportsDatabaseSwitching` defaults to true on `DriverPlugin`, so the
+    /// grouping strategy is what keeps an engine that never declared one out of the tree.
     func supportsDatabaseTree(for databaseType: DatabaseType) -> Bool {
-        guard connectionMode(for: databaseType) == .network,
+        guard connectionMode(for: databaseType) != .fileBased,
               supportsDatabaseSwitching(for: databaseType) else {
             return false
         }

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
@@ -583,13 +583,14 @@ extension PluginMetadataRegistry {
                     ExplainVariant(id: "explain", label: "EXPLAIN", sqlPrefix: "EXPLAIN", format: .indentedText),
                 ],
                 pathFieldRole: .database,
-                supportsHealthMonitor: false, urlSchemes: ["duckdb", "quack"], postConnectActions: [],
+                supportsHealthMonitor: false, urlSchemes: ["duckdb", "quack"],
+                postConnectActions: [.selectSchemaFromLastSession],
                 brandColorHex: "#FFD900",
                 queryLanguageName: "SQL", editorLanguage: .sql,
-                connectionMode: .apiOnly, supportsDatabaseSwitching: false,
+                connectionMode: .apiOnly, supportsDatabaseSwitching: true,
                 supportsColumnReorder: false,
                 capabilities: PluginMetadataSnapshot.CapabilityFlags(
-                    supportsSchemaSwitching: false,
+                    supportsSchemaSwitching: true,
                     supportsImport: true,
                     supportsExport: true,
                     supportsSSH: false,
@@ -604,16 +605,16 @@ extension PluginMetadataRegistry {
                     supportsConnectionPooling: false
                 ),
                 schema: PluginMetadataSnapshot.SchemaInfo(
-                    defaultSchemaName: "public",
+                    defaultSchemaName: "main",
                     defaultGroupName: "main",
                     tableEntityName: "Tables",
                     containerEntityName: "Database",
                     defaultPrimaryKeyColumn: nil,
                     immutableColumns: [],
-                    systemDatabaseNames: ["information_schema", "pg_catalog"],
+                    systemDatabaseNames: ["system", "temp"],
                     systemSchemaNames: [],
                     fileExtensions: ["duckdb", "ddb"],
-                    databaseGroupingStrategy: .flat,
+                    databaseGroupingStrategy: .bySchema,
                     structureColumnFields: [.name, .type, .nullable, .defaultValue, .autoIncrement, .comment]
                 ),
                 editor: PluginMetadataSnapshot.EditorConfig(
@@ -625,7 +626,8 @@ extension PluginMetadataRegistry {
                     additionalConnectionFields: Self.duckdbConnectionFields,
                     category: .analytical,
                     tagline: String(localized: "Embedded and remote analytical SQL"),
-                    hidesBuiltInPassword: true
+                    hidesBuiltInPassword: true,
+                    hidesBuiltInDatabase: true
                 )
             )),
             ("Beancount", PluginMetadataSnapshot(

--- a/TablePro/Core/Plugins/PluginMetadataRegistry.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry.swift
@@ -174,6 +174,10 @@ struct PluginMetadataSnapshot: Sendable {
         let category: DatabaseCategory
         let tagline: String
         let hidesBuiltInPassword: Bool
+        /// An engine can switch database without the user naming one on the connection:
+        /// an embedded engine takes it from the file it opens. Showing the built-in
+        /// database field there offers a second, meaningless place to type one.
+        let hidesBuiltInDatabase: Bool
         let defaultUnixSocketPath: String?
         let defaultHost: String?
 
@@ -182,6 +186,7 @@ struct PluginMetadataSnapshot: Sendable {
             category: DatabaseCategory = .other,
             tagline: String = "",
             hidesBuiltInPassword: Bool = false,
+            hidesBuiltInDatabase: Bool = false,
             defaultUnixSocketPath: String? = nil,
             defaultHost: String? = nil
         ) {
@@ -189,6 +194,7 @@ struct PluginMetadataSnapshot: Sendable {
             self.category = category
             self.tagline = tagline
             self.hidesBuiltInPassword = hidesBuiltInPassword
+            self.hidesBuiltInDatabase = hidesBuiltInDatabase
             self.defaultUnixSocketPath = defaultUnixSocketPath
             self.defaultHost = defaultHost
         }
@@ -1162,6 +1168,7 @@ final class PluginMetadataRegistry: @unchecked Sendable {
                 tagline: existingSnapshot?.connection.tagline
                     ?? Self.fallbackTagline(forTypeId: driverType.databaseTypeId),
                 hidesBuiltInPassword: existingSnapshot?.connection.hidesBuiltInPassword ?? false,
+                hidesBuiltInDatabase: existingSnapshot?.connection.hidesBuiltInDatabase ?? false,
                 defaultUnixSocketPath: existingSnapshot?.connection.defaultUnixSocketPath,
                 defaultHost: existingSnapshot?.connection.defaultHost
             )

--- a/TablePro/Models/UI/WindowSidebarState.swift
+++ b/TablePro/Models/UI/WindowSidebarState.swift
@@ -49,6 +49,32 @@ internal final class WindowSidebarState {
     var expandedTreeDatabaseSchemas: Set<DatabaseSchemaKey> = [] { didSet { persistExpansion() } }
     var expandedTreeTables: Set<DatabaseTableKey> = [] { didSet { persistExpansion() } }
 
+    /// An all-empty expansion set means "the user collapsed everything" just as much as it
+    /// means "the user has never opened this tree", and seeding on the former would reopen
+    /// nodes they deliberately closed. This records that the seed already happened.
+    private(set) var didSeedExpansion = false
+
+    /// Opens the tree on the connection's current location the first time it is shown, so a
+    /// database whose objects all sit under one schema is not a row of closed triangles.
+    /// The tree renders before the connection resolves, so a call with nothing to seed
+    /// must not consume the one shot: it would leave the tree closed forever.
+    func seedExpansionIfNeeded(database: String?, schema: String?) {
+        guard !didSeedExpansion else { return }
+        let database = database?.nilIfEmpty
+        let schema = schema?.nilIfEmpty
+        guard database != nil || schema != nil else { return }
+
+        didSeedExpansion = true
+        if let schema { expandedTreeSchemas.insert(schema) }
+        if let database {
+            expandedTreeDatabases.insert(database)
+            if let schema {
+                expandedTreeDatabaseSchemas.insert(DatabaseSchemaKey(database: database, schema: schema))
+            }
+        }
+        persistExpansion()
+    }
+
     init(connectionId: UUID? = nil, defaults: UserDefaults = .standard) {
         self.connectionId = connectionId
         self.defaults = defaults
@@ -61,6 +87,7 @@ internal final class WindowSidebarState {
         var databases: [String]
         var databaseSchemas: [DatabaseSchemaKey]
         var tables: [DatabaseTableKey]?
+        var seeded: Bool?
     }
 
     private var storageKey: String? {
@@ -75,13 +102,15 @@ internal final class WindowSidebarState {
         expandedTreeDatabases = Set(decoded.databases)
         expandedTreeDatabaseSchemas = Set(decoded.databaseSchemas)
         expandedTreeTables = Set(decoded.tables ?? [])
+        didSeedExpansion = decoded.seeded ?? true
     }
 
     private func persistExpansion() {
         guard isLoaded, let storageKey else { return }
 
         if expandedTreeSchemas.isEmpty, expandedTreeDatabases.isEmpty,
-           expandedTreeDatabaseSchemas.isEmpty, expandedTreeTables.isEmpty {
+           expandedTreeDatabaseSchemas.isEmpty, expandedTreeTables.isEmpty,
+           !didSeedExpansion {
             defaults.removeObject(forKey: storageKey)
             return
         }
@@ -90,7 +119,8 @@ internal final class WindowSidebarState {
             schemas: Array(expandedTreeSchemas),
             databases: Array(expandedTreeDatabases),
             databaseSchemas: Array(expandedTreeDatabaseSchemas),
-            tables: Array(expandedTreeTables)
+            tables: Array(expandedTreeTables),
+            seeded: didSeedExpansion
         )
         if let data = try? JSONEncoder().encode(snapshot) {
             defaults.set(data, forKey: storageKey)

--- a/TablePro/Views/ConnectionForm/Panes/GeneralPaneView.swift
+++ b/TablePro/Views/ConnectionForm/Panes/GeneralPaneView.swift
@@ -18,6 +18,12 @@ struct GeneralPaneView: View {
         PluginManager.shared.connectionMode(for: type)
     }
 
+    private var showsBuiltInDatabaseField: Bool {
+        guard PluginManager.shared.supportsDatabaseSwitching(for: type) else { return false }
+        return PluginMetadataRegistry.shared.snapshot(forTypeId: type.pluginTypeId)?
+            .connection.hidesBuiltInDatabase != true
+    }
+
     var body: some View {
         Form {
             if let parsed = coordinator.clipboardCandidate {
@@ -79,7 +85,7 @@ struct GeneralPaneView: View {
                 }
             }
         case .apiOnly:
-            if PluginManager.shared.supportsDatabaseSwitching(for: type) {
+            if showsBuiltInDatabaseField {
                 Section(String(localized: "Connection")) {
                     TextField(
                         containerEntityName,

--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Expansion.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Expansion.swift
@@ -10,6 +10,7 @@ import TableProPluginKit
 extension DatabaseTreeOutlineCoordinator {
     internal func applyDesiredExpansion() {
         guard let outlineView = self.outlineView else { return }
+        seedExpansionFromSession()
         isApplyingExpansion = true
         defer { isApplyingExpansion = false }
         let searching = !searchText.isEmpty
@@ -57,6 +58,18 @@ extension DatabaseTreeOutlineCoordinator {
                 }
             }
         }
+    }
+
+    /// A connection knows where it is browsing from the moment it connects, so the tree can
+    /// open there instead of showing every container closed. Runs once per connection; after
+    /// that the user's own expansion state is the only input.
+    private func seedExpansionFromSession() {
+        guard let windowState, !windowState.didSeedExpansion else { return }
+        let session = DatabaseManager.shared.session(for: connectionId)
+        windowState.seedExpansionIfNeeded(
+            database: session?.resolvedBrowseDatabase,
+            schema: session?.browseSchema
+        )
     }
 
     private func restorePartitionExpansion(under parent: DatabaseTreeNode) {

--- a/TableProTests/Core/Database/ScopedDriverRoutingTests.swift
+++ b/TableProTests/Core/Database/ScopedDriverRoutingTests.swift
@@ -90,21 +90,40 @@ struct ScopedDriverRoutingTests {
 
     @Test("A single-database engine never leaves the session driver")
     func singleDatabaseEnginesNeverLeaveTheSessionDriver() throws {
-        for type in [DatabaseType.sqlite, DatabaseType.duckdb] {
-            let connection = Self.makeSession(type: type, browseDatabase: "main")
-            defer { DatabaseManager.shared.removeSession(for: connection.id) }
+        let connection = Self.makeSession(type: .sqlite, browseDatabase: "main")
+        defer { DatabaseManager.shared.removeSession(for: connection.id) }
 
-            #expect(PluginManager.shared.supportsDatabaseSwitching(for: type) == false)
+        #expect(PluginManager.shared.supportsDatabaseSwitching(for: .sqlite) == false)
 
-            let own = Self.scope(connection, database: "main")
-            let foreign = Self.scope(connection, database: "another_file")
+        let own = Self.scope(connection, database: "main")
+        let foreign = Self.scope(connection, database: "another_file")
 
-            #expect(DatabaseManager.shared.executionRoute(for: own) == .sessionDriver)
-            #expect(
-                DatabaseManager.shared.executionRoute(for: foreign) == .sessionDriver,
-                "A second read-write handle on the same file would fight the session driver's lock"
-            )
-        }
+        #expect(DatabaseManager.shared.executionRoute(for: own) == .sessionDriver)
+        #expect(
+            DatabaseManager.shared.executionRoute(for: foreign) == .sessionDriver,
+            "A second read-write handle on the same file would fight the session driver's lock"
+        )
+    }
+
+    /// DuckDB switches catalog with `USE` on the live connection, so it declares database
+    /// switching, but it still must not pool: a second `duckdb_open` is a different
+    /// database. Switching in place is exactly what keeps every scope on the one driver.
+    @Test("An embedded engine that switches catalogs stays on the session driver")
+    func embeddedCatalogSwitchingStaysOnTheSessionDriver() throws {
+        let connection = Self.makeSession(type: .duckdb, browseDatabase: "main")
+        defer { DatabaseManager.shared.removeSession(for: connection.id) }
+
+        #expect(PluginManager.shared.supportsDatabaseSwitching(for: .duckdb) == true)
+        #expect(PluginManager.shared.requiresReconnectForDatabaseSwitch(for: .duckdb) == false)
+
+        let own = Self.scope(connection, database: "main")
+        let attached = Self.scope(connection, database: "another_file")
+
+        #expect(DatabaseManager.shared.executionRoute(for: own) == .sessionDriver)
+        #expect(
+            DatabaseManager.shared.executionRoute(for: attached) == .sessionDriver,
+            "An ATTACH'd catalog lives on the same connection, so there is nothing to pool to"
+        )
     }
 
     @Test("An embedded engine keeps its metadata reads on the session driver too")

--- a/TableProTests/Core/Database/ScopedDriverRoutingTests.swift
+++ b/TableProTests/Core/Database/ScopedDriverRoutingTests.swift
@@ -29,6 +29,32 @@ struct ScopedDriverRoutingTests {
         DatabaseScope(connectionId: connection.id, database: database, schema: nil)
     }
 
+    /// A schema name only means something inside its own database. Inheriting the browsed
+    /// schema into a scope naming another database made the sidebar ask a newly attached
+    /// DuckDB catalog for a schema that lives in a different one, and DuckDB rejected the
+    /// whole read, so the attached database never listed its schemas.
+    @Test("A scope on another database does not inherit the browsed schema")
+    func foreignDatabaseScopeDoesNotInheritSchema() throws {
+        let connection = Self.makeSession(type: .duckdb, browseDatabase: "analytics")
+        defer { DatabaseManager.shared.removeSession(for: connection.id) }
+        DatabaseManager.shared.updateSession(connection.id) { $0.browseSchema = "sales" }
+
+        let own = DatabaseManager.shared.resolvedScope(
+            database: "analytics", schema: nil, for: connection.id
+        )
+        #expect(own?.schema == "sales", "The browsed database still inherits the browsed schema")
+
+        let attached = DatabaseManager.shared.resolvedScope(
+            database: "warehouse", schema: nil, for: connection.id
+        )
+        #expect(attached?.schema == nil, "A different database must not inherit 'sales'")
+
+        let explicit = DatabaseManager.shared.resolvedScope(
+            database: "warehouse", schema: "staging", for: connection.id
+        )
+        #expect(explicit?.schema == "staging", "An explicit schema still passes through")
+    }
+
     @Test("A pin-capable engine keeps the user's SQL on the session driver")
     func pinCapableEngineUsesTheSessionDriver() throws {
         let connection = Self.makeSession(type: .mysql, browseDatabase: "inventory")

--- a/TableProTests/Core/Plugins/ContainerEntityNameTests.swift
+++ b/TableProTests/Core/Plugins/ContainerEntityNameTests.swift
@@ -87,6 +87,16 @@ struct ContainerEntityNameTests {
         #expect(PluginManager.shared.containerSwitchTarget(for: .postgresql) == .database)
     }
 
+    /// A DuckDB catalog really is a database, so it keeps the default container name and
+    /// switches by database the way PostgreSQL does, with schemas one level below.
+    @Test("DuckDB containers are databases with a schema level")
+    func duckDBContainerIsDatabase() {
+        #expect(PluginManager.shared.containerEntityName(for: .duckdb) == "Database")
+        #expect(PluginManager.shared.containerSwitchTarget(for: .duckdb) == .database)
+        #expect(PluginManager.shared.supportsSchemaSwitching(for: .duckdb) == true)
+        #expect(PluginManager.shared.databaseGroupingStrategy(for: .duckdb) == .bySchema)
+    }
+
     @Test("Engines without switching have no target")
     func nonSwitchingEnginesHaveNoTarget() {
         #expect(PluginManager.shared.containerSwitchTarget(for: .redis) == nil)

--- a/TableProTests/Core/Plugins/DatabaseTreeCapabilityTests.swift
+++ b/TableProTests/Core/Plugins/DatabaseTreeCapabilityTests.swift
@@ -1,0 +1,89 @@
+//
+//  DatabaseTreeCapabilityTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+/// `supportsDatabaseTree` decides whether the sidebar can show a database level at all.
+/// Nothing pinned it before, so relaxing its connection-mode guard was unobservable.
+@MainActor
+@Suite("Database tree capability")
+struct DatabaseTreeCapabilityTests {
+    private func snapshot(forTypeId typeId: String) -> PluginMetadataSnapshot? {
+        PluginMetadataRegistry.shared.snapshot(forTypeId: typeId)
+    }
+
+    @Test("Networked engines that group by database or schema get a tree")
+    func networkedGroupingEnginesGetTree() {
+        for type in [DatabaseType.mysql, .postgresql, .mssql, .clickhouse, .cassandra] {
+            #expect(
+                PluginManager.shared.supportsDatabaseTree(for: type) == true,
+                "\(type.rawValue) should still have a database tree"
+            )
+        }
+    }
+
+    /// A file holds exactly one database, so there is nothing to draw a tree from.
+    @Test("File-based engines never get a tree")
+    func fileBasedEnginesNeverGetTree() {
+        for type in [DatabaseType.sqlite, .beancount] {
+            #expect(PluginManager.shared.supportsDatabaseTree(for: type) == false)
+        }
+    }
+
+    /// DuckDB is `.apiOnly` because it is embedded, not because it has one database:
+    /// `ATTACH` gives it siblings. The gate excludes file-based engines, not embedded ones.
+    @Test("DuckDB gets a database tree despite being apiOnly")
+    func duckDBGetsTree() {
+        #expect(PluginManager.shared.connectionMode(for: .duckdb) == .apiOnly)
+        #expect(PluginManager.shared.supportsDatabaseSwitching(for: .duckdb) == true)
+        #expect(PluginManager.shared.databaseGroupingStrategy(for: .duckdb) == .bySchema)
+        #expect(PluginManager.shared.supportsDatabaseTree(for: .duckdb) == true)
+    }
+
+    /// The grouping strategy, not the connection mode, is what keeps an engine that never
+    /// declared one out of the tree: `supportsDatabaseSwitching` defaults to true.
+    @Test("Flat and hierarchical engines stay out of the tree whatever their mode")
+    func nonGroupingEnginesStayOut() {
+        let types = [DatabaseType.mongodb, .redis, .cloudflareD1, .oracle, .bigQuery]
+            + [DatabaseType(rawValue: "Snowflake"), DatabaseType(rawValue: "Trino")]
+        for type in types {
+            #expect(
+                PluginManager.shared.supportsDatabaseTree(for: type) == false,
+                "\(type.rawValue) does not group by database or schema and must not get a tree"
+            )
+        }
+    }
+
+    /// `DatabaseType` is open, so a type with no snapshot falls back to a networked engine
+    /// that groups by database. Relaxing the connection-mode guard did not change that: the
+    /// fallback was already `.network`. Pinned so a future guard change has to be deliberate.
+    @Test("An unknown future type keeps the optimistic tree default")
+    func unknownTypeKeepsDefault() {
+        let unknown = DatabaseType(rawValue: "FuturePlugin")
+        #expect(PluginManager.shared.connectionMode(for: unknown) == .network)
+        #expect(PluginManager.shared.supportsDatabaseSwitching(for: unknown) == true)
+        #expect(PluginManager.shared.databaseGroupingStrategy(for: unknown) == .byDatabase)
+        #expect(PluginManager.shared.supportsDatabaseTree(for: unknown) == true)
+    }
+
+    /// The relaxed guard swapped `== .network` for `!= .fileBased`, so this walks every
+    /// registered type rather than a sample: a file is one database, always.
+    @Test("No file-based type anywhere in the registry gains a tree")
+    func noFileBasedTypeGainsTree() {
+        var checked = 0
+        for typeId in PluginMetadataRegistry.shared.allRegisteredTypeIds() {
+            guard let snap = snapshot(forTypeId: typeId), snap.connectionMode == .fileBased else { continue }
+            checked += 1
+            #expect(
+                PluginManager.shared.supportsDatabaseTree(for: DatabaseType(rawValue: typeId)) == false,
+                "\(typeId) is file-based and must not have a database tree"
+            )
+        }
+        #expect(checked > 0, "No file-based types found; the guard is no longer being exercised")
+    }
+}

--- a/TableProTests/Core/Plugins/DatabaseTreeCapabilityTests.swift
+++ b/TableProTests/Core/Plugins/DatabaseTreeCapabilityTests.swift
@@ -71,6 +71,33 @@ struct DatabaseTreeCapabilityTests {
         #expect(PluginManager.shared.supportsDatabaseTree(for: unknown) == true)
     }
 
+    /// Both non-mode terms of the guard are permissive by default, so a plugin that
+    /// declares only `.apiOnly` and nothing else now qualifies where it previously did
+    /// not. Recorded rather than asserted as desirable: widening the guard widened this.
+    @Test("An apiOnly plugin that declares no grouping qualifies for a tree")
+    func apiOnlyWithDefaultsQualifies() {
+        #expect(
+            PluginManager.supportsDatabaseTree(
+                connectionMode: .apiOnly, supportsDatabaseSwitching: true, grouping: .byDatabase
+            ) == true
+        )
+        #expect(
+            PluginManager.supportsDatabaseTree(
+                connectionMode: .fileBased, supportsDatabaseSwitching: true, grouping: .byDatabase
+            ) == false
+        )
+        #expect(
+            PluginManager.supportsDatabaseTree(
+                connectionMode: .apiOnly, supportsDatabaseSwitching: false, grouping: .byDatabase
+            ) == false
+        )
+        #expect(
+            PluginManager.supportsDatabaseTree(
+                connectionMode: .apiOnly, supportsDatabaseSwitching: true, grouping: .flat
+            ) == false
+        )
+    }
+
     /// The relaxed guard swapped `== .network` for `!= .fileBased`, so this walks every
     /// registered type rather than a sample: a file is one database, always.
     @Test("No file-based type anywhere in the registry gains a tree")

--- a/TableProTests/Core/Plugins/PluginMetadataRegistrySchemaSwitchingTests.swift
+++ b/TableProTests/Core/Plugins/PluginMetadataRegistrySchemaSwitchingTests.swift
@@ -64,6 +64,41 @@ struct PluginMetadataRegistrySchemaSwitchingTests {
         #expect(snap.postConnectActions.contains(.selectSchemaFromLastSession))
     }
 
+    // MARK: - DuckDB
+
+    @Test("DuckDB supports schema switching")
+    func duckDBSupportsSchemaSwitching() {
+        guard let snap = snapshot(forTypeId: "DuckDB") else {
+            Issue.record("Registry default for DuckDB missing")
+            return
+        }
+        #expect(snap.capabilities.supportsSchemaSwitching == true)
+    }
+
+    @Test("DuckDB post-connect actions restore last schema")
+    func duckDBRestoresLastSchema() {
+        guard let snap = snapshot(forTypeId: "DuckDB") else {
+            Issue.record("Registry default for DuckDB missing")
+            return
+        }
+        #expect(snap.postConnectActions.contains(.selectSchemaFromLastSession))
+    }
+
+    /// DuckDB's default schema is `main`. Inheriting PostgreSQL's `public` made every
+    /// table in the default schema render as `main.name` and broke export preselection.
+    @Test("DuckDB's default schema is main")
+    func duckDBDefaultSchemaIsMain() {
+        #expect(snapshot(forTypeId: "DuckDB")?.schema.defaultSchemaName == "main")
+    }
+
+    /// `information_schema` and `pg_catalog` are schemas of DuckDB's `system` catalog,
+    /// not databases. The system databases are `system` and `temp`.
+    @Test("DuckDB's system databases are its built-in catalogs")
+    func duckDBSystemDatabases() {
+        let names = snapshot(forTypeId: "DuckDB")?.schema.systemDatabaseNames ?? []
+        #expect(Set(names) == ["system", "temp"])
+    }
+
     // MARK: - PostgreSQL (regression for the working reference)
 
     @Test("PostgreSQL supports schema switching")
@@ -99,7 +134,7 @@ struct PluginMetadataRegistrySchemaSwitchingTests {
 
     @Test("Quick Switcher allowlist agrees with registry capability flag")
     func quickSwitcherAllowlistMatchesRegistry() {
-        let typesThatShouldSupportSchemas = ["PostgreSQL", "Redshift", "Oracle", "SQL Server"]
+        let typesThatShouldSupportSchemas = ["PostgreSQL", "Redshift", "Oracle", "SQL Server", "DuckDB"]
         for typeId in typesThatShouldSupportSchemas {
             guard let snap = snapshot(forTypeId: typeId) else {
                 Issue.record("Registry default for \(typeId) missing")

--- a/TableProTests/Models/UI/WindowSidebarStateSeedingTests.swift
+++ b/TableProTests/Models/UI/WindowSidebarStateSeedingTests.swift
@@ -1,0 +1,126 @@
+//
+//  WindowSidebarStateSeedingTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+/// An all-empty expansion set means "collapsed everything" as much as it means "never
+/// opened", so the seed has to record that it ran rather than infer it from emptiness.
+@MainActor
+@Suite("Sidebar tree expansion seeding")
+struct WindowSidebarStateSeedingTests {
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "com.TablePro.tests.sidebarSeeding.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("Could not create a test UserDefaults suite")
+        }
+        return defaults
+    }
+
+    @Test("Seeding opens the browsed database and schema")
+    func seedsBrowsedLocation() {
+        let state = WindowSidebarState(connectionId: UUID(), defaults: makeDefaults())
+        state.seedExpansionIfNeeded(database: "repro", schema: "main")
+
+        #expect(state.expandedTreeDatabases == ["repro"])
+        #expect(state.expandedTreeSchemas == ["main"])
+        #expect(state.expandedTreeDatabaseSchemas == [DatabaseSchemaKey(database: "repro", schema: "main")])
+        #expect(state.didSeedExpansion)
+    }
+
+    @Test("A schema-only engine seeds just the schema")
+    func seedsSchemaWithoutDatabase() {
+        let state = WindowSidebarState(connectionId: UUID(), defaults: makeDefaults())
+        state.seedExpansionIfNeeded(database: "", schema: "core")
+
+        #expect(state.expandedTreeDatabases.isEmpty)
+        #expect(state.expandedTreeSchemas == ["core"])
+        #expect(state.didSeedExpansion)
+    }
+
+    /// The outline renders before the connection resolves. Consuming the one shot on that
+    /// first empty call would leave the tree closed for the life of the connection.
+    @Test("Seeding with nothing to open does not consume the one shot")
+    func emptySeedDoesNotConsumeTheShot() {
+        let state = WindowSidebarState(connectionId: UUID(), defaults: makeDefaults())
+
+        state.seedExpansionIfNeeded(database: nil, schema: nil)
+        #expect(!state.didSeedExpansion)
+        state.seedExpansionIfNeeded(database: "", schema: "")
+        #expect(!state.didSeedExpansion)
+
+        state.seedExpansionIfNeeded(database: "repro", schema: "main")
+        #expect(state.didSeedExpansion)
+        #expect(state.expandedTreeDatabases == ["repro"])
+    }
+
+    @Test("Seeding runs once, so a later connect cannot reopen what the user closed")
+    func seedsOnlyOnce() {
+        let state = WindowSidebarState(connectionId: UUID(), defaults: makeDefaults())
+        state.seedExpansionIfNeeded(database: "repro", schema: "main")
+        state.expandedTreeDatabases = []
+        state.expandedTreeSchemas = []
+        state.expandedTreeDatabaseSchemas = []
+
+        state.seedExpansionIfNeeded(database: "repro", schema: "main")
+
+        #expect(state.expandedTreeDatabases.isEmpty)
+        #expect(state.expandedTreeSchemas.isEmpty)
+    }
+
+    @Test("A collapsed-everything tree stays collapsed across a reload")
+    func collapsedStateSurvivesReload() {
+        let defaults = makeDefaults()
+        let connectionId = UUID()
+
+        let first = WindowSidebarState(connectionId: connectionId, defaults: defaults)
+        first.seedExpansionIfNeeded(database: "repro", schema: "main")
+        first.expandedTreeDatabases = []
+        first.expandedTreeSchemas = []
+        first.expandedTreeDatabaseSchemas = []
+
+        let second = WindowSidebarState(connectionId: connectionId, defaults: defaults)
+        #expect(second.didSeedExpansion)
+        second.seedExpansionIfNeeded(database: "repro", schema: "main")
+        #expect(second.expandedTreeDatabases.isEmpty)
+        #expect(second.expandedTreeSchemas.isEmpty)
+    }
+
+    @Test("Expansion state persists across a reload")
+    func expansionSurvivesReload() {
+        let defaults = makeDefaults()
+        let connectionId = UUID()
+
+        let first = WindowSidebarState(connectionId: connectionId, defaults: defaults)
+        first.seedExpansionIfNeeded(database: "repro", schema: "main")
+
+        let second = WindowSidebarState(connectionId: connectionId, defaults: defaults)
+        #expect(second.expandedTreeDatabases == ["repro"])
+        #expect(second.expandedTreeSchemas == ["main"])
+        #expect(second.didSeedExpansion)
+    }
+
+    /// A window whose state predates the flag already carries the user's own choices,
+    /// so it must not be seeded over.
+    @Test("A pre-existing expansion blob counts as already seeded")
+    func legacyBlobCountsAsSeeded() throws {
+        let defaults = makeDefaults()
+        let connectionId = UUID()
+        let legacy = """
+        {"schemas":["public"],"databases":["app"],"databaseSchemas":[],"tables":[]}
+        """
+        defaults.set(
+            Data(legacy.utf8),
+            forKey: "com.TablePro.sidebar.treeExpansion.\(connectionId.uuidString)"
+        )
+
+        let state = WindowSidebarState(connectionId: connectionId, defaults: defaults)
+        #expect(state.didSeedExpansion)
+        state.seedExpansionIfNeeded(database: "other", schema: "main")
+        #expect(state.expandedTreeDatabases == ["app"])
+        #expect(state.expandedTreeSchemas == ["public"])
+    }
+}

--- a/TableProTests/Plugins/DuckDBSchemaQueriesTests.swift
+++ b/TableProTests/Plugins/DuckDBSchemaQueriesTests.swift
@@ -1,0 +1,137 @@
+//
+//  DuckDBSchemaQueriesTests.swift
+//  TableProTests
+//
+//  Tests for DuckDBSchemaQueries (compiled via project.yml from DuckDBDriverPlugin).
+//  DuckDB's namespace is catalog.schema.table and its catalog views span every attached
+//  catalog, so these pin the catalog predicate that keeps one catalog's objects from
+//  appearing under another's identically named schema.
+//
+
+import Foundation
+import Testing
+
+@Suite("DuckDB schema queries")
+struct DuckDBSchemaQueriesTests {
+    private static let catalogScopedQueries: [(name: String, sql: String)] = [
+        ("listSchemas", DuckDBSchemaQueries.listSchemas),
+        ("listTables", DuckDBSchemaQueries.listTables),
+        ("columnsForTable", DuckDBSchemaQueries.columnsForTable),
+        ("columnsForSchema", DuckDBSchemaQueries.columnsForSchema),
+        ("primaryKeyColumnsForSchema", DuckDBSchemaQueries.primaryKeyColumnsForSchema),
+        ("primaryKeyColumnsForTable", DuckDBSchemaQueries.primaryKeyColumnsForTable),
+        ("indexesForTable", DuckDBSchemaQueries.indexesForTable),
+        ("foreignKeysForTable", DuckDBSchemaQueries.foreignKeysForTable),
+        ("tableDDL", DuckDBSchemaQueries.tableDDL),
+        ("viewDefinition", DuckDBSchemaQueries.viewDefinition),
+        ("enumTypeNamesForSchema", DuckDBSchemaQueries.enumTypeNamesForSchema),
+    ]
+
+    // MARK: - Catalog scoping
+
+    @Test("Every metadata query is anchored to the current catalog")
+    func metadataQueriesAreCatalogScoped() {
+        for query in Self.catalogScopedQueries {
+            #expect(
+                query.sql.contains("current_database()"),
+                "\(query.name) has no catalog predicate, so it matches same-named schemas in attached catalogs"
+            )
+        }
+    }
+
+    @Test("information_schema queries scope on table_catalog, duckdb_ functions on database_name")
+    func catalogPredicateUsesTheRightColumn() {
+        for query in Self.catalogScopedQueries {
+            let usesInformationSchema = query.sql.contains("information_schema.")
+            let expected = usesInformationSchema ? "table_catalog = current_database()" : "database_name = current_database()"
+            #expect(query.sql.contains(expected), "\(query.name) should scope with '\(expected)'")
+        }
+    }
+
+    @Test("The all-tables metadata query is catalog scoped")
+    func allTablesMetadataIsCatalogScoped() {
+        let sql = DuckDBSchemaQueries.allTablesMetadata(schema: "core")
+        #expect(sql.contains("table_catalog = current_database()"))
+        #expect(sql.contains("table_schema = 'core'"))
+    }
+
+    // MARK: - Schema listing
+
+    @Test("The schema list never filters on the schema's own internal flag")
+    func schemaListDoesNotFilterOnInternal() {
+        // DuckDB marks the auto-created `main` internal in every catalog, so this
+        // predicate would hide the default schema of every database.
+        #expect(!DuckDBSchemaQueries.listSchemas.contains("internal"))
+    }
+
+    @Test("The schema list reads duckdb_schemas, not the catalog-blind schemata view")
+    func schemaListUsesDuckDBSchemas() {
+        #expect(DuckDBSchemaQueries.listSchemas.contains("duckdb_schemas()"))
+        #expect(!DuckDBSchemaQueries.listSchemas.contains("information_schema.schemata"))
+    }
+
+    // MARK: - Database listing
+
+    @Test("The database list hides DuckDB's built-in catalogs")
+    func databaseListExcludesInternalCatalogs() {
+        #expect(DuckDBSchemaQueries.listDatabases.contains("internal = false"))
+        #expect(DuckDBSchemaQueries.listDatabases.contains("duckdb_databases()"))
+    }
+
+    // MARK: - Switching
+
+    @Test("Switching schema names the catalog so the two-part form is unambiguous")
+    func useSchemaQualifiesWithCatalog() {
+        #expect(DuckDBSchemaQueries.useSchema("core", in: "repro") == #"USE "repro"."core""#)
+    }
+
+    @Test("Switching schema without a known catalog falls back to the bare form")
+    func useSchemaWithoutCatalog() {
+        #expect(DuckDBSchemaQueries.useSchema("core", in: nil) == #"USE "core""#)
+        #expect(DuckDBSchemaQueries.useSchema("core", in: "") == #"USE "core""#)
+    }
+
+    @Test("Switching schema never uses SET schema, which splits its value on a dot")
+    func useSchemaDoesNotUseSetSchema() {
+        #expect(!DuckDBSchemaQueries.useSchema("a.b", in: "db").contains("SET schema"))
+        #expect(DuckDBSchemaQueries.useSchema("a.b", in: "db") == #"USE "db"."a.b""#)
+    }
+
+    @Test("Switching database quotes the catalog name")
+    func useDatabaseQuotesIdentifier() {
+        #expect(DuckDBSchemaQueries.useDatabase("my-db") == #"USE "my-db""#)
+    }
+
+    // MARK: - Quoting
+
+    @Test("Embedded double quotes are doubled, not dropped")
+    func identifierQuotingEscapesQuotes() {
+        #expect(DuckDBSchemaQueries.quoteIdentifier(#"we"ird"#) == #""we""ird""#)
+        #expect(DuckDBSchemaQueries.useSchema(#"we"ird"#, in: "repro") == #"USE "repro"."we""ird""#)
+    }
+
+    @Test("A quoted identifier cannot be broken out of with an injection payload")
+    func identifierQuotingResistsInjection() {
+        let payload = #"x"; DROP TABLE users; --"#
+        #expect(DuckDBSchemaQueries.useDatabase(payload) == #"USE "x""; DROP TABLE users; --""#)
+    }
+
+    @Test("Single quotes in a schema literal are escaped")
+    func schemaLiteralEscapesQuotes() {
+        let sql = DuckDBSchemaQueries.allTablesMetadata(schema: "it's")
+        #expect(sql.contains("table_schema = 'it''s'"))
+    }
+
+    @Test("The row count probe qualifies the table with its schema")
+    func rowCountProbeQualifiesTable() {
+        let sql = DuckDBSchemaQueries.rowCountProbe(schema: "core", table: "bars", limit: 100_001)
+        #expect(sql.contains(#""core"."bars""#))
+        #expect(sql.contains("LIMIT 100001"))
+    }
+
+    @Test("Enum label lookup qualifies the type with its schema")
+    func enumLabelsQualifyType() {
+        let sql = DuckDBSchemaQueries.enumLabels(schema: "core", typeName: "mood")
+        #expect(sql.contains(#"NULL::"core"."mood""#))
+    }
+}

--- a/docs/databases/duckdb.mdx
+++ b/docs/databases/duckdb.mdx
@@ -62,9 +62,21 @@ See [Connection URL Reference](/databases/connection-urls) for all parameters.
 
 Double-click a `.duckdb` or `.ddb` file in Finder to open it directly in TablePro.
 
-## Schemas
+## Databases and schemas
 
-DuckDB supports multiple schemas per database; the default is `main`. Browse them in the sidebar. DuckDB has no toolbar schema switcher.
+A DuckDB connection opens one database, named after the file (`analytics.duckdb` becomes `analytics`). Each database holds one or more schemas, and the default is `main`.
+
+The sidebar shows both levels. Switch it to Tree layout from View > Sidebar Layout to get database > schema > tables; in the default Flat layout it lists the current schema's objects and you change schema from Database > Schema. The toolbar chip and `⌘K` switch database.
+
+`ATTACH` a second file and it appears as a sibling database after a sidebar refresh:
+
+```sql
+ATTACH 'warehouse.duckdb' AS warehouse;
+```
+
+Attachments last for the session. DuckDB does not persist them, so they are gone after a reconnect.
+
+DuckDB's built-in `system` and `temp` catalogs are hidden, and with them `information_schema` and `pg_catalog`, which live inside `system`.
 
 ## Querying files directly
 

--- a/project.yml
+++ b/project.yml
@@ -316,6 +316,7 @@ targets:
       - Plugins/ClickHouseDriverPlugin/ClickHouseCredentials.swift
       - Plugins/ClickHouseDriverPlugin/ClickHouseGeneratedColumnClassification.swift
       - Plugins/ClickHouseDriverPlugin/ClickHouseTableOperations.swift
+      - Plugins/DuckDBDriverPlugin/DuckDBSchemaQueries.swift
       - Plugins/DuckDBDriverPlugin/DuckDBTypeRendering.swift
       - Plugins/DuckDBDriverPlugin/QuackConnectBuilder.swift
       - Plugins/DynamoDBDriverPlugin/DynamoDBQueryBuilder.swift


### PR DESCRIPTION
Fixes #2131.

## Root cause

The reporter blamed a disagreement between the DuckDB plugin and the app registry. That is not what was happening: I diffed every plugin's statics against every registry default, and DuckDB's two sources agreed. Both were wrong.

`PluginMetadataRegistry.buildMetadataSnapshot` reads `supportsSchemaSwitching` and `databaseGroupingStrategy` straight off the plugin class and overwrites the curated entry on every plugin load, so the plugin is the operative source of truth. It declared `databaseGroupingStrategy = .flat` and never overrode `supportsSchemaSwitching`, inheriting `false`. So **the plugin's navigation metadata described a flat, single-database engine, contradicting its own driver**, which already implemented `fetchSchemas()`, `switchSchema(to:)`, `fetchDatabases()` and schema-aware `fetchTables(schema:)`. `SchemaService.runLoad` believed the metadata, dropped the schema list, and called `fetchTables()` with no schema; the driver resolved nil to its default `main`. The driver's `.multiSchema` capability is dead weight, nothing in the app reads it.

Two further bugs kept that dead code from ever being noticed. Both measured against a live DuckDB (CLI 1.5.4; the plugin bundles 1.5.3) using the issue's exact repro.

**Every metadata query discarded the catalog.** DuckDB's namespace is `catalog.schema.table`, and `information_schema` spans every attached catalog:

```
SELECT schema_name FROM information_schema.schemata ORDER BY schema_name
  -> core, information_schema, main, main, main, meta, pg_catalog
```

`main` appears once per catalog (the file, `system`, `temp`), alongside `information_schema` and `pg_catalog`, which are schemas *inside* `system`. Flipping the grouping flag alone would have shipped a sidebar with three identical `main` sections.

The table queries leaked the same way, which is reachable today because remote Quack mode always ATTACHes:

```
ATTACH 'other.duckdb' AS other;
SELECT table_catalog, table_name FROM information_schema.tables WHERE table_schema = 'main'
  -> other | t2        <- wrong catalog
     repro | something
```

**`main` is `internal = true` in every catalog**, so the obvious filter `duckdb_schemas() WHERE internal = false` hides the default schema everywhere. Catalogs are the level to filter, not schemas.

## The fix

DuckDB now uses the same sidebar shape as PostgreSQL: catalogs where PostgreSQL has databases, schemas where PostgreSQL has schemas. The reporter's own words were "like the PostgreSQL tree".

- **Plugin metadata**: `supportsDatabaseSwitching`, `supportsSchemaSwitching`, `databaseGroupingStrategy = .bySchema`, `defaultSchemaName = "main"`, `systemDatabaseNames = ["system", "temp"]` (it listed `information_schema` and `pg_catalog`, which are schemas, so the constant was filtering the wrong axis), and `.selectSchemaFromLastSession`. `defaultSchemaName` is load-bearing rather than tidying: `QueryTabManager.tabTitle` drops the schema prefix only when it matches, so every `main` table was going to be titled `main.something`.
- **New `DuckDBSchemaQueries`**, a pure SQL namespace. Every `information_schema` query gained `table_catalog = current_database()` and every `duckdb_*` function `database_name = current_database()`; `fetchDatabases()` gained `internal = false`; `fetchSchemas()` moved from the catalog-blind `information_schema.schemata` to `duckdb_schemas()`. Extraction rather than in-place edits because DuckDB is registry-only, so PR CI never compiles it, and a `#if canImport(CDuckDB)` test would silently test nothing. A pure file in the test target gets both compiled and tested by CI.
- **`switchDatabase(to:)`**, new. The PluginKit default throws, so the tree could not load a second catalog without it. `switchSchema` moved from `SET schema` to `USE "catalog"."schema"`: `SET schema` splits its value on `.`, so it cannot address a schema whose name contains one and cannot say which catalog it means.
- **`supportsDatabaseTree`** relaxed from `connectionMode == .network` to `!= .fileBased`. A file is one database; a server or an embedded engine with attachable catalogs can have several. I enumerated all 26 registered types: no current engine's behaviour changes, and the new `DatabaseTreeCapabilityTests` pins that.
- **`PluginDatabaseDriver.currentDatabase`**, a new requirement with a `nil` default, so `DatabaseManager` can seed the browsed database the way it already seeds the browsed schema. An embedded engine names its database from the file it opened, so nothing outside the driver can derive it. DuckDB is the only driver that returns non-nil.
- **`hidesBuiltInDatabase`** on the curated connection config. Turning on database switching would otherwise add a stray, meaningless "Database" field beside DuckDB's "Database File". Follows `hidesBuiltInPassword` exactly, so no PluginKit change and no plugin re-release.
- **Sidebar tree seeding**: the tree now opens on the database and schema the connection is already on, once per connection, then the user's expansion state wins. Without it this fix would trade a working flat list for a row of closed triangles. The persisted blob gained a `seeded` flag so "never opened" stays distinguishable from "collapsed everything".

## Known cost

`DatabaseScope.database` for a DuckDB connection goes from `""` to the catalog name, so five stores keyed on the browse database will not find their existing entries: column layouts, per-table filters, favourites, recent tables, and persisted tab state. No data is at risk, only UI preferences, and only on DuckDB connections. A migration would mean touching five key encodings, a larger new risk surface than the loss it prevents, so this is recorded in the CHANGELOG instead.

## What I built and tested

- `TablePro` and `AllPlugins` schemes both build. `AllPlugins` is not optional here: PR CI never compiles registry-only plugins.
- `swiftlint lint --strict` clean across all 1424 files in scope.
- Suites run green: the four new/extended ones (`DuckDBSchemaQueriesTests`, `DatabaseTreeCapabilityTests`, `WindowSidebarStateSeedingTests`, plus DuckDB cases added to `PluginMetadataRegistrySchemaSwitchingTests` and `ContainerEntityNameTests`) and the neighbours that could regress: `ScopedDriverRoutingTests`, `SchemaServiceHierarchicalTests`, `SchemaServiceRefreshTests`, `SchemaServiceTests`, `SidebarRootShapeResolverTests`, `DatabaseTreeMetadataServiceTests` and its three refresh suites, `MetadataConnectionPoolTests`, `DatabaseTreeFilterTests`, `DatabaseTreeVisibilityTests`, `DriverPluginMetadataTests`, `PluginMetadataRegistry{SystemDatabase,Variant,CuratedCapability,Downloadable}Tests`, `DuckDBConnectionFieldsTests`, `DuckDBQuackConnectTests`, `PasswordHidingTests`, `ConnectionURLParserTests`, `ConnectionURLFormatterTests`, `ServerDashboardViewModelTests`.
- `ScopedDriverRoutingTests` had a premise this change intends to break (`supportsDatabaseSwitching(for: .duckdb) == false`). The routing it actually guards is unchanged, because `requiresReconnectForDatabaseSwitch` stays false, so DuckDB still never leaves the session driver and still never pools. SQLite keeps the original test; DuckDB got its own asserting exactly that.
- **End-to-end against the real plugin bundle**, loaded into a headless harness with the issue's exact repro file. Before, only `main.something` was reachable:

```
driver.currentDatabase   = repro
fetchDatabases()         = ["repro"]                          # system and temp excluded
fetchSchemas()           = ["core", "main", "meta", "we\"ird"] # no duplicates, no system schemas
fetchTables(core)        = ["bars:TABLE", "bars_v:VIEW"]
fetchTables(meta)        = ["bar_series:TABLE"]

ATTACH 'other.duckdb' AS other
fetchDatabases()         = ["other", "repro"]
fetchTables(main)        = ["something"]                       # other.t2 no longer leaks in
switchDatabase(other)    -> other / main, schemas ["extra", "main"], extra -> ["t1"]
switchSchema(extra)      -> other / extra
switchDatabase(repro)    -> repro / main, main -> ["something"]
```

The `we"ird` schema is deliberate: it proves identifier quoting round-trips.

No `TableProUITests` automation. The sidebar shape needs a live DuckDB file plus the registry-only plugin installed into the app under test, which the UI test harness cannot stage.

## Shipping

No PluginKit ABI bump. `currentDatabase` is a new requirement *with* a default, the three metadata statics are existing requirements, and `.bySchema` is an existing `GroupingStrategy` case. `currentPluginKitVersion` and the plugin's `TableProPluginKitVersion` (19) stay put, and this is not a `release-all-plugins.sh` scenario.

DuckDB is registry-only, so the fix reaches users through a single-plugin release: `pluginVersion` is bumped to 1.1.0 here, then tag `plugin-duckdb-v1.1.0`. The app-side changes ride the next app release and the two are independent: the relaxed `supportsDatabaseTree` gate and `hidesBuiltInDatabase` are inert until the new plugin lands.

**Release the plugin before or with the app release, not after.** The plugin's statics override the app's curated registry defaults on load, which is the whole reason this bug survived, so an installed 1.0.0 plugin puts DuckDB back on `.flat` even on an app that has this change. Shipping the app first would give users the CHANGELOG entry without the fix.

## Fixed during self-review

A review pass caught four real defects in the first draft, all fixed in the second commit:

- **The headline feature was broken for attached databases.** `DatabaseTreeMetadataService` asks for a database's schemas with no schema of its own, and `resolvedScope` filled that in from the *session's* schema, which belongs to a different catalog. `pin` then issued `USE "warehouse"."sales"` and DuckDB rejected it, so an attached database never listed anything whenever the user was not on `main`. DuckDB is the only engine that reaches this: every other multi-database engine pools, and `MetadataConnectionPool` never runs `pin`. `resolvedScope` now stops the browsing fallback at a database boundary, which is correct on its own terms: a schema name means nothing outside its own database.
- **`switchDatabase` assumed the new catalog's default schema is `main`.** True for a DuckDB-native catalog, false for one attached through the postgres or mysql scanner, which defaults to `public`. It now reads `current_schema()` back instead of assuming.
- **The constraint joins anchored only one side to the catalog.** DuckDB derives constraint names from the table, so attaching a copy of the same file gave two catalogs identical schema *and* constraint names and the rows joined across them. Reproduced against the engine: the old join returned each primary key twice, the fixed one returns it once.
- A comment on `supportsDatabaseTree` claimed a guard that does not exist. Both remaining terms are permissive by default, so a plugin declaring only `.apiOnly` now qualifies where it did not before. The rule is extracted as a pure function and that combination is pinned by a test rather than left implied.

Two findings are recorded rather than fixed, deliberately:

- `qualifiedTableName` builds DDL from the driver's ambient schema with no gate between generation and execution, so a background sidebar read that re-pins the driver in between could produce SQL naming the wrong schema. This is the existing app-wide contract (Oracle has the identical shape) and closing it means threading the tab's scope into DDL generation across every plugin. Widening `pin` to move the catalog widens the window, so it is worth doing, but not here.
- `pin` re-issues the database switch on every scoped read, which costs DuckDB two extra local statements. That is by design: nothing tracks where the driver actually is, and a user can type `USE other` in the editor.

## Follow-up found on the way

`fetchEnumLabelMap` filters `duckdb_types()` on `type_category = 'ENUM'`, but DuckDB 1.5.x reports `type_category` as NULL for a user enum and puts `ENUM` in `logical_type`. So enum columns never get their allowed values. It predates this change and returns zero rows with or without the catalog predicate, so I left the query semantically identical rather than change untested behaviour here. `duckdb_types()` also exposes a `labels` array that removes the per-type `enum_range` round trip. Shipping separately.
