### PR TITLE
fix(sidebar): list every object kind the connection returned in flat layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The flat sidebar dropped its Materialized Views, Foreign Tables, Procedures and Functions sections while a connection was recovering from a dropped SSH or proxy tunnel, including after the Mac woke from sleep. Their objects were still listed a moment earlier and came back only once the reconnect finished. The sidebar now lists whatever the connection returned, and switching between the flat and tree layouts shows the same object kinds either way. (#2173)
 - Sixteen-byte SQL binary columns respect their Display As setting in the grid, the row inspector, VoiceOver, and single-cell copy. Raw Value stays selected after refresh, filtered rows keep their identity when the format changes, and MongoDB binary UUIDs remain under the driver's Legacy UUID Encoding setting. (#2157)
 - Viewing a very long single line with word wrap on could use enormous amounts of memory and stall or kill the app. This hit the JSON value viewer, chat code blocks and the SQL review sheet, which always wrap, and the SQL editor when Word Wrap is on. Wrapped text is now laid out once instead of once per wrapped row, so a long line stays fast no matter how long it is.
 - An open cell overlay in the data grid kept its old border and background colour if the appearance changed while it was on screen, such as an automatic switch to dark at sunset. It repaints now.

--- a/TablePro/Models/Sidebar/SidebarObjectKind.swift
+++ b/TablePro/Models/Sidebar/SidebarObjectKind.swift
@@ -1,5 +1,4 @@
 import Foundation
-import TableProPluginKit
 
 struct DatabaseTreeObjectGroup: Hashable, Sendable {
     let database: String
@@ -56,16 +55,6 @@ enum SidebarObjectKind: String, CaseIterable, Sendable, Hashable {
         }
     }
 
-    var capabilityFlag: PluginCapabilities? {
-        switch self {
-        case .table, .view:     return nil
-        case .materializedView: return .materializedViews
-        case .foreignTable:     return .foreignTables
-        case .procedure:        return .storedProcedures
-        case .function:         return .userFunctions
-        }
-    }
-
     var isRoutine: Bool {
         self == .procedure || self == .function
     }
@@ -83,11 +72,20 @@ enum SidebarObjectKind: String, CaseIterable, Sendable, Hashable {
         self == .table
     }
 
-    /// The flat list's rule for a fixed section, which exists as chrome before its contents do. The
-    /// tree builds its groups from what a container holds, so it does not ask this.
-    func shouldRender(itemCount: Int, capabilities: PluginCapabilities) -> Bool {
-        if self == .table { return true }
-        if let capabilityFlag, !capabilities.contains(capabilityFlag) { return false }
-        return itemCount > 0
+    /// Which kinds a container lists, in declaration order. The count is the whole rule: a plugin's
+    /// capability flag says what it declared, not what its driver returned, so gating on one hides
+    /// objects that came back with no section, no status row and no error.
+    ///
+    /// `includingEmptyTables` is the only thing the two sidebar layouts disagree on. The flat root's
+    /// sections are chrome that exists before their contents do, so it keeps Tables whatever the
+    /// count. A tree container answers for itself with its own status row instead.
+    static func visible(
+        itemCounts: [SidebarObjectKind: Int],
+        includingEmptyTables: Bool
+    ) -> [SidebarObjectKind] {
+        allCases.filter { kind in
+            if includingEmptyTables, kind == .table { return true }
+            return itemCounts[kind, default: 0] > 0
+        }
     }
 }

--- a/TablePro/ViewModels/SidebarViewModel.swift
+++ b/TablePro/ViewModels/SidebarViewModel.swift
@@ -5,7 +5,6 @@
 
 import Observation
 import SwiftUI
-import TableProPluginKit
 
 @MainActor @Observable
 final class SidebarViewModel {
@@ -269,23 +268,6 @@ final class SidebarViewModel {
                 forKey: SidebarPersistenceKey.expanded(connectionId: connectionId, kind: kind)
             )
         }
-    }
-
-    // MARK: - Capability Gating
-
-    func capabilities(for connectionId: UUID) -> PluginCapabilities {
-        guard let adapter = DatabaseManager.shared.driver(for: connectionId) as? PluginDriverAdapter else {
-            return []
-        }
-        return adapter.schemaPluginDriver.capabilities
-    }
-
-    func sectionShouldRender(
-        kind: SidebarObjectKind,
-        itemCount: Int,
-        capabilities: PluginCapabilities
-    ) -> Bool {
-        kind.shouldRender(itemCount: itemCount, capabilities: capabilities)
     }
 
     // MARK: - Batch Operations

