### PR TITLE
fix(toolbar): remove the rule under the toolbar and the tab strip track fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The connection window drew a rule under its toolbar that began at the sidebar divider and ran to the right edge, dividing two areas that are the same colour. It is gone.
+- The editor tab bar filled a capsule behind the tabs. In dark mode that fill read as a lighter panel than anything else in the window, so the tabs now sit directly on the window background.
 - Data-grid columns now reserve space for trailing editor and foreign-key actions instead of truncating otherwise fitting values.
 - Empty Structure tabs and structured-value errors keep their toolbar at the top and center the message in the remaining content area.
 - Adding or removing a favorite table updates its sidebar star immediately instead of waiting for the sidebar to reopen.

--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -21,6 +21,13 @@ private final class EditorWindow: NSWindow, NSDraggingDestination {
         }
     }
 
+    /// Hiding the toolbar is what drops the content pane's top safe area, so the titlebar has to be
+    /// reconsidered every time the user sends this from View > Show Toolbar.
+    override func toggleToolbarShown(_ sender: Any?) {
+        super.toggleToolbarShown(sender)
+        TabWindowController.applyTitlebarChrome(to: self)
+    }
+
     func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
         FileDropDestination.acceptedURLs(from: sender.draggingPasteboard).isEmpty ? [] : .copy
     }
@@ -61,23 +68,7 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         self.payload = payload
         self.controllerId = UUID()
 
-        let window = EditorWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 1_200, height: 800),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
-            backing: .buffered,
-            defer: false
-        )
-        window.identifier = NSUserInterfaceItemIdentifier("main")
-        window.minSize = NSSize(width: 720, height: 480)
-        window.isRestorable = false
-        window.toolbarStyle = .unified
-        window.titleVisibility = .visible
-        /// `.automatic` is AppKit reading the user's own tabbing preference. Hard-coding
-        /// `.preferred` overrode that setting, which an app that draws its own editor tabs has no
-        /// reason to do.
-        window.tabbingMode = .automatic
-        window.tabbingIdentifier = WindowManager.mainTabbingIdentifier
-        window.collectionBehavior.insert([.fullScreenPrimary, .managed])
+        let window = Self.makeEditorWindow()
 
         let splitVC = MainSplitViewController(
             payload: payload,
@@ -115,6 +106,56 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         fatalError("TabWindowController does not support NSCoder init")
     }
 
