### PR TITLE
ci: report a gate check on every pull request so main can require it

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -25,38 +25,36 @@ env:
   TEST_DESTINATION: "platform=iOS Simulator,name=iPhone 17 Pro,OS=latest"
 
 jobs:
+  # No `permissions:` block here either. See the note in macos-tests.yml: this workflow has no
+  # workflow_call caller today, but the same shape must not be copied back into one.
   changes:
     name: Detect relevant changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      pull-requests: read
     outputs:
       run: ${{ steps.decide.outputs.run }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Decide whether the iOS suite needs to run
         id: decide
         env:
           EVENT_NAME: ${{ github.event_name }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
 
-          run_all() {
+          if [ "$EVENT_NAME" != "pull_request" ]; then
               echo "run=true" >> "$GITHUB_OUTPUT"
               exit 0
-          }
+          fi
 
-          [ "$EVENT_NAME" = "pull_request" ] || run_all
+          FILES="$(git diff --name-only "$BASE_SHA" HEAD)"
 
-          FILES="$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')"
-
-          # The pull request files API stops at 3000 entries, past which absence proves nothing.
-          [ "$(printf '%s\n' "$FILES" | wc -l)" -lt 3000 ] || run_all
-
-          if printf '%s\n' "$FILES" | grep -qE '^(TableProMobile/|Configs/|Packages/TableProCore/|Libs/|\.github/workflows/ios-tests\.yml$)'; then
+          # A here-string, not a pipe. See the note in macos-tests.yml about grep -q and pipefail.
+          if grep -qE '^(TableProMobile/|Configs/|Packages/TableProCore/|Libs/|\.github/workflows/ios-tests\.yml$)' <<< "$FILES"; then
               echo "run=true" >> "$GITHUB_OUTPUT"
           else
               echo "run=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -1,13 +1,9 @@
 name: iOS Tests
 
 on:
+  # No paths filter here on purpose. See the note in macos-tests.yml: a workflow skipped by a
+  # paths filter never reports, so a required check would hang on every unrelated pull request.
   pull_request:
-    paths:
-      - "TableProMobile/**"
-      - "Configs/**"
-      - "Packages/TableProCore/**"
-      - "Libs/**"
-      - ".github/workflows/ios-tests.yml"
   push:
     branches: [main]
     paths:
@@ -29,8 +25,47 @@ env:
   TEST_DESTINATION: "platform=iOS Simulator,name=iPhone 17 Pro,OS=latest"
 
 jobs:
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - name: Decide whether the iOS suite needs to run
+        id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          run_all() {
+              echo "run=true" >> "$GITHUB_OUTPUT"
+              exit 0
+          }
+
+          [ "$EVENT_NAME" = "pull_request" ] || run_all
+
+          FILES="$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')"
+
+          # The pull request files API stops at 3000 entries, past which absence proves nothing.
+          [ "$(printf '%s\n' "$FILES" | wc -l)" -lt 3000 ] || run_all
+
+          if printf '%s\n' "$FILES" | grep -qE '^(TableProMobile/|Configs/|Packages/TableProCore/|Libs/|\.github/workflows/ios-tests\.yml$)'; then
+              echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+              echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
     name: Run iOS Tests
+    needs: changes
+    if: needs.changes.outputs.run == 'true'
     runs-on: macos-26
     timeout-minutes: 25
 
@@ -124,3 +159,27 @@ jobs:
             -scheme "$XCODE_SCHEME" \
             -skipPackagePluginValidation 2>&1 \
             | grep -E "iOS Simulator.*iPhone" || true
+
+  # The one check to mark required on main. See the note in macos-tests.yml.
+  gate:
+    name: iOS Tests Gate
+    if: always()
+    needs: [changes, test]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require the suite to have passed or been skipped
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          set -euo pipefail
+          echo "suite results: $RESULTS"
+          for result in $RESULTS; do
+              case "$result" in
+                  success|skipped) ;;
+                  *)
+                      echo "The iOS suite reported '$result'." >&2
+                      exit 1
+                      ;;
+              esac
+          done

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -51,10 +51,12 @@ jobs:
               exit 0
           fi
 
-          FILES="$(git diff --name-only "$BASE_SHA" HEAD)"
+          # Raw NUL-separated records, read from a file. See the note in macos-tests.yml for what
+          # core.quotePath and a pipeline each break here.
+          git -c core.quotePath=false diff --no-renames --name-only -z \
+              "$BASE_SHA" HEAD > "$RUNNER_TEMP/changed-files"
 
