### PR TITLE
perf(datagrid): scan the editable-table parser over a UTF-16 buffer

### DIFF
--- a/TablePro/Core/Utilities/SQL/SelectSourceTableParser.swift
+++ b/TablePro/Core/Utilities/SQL/SelectSourceTableParser.swift
@@ -44,7 +44,13 @@ enum SelectSourceTableParser {
     }
 
     private struct Cursor {
+        /// Scanning reads one code unit at a time. `NSString.character(at:)` leaves its fast path
+        /// as soon as the bridged string is not ASCII, so a single accented character anywhere in
+        /// the text made every later read transcode and turned a 4 ms scan of a wide select list
+        /// into 33 ms on the main actor. Transcoding once up front keeps every read a subscript.
+        /// The `NSString` stays only for `SqlDollarQuote`, which takes one.
         private let text: NSString
+        private let units: [UInt16]
         private let length: Int
         private let dialect: SqlDialect
         private var index = 0
@@ -52,12 +58,13 @@ enum SelectSourceTableParser {
 
         init(_ sql: String, dialect: SqlDialect) {
             text = sql as NSString
-            length = text.length
+            units = Array(sql.utf16)
+            length = units.count
             self.dialect = dialect
         }
 
         private func unit(at position: Int) -> UInt16? {
-            position < length ? text.character(at: position) : nil
+            position < length ? units[position] : nil
         }
 
         private static func isSpace(_ ch: UInt16) -> Bool {
@@ -82,7 +89,7 @@ enum SelectSourceTableParser {
 
         private mutating func skipTrivia() {
             while index < length {
-                let ch = text.character(at: index)
+                let ch = units[index]
                 if Self.isSpace(ch) {
                     index += 1
                 } else if ch == 0x2D, unit(at: index + 1) == 0x2D {
@@ -103,7 +110,7 @@ enum SelectSourceTableParser {
         /// endings does not swallow the rest of the statement as trivia.
         private mutating func skipToEndOfLine() {
             while index < length {
-                let ch = text.character(at: index)
+                let ch = units[index]
                 if ch == 0x0A || ch == 0x0D { return }
                 index += 1
             }
@@ -117,10 +124,10 @@ enum SelectSourceTableParser {
             var depth = 1
             let nests = dialect == .postgres
             while index < length, depth > 0 {
-                if nests, text.character(at: index) == 0x2F, unit(at: index + 1) == 0x2A {
+                if nests, units[index] == 0x2F, unit(at: index + 1) == 0x2A {
                     depth += 1
                     index += 2
-                } else if text.character(at: index) == 0x2A, unit(at: index + 1) == 0x2F {
+                } else if units[index] == 0x2A, unit(at: index + 1) == 0x2F {
                     depth -= 1
                     index += 2
                 } else {
@@ -132,9 +139,9 @@ enum SelectSourceTableParser {
         /// PostgreSQL honours backslash escapes only inside an `E'...'` literal.
         private func hasEscapeStringPrefix(at quote: Int) -> Bool {
             guard quote > 0 else { return false }
-            let previous = text.character(at: quote - 1)
+            let previous = units[quote - 1]
             guard previous == 0x45 || previous == 0x65 else { return false }
-            return quote < 2 || !Self.isIdentifierUnit(text.character(at: quote - 2))
+            return quote < 2 || !Self.isIdentifierUnit(units[quote - 2])
         }
 
         private mutating func skipStringLiteral() {
@@ -142,7 +149,7 @@ enum SelectSourceTableParser {
                 || (dialect.supportsEscapeStringPrefix && hasEscapeStringPrefix(at: index))
             index += 1
             while index < length {
-                let ch = text.character(at: index)
+                let ch = units[index]
                 if escapesWithBackslash, ch == 0x5C, index + 1 < length {
                     index += 2
                     continue
@@ -165,7 +172,7 @@ enum SelectSourceTableParser {
             let start = index
             var doubled = false
             while index < length {
-                let ch = text.character(at: index)
+                let ch = units[index]
                 if closing == 0x22, dialect.requiresBackslashEscapesInSingleQuotes,
                    ch == 0x5C, index + 1 < length {
                     index += 2
@@ -177,7 +184,7 @@ enum SelectSourceTableParser {
                         index += 2
                         continue
                     }
-                    let raw = text.substring(with: NSRange(location: start, length: index - start))
+                    let raw = String(decoding: units[start..<index], as: UTF16.self)
                     index += 1
                     guard doubled, let scalar = UnicodeScalar(closing) else { return raw }
                     let quote = String(Character(scalar))
@@ -189,10 +196,10 @@ enum SelectSourceTableParser {
         }
 
         private mutating func readWord() -> String? {
-            guard index < length, Self.isIdentifierUnit(text.character(at: index)) else { return nil }
+            guard index < length, Self.isIdentifierUnit(units[index]) else { return nil }
             let start = index
-            while index < length, Self.isIdentifierUnit(text.character(at: index)) { index += 1 }
-            return text.substring(with: NSRange(location: start, length: index - start))
+            while index < length, Self.isIdentifierUnit(units[index]) { index += 1 }
+            return String(decoding: units[start..<index], as: UTF16.self)
         }
 
         private mutating func peekWord() -> String? {
@@ -217,11 +224,11 @@ enum SelectSourceTableParser {
         /// tens of thousands of words and this runs on every execution.
         private mutating func skipWordMatchingAny(_ keywords: [[UInt16]]) -> Bool {
             let start = index
-            while index < length, Self.isIdentifierUnit(text.character(at: index)) { index += 1 }
+            while index < length, Self.isIdentifierUnit(units[index]) { index += 1 }
             let count = index - start
             candidates: for keyword in keywords where keyword.count == count {
                 for offset in 0..<count {
-                    let codeUnit = text.character(at: start + offset)
+                    let codeUnit = units[start + offset]
                     let folded = (codeUnit >= 0x61 && codeUnit <= 0x7A) ? codeUnit - 0x20 : codeUnit
                     if folded != keyword[offset] { continue candidates }
                 }
@@ -233,7 +240,7 @@ enum SelectSourceTableParser {
         private mutating func skipDollarQuotedBody(openerLength: Int, tag: String) -> Bool {
             index += openerLength
             while index < length {
-                if text.character(at: index) == SqlDollarQuote.dollar,
+                if units[index] == SqlDollarQuote.dollar,
                    SqlDollarQuote.matchesClose(at: index, tag: tag, in: text, bufLen: length) {
                     index += (tag as NSString).length + 2
                     return true
@@ -255,7 +262,7 @@ enum SelectSourceTableParser {
             while true {
                 skipTrivia()
                 guard index < length else { return false }
-                let ch = text.character(at: index)
+                let ch = units[index]
                 switch ch {
                 case 0x28:
                     depth += 1
@@ -373,7 +380,7 @@ enum SelectSourceTableParser {
         private mutating func consumeUnqualifiedIdentifier() -> String? {
             skipTrivia()
             guard index < length else { return nil }
-            let ch = text.character(at: index)
+            let ch = units[index]
             let name: String?
             if let closing = Self.closingDelimiter(for: ch) {
                 name = consumeDelimited(closing: closing)
@@ -390,7 +397,7 @@ enum SelectSourceTableParser {
         mutating func consumeOptionalAlias() -> Bool {
             skipTrivia()
             guard index < length else { return true }
-            let ch = text.character(at: index)
+            let ch = units[index]
             if let closing = Self.closingDelimiter(for: ch) {
                 return consumeDelimited(closing: closing) != nil
             }
@@ -403,7 +410,7 @@ enum SelectSourceTableParser {
             }
             skipTrivia()
             guard index < length else { return false }
-            let aliasChar = text.character(at: index)
+            let aliasChar = units[index]
             if let closing = Self.closingDelimiter(for: aliasChar) {
                 return consumeDelimited(closing: closing) != nil
             }
@@ -413,7 +420,7 @@ enum SelectSourceTableParser {
         mutating func atClauseBoundary() -> Bool {
             skipTrivia()
             guard index < length else { return true }
-            if text.character(at: index) == 0x3B { return true }
+            if units[index] == 0x3B { return true }
             guard let word = peekWord() else { return false }
             let keyword = word.uppercased()
             guard clauseTerminators.contains(keyword) else { return false }


### PR DESCRIPTION
Follow-up to #2153. No behavior change.

## Problem

`SelectSourceTableParser.Cursor` read the statement one code unit at a time through `NSString.character(at:)`. That call leaves its fast path as soon as the bridged string is not ASCII-backed, so **a single non-ASCII character anywhere in the text** — an accented word in a comment, a CJK column alias, an emoji in a string literal — made every subsequent read transcode.

`resolveTableEditability` runs synchronously on `@MainActor` once per query execution (`MainContentCoordinator.swift:1069`), so the cost lands on a UI action.

## Fix

Transcode once in `Cursor.init` (`Array(sql.utf16)`) and index that buffer. The `NSString` stays, used only by the two `SqlDollarQuote` calls that take one.

## Measured

`swiftc -O`, mean of 5 runs, Apple silicon:

| input | before | after | |
|---|---|---|---|
| typical 36-char query | 0.01 ms | 0.01 ms | — |
| 50k columns, all ASCII (1.1 MB) | 4.27 ms | 3.12 ms | 1.4x |
| 50k columns, **one** non-ASCII scalar | 33.05 ms | 3.01 ms | **11x** |
| 50k columns, all CJK | 24.38 ms | 1.40 ms | **17.5x** |
| 1 MB single token, no `FROM` | 2.47 ms | 3.37 ms | 0.7x |
| 60k line comments (1 MB) | 2.37 ms | 2.49 ms | 1.0x |
| 100k nested parens | 1.11 ms | 0.74 ms | 1.5x |

The one regression is the last-place case: building the buffer up front costs ~0.9 ms on a megabyte of input the scanner would otherwise abandon early. That is the trade for removing a 30 ms main-thread stall, and it is the right way round.

Memory cost is 2 bytes per code unit for the duration of one parse.

## Equivalence

The change must not alter a single result, because this parser decides which table an `UPDATE`/`DELETE` targets. Both implementations were compiled side by side and run over a corpus of **79 statements x 4 dialects = 316 combinations**, covering every case in `SelectSourceTableParserTests` plus the attack inputs from the #2153 review (dollar quotes, MySQL `"` strings, bracket subscripts, nested block comments, `FROM ONLY`, set operators past a clause, `FOR SYSTEM_TIME`, unterminated delimiters, CJK and accented identifiers).

**316/316 identical.**

## Verification

| Check | Result |
|---|---|
| `scripts/generate-project.sh` | PASS |
| `xcodebuild -scheme TablePro build` | PASS |
| 7 suites, 157 cases | 157 passed, 0 failed |
| `swiftlint lint --strict` | 0 violations |

Suites: `SelectSourceTableParserTests`, `ExtractTableNameTests`, `QueryExecutorTests`, `QueryClassifierTests`, `SQLStatementScannerTests`, `SQLLimitDetectorTests`, `SQLFileParserTests`.

## No changelog entry

Deliberate. There is no behavior change, and the improvement is only perceptible on queries around a megabyte that contain non-ASCII text. Happy to add one if you would rather record it.