+    /// The one place an editor window's chrome is configured, so a test can hold the whole shape.
+    internal static func makeEditorWindow() -> NSWindow {
+        let window = EditorWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1_200, height: 800),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.identifier = NSUserInterfaceItemIdentifier("main")
+        window.minSize = NSSize(width: 720, height: 480)
+        window.isRestorable = false
+        window.toolbarStyle = .unified
+        window.titleVisibility = .visible
+        applyTitlebarChrome(to: window)
+        /// `.automatic` is AppKit reading the user's own tabbing preference. Hard-coding
+        /// `.preferred` overrode that setting, which an app that draws its own editor tabs has no
+        /// reason to do.
+        window.tabbingMode = .automatic
+        window.tabbingIdentifier = WindowManager.mainTabbingIdentifier
+        window.collectionBehavior.insert([.fullScreenPrimary, .managed])
+        return window
+    }
+
+    /// AppKit rules a line between the toolbar and the content pane, and stops it at the sidebar
+    /// divider, so a window whose toolbar and content are the same colour gets a half-width rule
+    /// separating nothing. `titlebarSeparatorStyle` is the property for that, and it stopped
+    /// reaching the rule in macOS 26: the content section's titlebar background now draws it
+    /// through a scroll pocket, and `.none`, `.line` and `.shadow` all render identically there.
+    ///
+    /// `isFullScreen` is passed in for the transition hooks, which run either side of the style
+    /// mask changing rather than at the moment it does.
+    internal static func applyTitlebarChrome(to window: NSWindow, isFullScreen: Bool? = nil) {
+        window.titlebarSeparatorStyle = .none
+        guard #available(macOS 26.0, *) else { return }
+        window.titlebarAppearsTransparent = titlebarIsTransparent(
+            isFullScreen: isFullScreen ?? window.styleMask.contains(.fullScreen),
+            toolbarVisible: window.toolbar?.isVisible ?? false
+        )
+    }
+
+    /// A transparent titlebar is what removes that rule, and it is free while the content pane is
+    /// inset below the titlebar, which it is in every state but one. A full-screen window with its
+    /// toolbar hidden has a top safe area of zero, so its content owns the whole screen, and the
+    /// titlebar AppKit slides back down over that content needs a background of its own to stay
+    /// legible. Nothing is lost by making it opaque there, because a titlebar that only appears on
+    /// demand has no rule to suppress.
+    internal static func titlebarIsTransparent(isFullScreen: Bool, toolbarVisible: Bool) -> Bool {
+        isFullScreen ? toolbarVisible : true
+    }
+
     // MARK: - NSWindowDelegate
 
     internal func windowDidResize(_ notification: Notification) {
@@ -131,6 +172,19 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
     internal func windowDidMove(_ notification: Notification) {
         guard let window = notification.object as? NSWindow else { return }
         window.saveFrame(usingName: Self.frameAutosaveName)
+    }
+
+    /// Both hooks name the state they are moving to, because neither runs at the moment the style
+    /// mask flips: `willEnter` still reads windowed, and `didExit` is the first point that reads
+    /// windowed again.
+    internal func windowWillEnterFullScreen(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow else { return }
+        Self.applyTitlebarChrome(to: window, isFullScreen: true)
+    }
+
+    internal func windowDidExitFullScreen(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow else { return }
+        Self.applyTitlebarChrome(to: window, isFullScreen: false)
     }
 
     internal func windowDidBecomeKey(_ notification: Notification) {

--- a/TablePro/Views/Main/EditorTabStrip.swift
+++ b/TablePro/Views/Main/EditorTabStrip.swift
@@ -10,10 +10,12 @@ import SwiftUI
 /// every window in it, so one window hosting several connections could only ever show all of
 /// their tabs interleaved.
 ///
-/// Glass is applied where the system applies it and nowhere else. The system's track is a private
-/// subdued glass; the public effect is full strength, and the strip sits under a unified toolbar
-/// that is itself glass, so the track is a flat fill here. Only the selected tab and the new-tab
-/// button carry glass, which is the one pane the system slides along its track.
+/// Glass is applied where the system applies it and nowhere else: the selected tab and the new-tab
+/// button, which is the one pane the system slides along its track. The track carries no fill of
+/// its own. The strip sits in the content view over plain window background rather than on toolbar
+/// material, and an alpha fill lands at very different strength on the two appearances there:
+/// `quaternarySystemFill` is a white wash over the dark chrome and a black one over the light
+/// chrome, which in dark mode reads as a raised panel no other part of the window has.
 internal struct EditorTabStrip: View {
     internal let tabManager: QueryTabManager
     internal let onClose: (UUID) -> Void
@@ -66,10 +68,6 @@ internal struct EditorTabStrip: View {
             }
             .frame(height: EditorTabStripLayout.tabHeight)
             .padding(EditorTabStripLayout.trackPadding)
-            .background(
-                Capsule(style: .continuous)
-                    .fill(Color(nsColor: .quaternarySystemFill))
-            )
         }
         .frame(height: EditorTabStripLayout.trackHeight)
     }

--- a/TableProTests/Services/EditorWindowChromeTests.swift
+++ b/TableProTests/Services/EditorWindowChromeTests.swift
@@ -1,0 +1,78 @@
+//
+//  EditorWindowChromeTests.swift
+//  TableProTests
+//
+
+import AppKit
+import Testing
+
+@testable import TablePro
+
+@Suite("Editor window chrome")
+@MainActor
+struct EditorWindowChromeTests {
+    /// The real window the app opens, not a stand-in, so removing the chrome call from
+    /// `makeEditorWindow` fails here rather than passing against a window the test configured.
+    private func withEditorWindow(_ body: (NSWindow) -> Void) {
+        let window = TabWindowController.makeEditorWindow()
+        window.isReleasedWhenClosed = false
+        body(window)
+        window.close()
+    }
+
+    @Test("The editor window asks for no rule between its toolbar and its content pane")
+    func titlebarCarriesNoSeparator() {
+        withEditorWindow { window in
+            #expect(window.titlebarSeparatorStyle == .none)
+        }
+    }
+
+    /// `titlebarSeparatorStyle` stopped reaching that rule in macOS 26, so the transparent titlebar
+    /// is the part that does the work there, and only there.
+    @Test("A transparent titlebar is used only where the separator preference stopped working")
+    func transparentTitlebarIsVersionGated() {
+        withEditorWindow { window in
+            if #available(macOS 26.0, *) {
+                #expect(window.titlebarAppearsTransparent)
+            } else {
+                #expect(!window.titlebarAppearsTransparent)
+            }
+        }
+    }
+
+    /// A full-screen window with no toolbar has a top safe area of zero, so its content reaches the
+    /// screen edge and the titlebar that slides down over it has to bring its own background.
+    @Test(
+        "The titlebar stays opaque only in full screen with the toolbar hidden",
+        arguments: [
+            (isFullScreen: false, toolbarVisible: false, transparent: true),
+            (isFullScreen: false, toolbarVisible: true, transparent: true),
+            (isFullScreen: true, toolbarVisible: true, transparent: true),
+            (isFullScreen: true, toolbarVisible: false, transparent: false),
+        ]
+    )
+    func transparencyFollowsTheSafeArea(state: (isFullScreen: Bool, toolbarVisible: Bool, transparent: Bool)) {
+        #expect(
+            TabWindowController.titlebarIsTransparent(
+                isFullScreen: state.isFullScreen,
+                toolbarVisible: state.toolbarVisible
+            ) == state.transparent
+        )
+    }
+
+    @Test("Entering full screen with the toolbar hidden restores the titlebar background")
+    func enteringFullScreenWithoutAToolbarRestoresTheBackground() {
+        withEditorWindow { window in
+            TabWindowController.applyTitlebarChrome(to: window, isFullScreen: true)
+
+            if #available(macOS 26.0, *) {
+                #expect(!window.titlebarAppearsTransparent)
+            }
+
+            TabWindowController.applyTitlebarChrome(to: window, isFullScreen: false)
+            if #available(macOS 26.0, *) {
+                #expect(window.titlebarAppearsTransparent)
+            }
+        }
+    }
+}