-          # A here-string, not a pipe. See the note in macos-tests.yml about grep -q and pipefail.
-          if grep -qE '^(TableProMobile/|Configs/|Packages/TableProCore/|Libs/|\.github/workflows/ios-tests\.yml$)' <<< "$FILES"; then
+          if LC_ALL=C grep -zqE '^(TableProMobile/|Configs/|Packages/TableProCore/|Libs/|\.github/workflows/ios-tests\.yml$)' "$RUNNER_TEMP/changed-files"; then
               echo "run=true" >> "$GITHUB_OUTPUT"
           else
               echo "run=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -67,13 +67,19 @@ jobs:
               exit 0
           fi
 
-          FILES="$(git diff --name-only "$BASE_SHA" HEAD)"
+          # core.quotePath defaults to true, which wraps any path holding a non-ASCII byte or a
+          # control character in double quotes and C-escapes it, so `TablePro/Café.swift` arrives
+          # as `"TablePro/Caf\303\251.swift"` and the leading quote defeats the `^` anchor. This
+          # detector fails open, so a misread means every suite skips behind a green gate. Reading
+          # raw NUL-separated records removes both that and any embedded-newline trick.
+          #
+          # A file, not a variable: bash drops NUL bytes from "$(...)", which would run every path
+          # together into one record. It also keeps grep out of a pipeline, so the SIGPIPE that
+          # scripts/check-freetds-fedauth.sh:69 warns about cannot come back.
+          git -c core.quotePath=false diff --no-renames --name-only -z \
+              "$BASE_SHA" HEAD > "$RUNNER_TEMP/changed-files"
 
-          # A here-string, not a pipe. `grep -q` closes the pipe on its first match, which kills
-          # the writer with SIGPIPE, and under `set -o pipefail` that turns a match into exit 141
-          # and silently inverts the answer. scripts/check-freetds-fedauth.sh:69 carries the same
-          # warning for the same reason.
-          if grep -qE '^(TablePro/|Plugins/|Packages/|LocalPackages/|TableProTests/|TableProUITests/|Configs/|Libs/|project\.yml$|\.github/workflows/macos-tests\.yml$)' <<< "$FILES"; then
+          if LC_ALL=C grep -zqE '^(TablePro/|Plugins/|Packages/|LocalPackages/|TableProTests/|TableProUITests/|Configs/|Libs/|project\.yml$|\.github/workflows/macos-tests\.yml$)' "$RUNNER_TEMP/changed-files"; then
               echo "run=true" >> "$GITHUB_OUTPUT"
           else
               echo "run=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -1,18 +1,11 @@
 name: macOS Tests
 
 on:
+  # No paths filter here on purpose. A required status check has to report on every pull
+  # request, and a workflow skipped by a paths filter reports nothing at all, which leaves
+  # the check pending forever and blocks docs-only work. The filtering moved into the
+  # changes job below, so the gate job always runs and always reports.
   pull_request:
-    paths:
-      - "TablePro/**"
-      - "Plugins/**"
-      - "Packages/**"
-      - "LocalPackages/**"
-      - "TableProTests/**"
-      - "TableProUITests/**"
-      - "project.yml"
-      - "Configs/**"
-      - "Libs/**"
-      - ".github/workflows/macos-tests.yml"
   push:
     branches: [main]
     paths:
@@ -40,8 +33,53 @@ env:
   TEST_DESTINATION: "platform=macOS"
 
 jobs:
+  # Reproduces the paths filter this workflow used to carry on `on: pull_request`, with the
+  # same union of paths, so a pull request runs exactly the suites it ran before.
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - name: Decide whether the macOS suites need to run
+        id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          run_all() {
+              echo "run=true" >> "$GITHUB_OUTPUT"
+              exit 0
+          }
+
+          # Anything that is not a pull request runs the full suite: a release calls this
+          # workflow with workflow_call, and a release that skipped its tests is the failure
+          # this guard exists to prevent.
+          [ "$EVENT_NAME" = "pull_request" ] || run_all
+
+          FILES="$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')"
+
+          # The pull request files API stops at 3000 entries. Past that the list is truncated
+          # and no longer proves a path is absent, so run everything.
+          [ "$(printf '%s\n' "$FILES" | wc -l)" -lt 3000 ] || run_all
+
+          if printf '%s\n' "$FILES" | grep -qE '^(TablePro/|Plugins/|Packages/|LocalPackages/|TableProTests/|TableProUITests/|Configs/|Libs/|project\.yml$|\.github/workflows/macos-tests\.yml$)'; then
+              echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+              echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   package-tests:
     name: TableProCore Package Tests
+    needs: changes
+    if: needs.changes.outputs.run == 'true'
     runs-on: macos-26
     timeout-minutes: 20
     steps:
