### PR TITLE
fix(hig): disable Save As and Export Results when they cannot run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DuckDB tables outside the `main` schema are visible again. The sidebar lists every schema of the connected database, Tree layout shows database, schema and tables, and `ATTACH`ed databases appear alongside the one you opened. (#2131)
 - DuckDB metadata no longer mixes up databases that share a schema name, so an `ATTACH`ed file's tables stay out of the database you opened.
 - A DuckDB table in the default schema is titled `orders` again rather than `main.orders`, and exports preselect the schema you are browsing.
+- **File > Save As...** stayed available on a table, structure or diagram tab, and **File > Export > Export Results...** stayed available with no rows to export. Both did nothing when chosen. They are dimmed now until they can run.
 
 ### Changed
 

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController+MenuValidation.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController+MenuValidation.swift
@@ -18,6 +18,10 @@ struct MenuValidationContext: Equatable {
     var isConnected = false
     var isReadOnly = false
     var isTableTab = false
+    /// Save As writes the selected tab's SQL, so it needs a query tab and not merely a connection.
+    var isQueryTab = false
+    /// Export Results exports the selected tab's rows, so an empty grid has nothing to offer.
+    var hasResultRows = false
     var isCurrentTabEditable = false
     var isQueryExecuting = false
     var hasQueryText = false
@@ -66,7 +70,6 @@ extension MainSplitViewController: NSMenuItemValidation {
         switch selector {
         case #selector(openSQLFile(_:)),
              #selector(exportTables(_:)),
-             #selector(exportQueryResults(_:)),
              #selector(refreshDatabase(_:)),
              #selector(openQuickSwitcher(_:)),
              #selector(switchConnection(_:)),
@@ -88,7 +91,9 @@ extension MainSplitViewController: NSMenuItemValidation {
         case #selector(saveDocument(_:)):
             return context.isConnected && !context.isReadOnly && context.hasPendingChanges
         case #selector(saveDocumentAs(_:)):
-            return context.isConnected
+            return context.isConnected && context.isQueryTab
+        case #selector(exportQueryResults(_:)):
+            return context.isConnected && context.hasResultRows
 
         /// AppKit validated New Tab and Close Tab for free while they were its own selectors.
         /// `NSWindow.validateUserInterfaceItem` only speaks to the native ones, so these are
@@ -198,6 +203,8 @@ extension MainSplitViewController: NSMenuItemValidation {
             isConnected: isConnected,
             isReadOnly: actions.isReadOnly,
             isTableTab: actions.isTableTab,
+            isQueryTab: actions.isQueryTab,
+            hasResultRows: actions.hasResultRows,
             isCurrentTabEditable: actions.isCurrentTabEditable,
             isQueryExecuting: actions.isQueryExecuting,
             hasQueryText: actions.hasQueryText,

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -341,6 +341,18 @@ final class MainContentCommandActions {
         coordinator?.toolbarState.isTableTab ?? false
     }
 
+    /// The two facts Save As and Export Results actually turn on. Their menu items used to be
+    /// validated on `isConnected` alone, so both stayed lit in states where the handler returns at
+    /// its first guard and the click does nothing at all.
+    var isQueryTab: Bool {
+        coordinator?.tabManager.selectedTab?.tabType == .query
+    }
+
+    var hasResultRows: Bool {
+        guard let coordinator, let tab = coordinator.tabManager.selectedTab else { return false }
+        return !coordinator.tabSessionRegistry.tableRows(for: tab.id).rows.isEmpty
+    }
+
     var hasRowSelection: Bool {
         !resolvedRowSelection().isEmpty
     }

--- a/TableProTests/Core/Menu/MainMenuBuilderTests.swift
+++ b/TableProTests/Core/Menu/MainMenuBuilderTests.swift
@@ -167,6 +167,35 @@ struct MainMenuValidationTests {
         #expect(!enabled(#selector(MainSplitViewController.saveDocument(_:)), context))
     }
 
+    /// Both handlers return at their first guard in states the old validation called enabled, so
+    /// the item stayed lit and the click did nothing at all.
+    @Test("Save As needs a query tab, not just a connection")
+    func saveAsNeedsAQueryTab() {
+        var context = MenuValidationContext()
+        context.isConnected = true
+        #expect(!enabled(#selector(MainSplitViewController.saveDocumentAs(_:)), context))
+        context.isQueryTab = true
+        #expect(enabled(#selector(MainSplitViewController.saveDocumentAs(_:)), context))
+    }
+
+    @Test("Export Results needs rows to export")
+    func exportResultsNeedsRows() {
+        var context = MenuValidationContext()
+        context.isConnected = true
+        #expect(!enabled(#selector(MainSplitViewController.exportQueryResults(_:)), context))
+        context.hasResultRows = true
+        #expect(enabled(#selector(MainSplitViewController.exportQueryResults(_:)), context))
+    }
+
+    @Test("Neither survives losing the connection")
+    func bothStillNeedAConnection() {
+        var context = MenuValidationContext()
+        context.isQueryTab = true
+        context.hasResultRows = true
+        #expect(!enabled(#selector(MainSplitViewController.saveDocumentAs(_:)), context))
+        #expect(!enabled(#selector(MainSplitViewController.exportQueryResults(_:)), context))
+    }
+
     @Test("Read-only connections block destructive commands")
     func readOnlyBlocksMutations() {
         var context = MenuValidationContext()
@@ -222,6 +251,8 @@ struct MainMenuValidationTests {
     private func capableContext() -> MenuValidationContext {
         var context = MenuValidationContext()
         context.isTableTab = true
+        context.isQueryTab = true
+        context.hasResultRows = true
         context.hasQueryText = true
         context.hasPendingChanges = true
         context.hasDataPendingChanges = true


### PR DESCRIPTION
Found while investigating the dead **Load in Editor** / **Run in New Tab** buttons in the query history drawer (#2137). Same class of defect, different menu, so it gets its own PR. Based on `main`.

## The defect

Two File menu items are validated on `context.isConnected` alone, while their handlers require something narrower and return at the first guard when it is missing. The item stays lit, full contrast, and choosing it does nothing: no panel, no sheet, no error, no log line.

**File > Save As...** is validated by `case #selector(saveDocumentAs(_:)): return context.isConnected`. `saveFileAs()` requires `tab.tabType == .query`. Connect to anything and double-click a table in the sidebar so the selected tab is a `.table` tab (or Structure, ER diagram, Users & Roles): Save As renders enabled, `Cmd+Shift+S` is live, and nothing happens. Same with zero tabs open, where `selectedTab` is nil.

Its sibling is validated correctly, which is what makes the omission specific rather than a house style: `saveDocument` gets `isConnected && !isReadOnly && hasPendingChanges`.

**File > Export > Export Results...** is grouped into the block that returns `context.isConnected`. `openExportQueryResultsDialog()` requires a selected tab whose rows are not empty. Open a new query tab and run nothing, or run a query returning zero rows: the item is enabled and clicking it returns at `rows.isEmpty`. The grid's context menu reaches the same guard through `AppCommands.shared.exportQueryResults`.

Apple's HIG on menus: *"Disable unavailable menu items. A disabled menu item, which appears gray and doesn't highlight when the pointer moves over it, helps people understand that an item is unavailable."*

## The fix

`MenuValidationContext` gains the two facts the handlers actually turn on, `isQueryTab` and `hasResultRows`, sourced from `MainContentCommandActions` alongside the flags already there. Neither existed in the context, which is why neither could be validated on. `exportQueryResults` moves out of the shared `isConnected` block into its own case.

Nothing about either handler changed. The item just tells the truth now, and a future regression of this class shows up as a dimmed item, which is diagnosable, rather than a dead click, which is not.

## Verified

- `TableProTests/MainMenuValidationTests`, `MainMenuStructureTests`, `MainMenuShortcutCoverageTests`: 28 passed, 0 failures, including three new tests covering both selectors and the case where the connection is gone.
- `capableContext()` in the existing suite gained the two new flags, since it exists to turn every capability on and prove only the window phase decides. Without that, `onlyConnectedPhaseEnablesCommands` fails, which is the check working.
- `swiftlint lint --strict`: 0 violations.
- Built as part of the test run.

No UI automation: an `NSMenuItem`'s enabled state under `autoenablesItems` is resolved at display time by the responder chain, and the existing menu suites already assert this layer directly and purely, which is a better test than driving a menu open.