--- a/TableProTests/Views/Main/EditorTabStripChromeTests.swift
+++ b/TableProTests/Views/Main/EditorTabStripChromeTests.swift
@@ -1,0 +1,127 @@
+//
+//  EditorTabStripChromeTests.swift
+//  TableProTests
+//
+
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import TablePro
+
+/// The strip sits in the content view over flat window background, so anything it fills behind the
+/// tabs is a second surface the rest of the window does not have. Sampling is symmetric about the
+/// band's centre so the assertions hold whichever way the hosting view flips its coordinates.
+@Suite("Editor tab strip chrome")
+@MainActor
+struct EditorTabStripChromeTests {
+    private static let width: CGFloat = 600
+    private static let margin: CGFloat = 20
+    private static let bandHeight = EditorTabStripLayout.trackHeight + EditorTabStripLayout.stripInset * 2
+
+    private static var totalHeight: CGFloat { bandHeight + margin * 2 }
+
+    /// Two points inside the track's own padding, above and below every tab, where only a track
+    /// fill could ever paint.
+    private static var trackRows: [CGFloat] {
+        let trackTop = margin + EditorTabStripLayout.stripInset
+        let trackBottom = trackTop + EditorTabStripLayout.trackHeight
+        return [trackTop + 1, trackBottom - 1]
+    }
+
+    /// The same distance outside the band on each side, which is untouched window background.
+    private static var backdropRows: [CGFloat] { [margin / 2, totalHeight - margin / 2] }
+
+    private static let sampleColumns: [CGFloat] = [200, 300, 400]
+
+    private func makeHost(appearance: NSAppearance.Name) -> NSView {
+        let manager = QueryTabManager()
+        manager.tabs = ["Album", "Artist", "Customer"].map { QueryTab(title: $0) }
+        manager.selectedTabId = manager.tabs.first?.id
+
+        let strip = EditorTabStrip(
+            tabManager: manager,
+            onClose: { _ in },
+            onCloseOthers: { _ in },
+            onCloseAll: {},
+            onNewTab: {}
+        )
+
+        let content = ZStack {
+            Color(nsColor: .windowBackgroundColor)
+            VStack(spacing: 0) {
+                Color.clear.frame(height: Self.margin)
+                strip
+                Color.clear.frame(height: Self.margin)
+            }
+        }
+        .frame(width: Self.width, height: Self.totalHeight)
+
+        let host = NSHostingView(rootView: AnyView(content))
+        host.frame = NSRect(x: 0, y: 0, width: Self.width, height: Self.totalHeight)
+
+        let window = NSWindow(
+            contentRect: host.frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.appearance = NSAppearance(named: appearance)
+        window.contentView = host
+        settle(window)
+        return host
+    }
+
+    /// Laying the hosting view's own subtree out is enough here. Spinning the run loop instead
+    /// would let another suite's queued main-actor work run in the middle of this one.
+    private func settle(_ window: NSWindow) {
+        window.layoutIfNeeded()
+        window.contentView?.layoutSubtreeIfNeeded()
+    }
+
+    private func windowBackgroundBrightness(for appearance: NSAppearance.Name) -> CGFloat {
+        var brightness: CGFloat = 0
+        NSAppearance(named: appearance)?.performAsCurrentDrawingAppearance {
+            brightness = NSColor.windowBackgroundColor.usingColorSpace(.deviceRGB)?.brightnessComponent ?? 0
+        }
+        return brightness
+    }
+
+    private func brightness(of view: NSView, rows: [CGFloat], columns: [CGFloat]) -> [CGFloat] {
+        guard let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds) else { return [] }
+        view.cacheDisplay(in: view.bounds, to: rep)
+        let scale = CGFloat(rep.pixelsHigh) / view.bounds.height
+        return rows.flatMap { row in
+            columns.compactMap { column -> CGFloat? in
+                let x = min(rep.pixelsWide - 1, Int(column * scale))
+                let y = min(rep.pixelsHigh - 1, Int(row * scale))
+                return rep.colorAt(x: x, y: y)?.brightnessComponent
+            }
+        }
+    }
+
+    @Test("The strip paints no track behind the tabs", arguments: [NSAppearance.Name.aqua, .darkAqua])
+    func trackIsUnpainted(appearance: NSAppearance.Name) {
+        let host = makeHost(appearance: appearance)
+
+        let backdrop = brightness(of: host, rows: Self.backdropRows, columns: Self.sampleColumns)
+        let track = brightness(of: host, rows: Self.trackRows, columns: Self.sampleColumns)
+
+        guard let reference = backdrop.first else {
+            Issue.record("The strip did not rasterise")
+            return
+        }
+        /// Anchored to the colour the band is supposed to be, so an all-black or otherwise empty
+        /// bitmap cannot satisfy the comparisons below by agreeing with itself.
+        #expect(abs(reference - windowBackgroundBrightness(for: appearance)) < 0.01)
+
+        #expect(track.count == backdrop.count)
+        #expect(backdrop.allSatisfy { abs($0 - reference) < 0.005 })
+        #expect(track.allSatisfy { abs($0 - reference) < 0.005 })
+
+        /// Without this, a strip that drew nothing at all would satisfy every assertion above.
+        let bandCentre = Self.margin + Self.bandHeight / 2
+        let ink = brightness(of: host, rows: [bandCentre], columns: Array(stride(from: 20, to: Self.width - 20, by: 4)))
+        #expect(ink.contains { abs($0 - reference) > 0.01 })
+    }
+}


