### PR TITLE
fix(editor): say when the query history store cannot be opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DuckDB tables outside the `main` schema are visible again. The sidebar lists every schema of the connected database, Tree layout shows database, schema and tables, and `ATTACH`ed databases appear alongside the one you opened. (#2131)
 - DuckDB metadata no longer mixes up databases that share a schema name, so an `ATTACH`ed file's tables stay out of the database you opened.
 - A DuckDB table in the default schema is titled `orders` again rather than `main.orders`, and exports preselect the schema you are browsing.
+- A query history database TablePro cannot open showed as "No Query History", which reads as though nothing had ever been recorded. The drawer now says the store could not be opened and that your history is still on disk.
 
 ### Changed
 

--- a/TablePro/Core/Storage/QueryHistoryManager.swift
+++ b/TablePro/Core/Storage/QueryHistoryManager.swift
@@ -51,6 +51,10 @@ final class QueryHistoryManager: QueryHistoryRecording, QueryHistoryReading {
 
     // MARK: - Reading
 
+    func isStoreAvailable() async -> Bool {
+        await storage.isStoreAvailable()
+    }
+
     func fetch(_ filter: QueryHistoryFilter, after cursor: QueryHistoryCursor?, limit: Int) async -> QueryHistoryPage {
         await storage.fetch(filter, after: cursor, limit: limit)
     }

--- a/TablePro/Core/Storage/QueryHistoryRecording.swift
+++ b/TablePro/Core/Storage/QueryHistoryRecording.swift
@@ -10,6 +10,14 @@ protocol QueryHistoryReading: Sendable {
     func delete(id: UUID) async -> Bool
     func clear(matching filter: QueryHistoryFilter) async -> Bool
     func count(scope: QueryHistoryScope) async -> Int
+    /// False when the store could not be opened, which `fetch` cannot say for itself: it returns
+    /// the same empty page for "no rows" and for "could not read", and the drawer rendered that as
+    /// a positive statement that nothing had ever been recorded.
+    func isStoreAvailable() async -> Bool
+}
+
+extension QueryHistoryReading {
+    func isStoreAvailable() async -> Bool { true }
 }
 
 extension QueryHistoryReading {

--- a/TablePro/Core/Storage/QueryHistoryStorage.swift
+++ b/TablePro/Core/Storage/QueryHistoryStorage.swift
@@ -366,6 +366,8 @@ actor QueryHistoryStorage {
 
     // MARK: - Reads
 
+    func isStoreAvailable() -> Bool { db != nil }
+
     func fetch(_ filter: QueryHistoryFilter, after cursor: QueryHistoryCursor?, limit: Int) -> QueryHistoryPage {
         guard db != nil, limit > 0, !filter.matchesNothing else { return .empty }
 

--- a/TablePro/ViewModels/HistoryPanelViewModel.swift
+++ b/TablePro/ViewModels/HistoryPanelViewModel.swift
@@ -14,6 +14,9 @@ final class HistoryPanelViewModel {
     private(set) var hasLoadedOnce = false
     private(set) var hasMore = false
     private(set) var totalLoaded = 0
+    /// An unreadable store returns the same empty page as a store with nothing in it, so without
+    /// this the drawer stated positively that no query had ever been recorded.
+    private(set) var isStoreUnavailable = false
 
     var selectedEntryId: UUID?
 
@@ -113,7 +116,10 @@ final class HistoryPanelViewModel {
         }
         let windowLimit = min(max(pageSize, loadedPageCount * pageSize), Self.maximumRefreshWindow)
         let page = await history.fetch(state.filter(), after: nil, limit: windowLimit)
+        let storeAvailable = await history.isStoreAvailable()
         guard loadToken == token else { return }
+
+        isStoreUnavailable = !storeAvailable
 
         entries = page.entries
         nextCursor = page.nextCursor

--- a/TablePro/Views/Editor/History/HistoryListPane.swift
+++ b/TablePro/Views/Editor/History/HistoryListPane.swift
@@ -99,7 +99,13 @@ struct HistoryListPane: View {
 
     private var emptyState: some View {
         Group {
-            if viewModel.state.hasNarrowingFilter {
+            if viewModel.isStoreUnavailable {
+                ContentUnavailableView {
+                    Label(String(localized: "Query History Is Unavailable"), systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text("TablePro could not open its query history database, so nothing is being recorded and nothing can be shown. Your existing history is still on disk.")
+                }
+            } else if viewModel.state.hasNarrowingFilter {
                 ContentUnavailableView {
                     Label(String(localized: "No Matching Queries"), systemImage: "magnifyingglass")
                 } description: {

--- a/TableProTests/ViewModels/HistoryPanelViewModelTests.swift
+++ b/TableProTests/ViewModels/HistoryPanelViewModelTests.swift
@@ -8,6 +8,12 @@ import Foundation
 import Testing
 
 private actor RecordingHistoryReader: QueryHistoryReading {
+    var storeIsAvailable = true
+
+    func isStoreAvailable() -> Bool { storeIsAvailable }
+
+    func setStoreAvailable(_ available: Bool) { storeIsAvailable = available }
+
     private var entries: [QueryHistoryEntry]
     private(set) var receivedFilters: [QueryHistoryFilter] = []
     private(set) var clearCalls: [QueryHistoryFilter] = []
@@ -121,6 +127,24 @@ struct HistoryPanelViewModelTests {
             pageSize: pageSize
         )
         return (viewModel, reader)
+    }
+
+    /// The store returns the same empty page for "nothing recorded" and "could not read", so a
+    /// corrupt or unwritable database told the user their history was empty and kept saying so.
+    @Test("an unreadable store is reported, not shown as an empty history")
+    func unreadableStoreIsReported() async {
+        let connectionId = UUID()
+        let (viewModel, reader) = makeViewModel(connectionId: connectionId, entries: [])
+
+        await viewModel.reload()
+        #expect(!viewModel.isStoreUnavailable, "An empty but readable store is simply empty")
+        #expect(viewModel.isEmpty)
+
+        await reader.setStoreAvailable(false)
+        await viewModel.reload()
+
+        #expect(viewModel.isStoreUnavailable)
+        #expect(viewModel.isEmpty)
     }
 
     @Test("the panel scopes to its own connection by default")


### PR DESCRIPTION
Found while investigating the dead **Load in Editor** / **Run in New Tab** buttons in the query history drawer (#2137). Independent of that fix, so this is based on `main`.

## The defect

`QueryHistoryStorage` returns the identical `.empty` page for "there are no rows" and for "I could not read anything":

- `guard db != nil, limit > 0, !filter.matchesNothing else { return .empty }`
- `guard sqlite3_prepare_v2(...) == SQLITE_OK else { logSqliteError(...); return .empty }`

`db` is nil for the whole process lifetime when `sqlite3_open` fails during `setupDatabase()`. `QueryHistoryPage` carries no failure channel, and `HistoryPanelViewModel` had no error state at all, so `reload()` committed the empty page unconditionally and `HistoryListPane` fell to its `isEmpty` branch.

Failure scenario: `query_history.db` is corrupt, or Application Support is not writable. Every fetch returns empty and every `record()` returns false. The drawer then states positively:

> **No Query History**
> Queries you run appear here.

The trash button is disabled too, because `viewModel.isEmpty` is true. Nothing anywhere says the store could not be opened. The user concludes their history was deleted and keeps running queries that are never recorded. The only trace is one OSLog line at launch.

## The fix

`QueryHistoryReading` gains `isStoreAvailable()`, defaulted to `true` in a protocol extension so no other conformer changes. `QueryHistoryStorage` answers `db != nil`. `HistoryPanelViewModel` records it on reload, and the drawer's empty state distinguishes the two cases:

> **Query History Is Unavailable**
> TablePro could not open its query history database, so nothing is being recorded and nothing can be shown. Your existing history is still on disk.

That last sentence is the point: the failure is that the file could not be opened, not that its contents went away, and the old message implied the opposite.

Scope note: this covers the case the store cannot report any other way, which is the one that persists for the whole session and silently stops recording. A mid-session prepare failure on an otherwise-open database still reads as empty; giving `QueryHistoryPage` a real failure channel is a larger change and is not attempted here.

## Verified

- `TableProTests/HistoryPanelViewModelTests`: 22 passed, 0 failures, including a new test that asserts an empty-but-readable store is simply empty while an unreadable one is reported.
- `swiftlint lint --strict`: 0 violations.
- Built as part of the test run.

No UI automation: the failure needs `sqlite3_open` to fail, and the app under test resolves its store from a sandbox directory `UITestCase` creates, so there is no deterministic way to make it fail from a UI test without adding a test-only hook to the app. The app deliberately cannot detect that it is under XCUITest, so that hook would be live in the shipping build.