@@ -57,6 +95,8 @@ jobs:
 
   editor-tests:
     name: CodeEditTextView Package Tests
+    needs: changes
+    if: needs.changes.outputs.run == 'true'
     runs-on: macos-26
     timeout-minutes: 20
     steps:
@@ -81,6 +121,8 @@ jobs:
   # UI retry costs another minute or two, so 40 left no headroom and killed the job mid-suite.
   app-tests:
     name: macOS App Tests
+    needs: changes
+    if: needs.changes.outputs.run == 'true'
     runs-on: macos-26
     timeout-minutes: 60
     steps:
@@ -209,3 +251,28 @@ jobs:
           name: macos-test-results
           path: TestResults.xcresult
           retention-days: 7
+
+  # The one check to mark required on main. It reports on every pull request, so a docs-only
+  # change passes on skipped suites instead of hanging, and a red suite cannot be merged past.
+  gate:
+    name: macOS Tests Gate
+    if: always()
+    needs: [changes, package-tests, editor-tests, app-tests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every suite to have passed or been skipped
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          set -euo pipefail
+          echo "suite results: $RESULTS"
+          for result in $RESULTS; do
+              case "$result" in
+                  success|skipped) ;;
+                  *)
+                      echo "A macOS suite reported '$result'." >&2
+                      exit 1
+                      ;;
+              esac
+          done

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -35,42 +35,45 @@ env:
 jobs:
   # Reproduces the paths filter this workflow used to carry on `on: pull_request`, with the
   # same union of paths, so a pull request runs exactly the suites it ran before.
