### PR TITLE
fix(ci): test the Dameng vendored crates through the bridge workspace

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -15,6 +15,7 @@ on:
       - "LocalPackages/**"
       - "TableProTests/**"
       - "TableProUITests/**"
+      - "Native/**"
       - "project.yml"
       - "Configs/**"
       - "Libs/**"
@@ -33,8 +34,10 @@ env:
   TEST_DESTINATION: "platform=macOS"
 
 jobs:
-  # Reproduces the paths filter this workflow used to carry on `on: pull_request`, with the
-  # same union of paths, so a pull request runs exactly the suites it ran before.
+  # Reproduces the paths filter this workflow used to carry on `on: pull_request`. Keep this
+  # list and the `push:` paths above identical, so a pull request and a push to main run the
+  # same suites. `Native/` is on both because the Dameng steps below build and test the Rust
+  # bridge that lives there, and a bridge-only change would otherwise compile nowhere.
   # Never give this job a `permissions:` block. build.yml calls this workflow with
   # workflow_call, and a called job may not request more than the caller holds. The repository
   # default is read, which carries no pull-requests scope, so asking for one fails the whole
@@ -79,7 +82,7 @@ jobs:
           git -c core.quotePath=false diff --no-renames --name-only -z \
               "$BASE_SHA" HEAD > "$RUNNER_TEMP/changed-files"
 
-          if LC_ALL=C grep -zqE '^(TablePro/|Plugins/|Packages/|LocalPackages/|TableProTests/|TableProUITests/|Configs/|Libs/|project\.yml$|\.github/workflows/macos-tests\.yml$)' "$RUNNER_TEMP/changed-files"; then
+          if LC_ALL=C grep -zqE '^(TablePro/|Plugins/|Packages/|LocalPackages/|TableProTests/|TableProUITests/|Native/|Configs/|Libs/|project\.yml$|\.github/workflows/macos-tests\.yml$)' "$RUNNER_TEMP/changed-files"; then
               echo "run=true" >> "$GITHUB_OUTPUT"
           else
               echo "run=false" >> "$GITHUB_OUTPUT"
@@ -161,18 +164,14 @@ jobs:
       - name: Build Dameng native bridge
         run: scripts/build-dameng.sh arm64
 
-      # The vendored crates are path dependencies, not workspace members, so testing the bridge
-      # manifest alone skips every decoder test they carry.
+      # --workspace reaches the vendored crates and the decoder tests they carry. Testing each
+      # manifest on its own instead would need a lockfile per crate that nothing commits.
+      # Run from the bridge directory so rustup reads its rust-toolchain.toml: rustup resolves
+      # that file from the working directory, not from --manifest-path, and testing on the
+      # runner's default Rust would not be the toolchain the shipped staticlib is built with.
       - name: Test Dameng native bridge
-        run: |
-          for manifest in \
-            Native/DamengBridge/Cargo.toml \
-            Native/DamengBridge/Vendor/dameng-types/Cargo.toml \
-            Native/DamengBridge/Vendor/dameng-protocol/Cargo.toml \
-            Native/DamengBridge/Vendor/dameng/Cargo.toml
-          do
-            cargo test --manifest-path "$manifest" --locked
-          done
+        working-directory: Native/DamengBridge
+        run: cargo test --workspace --locked
 
       # Secrets.xcconfig is gitignored. Tests do not need analytics keys, so an empty
       # value is enough for the project to resolve $(ANALYTICS_HMAC_SECRET).

--- a/.gitignore
+++ b/.gitignore
@@ -164,9 +164,9 @@ Libs/.downloaded
 Libs/dylibs/
 Libs/ios/
 
-# Rust driver build outputs (keep the bridge lockfile, ignore vendored crate locks)
+# Rust driver build outputs. The vendored crates are workspace members, so the bridge
+# lockfile is the only one cargo writes.
 Native/DamengBridge/**/target/
