### PR TITLE
fix(editor): say what clearing query history will actually delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DuckDB tables outside the `main` schema are visible again. The sidebar lists every schema of the connected database, Tree layout shows database, schema and tables, and `ATTACH`ed databases appear alongside the one you opened. (#2131)
 - DuckDB metadata no longer mixes up databases that share a schema name, so an `ATTACH`ed file's tables stay out of the database you opened.
 - A DuckDB table in the default schema is titled `orders` again rather than `main.orders`, and exports preselect the schema you are browsing.
+- Clearing query history from the drawer promised to delete the connection's history while the source filter was quietly sparing table browsing, row edits, imports and AI queries. The confirmation now says what it will actually delete, and clearing itself is unchanged.
 
 ### Changed
 

--- a/TablePro/Models/UI/HistoryClearSummary.swift
+++ b/TablePro/Models/UI/HistoryClearSummary.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// What the trash button is about to delete, said out loud.
+///
+/// The delete narrows by everything the drawer is showing: scope, source, outcome, date range and
+/// the search text. The confirmation used to name only the scope and the date range, so at the
+/// panel's own default filter it promised "this connection's query history" while quietly sparing
+/// every table browse, row edit, import and MCP query. That is the wrong way round for something
+/// with no undo, and the entries it spares are the ones most likely to hold a value the user
+/// wanted gone.
+internal enum HistoryClearSummary {
+    /// True when the filter hides any recorded query, measured against everything on record rather
+    /// than against the panel's defaults. The default source filter already hides five of the seven
+    /// sources, which is exactly the case the old message got wrong.
+    internal static func hidesRecordedQueries(
+        sources: Set<QueryHistorySource>,
+        outcome: QueryHistoryOutcome,
+        dateRange: HistoryDateRange,
+        searchText: String
+    ) -> Bool {
+        sources != Set(QueryHistorySource.allCases)
+            || outcome != .any
+            || dateRange != .all
+            || !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    internal static func message(
+        showsAllConnections: Bool,
+        sources: Set<QueryHistorySource>,
+        outcome: QueryHistoryOutcome,
+        dateRange: HistoryDateRange,
+        searchText: String
+    ) -> String {
+        let narrowed = hidesRecordedQueries(
+            sources: sources,
+            outcome: outcome,
+            dateRange: dateRange,
+            searchText: searchText
+        )
+
+        guard narrowed else {
+            return showsAllConnections
+                ? String(localized: "This deletes the query history of every connection. You cannot undo this.")
+                : String(localized: "This deletes this connection's query history. You cannot undo this.")
+        }
+
+        return showsAllConnections
+            ? String(localized: """
+                This deletes only the queries listed here, across every connection. Queries the \
+                source, date, outcome and search filters are hiding stay. You cannot undo this.
+                """)
+            : String(localized: """
+                This deletes only the queries listed here, from this connection. Queries the \
+                source, date, outcome and search filters are hiding stay. You cannot undo this.
+                """)
+    }
+}

--- a/TablePro/Views/Editor/History/HistoryPanelToolbar.swift
+++ b/TablePro/Views/Editor/History/HistoryPanelToolbar.swift
@@ -194,15 +194,12 @@ struct HistoryPanelToolbar: View {
     }
 
     private var clearMessage: String {
-        let range = state.dateRange
-        if range == .all {
-            return state.showsAllConnections
-                ? String(localized: "This deletes the query history of every connection. You cannot undo this.")
-                : String(localized: "This deletes this connection's query history. You cannot undo this.")
-        }
-        return String(
-            format: String(localized: "This deletes the query history from %@. You cannot undo this."),
-            range.title.lowercased()
+        HistoryClearSummary.message(
+            showsAllConnections: state.showsAllConnections,
+            sources: state.sources,
+            outcome: state.outcome,
+            dateRange: state.dateRange,
+            searchText: state.searchText
         )
     }
 

--- a/TableProTests/Models/HistoryClearSummaryTests.swift
+++ b/TableProTests/Models/HistoryClearSummaryTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("HistoryClearSummary")
+struct HistoryClearSummaryTests {
+    private let everySource = Set(QueryHistorySource.allCases)
+
+    /// The panel opens filtered to the user's own queries, so the default state already hides five
+    /// of the seven sources. Calling that "unfiltered" is what made the old message promise a wipe
+    /// it never performed.
+    @Test("The panel's own default source filter counts as hiding queries")
+    func defaultSourceFilterHidesQueries() {
+        #expect(
+            HistoryClearSummary.hidesRecordedQueries(
+                sources: QueryHistorySource.userAuthored,
+                outcome: .any,
+                dateRange: .all,
+                searchText: ""
+            )
+        )
+    }
+
+    @Test("Nothing is hidden only when every filter is wide open")
+    func nothingHiddenWithEveryFilterOpen() {
+        #expect(
+            !HistoryClearSummary.hidesRecordedQueries(
+                sources: everySource,
+                outcome: .any,
+                dateRange: .all,
+                searchText: "   "
+            )
+        )
+    }
+
+    @Test("An outcome, a date range or a search each count as hiding queries", arguments: [0, 1, 2])
+    func eachNarrowingCounts(_ which: Int) {
+        let hidden = HistoryClearSummary.hidesRecordedQueries(
+            sources: everySource,
+            outcome: which == 0 ? .failed : .any,
+            dateRange: which == 1 ? .week : .all,
+            searchText: which == 2 ? "customers" : ""
+        )
+        #expect(hidden)
+    }
+
+    @Test("A wide open filter promises the whole connection")
+    func unfilteredMessageNamesTheConnection() {
+        let message = HistoryClearSummary.message(
+            showsAllConnections: false,
+            sources: everySource,
+            outcome: .any,
+            dateRange: .all,
+            searchText: ""
+        )
+
+        #expect(message.contains("this connection's query history"))
+        #expect(!message.contains("only the queries listed here"))
+    }
+
+    @Test("A narrowed filter says only what is listed goes")
+    func narrowedMessageSaysOnlyWhatIsListed() {
+        let message = HistoryClearSummary.message(
+            showsAllConnections: false,
+            sources: QueryHistorySource.userAuthored,
+            outcome: .any,
+            dateRange: .all,
+            searchText: ""
+        )
+
+        #expect(message.contains("only the queries listed here"))
+        #expect(message.contains("stay"))
+    }
+
+    @Test("Widening the scope is named in both messages")
+    func scopeIsNamedWhetherOrNotFiltersNarrow() {
+        let wideOpen = HistoryClearSummary.message(
+            showsAllConnections: true,
+            sources: everySource,
+            outcome: .any,
+            dateRange: .all,
+            searchText: ""
+        )
+        let narrowed = HistoryClearSummary.message(
+            showsAllConnections: true,
+            sources: everySource,
+            outcome: .any,
+            dateRange: .week,
+            searchText: ""
+        )
+
+        #expect(wideOpen.contains("every connection"))
+        #expect(narrowed.contains("every connection"))
+    }
+}

--- a/docs/features/query-history.mdx
+++ b/docs/features/query-history.mdx
@@ -75,7 +75,7 @@ Click a row to select it and the details appear beside it; the keyboard stays in
 
 ## Clearing History
 
-The trash button clears exactly what the drawer is showing. Scoped to one connection, it leaves every other connection's history alone; with a date range selected, it only clears that range. It asks first.
+The trash button clears exactly what the drawer is showing, including whatever the filters are hiding. Scoped to one connection it leaves every other connection alone; with a date range selected it only clears that range; and with the default **My Queries** source it leaves table browsing, row edits, imports and AI queries in place. It asks first, and the confirmation says which of those two it is about to do. There is no undo.
 
 **Settings > Data > Query History > Clear History...** clears everything, for every connection.
 


### PR DESCRIPTION
Found while investigating the dead **Load in Editor** / **Run in New Tab** buttons in the query history drawer (#2137). Independent of that fix, so this is based on `main`.

## The defect

The drawer's trash button deletes by `state.filter()`, which narrows on **scope, source, outcome, date range and search text**. `QueryHistoryStorage.clear` is explicit about honouring all five: *"Deleting has to narrow by exactly what the caller is looking at. Scope and date alone would take rows a source, outcome or search filter is hiding."*

The confirmation only ever named two of them. It branched on the date range and, when that was `All Time`, said:

> This deletes this connection's query history. You cannot undo this.

Failure scenario, reachable with zero user interaction: the panel's default source filter is `QueryHistorySource.userAuthored`, which is `[.editor, .explain]`. So on a fresh install, a user who has run editor queries plus browsed a table, saved grid edits and run an import reads "this deletes this connection's query history", confirms, and every `table_browse`, `row_edit`, `structure_ddl`, `import` and `mcp` entry survives. They believe the history is gone. It is not, there is no undo, and the entries that survived are the ones most likely to hold a value they wanted removed.

The date-range branch had the mirror problem: it dropped the connection scope from the sentence entirely, so "This deletes the query history from last hour." never said whether it meant this connection or all of them. It also called `lowercased()` on an already-localized display string and spliced it into another localized sentence, which decapitalizes German nouns and mishandles Turkish dotted I.

## The fix

`HistoryClearSummary` is a pure type that answers two questions: does the current filter hide any recorded query, and what should the confirmation say. Critically, "hides queries" is measured against **everything on record**, not against the panel's defaults, because the defaults are exactly what got this wrong. `HistoryPanelState.hasNarrowingFilter` already exists and deliberately measures the other way (against the defaults, so an untouched panel does not show a "filtered" empty state), which is right for that job and wrong for this one.

The delete itself is unchanged. Only the promise made about it changed, and the interpolated-lowercased string is gone.

## Verified

- `TableProTests/HistoryClearSummaryTests`: 8 passed, 0 failures. The first test pins the case that shipped broken, that the panel's own default source filter counts as hiding queries.
- `swiftlint lint --strict`: 0 violations.
- Built as part of the test run.

Docs updated: the Clearing History section now names the source filter, since that is the surprising half.
