### PR TITLE
fix(hig): switch fixed row tints with the selection background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The failure marker and the connection dot in the query history drawer, and the connection colour and status marks in the connection switcher, kept their own colour on the blue selection fill and were hard to make out. They now switch with the background like the rest of the row.
 - Refreshing the database switcher replaced the list with a spinner, and a refresh that failed hid the databases you were already looking at.
 - The database switcher reset your highlighted database when the rest of its details finished loading, and it could highlight a database the search filter hides, which left Return doing nothing.
 - Right-clicking a day heading in the query history drawer cleared the selected entry and showed no menu. Right-clicking a row in the connection switcher moved the highlight without showing a menu.

--- a/TablePro/Views/Editor/History/HistoryRowView.swift
+++ b/TablePro/Views/Editor/History/HistoryRowView.swift
@@ -6,8 +6,7 @@ struct HistoryRowView: View {
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
-            Image(systemName: entry.wasSuccessful ? "checkmark.circle.fill" : "exclamationmark.circle.fill")
-                .foregroundStyle(entry.wasSuccessful ? Color.secondary : Color.red)
+            statusIcon
                 .accessibilityLabel(
                     entry.wasSuccessful
                         ? String(localized: "Succeeded")
@@ -25,9 +24,7 @@ struct HistoryRowView: View {
                         Label {
                             Text(connectionLabel.name)
                         } icon: {
-                            Image(systemName: "circle.fill")
-                                .font(.system(size: 6))
-                                .foregroundStyle(connectionLabel.color?.color ?? .secondary)
+                            connectionDot(connectionLabel.color?.color)
                         }
                         .labelStyle(.titleAndIcon)
                         Text(verbatim: "·")
@@ -63,5 +60,30 @@ struct HistoryRowView: View {
         }
         .padding(.vertical, 3)
         .accessibilityElement(children: .combine)
+    }
+
+    /// `Color.secondary` already switches to the selected-content colour on a prominent fill, so it
+    /// is left alone. A fixed red does not, and stayed unreadable on the accent selection.
+    @ViewBuilder
+    private var statusIcon: some View {
+        if entry.wasSuccessful {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(Color.secondary)
+        } else {
+            Image(systemName: "exclamationmark.circle.fill")
+                .selectionAwareTint(.red)
+        }
+    }
+
+    /// A connection's own colour is a fixed value, so it disappears into the accent fill unless it
+    /// switches with the background. The unnamed case is secondary content and adapts by itself.
+    @ViewBuilder
+    private func connectionDot(_ color: Color?) -> some View {
+        let dot = Image(systemName: "circle.fill").font(.system(size: 6))
+        if let color {
+            dot.selectionAwareTint(color)
+        } else {
+            dot.foregroundStyle(Color.secondary)
+        }
     }
 }

--- a/TablePro/Views/Toolbar/ConnectionSwitcherPopover.swift
+++ b/TablePro/Views/Toolbar/ConnectionSwitcherPopover.swift
@@ -219,7 +219,7 @@ struct ConnectionSwitcherPopover: View {
         )
         return HStack(spacing: 8) {
             Circle()
-                .fill(connection.displayColor)
+                .selectionAwareTint(connection.displayColor)
                 .frame(width: 8, height: 8)
 
             VStack(alignment: .leading, spacing: 1) {
@@ -246,11 +246,11 @@ struct ConnectionSwitcherPopover: View {
 
             if isActive {
                 Image(systemName: "checkmark.circle.fill")
-                    .foregroundStyle(.green)
+                    .selectionAwareTint(.green)
                     .font(.body)
             } else if isConnected {
                 Circle()
-                    .fill(.green)
+                    .selectionAwareTint(.green)
                     .frame(width: 6, height: 6)
             }
 

--- a/TableProTests/Views/HistoryRowTintTests.swift
+++ b/TableProTests/Views/HistoryRowTintTests.swift
@@ -1,0 +1,103 @@
+//
+//  HistoryRowTintTests.swift
+//  TableProTests
+//
+
+import AppKit
+import SwiftUI
+@testable import TablePro
+import Testing
+
+@Suite("History row tints on a selection fill")
+@MainActor
+struct HistoryRowTintTests {
+    private func entry(wasSuccessful: Bool) -> QueryHistoryEntry {
+        QueryHistoryEntry(
+            query: "SELECT 1",
+            connectionId: UUID(),
+            databaseName: "db",
+            databaseType: .postgresql,
+            source: .editor,
+            executedAt: Date(timeIntervalSince1970: 0),
+            executionTime: 0.01,
+            rowCount: 1,
+            wasSuccessful: wasSuccessful
+        )
+    }
+
+    /// Renders the row over the same fill AppKit paints for an emphasized selection, and counts the
+    /// pixels that are still the raw tint rather than the selected-content colour.
+    private func offTintPixels(
+        wasSuccessful: Bool,
+        connectionLabel: HistoryConnectionLabel?,
+        prominence: BackgroundProminence,
+        matches: (NSColor) -> Bool
+    ) -> Int {
+        let row = HistoryRowView(entry: entry(wasSuccessful: wasSuccessful), connectionLabel: connectionLabel)
+            .frame(width: 320, height: 44)
+            .background(Color(nsColor: .selectedContentBackgroundColor))
+            .environment(\.backgroundProminence, prominence)
+
+        let renderer = ImageRenderer(content: row)
+        renderer.scale = 1
+        guard let image = renderer.cgImage else {
+            Issue.record("The row did not render")
+            return -1
+        }
+        let bitmap = NSBitmapImageRep(cgImage: image)
+        var count = 0
+        for y in 0 ..< bitmap.pixelsHigh {
+            for x in 0 ..< bitmap.pixelsWide {
+                guard let color = bitmap.colorAt(x: x, y: y)?.usingColorSpace(.sRGB) else { continue }
+                if matches(color) { count += 1 }
+            }
+        }
+        return count
+    }
+
+    private func isRed(_ color: NSColor) -> Bool {
+        color.redComponent > 0.6 && color.greenComponent < 0.45 && color.blueComponent < 0.45
+    }
+
+    private func isGreenish(_ color: NSColor) -> Bool {
+        color.greenComponent > 0.45 && color.greenComponent - color.blueComponent > 0.2
+    }
+
+    /// The regression. A failed entry drew a fixed red glyph, which SwiftUI does not remap, so it
+    /// sat on the accent fill at roughly 1.5:1 and read as a dark blob.
+    @Test("The failure glyph leaves the accent fill when the row is emphasized")
+    func failureGlyphAdaptsToProminence() {
+        let standard = offTintPixels(
+            wasSuccessful: false, connectionLabel: nil, prominence: .standard, matches: isRed
+        )
+        let increased = offTintPixels(
+            wasSuccessful: false, connectionLabel: nil, prominence: .increased, matches: isRed
+        )
+
+        #expect(standard > 0)
+        #expect(increased == 0)
+    }
+
+    @Test("A successful entry never draws red at either prominence")
+    func successGlyphIsNeverRed() {
+        #expect(offTintPixels(wasSuccessful: true, connectionLabel: nil, prominence: .standard, matches: isRed) == 0)
+        #expect(offTintPixels(wasSuccessful: true, connectionLabel: nil, prominence: .increased, matches: isRed) == 0)
+    }
+
+    /// A connection colour is a stored value, so it stayed itself on the fill. Green is the clearest
+    /// of the palette to count against an accent-blue background.
+    @Test("The connection dot leaves the accent fill when the row is emphasized")
+    func connectionDotAdaptsToProminence() {
+        let label = HistoryConnectionLabel(name: "Chinook", color: .green)
+
+        let standard = offTintPixels(
+            wasSuccessful: true, connectionLabel: label, prominence: .standard, matches: isGreenish
+        )
+        let increased = offTintPixels(
+            wasSuccessful: true, connectionLabel: label, prominence: .increased, matches: isGreenish
+        )
+
+        #expect(standard > 0)
+        #expect(increased == 0)
+    }
+}


### PR DESCRIPTION
Found while investigating the connection switcher row highlight (#2140). Separate defect, separate PR.

That fix made the semantic foregrounds in a selected row adapt again. It cannot help content painted in a fixed colour, and both switcher rows have some.

Measured with `ImageRenderer` over `NSColor.selectedContentBackgroundColor`, light appearance, taking the most common quantized colour of the glyph:

| foreground | `.standard` | `.increased` |
| --- | --- | --- |
| `Color.secondary` | `rgb(0,64,128)` | `rgb(192,192,224)` adapts |
| default / `.primary` | `rgb(0,0,32)` | `rgb(256,224,256)` adapts |
| `Color.red` | `rgb(256,64,64)` | `rgb(256,64,64)` unchanged |

Contrast of `systemRed` against the light accent fill `#0064E1` measures 1.50:1. A blue or purple connection colour leaves no distinguishable glyph pixels at all.

## What changes

- Query history drawer: the failed-query marker and the connection dot.
- Connection switcher: the connection's colour dot, the active checkmark, and the connected dot.

`Color.secondary` is deliberately left alone, in both the successful-query marker and the unnamed-connection dot. It already switches to a muted light tone on a prominent fill, and routing it through `selectionAwareTint` would push it to full white and lose that distinction.

`selectionAwareTint` is the helper the codebase already uses for this in `TableRowView`, `FavoriteRowView`, `RoutineRowView`, `LinkedFavoriteRowView` and the database switcher rows. This adds the two rows that were missing it.

The type badge in the connection switcher keeps its `separatorColor` chip. Its text adapts already, and changing a background treatment is a design decision rather than a defect fix.

## Verification

- `xcodebuild build` on the `TablePro` scheme: succeeds.
- `TableProTests/HistoryRowTintTests`: 3 new cases that render the real row over the selection fill and count pixels still holding the raw tint. `failureGlyphAdaptsToProminence` and `connectionDotAdaptsToProminence` both fail on the code this replaces.
- `SelectionAwareTintTests`: passes.
- `swiftlint lint --strict` on all three changed files: clean.

No `TableProUITests` case: a rendered glyph colour is not exposed through the accessibility API that XCUITest queries, which is why the check is a rendering test instead. The connection switcher row is covered by the same helper but not by a rendering test, because its row builder is private to the popover and the popover needs live sessions to lay out.
