### PR TITLE
fix(hig): draw the preselected row emphasized when a search-driven list opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The row highlighted when the connection switcher, the database switcher or the query history drawer first opens kept its dark text on the blue selection fill. It was only readable after moving the selection off the row and back.
 - DuckDB `TIMESTAMP_S`, `TIMESTAMP_MS` and `TIMESTAMP_NS` columns showed `1970-01-01 00:00:00` on every row instead of the stored value. They now read exactly as the DuckDB CLI prints them, keeping sub-second digits. (#2130)
 - DuckDB `UUID`, `ENUM`, `BIT`, `LIST`, `STRUCT`, `MAP`, `ARRAY` and `UNION` columns showed an empty cell instead of their value. (#2130)
 - Querying two DuckDB tables that share a column name could repeat one table's value in both columns. (#2130)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The row highlighted when the connection switcher, the database switcher or the query history drawer first opens kept its dark text on the blue selection fill. It was only readable after moving the selection off the row and back.
+- The row highlighted when the connection switcher, the database switcher or the query history drawer first opens kept its dark text on the blue selection fill. It was only readable after moving the selection off the row and back. (#2140)
 - DuckDB `TIMESTAMP_S`, `TIMESTAMP_MS` and `TIMESTAMP_NS` columns showed `1970-01-01 00:00:00` on every row instead of the stored value. They now read exactly as the DuckDB CLI prints them, keeping sub-second digits. (#2130)
 - DuckDB `UUID`, `ENUM`, `BIT`, `LIST`, `STRUCT`, `MAP`, `ARRAY` and `UNION` columns showed an empty cell instead of their value. (#2130)
 - Querying two DuckDB tables that share a column name could repeat one table's value in both columns. (#2130)

--- a/TablePro/Views/Shared/FieldDrivenList.swift
+++ b/TablePro/Views/Shared/FieldDrivenList.swift
@@ -200,9 +200,14 @@ internal struct FieldDrivenList<Item: Identifiable, Row: View>: NSViewRepresenta
             }
         }
 
+        /// The emphasis rule is pushed onto the row here rather than read back off the view
+        /// hierarchy, because AppKit installs a row's cell views before the row itself reaches the
+        /// table. See `FieldDrivenRowView`.
         internal func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
-            tableView.makeView(withIdentifier: FieldDrivenRowView.reuseIdentifier, owner: self) as? FieldDrivenRowView
-                ?? FieldDrivenRowView.make()
+            let rowView = tableView.makeView(withIdentifier: FieldDrivenRowView.reuseIdentifier, owner: self)
+                as? FieldDrivenRowView ?? FieldDrivenRowView.make()
+            rowView.followsWindowKeyState = !owner.acceptsFocus
+            return rowView
         }
 
         internal func tableView(_ tableView: NSTableView, isGroupRow row: Int) -> Bool {
@@ -273,10 +278,13 @@ internal struct FieldDrivenList<Item: Identifiable, Row: View>: NSViewRepresenta
 }
 
 /// A chooser's highlight stands for the search field's selection, so it draws emphasized whenever
-/// the window is key: the field is the thing holding focus. A browser owns its own focus, so its
-/// highlight follows first responder the way every other list on the system does.
+/// the window is key: the field is the thing holding focus. A browser owns its own focus, so AppKit
+/// already emphasizes it exactly right and this row leaves the property alone.
 internal final class FieldDrivenRowView: NSTableRowView {
     internal static let reuseIdentifier = NSUserInterfaceItemIdentifier("FieldDrivenRow")
+
+    /// Set from `tableView(_:rowViewForRow:)`, which runs before AppKit installs any cell view.
+    internal var followsWindowKeyState = false
 
     internal static func make() -> FieldDrivenRowView {
         let view = FieldDrivenRowView()
@@ -284,16 +292,26 @@ internal final class FieldDrivenRowView: NSTableRowView {
         return view
     }
 
-    /// `NSTableRowView` declares this settable, so an override has to supply a setter. AppKit is
-    /// the only caller and it has nothing to tell this row that the window does not.
+    /// The setter has to forward, because AppKit's own stored value is what a browser row draws
+    /// from and swallowing the write would leave every browser row permanently unemphasized.
     override internal var isEmphasized: Bool {
-        get {
-            guard let table = superview as? FieldDrivenTableView, table.acceptsFocus else {
-                return window?.isKeyWindow ?? false
-            }
-            return window?.firstResponder === table
+        get { followsWindowKeyState ? window?.isKeyWindow ?? false : super.isEmphasized }
+        set { super.isEmphasized = newValue }
+    }
+
+    /// AppKit copies `interiorBackgroundStyle` into the cell views from `didAddSubview`, and a row
+    /// is populated before it is added to the table, so at that moment `window` is still nil and a
+    /// key-state-derived emphasis reads false. The row then paints its accent fill from the live
+    /// value while the cells keep the unemphasized foreground: blue fill, dark text, until some
+    /// later selection change happens to re-run the copy. Repeating it here is the first point the
+    /// derived value is true, and AppKit keeps the two in step from then on.
+    override internal func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard followsWindowKeyState else { return }
+        let style = interiorBackgroundStyle
+        for case let cell as NSTableCellView in subviews where cell.backgroundStyle != style {
+            cell.backgroundStyle = style
         }
-        set {}
     }
 }
 

--- a/TableProTests/Views/FieldDrivenListEmphasisTests.swift
+++ b/TableProTests/Views/FieldDrivenListEmphasisTests.swift
@@ -1,0 +1,112 @@
+//
+//  FieldDrivenListEmphasisTests.swift
+//  TableProTests
+//
+
+import AppKit
+@testable import TablePro
+import Testing
+
+@Suite("Field driven list row emphasis")
+@MainActor
+struct FieldDrivenListEmphasisTests {
+    /// The headless test host never gives a window the keyboard, so the one input the chooser rule
+    /// reads is stated here instead of hoping for real focus.
+    private final class KeyWindow: NSWindow {
+        override var isKeyWindow: Bool { true }
+    }
+
+    private func makeWindow(isKeyWindow: Bool) -> NSWindow {
+        let frame = NSRect(x: 0, y: 0, width: 300, height: 200)
+        let window = isKeyWindow
+            ? KeyWindow(contentRect: frame, styleMask: [.titled], backing: .buffered, defer: false)
+            : NSWindow(contentRect: frame, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = NSView(frame: frame)
+        return window
+    }
+
+    /// AppKit populates a row view before it adds that row to the table, so this is the order the
+    /// framework really uses and the order the bug lived in.
+    private func makeRow(followsWindowKeyState: Bool, isSelected: Bool) -> (FieldDrivenRowView, NSTableCellView) {
+        let rowView = FieldDrivenRowView.make()
+        rowView.followsWindowKeyState = followsWindowKeyState
+        rowView.isSelected = isSelected
+        let cell = NSTableCellView(frame: NSRect(x: 0, y: 0, width: 300, height: 32))
+        rowView.addSubview(cell)
+        return (rowView, cell)
+    }
+
+    /// The regression. AppKit copies `interiorBackgroundStyle` into the cell views while the row is
+    /// still outside the window, where a key-state-derived emphasis can only read false, and it
+    /// never repeats the copy when the row arrives. The row then painted its accent fill from the
+    /// live value over cells that had kept the unemphasized foreground.
+    @Test("A chooser row emphasizes cells that were installed before it reached the window")
+    func chooserEmphasizesCellsInstalledBeforeTheWindow() {
+        let (rowView, cell) = makeRow(followsWindowKeyState: true, isSelected: true)
+        #expect(cell.backgroundStyle == .normal)
+
+        makeWindow(isKeyWindow: true).contentView?.addSubview(rowView)
+
+        #expect(cell.backgroundStyle == .emphasized)
+    }
+
+    @Test("A chooser row leaves an unselected row's cells alone")
+    func chooserLeavesUnselectedCellsAlone() {
+        let (rowView, cell) = makeRow(followsWindowKeyState: true, isSelected: false)
+
+        makeWindow(isKeyWindow: true).contentView?.addSubview(rowView)
+
+        #expect(cell.backgroundStyle == .normal)
+    }
+
+    @Test("A chooser row in a window without the keyboard is not emphasized")
+    func chooserNeedsTheKeyWindow() {
+        let (rowView, cell) = makeRow(followsWindowKeyState: true, isSelected: true)
+
+        makeWindow(isKeyWindow: false).contentView?.addSubview(rowView)
+
+        #expect(cell.backgroundStyle == .normal)
+        #expect(rowView.isEmphasized == false)
+    }
+
+    @Test("A chooser row is emphasized as soon as it is in a key window")
+    func chooserReadsTheWindow() {
+        let (rowView, _) = makeRow(followsWindowKeyState: true, isSelected: true)
+        #expect(rowView.isEmphasized == false)
+
+        makeWindow(isKeyWindow: true).contentView?.addSubview(rowView)
+
+        #expect(rowView.isEmphasized)
+        #expect(rowView.interiorBackgroundStyle == .emphasized)
+    }
+
+    /// A browser holds its own focus, so AppKit's stored value is the right answer and the setter
+    /// has to forward. Swallowing the write would leave every row of the query history drawer
+    /// permanently unemphasized.
+    /// The starting value matters as much as the forwarding: a browser row is built before AppKit
+    /// has said anything about it, and cells are copied from it in that state. `NSTableRowView`
+    /// starts unemphasized, so an untouched row reads as unemphasized too.
+    @Test("A browser row reports the emphasis AppKit gave it")
+    func browserForwardsStoredEmphasis() {
+        let rowView = FieldDrivenRowView.make()
+        #expect(rowView.isEmphasized == false)
+
+        rowView.isEmphasized = true
+        #expect(rowView.isEmphasized)
+
+        rowView.isEmphasized = false
+        #expect(rowView.isEmphasized == false)
+    }
+
+    /// A chooser answers from the window, not from what AppKit stored, because AppKit drops
+    /// emphasis the moment the search field rather than the table holds the keyboard.
+    @Test("A chooser row ignores the emphasis AppKit stored")
+    func chooserIgnoresStoredEmphasis() {
+        let rowView = FieldDrivenRowView.make()
+        rowView.followsWindowKeyState = true
+
+        rowView.isEmphasized = true
+
+        #expect(rowView.isEmphasized == false)
+    }
+}


### PR DESCRIPTION
The connection switcher opens with the active connection preselected. That row drew the blue accent fill with dark text on it, so the name was close to unreadable. Pressing Down then Up reselected the same row and it then drew correctly in white.

The database switcher and the query history drawer share the same list and had the same defect.

## Root cause

`NSTableRowView` copies its `interiorBackgroundStyle` into its `NSTableCellView` subviews from `didAddSubview`. AppKit populates a row view before it adds that row to the table, so at the moment of that copy the row's `window` and `superview` are both nil.

`FieldDrivenRowView` derived its emphasis from `window?.isKeyWindow`, which can only read false at that point, so the cells were left at `backgroundStyle == .normal`. SwiftUI publishes that as `backgroundProminence == .standard`, and the row's `Text` therefore kept `labelColor`. The accent fill was right because the row paints it later, from a fresh read of the same getter.

Nothing re-ran the copy afterwards. `setSelected:` does, which is why moving the selection off the row and back repaired it.

Measured with a standalone AppKit probe that reproduces the popover, the shipping code and the fix side by side:

```
[BROKEN] first display   sel=true emph=true rowIBS=EMPHASIZED CELL=normal      backgroundProminence=.standard
[BROKEN] after Down/Up   sel=true emph=true rowIBS=EMPHASIZED CELL=EMPHASIZED  backgroundProminence=.increased
[FIXED]  first display   sel=true emph=true rowIBS=EMPHASIZED CELL=EMPHASIZED  backgroundProminence=.increased
```

## The fix

Three changes to `FieldDrivenRowView`, all in `FieldDrivenList.swift`:

- The chooser/browser rule is pushed onto the row from `tableView(_:rowViewForRow:)`, which runs before AppKit installs any cell view, instead of being read back off `superview` at a moment when there is no superview.
- A browser leaves emphasis to AppKit. A list that holds its own focus already gets the right value from the framework, and the old override reimplemented it with an identity check on `firstResponder`. The setter now forwards, because AppKit's stored value is what a browser row draws from.
- A chooser repeats the copy in `viewDidMoveToWindow()`, which is the first point its derived value can be true. AppKit keeps the two in step from then on, including when the window loses and regains the keyboard.

The query history drawer is a browser and was affected too, for the same reason: its old branch read `window?.firstResponder === table`, which is also false when there is no window. Handing the property back to AppKit fixes it, because `NSTableRowView` starts unemphasized and the framework sets the real value at the right time:

```
browser, table focused, first display   before: CELL=normal   after: CELL=EMPHASIZED, accent fill 4825px
browser, table not focused, first display              after: CELL=normal, accent fill 0px
```

Overriding `interiorBackgroundStyle` alone does not work: it is read at the same moment, so it reads false too. Setting AppKit's own `isEmphasized` does not work either, because AppKit rewrites it to false on every key-state change for a table that is not first responder. Both were measured before being rejected.

## Verification

- `xcodebuild build` on the `TablePro` scheme: succeeds.
- `TableProTests/FieldDrivenListEmphasisTests`: 6 new cases, all pass. `chooserEmphasizesCellsInstalledBeforeTheWindow` is the regression test and fails on the code this replaces.
- `FieldDrivenListEntryTests`, `SortableHeaderEmphasisTests`, `SortableHeaderRenderingTests`, `ConnectionSwitcherFilterTests`, `DatabaseSwitcherFilterTests`, `QuickSwitcherPanelControllerTests`: all pass.
- `swiftlint lint --strict` on both changed files: clean.

No `TableProUITests` case: the defect is a rendered text colour, and neither the colour nor `NSTableCellView.backgroundStyle` is exposed through the accessibility API that XCUITest queries. The row's selection state, which is all XCUITest can see, was already correct before this change.
