### PR TITLE
fix(editor): make query history Load in Editor and Run in New Tab work

### DIFF
--- a/.claude/skills/fix-issue/references/verification.md
+++ b/.claude/skills/fix-issue/references/verification.md
@@ -83,7 +83,9 @@ xcodebuild -project TablePro.xcodeproj -scheme TablePro test -skipPackagePluginV
 - The Chinook sample has no `users` table. Use `Track`.
 - "Open Sample Database" lives only in the **Help** menu.
 
-**Never put `.accessibilityIdentifier` on a SwiftUI container.** It replaces the identifier of every descendant control in the same hosting tree, so a whole panel's buttons, search field, and popups all report the container's identifier and their own is gone. The symptom is a test that cannot find a control you can plainly see, and the obvious diagnoses (wrong query, wrong element type, timing) are all wrong. Identify the leaf controls only, and detect a container through one of them. Children behind an `NSViewRepresentable` boundary keep their own identifiers, since that is a separate hosting tree.
+**Never put `.accessibilityIdentifier` on a SwiftUI container by itself.** It replaces the identifier of every descendant control in the same hosting tree, so a whole panel's buttons, search field, and popups all report the container's identifier and their own is gone. The symptom is a test that cannot find a control you can plainly see, and the obvious diagnoses (wrong query, wrong element type, timing) are all wrong. Children behind an `NSViewRepresentable` boundary keep their own identifiers, since that is a separate hosting tree.
+
+When a container genuinely needs its own identifier, pair it with `.accessibilityElement(children: .contain)`, which makes the view an accessibility container instead of one merged element, so every leaf keeps its identifier and the container keeps its own. Measured on the query history detail pane from a dumped tree: before, all three action buttons reported `query-history-detail`; after, they reported `query-history-copy`, `query-history-run-in-new-tab` and `query-history-load-in-editor` with the container still addressable. Order matters, `children: .contain` before the identifier.
 
 **Diagnose by dumping the real tree, not by guessing:** `print(app.windows.firstMatch.debugDescription)` inside a `UITestCase`, run the suite, read the output.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Query History's "Load in Editor" and "Run in New Tab" did nothing when clicked. Both work again, from the buttons, the right-click menu, and `Return` or a double-click on a row.