-Native/DamengBridge/Vendor/*/Cargo.lock
 
 # Issue analysis blueprints (local only)
 .analysis/

--- a/Native/DamengBridge/Cargo.toml
+++ b/Native/DamengBridge/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["Vendor/*"]
+
 [package]
 name = "tablepro-dameng-bridge"
 version = "0.1.0"

--- a/Plugins/DamengDriverPlugin/README.md
+++ b/Plugins/DamengDriverPlugin/README.md
@@ -30,8 +30,7 @@ Use `scripts/build-dameng.sh arm64` or `x86_64` only for architecture-specific d
 Run protocol, bridge, and Swift tests before submitting a change:
 
 ```bash
-cargo test --manifest-path Native/DamengBridge/Vendor/dameng-protocol/Cargo.toml
-cargo test --manifest-path Native/DamengBridge/Cargo.toml
+(cd Native/DamengBridge && cargo test --workspace --locked)
 xcodebuild -project TablePro.xcodeproj -scheme DamengDriverTests \
   -configuration Debug build-for-testing CODE_SIGNING_ALLOWED=NO
 ```


### PR DESCRIPTION
Fixes the red `macOS Tests` gate on `main` ([run 32092492520](https://github.com/TableProApp/TablePro/actions/runs/32092492520)).

## Root cause

The `Test Dameng native bridge` step added in #2114 loops over four cargo manifests with `--locked`:

```
error: cannot create the lock file .../Vendor/dameng-types/Cargo.lock
because --locked was passed to prevent this
```

Only the bridge lockfile is committed; `Native/DamengBridge/Vendor/*/Cargo.lock` was gitignored. The first iteration passed, the second exited 101, and the required `macOS Tests Gate` went down with it. Reproduced locally on a pristine tree.

## Fix

Make the vendored crates real workspace members, so the single committed lockfile covers all four and one command tests them.

- **`Native/DamengBridge/Cargo.toml`** — added `[workspace]` / `members = ["Vendor/*"]`. The glob tolerates the non-crate `Vendor/UPSTREAM.md` and picks up a future re-vendored crate automatically. `Cargo.lock` is **byte-identical** afterwards (`02bba5b9…` before and after), because lock format v4 records a path package the same way whether it is a member or a path dependency, and no vendored crate has real `[dev-dependencies]`. The MIT vendored manifests are untouched; the table lives in TablePro's own manifest.
- **`.github/workflows/macos-tests.yml`** — the loop becomes `cargo test --workspace --locked` with `working-directory: Native/DamengBridge`. The working directory is load-bearing: rustup resolves `rust-toolchain.toml` from the CWD, not from `--manifest-path`, so running from the repository root tested under the runner's default Rust instead of the pinned 1.91.1 that `scripts/build-dameng.sh` builds the shipped `.a` with. The preceding build step already installs that toolchain.
- **`.gitignore`** — removed the now-dead vendored-lock line.
- **`Plugins/DamengDriverPlugin/README.md`** — one command. The documented pair only ever covered 2 of the 4 crates.

## Related gap closed

`Native/` was in **neither** the `push: paths` list nor the `changes` job grep, so a pull request touching only the Rust bridge skipped every macOS suite — the Dameng build and test steps never ran for the code they exist to cover. Added to both, and the two filters were compared programmatically to confirm they stay symmetric.

## Verification

| Check | Result |
|---|---|
| `cargo test --workspace --locked` from `Native/DamengBridge` | **201 passed** — dameng 32, dameng-protocol 134, dameng-types 33, bridge 2 (+1 ignored, needs a live DM8) |
| Toolchain | 1.91.1, matching `build-dameng.sh` |
| `Cargo.lock` after test and release build | unmodified |
| Stray `Vendor/*/Cargo.lock` | 0 |
| Release build + `nm -gU` | 19 `_tp_dm_*` symbols, `_tp_dm_connect` present |
| YAML parse, filter parity | OK, no asymmetry |

## Reviewer note

`cargo test --workspace` on a package with **no** `[workspace]` table exits 0 having run only that package's own tests — a lone package is its own single-member workspace, and there is no warning. Without the manifest change in this PR, the workflow change alone would report green while the 199 vendored tests never execute, which is worse than the current red. Worth confirming the per-crate `test result:` lines in the CI log rather than the step's exit status.

No changelog entry: CI and build configuration, not user-visible behavior (AGENTS.md).

The cross-vendor Codex review could not run — the plugin is not installed locally and the CLI reported the workspace is out of credits. Its threat list did drive the glob members and the toolchain pinning before it failed.
