### PR TITLE
fix(hig): ask for the context menu before moving the selection to the clicked row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Right-clicking a day heading in the query history drawer cleared the selected entry and showed no menu. Right-clicking a row in the connection switcher moved the highlight without showing a menu.
 - DuckDB `TIMESTAMP_S`, `TIMESTAMP_MS` and `TIMESTAMP_NS` columns showed `1970-01-01 00:00:00` on every row instead of the stored value. They now read exactly as the DuckDB CLI prints them, keeping sub-second digits. (#2130)
 - DuckDB `UUID`, `ENUM`, `BIT`, `LIST`, `STRUCT`, `MAP`, `ARRAY` and `UNION` columns showed an empty cell instead of their value. (#2130)
 - Querying two DuckDB tables that share a column name could repeat one table's value in both columns. (#2130)

--- a/TablePro/Views/Shared/FieldDrivenList.swift
+++ b/TablePro/Views/Shared/FieldDrivenList.swift
@@ -328,14 +328,21 @@ internal final class FieldDrivenTableView: NSTableView {
         onCopy?()
     }
 
+    /// The menu is resolved before the selection moves, because `selectRowIndexes` does not consult
+    /// `tableView(_:shouldSelectRow:)`: a right-click on a section header would otherwise select a
+    /// row that carries no item, which reads back as an empty selection. Resolving first also keeps
+    /// a right-click that produces no menu from moving the selection behind it. The targets a menu
+    /// is built for are unaffected, since a click outside the selection always acts on its own row.
     override internal func menu(for event: NSEvent) -> NSMenu? {
         let point = convert(event.locationInWindow, from: nil)
         let row = row(at: point)
-        guard row >= 0 else { return nil }
+        guard row >= 0,
+              let provider = delegate as? (any FieldDrivenMenuProviding),
+              let menu = provider.menu(forRow: row) else { return nil }
         if !selectedRowIndexes.contains(row) {
             selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false)
         }
-        return (delegate as? (any FieldDrivenMenuProviding))?.menu(forRow: row)
+        return menu
     }
 }
 

--- a/TableProTests/Views/FieldDrivenListMenuTests.swift
+++ b/TableProTests/Views/FieldDrivenListMenuTests.swift
@@ -1,0 +1,156 @@
+//
+//  FieldDrivenListMenuTests.swift
+//  TableProTests
+//
+
+import AppKit
+@testable import TablePro
+import Testing
+
+@Suite("Field driven list context menu")
+@MainActor
+struct FieldDrivenListMenuTests {
+    private static let rowCount = 3
+
+    /// Stands in for the coordinator: row 0 is a section header and carries no menu, row 1 is an
+    /// item, and row 2 belongs to a list that supplies no menu items at all.
+    private final class Provider: NSObject, NSTableViewDelegate, FieldDrivenMenuProviding {
+        private(set) var askedRows: [Int] = []
+
+        func menu(forRow row: Int) -> NSMenu? {
+            askedRows.append(row)
+            guard row == 1 else { return nil }
+            let menu = NSMenu()
+            menu.addItem(NSMenuItem(title: "Copy", action: nil, keyEquivalent: ""))
+            return menu
+        }
+    }
+
+    private final class Source: NSObject, NSTableViewDataSource {
+        func numberOfRows(in tableView: NSTableView) -> Int { rowCount }
+    }
+
+    private struct List {
+        let tableView: FieldDrivenTableView
+        let provider: Provider
+        let source: Source
+        let window: NSWindow
+    }
+
+    private func makeList() -> List {
+        let tableView = FieldDrivenTableView()
+        tableView.headerView = nil
+        tableView.rowHeight = 30
+        tableView.allowsEmptySelection = true
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("FieldDrivenColumn"))
+        column.width = 280
+        tableView.addTableColumn(column)
+
+        let provider = Provider()
+        let source = Source()
+        tableView.dataSource = source
+        tableView.delegate = provider
+
+        let frame = NSRect(x: 0, y: 0, width: 300, height: 200)
+        let scrollView = NSScrollView(frame: frame)
+        scrollView.documentView = tableView
+        let window = NSWindow(contentRect: frame, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = scrollView
+        tableView.reloadData()
+        window.layoutIfNeeded()
+        tableView.layoutSubtreeIfNeeded()
+        return List(tableView: tableView, provider: provider, source: source, window: window)
+    }
+
+    private func rightClick(_ list: List, row: Int) -> NSMenu? {
+        let rect = list.tableView.rect(ofRow: row)
+        let inWindow = list.tableView.convert(NSPoint(x: rect.midX, y: rect.midY), to: nil)
+        guard let event = NSEvent.mouseEvent(
+            with: .rightMouseDown,
+            location: inWindow,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: list.window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ) else {
+            Issue.record("Could not synthesize a right-click event")
+            return nil
+        }
+        return list.tableView.menu(for: event)
+    }
+
+    /// The regression. `selectRowIndexes` does not consult `tableView(_:shouldSelectRow:)`, so a
+    /// right-click on a day header in the query history drawer used to select the header, which the
+    /// coordinator reads back as an empty selection, and then showed no menu at all.
+    @Test("Right-clicking a row with no menu leaves the selection alone")
+    func rightClickWithoutMenuKeepsSelection() {
+        let list = makeList()
+        list.tableView.selectRowIndexes(IndexSet(integer: 2), byExtendingSelection: false)
+
+        let menu = rightClick(list, row: 0)
+
+        #expect(menu == nil)
+        #expect(list.tableView.selectedRowIndexes == IndexSet(integer: 2))
+    }
+
+    @Test("Right-clicking a row that has a menu selects it and returns the menu")
+    func rightClickWithMenuSelectsTheRow() {
+        let list = makeList()
+        list.tableView.selectRowIndexes(IndexSet(integer: 2), byExtendingSelection: false)
+
+        let menu = rightClick(list, row: 1)
+
+        #expect(menu?.items.count == 1)
+        #expect(list.tableView.selectedRowIndexes == IndexSet(integer: 1))
+    }
+
+    /// A right-click inside an existing selection acts on the whole selection, so it must not
+    /// collapse it down to the clicked row.
+    @Test("Right-clicking inside the selection keeps the whole selection")
+    func rightClickInsideSelectionKeepsIt() {
+        let list = makeList()
+        list.tableView.allowsMultipleSelection = true
+        list.tableView.selectRowIndexes(IndexSet([1, 2]), byExtendingSelection: false)
+
+        let menu = rightClick(list, row: 1)
+
+        #expect(menu?.items.count == 1)
+        #expect(list.tableView.selectedRowIndexes == IndexSet([1, 2]))
+    }
+
+    @Test("The delegate is asked before the selection is touched")
+    func providerIsConsultedFirst() {
+        let list = makeList()
+        list.tableView.selectRowIndexes(IndexSet(integer: 2), byExtendingSelection: false)
+
+        _ = rightClick(list, row: 0)
+
+        #expect(list.provider.askedRows == [0])
+    }
+
+    @Test("A click outside every row produces no menu and no selection change")
+    func clickBelowTheRowsIsIgnored() {
+        let list = makeList()
+        list.tableView.selectRowIndexes(IndexSet(integer: 2), byExtendingSelection: false)
+
+        let below = list.tableView.convert(NSPoint(x: 10, y: list.tableView.bounds.height + 40), to: nil)
+        let event = NSEvent.mouseEvent(
+            with: .rightMouseDown,
+            location: below,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: list.window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        )
+
+        #expect(event.flatMap { list.tableView.menu(for: $0) } == nil)
+        #expect(list.tableView.selectedRowIndexes == IndexSet(integer: 2))
+        #expect(list.provider.askedRows.isEmpty)
+    }
+}