+  # Never give this job a `permissions:` block. build.yml calls this workflow with
+  # workflow_call, and a called job may not request more than the caller holds. The repository
+  # default is read, which carries no pull-requests scope, so asking for one fails the whole
+  # release at run creation, before a single job starts. Reading the diff from git keeps this
+  # job inside contents:read, which every caller already grants.
   changes:
     name: Detect relevant changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      pull-requests: read
     outputs:
       run: ${{ steps.decide.outputs.run }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Decide whether the macOS suites need to run
         id: decide
         env:
           EVENT_NAME: ${{ github.event_name }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
-
-          run_all() {
-              echo "run=true" >> "$GITHUB_OUTPUT"
-              exit 0
-          }
 
           # Anything that is not a pull request runs the full suite: a release calls this
           # workflow with workflow_call, and a release that skipped its tests is the failure
           # this guard exists to prevent.
-          [ "$EVENT_NAME" = "pull_request" ] || run_all
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+              echo "run=true" >> "$GITHUB_OUTPUT"
+              exit 0
+          fi
 
-          FILES="$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')"
+          FILES="$(git diff --name-only "$BASE_SHA" HEAD)"
 
-          # The pull request files API stops at 3000 entries. Past that the list is truncated
-          # and no longer proves a path is absent, so run everything.
-          [ "$(printf '%s\n' "$FILES" | wc -l)" -lt 3000 ] || run_all
-
-          if printf '%s\n' "$FILES" | grep -qE '^(TablePro/|Plugins/|Packages/|LocalPackages/|TableProTests/|TableProUITests/|Configs/|Libs/|project\.yml$|\.github/workflows/macos-tests\.yml$)'; then
+          # A here-string, not a pipe. `grep -q` closes the pipe on its first match, which kills
+          # the writer with SIGPIPE, and under `set -o pipefail` that turns a match into exit 141
+          # and silently inverts the answer. scripts/check-freetds-fedauth.sh:69 carries the same
+          # warning for the same reason.
+          if grep -qE '^(TablePro/|Plugins/|Packages/|LocalPackages/|TableProTests/|TableProUITests/|Configs/|Libs/|project\.yml$|\.github/workflows/macos-tests\.yml$)' <<< "$FILES"; then
               echo "run=true" >> "$GITHUB_OUTPUT"
           else
               echo "run=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why

PR #2154 merged with both `macOS App Tests` and `Run iOS Tests` red, which is how `main` ended up unable to link `MSSQLDriver` for a day. Nothing required those checks to pass: `main` has no branch protection, no rulesets, and no `CODEOWNERS`.

Marking the existing jobs required does not work as-is. Both workflows filter on `paths:` under `on: pull_request`, so a PR touching only `docs/` or `.claude/` never triggers them. A required check that never runs reports nothing and sits at "Expected - waiting for status" forever, which would block every documentation PR.

## What this does

Each workflow keeps its path filtering but moves it off the trigger and into a `changes` job, so the workflow always starts and always reports.

- `on: pull_request` loses its `paths:` filter. The `push` trigger keeps its filter, since pushes do not gate anything.
- A new `changes` job computes the changed paths with `git diff` and outputs a single `run` flag.
- `package-tests`, `editor-tests`, `app-tests` and the iOS `test` job gain `needs: changes` and `if: needs.changes.outputs.run == 'true'`, so they run on exactly the same paths as before.
- A new `gate` job with `if: always()` reads `join(needs.*.result)` and passes only when every suite succeeded or was skipped.

`macOS Tests Gate` and `iOS Tests Gate` are the two checks to mark required on `main` after this merges. A docs-only PR passes them on skipped suites. A red suite cannot be merged past them.

## Anything that is not a pull request runs everything

`build.yml` calls `macos-tests.yml` with `workflow_call` on `v*` tags. The `changes` job returns early with `run=true` for every event that is not a `pull_request`, so a release, a push to `main`, and a manual dispatch all run the full suite. A release that skipped its own tests is the failure that guard exists to prevent.

## Three bugs found in review and fixed here

All three were caught by adversarial review, each of an earlier commit on this branch. Every one of them failed in the dangerous direction: a green check over work that never ran, or a release that never started.

**The first version broke every tagged release.** The `changes` job carried `permissions: pull-requests: read` so it could call the pull request files API. A job in a called workflow may not request more than its caller holds, and this repository's `default_workflow_permissions` is `read`, which carries no pull-requests scope. `build.yml`'s calling job declares no permissions, so pushing a `v*` tag would have failed the entire run at creation, before any job started. PR CI cannot catch this, because a direct run is allowed to ask for more than the repository default. It would only have appeared on a real release tag.

The fix is to read the diff from git rather than the API. That stays inside `contents: read`, which every caller already grants, so the job needs no `permissions:` block at all. There is a comment on the job explaining why one must not be added back.

**The first version could report green having run nothing.** `printf '%s\n' "$FILES" | grep -qE ...` under `set -o pipefail` inverts its own answer: `grep -q` exits at the first match and closes the pipe, `printf` dies on SIGPIPE, and `pipefail` turns a match into exit 141, so the `if` takes the else branch and writes `run=false`. `scripts/check-freetds-fedauth.sh:69` already carries this warning for the same reason.

Measured on a 200,001 line input whose first line matches:

```
old form (printf | grep -q) : run=false
new form (grep -q <<< ...)  : run=true
```

It became a here-string, and then a file read, which is not a pipeline either.

**The third version skipped every suite on an accented filename.** `git diff --name-only` does not emit raw paths. `core.quotePath` defaults to true, so any path holding a non-ASCII byte or a control character comes back double quoted and C-escaped: `TablePro/Café.swift` arrives as `"TablePro/Caf\303\251.swift"`. The leading quote defeats the `^TablePro/` anchor. Since the detector fails open, a PR whose only watched-path file has an accented or emoji name would skip `package-tests`, `editor-tests` and `app-tests`, and `macOS Tests Gate` would report success over code nothing compiled.

Reproduced in a throwaway repository:

```
$ git diff --name-only $BASE HEAD
"TablePro/Caf\303\251.swift"
docs/note.md
old form -> RUN=false      # every suite skipped, gate green
new form -> RUN=true
```

It now reads raw NUL-separated records into a file with `git -c core.quotePath=false diff --no-renames --name-only -z`, matched by `LC_ALL=C grep -zqE`. NUL separation also removes the embedded-newline trick, and reading a file keeps grep out of a pipeline for good.

Three independent review lenses found this one separately, which is the reason it is worth stating rather than quietly fixing.

## Verification

- `actionlint` passes on both changed files. The remaining repository findings are pre-existing in `build-plugin.yml` and `build.yml`.
- The two matchers were checked against 24 cases in their real shape, NUL-separated records matched with `LC_ALL=C grep -zqE`. They cover the docs-only and agent-config shapes that would otherwise hang a required check, a mobile-only PR, `TableProMobile/project.yml` against the root `project.yml` entry, a `docs/TablePro/` path that must not match `^TablePro/`, and accented, emoji and embedded-newline filenames both inside and outside the watched directories. All 24 pass.
- Both the SIGPIPE inversion and the quoted-path skip were reproduced and their fixes measured, rather than argued.
- Not verified: the gate jobs have never executed on a runner. This PR is what exercises them. Check that `macOS Tests Gate` and `iOS Tests Gate` both report here before marking them required.
- Not done: cross-model review. The Codex CLI returns "Your workspace is out of credits", so the review of this change is same-vendor only. Worth a Codex pass given that same-vendor review found three real bugs across two rounds here.

## After merge

Enable branch protection on `main` requiring `macOS Tests Gate` and `iOS Tests Gate`. Leaving admin enforcement off keeps an emergency direct push available, which the library checksum repair needed today.
