### PR TITLE
fix(sidebar): refresh favorite stars immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Adding or removing a favorite table updates its sidebar star immediately instead of waiting for the sidebar to reopen.
 - The failure marker and the connection dot in the query history drawer, and the connection colour and status marks in the connection switcher, kept their own colour on the blue selection fill and were hard to make out. They now switch with the background like the rest of the row.
 - Refreshing the database switcher replaced the list with a spinner, and a refresh that failed hid the databases you were already looking at.
 - The database switcher reset your highlighted database when the rest of its details finished loading, and it could highlight a database the search filter hides, which left Return doing nothing.

--- a/TablePro/Views/Sidebar/DatabaseTreeCellView.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeCellView.swift
@@ -9,7 +9,17 @@ import SwiftUI
 /// One row of the object tree. All the hosting geometry is `SidebarHostingCellView`'s; this only
 /// knows how to turn a node into the row it draws.
 final class DatabaseTreeCellView: SidebarHostingCellView<DatabaseTreeRowView> {
-    func configure(node: DatabaseTreeNode, context: DatabaseTreeRowContext, actions: DatabaseTreeRowActions) {
-        update(rootView: DatabaseTreeRowView(node: node, context: context, actions: actions))
+    func configure(
+        node: DatabaseTreeNode,
+        isFavorite: Bool,
+        context: DatabaseTreeRowContext,
+        actions: DatabaseTreeRowActions
+    ) {
+        update(rootView: DatabaseTreeRowView(
+            node: node,
+            isFavorite: isFavorite,
+            context: context,
+            actions: actions
+        ))
     }
 }

--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator.swift
@@ -13,6 +13,7 @@ final class DatabaseTreeOutlineCoordinator: NSObject {
     internal weak var outlineView: NSOutlineView?
     internal let service = DatabaseTreeMetadataService.shared
     private static let cellIdentifier = NSUserInterfaceItemIdentifier("DatabaseTreeCell")
+    private let favoriteTablesStorage: FavoriteTablesStorage
 
     internal var connectionId = UUID()
     internal var databaseType: DatabaseType = .mysql
@@ -47,6 +48,11 @@ final class DatabaseTreeOutlineCoordinator: NSObject {
     internal let schemaService = SchemaService.shared
     private var favoriteTables: Set<FavoriteTablesStorage.FavoriteEntry> = []
     private var favoritesObserver: (any NSObjectProtocol)?
+
+    init(favoriteTablesStorage: FavoriteTablesStorage = .shared) {
+        self.favoriteTablesStorage = favoriteTablesStorage
+        super.init()
+    }
 
     internal var supportsSchemaLevel: Bool {
         PluginManager.shared.databaseGroupingStrategy(for: databaseType) == .bySchema
@@ -213,12 +219,17 @@ final class DatabaseTreeOutlineCoordinator: NSObject {
             guard let node = outlineView.item(atRow: row) as? DatabaseTreeNode,
                   let cell = outlineView.view(atColumn: 0, row: row, makeIfNecessary: false) as? DatabaseTreeCellView
             else { continue }
-            cell.configure(node: node, context: rowContext, actions: rowActions)
+            cell.configure(
+                node: node,
+                isFavorite: favoriteState(for: node),
+                context: rowContext,
+                actions: rowActions
+            )
         }
     }
 
     private func reloadFavorites() {
-        favoriteTables = FavoriteTablesStorage.shared.favorites(for: connectionId)
+        favoriteTables = favoriteTablesStorage.favorites(for: connectionId)
     }
 
     private func favoriteEntry(for ref: DatabaseTreeTableRef) -> FavoriteTablesStorage.FavoriteEntry {
@@ -234,9 +245,14 @@ final class DatabaseTreeOutlineCoordinator: NSObject {
         favoriteTables.contains(favoriteEntry(for: ref))
     }
 
+    private func favoriteState(for node: DatabaseTreeNode) -> Bool {
+        guard let ref = DatabaseTreeSelection.tableRef(of: node) else { return false }
+        return isFavorite(ref)
+    }
+
     internal func toggleFavorite(_ ref: DatabaseTreeTableRef) {
         let entry = favoriteEntry(for: ref)
-        FavoriteTablesStorage.shared.toggle(
+        favoriteTablesStorage.toggle(
             name: entry.name, schema: entry.schema, database: entry.database, connectionId: connectionId
         )
     }
@@ -414,8 +430,7 @@ final class DatabaseTreeOutlineCoordinator: NSObject {
                 kind == .table
                     ? PluginManager.shared.tableEntityName(for: databaseType)
                     : kind.pluralDisplayName
-            },
-            isFavorite: { [weak self] ref in self?.isFavorite(ref) ?? false }
+            }
         )
     }
 
@@ -494,7 +509,12 @@ extension DatabaseTreeOutlineCoordinator: NSOutlineViewDelegate {
         guard let node = item as? DatabaseTreeNode else { return nil }
         let cell = outlineView.makeView(withIdentifier: Self.cellIdentifier, owner: self) as? DatabaseTreeCellView
             ?? makeCell()
-        cell.configure(node: node, context: rowContext, actions: rowActions)
+        cell.configure(
+            node: node,
+            isFavorite: favoriteState(for: node),
+            context: rowContext,
+            actions: rowActions
+        )
         return cell
     }
 

--- a/TablePro/Views/Sidebar/DatabaseTreeRowView.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeRowView.swift
@@ -26,11 +26,11 @@ struct DatabaseTreeRowContext {
     var isExternalSchema: @MainActor (String, String) -> Bool = { _, _ in false }
     /// The plugin decides what a table is called, so a section header cannot hardcode "Tables".
     var objectKindTitle: @MainActor (SidebarObjectKind) -> String = { $0.pluralDisplayName }
-    var isFavorite: @MainActor (DatabaseTreeTableRef) -> Bool = { _ in false }
 }
 
 struct DatabaseTreeRowView: View {
     let node: DatabaseTreeNode
+    let isFavorite: Bool
     let context: DatabaseTreeRowContext
     let actions: DatabaseTreeRowActions
 
@@ -109,7 +109,7 @@ struct DatabaseTreeRowView: View {
             table: ref.table,
             isPendingTruncate: context.pendingTruncates.contains(ref.table.name),
             isPendingDelete: context.pendingDeletes.contains(ref.table.name),
-            isFavorite: context.isFavorite(ref),
+            isFavorite: isFavorite,
             onToggleFavorite: { actions.toggleFavorite(ref) }
         )
     }

--- a/TableProTests/Views/Sidebar/SidebarOutlineScaffoldTests.swift
+++ b/TableProTests/Views/Sidebar/SidebarOutlineScaffoldTests.swift
@@ -5,6 +5,7 @@
 
 import AppKit
 import SwiftUI
+import TableProSyncTransport
 import Testing
 
 @testable import TablePro
@@ -119,5 +120,112 @@ struct SidebarHostingCellViewTests {
     @Test("Both lists inset their content by the same amount")
     func sharesOneInset() {
         #expect(SidebarHostingCellView<Text>.contentInset == FavoritesOutlineCellView<Text>.contentInset)
+    }
+}
+
+@Suite("Database tree favorite refresh", .serialized)
+@MainActor
+struct DatabaseTreeFavoriteRefreshTests {
+    private static let width: CGFloat = 320
+    private static let height: CGFloat = 120
+
+    @Test("Adding and removing a favorite repaints every visible copy without replacing its host")
+    func favoriteMutationRepaintsVisibleRows() throws {
+        let favoritesSuite = "DatabaseTreeFavoriteRefreshTests.favorites.\(UUID().uuidString)"
+        let syncSuite = "DatabaseTreeFavoriteRefreshTests.sync.\(UUID().uuidString)"
+        let favoritesDefaults = try #require(UserDefaults(suiteName: favoritesSuite))
+        let syncDefaults = try #require(UserDefaults(suiteName: syncSuite))
+        favoritesDefaults.removePersistentDomain(forName: favoritesSuite)
+        syncDefaults.removePersistentDomain(forName: syncSuite)
+        defer {
+            favoritesDefaults.removePersistentDomain(forName: favoritesSuite)
+            syncDefaults.removePersistentDomain(forName: syncSuite)
+        }
+
+        let metadata = SyncMetadataStorage(userDefaults: syncDefaults)
+        let tracker = SyncChangeTracker(metadataStorage: metadata)
+        let storage = FavoriteTablesStorage(userDefaults: favoritesDefaults, syncTracker: tracker)
+        let coordinator = DatabaseTreeOutlineCoordinator(favoriteTablesStorage: storage)
+        let connectionId = UUID()
+        let table = TableInfo(name: "orders", type: .table, rowCount: nil, schema: "public")
+        let ref = DatabaseTreeTableRef(database: "shop", schema: "public", table: table)
+        let ordinary = DatabaseTreeNode(id: DatabaseTreeNode.tableId(ref), kind: .table(ref))
+        let recent = DatabaseTreeNode(id: DatabaseTreeNode.recentTableId(ref), kind: .recentTable(ref))
+        let outlineView = NSOutlineView()
+        let scrollView = SidebarOutlineScaffold.makeScrollView(
+            outlineView: outlineView,
+            configuration: SidebarOutlineScaffold.Configuration(
+                columnIdentifier: "FavoriteRefreshColumn",
+                allowsMultipleSelection: true,
+                rowSizePreference: .medium
+            )
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: Self.width, height: Self.height),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.appearance = NSAppearance(named: .aqua)
+        window.contentView = scrollView
+
+        coordinator.connectionId = connectionId
+        coordinator.databaseType = .sqlite
+        coordinator.childrenCache[""] = [ordinary, recent]
+        outlineView.dataSource = coordinator
+        outlineView.delegate = coordinator
+        coordinator.attach(outlineView: outlineView)
+        outlineView.reloadData()
+        settle(window)
+
+        #expect(outlineView.numberOfRows == 2)
+        let cells = try (0..<2).map { row in
+            try #require(
+                outlineView.view(atColumn: 0, row: row, makeIfNecessary: true) as? DatabaseTreeCellView
+            )
+        }
+        settle(window)
+        let hosts = cells.map(\.hostedView)
+        let unfavoritePixels = try cells.map(trailingPixels)
+
+        coordinator.toggleFavorite(ref)
+        settle(window)
+
+        #expect(coordinator.isFavorite(ref))
+        #expect(cells.indices.allSatisfy { cells[$0].hostedView === hosts[$0] })
+        let favoritePixels = try cells.map(trailingPixels)
+        #expect(zip(unfavoritePixels, favoritePixels).allSatisfy(!=))
+
+        coordinator.toggleFavorite(ref)
+        settle(window)
+
+        #expect(!coordinator.isFavorite(ref))
+        #expect(cells.indices.allSatisfy { cells[$0].hostedView === hosts[$0] })
+        let removedPixels = try cells.map(trailingPixels)
+        #expect(zip(favoritePixels, removedPixels).allSatisfy(!=))
+    }
+
+    private func settle(_ window: NSWindow) {
+        window.layoutIfNeeded()
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        window.layoutIfNeeded()
+    }
+
+    private func trailingPixels(of view: NSView) throws -> Data {
+        view.layoutSubtreeIfNeeded()
+        let representation = try #require(view.bitmapImageRepForCachingDisplay(in: view.bounds))
+        view.cacheDisplay(in: view.bounds, to: representation)
+        let bitmap = try #require(representation.bitmapData)
+        let bytesPerPixel = try #require(representation.bitsPerPixel / 8 > 0 ? representation.bitsPerPixel / 8 : nil)
+        let scale = CGFloat(representation.pixelsWide) / view.bounds.width
+        let trailingWidth = min(representation.pixelsWide, Int((32 * scale).rounded(.up)))
+        let startX = representation.pixelsWide - trailingWidth
+        let rowByteCount = trailingWidth * bytesPerPixel
+        var pixels = Data(capacity: rowByteCount * representation.pixelsHigh)
+        for y in 0..<representation.pixelsHigh {
+            let offset = y * representation.bytesPerRow + startX * bytesPerPixel
+            pixels.append(bitmap.advanced(by: offset), count: rowByteCount)
+        }
+        return pixels
     }
 }


### PR DESCRIPTION
## Summary

- Pass favorite state into each hosted database-tree row as a concrete SwiftUI input.
- Refresh both regular and Recent copies in place while preserving their `NSHostingView` identity.
- Add a rendered AppKit and SwiftUI regression for add and remove transitions.
- Record the user-visible fix in the changelog.

## Root cause

`FavoriteTablesStorage` persisted changes and `DatabaseTreeOutlineCoordinator` received the notification, but visible rows were reconfigured with the same cached node, context, and actions. Favorite state lived behind a cached closure, so `NSHostingView` received no changed stored input and SwiftUI did not reevaluate the star until the sidebar was rebuilt.

The coordinator now computes a Boolean favorite snapshot for each row configuration. That gives SwiftUI a changed root input while retaining the existing notification-driven visible-row refresh.

## Validation

- Reproduced before the fix: removal left the rendered star pixels unchanged.
- `DatabaseTreeFavoriteRefreshTests`: passed in the clean PR worktree.
- The same targeted regression passed 3 consecutive iterations.
- Six neighboring sidebar and favorite suites: 56 tests passed.
- Debug `TablePro` build passed.
- Strict SwiftLint on all four changed Swift files: 0 violations.
- Project generation and `git diff --check` passed.
- Internal adversarial review reported no findings.

## Test scope

The component regression drives the real favorite notification through the coordinator into reused `NSHostingView` rows with isolated favorite and sync metadata stores. It covers both normal and Recent table rows and verifies the full false to true to false transition.

A mutating XCUITest is intentionally deferred because `FavoriteTablesStorage.shared` and `SyncMetadataStorage.shared` currently bypass the UI-test `UserDefaults` sandbox. Such a test could alter developer favorites or create a real sync tombstone.

## Review limitation

The cross-vendor Claude review could not run because the local Claude CLI OAuth token was expired. The required fallback internal adversarial review completed with no findings.