### PR TITLE
fix(datagrid): make an aliased single-table SELECT editable again (#2150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Query results were read-only whenever the `SELECT` gave its table an alias, as in `select * from users u where u.id = 1`. Editing works on those results now, and also on queries written across several lines, preceded by a comment, or ending in `FOR UPDATE`. (#2150)
+- A `UNION`, `EXCEPT` or `INTERSECT` result could be edited as though it were a single table, and the edit was written to one of the branches rather than to the rows on screen. Those results are read-only now. So are results from a join, a subquery, a CTE, a temporal `FOR SYSTEM_TIME` read, `FROM ONLY`, and a schema-qualified name such as `public.users`.
 - Data-grid columns now reserve space for trailing editor and foreign-key actions instead of truncating otherwise fitting values.
 - Empty Structure tabs and structured-value errors keep their toolbar at the top and center the message in the remaining content area.
 - Adding or removing a favorite table updates its sidebar star immediately instead of waiting for the sidebar to reopen.

--- a/TablePro/Core/Services/Query/QuerySqlParser.swift
+++ b/TablePro/Core/Services/Query/QuerySqlParser.swift
@@ -2,11 +2,6 @@ import Foundation
 import TableProPluginKit
 
 enum QuerySqlParser {
-    private static let tableNameRegex = try? NSRegularExpression(
-        pattern: #"(?i)^\s*SELECT\s+.+?\s+FROM\s+(?:\[([^\]]+)\]|[`"]([^`"]+)[`"]|([\w$]+))\s*(?:WHERE|ORDER|LIMIT|GROUP|HAVING|OFFSET|FETCH|$|;)"#,
-        options: []
-    )
-
     private static let mongoCollectionRegex = try? NSRegularExpression(
         pattern: #"^\s*db\.(\w+)\."#,
         options: []
@@ -17,18 +12,14 @@ enum QuerySqlParser {
         options: []
     )
 
-    static func extractTableName(from sql: String) -> String? {
-        let nsRange = NSRange(sql.startIndex..., in: sql)
-
-        if let regex = tableNameRegex,
-           let match = regex.firstMatch(in: sql, options: [], range: nsRange) {
-            for group in 1...3 {
-                let r = match.range(at: group)
-                if r.location != NSNotFound, let range = Range(r, in: sql) {
-                    return String(sql[range])
-                }
-            }
+    /// The table a result grid may be edited through, or `nil` when the statement reads from
+    /// anything other than exactly one table.
+    static func extractTableName(from sql: String, dialect: SqlDialect = .generic) -> String? {
+        if let table = SelectSourceTableParser.singleSourceTable(in: sql, dialect: dialect) {
+            return table
         }
+
+        let nsRange = NSRange(sql.startIndex..., in: sql)
 
         if let regex = mongoBracketCollectionRegex,
            let match = regex.firstMatch(in: sql, options: [], range: nsRange),

--- a/TablePro/Core/Utilities/SQL/SelectSourceTableParser.swift
+++ b/TablePro/Core/Utilities/SQL/SelectSourceTableParser.swift
@@ -1,0 +1,432 @@
+//
+//  SelectSourceTableParser.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+/// Resolves the one table a `SELECT` reads from, or nothing.
+///
+/// The result decides whether a result grid is editable, and it becomes the target of the
+/// generated `UPDATE` and `DELETE`. A wrong name would write to the wrong table, so every
+/// shape this cannot prove is single-source resolves to `nil` and leaves the grid read-only:
+/// joins, comma lists, derived tables, CTEs, set operators, and schema-qualified names.
+enum SelectSourceTableParser {
+    /// Keywords that may legally follow the single table reference. Anything else means the
+    /// statement reads from more than the one table, so the whitelist is the safety property.
+    private static let clauseTerminators: Set<String> = [
+        "WHERE", "GROUP", "HAVING", "ORDER", "LIMIT", "OFFSET", "FETCH", "FOR", "WINDOW", "QUALIFY",
+    ]
+
+    private static let nonAliasKeywords: Set<String> = clauseTerminators.union([
+        "JOIN", "INNER", "LEFT", "RIGHT", "FULL", "OUTER", "CROSS", "NATURAL", "STRAIGHT_JOIN",
+        "ON", "USING", "UNION", "INTERSECT", "EXCEPT", "MINUS",
+        "AS", "SELECT", "FROM", "INTO", "SET", "RETURNING", "VALUES", "WITH",
+        "TABLESAMPLE", "LATERAL", "PARTITION", "PIVOT", "UNPIVOT",
+        "USE", "IGNORE", "FORCE", "ONLY", "WITHIN", "START", "CONNECT", "SAMPLE",
+    ])
+
+    /// `FOR UPDATE` and its relatives lock rows of the same table, so the read stays single-source.
+    /// `FOR SYSTEM_TIME` returns historical row versions and `FOR JSON`/`FOR XML` return a synthetic
+    /// column, so neither describes rows that can be written back.
+    private static let rowLockingModifiers: Set<String> = ["UPDATE", "SHARE", "NO", "KEY", "READ"]
+
+    static func singleSourceTable(in sql: String, dialect: SqlDialect) -> String? {
+        var cursor = Cursor(sql, dialect: dialect)
+        guard cursor.consumeKeyword("SELECT") else { return nil }
+        guard cursor.advanceToTopLevelFrom() else { return nil }
+        guard let table = cursor.consumeTableReference() else { return nil }
+        guard cursor.consumeOptionalAlias() else { return nil }
+        guard cursor.atClauseBoundary() else { return nil }
+        guard !cursor.hasTopLevelSetOperator() else { return nil }
+        return table
+    }
+
+    private struct Cursor {
+        private let text: NSString
+        private let length: Int
+        private let dialect: SqlDialect
+        private var index = 0
+        private(set) var didAbortLexing = false
+
+        init(_ sql: String, dialect: SqlDialect) {
+            text = sql as NSString
+            length = text.length
+            self.dialect = dialect
+        }
+
+        private func unit(at position: Int) -> UInt16? {
+            position < length ? text.character(at: position) : nil
+        }
+
+        private static func isSpace(_ ch: UInt16) -> Bool {
+            ch == 0x20 || ch == 0x09 || ch == 0x0A || ch == 0x0D || ch == 0x0B || ch == 0x0C
+        }
+
+        /// Treats every non-ASCII code unit as an identifier character, which keeps unquoted
+        /// non-Latin table names intact without decoding surrogate pairs.
+        private static func isIdentifierUnit(_ ch: UInt16) -> Bool {
+            (ch >= 0x41 && ch <= 0x5A) || (ch >= 0x61 && ch <= 0x7A)
+                || (ch >= 0x30 && ch <= 0x39) || ch == 0x5F || ch == 0x24 || ch >= 0x80
+        }
+
+        private static func closingDelimiter(for opener: UInt16) -> UInt16? {
+            switch opener {
+            case 0x22: return 0x22
+            case 0x60: return 0x60
+            case 0x5B: return 0x5D
+            default: return nil
+            }
+        }
+
+        private mutating func skipTrivia() {
+            while index < length {
+                let ch = text.character(at: index)
+                if Self.isSpace(ch) {
+                    index += 1
+                } else if ch == 0x2D, unit(at: index + 1) == 0x2D {
+                    index += 2
+                    skipToEndOfLine()
+                } else if ch == 0x23, dialect.supportsHashLineComments {
+                    index += 1
+                    skipToEndOfLine()
+                } else if ch == 0x2F, unit(at: index + 1) == 0x2A {
+                    skipBlockComment()
+                } else {
+                    return
+                }
+            }
+        }
+
+        /// A lone carriage return ends a line comment too, so SQL pasted with classic Mac line
+        /// endings does not swallow the rest of the statement as trivia.
+        private mutating func skipToEndOfLine() {
+            while index < length {
+                let ch = text.character(at: index)
+                if ch == 0x0A || ch == 0x0D { return }
+                index += 1
+            }
+        }
+
+        /// Only PostgreSQL nests block comments. Counting depth on a dialect that does not nest
+        /// would swallow real SQL, and not counting it on PostgreSQL would expose commented-out
+        /// SQL as if it were live.
+        private mutating func skipBlockComment() {
+            index += 2
+            var depth = 1
+            let nests = dialect == .postgres
+            while index < length, depth > 0 {
+                if nests, text.character(at: index) == 0x2F, unit(at: index + 1) == 0x2A {
+                    depth += 1
+                    index += 2
+                } else if text.character(at: index) == 0x2A, unit(at: index + 1) == 0x2F {
+                    depth -= 1
+                    index += 2
+                } else {
+                    index += 1
+                }
+            }
+        }
+
+        /// PostgreSQL honours backslash escapes only inside an `E'...'` literal.
+        private func hasEscapeStringPrefix(at quote: Int) -> Bool {
+            guard quote > 0 else { return false }
+            let previous = text.character(at: quote - 1)
+            guard previous == 0x45 || previous == 0x65 else { return false }
+            return quote < 2 || !Self.isIdentifierUnit(text.character(at: quote - 2))
+        }
+
+        private mutating func skipStringLiteral() {
+            let escapesWithBackslash = dialect.requiresBackslashEscapesInSingleQuotes
+                || (dialect.supportsEscapeStringPrefix && hasEscapeStringPrefix(at: index))
+            index += 1
+            while index < length {
+                let ch = text.character(at: index)
+                if escapesWithBackslash, ch == 0x5C, index + 1 < length {
+                    index += 2
+                    continue
+                }
+                if ch == 0x27 {
+                    if unit(at: index + 1) == 0x27 {
+                        index += 2
+                        continue
+                    }
+                    index += 1
+                    return
+                }
+                index += 1
+            }
+        }
+
+        /// Returns the unescaped identifier, or `nil` when the closing delimiter is missing.
+        private mutating func consumeDelimited(closing: UInt16) -> String? {
+            index += 1
+            let start = index
+            var doubled = false
+            while index < length {
+                let ch = text.character(at: index)
+                if closing == 0x22, dialect.requiresBackslashEscapesInSingleQuotes,
+                   ch == 0x5C, index + 1 < length {
+                    index += 2
+                    continue
+                }
+                if ch == closing {
+                    if unit(at: index + 1) == closing {
+                        doubled = true
+                        index += 2
+                        continue
+                    }
+                    let raw = text.substring(with: NSRange(location: start, length: index - start))
+                    index += 1
+                    guard doubled, let scalar = UnicodeScalar(closing) else { return raw }
+                    let quote = String(Character(scalar))
+                    return raw.replacingOccurrences(of: quote + quote, with: quote)
+                }
+                index += 1
+            }
+            return nil
+        }
+
+        private mutating func readWord() -> String? {
+            guard index < length, Self.isIdentifierUnit(text.character(at: index)) else { return nil }
+            let start = index
+            while index < length, Self.isIdentifierUnit(text.character(at: index)) { index += 1 }
+            return text.substring(with: NSRange(location: start, length: index - start))
+        }
+
+        private mutating func peekWord() -> String? {
+            skipTrivia()
+            let saved = index
+            let word = readWord()
+            index = saved
+            return word
+        }
+
+        mutating func consumeKeyword(_ keyword: String) -> Bool {
+            skipTrivia()
+            let saved = index
+            guard let word = readWord(), word.uppercased() == keyword else {
+                index = saved
+                return false
+            }
+            return true
+        }
+
+        /// Compares a word in place instead of allocating a `String`. A wide select list holds
+        /// tens of thousands of words and this runs on every execution.
+        private mutating func skipWordMatchingAny(_ keywords: [[UInt16]]) -> Bool {
+            let start = index
+            while index < length, Self.isIdentifierUnit(text.character(at: index)) { index += 1 }
+            let count = index - start
+            candidates: for keyword in keywords where keyword.count == count {
+                for offset in 0..<count {
+                    let codeUnit = text.character(at: start + offset)
+                    let folded = (codeUnit >= 0x61 && codeUnit <= 0x7A) ? codeUnit - 0x20 : codeUnit
+                    if folded != keyword[offset] { continue candidates }
+                }
+                return true
+            }
+            return false
+        }
+
+        private mutating func skipDollarQuotedBody(openerLength: Int, tag: String) -> Bool {
+            index += openerLength
+            while index < length {
+                if text.character(at: index) == SqlDollarQuote.dollar,
+                   SqlDollarQuote.matchesClose(at: index, tag: tag, in: text, bufLen: length) {
+                    index += (tag as NSString).length + 2
+                    return true
+                }
+                index += 1
+            }
+            return false
+        }
+
+        /// Scans forward for one of `keywords` appearing as a bare word outside any parentheses.
+        /// Parenthesised subqueries, string literals, delimited identifiers, dollar-quoted bodies
+        /// and comments are skipped, so a keyword hidden inside any of them never matches.
+        ///
+        /// Returning `false` means "not found", which callers read as safe. Anything this cannot
+        /// lex confidently sets `didAbortLexing` instead, so a caller asking whether a disqualifying
+        /// keyword is present never mistakes an abandoned scan for a clean one.
+        private mutating func advanceToTopLevelWord(matching keywords: [[UInt16]]) -> Bool {
+            var depth = 0
+            while true {
+                skipTrivia()
+                guard index < length else { return false }
+                let ch = text.character(at: index)
+                switch ch {
+                case 0x28:
+                    depth += 1
+                    index += 1
+                case 0x29:
+                    depth -= 1
+                    index += 1
+                case 0x27:
+                    skipStringLiteral()
+                case 0x3B:
+                    return false
+                case 0x23 where dialect == .generic,
+                     0x2F where dialect == .generic && unit(at: index + 1) == 0x2F:
+                    // ClickHouse spells line comments `#` and `//` and lands in `.generic`, which
+                    // it shares with dialects that read both as operators. Neither reading can be
+                    // trusted, and guessing wrong hides the real `FROM`. MySQL never reaches here
+                    // because `skipTrivia` has already taken its `#` comment, and PostgreSQL keeps
+                    // `#` as the jsonb path operator it is.
+                    didAbortLexing = true
+                    return false
+                default:
+                    if ch == SqlDollarQuote.dollar,
+                       case .opener(let openerLength, let tag) = SqlDollarQuote.scanOpener(
+                           at: index, in: text, bufLen: length
+                       ) {
+                        guard consumeDollarQuoted(openerLength: openerLength, tag: tag, keywords: keywords) else {
+                            return false
+                        }
+                    } else if ch != 0x5B, let closing = Self.closingDelimiter(for: ch) {
+                        guard consumeDelimited(closing: closing) != nil else {
+                            didAbortLexing = true
+                            return false
+                        }
+                    } else if Self.isIdentifierUnit(ch) {
+                        if skipWordMatchingAny(keywords), depth == 0 { return true }
+                    } else {
+                        index += 1
+                    }
+                }
+            }
+        }
+
+        /// A dollar-quoted body is only a literal on PostgreSQL. DuckDB accepts the same spelling
+        /// but maps to `.sqlite`, so on any other dialect a body that really is closed means the
+        /// text cannot be lexed as SQL and the statement must not resolve. An opener with no closer
+        /// is an ordinary `$` in an identifier and rewinds.
+        private mutating func consumeDollarQuoted(
+            openerLength: Int,
+            tag: String,
+            keywords: [[UInt16]]
+        ) -> Bool {
+            let saved = index
+            let closed = skipDollarQuotedBody(openerLength: openerLength, tag: tag)
+            if dialect.supportsDollarQuotes {
+                guard closed else { return false }
+                return true
+            }
+            if closed {
+                didAbortLexing = true
+                return false
+            }
+            index = saved
+            _ = skipWordMatchingAny(keywords)
+            return true
+        }
+
+        /// Finds the `FROM` belonging to the outer query.
+        mutating func advanceToTopLevelFrom() -> Bool {
+            advanceToTopLevelWord(matching: [[0x46, 0x52, 0x4F, 0x4D]])
+        }
+
+        /// A set operator anywhere after the table reference means the grid holds rows from more
+        /// than one source. Checking only the token right after the table would miss the common
+        /// `SELECT ... FROM a WHERE ... UNION SELECT ... FROM b`, whose rows would then be written
+        /// back to whichever branch happened to parse first. A scan that could not be lexed counts
+        /// as present, because the alternative is editing rows whose origin is unknown.
+        ///
+        /// `MINUS` is only a set operator where Oracle, Snowflake and Teradata land. Elsewhere it
+        /// is an ordinary column name.
+        mutating func hasTopLevelSetOperator() -> Bool {
+            var keywords: [[UInt16]] = [
+                [0x55, 0x4E, 0x49, 0x4F, 0x4E],
+                [0x45, 0x58, 0x43, 0x45, 0x50, 0x54],
+                [0x49, 0x4E, 0x54, 0x45, 0x52, 0x53, 0x45, 0x43, 0x54],
+            ]
+            if dialect == .generic {
+                keywords.append([0x4D, 0x49, 0x4E, 0x55, 0x53])
+            }
+            if advanceToTopLevelWord(matching: keywords) { return true }
+            return didAbortLexing
+        }
+
+        /// `FROM ONLY tbl` never resolves. On PostgreSQL it excludes inheritance children, and the
+        /// generated write carries no `ONLY`, so it would reach the descendant rows the query left
+        /// out. On a dialect without the modifier the same text is a table named `only` wearing an
+        /// alias, and reading it as a modifier would return the alias as the write target. A table
+        /// genuinely named `only` with no reference after it still resolves.
+        mutating func consumeTableReference() -> String? {
+            skipTrivia()
+            let saved = index
+            if peekWord()?.uppercased() == "ONLY" {
+                _ = readWord()
+                if let modified = consumeUnqualifiedIdentifier(),
+                   !nonAliasKeywords.contains(modified.uppercased()) {
+                    return nil
+                }
+                index = saved
+            }
+            return consumeUnqualifiedIdentifier()
+        }
+
+        /// Rejects a qualified reference. The caller quotes the result as a single identifier and
+        /// takes the schema from the tab, which never carries one for a query tab, so returning
+        /// `users` for `analytics.users` would aim the write at whatever the search path resolves.
+        private mutating func consumeUnqualifiedIdentifier() -> String? {
+            skipTrivia()
+            guard index < length else { return nil }
+            let ch = text.character(at: index)
+            let name: String?
+            if let closing = Self.closingDelimiter(for: ch) {
+                name = consumeDelimited(closing: closing)
+            } else if Self.isIdentifierUnit(ch) {
+                name = readWord()
+            } else {
+                name = nil
+            }
+            guard let name, !name.isEmpty else { return nil }
+            guard unit(at: index) != 0x2E else { return nil }
+            return name
+        }
+
+        mutating func consumeOptionalAlias() -> Bool {
+            skipTrivia()
+            guard index < length else { return true }
+            let ch = text.character(at: index)
+            if let closing = Self.closingDelimiter(for: ch) {
+                return consumeDelimited(closing: closing) != nil
+            }
+            guard Self.isIdentifierUnit(ch) else { return true }
+            let saved = index
+            guard let word = readWord() else { return true }
+            guard word.uppercased() == "AS" else {
+                if nonAliasKeywords.contains(word.uppercased()) { index = saved }
+                return true
+            }
+            skipTrivia()
+            guard index < length else { return false }
+            let aliasChar = text.character(at: index)
+            if let closing = Self.closingDelimiter(for: aliasChar) {
+                return consumeDelimited(closing: closing) != nil
+            }
+            return readWord() != nil
+        }
+
+        mutating func atClauseBoundary() -> Bool {
+            skipTrivia()
+            guard index < length else { return true }
+            if text.character(at: index) == 0x3B { return true }
+            guard let word = peekWord() else { return false }
+            let keyword = word.uppercased()
+            guard clauseTerminators.contains(keyword) else { return false }
+            return keyword == "FOR" ? startsRowLockingClause() : true
+        }
+
+        private mutating func startsRowLockingClause() -> Bool {
+            let saved = index
+            defer { index = saved }
+            skipTrivia()
+            _ = readWord()
+            guard let modifier = peekWord()?.uppercased() else { return false }
+            return rowLockingModifiers.contains(modifier)
+        }
+    }
+}

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -1330,7 +1330,7 @@ final class MainContentCoordinator {
     // MARK: - SQL Parsing
 
     func extractTableName(from sql: String) -> String? {
-        QuerySqlParser.extractTableName(from: sql)
+        QuerySqlParser.extractTableName(from: sql, dialect: sqlDialect)
     }
 
     // MARK: - Sorting

--- a/TableProTests/Core/Utilities/SQL/SelectSourceTableParserTests.swift
+++ b/TableProTests/Core/Utilities/SQL/SelectSourceTableParserTests.swift
@@ -1,0 +1,319 @@
+//
+//  SelectSourceTableParserTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+@Suite("SelectSourceTableParser")
+struct SelectSourceTableParserTests {
+    private func table(_ sql: String, _ dialect: SqlDialect = .postgres) -> String? {
+        SelectSourceTableParser.singleSourceTable(in: sql, dialect: dialect)
+    }
+
+    // MARK: - Table aliases (#2150)
+
+    @Test("An implicit table alias resolves to the table")
+    func implicitAlias() {
+        #expect(table("select * from users u WHERE u.id = 1;") == "users")
+        #expect(table("select * from users u WHERE u.id = 1") == "users")
+        #expect(table("SELECT * FROM users u") == "users")
+        #expect(table("SELECT u.* FROM users u") == "users")
+        #expect(table("SELECT * FROM users u1 WHERE u1.id = 1") == "users")
+    }
+
+    @Test("An AS alias resolves to the table")
+    func explicitAlias() {
+        #expect(table("SELECT * FROM users AS u WHERE u.id = 1") == "users")
+        #expect(table("SELECT * FROM users AS u;") == "users")
+        #expect(table("SELECT * FROM users AS \"u\" WHERE 1") == "users")
+        #expect(table("SELECT id FROM [Users] AS [u]") == "Users")
+    }
+
+    @Test("An alias is resolved after every clause keyword")
+    func aliasBeforeClauses() {
+        #expect(table("SELECT * FROM users u ORDER BY u.id") == "users")
+        #expect(table("SELECT * FROM users u LIMIT 10 OFFSET 5") == "users")
+        #expect(table("SELECT count(*) FROM users u GROUP BY u.id") == "users")
+        #expect(table("SELECT * FROM users u WINDOW w AS ()") == "users")
+        #expect(table("SELECT count(*) FROM users u HAVING count(*) > 1") == "users")
+        #expect(table("SELECT * FROM users u FETCH FIRST 10 ROWS ONLY") == "users")
+        #expect(table("SELECT * FROM users u OFFSET 5") == "users")
+        #expect(table("SELECT * FROM users u QUALIFY row_number() OVER () = 1", .generic) == "users")
+    }
+
+    @Test("A quoted table keeps resolving when an alias follows it")
+    func quotedTableWithAlias() {
+        #expect(table("SELECT * FROM \"users\" u WHERE u.id = 1") == "users")
+        #expect(table("SELECT * FROM `users` u WHERE u.id = 1") == "users")
+        #expect(table("SELECT id FROM [Users] u WHERE u.id = 1") == "Users")
+        #expect(table("SELECT * FROM users \"the alias\" WHERE 1") == "users")
+    }
+
+    @Test("A clause keyword is never mistaken for an alias")
+    func clauseKeywordIsNotAnAlias() {
+        #expect(table("select * from users where id = 1") == "users")
+        #expect(table("SELECT * FROM users order by id") == "users")
+        #expect(table("SELECT * FROM users group by id") == "users")
+        #expect(table("SELECT * FROM users whereabouts") == "users")
+        #expect(table("SELECT * FROM users_where WHERE id = 1") == "users_where")
+    }
+
+    // MARK: - Multi-source statements stay read-only
+
+    @Test("A join never resolves, with or without aliases")
+    func joinsAreNotSingleSource() {
+        #expect(table("SELECT * FROM users JOIN orders ON orders.user_id = users.id") == nil)
+        #expect(table("SELECT * FROM users u JOIN orders o ON o.user_id = u.id") == nil)
+        #expect(table("SELECT * FROM users u LEFT JOIN orders o ON 1=1") == nil)
+        #expect(table("SELECT * FROM users NATURAL JOIN orders") == nil)
+        #expect(table("SELECT * FROM users u CROSS JOIN orders") == nil)
+        #expect(table("SELECT * FROM users, orders WHERE users.id = orders.user_id") == nil)
+        #expect(table("SELECT * FROM users u, orders o WHERE 1") == nil)
+    }
+
+    /// The regex this replaced returned the *second* branch's table here, which made a union grid
+    /// editable and pointed its UPDATE at a table the rows did not come from.
+    @Test("A set operator never resolves, wherever it appears")
+    func setOperatorsAreNotSingleSource() {
+        #expect(table("SELECT * FROM users UNION SELECT * FROM admins") == nil)
+        #expect(table("SELECT * FROM users UNION ALL SELECT * FROM admins") == nil)
+        #expect(table("SELECT * FROM users EXCEPT SELECT * FROM admins") == nil)
+        #expect(table("SELECT * FROM users u INTERSECT SELECT * FROM admins") == nil)
+        #expect(table("SELECT id FROM emp e WHERE 1=1 MINUS SELECT id FROM ex_emp x", .generic) == nil)
+    }
+
+    @Test("A set operator after a clause in the first branch still blocks editing")
+    func setOperatorAfterFirstBranchClause() {
+        #expect(table("SELECT * FROM a WHERE x = 1 UNION SELECT * FROM b") == nil)
+        #expect(table("SELECT * FROM users u WHERE u.id > 0 UNION SELECT * FROM admins a WHERE a.id > 0") == nil)
+        #expect(table("SELECT dept FROM employees e GROUP BY dept INTERSECT SELECT dept FROM contractors c GROUP BY dept") == nil)
+        #expect(table("SELECT * FROM a u ORDER BY 1 UNION SELECT * FROM b") == nil)
+        #expect(table("SELECT * FROM a u LIMIT 1 UNION SELECT * FROM b") == nil)
+        #expect(table("SELECT *\nFROM live_orders o\nWHERE o.status='open'\nUNION ALL\nSELECT *\nFROM archive_orders a\nWHERE a.status='open'") == nil)
+    }
+
+    @Test("A set operator inside a subquery or a literal does not block editing")
+    func setOperatorBelowTopLevel() {
+        #expect(table("SELECT * FROM users u WHERE u.id IN (SELECT id FROM a UNION SELECT id FROM b)") == "users")
+        #expect(table("SELECT * FROM users u WHERE u.name = 'UNION'") == "users")
+        #expect(table("SELECT * FROM users u WHERE u.union_flag = 1") == "users")
+    }
+
+    @Test("Derived tables and CTEs never resolve")
+    func derivedSourcesAreNotSingleSource() {
+        #expect(table("SELECT * FROM (SELECT * FROM users) sub") == nil)
+        #expect(table("WITH recent AS (SELECT * FROM users) SELECT * FROM recent") == nil)
+        #expect(table("SELECT * FROM LATERAL (SELECT 1) x") == nil)
+    }
+
+    /// The write path quotes the result as one identifier and takes the schema from the tab, which
+    /// a query tab never carries, so a qualified source must stay read-only rather than resolve to
+    /// a bare name the search path would re-point.
+    @Test("A schema-qualified source never resolves")
+    func qualifiedSourcesAreNotSingleSource() {
+        #expect(table("SELECT * FROM public.users WHERE id = 1") == nil)
+        #expect(table("SELECT * FROM public.users u WHERE u.id = 1") == nil)
+        #expect(table("SELECT * FROM \"public\".\"users\" u") == nil)
+        #expect(table("SELECT * FROM db.public.users") == nil)
+    }
+
+    // MARK: - Row locking versus result-shaping FOR clauses
+
+    @Test("FOR UPDATE and its relatives keep the table editable")
+    func rowLockingClauses() {
+        #expect(table("SELECT * FROM users u FOR UPDATE") == "users")
+        #expect(table("SELECT * FROM users u FOR NO KEY UPDATE") == "users")
+        #expect(table("SELECT * FROM users u FOR SHARE") == "users")
+        #expect(table("SELECT * FROM users u FOR UPDATE OF users") == "users")
+    }
+
+    /// A temporal read returns historical row versions, so an edit would overwrite the current row.
+    @Test("FOR SYSTEM_TIME, FOR JSON and FOR XML stay read-only")
+    func resultShapingForClauses() {
+        #expect(table("SELECT * FROM t FOR SYSTEM_TIME AS OF '2020-01-01'", .mysql) == nil)
+        #expect(table("SELECT * FROM t FOR SYSTEM_TIME ALL", .mysql) == nil)
+        #expect(table("SELECT * FROM t FOR SYSTEM_TIME AS OF '2020' AS h WHERE h.id = 1", .mysql) == nil)
+        #expect(table("SELECT * FROM users u FOR JSON AUTO", .generic) == nil)
+        #expect(table("SELECT * FROM users u FOR XML PATH('r')", .generic) == nil)
+    }
+
+    // MARK: - Comments, literals and layout
+
+    @Test("Comments around the statement do not hide the table")
+    func comments() {
+        #expect(table("-- pick users\nSELECT * FROM users u WHERE u.id = 1") == "users")
+        #expect(table("/* pick */ SELECT * FROM users WHERE id = 1") == "users")
+        #expect(table("SELECT * FROM users u -- trailing") == "users")
+        #expect(table("SELECT * /* c */ FROM users u WHERE 1") == "users")
+        #expect(table("SELECT * FROM users/*c*/WHERE 1") == "users")
+    }
+
+    @Test("A line comment ends at a lone carriage return")
+    func carriageReturnEndsLineComment() {
+        #expect(table("SELECT * FROM users u -- note\rJOIN orders o ON o.uid = u.id WHERE 1") == nil)
+    }
+
+    @Test("Whitespace and line endings do not hide the table")
+    func layout() {
+        #expect(table("SELECT *\nFROM users u\nWHERE u.id = 1") == "users")
+        #expect(table("SELECT\n  id,\n  name\nFROM users") == "users")
+        #expect(table("SELECT *\r\nFROM users u\r\nWHERE u.id = 1") == "users")
+        #expect(table("SELECT *\tFROM users\tu\tWHERE u.id = 1") == "users")
+        #expect(table("SELECT*FROM t") == "t")
+        #expect(table("SELECTX FROM t") == nil)
+    }
+
+    @Test("A FROM inside a string literal is not the source table")
+    func stringLiterals() {
+        #expect(table("SELECT 'from x' FROM users u WHERE u.id = 1") == "users")
+        #expect(table("SELECT ';' FROM users u WHERE 1") == "users")
+        #expect(table("SELECT (SELECT 1 FROM a) FROM b WHERE 1") == "b")
+    }
+
+    // MARK: - Dialect-specific lexing
+
+    @Test("A dollar-quoted body hides its FROM on PostgreSQL only")
+    func dollarQuoting() {
+        #expect(table("SELECT $$ FROM evil $$ FROM users") == "users")
+        #expect(table("SELECT $tag$ FROM evil $tag$ AS c FROM users u WHERE 1") == "users")
+        #expect(table("SELECT * FROM users u WHERE u.id = $1") == "users")
+        #expect(table("SELECT $$ FROM evil FROM users") == nil)
+        #expect(table("SELECT $price$ FROM products WHERE id = 1", .mysql) == "products")
+        #expect(table("SELECT $tag$ AS a FROM t1 x WHERE 1", .sqlite) == "t1")
+    }
+
+    /// DuckDB accepts PostgreSQL's dollar quoting but maps to `.sqlite`, so a closed body on any
+    /// other dialect means the text cannot be lexed as SQL and must not resolve.
+    @Test("A closed dollar-quoted body off PostgreSQL blocks editing")
+    func dollarQuotingOffPostgres() {
+        let snippet = "SELECT $$SELECT * FROM audit_log a WHERE a.id=1$$ AS snippet FROM queries q WHERE q.id = 1"
+        #expect(table(snippet, .sqlite) == nil)
+        #expect(table("SELECT $sql$SELECT x FROM audit_log a WHERE 1$sql$ AS s FROM queries q WHERE 1", .sqlite) == nil)
+    }
+
+    @Test("# is a comment on MySQL and an operator on PostgreSQL")
+    func hashHandling() {
+        #expect(table("SELECT * # FROM evil\nFROM users", .mysql) == "users")
+        #expect(table("SELECT * FROM users u # note", .mysql) == "users")
+        #expect(table("SELECT id, data #>> '{name}' AS name FROM users WHERE id = 1") == "users")
+        #expect(table("SELECT data #> '{a}' FROM events e WHERE 1") == "events")
+    }
+
+    /// ClickHouse spells line comments `#` and `//` and lands in `.generic`, which it shares with
+    /// dialects that read both as operators. Guessing wrong would hide the real `FROM`.
+    @Test("A generic-dialect # or // blocks editing rather than being guessed")
+    func genericHashAndSlashComments() {
+        #expect(table("SELECT *\n# read FROM users_v2 where possible\nFROM users u WHERE u.id = 1", .generic) == nil)
+        #expect(table("SELECT *\n// read FROM users_v2\nFROM users u WHERE u.id = 1", .generic) == nil)
+        #expect(table("SELECT a # b FROM t WHERE 1", .generic) == nil)
+    }
+
+    @Test("A backslash escapes a quote on MySQL and in a PostgreSQL E-string only")
+    func backslashEscaping() {
+        #expect(table("SELECT '\\' AS a, 'FROM evil e WHERE' AS b FROM notes n WHERE n.id = 1", .sqlite) == "notes")
+        #expect(table("SELECT '\\' AS a, 'FROM evil e WHERE' AS b FROM notes n WHERE n.id = 1") == "notes")
+        #expect(table("SELECT 'it\\'s' FROM users u WHERE 1", .mysql) == "users")
+        #expect(table("SELECT E'it\\'s' FROM users u") == "users")
+    }
+
+    @Test("Block comments nest on PostgreSQL only")
+    func blockCommentNesting() {
+        #expect(table("SELECT * /* a /* b */ FROM evil */ FROM users") == "users")
+        #expect(table("SELECT * /* a /* b */ FROM users", .mysql) == "users")
+        #expect(table("SELECT /* a /* b */ x, '*/ FROM evil e WHERE' AS c FROM users u WHERE 1", .mysql) == "users")
+    }
+
+    // MARK: - Identifiers
+
+    /// A generated write carries no `ONLY`, so it would reach the inheritance children the query
+    /// excluded. On a dialect without the modifier the same text is a table named `only` wearing an
+    /// alias, and reading it as a modifier would return the alias as the write target.
+    @Test("FROM ONLY never resolves, on any dialect")
+    func onlyModifierNeverResolves() {
+        #expect(table("SELECT * FROM ONLY users") == nil)
+        #expect(table("SELECT * FROM ONLY users u WHERE 1") == nil)
+        #expect(table("SELECT * FROM ONLY accounts WHERE id = 5") == nil)
+        #expect(table("SELECT * FROM ONLY users JOIN o ON 1=1") == nil)
+        #expect(table("SELECT * FROM only orders WHERE id = 1", .mysql) == nil)
+        #expect(table("SELECT * FROM only o WHERE o.id = 1", .sqlite) == nil)
+    }
+
+    @Test("A table genuinely named only still resolves")
+    func tableNamedOnly() {
+        #expect(table("SELECT * FROM only WHERE id = 1", .mysql) == "only")
+        #expect(table("SELECT * FROM ONLY") == "ONLY")
+        #expect(table("SELECT * FROM ONLY LIMIT 5") == "ONLY")
+    }
+
+    /// MySQL reads `"` as a string with backslash escapes, not as a delimited identifier. Getting
+    /// that wrong shifts every later token and can hide a `UNION` from the multi-source check.
+    @Test("A MySQL double-quoted string is not read as an identifier")
+    func mysqlDoubleQuotedStrings() {
+        #expect(table(#"SELECT "a\"b" AS x, "FROM evil e WHERE" AS y FROM notes n WHERE n.id = 1"#, .mysql) == "notes")
+        #expect(table(#"SELECT * FROM parts WHERE label = "6\" pipe" UNION SELECT * FROM archive_parts"#, .mysql) == nil)
+        #expect(table(#"SELECT * FROM a WHERE x = CONCAT("q\"(", y) UNION SELECT * FROM b"#, .mysql) == nil)
+        #expect(table("SELECT * FROM \"users\" u", .mysql) == "users")
+    }
+
+    /// `[` is an array subscript on PostgreSQL, DuckDB and ClickHouse, and only a quoting character
+    /// where the table reference itself sits.
+    @Test("A bracket subscript in the select list is not an identifier")
+    func bracketSubscripts() {
+        #expect(table("SELECT a[strpos(b, ']')] FROM t WHERE 1") == "t")
+        #expect(table("SELECT id, ARRAY[tags[1]] AS f FROM orders WHERE id=1") == "orders")
+        #expect(table("SELECT a[strpos(b, ']')] AS c, ' FROM evil e WHERE' AS d FROM t WHERE 1") == "t")
+        #expect(table("SELECT * FROM t WHERE arr[idx(arr,']')]>1 UNION SELECT * FROM evil") == nil)
+        #expect(table("SELECT id FROM [Users] AS [u]", .generic) == "Users")
+    }
+
+    /// MINUS is a set operator only where Oracle, Snowflake and Teradata land. Elsewhere it is an
+    /// ordinary column name.
+    @Test("MINUS is a set operator only on the generic dialect")
+    func minusIsDialectSpecific() {
+        #expect(table("SELECT * FROM ledger ORDER BY minus") == "ledger")
+        #expect(table("SELECT * FROM ledger l WHERE l.minus > 0") == "ledger")
+        #expect(table("SELECT * FROM ledger GROUP BY minus", .mysql) == "ledger")
+        #expect(table("SELECT * FROM a MINUS SELECT * FROM b", .generic) == nil)
+    }
+
+    @Test("Identifier spelling is preserved and delimiters are unescaped")
+    func identifierSpelling() {
+        #expect(table("SELECT * FROM USERS AS U") == "USERS")
+        #expect(table("SELECT * FROM \"public.user\"") == "public.user")
+        #expect(table("SELECT * FROM \"us\"\"ers\" u") == "us\"ers")
+        #expect(table("SELECT * FROM `User Logs`") == "User Logs")
+        #expect(table("SELECT * FROM my$table WHERE id = 1") == "my$table")
+        #expect(table("SELECT * FROM benutzer ü WHERE 1") == "benutzer")
+    }
+
+    @Test("A statement that is not a single-table SELECT never resolves")
+    func nonSelectStatements() {
+        #expect(table("SELECT 1") == nil)
+        #expect(table("INSERT INTO users VALUES (1)") == nil)
+        #expect(table("UPDATE users SET x = 1") == nil)
+        #expect(table("DELETE FROM users") == nil)
+        #expect(table("SHOW TABLES") == nil)
+        #expect(table("CREATE TABLE foo (id INT)") == nil)
+        #expect(table("EXPLAIN SELECT * FROM users") == nil)
+        #expect(table("") == nil)
+        #expect(table("hello world this is not a query") == nil)
+        #expect(table("db.users.find({})") == nil)
+    }
+
+    @Test("An unterminated delimiter or a table modifier never resolves")
+    func unterminatedAndModified() {
+        #expect(table("SELECT * FROM \"users") == nil)
+        #expect(table("SELECT id FROM [Users") == nil)
+        #expect(table("SELECT * FROM /* users") == nil)
+        #expect(table("SELECT * FROM") == nil)
+        #expect(table("SELECT * FROM users AS") == nil)
+        #expect(table("SELECT * FROM users TABLESAMPLE BERNOULLI (10)") == nil)
+        #expect(table("SELECT * FROM users u USE INDEX (i) WHERE 1", .mysql) == nil)
+        #expect(table("SELECT 1; SELECT * FROM users") == nil)
+    }
+}

--- a/TableProTests/Views/Main/ExtractTableNameTests.swift
+++ b/TableProTests/Views/Main/ExtractTableNameTests.swift
@@ -15,8 +15,8 @@ import Testing
 @Suite("ExtractTableName")
 @MainActor
 struct ExtractTableNameTests {
-    private func makeCoordinator() -> MainContentCoordinator {
-        let connection = TestFixtures.makeConnection(database: "db_a")
+    private func makeCoordinator(type: DatabaseType = .mysql) -> MainContentCoordinator {
+        let connection = TestFixtures.makeConnection(database: "db_a", type: type)
         let tabManager = QueryTabManager()
         let changeManager = DataChangeManager()
         let toolbarState = ConnectionToolbarState()
@@ -161,5 +161,61 @@ struct ExtractTableNameTests {
 
         let result = coordinator.extractTableName(from: "INSERT INTO users VALUES (1)")
         #expect(result == nil)
+    }
+
+    // MARK: - Table editability (#2150)
+
+    @Test("SQL: a table alias resolves to the table")
+    func sqlTableAlias() {
+        let coordinator = makeCoordinator(type: .postgresql)
+        defer { coordinator.teardown() }
+
+        #expect(coordinator.extractTableName(from: "select * from users u WHERE u.id = 1;") == "users")
+        #expect(coordinator.extractTableName(from: "SELECT * FROM users AS u WHERE u.id = 1") == "users")
+    }
+
+    @Test("A query tab whose SELECT uses a table alias is editable")
+    func aliasedQueryTabIsEditable() {
+        let coordinator = makeCoordinator(type: .postgresql)
+        defer { coordinator.teardown() }
+
+        let sql = "select * from users u WHERE u.id = 1"
+        let tab = QueryTab(query: sql, tabType: .query)
+        let resolved = coordinator.resolveTableEditability(tab: tab, sql: sql)
+
+        #expect(resolved.tableName == "users")
+        #expect(resolved.isEditable)
+    }
+
+    @Test("A query tab reading from more than one table stays read-only")
+    func multiSourceQueryTabIsNotEditable() {
+        let coordinator = makeCoordinator(type: .postgresql)
+        defer { coordinator.teardown() }
+
+        let joinSQL = "SELECT * FROM users u JOIN orders o ON o.user_id = u.id"
+        let joined = coordinator.resolveTableEditability(tab: QueryTab(query: joinSQL, tabType: .query), sql: joinSQL)
+        #expect(joined.tableName == nil)
+        #expect(!joined.isEditable)
+
+        let unionSQL = "SELECT * FROM users u WHERE u.id > 0 UNION SELECT * FROM admins a WHERE a.id > 0"
+        let unioned = coordinator.resolveTableEditability(tab: QueryTab(query: unionSQL, tabType: .query), sql: unionSQL)
+        #expect(unioned.tableName == nil)
+        #expect(!unioned.isEditable)
+    }
+
+    @Test("PostgreSQL jsonb path operators are not read as comments")
+    func postgresJsonbOperatorsResolve() {
+        let coordinator = makeCoordinator(type: .postgresql)
+        defer { coordinator.teardown() }
+
+        #expect(coordinator.extractTableName(from: "SELECT data #>> '{name}' FROM users WHERE id = 1") == "users")
+    }
+
+    @Test("A MySQL hash comment does not hide the table")
+    func mysqlHashCommentIsTrivia() {
+        let coordinator = makeCoordinator(type: .mysql)
+        defer { coordinator.teardown() }
+
+        #expect(coordinator.extractTableName(from: "SELECT * # FROM evil\nFROM users") == "users")
     }
 }

--- a/docs/features/data-grid.mdx
+++ b/docs/features/data-grid.mdx
@@ -59,7 +59,9 @@ UUIDs and Unix timestamps render in a readable form when the column type and nam
 ## Editing
 
 <Warning>
-Editing works on simple `SELECT * FROM table` queries. Joins and aggregations are read-only, and so is any connection set to the Read-Only [safe mode](/features/safe-mode) level.
+Editing works when the results come from one table, with or without an alias, as in `SELECT * FROM orders o WHERE o.id = 1`. Comments, `DISTINCT`, `ORDER BY`, `LIMIT` and `FOR UPDATE` are fine. Joins, comma joins, subqueries in `FROM`, CTEs, `UNION`, `EXCEPT`, `INTERSECT`, `FROM ONLY`, and schema-qualified names such as `public.orders` are read-only, and so is any connection set to the Read-Only [safe mode](/features/safe-mode) level.
+
+Two shapes look editable but refuse to save. A column renamed with `AS` cannot be written back, though the other columns in the same row still can. A query that renames or omits the primary key blocks the whole save, because there is nothing to match the row on.
 </Warning>
 
 Double-click a cell to edit it. Press `Enter` to confirm or `Escape` to cancel. Some types open a dedicated editor:


### PR DESCRIPTION
Fixes #2150.

## Root cause

`QuerySqlParser.extractTableName` resolved the editable table with one regex that required the `FROM` identifier to be followed **immediately** by a clause keyword, `;`, or end of input:

```
(?i)^\s*SELECT\s+.+?\s+FROM\s+(?:\[([^\]]+)\]|[`"]([^`"]+)[`"]|([\w$]+))\s*(?:WHERE|ORDER|LIMIT|GROUP|HAVING|OFFSET|FETCH|$|;)
```

A table alias sits in exactly that slot, so the match failed and the function returned `nil`. From there: `MainContentCoordinator.resolveTableEditability` returned `(nil, false)` → `tab.tableContext.isEditable = false` → `TableViewCoordinator.editEligibility` blocked at its first guard. Double-clicking a cell was not dead; it opened the read-only overlay viewer, which reads as "nothing happened".

## Behavior

`select * from users u WHERE u.id = 1` is editable again, as are multi-line queries, queries preceded by a comment, and ones ending in `FOR UPDATE`.

The regex is replaced by `SelectSourceTableParser`, a dialect-aware UTF-16 scanner in `TablePro/Core/Utilities/SQL/` alongside `SQLStatementScanner` and `SQLLimitDetector`, whose lexing conventions it follows and whose `SqlDollarQuote` it reuses. It resolves a table only when the statement provably reads from exactly one, and returns `nil` otherwise. That asymmetry is the point: the returned name becomes the target of the generated `UPDATE`/`DELETE` in `SQLStatementGenerator`, so `nil` is safe and a wrong name writes to a table the user never queried.

`QuerySqlParser.extractTableName` keeps its signature and both MongoDB fallbacks; only its SQL branch delegates. `MainContentCoordinator` passes `sqlDialect`, mirroring how `SQLLimitDetector` is already called one file over.

### Also fixed, same root cause

`SELECT * FROM users UNION SELECT * FROM admins` resolved to `"admins"` on main. The union grid was editable and its `UPDATE` targeted a table the visible rows did not come from. A top-level set operator anywhere after the table reference now blocks editing, and a scan that cannot be lexed fails closed rather than open.

### Deliberately still read-only

Joins, comma joins, derived tables, CTEs, set operators, `FROM ONLY`, temporal `FOR SYSTEM_TIME` reads, and schema-qualified names such as `public.users`.

Schema qualification is the notable one. Resolving `public.users` to a bare `users` would be unsafe: the write path quotes the name as a single identifier and takes the schema from `tab.tableContext.schemaName`, which the query path never sets, so the `UPDATE` would land wherever `search_path` pointed. Supporting it properly means plumbing a schema through `resolveTableEditability` → `tabContext.schemaName` → `scope` → `fetchTableSchema`, which is its own change.

## Tests

- `TableProTests/Core/Utilities/SQL/SelectSourceTableParserTests.swift` — new, 31 cases covering aliases, multi-source rejection, dialect-specific lexing, and identifier spelling.
- `TableProTests/Views/Main/ExtractTableNameTests.swift` — 5 cases at the ownership boundary, including `resolveTableEditability` returning `isEditable == true` for the issue's exact statement. That function had no test before.

Neither suite is in `.github/macos-test-quarantine.txt`, so both gate CI.

## Verification

| Check | Result |
|---|---|
| `scripts/generate-project.sh` | PASS |
| `xcodebuild -scheme TablePro build` | PASS |
| 11 affected suites | 203 cases passed, 0 failed |
| `swiftlint lint --strict` (5 changed Swift files) | 0 violations |

Suites run: `SelectSourceTableParserTests`, `ExtractTableNameTests`, `QueryExecutorTests`, `InlineEditEligibilityTests`, `CellInteractionResolverReadOnlyTests`, `CellInteractionResolverEditableTests`, `MainMenuValidationTests`, `QueryClassifierTests`, `SQLStatementScannerTests`, `SQLLimitDetectorTests`, `SQLFileParserTests`.

Beyond the suites, a standalone differential harness compared the new parser against the deleted regex over **418 case/dialect combinations** with zero mismatches against expectation. Every case where the new parser returns `nil` and the regex returned a name is one where the regex returned the *wrong* table (set operators) or where the input cannot reach the parser (a second statement after `;`, which callers split first).

## Review

An independent multi-lens review of the first draft found five wrong-table names that this change would have introduced where the old regex returned `nil`. All five are fixed here and pinned by tests:

- **`FROM ONLY tbl`** — on MySQL/SQLite that text is a table named `only` wearing an alias, so it returned the alias; on PostgreSQL the generated write drops `ONLY` and reaches the inheritance children the query excluded. Never resolves now.
- **MySQL `"…"`** — a string with backslash escapes, not a delimited identifier. Mis-lexing shifted every later token and could hide a `UNION` from the multi-source check.
- **`[` subscripts** — an array subscript on PostgreSQL, DuckDB and ClickHouse. `SELECT id, ARRAY[tags[1]] FROM orders` regressed to `nil`, and a `]` inside a literal could produce a wrong name.
- **Dollar-quoted bodies off PostgreSQL** — DuckDB accepts `$$…$$` but maps to `.sqlite`, so the body was being lexed as live SQL.
- **`#` and `//` on the generic dialect** — ClickHouse spells line comments this way but shares `.generic` with dialects that read both as operators, so the parser now declines rather than guesses.

`MINUS` is also treated as a set operator only where Oracle, Snowflake and Teradata land; elsewhere it is an ordinary column name and treating it as an operator made `SELECT * FROM ledger l WHERE l.minus > 0` read-only.

## Limitations

- MSSQL and Teradata query tabs never reach this parser. Both implement `buildBrowseQuery`, so `resolveTableEditability` takes its `usesNoSQLBrowsing` branch and their editability is unchanged.
- `SELECT COUNT(*) FROM users` still resolves to `users`. Aggregate results were treated this way before this change too, and the save fails later in `DataChangeManager`.
- No UI automation was added. The deterministic signal for this flow is the enabled state of **Edit ▸ Add Row** on a query tab against the bundled sample database; it is feasible and worth a follow-up, but this change is covered at the unit level including the coordinator boundary.
- On a query over 1 MB that contains any non-ASCII character, the scanner costs roughly 22 ms on the main actor because it indexes a bridged `NSString` per code unit. For all-ASCII SQL it is about 4× faster than the regex it replaces. Materializing a `[UInt16]` buffer removes the cliff and is a reasonable follow-up.
- The review that produced the five fixes above was same-vendor. `/codex:review` is reserved for explicit user invocation, so the cross-vendor pass this repository asks for on data-loss-adjacent changes has not been run.
