### PR TITLE
fix(datagrid): refresh the deleted and inserted row tint when the theme changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A deleted or newly added row in the data grid kept the previous theme's tint after you switched theme or appearance. The row picked up the new colour only once you scrolled it away and back, or changed the row some other way. It updates straight away now, in the results grid and in the structure grid.
 - Format Query crashed the app on a string literal that was still open and ended in a backslash, as in `select * from t where c like 'C:\`. It formats such a query without crashing now. Format Query also used to move the last character of an unclosed `/*` comment out of the comment and reformat it as code; the whole comment is left alone now.
 - Pasting a large block of text into the query editor could crash the app. A paste of more than about a thousand characters is parsed in the background, and the editor's syntax highlighting was updated from that background work while the editor was still applying the same paste on screen. Highlighting is now updated on the main thread again, as the rest of the editor already did. (#2158)
 - A strip along the right edge of the SQL editor, as wide as 140 points, took clicks and did nothing with them. Clicking there now puts the caret on the line you clicked, like any other empty part of the editor. The same strip sat in the trigger editor, the JSON view, the structure DDL, the SQL review sheet, the import preview and chat code blocks, where it swallowed text selection instead. (#2156)

--- a/TablePro/Views/Results/DataGridRowView.swift
+++ b/TablePro/Views/Results/DataGridRowView.swift
@@ -45,8 +45,10 @@ class DataGridRowView: NSTableRowView {
         "hidden": NSNull(),
     ]
 
+    /// The tint derives from the row state and the active theme, so it is recomputed on every call
+    /// and the colour comparison below decides whether anything needs redrawing. Returning early on
+    /// an unchanged state would ignore the theme, which is the input a theme change moves.
     func applyVisualState(_ state: RowVisualState) {
-        guard state != visualState else { return }
         visualState = state
         let nextTint: NSColor? = if state.isDeleted {
             ThemeEngine.shared.colors.dataGrid.deleted

--- a/TableProTests/Views/Results/DataGridRowTintThemeTests.swift
+++ b/TableProTests/Views/Results/DataGridRowTintThemeTests.swift
@@ -1,0 +1,77 @@
+//
+//  DataGridRowTintThemeTests.swift
+//  TableProTests
+//
+
+import AppKit
+@testable import TablePro
+import Testing
+
+/// These tests activate a theme on the shared `ThemeEngine`. What keeps that from reaching a suite
+/// running in parallel is that both bodies are synchronous and `@MainActor`, so nothing else on the
+/// main actor can interleave between activating the test theme and restoring the original one.
+/// `.serialized` only orders tests inside this suite and does not provide that. Adding an `await`
+/// anywhere between the two would break it.
+@Suite("DataGridRowView tint follows the theme", .serialized)
+@MainActor
+struct DataGridRowTintThemeTests {
+    private static let deleted = RowVisualState(isDeleted: true, isInserted: false, modifiedColumns: [])
+
+    private func makeRowView() -> DataGridRowView {
+        DataGridRowView(frame: NSRect(x: 0, y: 0, width: 120, height: 24))
+    }
+
+    private func renderedTint(of rowView: DataGridRowView) throws -> NSColor {
+        let rep = try #require(rowView.bitmapImageRepForCachingDisplay(in: rowView.bounds))
+        rowView.cacheDisplay(in: rowView.bounds, to: rep)
+        let color = try #require(rep.colorAt(x: rep.pixelsWide / 2, y: rep.pixelsHigh / 2))
+        return try #require(color.usingColorSpace(.sRGB))
+    }
+
+    private func theme(_ base: ThemeDefinition, id: String, deletedHex: String) -> ThemeDefinition {
+        var copy = base
+        copy.id = id
+        copy.dataGrid.deleted = deletedHex
+        return copy
+    }
+
+    @Test("A deleted row takes the new theme's tint even though its state did not change")
+    func deletedRowTintFollowsThemeChange() throws {
+        let engine = ThemeEngine.shared
+        let original = engine.activeTheme
+        defer { engine.activateTheme(original) }
+
+        engine.activateTheme(theme(original, id: "test.tint.red", deletedHex: "#FF0000"))
+        let rowView = makeRowView()
+        rowView.applyVisualState(Self.deleted)
+        let firstTint = try renderedTint(of: rowView)
+
+        engine.activateTheme(theme(original, id: "test.tint.blue", deletedHex: "#0000FF"))
+        rowView.applyVisualState(Self.deleted)
+        let secondTint = try renderedTint(of: rowView)
+
+        #expect(firstTint.redComponent > secondTint.redComponent)
+        #expect(secondTint.blueComponent > firstTint.blueComponent)
+    }
+
+    @Test("A row with no deleted or inserted state stays untinted across a theme change")
+    func plainRowStaysUntinted() throws {
+        let engine = ThemeEngine.shared
+        let original = engine.activeTheme
+        defer { engine.activateTheme(original) }
+
+        engine.activateTheme(theme(original, id: "test.tint.red", deletedHex: "#FF0000"))
+        let rowView = makeRowView()
+        rowView.applyVisualState(.empty)
+        let firstTint = try renderedTint(of: rowView)
+
+        engine.activateTheme(theme(original, id: "test.tint.blue", deletedHex: "#0000FF"))
+        rowView.applyVisualState(.empty)
+        let secondTint = try renderedTint(of: rowView)
+
+        #expect(firstTint.redComponent == secondTint.redComponent)
+        #expect(firstTint.blueComponent == secondTint.blueComponent)
+        #expect(firstTint.alphaComponent == 0)
+        #expect(secondTint.alphaComponent == 0)
+    }
+}


### PR DESCRIPTION
## What you see now

A deleted or newly added row in the data grid kept the previous theme's tint after you switched theme
or appearance. The row only picked up the new colour once you scrolled it away and back, or changed
the row some other way. It updates straight away now, in the results grid and in the structure grid.

Found while fixing #2167, which is the same failure class: a colour resolved once and then held
behind a guard that does not test the input which actually moved.

## Root cause

`DataGridRowView.applyVisualState` opened with

```swift
guard state != visualState else { return }
```

and only recomputed `nextTint` from `ThemeEngine.shared.colors.dataGrid` after that guard.

The tint derives from two inputs, the row's `RowVisualState` and the active theme, but the guard
tested only the first. A theme change moves the second while the first stands still, so the guard
returned and the tint was never recomputed.

Verified end to end on `a5d15d607`:

- `DataGridCoordinator.observeThemeChanges` subscribes to `AppEvents.themeChanged` and calls
  `reloadVisibleRowsAndStates()`.
- `reloadVisibleRowsAndStates` reloads the visible rows, then calls `refreshVisibleRowVisualStates()`.
- `refreshVisibleRowVisualStates` calls `applyVisualState(visualState(for: row))` for every available
  row view, passing the state the theme change did not alter.
- The guard rejected it.

Nothing upstream cured it: that path does no `reloadData` of the whole table and no row-view
recreation.

## The fix

`applyVisualState` already had the right guard one line lower:

```swift
guard !colorsEqual(rowTint, nextTint) else { return }
```

That one tests the derived value, so it does not care which input moved. The fix deletes the state
guard and lets the tint be recomputed on every call, leaving the colour comparison to decide whether
anything needs redisplaying. It removes a short-circuit rather than adding a mechanism.

Deliberately not chosen: a separate `refreshTint()` for the theme path to call. That would leave the
same trap for the next caller and give the row two entry points for one piece of derived state,
against the single-source-of-truth design the surrounding code documents.

## Cost, because this is a per-visible-row path

`applyVisualState` runs for every row view returned from `tableView(_:rowViewForRow:)`, so the guard
was on a hot path and removing it needed checking rather than assuming.

The net change is negative. For a plain row `isDeleted` and `isInserted` are both false, so the `if`
takes its `else` branch and never reads `ThemeEngine`. The guard that went away was a synthesized
`RowVisualState` comparison including a `Set<Int>` equality, which is O(n) for equal but distinct
sets; what replaces it is one `Set` retain on the assignment plus `colorsEqual(nil, nil)`.

One property is load-bearing and holds: `ResolvedThemeColors.deleted` is a stored `let NSColor`,
rebuilt only in `ThemeEngine.activateTheme`, so repeat access returns the same instance and
`colorsEqual` short-circuits on identity. Had it been a computed or dynamic colour, every
`rowViewForRow` would have set `needsDisplay = true` and driven a self-perpetuating invalidation
loop.

## Blast radius

`StructureRowViewWithMenu` subclasses `DataGridRowView` and its context menu reads
`visualState.isDeleted` directly. `visualState` is still assigned on every call, so that is
unaffected, and the earlier bug recorded in the comment at `StructureGridDelegate.swift:415-423`,
where the deleted flag was assigned only on row-view creation, is not reintroduced. `needsDisplay`
has no observer and stays gated by the colour comparison, so the no-op case remains a no-op.
`applyVisualState` calls nothing that calls back into it.

`observeThemeChanges()` runs from `TableViewCoordinator.init`, so the structure and create-table
grids get the fix too.

## Files

- `TablePro/Views/Results/DataGridRowView.swift`
- `TableProTests/Views/Results/DataGridRowTintThemeTests.swift` (new)
- `CHANGELOG.md`

No docs, localization, plugin, ABI, or iOS surface.

## Verification

| step | verdict |
| --- | --- |
| `generate` | PASS |
| `build` | PASS |
| `test`, 5 suites | PASS, 33 of 33 cases |
| `lint --strict`, both changed files | PASS, 0 violations |

Suites: `DataGridRowTintThemeTests`, `DataGridRowViewCopyTests`, `DataGridCellViewDoubleClickTests`,
`DataGridCellSelectionFillTests`, `StructureGridDelegateTests`.

Against the unmodified `DataGridRowView.swift`, `deletedRowTintFollowsThemeChange` fails.
`plainRowStaysUntinted` passes on both, by design: it is a no-regression guard, not the gate.

The gate drives the real sequence rather than asserting on the guard. It applies a deleted state
under one theme, activates a theme whose `dataGrid.deleted` differs, then calls `applyVisualState`
with the **same** state, which is exactly what `refreshVisibleRowVisualStates` does, and reads the
rendered pixel.

## Review

Read-only adversarial review, no findings at P0 to P2. Two P3s, both fixed here:

- The suite comment credited `.serialized` with protecting the shared `ThemeEngine`. That is wrong:
  `.serialized` only orders tests within a suite. The real protection is that both bodies are
  synchronous and `@MainActor`, so nothing else on the main actor can interleave between activating
  the test theme and the `defer` that restores it. The comment now says that, and warns that adding
  an `await` between the two would break it.
- `plainRowStaysUntinted` compared only the first render against the second, so it would also pass if
  `drawBackground` stopped painting entirely. It now asserts the untinted row renders fully
  transparent, which was measured rather than assumed.

Not cross-vendor: the Codex workspace is out of credits, so the same fallback as #2167 applies.

## Known limitations

- No Codex review.
- Not exercised by UI automation. The tint is painted in `drawBackground` with no queryable
  attribute, so an XCUITest cannot see it.
- The manual check of switching theme with a deleted row on screen in the running app has not been
  done; the evidence here is the unit gate and the traced path.