--- a/TablePro/Views/Sidebar/DatabaseTreeNode.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeNode.swift
@@ -4,21 +4,17 @@
 //
 
 import Foundation
-import TableProPluginKit
 
-/// Which groups a container shows. A group stands for objects the container holds, so the count is
-/// the whole rule: a capability flag says what a plugin declared, not what its driver returned, and
-/// a container with nothing in it answers with its own status row instead.
+/// Which groups a container shows. A group stands for objects the container holds, and a container
+/// with nothing in it answers with its own status row instead, so it lists no empty group at all.
 internal enum DatabaseTreeObjectGroupResolver {
     internal static func groups(
         database: String,
         schema: String?,
         itemCounts: [SidebarObjectKind: Int]
     ) -> [DatabaseTreeObjectGroup] {
-        SidebarObjectKind.allCases.compactMap { kind in
-            guard itemCounts[kind, default: 0] > 0 else { return nil }
-            return DatabaseTreeObjectGroup(database: database, schema: schema, kind: kind)
-        }
+        SidebarObjectKind.visible(itemCounts: itemCounts, includingEmptyTables: false)
+            .map { DatabaseTreeObjectGroup(database: database, schema: schema, kind: $0) }
     }
 }
 

--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Nodes.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Nodes.swift
@@ -131,18 +131,18 @@ extension DatabaseTreeOutlineCoordinator {
         return nodes
     }
 