### PR DESCRIPTION
Found while investigating the connection switcher row highlight (#2140). Separate defect, separate PR.

`FieldDrivenTableView.menu(for:)` moved the selection onto the right-clicked row before it knew whether that row was selectable or whether there was a menu to show:

```swift
guard row >= 0 else { return nil }
if !selectedRowIndexes.contains(row) {
    selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false)
}
return (delegate as? (any FieldDrivenMenuProviding))?.menu(forRow: row)
```

`selectRowIndexes(_:byExtendingSelection:)` does not consult `tableView(_:shouldSelectRow:)`, so the header guard the list already has never ran on this path.

## What breaks

**Query history drawer.** Its sections are always titled, so there is a day heading at row 0 and after every day boundary. Select an entry, then right-click "Today". The heading gets selected, the coordinator maps it back to no item, the binding writes `selectedEntryId = nil`, the detail pane goes blank, and no menu appears. The user loses their selection to a right-click that showed them nothing.

**Connection switcher.** It passes no menu items, so `menu(forRow:)` always returns nil, but the selection write still ran. Right-click any row: no menu, and the highlight silently moves. Pressing Return afterwards opens the row you right-clicked rather than the one that was highlighted.

## The fix

Resolve the menu first, and only move the selection once there is one. `menu(forRow:)` already returns nil for a row with no item and for a list with no menu items, so both cases now leave the selection alone.

The targets a menu acts on are unaffected. `menu(forRow:)` builds them as `selection.contains(id) ? selection : [id]`, so a click outside the selection acts on its own row either way, and a click inside it still acts on the whole selection.

## Verification

- `xcodebuild build` on the `TablePro` scheme: succeeds.
- `TableProTests/FieldDrivenListMenuTests`: 5 new cases driving `menu(for:)` with a synthesized right-click. `rightClickWithoutMenuKeepsSelection` is the regression test and fails on the code this replaces.
- `FieldDrivenListEntryTests`: passes.
- `swiftlint lint --strict` on both changed files: clean.

No `TableProUITests` case: the drawer's context menu needs recorded query history and a live connection, so the flow does not run deterministically in the UI test host.
