### PR TITLE
fix(datagrid): edit results that qualify the table with the browsed schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Query results were read-only whenever the `SELECT` gave its table an alias, as in `select * from users u where u.id = 1`. Editing works on those results now, and also on queries written across several lines, preceded by a comment, or ending in `FOR UPDATE`. (#2150)
-- A `UNION`, `EXCEPT` or `INTERSECT` result could be edited as though it were a single table, and the edit was written to one of the branches rather than to the rows on screen. Those results are read-only now. So are results from a join, a subquery, a CTE, a temporal `FOR SYSTEM_TIME` read, `FROM ONLY`, and a schema-qualified name such as `public.users`.
+- A `UNION`, `EXCEPT` or `INTERSECT` result could be edited as though it were a single table, and the edit was written to one of the branches rather than to the rows on screen. Those results are read-only now. So are results from a join, a subquery, a CTE, a temporal `FOR SYSTEM_TIME` read, and `FROM ONLY`.
+- Writing the schema in front of the table, as in `select * from public.users u`, made the results read-only. They are editable now when the schema is the one the connection is already browsing. Naming a different schema stays read-only, because the saved edit would go to the browsed schema instead of the one you queried.
 - The connection window drew a rule under its toolbar that began at the sidebar divider and ran to the right edge, dividing two areas that are the same colour. It is gone.
 - The editor tab bar filled a capsule behind the tabs. In dark mode that fill read as a lighter panel than anything else in the window, so the tabs now sit directly on the window background.
 - Data-grid columns now reserve space for trailing editor and foreign-key actions instead of truncating otherwise fitting values.

--- a/TablePro/Core/Services/Query/QuerySqlParser.swift
+++ b/TablePro/Core/Services/Query/QuerySqlParser.swift
@@ -14,9 +14,21 @@ enum QuerySqlParser {
 
     /// The table a result grid may be edited through, or `nil` when the statement reads from
     /// anything other than exactly one table.
-    static func extractTableName(from sql: String, dialect: SqlDialect = .generic) -> String? {
-        if let table = SelectSourceTableParser.singleSourceTable(in: sql, dialect: dialect) {
-            return table
+    ///
+    /// The generated `UPDATE` and `DELETE` name the table without a qualifier and rely on the
+    /// session's own schema to resolve it. So a statement that spells a schema is only writable
+    /// when that schema is the one the session is already pointed at; `browseSchema` supplies it.
+    /// Any other schema stays read-only, because an unqualified write would land on whatever the
+    /// session resolves rather than on the table the query read.
+    static func extractTableName(
+        from sql: String,
+        dialect: SqlDialect = .generic,
+        browseSchema: String? = nil
+    ) -> String? {
+        if let source = SelectSourceTableParser.singleSourceTable(in: sql, dialect: dialect) {
+            guard let schema = source.schema else { return source.name }
+            guard let browseSchema, matchesSessionSchema(schema, browseSchema) else { return nil }
+            return source.name
         }
 
         let nsRange = NSRange(sql.startIndex..., in: sql)
@@ -34,6 +46,13 @@ enum QuerySqlParser {
         }
 
         return nil
+    }
+
+    /// Compares case-insensitively. An unquoted identifier folds case on every engine TablePro
+    /// reaches here, and a quoted one that differs only by case would still resolve to the same
+    /// schema through the session, so treating them as equal cannot widen the write target.
+    private static func matchesSessionSchema(_ parsed: String, _ session: String) -> Bool {
+        parsed.compare(session, options: .caseInsensitive) == .orderedSame
     }
 
     static func stripTrailingOrderBy(from sql: String) -> String {

--- a/TablePro/Core/Utilities/SQL/SelectSourceTableParser.swift
+++ b/TablePro/Core/Utilities/SQL/SelectSourceTableParser.swift
@@ -11,8 +11,17 @@ import TableProPluginKit
 /// The result decides whether a result grid is editable, and it becomes the target of the
 /// generated `UPDATE` and `DELETE`. A wrong name would write to the wrong table, so every
 /// shape this cannot prove is single-source resolves to `nil` and leaves the grid read-only:
-/// joins, comma lists, derived tables, CTEs, set operators, and schema-qualified names.
+/// joins, comma lists, derived tables, CTEs, and set operators.
+///
+/// A `schema.table` reference resolves to both parts. Deciding whether that schema is safe to
+/// write through belongs to the caller, not here.
 enum SelectSourceTableParser {
+    struct SourceTable: Equatable {
+        /// Present only when the statement spelled a qualified reference.
+        let schema: String?
+        let name: String
+    }
+
     /// Keywords that may legally follow the single table reference. Anything else means the
     /// statement reads from more than the one table, so the whitelist is the safety property.
     private static let clauseTerminators: Set<String> = [
@@ -32,7 +41,7 @@ enum SelectSourceTableParser {
     /// column, so neither describes rows that can be written back.
     private static let rowLockingModifiers: Set<String> = ["UPDATE", "SHARE", "NO", "KEY", "READ"]
 
-    static func singleSourceTable(in sql: String, dialect: SqlDialect) -> String? {
+    static func singleSourceTable(in sql: String, dialect: SqlDialect) -> SourceTable? {
         var cursor = Cursor(sql, dialect: dialect)
         guard cursor.consumeKeyword("SELECT") else { return nil }
         guard cursor.advanceToTopLevelFrom() else { return nil }
@@ -360,24 +369,33 @@ enum SelectSourceTableParser {
         /// out. On a dialect without the modifier the same text is a table named `only` wearing an
         /// alias, and reading it as a modifier would return the alias as the write target. A table
         /// genuinely named `only` with no reference after it still resolves.
-        mutating func consumeTableReference() -> String? {
+        mutating func consumeTableReference() -> SourceTable? {
             skipTrivia()
             let saved = index
             if peekWord()?.uppercased() == "ONLY" {
                 _ = readWord()
-                if let modified = consumeUnqualifiedIdentifier(),
-                   !nonAliasKeywords.contains(modified.uppercased()) {
+                if let modified = consumeQualifiedReference(),
+                   !nonAliasKeywords.contains(modified.name.uppercased()) {
                     return nil
                 }
                 index = saved
             }
-            return consumeUnqualifiedIdentifier()
+            return consumeQualifiedReference()
         }
 
-        /// Rejects a qualified reference. The caller quotes the result as a single identifier and
-        /// takes the schema from the tab, which never carries one for a query tab, so returning
-        /// `users` for `analytics.users` would aim the write at whatever the search path resolves.
-        private mutating func consumeUnqualifiedIdentifier() -> String? {
+        /// Accepts `table` and `schema.table`. A three-part `catalog.schema.table` is rejected:
+        /// the write path can express one qualifier, and silently dropping the catalog would aim
+        /// the statement at the connected database instead of the one the query named.
+        private mutating func consumeQualifiedReference() -> SourceTable? {
+            guard let first = consumeIdentifierPart() else { return nil }
+            guard unit(at: index) == 0x2E else { return SourceTable(schema: nil, name: first) }
+            index += 1
+            guard let second = consumeIdentifierPart() else { return nil }
+            guard unit(at: index) != 0x2E else { return nil }
+            return SourceTable(schema: first, name: second)
+        }
+
+        private mutating func consumeIdentifierPart() -> String? {
             skipTrivia()
             guard index < length else { return nil }
             let ch = units[index]
@@ -390,7 +408,6 @@ enum SelectSourceTableParser {
                 name = nil
             }
             guard let name, !name.isEmpty else { return nil }
-            guard unit(at: index) != 0x2E else { return nil }
             return name
         }
 

--- a/TablePro/Core/Utilities/SQL/SelectSourceTableParser.swift
+++ b/TablePro/Core/Utilities/SQL/SelectSourceTableParser.swift
@@ -44,7 +44,13 @@ enum SelectSourceTableParser {
     }
 
     private struct Cursor {
+        /// Scanning reads one code unit at a time. `NSString.character(at:)` leaves its fast path
+        /// as soon as the bridged string is not ASCII, so a single accented character anywhere in
+        /// the text made every later read transcode and turned a 4 ms scan of a wide select list
+        /// into 33 ms on the main actor. Transcoding once up front keeps every read a subscript.
+        /// The `NSString` stays only for `SqlDollarQuote`, which takes one.
         private let text: NSString
+        private let units: [UInt16]
         private let length: Int
         private let dialect: SqlDialect
         private var index = 0
@@ -52,12 +58,13 @@ enum SelectSourceTableParser {
 
         init(_ sql: String, dialect: SqlDialect) {
             text = sql as NSString
-            length = text.length
+            units = Array(sql.utf16)
+            length = units.count
             self.dialect = dialect
         }
 
         private func unit(at position: Int) -> UInt16? {
-            position < length ? text.character(at: position) : nil
+            position < length ? units[position] : nil
         }
 
         private static func isSpace(_ ch: UInt16) -> Bool {
@@ -82,7 +89,7 @@ enum SelectSourceTableParser {
 
         private mutating func skipTrivia() {
             while index < length {
-                let ch = text.character(at: index)
+                let ch = units[index]
                 if Self.isSpace(ch) {
                     index += 1
                 } else if ch == 0x2D, unit(at: index + 1) == 0x2D {
@@ -103,7 +110,7 @@ enum SelectSourceTableParser {
         /// endings does not swallow the rest of the statement as trivia.
         private mutating func skipToEndOfLine() {
             while index < length {
-                let ch = text.character(at: index)
+                let ch = units[index]
                 if ch == 0x0A || ch == 0x0D { return }
                 index += 1
             }
@@ -117,10 +124,10 @@ enum SelectSourceTableParser {
             var depth = 1
             let nests = dialect == .postgres
             while index < length, depth > 0 {
-                if nests, text.character(at: index) == 0x2F, unit(at: index + 1) == 0x2A {
+                if nests, units[index] == 0x2F, unit(at: index + 1) == 0x2A {
                     depth += 1
                     index += 2
-                } else if text.character(at: index) == 0x2A, unit(at: index + 1) == 0x2F {
+                } else if units[index] == 0x2A, unit(at: index + 1) == 0x2F {
                     depth -= 1
                     index += 2
                 } else {
@@ -132,9 +139,9 @@ enum SelectSourceTableParser {
         /// PostgreSQL honours backslash escapes only inside an `E'...'` literal.
         private func hasEscapeStringPrefix(at quote: Int) -> Bool {
             guard quote > 0 else { return false }
-            let previous = text.character(at: quote - 1)
+            let previous = units[quote - 1]
             guard previous == 0x45 || previous == 0x65 else { return false }
-            return quote < 2 || !Self.isIdentifierUnit(text.character(at: quote - 2))
+            return quote < 2 || !Self.isIdentifierUnit(units[quote - 2])
         }
 
         private mutating func skipStringLiteral() {
@@ -142,7 +149,7 @@ enum SelectSourceTableParser {
                 || (dialect.supportsEscapeStringPrefix && hasEscapeStringPrefix(at: index))
             index += 1
             while index < length {
-                let ch = text.character(at: index)
+                let ch = units[index]
                 if escapesWithBackslash, ch == 0x5C, index + 1 < length {
                     index += 2
                     continue
@@ -165,7 +172,7 @@ enum SelectSourceTableParser {
             let start = index
             var doubled = false
             while index < length {
-                let ch = text.character(at: index)
+                let ch = units[index]
                 if closing == 0x22, dialect.requiresBackslashEscapesInSingleQuotes,
                    ch == 0x5C, index + 1 < length {
                     index += 2
@@ -177,7 +184,7 @@ enum SelectSourceTableParser {
                         index += 2
                         continue
                     }
-                    let raw = text.substring(with: NSRange(location: start, length: index - start))
+                    let raw = String(decoding: units[start..<index], as: UTF16.self)
                     index += 1
                     guard doubled, let scalar = UnicodeScalar(closing) else { return raw }
                     let quote = String(Character(scalar))
@@ -189,10 +196,10 @@ enum SelectSourceTableParser {
         }
 
         private mutating func readWord() -> String? {
-            guard index < length, Self.isIdentifierUnit(text.character(at: index)) else { return nil }
+            guard index < length, Self.isIdentifierUnit(units[index]) else { return nil }
             let start = index
-            while index < length, Self.isIdentifierUnit(text.character(at: index)) { index += 1 }
-            return text.substring(with: NSRange(location: start, length: index - start))
+            while index < length, Self.isIdentifierUnit(units[index]) { index += 1 }
+            return String(decoding: units[start..<index], as: UTF16.self)
         }
 
         private mutating func peekWord() -> String? {
@@ -217,11 +224,11 @@ enum SelectSourceTableParser {
         /// tens of thousands of words and this runs on every execution.
         private mutating func skipWordMatchingAny(_ keywords: [[UInt16]]) -> Bool {
             let start = index
-            while index < length, Self.isIdentifierUnit(text.character(at: index)) { index += 1 }
+            while index < length, Self.isIdentifierUnit(units[index]) { index += 1 }
             let count = index - start
             candidates: for keyword in keywords where keyword.count == count {
                 for offset in 0..<count {
-                    let codeUnit = text.character(at: start + offset)
+                    let codeUnit = units[start + offset]
                     let folded = (codeUnit >= 0x61 && codeUnit <= 0x7A) ? codeUnit - 0x20 : codeUnit
                     if folded != keyword[offset] { continue candidates }
                 }
@@ -233,7 +240,7 @@ enum SelectSourceTableParser {
         private mutating func skipDollarQuotedBody(openerLength: Int, tag: String) -> Bool {
             index += openerLength
             while index < length {
-                if text.character(at: index) == SqlDollarQuote.dollar,
+                if units[index] == SqlDollarQuote.dollar,
                    SqlDollarQuote.matchesClose(at: index, tag: tag, in: text, bufLen: length) {
                     index += (tag as NSString).length + 2
                     return true
@@ -255,7 +262,7 @@ enum SelectSourceTableParser {
             while true {
                 skipTrivia()
                 guard index < length else { return false }
-                let ch = text.character(at: index)
+                let ch = units[index]
                 switch ch {
                 case 0x28:
                     depth += 1
@@ -373,7 +380,7 @@ enum SelectSourceTableParser {
         private mutating func consumeUnqualifiedIdentifier() -> String? {
             skipTrivia()
             guard index < length else { return nil }
-            let ch = text.character(at: index)
+            let ch = units[index]
             let name: String?
             if let closing = Self.closingDelimiter(for: ch) {
                 name = consumeDelimited(closing: closing)
@@ -390,7 +397,7 @@ enum SelectSourceTableParser {
         mutating func consumeOptionalAlias() -> Bool {
             skipTrivia()
             guard index < length else { return true }
-            let ch = text.character(at: index)
+            let ch = units[index]
             if let closing = Self.closingDelimiter(for: ch) {
                 return consumeDelimited(closing: closing) != nil
             }
@@ -403,7 +410,7 @@ enum SelectSourceTableParser {
             }
             skipTrivia()
             guard index < length else { return false }
-            let aliasChar = text.character(at: index)
+            let aliasChar = units[index]
             if let closing = Self.closingDelimiter(for: aliasChar) {
                 return consumeDelimited(closing: closing) != nil
             }
@@ -413,7 +420,7 @@ enum SelectSourceTableParser {
         mutating func atClauseBoundary() -> Bool {
             skipTrivia()
             guard index < length else { return true }
-            if text.character(at: index) == 0x3B { return true }
+            if units[index] == 0x3B { return true }
             guard let word = peekWord() else { return false }
             let keyword = word.uppercased()
             guard clauseTerminators.contains(keyword) else { return false }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -1330,7 +1330,11 @@ final class MainContentCoordinator {
     // MARK: - SQL Parsing
 
     func extractTableName(from sql: String) -> String? {
-        QuerySqlParser.extractTableName(from: sql, dialect: sqlDialect)
+        QuerySqlParser.extractTableName(
+            from: sql,
+            dialect: sqlDialect,
+            browseSchema: services.databaseManager.session(for: connectionId)?.browseSchema
+        )
     }
 
     // MARK: - Sorting

--- a/TableProTests/Core/Services/Query/QueryExecutorTests.swift
+++ b/TableProTests/Core/Services/Query/QueryExecutorTests.swift
@@ -56,6 +56,60 @@ struct QueryExecutorTests {
         #expect(QuerySqlParser.extractTableName(from: "CREATE TABLE foo (id INT)") == nil)
     }
 
+    // MARK: - Schema-qualified sources
+
+    /// A generated write names the table without a qualifier and lets the session resolve it, so a
+    /// schema the session is not pointed at must stay read-only.
+
+    @Test("A qualified source resolves when it names the session's own schema")
+    func qualifiedSourceMatchingSessionSchema() {
+        #expect(QuerySqlParser.extractTableName(
+            from: "SELECT * FROM public.users u WHERE u.id = 1",
+            dialect: .postgres,
+            browseSchema: "public"
+        ) == "users")
+        #expect(QuerySqlParser.extractTableName(
+            from: "SELECT * FROM \"public\".\"users\"",
+            dialect: .postgres,
+            browseSchema: "public"
+        ) == "users")
+    }
+
+    @Test("A qualified source naming another schema stays read-only")
+    func qualifiedSourceOtherSchema() {
+        #expect(QuerySqlParser.extractTableName(
+            from: "SELECT * FROM analytics.users u WHERE u.id = 1",
+            dialect: .postgres,
+            browseSchema: "public"
+        ) == nil)
+    }
+
+    @Test("A qualified source stays read-only when the session schema is unknown")
+    func qualifiedSourceWithoutSessionSchema() {
+        #expect(QuerySqlParser.extractTableName(
+            from: "SELECT * FROM public.users u WHERE u.id = 1",
+            dialect: .postgres
+        ) == nil)
+    }
+
+    @Test("Schema matching ignores case")
+    func qualifiedSourceCaseInsensitive() {
+        #expect(QuerySqlParser.extractTableName(
+            from: "SELECT * FROM PUBLIC.users u",
+            dialect: .postgres,
+            browseSchema: "public"
+        ) == "users")
+    }
+
+    @Test("An unqualified source is unaffected by the session schema")
+    func unqualifiedSourceIgnoresSessionSchema() {
+        #expect(QuerySqlParser.extractTableName(
+            from: "SELECT * FROM users u WHERE u.id = 1",
+            dialect: .postgres,
+            browseSchema: "analytics"
+        ) == "users")
+    }
+
     @Test("stripTrailingOrderBy removes a trailing ORDER BY clause")
     func stripTrailingOrderByRemovesClause() {
         let stripped = QuerySqlParser.stripTrailingOrderBy(from: "SELECT * FROM users ORDER BY id DESC")

--- a/TableProTests/Core/Utilities/SQL/SelectSourceTableParserTests.swift
+++ b/TableProTests/Core/Utilities/SQL/SelectSourceTableParserTests.swift
@@ -12,6 +12,16 @@ import Testing
 @Suite("SelectSourceTableParser")
 struct SelectSourceTableParserTests {
     private func table(_ sql: String, _ dialect: SqlDialect = .postgres) -> String? {
+        guard let source = SelectSourceTableParser.singleSourceTable(in: sql, dialect: dialect) else {
+            return nil
+        }
+        return source.schema == nil ? source.name : nil
+    }
+
+    private func source(
+        _ sql: String,
+        _ dialect: SqlDialect = .postgres
+    ) -> SelectSourceTableParser.SourceTable? {
         SelectSourceTableParser.singleSourceTable(in: sql, dialect: dialect)
     }
 
@@ -111,15 +121,36 @@ struct SelectSourceTableParserTests {
         #expect(table("SELECT * FROM LATERAL (SELECT 1) x") == nil)
     }
 
-    /// The write path quotes the result as one identifier and takes the schema from the tab, which
-    /// a query tab never carries, so a qualified source must stay read-only rather than resolve to
-    /// a bare name the search path would re-point.
-    @Test("A schema-qualified source never resolves")
-    func qualifiedSourcesAreNotSingleSource() {
-        #expect(table("SELECT * FROM public.users WHERE id = 1") == nil)
-        #expect(table("SELECT * FROM public.users u WHERE u.id = 1") == nil)
-        #expect(table("SELECT * FROM \"public\".\"users\" u") == nil)
-        #expect(table("SELECT * FROM db.public.users") == nil)
+    @Test("A schema-qualified source resolves to both parts")
+    func qualifiedSourcesReportSchema() {
+        #expect(source("SELECT * FROM public.users WHERE id = 1")
+            == .init(schema: "public", name: "users"))
+        #expect(source("SELECT * FROM public.users u WHERE u.id = 1")
+            == .init(schema: "public", name: "users"))
+        #expect(source("SELECT * FROM \"public\".\"users\" u")
+            == .init(schema: "public", name: "users"))
+        #expect(source("SELECT * FROM `db`.`orders` o WHERE 1", .mysql)
+            == .init(schema: "db", name: "orders"))
+        #expect(source("SELECT id FROM [dbo].[Users] AS [u]", .generic)
+            == .init(schema: "dbo", name: "Users"))
+        #expect(source("SELECT * FROM analytics.\"user events\" e WHERE 1")
+            == .init(schema: "analytics", name: "user events"))
+    }
+
+    @Test("An unqualified source reports no schema")
+    func unqualifiedSourcesReportNoSchema() {
+        #expect(source("SELECT * FROM users u WHERE u.id = 1")
+            == .init(schema: nil, name: "users"))
+        #expect(source("SELECT * FROM \"public.user\"")
+            == .init(schema: nil, name: "public.user"))
+    }
+
+    /// The write path can express one qualifier. Dropping the catalog would aim the statement at
+    /// the connected database rather than the one the query named.
+    @Test("A three-part catalog.schema.table never resolves")
+    func catalogQualifiedNeverResolves() {
+        #expect(source("SELECT * FROM db.public.users") == nil)
+        #expect(source("SELECT * FROM \"db\".\"public\".\"users\" u") == nil)
     }
 
     // MARK: - Row locking versus result-shaping FOR clauses

--- a/docs/features/data-grid.mdx
+++ b/docs/features/data-grid.mdx
@@ -59,7 +59,9 @@ UUIDs and Unix timestamps render in a readable form when the column type and nam
 ## Editing
 
 <Warning>
-Editing works when the results come from one table, with or without an alias, as in `SELECT * FROM orders o WHERE o.id = 1`. Comments, `DISTINCT`, `ORDER BY`, `LIMIT` and `FOR UPDATE` are fine. Joins, comma joins, subqueries in `FROM`, CTEs, `UNION`, `EXCEPT`, `INTERSECT`, `FROM ONLY`, and schema-qualified names such as `public.orders` are read-only, and so is any connection set to the Read-Only [safe mode](/features/safe-mode) level.
+Editing works when the results come from one table, with or without an alias, as in `SELECT * FROM orders o WHERE o.id = 1`. Comments, `DISTINCT`, `ORDER BY`, `LIMIT` and `FOR UPDATE` are fine. Joins, comma joins, subqueries in `FROM`, CTEs, `UNION`, `EXCEPT`, `INTERSECT` and `FROM ONLY` are read-only, and so is any connection set to the Read-Only [safe mode](/features/safe-mode) level.
+
+You can write the schema in front of the table, as in `SELECT * FROM public.orders o`, as long as it is the schema you are browsing. Naming a different schema keeps the results read-only: the saved edit does not repeat the schema, so it would go to the browsed one instead of the table you queried. Switch to that schema first if you want to edit through it.
 
 Two shapes look editable but refuse to save. A column renamed with `AS` cannot be written back, though the other columns in the same row still can. A query that renames or omits the primary key blocks the whole save, because there is nothing to match the row on.
 </Warning>


### PR DESCRIPTION
Follow-up to #2153. **Stacked on #2160** — both edit `SelectSourceTableParser.swift`, so please merge #2160 first; this branch contains its commit.

## The gap

#2153 left a schema-qualified source read-only:

```sql
SELECT * FROM public.users u WHERE u.id = 1   -- grid was not editable
```

PostgreSQL users write that constantly, so it was the most likely thing to be re-reported.

## Why it was not simply "resolve the name"

I traced the write path before designing, and the obvious fix is unsafe.

`SQLStatementGenerator` — the generator PostgreSQL, MySQL and SQLite all use, since none of them implements the plugin-side `generateStatements(table:schema:…)` — has **no schema concept at all**. It emits `UPDATE "users" SET …`, unqualified.

What makes that correct today is the session, not the statement: `LibPQDriverCore.applySchema(_:)` issues `SET search_path` and tracks `currentSchema`, and `DatabaseManager` mirrors it into `session.browseSchema`. So an unqualified write lands in the schema the connection is pointed at.

That is exactly why returning a bare `users` for `analytics.users` would be a silent wrong-table write while browsing `public`: the read comes from `analytics.users`, the write goes to `public.users`.

## What this does instead

Resolve the qualified reference, then allow editing **only when the named schema is the one the session is already on**. Then the unqualified write is correct by construction, and no change to the write path is needed.

- `SELECT * FROM public.users u` while browsing `public` — editable.
- `SELECT * FROM analytics.users u` while browsing `public` — read-only, as before.
- Session schema unknown — read-only.

Matching is case-insensitive: an unquoted identifier folds case on every engine that reaches this parser, and a quoted one differing only in case resolves to the same schema through the session, so this cannot widen the write target.

Three-part `catalog.schema.table` stays read-only. The write path can express one qualifier, and dropping the catalog would aim the statement at the connected database rather than the one the query named.

### Change shape

- `SelectSourceTableParser.singleSourceTable` now returns `SourceTable { schema: String?, name: String }` instead of `String?`, and parses `schema.table` with either part quoted (`"public"."users"`, `` `db`.`orders` ``, `[dbo].[Users]`). `"public.user"` as a single quoted identifier still parses as one name, unchanged.
- `QuerySqlParser.extractTableName` gains `browseSchema:` and owns the policy in one place, so both the single-statement and multi-statement paths get it.
- `MainContentCoordinator.extractTableName` supplies `session(for:)?.browseSchema`.

## Tests

`SelectSourceTableParserTests` — qualified references report both parts across all four quoting styles; unqualified report `schema == nil`; three-part rejected.

`QueryExecutorTests` — the policy itself: matching schema resolves, a different schema does not, an unknown session schema does not, matching ignores case, and an unqualified source is unaffected by the session schema.

## Verification

| Check | Result |
|---|---|
| `scripts/generate-project.sh` | PASS |
| `xcodebuild -scheme TablePro build` | PASS |
| 7 suites | 165 passed, 0 failed |
| `swiftlint lint --strict` (5 files) | 0 violations |

## Limitations

- **The underlying asymmetry remains**: reads qualify (`TableQueryBuilder.qualifiedTable`), writes do not. This change works within that rather than fixing it. Teaching `SQLStatementGenerator` to qualify would let any schema be editable, but it changes the write path for every engine and every table tab, and "schema" is not one concept across them (MySQL has databases, SQLite has attached-database prefixes, DuckDB has catalog.schema). That deserves its own change.
- I did **not** find a pre-existing wrong-write bug for table tabs: browsing a schema moves the driver's `search_path`, so their unqualified writes resolve correctly. The comment at `DatabaseManager+Sessions.swift:335` shows this invariant is deliberate.
- The schema comparison trusts `session.browseSchema` to reflect the driver's real `search_path`. That is maintained by `resetSchema`/`applySchema`; if they ever drift, this decision drifts with them.
- No cross-vendor review — `/codex:review` needs explicit user invocation.
