### PR TITLE
fix(sidebar): show returned object kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Flat sidebar layouts show every object kind returned by the driver, matching Tree layout even when plugin capability metadata omits a kind. (#2173)
 - Sixteen-byte SQL binary columns respect their Display As setting in the grid, the row inspector, VoiceOver, and single-cell copy. Raw Value stays selected after refresh, filtered rows keep their identity when the format changes, and MongoDB binary UUIDs remain under the driver's Legacy UUID Encoding setting. (#2157)
 - Viewing a very long single line with word wrap on could use enormous amounts of memory and stall or kill the app. This hit the JSON value viewer, chat code blocks and the SQL review sheet, which always wrap, and the SQL editor when Word Wrap is on. Wrapped text is now laid out once instead of once per wrapped row, so a long line stays fast no matter how long it is.
 - An open cell overlay in the data grid kept its old border and background colour if the appearance changed while it was on screen, such as an automatic switch to dark at sunset. It repaints now.

--- a/TablePro/Models/Sidebar/SidebarObjectKind.swift
+++ b/TablePro/Models/Sidebar/SidebarObjectKind.swift
@@ -1,5 +1,4 @@
 import Foundation
-import TableProPluginKit
 
 struct DatabaseTreeObjectGroup: Hashable, Sendable {
     let database: String
@@ -56,16 +55,6 @@ enum SidebarObjectKind: String, CaseIterable, Sendable, Hashable {
         }
     }
 
-    var capabilityFlag: PluginCapabilities? {
-        switch self {
-        case .table, .view:     return nil
-        case .materializedView: return .materializedViews
-        case .foreignTable:     return .foreignTables
-        case .procedure:        return .storedProcedures
-        case .function:         return .userFunctions
-        }
-    }
-
     var isRoutine: Bool {
         self == .procedure || self == .function
     }
@@ -83,11 +72,7 @@ enum SidebarObjectKind: String, CaseIterable, Sendable, Hashable {
         self == .table
     }
 
-    /// The flat list's rule for a fixed section, which exists as chrome before its contents do. The
-    /// tree builds its groups from what a container holds, so it does not ask this.
-    func shouldRender(itemCount: Int, capabilities: PluginCapabilities) -> Bool {
-        if self == .table { return true }
-        if let capabilityFlag, !capabilities.contains(capabilityFlag) { return false }
-        return itemCount > 0
+    func shouldRender(itemCount: Int) -> Bool {
+        self == .table || itemCount > 0
     }
 }

--- a/TablePro/ViewModels/SidebarViewModel.swift
+++ b/TablePro/ViewModels/SidebarViewModel.swift
@@ -5,7 +5,6 @@
 
 import Observation
 import SwiftUI
-import TableProPluginKit
 
 @MainActor @Observable
 final class SidebarViewModel {
@@ -271,21 +270,13 @@ final class SidebarViewModel {
         }
     }
 
-    // MARK: - Capability Gating
-
-    func capabilities(for connectionId: UUID) -> PluginCapabilities {
-        guard let adapter = DatabaseManager.shared.driver(for: connectionId) as? PluginDriverAdapter else {
-            return []
-        }
-        return adapter.schemaPluginDriver.capabilities
-    }
+    // MARK: - Section Visibility
 
     func sectionShouldRender(
         kind: SidebarObjectKind,
-        itemCount: Int,
-        capabilities: PluginCapabilities
+        itemCount: Int
     ) -> Bool {
-        kind.shouldRender(itemCount: itemCount, capabilities: capabilities)
+        kind.shouldRender(itemCount: itemCount)
     }
 
     // MARK: - Batch Operations

--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Nodes.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Nodes.swift
@@ -4,7 +4,6 @@
 //
 
 import AppKit
-import TableProPluginKit
 
 /// Turning the connection's metadata into the rows the outline draws. The three sidebar shapes
 /// differ only in what this builds at the root; everything below the root is shared.
@@ -131,16 +130,12 @@ extension DatabaseTreeOutlineCoordinator {
         return nodes
     }
 
-    /// The section list is the same rule the flat list used, so a kind that was hidden before stays
-    /// hidden: Tables always shows, anything else needs both the capability and something in it.
     private func visibleObjectKinds() -> [SidebarObjectKind] {
         guard let viewModel else { return [] }
-        let capabilities = viewModel.capabilities(for: connectionId)
         return SidebarObjectKind.allCases.filter { kind in
             viewModel.sectionShouldRender(
                 kind: kind,
-                itemCount: flatItemCount(for: kind),
-                capabilities: capabilities
+                itemCount: flatItemCount(for: kind)
             )
         }
     }

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -30,10 +30,6 @@ struct SidebarView: View {
         schemaService.routines(for: connectionId)
     }
 
-    private var pluginCapabilities: PluginCapabilities {
-        viewModel.capabilities(for: connectionId)
-    }
-
     private var hasAnyMatch: Bool {
         SidebarObjectKind.allCases.contains { kind in
             countFor(kind: kind) > 0

--- a/TableProTests/ViewModels/SidebarViewModelTests.swift
+++ b/TableProTests/ViewModels/SidebarViewModelTests.swift
@@ -6,10 +6,9 @@
 //
 
 import Foundation
-import TableProPluginKit
 import SwiftUI
-import Testing
 @testable import TablePro
+import Testing
 
 private final class SidebarMockClipboard: ClipboardProvider {
     var lastWrittenText: String?
@@ -432,46 +431,27 @@ struct SidebarViewModelMultiSectionTests {
     @MainActor
     func tablesAlwaysShown() {
         let vm = makeViewModel()
-        let empty: PluginCapabilities = []
 
-        #expect(vm.sectionShouldRender(kind: .table, itemCount: 0, capabilities: empty))
-        #expect(vm.sectionShouldRender(kind: .table, itemCount: 5, capabilities: empty))
+        #expect(vm.sectionShouldRender(kind: .table, itemCount: 0))
+        #expect(vm.sectionShouldRender(kind: .table, itemCount: 5))
     }
 
-    @Test("sectionShouldRender hides matview when capability missing")
+    @Test("sectionShouldRender shows every populated object kind")
     @MainActor
-    func hidesMatviewWithoutCapability() {
+    func showsEveryPopulatedObjectKind() {
         let vm = makeViewModel()
-        let result = vm.sectionShouldRender(
-            kind: .materializedView,
-            itemCount: 10,
-            capabilities: []
-        )
-        #expect(result == false)
+        for kind in SidebarObjectKind.allCases {
+            #expect(vm.sectionShouldRender(kind: kind, itemCount: 1))
+        }
     }
 
-    @Test("sectionShouldRender shows matview when capability present and items exist")
+    @Test("sectionShouldRender hides empty non-table kinds")
     @MainActor
-    func showsMatviewWithCapability() {
+    func hidesEmptyNonTableKinds() {
         let vm = makeViewModel()
-        let result = vm.sectionShouldRender(
-            kind: .materializedView,
-            itemCount: 3,
-            capabilities: [.materializedViews]
-        )
-        #expect(result == true)
-    }
-
-    @Test("sectionShouldRender hides matview when no items even with capability")
-    @MainActor
-    func hidesEmptyMatviewWithCapability() {
-        let vm = makeViewModel()
-        let result = vm.sectionShouldRender(
-            kind: .materializedView,
-            itemCount: 0,
-            capabilities: [.materializedViews]
-        )
-        #expect(result == false)
+        for kind in SidebarObjectKind.allCases where kind != .table {
+            #expect(!vm.sectionShouldRender(kind: kind, itemCount: 0))
+        }
     }
 
     @Test("default expansion is true for tables only")

--- a/docs/databases/overview.mdx
+++ b/docs/databases/overview.mdx
@@ -175,7 +175,7 @@ Hover a connection row and click the star, or right-click and choose **Add to Fa
 
 Leave the **Database** field empty when creating a connection to browse every database your user can access (MySQL, MariaDB, MongoDB, SQL Server, ClickHouse). PostgreSQL and Redshift need an initial database; connect to `postgres` (Redshift: `dev`) and switch with `Cmd+K`.
 
-When the sidebar is in tree layout, each database or schema groups its tables, views, materialized views, foreign tables, procedures, and functions into collapsible folders. View > Filter Databases limits the tree to checked databases, and the same command is in the sidebar right-click menu. The choice is saved per connection.
+When the sidebar is in tree layout, each database or schema groups its tables, views, materialized views, foreign tables, procedures, and functions into collapsible folders. Flat layout shows the same object kinds as top-level sections, and both layouts show every kind the connection reports. View > Filter Databases limits the tree to checked databases, and the same command is in the sidebar right-click menu. The choice is saved per connection.
 
 ## Dock Menu
 


### PR DESCRIPTION
> [!NOTE]
> Maintainer PR #2177 was opened while this draft's preview builds were running. Both pull requests address #2173. This pull request remains a draft until the overlap is resolved.

## Summary

- show every nonempty object-kind section in Flat sidebar layout
- remove capability metadata from section visibility decisions
- keep the empty Tables section while continuing to hide empty optional sections
- update sidebar tests, the changelog, and database navigation documentation

## Root cause

Flat layout required both returned items and the matching plugin capability before rendering Materialized Views, Foreign Tables, Procedures, or Functions. Tree layout already used returned item counts as its source of truth.

That mismatch hid real objects when a plugin omitted a capability flag. It also hid every gated kind while `DatabaseManager` temporarily had no active driver, because that path resolved capabilities to an empty set while cached schema objects remained visible.

Closes #2173

## Preview

Both screenshots use the same isolated fixture. The driver returns `RevenueSummary` as a materialized view without declaring the materialized-view capability, then the sidebar filters for `Revenue`.

### Before

![Flat sidebar before the fix, with the returned materialized view missing](https://raw.githubusercontent.com/sophiathedev/TablePro/pr-assets-2173/.github/pr-assets/2173/sidebar-object-kinds-before.png)

### After

![Flat sidebar after the fix, showing the returned materialized view](https://raw.githubusercontent.com/sophiathedev/TablePro/pr-assets-2173/.github/pr-assets/2173/sidebar-object-kinds-after.png)

## Verification

- [x] 176 focused sidebar, filtering, outline, and type-select tests
- [x] TablePro Debug build
- [x] strict SwiftLint on changed production Swift files, 0 violations
- [x] changed test code linted with existing file-wide baseline rules excluded, 0 additional violations
- [x] `git diff --check`

## Test notes

A deterministic XCUITest is not included because the checked-in SQLite UI fixture does not produce an optional object kind with missing capability metadata. The regression is covered at the visibility boundary for all six object kinds, while existing native outline tests cover Flat and Tree hierarchy behavior.

The verification wrapper's documentation add-on reports an existing `upstream/main` reference to `/Applications/Xcode-beta.app`, which is not installed on this host. SwiftLint itself completed with zero violations on the changed production files.