-    /// The section list is the same rule the flat list used, so a kind that was hidden before stays
-    /// hidden: Tables always shows, anything else needs both the capability and something in it.
+    /// The same rule a tree container uses, so toggling the layout never changes which object kinds
+    /// are on screen. Tables is the one section that survives an empty count, because the flat root
+    /// has no container status row to say so instead.
+    ///
+    /// A torn-down sidebar has no view model and lists nothing at all, Tables included. Counting its
+    /// way to an empty root would put a lone Tables section in a pane that is on its way out.
     private func visibleObjectKinds() -> [SidebarObjectKind] {
-        guard let viewModel else { return [] }
-        let capabilities = viewModel.capabilities(for: connectionId)
-        return SidebarObjectKind.allCases.filter { kind in
-            viewModel.sectionShouldRender(
-                kind: kind,
-                itemCount: flatItemCount(for: kind),
-                capabilities: capabilities
-            )
+        guard viewModel != nil else { return [] }
+        let itemCounts = SidebarObjectKind.allCases.reduce(into: [SidebarObjectKind: Int]()) {
+            $0[$1] = flatItemCount(for: $1)
         }
+        return SidebarObjectKind.visible(itemCounts: itemCounts, includingEmptyTables: true)
     }
 
     internal func flatItemCount(for kind: SidebarObjectKind) -> Int {

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -30,10 +30,6 @@ struct SidebarView: View {
         schemaService.routines(for: connectionId)
     }
 
-    private var pluginCapabilities: PluginCapabilities {
-        viewModel.capabilities(for: connectionId)
-    }
-
     private var hasAnyMatch: Bool {
         SidebarObjectKind.allCases.contains { kind in
             countFor(kind: kind) > 0

--- a/TableProTests/Models/Sidebar/SidebarObjectKindTests.swift
+++ b/TableProTests/Models/Sidebar/SidebarObjectKindTests.swift
@@ -1,0 +1,83 @@
+//
+//  SidebarObjectKindTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+@testable import TablePro
+
+@Suite("SidebarObjectKind visibility")
+struct SidebarObjectKindTests {
+    private let everyKind: [SidebarObjectKind: Int] = [
+        .table: 2, .view: 1, .materializedView: 1, .foreignTable: 1, .procedure: 1, .function: 1,
+    ]
+
+    /// The bug: a driver can return materialized views, foreign tables, procedures or functions that
+    /// its plugin never declared a capability for, and the flat list used to drop them with no
+    /// section, no status row and no error.
+    @Test("A kind with items renders whatever its plugin declared")
+    func itemsAlwaysRender() {
+        for includingEmptyTables in [true, false] {
+            let visible = SidebarObjectKind.visible(
+                itemCounts: everyKind,
+                includingEmptyTables: includingEmptyTables
+            )
+            #expect(visible == [.table, .view, .materializedView, .foreignTable, .procedure, .function])
+        }
+    }
+
+    @Test("Both sidebar layouts list the same object kinds for the same contents")
+    func layoutsAgreeOnNonTableKinds() {
+        let counts: [SidebarObjectKind: Int] = [.materializedView: 3, .foreignTable: 1, .function: 2]
+
+        let flat = SidebarObjectKind.visible(itemCounts: counts, includingEmptyTables: true)
+        let container = SidebarObjectKind.visible(itemCounts: counts, includingEmptyTables: false)
+
+        #expect(flat.filter { $0 != .table } == container.filter { $0 != .table })
+        #expect(container == [.materializedView, .foreignTable, .function])
+    }
+
+    /// The flat root's sections are chrome that exists before their contents do, so Tables stays.
+    /// A tree container says the same thing with its own status row and lists no empty group.
+    @Test("Only the flat root keeps an empty Tables section")
+    func emptyTablesSectionIsFlatOnly() {
+        let counts: [SidebarObjectKind: Int] = [.view: 1]
+
+        #expect(SidebarObjectKind.visible(itemCounts: counts, includingEmptyTables: true) == [.table, .view])
+        #expect(SidebarObjectKind.visible(itemCounts: counts, includingEmptyTables: false) == [.view])
+    }
+
+    @Test("An empty kind other than tables never renders")
+    func emptyKindsAreOmitted() {
+        let counts: [SidebarObjectKind: Int] = [.table: 4]
+
+        #expect(SidebarObjectKind.visible(itemCounts: counts, includingEmptyTables: true) == [.table])
+        #expect(SidebarObjectKind.visible(itemCounts: counts, includingEmptyTables: false) == [.table])
+    }
+
+    @Test("Nothing at all leaves the flat root with Tables and a container with no groups")
+    func noContents() {
+        #expect(SidebarObjectKind.visible(itemCounts: [:], includingEmptyTables: true) == [.table])
+        #expect(SidebarObjectKind.visible(itemCounts: [:], includingEmptyTables: false).isEmpty)
+    }
+
+    /// The flat root supplies a count for every kind, so a zero has to read the same as a key that
+    /// was never there.
+    @Test("A kind counted as zero reads the same as a kind with no count at all")
+    func explicitZeroCounts() {
+        let counted: [SidebarObjectKind: Int] = [
+            .table: 0, .view: 0, .materializedView: 0, .foreignTable: 0, .procedure: 0, .function: 1,
+        ]
+
+        for includingEmptyTables in [true, false] {
+            #expect(
+                SidebarObjectKind.visible(itemCounts: counted, includingEmptyTables: includingEmptyTables)
+                    == SidebarObjectKind.visible(
+                        itemCounts: [.function: 1], includingEmptyTables: includingEmptyTables
+                    )
+            )
+        }
+        #expect(SidebarObjectKind.visible(itemCounts: counted, includingEmptyTables: false) == [.function])
+    }
+}

--- a/TableProTests/ViewModels/SidebarViewModelTests.swift
+++ b/TableProTests/ViewModels/SidebarViewModelTests.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import TableProPluginKit
 import SwiftUI
 import Testing
 @testable import TablePro
@@ -425,52 +424,6 @@ struct SidebarViewModelMultiSectionTests {
 
         let result = vm.effectiveExpanded(kind: .function, hasMatches: false)
 
-        #expect(result == false)
-    }
-
-    @Test("sectionShouldRender always shows tables")
-    @MainActor
-    func tablesAlwaysShown() {
-        let vm = makeViewModel()
-        let empty: PluginCapabilities = []
-
-        #expect(vm.sectionShouldRender(kind: .table, itemCount: 0, capabilities: empty))
-        #expect(vm.sectionShouldRender(kind: .table, itemCount: 5, capabilities: empty))
-    }
-
-    @Test("sectionShouldRender hides matview when capability missing")
-    @MainActor
-    func hidesMatviewWithoutCapability() {
-        let vm = makeViewModel()
-        let result = vm.sectionShouldRender(
-            kind: .materializedView,
-            itemCount: 10,
-            capabilities: []
-        )
-        #expect(result == false)
-    }
-
-    @Test("sectionShouldRender shows matview when capability present and items exist")
-    @MainActor
-    func showsMatviewWithCapability() {
-        let vm = makeViewModel()
-        let result = vm.sectionShouldRender(
-            kind: .materializedView,
-            itemCount: 3,
-            capabilities: [.materializedViews]
-        )
-        #expect(result == true)
-    }
-
-    @Test("sectionShouldRender hides matview when no items even with capability")
-    @MainActor
-    func hidesEmptyMatviewWithCapability() {
-        let vm = makeViewModel()
-        let result = vm.sectionShouldRender(
-            kind: .materializedView,
-            itemCount: 0,
-            capabilities: [.materializedViews]
-        )
         #expect(result == false)
     }
 


### PR DESCRIPTION
Fixes #2173

## Root cause

The sidebar answered "which object kinds does this container list?" in two places.

Tree and hierarchical containers went through `DatabaseTreeObjectGroupResolver.groups`, which counts contents. The flat root went through `visibleObjectKinds()` → `SidebarViewModel.sectionShouldRender` → `SidebarObjectKind.shouldRender(itemCount:capabilities:)`, which additionally required the plugin to have declared a capability flag. That flag only ever suppressed, so for a kind that had rows it was the difference between showing them and hiding them.

Two paths reached it, and neither is a plugin bug.

**The live one.** `capabilities(for:)` returned `[]` whenever `DatabaseManager.driver(for:)` had no active session:

```swift
guard let adapter = DatabaseManager.shared.driver(for: connectionId) as? PluginDriverAdapter else {
    return []
}
```

`PluginDriverAdapter` is the only `DatabaseDriver` conformer in the app, so the cast never failed. The lookup did. `DatabaseManager.recoverDeadTunnel` sets `session.driver = nil` and then retries with exponential backoff, up to 10 attempts with delays growing to 120s, and it is what a dead SSH, Cloudflare, Cloud SQL or SOCKS tunnel and the wake-from-sleep handler both run. For that whole window every gated kind was hidden while `SchemaService`'s cached tables kept the rest of the list on screen. The ordinary health-monitor reconnect is not affected: `reconnectSession` disconnects the driver but leaves the reference in place, and `capabilities` is a pure property that does not need a live connection.

**The latent one.** A driver returns `MATERIALIZED VIEW` or `FOREIGN TABLE` rows from `fetchTables`, or procedures and functions from `fetchRoutines`, while its plugin omits the matching flag. `DatabaseType` is string-backed and the plugin domain is open, so a registry driver only has to forget one line, and the flat list then drops those objects with no section, no `No items` row and no error. I checked all 31 shipped plugins and none trips it today: everything that emits a materialized view or a foreign table declares the flag, MySQL and PostgreSQL are the only drivers implementing `fetchRoutines` and both declare theirs, and Redshift and CockroachDB collapse their view types before the app sees them. So this half is a trap set for the next driver rather than a symptom users hit now.

## The fix

One rule, on the model that owns the kind vocabulary:

```swift
static func visible(itemCounts: [SidebarObjectKind: Int], includingEmptyTables: Bool) -> [SidebarObjectKind]
```

Both the group resolver and the flat root call it. Capabilities no longer decide what is on screen, so toggling **View > Sidebar Layout** cannot change the set of object kinds.

`includingEmptyTables` is now the only thing the two layouts disagree on, and it is deliberate: the flat root's sections are chrome that exists before their contents do, so it keeps Tables whatever the count, while a tree container says the same thing with its own status row and lists no empty group.

An empty section for a *declared* kind stays unrendered, which is what ships today. That was the only remaining use for the flag, so with it declined the flag has no reader left. Removed as dead code:

- `SidebarObjectKind.capabilityFlag` and `shouldRender(itemCount:capabilities:)`
- `SidebarViewModel.sectionShouldRender(kind:itemCount:capabilities:)` and `capabilities(for:)`
- `SidebarView.pluginCapabilities`, which was already dead before this change

The four `PluginCapabilities` constants stay in TableProPluginKit untouched. They are public ABI and every driver plugin declares them; removing a published `public static let` would break every shipped plugin.

## Tests

`TableProTests/Models/Sidebar/SidebarObjectKindTests.swift` pins the shared rule, including the regression itself (a kind with items renders whatever its plugin declared) and the one deliberate difference between the layouts. The four `sectionShouldRender` cases in `SidebarViewModelTests` that pinned the old flat behaviour are gone; `DatabaseTreeNodeTests.objectGroupResolution` is unchanged and still passes, which is the guard that the tree side did not move.

No `TableProUITests` coverage: reproducing this needs a live connection whose driver returns an object kind its plugin does not declare, which does not run deterministically in CI.

## Verified

- `verify.sh generate`: PASS
- `verify.sh build`: PASS
- `verify.sh test SidebarObjectKindTests SidebarViewModelTests DatabaseTreeNodeTests`: PASS, 26 cases
- `verify.sh lint TablePro TableProTests`: PASS, 0 violations

The last change after the full build was a doc comment on `visibleObjectKinds()`, re-linted on its own.