### PR DESCRIPTION
## Summary

- Suppress the 1pt rule AppKit draws between the toolbar and the content pane of every connection window.
- Remove the track capsule behind the editor tabs, which was a different colour from the rest of the window in dark mode.
- Add a rasterisation regression test for the strip band and a chrome test for the window's own construction path.

## Root cause

**The rule is AppKit's, not ours.** On macOS 26/27 the content pane's `NSTitlebarBackgroundView` hosts an `NSScrollPocket` whose `NSHardPocketView` paints a 1pt `_NSLayerBasedFillColorView`. The sidebar section gets an `NSContainerConcentricGlassEffectView` instead, which is why the rule began at the sidebar divider and ran to the right edge. TablePro's toolbar and content background resolve to the same colour, so it divided nothing.

`titlebarSeparatorStyle` is the property documented for this and no longer reaches that rule. Measured against a standalone AppKit probe replicating the window (`.fullSizeContentView` + `toolbarStyle = .unified` + `NSSplitViewController` + `.sidebarTrackingSeparator`), captured through the window server and sampled in sRGB: `.none`, `.line` and `.shadow` render byte-identically at both window and split-item level, with readback confirming the stored value. SwiftUI's `scrollEdgeEffectHidden`/`scrollEdgeEffectStyle`, scroll position, `NSSplitViewItem.automaticallyAdjustsSafeAreaInsets` and `contentListWithViewController:` all change nothing. `titlebarAppearsTransparent = true` removes it. Finder on the same OS shows no such rule.