+- "Run in New Tab" runs the query it opens, and asks first when that query writes, even with safe mode set to Silent.
+- A history entry recorded against another connection opens in that connection's window, and one recorded against another database opens in its own tab bound to that database, instead of loading into whatever is in front of you.
 - DuckDB `TIMESTAMP_S`, `TIMESTAMP_MS` and `TIMESTAMP_NS` columns showed `1970-01-01 00:00:00` on every row instead of the stored value. They now read exactly as the DuckDB CLI prints them, keeping sub-second digits. (#2130)
 - DuckDB `UUID`, `ENUM`, `BIT`, `LIST`, `STRUCT`, `MAP`, `ARRAY` and `UNION` columns showed an empty cell instead of their value. (#2130)
 - Querying two DuckDB tables that share a column name could repeat one table's value in both columns. (#2130)

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator.swift
@@ -15,7 +15,7 @@ final class QueryExecutionCoordinator {
 
     // MARK: - Run All Statements
 
-    func runAllStatements() {
+    func runAllStatements(extraCapabilities: CallerCapabilities = []) {
         guard let (tab, index) = parent.tabManager.selectedTabAndIndex,
               !parent.tabExecution.isExecuting(tab.id),
               tab.tabType == .query else { return }
@@ -42,18 +42,28 @@ final class QueryExecutionCoordinator {
                     return
                 }
 
-                dispatchParameterizedStatements(statements, parameters: reconciled, tabIndex: index)
+                dispatchParameterizedStatements(
+                    statements,
+                    parameters: reconciled,
+                    tabIndex: index,
+                    extraCapabilities: extraCapabilities
+                )
                 return
             }
         }
 
-        dispatchStatements(statements, tabIndex: index)
+        dispatchStatements(statements, tabIndex: index, extraCapabilities: extraCapabilities)
     }
 
-    func dispatchStatements(_ statements: [String], tabIndex index: Int, bypassRowLimit: Bool = false) {
+    func dispatchStatements(
+        _ statements: [String],
+        tabIndex index: Int,
+        bypassRowLimit: Bool = false,
+        extraCapabilities: CallerCapabilities = []
+    ) {
         guard !parent.isShowingSafeModePrompt else { return }
         parent.isShowingSafeModePrompt = true
-        let request = makeExecuteRequest(statements: statements)
+        let request = makeExecuteRequest(statements: statements, extraCapabilities: extraCapabilities)
         Task { [parent] in
             defer { parent.isShowingSafeModePrompt = false }
             switch await ExecutionGateProvider.shared.authorize(request) {
@@ -69,14 +79,17 @@ final class QueryExecutionCoordinator {
         }
     }
 
-    private func makeExecuteRequest(statements: [String]) -> OperationRequest {
+    private func makeExecuteRequest(
+        statements: [String],
+        extraCapabilities: CallerCapabilities = []
+    ) -> OperationRequest {
         OperationRequest(
             connectionId: parent.connectionId,
             databaseType: parent.connection.type,
             sql: statements.joined(separator: "\n"),
             kind: OperationKind.worst(of: statements, databaseType: parent.connection.type),
             caller: .userInterface,
-            capabilities: .interactiveUser,
+            capabilities: CallerCapabilities.interactiveUser.union(extraCapabilities),
             operationDescription: String(localized: "Execute Query")
         )
     }
@@ -85,12 +98,13 @@ final class QueryExecutionCoordinator {
         _ statements: [String],
         parameters: [QueryParameter],
         tabIndex index: Int,
-        bypassRowLimit: Bool = false
+        bypassRowLimit: Bool = false,
+        extraCapabilities: CallerCapabilities = []
     ) {
         guard !parent.isShowingSafeModePrompt else { return }
         parent.isShowingSafeModePrompt = true
         let tabId = parent.tabManager.tabs[index].id
-        let request = makeExecuteRequest(statements: statements)
+        let request = makeExecuteRequest(statements: statements, extraCapabilities: extraCapabilities)
         Task { [parent] in
             defer { parent.isShowingSafeModePrompt = false }
             switch await ExecutionGateProvider.shared.authorize(request) {

--- a/TablePro/Core/Services/Execution/DefaultExecutionGate.swift
+++ b/TablePro/Core/Services/Execution/DefaultExecutionGate.swift
@@ -50,9 +50,16 @@ internal actor DefaultExecutionGate: ExecutionGate {
             ))
         }
 
+        /// Narrower than `effectiveWrite`, which is true for every statement on a driver that
+        /// cannot be opened read-only. A caller asking to confirm its writes means the ones that
+        /// actually write, not every `GET` sent to Redis.
+        let isWriteStatement = request.kind.declaresWrite || tier == .write || tier == .destructive
+
         let isMetadataRead = request.kind == .metadataRead
         let needsConfirmation = !isMetadataRead
-            && (isDestructive || (level.requiresConfirmation && (effectiveWrite || level.appliesToAllQueries)))
+            && (isDestructive
+                || (isWriteStatement && caps.contains(.confirmsWrites))
+                || (level.requiresConfirmation && (effectiveWrite || level.appliesToAllQueries)))
         if needsConfirmation, !caps.contains(.preCleared), !caps.contains(.confirmationPreCleared) {
             if caps.contains(.cannotPrompt) {
                 return .denied(reason: String(localized: "Confirmation is required for this operation"))

--- a/TablePro/Core/Services/Execution/OperationCaller.swift
+++ b/TablePro/Core/Services/Execution/OperationCaller.swift
@@ -23,5 +23,11 @@ internal struct CallerCapabilities: OptionSet, Sendable {
     static let cannotPrompt = CallerCapabilities(rawValue: 1 << 4)
     static let confirmationPreCleared = CallerCapabilities(rawValue: 1 << 5)
 
+    /// Confirm any write from this caller whatever the connection's safe mode says. A statement the
+    /// user is replaying rather than writing reaches the server on one click, and a row-scoped
+    /// `DELETE ... WHERE id = 5` is an ordinary write that Silent mode would otherwise send straight
+    /// through.
+    static let confirmsWrites = CallerCapabilities(rawValue: 1 << 6)
+
     static let interactiveUser: CallerCapabilities = [.mayWrite, .mayRunDestructive, .mayRunMultiStatement]
 }

--- a/TablePro/Views/Editor/History/HistoryDetailPane.swift
+++ b/TablePro/Views/Editor/History/HistoryDetailPane.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct HistoryDetailPane: View {
     let entry: QueryHistoryEntry?
     let connectionLabel: HistoryConnectionLabel?
+    let canRunInNewTab: Bool
 
     let onLoadInEditor: (QueryHistoryEntry) -> Void
     let onRunInNewTab: (QueryHistoryEntry) -> Void
@@ -21,6 +22,7 @@ struct HistoryDetailPane: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("query-history-detail")
     }
 
@@ -89,6 +91,10 @@ struct HistoryDetailPane: View {
         return "\(entry.databaseDisplayName).\(schemaName)"
     }
 
+    /// Return already belongs to the list, which activates the row the user is standing on. This is
+    /// a persistent pane rather than a dialog, so the primary action is marked by prominence alone
+    /// and never takes the window's default action, which would fire on any responder that ignores
+    /// Return.
     private func actions(for entry: QueryHistoryEntry) -> some View {
         HStack {
             Button(String(localized: "Copy")) { onCopy(entry) }
@@ -99,11 +105,15 @@ struct HistoryDetailPane: View {
 
             Button(String(localized: "Run in New Tab")) { onRunInNewTab(entry) }
                 .controlSize(.small)
+                .disabled(!canRunInNewTab)
+                .help(canRunInNewTab
+                    ? String(localized: "Open this query in a new tab and run it")
+                    : String(localized: "This query belongs to another connection. Load it in the editor to run it there."))
                 .accessibilityIdentifier("query-history-run-in-new-tab")
 
             Button(String(localized: "Load in Editor")) { onLoadInEditor(entry) }
                 .controlSize(.small)
-                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
                 .accessibilityIdentifier("query-history-load-in-editor")
         }
         .padding(10)

--- a/TablePro/Views/Editor/History/HistoryListPane.swift
+++ b/TablePro/Views/Editor/History/HistoryListPane.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct HistoryListPane: View {
     @Bindable var viewModel: HistoryPanelViewModel
 
+    let canRunInNewTab: (QueryHistoryEntry) -> Bool
     let onLoadInEditor: (QueryHistoryEntry) -> Void
     let onRunInNewTab: (QueryHistoryEntry) -> Void
     let onCopy: (QueryHistoryEntry) -> Void
@@ -125,7 +126,10 @@ struct HistoryListPane: View {
         guard let id = ids.first, let entry = entry(id) else { return [] }
         return [
             FieldDrivenMenuItem(title: String(localized: "Load in Editor")) { onLoadInEditor(entry) },
-            FieldDrivenMenuItem(title: String(localized: "Run in New Tab")) { onRunInNewTab(entry) },
+            FieldDrivenMenuItem(
+                title: String(localized: "Run in New Tab"),
+                isEnabled: canRunInNewTab(entry)
+            ) { onRunInNewTab(entry) },
             .separator,
             FieldDrivenMenuItem(title: String(localized: "Copy Query")) { onCopy(entry) },
             FieldDrivenMenuItem(title: String(localized: "Save as Favorite…")) { onSaveAsFavorite(entry) },

--- a/TablePro/Views/Editor/History/HistoryPanelView.swift
+++ b/TablePro/Views/Editor/History/HistoryPanelView.swift
@@ -2,13 +2,17 @@ import AppKit
 import SwiftUI
 
 struct HistoryPanelView: View {
-    let connectionId: UUID
+    /// Held directly rather than resolved from a focused value. The app runs the AppKit lifecycle
+    /// with no SwiftUI `Scene`, so `focusedSceneValue` has nothing to publish into and every action
+    /// that read one was silently dead. Every other call site in the app reaches actions this way.
+    let coordinator: MainContentCoordinator
 
     @Environment(\.appServices) private var services
-    @FocusedValue(\.commandActions) private var actions
 
     @State private var viewModel: HistoryPanelViewModel?
     @State private var favoriteDialogQuery: FavoriteDialogQuery?
+
+    private var connectionId: UUID { coordinator.connectionId }
 
     var body: some View {
         Group {
@@ -46,6 +50,7 @@ struct HistoryPanelView: View {
         ) {
             HistoryListPane(
                 viewModel: viewModel,
+                canRunInNewTab: { canRun($0) },
                 onLoadInEditor: { load($0) },
                 onRunInNewTab: { runInNewTab($0) },
                 onCopy: { copy($0) },
@@ -55,6 +60,7 @@ struct HistoryPanelView: View {
             HistoryDetailPane(
                 entry: viewModel.selectedEntry,
                 connectionLabel: viewModel.selectedEntry.flatMap { viewModel.connectionLabel(for: $0) },
+                canRunInNewTab: viewModel.selectedEntry.map { canRun($0) } ?? false,
                 onLoadInEditor: { load($0) },
                 onRunInNewTab: { runInNewTab($0) },
                 onCopy: { copy($0) }
@@ -65,16 +71,29 @@ struct HistoryPanelView: View {
         }
     }
 
+    /// Running belongs to the connection that recorded the query, and this window only drives its
+    /// own. A foreign entry still loads, into that connection's window, where the user runs it.
+    private func canRun(_ entry: QueryHistoryEntry) -> Bool {
+        entry.connectionId == connectionId
+    }
+
     private func load(_ entry: QueryHistoryEntry) {
-        guard entry.connectionId == connectionId else {
-            actions?.newTab(initialQuery: entry.query)
-            return
-        }
-        actions?.loadQueryIntoEditor(entry.query)
+        coordinator.openQuery(
+            entry.query,
+            on: entry.connectionId,
+            databaseName: entry.databaseName,
+            intent: .loadIntoFrontTab
+        )
     }
 
     private func runInNewTab(_ entry: QueryHistoryEntry) {
-        actions?.newTab(initialQuery: entry.query)
+        guard canRun(entry) else { return }
+        coordinator.openQuery(
+            entry.query,
+            on: entry.connectionId,
+            databaseName: entry.databaseName,
+            intent: .runInNewTab
+        )
     }
 
     private func copy(_ entry: QueryHistoryEntry) {

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -104,7 +104,7 @@ struct MainEditorContentView: View {
                 }
             },
             bottomContent: {
-                HistoryPanelView(connectionId: connectionId)
+                HistoryPanelView(coordinator: coordinator)
             }
         )
         .background(.background)

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ExecuteAll.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ExecuteAll.swift
@@ -6,8 +6,8 @@
 import Foundation
 
 extension MainContentCoordinator {
-    func runAllStatements() {
-        queryExecutionCoordinator.runAllStatements()
+    func runAllStatements(extraCapabilities: CallerCapabilities = []) {
+        queryExecutionCoordinator.runAllStatements(extraCapabilities: extraCapabilities)
     }
 
     internal func dispatchStatements(_ statements: [String], tabIndex index: Int, bypassRowLimit: Bool = false) {

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryRouting.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryRouting.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// What the caller wants done with a query it already has. Two cases rather than two flags,
+/// because "run it, but in the tab already in front" is not a state any caller means, and a pair
+/// of Bools would let one ask for it.
+internal enum QueryOpenIntent {
+    case loadIntoFrontTab
+    case runInNewTab
+}
+
+extension MainContentCoordinator {
+    /// The one route for "put this recorded SQL into an editor".
+    ///
+    /// The history drawer can list entries from connections this window does not host, so the
+    /// connection that owns the query is named rather than assumed to be this one. A foreign query
+    /// goes to its own connection's window, where the payload waits for a session if that
+    /// connection is not open yet, instead of running against whatever is in front of the user.
+    ///
+    /// An empty `databaseName` means "wherever this connection is pointing", which is what a
+    /// connection opened without a default database records; passing it through as a name would
+    /// match no tab and open a second one. Running is refused while a confirmation is already up,
+    /// because the gate would drop the dispatch and leave a tab whose query never ran.
+    func openQuery(
+        _ query: String,
+        on owningConnectionId: UUID,
+        databaseName: String?,
+        intent: QueryOpenIntent
+    ) {
+        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+
+        let targetDatabase = (databaseName?.isEmpty ?? true) ? nil : databaseName
+
+        guard owningConnectionId == connectionId else {
+            routeToOwningConnection(query, connectionId: owningConnectionId, databaseName: targetDatabase)
+            return
+        }
+
+        guard intent == .runInNewTab else {
+            guard loadQueryIntoEditor(query, databaseName: targetDatabase) == .currentCoordinator,
+                  let tabId = tabManager.selectedTabId else { return }
+            tabManager.pendingFocusTabId = tabId
+            return
+        }
+
+        guard !isShowingSafeModePrompt else { return }
+
+        tabManager.addTab(
+            initialQuery: query,
+            databaseName: targetDatabase ?? browseDatabaseName,
+            claimFocus: true
+        )
+        runAllStatements(extraCapabilities: .confirmsWrites)
+    }
+
+    /// Deleting a connection deletes its query history with it, so an id that resolves to nothing
+    /// means the two stores disagree. Say so, rather than opening a window onto a connection that
+    /// is no longer there.
+    private func routeToOwningConnection(_ query: String, connectionId owner: UUID, databaseName: String?) {
+        guard connectionExists(owner) else {
+            AlertHelper.showErrorSheet(
+                title: String(localized: "Could Not Open Query"),
+                message: String(localized: "The connection this query was recorded against no longer exists."),
+                window: contentWindow
+            )
+            return
+        }
+
+        openTabInNewWindow(
+            EditorTabPayload(
+                connectionId: owner,
+                tabType: .query,
+                databaseName: databaseName,
+                initialQuery: query
+            )
+        )
+    }
+}

--- a/TablePro/Views/Main/Extensions/MainContentView+Modifiers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Modifiers.swift
@@ -26,23 +26,6 @@ struct ToolbarTintModifier: ViewModifier {
     }
 }
 
-// MARK: - Focused Command Actions Modifier
-
-/// Conditionally publishes `MainContentCommandActions` as a focused scene value.
-/// `focusedSceneValue` requires a non-optional value, so this modifier
-/// only applies it when the actions object has been created.
-struct FocusedCommandActionsModifier: ViewModifier {
-    let actions: MainContentCommandActions?
-
-    func body(content: Content) -> some View {
-        if let actions {
-            content.focusedSceneValue(\.commandActions, actions)
-        } else {
-            content
-        }
-    }
-}
-
 // MARK: - Preview
 
 #Preview("With Connection") {

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -2,7 +2,7 @@
 //  MainContentCommandActions.swift
 //  TablePro
 //
-//  Provides command actions for MainContentView, accessible via @FocusedValue.
+//  Provides command actions for MainContentView, reached through MainContentCoordinator.
 //  Menu commands and toolbar buttons call methods directly instead of posting notifications.
 //  Retains NotificationCenter subscribers only for legitimate multi-listener broadcasts.
 //
@@ -16,7 +16,7 @@ import SwiftUI
 import TableProPluginKit
 import UniformTypeIdentifiers
 
-/// Provides command actions for MainContentView, accessible via @FocusedValue
+/// Provides command actions for MainContentView, reached through `MainContentCoordinator.commandActions`.
 @MainActor
 @Observable
 final class MainContentCommandActions {
@@ -177,7 +177,6 @@ final class MainContentCommandActions {
     private func setupObservers() {
         setupNonMenuNotificationObservers()
         setupDataBroadcastObservers()
-        setupTabBroadcastObservers()
         setupDatabaseBroadcastObservers()
         setupWindowObservers()
         setupFileOpenObservers()
@@ -1136,13 +1135,6 @@ final class MainContentCommandActions {
             .store(in: &eventCancellables)
     }
 
-    // MARK: Tab Broadcasts
-
-    private func setupTabBroadcastObservers() {
-        // All tab notifications (newQueryTab, loadQueryIntoEditor, insertQueryFromAI)
-        // have been replaced with direct method calls via @FocusedValue.
-    }
-
     // MARK: Database Broadcasts
 
     private func setupDatabaseBroadcastObservers() {
@@ -1199,18 +1191,5 @@ final class MainContentCommandActions {
                 try? await TabRouter.shared.route(.openSQLFile(url))
             }
         }
-    }
-}
-
-// MARK: - Focused Value Key
-
-private struct CommandActionsKey: FocusedValueKey {
-    typealias Value = MainContentCommandActions
-}
-
-extension FocusedValues {
-    var commandActions: MainContentCommandActions? {
-        get { self[CommandActionsKey.self] }
-        set { self[CommandActionsKey.self] = newValue }
     }
 }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -168,7 +168,8 @@ final class MainContentCoordinator {
     @ObservationIgnored weak var contentWindow: NSWindow?
 
     /// Back-reference to this coordinator's command actions, enabling window → coordinator → actions
-    /// lookup when `@FocusedValue(\.commandActions)` has not resolved (e.g. focus in an AppKit subview).
+    /// lookup. The app runs the AppKit lifecycle with no SwiftUI `Scene`, so a focused value has
+    /// nothing to resolve against; this reference reaches every caller, AppKit and SwiftUI alike.
     @ObservationIgnored weak var commandActions: MainContentCommandActions?
 
     /// Presents the quick switcher as a floating panel anchored over this coordinator's window.
@@ -197,6 +198,10 @@ final class MainContentCoordinator {
 
     @ObservationIgnored var openTabInNewWindow: (EditorTabPayload) -> Void = {
         WindowManager.shared.openTab(payload: $0)
+    }
+
+    @ObservationIgnored var connectionExists: (UUID) -> Bool = { id in
+        ConnectionStorage.shared.loadConnections().contains { $0.id == id }
     }
 
     // MARK: - Internal State

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -117,7 +117,6 @@ struct MainContentView: View {
             } message: { request in
                 Text(request.message)
             }
-            .modifier(FocusedCommandActionsModifier(actions: commandActions))
     }
 
     private var dropConfirmationBinding: Binding<Bool> {

--- a/TablePro/Views/Shared/FieldDrivenList.swift
+++ b/TablePro/Views/Shared/FieldDrivenList.swift
@@ -21,17 +21,20 @@ internal struct FieldDrivenListSection<Item: Identifiable>: Identifiable {
 internal struct FieldDrivenMenuItem {
     internal let title: String
     internal let isSeparator: Bool
+    internal let isEnabled: Bool
     internal let action: () -> Void
 
-    internal init(title: String, action: @escaping () -> Void) {
+    internal init(title: String, isEnabled: Bool = true, action: @escaping () -> Void) {
         self.title = title
         self.isSeparator = false
+        self.isEnabled = isEnabled
         self.action = action
     }
 
     private init() {
         self.title = ""
         self.isSeparator = true
+        self.isEnabled = false
         self.action = {}
     }
 
@@ -244,6 +247,8 @@ internal struct FieldDrivenList<Item: Identifiable, Row: View>: NSViewRepresenta
             (sender.representedObject as? MenuAction)?.perform()
         }
 
+        /// Auto-enabling asks the target whether it responds to the item's selector, which it
+        /// always does, so a descriptor's own `isEnabled` would be overwritten on display.
         internal func menu(forRow row: Int) -> NSMenu? {
             guard let build = owner.menuItems, row >= 0, row < entries.count,
                   let id = entries[row].itemId else { return nil }
@@ -251,6 +256,7 @@ internal struct FieldDrivenList<Item: Identifiable, Row: View>: NSViewRepresenta
             let descriptors = build(targets)
             guard !descriptors.isEmpty else { return nil }
             let menu = NSMenu()
+            menu.autoenablesItems = false
             for descriptor in descriptors {
                 if descriptor.isSeparator {
                     menu.addItem(.separator())
@@ -258,6 +264,7 @@ internal struct FieldDrivenList<Item: Identifiable, Row: View>: NSViewRepresenta
                 }
                 let item = NSMenuItem(title: descriptor.title, action: #selector(performMenuItem(_:)), keyEquivalent: "")
                 item.target = self
+                item.isEnabled = descriptor.isEnabled
                 item.representedObject = MenuAction(descriptor.action)
                 menu.addItem(item)
             }

--- a/TableProTests/Core/Services/Execution/ExecutionGateTests.swift
+++ b/TableProTests/Core/Services/Execution/ExecutionGateTests.swift
@@ -95,6 +95,76 @@ struct ExecutionGateTests {
         #expect(auth.callCount == 0)
     }
 
+    /// A row-scoped DELETE is an ordinary write, so Silent mode sends it straight through. Replaying
+    /// one from query history is a single click, which is why that caller asks for the confirmation
+    /// its safe-mode level would not give it.
+    @Test("A caller that confirms its writes is prompted even in Silent mode")
+    func confirmsWritesPromptsUnderSilent() async {
+        let confirm = StubConfirming(answer: true)
+        let auth = StubAuthenticating(answer: true)
+        let gate = makeGate(level: .silent, confirm: confirm, auth: auth)
+
+        let decision = await gate.authorize(makeRequest(
+            sql: "DELETE FROM users WHERE id = 5",
+            kind: .writeQuery,
+            capabilities: CallerCapabilities.interactiveUser.union(.confirmsWrites)
+        ))
+
+        #expect(decision.isAuthorized)
+        #expect(confirm.callCount == 1)
+        #expect(!confirm.lastDestructive)
+        #expect(auth.callCount == 0)
+    }
+
+    @Test("A caller that confirms its writes still runs reads without prompting")
+    func confirmsWritesLeavesReadsAlone() async {
+        let confirm = StubConfirming(answer: true)
+        let auth = StubAuthenticating(answer: true)
+        let gate = makeGate(level: .silent, confirm: confirm, auth: auth)
+
+        let decision = await gate.authorize(makeRequest(
+            sql: "SELECT * FROM users",
+            kind: .readQuery,
+            capabilities: CallerCapabilities.interactiveUser.union(.confirmsWrites)
+        ))
+
+        #expect(decision.isAuthorized)
+        #expect(confirm.callCount == 0)
+    }
+
+    /// `effectiveWrite` is true for every statement on a driver that cannot be opened read-only,
+    /// so gating the extra prompt on it would ask before every Redis `GET`.
+    @Test("A caller that confirms its writes still runs reads on a driver with no read-only mode")
+    func confirmsWritesLeavesReadsAloneWhenTheDriverForcesWrite() async {
+        let confirm = StubConfirming(answer: true)
+        let auth = StubAuthenticating(answer: true)
+        let gate = makeGate(level: .silent, forcesWrite: true, confirm: confirm, auth: auth)
+
+        let decision = await gate.authorize(makeRequest(
+            sql: "SELECT * FROM users",
+            kind: .readQuery,
+            capabilities: CallerCapabilities.interactiveUser.union(.confirmsWrites)
+        ))
+
+        #expect(decision.isAuthorized)
+        #expect(confirm.callCount == 0)
+    }
+
+    @Test("A confirmed write that the user cancels is denied")
+    func confirmsWritesCancelled() async {
+        let confirm = StubConfirming(answer: false)
+        let auth = StubAuthenticating(answer: true)
+        let gate = makeGate(level: .silent, confirm: confirm, auth: auth)
+
+        let decision = await gate.authorize(makeRequest(
+            sql: "UPDATE users SET name = 'x' WHERE id = 5",
+            kind: .writeQuery,
+            capabilities: CallerCapabilities.interactiveUser.union(.confirmsWrites)
+        ))
+
+        #expect(!decision.isAuthorized)
+    }
+
     @Test("Silent still confirms destructive operations")
     func silentConfirmsDestructive() async {
         let confirm = StubConfirming(answer: true)

--- a/TableProTests/Views/Main/CoordinatorQueryRoutingTests.swift
+++ b/TableProTests/Views/Main/CoordinatorQueryRoutingTests.swift
@@ -1,0 +1,197 @@
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("CoordinatorQueryRouting")
+struct CoordinatorQueryRoutingTests {
+    @MainActor
+    private func makeCoordinator() -> (MainContentCoordinator, QueryTabManager) {
+        let connection = TestFixtures.makeConnection(database: "testdb")
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        coordinator.openTabInNewWindow = { _ in }
+        coordinator.connectionExists = { _ in true }
+        return (coordinator, tabManager)
+    }
+
+    @Test("A query from this connection replaces the front tab and claims its focus")
+    @MainActor
+    func loadsIntoTheFrontTab() {
+        let (coordinator, tabManager) = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        tabManager.addTab(initialQuery: "SELECT 1", databaseName: "testdb")
+
+        coordinator.openQuery(
+            "SELECT * FROM Genre",
+            on: coordinator.connectionId,
+            databaseName: "testdb",
+            intent: .loadIntoFrontTab
+        )
+
+        #expect(tabManager.tabs.count == 1)
+        #expect(tabManager.tabs[0].content.query == "SELECT * FROM Genre")
+        #expect(tabManager.pendingFocusTabId == tabManager.tabs[0].id)
+    }
+
+    @Test("Forcing a new tab leaves the front tab alone and carries the entry's database")
+    @MainActor
+    func opensASecondTab() {
+        let (coordinator, tabManager) = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        tabManager.addTab(initialQuery: "SELECT 1", databaseName: "testdb")
+
+        coordinator.openQuery(
+            "SELECT * FROM Genre",
+            on: coordinator.connectionId,
+            databaseName: "analytics",
+            intent: .runInNewTab
+        )
+
+        #expect(tabManager.tabs.count == 2)
+        #expect(tabManager.tabs[0].content.query == "SELECT 1")
+        #expect(tabManager.tabs[1].content.query == "SELECT * FROM Genre")
+        #expect(tabManager.tabs[1].tableContext.databaseName == "analytics")
+        #expect(tabManager.pendingFocusTabId == tabManager.tabs[1].id)
+    }
+
+    /// The drawer lists other connections' queries once the scope widens, and running one of those
+    /// against whatever is in front of the user is worse than the dead click this replaced.
+    @Test("A query from another connection goes to that connection, never into this tab list")
+    @MainActor
+    func routesAForeignQueryToItsOwnConnection() {
+        let (coordinator, tabManager) = makeCoordinator()
+        defer { coordinator.teardown() }
+        var opened: EditorTabPayload?
+        coordinator.openTabInNewWindow = { opened = $0 }
+
+        tabManager.addTab(initialQuery: "SELECT 1", databaseName: "testdb")
+        let otherConnectionId = UUID()
+
+        coordinator.openQuery(
+            "SELECT * FROM Genre",
+            on: otherConnectionId,
+            databaseName: "warehouse",
+            intent: .loadIntoFrontTab
+        )
+
+        #expect(tabManager.tabs.count == 1)
+        #expect(tabManager.tabs[0].content.query == "SELECT 1")
+        #expect(opened?.connectionId == otherConnectionId)
+        #expect(opened?.databaseName == "warehouse")
+        #expect(opened?.initialQuery == "SELECT * FROM Genre")
+        #expect(opened?.tabType == .query)
+    }
+
+    /// Deleting a connection deletes its history with it, so an id that resolves to nothing means
+    /// the two stores disagree. Opening a window onto a connection that is gone is not a recovery.
+    /// A connection opened without a default database records its queries against "", which is not
+    /// the name of a database any tab can be browsing.
+    @Test("An entry recorded with no database still fills the tab in front")
+    @MainActor
+    func treatsAnEmptyDatabaseAsUnset() {
+        let (coordinator, tabManager) = makeCoordinator()
+        defer { coordinator.teardown() }
+        var opened: EditorTabPayload?
+        coordinator.openTabInNewWindow = { opened = $0 }
+
+        tabManager.addTab(initialQuery: "SELECT 1", databaseName: "app")
+
+        coordinator.openQuery(
+            "SELECT * FROM Genre",
+            on: coordinator.connectionId,
+            databaseName: "",
+            intent: .loadIntoFrontTab
+        )
+
+        #expect(tabManager.tabs.count == 1)
+        #expect(tabManager.tabs[0].content.query == "SELECT * FROM Genre")
+        #expect(opened == nil)
+    }
+
+    /// The execution gate drops a dispatch while a confirmation is already up, so a tab opened
+    /// before that check would sit there carrying a query that never ran.
+    @Test("Run in New Tab opens no tab while a confirmation is already up")
+    @MainActor
+    func opensNoTabWhileAPromptIsUp() {
+        let (coordinator, tabManager) = makeCoordinator()
+        defer { coordinator.teardown() }
+        coordinator.isShowingSafeModePrompt = true
+
+        coordinator.openQuery(
+            "DELETE FROM Genre WHERE GenreId = 1",
+            on: coordinator.connectionId,
+            databaseName: "testdb",
+            intent: .runInNewTab
+        )
+
+        #expect(tabManager.tabs.isEmpty)
+    }
+
+    @Test("A query whose connection no longer exists opens no window")
+    @MainActor
+    func refusesAQueryFromADeletedConnection() {
+        let (coordinator, _) = makeCoordinator()
+        defer { coordinator.teardown() }
+        var opened: EditorTabPayload?
+        coordinator.openTabInNewWindow = { opened = $0 }
+        coordinator.connectionExists = { _ in false }
+
+        coordinator.openQuery(
+            "SELECT * FROM Genre",
+            on: UUID(),
+            databaseName: "warehouse",
+            intent: .loadIntoFrontTab
+        )
+
+        #expect(opened == nil)
+    }
+
+    @Test("A blank query opens nothing at all")
+    @MainActor
+    func ignoresABlankQuery() {
+        let (coordinator, tabManager) = makeCoordinator()
+        defer { coordinator.teardown() }
+        var opened: EditorTabPayload?
+        coordinator.openTabInNewWindow = { opened = $0 }
+
+        coordinator.openQuery(
+            "   \n\t ",
+            on: coordinator.connectionId,
+            databaseName: "testdb",
+            intent: .runInNewTab
+        )
+
+        #expect(tabManager.tabs.isEmpty)
+        #expect(opened == nil)
+    }
+
+    @Test("A query for a database no tab is browsing opens its own tab instead of overwriting one")
+    @MainActor
+    func doesNotOverwriteATabFromAnotherDatabase() {
+        let (coordinator, tabManager) = makeCoordinator()
+        defer { coordinator.teardown() }
+        var opened: EditorTabPayload?
+        coordinator.openTabInNewWindow = { opened = $0 }
+
+        tabManager.addTab(initialQuery: "SELECT private_data", databaseName: "primary")
+
+        coordinator.openQuery(
+            "SELECT public_data",
+            on: coordinator.connectionId,
+            databaseName: "analytics",
+            intent: .loadIntoFrontTab
+        )
+
+        #expect(tabManager.tabs[0].content.query == "SELECT private_data")
+        #expect(opened?.databaseName == "analytics")
+        #expect(opened?.initialQuery == "SELECT public_data")
+    }
+}

--- a/TableProUITests/QueryHistoryActionsUITests.swift
+++ b/TableProUITests/QueryHistoryActionsUITests.swift
@@ -1,0 +1,144 @@
+import XCTest
+
+/// Sending a query from the drawer back to the editor is the reason the drawer exists, and every
+/// way of asking for it shipped dead: the buttons, the context menu and the list's own Return all
+/// funnelled into one handler that resolved its target through a channel this app cannot serve.
+/// Nothing here asserted that a click changed anything, which is why it reached a release.
+final class QueryHistoryActionsUITests: UITestCase {
+    private let marker = "tablepro_probe"
+    private var probeQuery: String { "SELECT '\(marker)' AS marker;" }
+
+    func testLoadInEditorFillsTheTabInFrontInsteadOfOpeningAnother() throws {
+        let app = try launchWithSampleDatabase()
+        runProbeQuery(in: app)
+        openEmptyTab(in: app)
+
+        showHistoryDrawer(in: app)
+        selectFirstEntry(in: app)
+        XCTAssertEqual(editorsShowingMarker(in: app), 1, "Only the drawer's preview shows the query yet")
+        let tabsBefore = tabCount(in: app)
+
+        let load = app.buttons["query-history-load-in-editor"]
+        XCTAssertTrue(load.waitForExistence(timeout: 10), "The detail pane must offer Load in Editor")
+        load.click()
+
+        XCTAssertTrue(
+            waitForPredicate(timeout: 10) { editorsShowingMarker(in: app) == 2 },
+            "Load in Editor must put the selected query into the editor"
+        )
+        XCTAssertEqual(
+            tabCount(in: app),
+            tabsBefore,
+            "Load in Editor uses the tab in front rather than opening another one"
+        )
+    }
+
+    /// The list owns Return, so the keyboard reaches the same handler the buttons do.
+    func testReturnInTheListLoadsTheSelectedEntry() throws {
+        let app = try launchWithSampleDatabase()
+        runProbeQuery(in: app)
+        openEmptyTab(in: app)
+
+        showHistoryDrawer(in: app)
+        selectFirstEntry(in: app)
+
+        app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
+
+        XCTAssertTrue(
+            waitForPredicate(timeout: 10) { editorsShowingMarker(in: app) == 2 },
+            "Return on a selected entry must load it into the editor"
+        )
+    }
+
+    func testRunInNewTabOpensATabAndActuallyRunsTheQuery() throws {
+        let app = try launchWithSampleDatabase()
+        runProbeQuery(in: app)
+        openEmptyTab(in: app)
+
+        showHistoryDrawer(in: app)
+        selectFirstEntry(in: app)
+        let tabsBefore = tabCount(in: app)
+
+        let run = app.buttons["query-history-run-in-new-tab"]
+        XCTAssertTrue(run.waitForExistence(timeout: 10), "The detail pane must offer Run in New Tab")
+        run.click()
+
+        XCTAssertTrue(
+            waitForPredicate(timeout: 15) { tabCount(in: app) > tabsBefore },
+            "Run in New Tab must open another editor tab"
+        )
+        XCTAssertTrue(
+            waitForPredicate(timeout: 15) {
+                app.windows.firstMatch.descendants(matching: .any)
+                    .matching(NSPredicate(format: "value == %@", marker)).firstMatch.exists
+            },
+            "Run in New Tab must run the query it opens, not just load it"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func tabCount(in app: XCUIApplication) -> Int {
+        app.buttons.matching(identifier: "editor-tab").count
+    }
+
+    /// The drawer's preview is a text view too, so the marker's own count is what separates
+    /// "the editor received it" from "the drawer is merely showing it".
+    private func editorsShowingMarker(in app: XCUIApplication) -> Int {
+        app.windows.firstMatch.textViews
+            .matching(NSPredicate(format: "value CONTAINS %@", marker)).count
+    }
+
+    private func showHistoryDrawer(in app: XCUIApplication) {
+        app.typeKey("y", modifierFlags: .command)
+        let detail = app.windows.firstMatch.descendants(matching: .any)
+            .matching(identifier: "query-history-detail").firstMatch
+        XCTAssertTrue(detail.waitForExistence(timeout: 10), "Cmd+Y must show the query history drawer")
+    }
+
+    /// Row 0 is the day section header, so the first entry is row 1.
+    private func selectFirstEntry(in app: XCUIApplication) {
+        let list = app.windows.firstMatch.tables.matching(identifier: "query-history-list").firstMatch
+        XCTAssertTrue(list.waitForExistence(timeout: 10))
+        let row = list.tableRows.element(boundBy: 1)
+        XCTAssertTrue(row.waitForExistence(timeout: 10), "The drawer must list the query just run")
+        row.click()
+
+        let preview = app.textViews["query-history-detail-query"]
+        XCTAssertTrue(preview.waitForExistence(timeout: 10))
+        XCTAssertTrue(
+            waitForPredicate(timeout: 5) { ((preview.value as? String) ?? "").contains(marker) },
+            "Selecting a row must show that row in the preview"
+        )
+    }
+
+    private func openEmptyTab(in app: XCUIApplication) {
+        app.typeKey("t", modifierFlags: .command)
+        let editor = app.windows.firstMatch.textViews.firstMatch
+        XCTAssertTrue(editor.waitForExistence(timeout: 10))
+        XCTAssertTrue(
+            waitForPredicate(timeout: 5) { editorsShowingMarker(in: app) == 0 },
+            "A tab opened with Cmd+T starts empty"
+        )
+    }
+
+    private func runProbeQuery(in app: XCUIApplication) {
+        app.typeKey("t", modifierFlags: .command)
+        let editor = app.windows.firstMatch.textViews.firstMatch
+        XCTAssertTrue(editor.waitForExistence(timeout: 10))
+        app.typeText(probeQuery)
+        app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: .command)
+
+        let results = app.windows.firstMatch.tables.matching(identifier: "data-grid").firstMatch
+        XCTAssertTrue(results.waitForExistence(timeout: 15), "The query must produce a result grid")
+    }
+
+    private func waitForPredicate(timeout: TimeInterval, _ condition: () -> Bool) -> Bool {
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
+        }
+        return condition()
+    }
+}

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -199,7 +199,7 @@ See [Filtering](/features/filtering) for the filter panel itself.
 
 ### Query History Drawer
 
-With the drawer open (`Cmd+Y`): `Return` loads the selected entry in the editor, `Delete` removes it, `Cmd+C` copies its query. `Cmd+Y` again hides the drawer.
+With the drawer open (`Cmd+Y`) and its entry list focused: `Return` loads the selected entry in the editor, `Delete` removes it, `Cmd+C` copies its query. `Cmd+Y` again hides the drawer. `Return` anywhere else in the window belongs to whatever you are typing in.
 
 ## Welcome Window
 

--- a/docs/features/query-history.mdx
+++ b/docs/features/query-history.mdx
@@ -26,7 +26,7 @@ Recent queries also appear in the [Quick Switcher](/features/quick-switcher).
 
 History is scoped to the connection you are looking at. Switch the first popup to **All Connections** to search across every connection you have; rows then show which connection each query came from, so you can tell two databases named `app` apart.
 
-Loading a query that belongs to another connection opens it in a new tab rather than running it against the connection in front of you.
+Loading a query that belongs to another connection opens it in a new tab in that connection's own window, rather than running it against the connection in front of you. **Run in New Tab** is dimmed for those entries, because only the connection that recorded a query can run it. Load it there and run it from that window.
 
 ## Filtering
 
@@ -65,13 +65,15 @@ Turn on **Table Browsing** to see exactly what the app sent while you clicked ar
 | Action | How |
 |--------|-----|
 | Load into the editor | Select an entry and click **Load in Editor**, or press `Return` |
-| Run again | **Run in New Tab**, or right-click > **Run in New Tab** |
+| Run it again | **Run in New Tab**, or right-click > **Run in New Tab**. It opens a new tab and runs the query there |
 | Copy the query | `Cmd+C`, the **Copy** button, or right-click > **Copy Query** |
 | Save as favorite | Right-click > **Save as Favorite…** (see [Favorites](/features/favorites)) |
 | Delete one entry | `Delete` key or right-click > **Delete** |
 | Load older entries | **Load More** at the bottom of the list |
 
-Click a row to select it and the details appear beside it; the keyboard stays in the list, so arrow keys keep moving through entries. Loading a query into the editor is a separate, deliberate step: press `Return`, double-click the row, or click **Load in Editor**.
+Click a row to select it and the details appear beside it; the keyboard stays in the list, so arrow keys keep moving through entries. Loading a query into the editor is a separate, deliberate step: press `Return` with the list focused, double-click the row, or click **Load in Editor**.
+
+**Run in New Tab** sends the query to the server, so an entry that writes (INSERT, UPDATE, DELETE, or a schema change) asks for confirmation first, whatever the connection's [safe mode](/features/safe-mode) is set to. Reads run straight away. An entry that uses [query parameters](/features/query-parameters) opens the parameter panel instead of running, because parameter values are never recorded.
 
 ## Clearing History
 


### PR DESCRIPTION
## What was wrong

Every way of sending a query from the Query History drawer back to the editor did nothing:

- the **Load in Editor** and **Run in New Tab** buttons in the detail pane
- the same two items in the list's right-click menu
- `Return` or a double-click on a row

**Copy** worked, because it is the only one that does not need an editor target.

## Root cause

`HistoryPanelView` resolved its editor actions through `@FocusedValue(\.commandActions)`, published only by `.focusedSceneValue`. A focused *scene* value resolves through a SwiftUI `Scene`, and this app deliberately has none: it runs the AppKit lifecycle from `main.swift` (#2075), and `CLAUDE.md` forbids reintroducing a SwiftUI `App`. So the value was always `nil`, both handlers optional-chained on it, and five affordances were silent no-ops.

The drawer was written in #2125, after #2075 had already killed that channel. Nothing complained, because the API compiles and fails silently. `HistoryPanelView` was the only `@FocusedValue` reader in the app and `FocusedCommandActionsModifier` its only publisher, so the mechanism was dead end to end.

## The fix

`HistoryPanelView` now holds the `MainContentCoordinator` directly, the way every other call site in the app reaches these actions, so the target is no longer optional and the failure stops being representable. The dead focused-value machinery is deleted, so the next feature cannot be wired to it.

A new `MainContentCoordinator.openQuery(_:on:databaseName:intent:)` owns the routing:

- **Load in Editor** puts the SQL in the front tab, bound to the database the entry was recorded against, and moves focus to the editor.
- **Run in New Tab** opens a tab and runs it there, through the same gate as `Cmd+Return`.
- An entry from another connection opens in *that* connection's window instead of loading into the one in front of you, which is what the docs already promised. **Run in New Tab** is dimmed for those entries, because only the connection that recorded a query can run it.

Two things are folded in because this fix makes them reachable, or because they blocked the test:

- **Replaying a write now asks first.** A row-scoped `DELETE ... WHERE id = 5` is an ordinary write, so Silent mode (the default) sent it straight through. Re-running a `DELETE` recorded from a grid edit on one click is not something to do without asking, so the run path carries a new `CallerCapabilities.confirmsWrites` and the existing execution gate prompts. Reads are untouched. This reuses the app's one confirmation surface rather than adding a history-only dialog, which is where every competitor puts the guard too.
- **The detail pane's container identifier was erasing its buttons' own identifiers**, so no test could address them. Measured from a dumped accessibility tree: all three buttons reported `query-history-detail`. `.accessibilityElement(children: .contain)` makes it a real container and gives every leaf its identifier back, measured again after the change.

`.keyboardShortcut(.defaultAction)` also came off **Load in Editor**. A persistent pane is not a dialog, the list already owns `Return`, and the shortcut would have gone live with this fix on any responder that ignores `Return`. The button keeps its prominence through `.buttonStyle(.borderedProminent)`.

## Verified

Both original UI tests were written first and **fail on the unfixed code**, with exactly the reported symptom:

```
QueryHistoryActionsUITests testLoadInEditor... : XCTAssertTrue failed - Load in Editor must put the selected query into the editor
QueryHistoryActionsUITests testRunInNewTab... : XCTAssertTrue failed - Run in New Tab must open another editor tab
```

After the fix:

- `TableProUITests`: `QueryHistoryActionsUITests` (3), `QueryHistoryPanelUITests` (5), `QueryHistoryFocusUITests` (1). 9 passed, 0 failures. The run test asserts the query's own marker value shows up in a result grid, so it proves execution rather than just that a tab appeared.
- `TableProTests`: `CoordinatorQueryRoutingTests`, `CoordinatorEditorLoadTests`, `ExecutionGateTests`. 52 passed, 0 failures.
- `xcodebuild -scheme TablePro -configuration Debug build`: BUILD SUCCEEDED.
- `swiftlint lint --strict`: 0 violations.

No plugin changed, so the `AllPlugins` scheme was not needed.

## From self-review

Three findings were real and are fixed here:

- `.confirmsWrites` was gated on `effectiveWrite`, which is true for *every* statement on a driver that cannot be opened read-only (MongoDB, Redis, Etcd). A recorded Redis `GET` would have prompted on every run. It is gated on the statement's classified tier now, with a test that pins a read on a forced-write driver.
- `QueryHistoryEntry.databaseName` is a non-optional `String` that is `""` for a connection opened without a default database. Passing that through as a name matched no tab, so an older entry opened a second tab instead of filling the one in front. Empty maps to nil now.
- `runAllStatements` refuses a dispatch while a confirmation is already up, and the tab was created before that check, so a double-click left a tab whose query never ran. The guard moved ahead of the tab.

Two are noted rather than fixed:

- **The entry's schema is not carried onto the new tab.** Real, but it is a pre-existing gap in every query-tab creation path (`EditorTabOpener` and the quick switcher drop it too), and it does not change which table the query hits: `SET search_path` is issued per connection, not per tab, so the SQL resolves exactly as it would if the user pasted it. What it does affect is the tab's own context for exports, structure and autocomplete. Reported rather than fixed, because deciding whether a query tab should pin a schema at all is a product call, not a defect with one right answer.
- **The cross-connection route does not dial a closed connection.** Deliberate. The window for that connection opens with the query queued and it appears once you connect. Dialing a server, possibly through an SSH tunnel, as a side effect of loading text is a bigger action than the one the user asked for.

## Notes

- A parameterized history entry opens the parameter panel instead of running, because parameter values are deliberately never recorded. That matches `Cmd+Return` in the editor, and it is now documented.
- The competitor survey argued for renaming **Run in New Tab** to **Open in New Tab** and never executing, since DataGrip, Postico 2 and Sequel Ace never run from history. TablePlus, whose habits most of our users arrive with, documents its `Run` item as "execute the query in a new tab", and our own label and shipped docs already promise that. This delivers it and puts the guard at the execution boundary, which is where all four of those tools put theirs.
