### PR TITLE
fix(sidebar): keep the database switcher list and selection through a refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Refreshing the database switcher replaced the list with a spinner, and a refresh that failed hid the databases you were already looking at.
+- The database switcher reset your highlighted database when the rest of its details finished loading, and it could highlight a database the search filter hides, which left Return doing nothing.
 - DuckDB `TIMESTAMP_S`, `TIMESTAMP_MS` and `TIMESTAMP_NS` columns showed `1970-01-01 00:00:00` on every row instead of the stored value. They now read exactly as the DuckDB CLI prints them, keeping sub-second digits. (#2130)
 - DuckDB `UUID`, `ENUM`, `BIT`, `LIST`, `STRUCT`, `MAP`, `ARRAY` and `UNION` columns showed an empty cell instead of their value. (#2130)
 - Querying two DuckDB tables that share a column name could repeat one table's value in both columns. (#2130)

--- a/TablePro/ViewModels/DatabaseSwitcherViewModel.swift
+++ b/TablePro/ViewModels/DatabaseSwitcherViewModel.swift
@@ -35,6 +35,8 @@ final class DatabaseSwitcherViewModel {
     private let databaseType: DatabaseType
     @ObservationIgnored private let services: AppServices
     private let sidebarState: SharedSidebarState?
+    @ObservationIgnored private var hasLoadedOnce = false
+    @ObservationIgnored private var loadToken: UUID?
 
     private var treeVisibleDatabases: [DatabaseMetadata] {
         guard switchTarget == .database else { return databases }
@@ -76,9 +78,14 @@ final class DatabaseSwitcherViewModel {
         self.switchTarget = services.pluginManager.containerSwitchTarget(for: databaseType) ?? .database
     }
 
+    /// A refresh never blanks the list it is refreshing, and a failed one never replaces data the
+    /// popover is still showing. Only a load that has nothing to fall back on reports either state.
     func fetchDatabases() async {
-        isLoading = true
-        errorMessage = nil
+        let token = UUID()
+        loadToken = token
+        if !hasLoadedOnce {
+            isLoading = true
+        }
 
         do {
             let target = switchTarget
@@ -88,27 +95,36 @@ final class DatabaseSwitcherViewModel {
                 case .schema: try await driver.fetchSchemas()
                 }
             }
-            databases = names.sorted().map { name in
-                DatabaseMetadata.minimal(name: name, isSystem: isSystemItem(name))
-            }
+            guard loadToken == token else { return }
+            applyFetched(names.sorted().map { DatabaseMetadata.minimal(name: $0, isSystem: isSystemItem($0)) })
 
-            preselectDatabase()
-
-            isLoading = false
             guard switchTarget == .database else { return }
             do {
                 let metadataList = try await services.databaseManager.withBrowseMetadataDriver(connectionId: connectionId, workload: .bulk) { driver in
                     try await driver.fetchAllDatabaseMetadata()
                 }
-                databases = metadataList.sorted { $0.name < $1.name }
-                preselectDatabase()
+                guard loadToken == token else { return }
+                applyFetched(metadataList.sorted { $0.name < $1.name })
             } catch {
                 Self.logger.error("Failed to fetch database metadata: \(error)")
             }
         } catch {
-            errorMessage = error.localizedDescription
+            guard loadToken == token else { return }
             isLoading = false
+            guard !hasLoadedOnce else {
+                Self.logger.error("Failed to refresh databases: \(error)")
+                return
+            }
+            errorMessage = error.localizedDescription
         }
+    }
+
+    func applyFetched(_ metadata: [DatabaseMetadata]) {
+        databases = metadata
+        hasLoadedOnce = true
+        errorMessage = nil
+        isLoading = false
+        reconcileSelection()
     }
 
     func refreshDatabases() async {
@@ -162,11 +178,23 @@ final class DatabaseSwitcherViewModel {
         }
     }
 
+    /// A selection the user made outlives a refresh. The slow bulk metadata pass lands well after
+    /// the list is interactive, so resetting the selection there took the row out from under them.
+    private func reconcileSelection() {
+        selectedDatabases.formIntersection(Set(filteredDatabases.map(\.name)))
+        guard selectedDatabases.isEmpty else { return }
+        preselectDatabase()
+    }
+
+    /// The selection has to be a row the list actually shows, because `primarySelection` and the
+    /// arrow keys all resolve it through `filteredDatabases`. Preselecting a hidden row left Return
+    /// doing nothing at all.
     private func preselectDatabase() {
-        if let current = currentDatabase, databases.contains(where: { $0.name == current }) {
+        let items = filteredDatabases
+        if let current = currentDatabase, items.contains(where: { $0.name == current }) {
             selectedDatabase = current
         } else {
-            selectedDatabase = databases.first?.name
+            selectedDatabase = items.first?.name
         }
     }
 

--- a/TableProTests/ViewModels/DatabaseSwitcherRefreshTests.swift
+++ b/TableProTests/ViewModels/DatabaseSwitcherRefreshTests.swift
@@ -1,0 +1,131 @@
+//
+//  DatabaseSwitcherRefreshTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Database switcher refresh")
+@MainActor
+struct DatabaseSwitcherRefreshTests {
+    private func makeViewModel(currentDatabase: String? = nil) -> DatabaseSwitcherViewModel {
+        DatabaseSwitcherViewModel(
+            connectionId: UUID(),
+            currentDatabase: currentDatabase,
+            databaseType: .mysql,
+            sidebarState: SharedSidebarState()
+        )
+    }
+
+    private func metadata(_ names: [String]) -> [DatabaseMetadata] {
+        names.map { DatabaseMetadata.minimal(name: $0, isSystem: false) }
+    }
+
+    @Test("The first load preselects the current database")
+    func firstLoadPreselectsCurrent() {
+        let viewModel = makeViewModel(currentDatabase: "chinook")
+
+        viewModel.applyFetched(metadata(["analytics", "chinook", "staging"]))
+
+        #expect(viewModel.selectedDatabase == "chinook")
+    }
+
+    @Test("The first load falls back to the first row when there is no current database")
+    func firstLoadFallsBackToFirstRow() {
+        let viewModel = makeViewModel()
+
+        viewModel.applyFetched(metadata(["analytics", "chinook"]))
+
+        #expect(viewModel.selectedDatabase == "analytics")
+    }
+
+    /// The regression. The slow bulk metadata pass lands after the list is interactive, and it used
+    /// to reset the selection to the current database, so the row the user had arrowed to was taken
+    /// out from under them.
+    @Test("A later fetch keeps the selection the user made")
+    func laterFetchKeepsUserSelection() {
+        let viewModel = makeViewModel(currentDatabase: "chinook")
+        viewModel.applyFetched(metadata(["analytics", "chinook", "staging"]))
+        viewModel.selectedDatabase = "staging"
+
+        viewModel.applyFetched(metadata(["analytics", "chinook", "staging"]))
+
+        #expect(viewModel.selectedDatabase == "staging")
+    }
+
+    @Test("A selection that no longer exists is replaced")
+    func vanishedSelectionIsReplaced() {
+        let viewModel = makeViewModel(currentDatabase: "chinook")
+        viewModel.applyFetched(metadata(["analytics", "chinook", "staging"]))
+        viewModel.selectedDatabase = "staging"
+
+        viewModel.applyFetched(metadata(["analytics", "chinook"]))
+
+        #expect(viewModel.selectedDatabase == "chinook")
+    }
+
+    @Test("A multiple selection keeps the rows that survived and drops the rest")
+    func multipleSelectionIsPruned() {
+        let viewModel = makeViewModel()
+        viewModel.applyFetched(metadata(["analytics", "chinook", "staging"]))
+        viewModel.selectedDatabases = ["analytics", "staging"]
+
+        viewModel.applyFetched(metadata(["analytics", "chinook"]))
+
+        #expect(viewModel.selectedDatabases == ["analytics"])
+    }
+
+    /// Preselecting a row the filter hides left `primarySelection` nil, so Return did nothing and
+    /// the switcher looked dead.
+    @Test("A fetch under an active filter selects a row the filter shows")
+    func fetchUnderFilterSelectsAVisibleRow() {
+        let viewModel = makeViewModel(currentDatabase: "chinook")
+        viewModel.applyFetched(metadata(["analytics", "chinook", "reporting"]))
+        viewModel.searchText = "rep"
+
+        viewModel.applyFetched(metadata(["analytics", "chinook", "reporting"]))
+
+        #expect(viewModel.selectedDatabase == "reporting")
+        #expect(viewModel.primarySelection == "reporting")
+    }
+
+    @Test("A successful fetch clears an error left by an earlier failure")
+    func successClearsTheError() {
+        let viewModel = makeViewModel()
+        viewModel.errorMessage = "Lost connection"
+
+        viewModel.applyFetched(metadata(["analytics"]))
+
+        #expect(viewModel.errorMessage == nil)
+        #expect(viewModel.isLoading == false)
+    }
+
+    /// The CLAUDE.md invariant: a refresh never clears the cache it is refreshing. Nothing is
+    /// connected here, so the fetch fails, which is exactly the case being guarded.
+    @Test("A failed refresh keeps the loaded list and reports no error")
+    func failedRefreshKeepsData() async {
+        let viewModel = makeViewModel(currentDatabase: "chinook")
+        viewModel.applyFetched(metadata(["analytics", "chinook"]))
+        viewModel.selectedDatabase = "analytics"
+
+        await viewModel.fetchDatabases()
+
+        #expect(viewModel.databases.map(\.name) == ["analytics", "chinook"])
+        #expect(viewModel.selectedDatabase == "analytics")
+        #expect(viewModel.errorMessage == nil)
+        #expect(viewModel.isLoading == false)
+    }
+
+    @Test("A failed first load reports the error, because there is nothing to fall back on")
+    func failedFirstLoadReportsTheError() async {
+        let viewModel = makeViewModel()
+
+        await viewModel.fetchDatabases()
+
+        #expect(viewModel.databases.isEmpty)
+        #expect(viewModel.errorMessage != nil)
+        #expect(viewModel.isLoading == false)
+    }
+}


### PR DESCRIPTION
Found while investigating the connection switcher row highlight (#2140). Two defects in one method, so one PR.

`DatabaseSwitcherViewModel.fetchDatabases()` treated every call as a cold first load. It runs twice per open: a fast name-only pass that makes the list interactive, then a slow `fetchAllDatabaseMetadata()` pass. Cmd+R in the popover calls the whole thing again.

## What breaks

**A refresh blanks the list.** `isLoading = true` runs unconditionally, and the popover branches on it before the list, so Cmd+R replaced the whole popover with a spinner and tore down the list view and its coordinator. When the data came back the list was rebuilt at the top with the selection reset. This is the CLAUDE.md invariant "a refresh never clears the cache it is refreshing", the same shape as #1916.

**A failed refresh hides good data.** On a throw the error view replaced a list that was still perfectly valid, and `errorMessage` was only cleared by the next fetch, so the only way back was a Retry that hit the same dead connection.

**The slow pass discards your selection.** The second `preselectDatabase()` was unconditional, so a database you arrowed to while the bulk metadata was still in flight got reset to the current one. The list also scrolled back to it.

**Preselection could pick a hidden row.** `preselectDatabase()` matched against `databases`, while `primarySelection` and the arrow keys all resolve through `filteredDatabases`. With a filter typed, the reset could land on a row the list does not show, `primarySelection` went nil, and Return did nothing at all.

## The fix

Follows `HistoryPanelViewModel.reload`, the closest sibling in the codebase:

- `isLoading` is gated on `hasLoadedOnce`, so only a load with nothing to fall back on reports loading.
- A failure with content already on screen is logged and the list is kept. A first load that fails still reports the error, because there is nothing else to show.
- A `loadToken` discards a fetch that a newer one has overtaken, so two overlapping refreshes cannot land out of order.
- `reconcileSelection()` keeps the rows that still exist, drops the ones that do not, and preselects only when nothing is left.
- `preselectDatabase()` chooses from `filteredDatabases`, so the selection is always a row the list shows.

## Verification

- `xcodebuild build` on the `TablePro` scheme: succeeds.
- `TableProTests/DatabaseSwitcherRefreshTests`: 9 new cases. Three of them fail on the code this replaces: `failedRefreshKeepsData`, `laterFetchKeepsUserSelection` and `fetchUnderFilterSelectsAVisibleRow`.
- `DatabaseSwitcherFilterTests`: passes.
- `swiftlint lint --strict` on both changed files: clean.

No `TableProUITests` case: the switcher needs a live server connection with several databases and a slow metadata round trip, so the flow does not run deterministically in the UI test host.
