### PR TITLE
fix(editor): let clicks reach the editor's trailing edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A strip along the right edge of the SQL editor, as wide as 140 points, took clicks and did nothing with them. Clicking there now puts the caret on the line you clicked, like any other empty part of the editor. The same strip sat in the trigger editor, the JSON view, the structure DDL, the SQL review sheet, the import preview and chat code blocks, where it swallowed text selection instead. (#2156)
 - Query results were read-only whenever the `SELECT` gave its table an alias, as in `select * from users u where u.id = 1`. Editing works on those results now, and also on queries written across several lines, preceded by a comment, or ending in `FOR UPDATE`. (#2150)
 - A `UNION`, `EXCEPT` or `INTERSECT` result could be edited as though it were a single table, and the edit was written to one of the branches rather than to the rows on screen. Those results are read-only now. So are results from a join, a subquery, a CTE, a temporal `FOR SYSTEM_TIME` read, `FROM ONLY`, and a schema-qualified name such as `public.users`.
 - The connection window drew a rule under its toolbar that began at the sidebar divider and ran to the right edge, dividing two areas that are the same colour. It is gone.

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Minimap/MinimapView.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Minimap/MinimapView.swift
@@ -279,6 +279,10 @@ public class MinimapView: FlippedNSView {
     }
 
     override public func hitTest(_ point: NSPoint) -> NSView? {
+        // This override replaces `NSView`'s hit testing, which declines hidden views. Without the
+        // same check a minimap the editor was configured without still answers for its width, and
+        // `mouseDown(with:)` below then eats every click in that strip.
+        guard !isHiddenOrHasHiddenAncestor else { return nil }
         guard let point = superview?.convert(point, to: self) else { return nil }
         // For performance, don't hitTest the layout fragment views, but make sure the `documentVisibleView` is
         // hittable.

--- a/TableProTests/Views/Editor/MinimapHitTestTests.swift
+++ b/TableProTests/Views/Editor/MinimapHitTestTests.swift
@@ -1,0 +1,152 @@
+//
+//  MinimapHitTestTests.swift
+//  TableProTests
+//
+//  Regression tests for #2156. Every TablePro editor is configured with `showMinimap: false`, which
+//  hides the minimap but leaves it in the scroll view as a floating subview at its full width.
+//  `MinimapView.hitTest` replaces `NSView`'s hit testing without repeating its hidden check, so the
+//  hidden minimap answered for that width, and its empty `mouseDown` then discarded the click. The
+//  trailing strip of the editor took clicks and did nothing with them.
+//
+
+import AppKit
+import CodeEditLanguages
+@testable import CodeEditSourceEditor
+import CodeEditTextView
+import Testing
+
+@MainActor
+@Suite("Hidden minimap hit testing")
+struct MinimapHitTestTests {
+    private static let paneWidth: CGFloat = 1_000
+    private static let paneHeight: CGFloat = 300
+
+    /// No window and no run loop turn. `MinimapView` overrides `visibleRect` to read its own inner
+    /// scroll view's `documentVisibleRect`, which `layoutSubtreeIfNeeded` alone resolves, so the
+    /// branch under test is reachable the same way `GutterHighlightTests` reaches its own.
+    @MainActor
+    private final class Harness {
+        let host: NSView
+        let controller: TextViewController
+
+        init(showMinimap: Bool) {
+            let theme = EditorTheme(
+                text: EditorTheme.Attribute(color: .textColor),
+                insertionPoint: .textColor,
+                invisibles: EditorTheme.Attribute(color: .gray),
+                background: .textBackgroundColor,
+                lineHighlight: .selectedTextBackgroundColor,
+                selection: .selectedTextColor,
+                keywords: EditorTheme.Attribute(color: .systemPink),
+                commands: EditorTheme.Attribute(color: .systemBlue),
+                types: EditorTheme.Attribute(color: .systemMint),
+                attributes: EditorTheme.Attribute(color: .systemTeal),
+                variables: EditorTheme.Attribute(color: .systemCyan),
+                values: EditorTheme.Attribute(color: .systemOrange),
+                numbers: EditorTheme.Attribute(color: .systemYellow),
+                strings: EditorTheme.Attribute(color: .systemRed),
+                characters: EditorTheme.Attribute(color: .systemRed),
+                comments: EditorTheme.Attribute(color: .systemGreen)
+            )
+            let configuration = SourceEditorConfiguration(
+                appearance: .init(
+                    theme: theme,
+                    font: .monospacedSystemFont(ofSize: 12, weight: .regular),
+                    lineHeightMultiple: 1.0,
+                    wrapLines: false,
+                    tabWidth: 4
+                ),
+                layout: .init(contentInsets: NSEdgeInsets(top: 0, left: 0, bottom: 8, right: 0)),
+                peripherals: .init(showGutter: true, showMinimap: showMinimap, showFoldingRibbon: false)
+            )
+            controller = TextViewController(
+                string: "SELECT * FROM users;\nSELECT * FROM orders;",
+                language: .default,
+                configuration: configuration,
+                cursorPositions: [],
+                highlightProviders: []
+            )
+
+            let bounds = NSRect(x: 0, y: 0, width: paneWidth, height: paneHeight)
+            host = NSView(frame: bounds)
+            controller.loadView()
+            controller.view.frame = bounds
+            host.addSubview(controller.view)
+            controller.viewWillAppear()
+            controller.viewDidAppear()
+            host.layoutSubtreeIfNeeded()
+            controller.textView.layoutManager.layoutLines(in: bounds)
+        }
+
+        /// The centre of the minimap's strip, in `host` coordinates. Converted rather than
+        /// computed: `host` is unflipped and the editor's views are flipped, so a hand-picked `y`
+        /// means different places in the two spaces.
+        var pointInMinimapStrip: NSPoint {
+            let minimap: MinimapView = controller.minimapView
+            return minimap.convert(NSPoint(x: minimap.bounds.midX, y: minimap.bounds.midY), to: host)
+        }
+
+        /// True when `MinimapView.hitTest`'s `visibleRect` branch, the one the fix short-circuits,
+        /// would answer for the strip's centre. If this were ever false the two hidden-minimap tests
+        /// would pass without the fix, so they assert it rather than trust it.
+        var minimapStripIsLiveForHitTesting: Bool {
+            let minimap: MinimapView = controller.minimapView
+            return minimap.visibleRect.contains(NSPoint(x: minimap.bounds.midX, y: minimap.bounds.midY))
+        }
+
+        /// The trailing edge of the gutter, in `host` coordinates.
+        var gutterMaxXInHost: CGFloat {
+            let gutter: GutterView = controller.gutterView
+            return gutter.convert(NSPoint(x: gutter.bounds.maxX, y: 0), to: host).x
+        }
+
+        func hit(_ point: NSPoint) -> NSView? {
+            host.hitTest(point)
+        }
+    }
+
+    @Test("A hidden minimap leaves the trailing strip to the text view")
+    func hiddenMinimapDoesNotClaimItsStrip() throws {
+        let harness = Harness(showMinimap: false)
+
+        // Without these the test could pass because the strip is not there at all, or because the
+        // branch the guard short-circuits never ran.
+        #expect(harness.controller.minimapView.isHidden)
+        #expect(harness.controller.minimapView.frame.width > 0)
+        #expect(harness.minimapStripIsLiveForHitTesting)
+
+        let hit = harness.hit(harness.pointInMinimapStrip)
+        #expect(hit === harness.controller.textView)
+    }
+
+    @Test("The whole width right of the gutter answers for the text view when the minimap is off")
+    func everyPointRightOfTheGutterReachesTheTextView() throws {
+        let harness = Harness(showMinimap: false)
+        #expect(harness.minimapStripIsLiveForHitTesting)
+        let y = harness.pointInMinimapStrip.y
+
+        var unreachable: [CGFloat] = []
+        var x = harness.gutterMaxXInHost + 1
+        while x < Self.paneWidth {
+            if harness.hit(NSPoint(x: x, y: y)) !== harness.controller.textView {
+                unreachable.append(x)
+            }
+            x += 1
+        }
+        #expect(unreachable.isEmpty, "x positions that do not reach the text view: \(unreachable)")
+    }
+
+    /// Also the guard on the two tests above. They only mean something in an environment where a
+    /// minimap can claim a point at all, so if this fails they are passing for the wrong reason.
+    @Test("A shown minimap still claims its strip")
+    func shownMinimapStillClaimsItsStrip() throws {
+        let harness = Harness(showMinimap: true)
+        #expect(!harness.controller.minimapView.isHidden)
+
+        let hit = try #require(harness.hit(harness.pointInMinimapStrip))
+        #expect(
+            hit === harness.controller.minimapView || hit.isDescendant(of: harness.controller.minimapView),
+            "expected the minimap or one of its subviews, got \(type(of: hit))"
+        )
+    }
+}

--- a/TableProUITests/EditorTrailingClickUITests.swift
+++ b/TableProUITests/EditorTrailingClickUITests.swift
@@ -1,0 +1,63 @@
+import XCTest
+
+/// #2156: the trailing strip of the SQL editor, where a hidden minimap still sat, took clicks and
+/// did nothing with them. Clicking there must move the caret to the clicked line like any other
+/// empty space in the editor.
+final class EditorTrailingClickUITests: UITestCase {
+    private let query = "SELECT 1;"
+
+    func testClickingTheTrailingEdgePutsTheCaretAtTheEndOfThatLine() throws {
+        let app = try launchWithSampleDatabase()
+        let editor = openQueryTab(in: app)
+
+        app.typeText(query)
+        XCTAssertTrue(waitForValue(query, in: editor))
+
+        let frame = editor.frame
+        XCTAssertGreaterThan(
+            frame.width, 200,
+            "The editor must be wide enough for the trailing strip to be distinct from the text"
+        )
+
+        // Click inside the text, which also dismisses any completion popup. Escape is not usable
+        // here: with no popup open the editor treats it as a request to show completions.
+        click(on: editor, dx: frame.width / 2, dy: 10)
+        app.typeKey(XCUIKeyboardKey.leftArrow.rawValue, modifierFlags: .command)
+
+        click(on: editor, dx: frame.width - 12, dy: 10)
+        app.typeText("X")
+
+        XCTAssertTrue(
+            waitForValue(query + "X", in: editor),
+            "A click on the editor's trailing edge must put the caret at the end of that line; got "
+                + "'\(editor.value as? String ?? "nil")'"
+        )
+    }
+
+    private func click(on element: XCUIElement, dx: CGFloat, dy: CGFloat) {
+        element.coordinate(withNormalizedOffset: .zero)
+            .withOffset(CGVector(dx: dx, dy: dy))
+            .click()
+    }
+
+    private func openQueryTab(in app: XCUIApplication) -> XCUIElement {
+        app.typeKey("t", modifierFlags: .command)
+        let editor = editorTextView(in: app)
+        XCTAssertTrue(editor.waitForExistence(timeout: 10))
+        XCTAssertTrue(waitForValue("", in: editor), "A new tab starts with an empty editor")
+        return editor
+    }
+
+    private func editorTextView(in app: XCUIApplication) -> XCUIElement {
+        let window = app.windows.firstMatch
+        let identified = window.textViews.matching(identifier: "sql-editor-textview").firstMatch
+        if identified.exists {
+            return identified
+        }
+        return window.textViews.firstMatch
+    }
+
+    private func waitForValue(_ expected: String, in element: XCUIElement) -> Bool {
+        waitForPredicate(timeout: 5) { (element.value as? String) == expected }
+    }
+}


### PR DESCRIPTION
## What you see now

A strip along the right edge of the SQL editor, as wide as 140 points, took clicks and did nothing
with them. The caret stayed where it was and the editor did not take focus, so the area read as
padding that happened to be inside the editor. Clicking there now puts the caret on the line you
clicked, the same as any other empty part of the editor.

## Root cause

`TextViewController.loadView` creates the minimap unconditionally and adds it to the scroll view as
a floating subview (`TextViewController+Lifecycle.swift:47-48`). `showMinimap: false` only hides it
(`SourceEditorConfiguration+Peripherals.swift:56-57`); it stays in the hierarchy at its full width,
which is `min(0.17 x pane width, MinimapView.maxWidth)` and so up to 140 points
(`TextViewController+Lifecycle.swift:89-93`, `MinimapView.swift:28`).

`MinimapView.hitTest` overrides `NSView`'s hit testing and does not repeat its hidden check, so the
hidden minimap still answered for that width. `MinimapView.mouseDown(with:)` is deliberately empty,
to stop a click on a *visible* minimap reaching the text view, so the click was then discarded and
nothing else in the responder chain saw it.

The strip is invisible because a hidden view draws nothing and the text view paints through it.
`TextSelectionManager+Draw.swift:54` caps the current-line highlight at `textView.frame.width`, and
the text view is full width (`TextView+Layout.swift:89-91`), so there is no seam to notice. Pixel
sampling of the reporter's screenshot confirmed the highlight reaches the window edge.

Nothing else was wrong behind it: `TextLayoutManager+Public.swift:90-91` already returns
end-of-line for a point past a line's text, so once the text view receives the click the caret lands
correctly.

## The fix

One guard in the override that dropped the check:

```swift
guard !isHiddenOrHasHiddenAncestor else { return nil }
```

Every TablePro editor passes `showMinimap: false`, so all seven had the strip: the SQL editor, the
trigger editor, the JSON view, the structure DDL, the SQL review sheet, the import preview, and chat
code blocks. One fix in the package clears all of them.

Alternatives rejected: removing the minimap from the hierarchy when hidden, which changes its
lifecycle and collides with the suspend-and-rebuild logic already keyed on hidden-but-present at
`MinimapView.swift:77-85`; zeroing its width, which fights its Auto Layout constraints and leaves
the missing check in place for other callers; and fixing it in TablePro, which is not possible
because the minimap is created unconditionally.

## How the root cause was established

A standalone AppKit probe, a SwiftPM executable built against the three vendored `LocalPackages`,
hosting a real `TextViewController` with `SQLEditorView.makeConfiguration()`'s shape and sweeping
`hitTest` one point at a time across the pane width. Before: `1010...1148 -> MinimapView`, with the
dump on the line above reporting `MinimapView hidden=true`. After: the text view answers the whole
width right of the gutter. Measured at 1150pt and 420pt panes, with `wrapLines` both ways, and with
`showMinimap: true` as the no-regression case.

## Files

- `LocalPackages/CodeEditSourceEditor/.../Minimap/MinimapView.swift`: the guard. A vendored package,
  which this repository already patches directly under `fix(editor):` scopes.
- `TableProTests/Views/Editor/MinimapHitTestTests.swift`: new, 3 cases, built on
  `GutterHighlightTests`' `@testable import` harness. No window and no timed wait.
- `TableProUITests/EditorTrailingClickUITests.swift`: new, the real click. Types a line, puts the
  caret at its start, clicks the trailing strip, then asserts the typed character landed at the end
  of the line rather than the start.
- `CHANGELOG.md`

## Verification

| step | verdict |
| --- | --- |
| `generate` | PASS |
| `build TablePro` | PASS |
| `lint`, all changed Swift files | PASS |
| `test MinimapHitTestTests` | PASS, 3 of 3 |
| `test` + `GutterHighlightTests`, `EditorContextMenuRoutingTests`, three `SQLEditorCoordinator` suites | PASS, 26 of 26 |
| `uitest EditorTrailingClickUITests QueryTabDeleteLineUITests` | PASS, 6 of 6 |
| guard reverted, `test MinimapHitTestTests` | FAIL on the two hidden-minimap cases, shown-minimap case still passes |
| guard reverted, `uitest EditorTrailingClickUITests` | FAIL, 0 of 2 |

The last two rows are the point of the tests: both fail on the old behaviour and pass on the new
one. Two further things keep them from passing for the wrong reason.
`shownMinimapStillClaimsItsStrip` asserts that a minimap which *is* shown still claims the strip, so
the other two cases cannot be green merely because nothing was there. And the hidden cases assert
`minimapStripIsLiveForHitTesting`, which is the branch the guard short-circuits, so they cannot pass
if a future AppKit change stops that branch running.

## Not verified, and limitations

- **The mouse cursor over the strip is unchecked.** `MinimapView.swift:271-273` installs an arrow
  cursor rect over the minimap's whole bounds. If AppKit establishes cursor rects for hidden views,
  the strip still shows an arrow rather than an I-beam, which would be the other half of "it looks
  like padding". Cursor rects need real pointer tracking, which neither the probe nor XCTest
  establishes, so this is queued as a follow-up to check by hovering a running build.
- **Independent cross-vendor review did not run.** Codex returned
  `You've hit your usage limit ... try again at Aug 23rd, 2026`, so this change has not been reviewed
  by the other vendor. A Claude adversarial pass was run in its place; that is not cross-vendor and
  is stated as such.
- `MinimapView.hitTest`'s `else` branch passes an already-converted point to `super.hitTest(point)`,
  where `NSView` expects the superview's space. Real but unreachable for this defect, since that
  branch only runs for points outside `visibleRect` where `super` returns nil regardless. Left alone
  to keep the change on the root cause.

### A note on the verification runs

Several runs here first came back `INCONCLUSIVE` with 0 cases executed and
`The test runner hung before establishing connection`. That was not this change. Peer sessions were
building and testing in their own worktrees at the same time, and `testmanagerd` is a single
system-wide daemon, so concurrent test runs collide. `verify.sh` serialises on an `xcodebuild` in its
own checkout, which does not catch a peer in a different worktree. Every verdict in the table above
was taken on a quiet machine, and every earlier `INCONCLUSIVE` was rerun rather than recorded as a
pass.

Closes #2156
