### PR TITLE
fix(main-content): stop a routing alert hanging the macOS unit test job

### DIFF
--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryRouting.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+QueryRouting.swift
@@ -57,10 +57,10 @@ extension MainContentCoordinator {
     /// is no longer there.
     private func routeToOwningConnection(_ query: String, connectionId owner: UUID, databaseName: String?) {
         guard connectionExists(owner) else {
-            AlertHelper.showErrorSheet(
-                title: String(localized: "Could Not Open Query"),
-                message: String(localized: "The connection this query was recorded against no longer exists."),
-                window: contentWindow
+            presentError(
+                String(localized: "Could Not Open Query"),
+                String(localized: "The connection this query was recorded against no longer exists."),
+                contentWindow
             )
             return
         }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -204,6 +204,14 @@ final class MainContentCoordinator {
         ConnectionStorage.shared.loadConnections().contains { $0.id == id }
     }
 
+    /// Routing failures report through here so a test can observe the message instead of raising a
+    /// real alert. `AlertHelper.present` runs application-modal when no window qualifies, and a
+    /// unit test host has no window, so calling it directly parks the main thread in a modal loop
+    /// that nothing can dismiss and no test time limit can interrupt.
+    @ObservationIgnored var presentError: (String, String, NSWindow?) -> Void = { title, message, window in
+        AlertHelper.showErrorSheet(title: title, message: message, window: window)
+    }
+
     // MARK: - Internal State
 
     /// Per-tab execution ownership. Replaces a per-window generation counter, a stored per-tab

--- a/TableProTests/Views/Main/CoordinatorQueryRoutingTests.swift
+++ b/TableProTests/Views/Main/CoordinatorQueryRoutingTests.swift
@@ -143,6 +143,8 @@ struct CoordinatorQueryRoutingTests {
         var opened: EditorTabPayload?
         coordinator.openTabInNewWindow = { opened = $0 }
         coordinator.connectionExists = { _ in false }
+        var reportedErrors = 0
+        coordinator.presentError = { _, _, _ in reportedErrors += 1 }
 
         coordinator.openQuery(
             "SELECT * FROM Genre",
@@ -152,6 +154,7 @@ struct CoordinatorQueryRoutingTests {
         )
 
         #expect(opened == nil)
+        #expect(reportedErrors == 1)
     }
 
     @Test("A blank query opens nothing at all")


### PR DESCRIPTION
## The failure

`macOS App Tests` hangs in `Run unit tests` and burns the full 60 minute job timeout. Three runs, three commits, three runners, so it is deterministic rather than flaky:

| Run | Commit | Result |
|---|---|---|
| 31945145629 | b31fbb896 | hang |
| 32039425012 | a5d15d607 | hang, cancelled at 60m |
| 32042525398 | ec1eeb50e | hang, cancelled at 1h0m31s |

The console log points at the wrong place. xcbeautify block buffers at about 16 KB, so the rendered tail lags execution by roughly 20 suites and appears to stop inside `MainContentCoordinator column visibility helpers`. The `TestResults.xcresult` artifact that the hanging job uploads names the real one.

## What hangs

`CoordinatorQueryRoutingTests.refusesAQueryFromADeletedConnection()`, `TableProTests/Views/Main/CoordinatorQueryRoutingTests.swift:138`.

The test sets `connectionExists = { _ in false }`, so `routeToOwningConnection` takes its guard branch and shows an error sheet with `contentWindow` nil. `AlertHelper.resolveWindow` finds no titled visible window in the unit test host, so `AlertHelper.present` falls through to `completion(alert.runModal())` at `TablePro/Core/Utilities/UI/AlertHelper.swift:63-66`. That parks the main thread in an application modal loop with nobody to click OK. A Swift Testing `.timeLimit` cannot interrupt a thread blocked in `runModal`, and the step passes `-parallel-testing-enabled NO`, so one blocked test stops the entire run.

Evidence from artifact 9292211607 of run 32039425012: stdout ends at `◇ Test "A query whose connection no longer exists opens no window" started.` followed by one app log line and EOF, and the host session log records `testCaseDidStart` for `refusesAQueryFromADeletedConnection()` with no matching `didFinish`. Artifact 9263810794 of run 31945145629 ends on the identical line.

## The fix

`MainContentCoordinator` already injects `openTabInNewWindow` and `connectionExists` for exactly this reason. This adds a third seam next to them, `presentError`, defaulting to `AlertHelper.showErrorSheet`, and routes the deleted-connection guard through it. The test injects a counter and now asserts both that no window opened and that the error was surfaced, so the branch is covered rather than merely not crashing.

No user-facing behavior changes. The same alert with the same text still reaches the user through the same helper, so there is no changelog entry.

## Origin

Not caused by anything in today's library or CI work. `7f9adefc1` (PR #2137, 2026-08-16) added both the alert branch and the test in the same commit. The last run whose `Run unit tests` step completed is 31941528274 at `1d7935612`, 13m44s, and it contains no `CoordinatorQueryRouting` lines at all. Every run since that reached the step has hung. The missing FreeTDS symbol was failing the job earlier at `Compile every plugin`, which hid this for a day.

## Verification

- `verify.sh test CoordinatorQueryRoutingTests`: 8 executed, 8 passed.
- `verify.sh lint` on both changed app files: 0 violations.
- Not reproducible locally, and this is worth stating plainly. A local test host runs against a real window server, so `resolveWindow` finds a titled visible window and takes the `beginSheetModal` path, which returns immediately. I reverted the fix and re-ran to check, and sampling the host showed the ordinary run loop with no modal frame. The `runModal` branch only triggers where no window qualifies, which is the CI runner. **CI on this PR is the only thing that can prove the fix**, so check that `Run unit tests` completes here rather than timing out.

## Residual risk

This hang masked everything after it, so the unit suite has not run to completion on CI since 2026-08-16. Nine other `AlertHelper.showErrorSheet` call sites exist across the coordinator extensions. Any of them reached by a test would hang the same way. If a new hang appears at a different suite once this merges, that is the likely shape, and the same seam pattern applies.

Separately, `TableProTests/.../BeancountPluginDriverTests.swift:52-56` waits on a subprocess with undrained pipes and no timeout. It is not this hang, but it is a real hazard worth its own issue.