**The tab track** filled a capsule with `NSColor.quaternarySystemFill`. That token is a white overlay in dark and a black overlay in light at the same 2.7% alpha, so it measured **+12.5% Weber contrast in dark against only −2.4% in light** and read as a raised panel with a background nothing else in the window had. The strip's own comment assumed it sat on toolbar glass; it actually sits in the content view over plain window background.

## Behaviour

- `TabWindowController.applyTitlebarChrome(to:isFullScreen:)` sets `titlebarSeparatorStyle = .none` on every version and `titlebarAppearsTransparent` on macOS 26+ only, where the documented property stopped working.
- The transparency is gated by `titlebarIsTransparent(isFullScreen:toolbarVisible:)`. A full-screen window with its toolbar hidden (⌃⌘F then ⌥⌘T, both shipping View menu items) has a **top safe area of zero**, so its content owns the whole screen and the titlebar AppKit slides back down over it needs its own background. Nothing is lost by staying opaque there, because an on-demand titlebar has no rule to suppress. `windowWillEnterFullScreen`, `windowDidExitFullScreen` and an `EditorWindow.toggleToolbarShown` override keep the state current.
- Window construction moved into `TabWindowController.makeEditorWindow()` so the chrome wiring is reachable from a test. Building a whole `TabWindowController` is not viable in a unit test; it reaches `DatabaseManager.shared` and `ConnectionStorage.shared` through `MainSplitViewController`.
- `EditorTabStrip` no longer fills the track. Geometry is untouched, so tab widths, the 2pt track padding and the separator ticks between plain tabs are unchanged.

## Tests

- `EditorTabStripChromeTests` rasterises the strip in a real `NSWindow` under both `.aqua` and `.darkAqua`, and asserts the track rows match the surrounding band. It samples symmetric rows about the band centre so it does not depend on `NSHostingView.isFlipped`, anchors the reference to a resolved `windowBackgroundColor` so an empty bitmap cannot pass by agreeing with itself, and requires the strip to have drawn something. **Verified failing on the pre-fix code in both appearances**, at Δ 0.0275 aqua and Δ 0.0235 darkAqua against a 0.005 tolerance.
- `EditorWindowChromeTests` builds the real `makeEditorWindow()` and covers all four `(isFullScreen, toolbarVisible)` combinations plus the enter/exit full-screen transitions.

## Validation

Run on this branch in a clean worktree, without the unrelated work in progress in the main checkout:

- `xcodebuild build` succeeds.
- 95 tests across 15 suites pass: the two new suites plus `EditorTabStripLayoutTests`, the five `MainWindowToolbar*` suites, `MainSplitViewControllerDetailWidthTests`, `SplitPaneHoldingPriorityTests`, `MainStatusBarLayoutTests`, `SortableHeaderRenderingTests`, `AppStorageEnvironmentTests`, `WindowTitleResolverWindowTests`, `MaintenanceMenuDelegateTests`.
- `swiftlint --strict` reports 0 violations on all four files.
- UI suites touching the `editor-tab` identifier (`QueryHistoryActionsUITests`, `QuickSwitcherCrossConnectionUITests`) pass, 5 cases.
- Measured as unaffected: the sidebar column and the `.sidebarTrackingSeparator` boundary are pixel-identical, `NSToolbarItemGroup` glass still renders, and the native window tab bar still draws its own track and glass correctly under the transparent titlebar.

## Limitations

- **macOS 14/15 is not verified.** Only macOS 27 is measurable on this host, so the `titlebarSeparatorStyle = .none` path for older systems rests on the SDK header (`NSWindow.h`: "Changing this value will override any preference made by `NSSplitViewItem`") rather than on a measurement.
- The full-screen-with-hidden-toolbar titlebar was not pixel-captured; that guard rests on the measured mechanism, that the top safe area collapses to 0 and that `titlebarAppearsTransparent` works by hiding `NSTitlebarBackgroundView`.
- UI automation cannot see a 1pt rule or a background colour, so the gate for both defects is the rasterisation unit test rather than a `UITestCase`.
- Not addressed here: the CSV inspector window (`InspectorWindowController.swift:67`) also uses a `.unified` toolbar and likely shows the same rule, but there it separates a genuinely different surface.
