### PR TITLE
fix(tabs): draw the editor tab strip as the system tab bar, in the window chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - When a connection fails because a sign-in expired, TablePro now offers to sign in again and reconnects for you, instead of leaving you on an error screen whose only button repeats the same failure. This covers Microsoft Entra ID and AWS SSO, on the connection itself as well as in the connection form's Test button.
+- The editor tab bar moved into the window chrome below the toolbar, where macOS puts its own, and it lines up with the content pane instead of spanning the whole window. Its tabs sit in a filled track rather than floating on the window background, and the selected tab is drawn raised out of that track instead of ringed by a shadow. The bar still appears only once a connection has a second tab.
 
 ### Fixed
 
@@ -34,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A `UNION`, `EXCEPT` or `INTERSECT` result could be edited as though it were a single table, and the edit was written to one of the branches rather than to the rows on screen. Those results are read-only now. So are results from a join, a subquery, a CTE, a temporal `FOR SYSTEM_TIME` read, and `FROM ONLY`.
 - Writing the schema in front of the table, as in `select * from public.users u`, made the results read-only. They are editable now when the schema is the one the connection is already browsing. Naming a different schema stays read-only, because the saved edit would go to the browsed schema instead of the one you queried.
 - The connection window drew a rule under its toolbar that began at the sidebar divider and ran to the right edge, dividing two areas that are the same colour. It is gone.
-- The editor tab bar filled a capsule behind the tabs. In dark mode that fill read as a lighter panel than anything else in the window, so the tabs now sit directly on the window background.
 - Data-grid columns now reserve space for trailing editor and foreign-key actions instead of truncating otherwise fitting values.
 - Empty Structure tabs and structured-value errors keep their toolbar at the top and center the message in the remaining content area.
 - Adding or removing a favorite table updates its sidebar star immediately instead of waiting for the sidebar to reopen.

--- a/TablePro/Core/Services/Infrastructure/ConnectionWindowPaneResolver.swift
+++ b/TablePro/Core/Services/Infrastructure/ConnectionWindowPaneResolver.swift
@@ -43,4 +43,11 @@ internal enum ConnectionWindowPaneResolver {
             return true
         }
     }
+
+    /// The tab strip's band is a list of tabs, so it appears only when there is a list worth
+    /// showing: content behind it, and more than one tab in it. A window with a single tab keeps
+    /// the chrome it always had, which is what the system does too.
+    internal static func showsTabStrip(for pane: ConnectionWindowPane, tabCount: Int) -> Bool {
+        pane == .content && tabCount > 1
+    }
 }

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController+TabStripAccessory.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController+TabStripAccessory.swift
@@ -1,0 +1,92 @@
+//
+//  MainSplitViewController+TabStripAccessory.swift
+//  TablePro
+//
+
+import AppKit
+import SwiftUI
+
+internal extension MainSplitViewController {
+    /// Installed from `TabWindowController.init`, right after the content view controller is
+    /// assigned, rather than from `viewWillAppear`. A window that joins a tab group without ever
+    /// being activated never runs its appearance lifecycle, so a band added there would be missing
+    /// from every background tab until the user clicked it. That is the same shape as the blank
+    /// window title CLAUDE.md records, and the fix is the same: do it at construction.
+    func installTabStripAccessory(on window: NSWindow) {
+        guard !window.titlebarAccessoryViewControllers.contains(where: { $0 === tabStripAccessory }) else { return }
+        tabStripAccessory.setBandVisible(false)
+        window.addTitlebarAccessoryViewController(tabStripAccessory)
+        showSelectedTabStrip()
+    }
+
+    /// The strip is built per connection like the other three panes, so a connection the user is
+    /// not looking at keeps its own strip rather than rebuilding it on every switch.
+    func refreshTabStripPane(of workspace: ConnectionWorkspace) {
+        workspace.panes.tabStrip.rootView = AnyView(buildTabStripView(for: workspace))
+    }
+
+    func showSelectedTabStrip() {
+        tabStripAccessory.show(workspaces.selected?.panes.tabStrip)
+        applyTabStripVisibility()
+    }
+
+    /// Re-arms on every call, which is what makes this safe to drive from anywhere. The first arm
+    /// a window makes is worthless on its own: it runs from `TabWindowController.init`, before the
+    /// connection has a session, so the tracking closure reads through a nil `sessionState` and
+    /// registers a dependency on nothing. Only the call that follows the session coming up sees a
+    /// real `tabManager` to observe, and there is no single moment in the lifecycle that is
+    /// reliably that call.
+    func applyTabStripVisibility() {
+        let tabCount = workspaces.selected?.sessionState?.tabManager.tabs.count ?? 0
+        tabStripAccessory.setBandVisible(
+            ConnectionWindowPaneResolver.showsTabStrip(for: currentPane, tabCount: tabCount)
+        )
+        armTabStripObservation()
+    }
+
+    /// `withObservationTracking` fires once per registration, so something has to re-register.
+    /// Every arm carries the generation it was made at and the newest arm wins, so the arms left
+    /// behind by a repeated call, or by the connection that just left the window, fail their guard
+    /// and die instead of racing the live one. `workspaces.selected` is not itself observable, so a
+    /// workspace switch could never reach the closure and has to re-register from outside.
+    private func armTabStripObservation() {
+        tabStripObservationGeneration += 1
+        let generation = tabStripObservationGeneration
+        withObservationTracking { [weak self] in
+            _ = self?.workspaces.selected?.sessionState?.tabManager.tabs.count
+        } onChange: { [weak self] in
+            /// Observation reports the change before it lands, so the count is read on the next
+            /// turn of the main actor rather than in the callback.
+            Task { @MainActor [weak self] in
+                guard let self, generation == self.tabStripObservationGeneration else { return }
+                self.applyTabStripVisibility()
+            }
+        }
+    }
+
+    /// `commandActions` is read at click time rather than captured, because it only exists once
+    /// the detail pane has appeared and this strip is built alongside that pane, not after it.
+    /// The workspace is held weakly: it owns the hosting controller these closures live in.
+    @ViewBuilder
+    private func buildTabStripView(for workspace: ConnectionWorkspace) -> some View {
+        if let sessionState = workspace.sessionState {
+            EditorTabStrip(
+                tabManager: sessionState.tabManager,
+                onClose: { [weak workspace] id in
+                    workspace?.sessionState?.coordinator.commandActions?.closeTab(id: id)
+                },
+                onCloseOthers: { [weak workspace] id in
+                    workspace?.sessionState?.coordinator.commandActions?.closeOtherTabs(anchoredOn: id)
+                },
+                onCloseAll: { [weak workspace] in
+                    workspace?.sessionState?.coordinator.commandActions?.closeAllTabs()
+                },
+                onNewTab: { [weak workspace] in
+                    workspace?.sessionState?.coordinator.commandActions?.newTab()
+                }
+            )
+        } else {
+            Color.clear
+        }
+    }
+}

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController+TabStripAccessory.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController+TabStripAccessory.swift
@@ -44,14 +44,26 @@ internal extension MainSplitViewController {
         armTabStripObservation()
     }
 
-    /// `withObservationTracking` fires once per registration, so something has to re-register.
-    /// Every arm carries the generation it was made at and the newest arm wins, so the arms left
-    /// behind by a repeated call, or by the connection that just left the window, fail their guard
-    /// and die instead of racing the live one. `workspaces.selected` is not itself observable, so a
-    /// workspace switch could never reach the closure and has to re-register from outside.
+    /// `withObservationTracking` fires once per registration and cannot be cancelled, so something
+    /// has to re-register and nothing may register twice. `applyTabStripVisibility()` runs on every
+    /// phase change and every workspace switch, which would otherwise leave a live arm behind each
+    /// time and wake all of them on the next tab change. An arm is therefore made only when there
+    /// is none, or when the connection on screen changed and the live one is watching the previous
+    /// connection's tab manager: `workspaces.selected` is not itself observable, so a switch can
+    /// never reach the closure on its own.
+    ///
+    /// The generation is still carried, because an arm that has already fired cannot be recalled
+    /// and must fail its own guard rather than act on a window that has moved on.
     private func armTabStripObservation() {
+        let manager = workspaces.selected?.sessionState?.tabManager
+        let identity = manager.map(ObjectIdentifier.init)
+        guard !tabStripObservationIsArmed || identity != tabStripObservedManager else { return }
+
         tabStripObservationGeneration += 1
+        tabStripObservationIsArmed = true
+        tabStripObservedManager = identity
         let generation = tabStripObservationGeneration
+
         withObservationTracking { [weak self] in
             _ = self?.workspaces.selected?.sessionState?.tabManager.tabs.count
         } onChange: { [weak self] in
@@ -59,6 +71,7 @@ internal extension MainSplitViewController {
             /// turn of the main actor rather than in the callback.
             Task { @MainActor [weak self] in
                 guard let self, generation == self.tabStripObservationGeneration else { return }
+                self.tabStripObservationIsArmed = false
                 self.applyTabStripVisibility()
             }
         }

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -89,6 +89,15 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     private var detailPaneHost: WorkspacePaneHost!
     private var inspectorPaneHost: WorkspacePaneHost!
 
+    /// The editor tab strip's band. It is a titlebar accessory rather than a split item, so it is
+    /// owned here but installed on the window, and it follows the selected workspace the same way
+    /// the two hosts above do.
+    let tabStripAccessory = EditorTabStripAccessoryController()
+
+    /// Re-armed each time it fires, and stale arms are dropped by comparing this against the
+    /// generation captured when they registered.
+    var tabStripObservationGeneration = 0
+
     private var chromeState: ChromeState = .unapplied
 
     // MARK: - Panel Layout State
@@ -598,6 +607,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         workspace.panes.sidebar.rootView = AnyView(buildSidebarView(for: workspace))
         workspace.panes.detail.rootView = AnyView(buildDetailView(for: workspace))
         workspace.panes.inspector.rootView = AnyView(buildInspectorView(for: workspace))
+        refreshTabStripPane(of: workspace)
         guard isShowing(workspace) else { return }
         bindSidebarChrome(to: workspace)
     }
@@ -614,6 +624,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         navigationSidebar.objectBrowser.show(selected?.panes.sidebar)
         detailPaneHost.show(selected?.panes.detail)
         inspectorPaneHost.show(selected?.panes.inspector)
+        showSelectedTabStrip()
         if let selected { bindSidebarChrome(to: selected) }
     }
 
@@ -1073,6 +1084,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         } else {
             revealWindowChrome()
         }
+        applyTabStripVisibility()
         toolbarOwner?.managedToolbar.validateVisibleItems()
         recomputeWindowMinSize()
     }

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -98,6 +98,13 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     /// generation captured when they registered.
     var tabStripObservationGeneration = 0
 
+    /// `withObservationTracking` has no way to cancel a registration, so re-registering blindly
+    /// leaves one live arm per call behind until the next change wakes them all. These two say
+    /// whether the live arm still watches the right tab manager, so a repeated call is free and
+    /// only a workspace switch or a fired arm registers again.
+    var tabStripObservationIsArmed = false
+    var tabStripObservedManager: ObjectIdentifier?
+
     private var chromeState: ChromeState = .unapplied
 
     // MARK: - Panel Layout State

--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -80,6 +80,7 @@ internal final class TabWindowController: NSWindowController, NSWindowDelegate {
         FileDropDestination.register(on: window)
         window.title = splitVC.windowTitle
         window.subtitle = splitVC.windowSubtitle
+        splitVC.installTabStripAccessory(on: window)
 
         super.init(window: window)
 

--- a/TablePro/Core/Services/Infrastructure/WorkspacePaneHost.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspacePaneHost.swift
@@ -5,12 +5,14 @@
 
 import AppKit
 
-/// A split item's stable view controller, showing one connection's pane at a time.
+/// A stable container showing one connection's pane at a time, used by the split items and by the
+/// titlebar accessory that carries the editor tab strip.
 ///
 /// `NSSplitViewItem.viewController` cannot be reassigned once the item is installed in an
 /// `NSSplitViewController`, so a window that hosts several connections cannot swap the item itself.
 /// It swaps the item's child instead, which is what lets every other connection's view tree stay
-/// alive rather than be rebuilt from scratch on each switch.
+/// alive rather than be rebuilt from scratch on each switch. A titlebar accessory has the same
+/// shape of problem: one accessory per window, one strip per connection.
 ///
 /// The container publishes no size of its own: it owns no intrinsic content size and every pane it
 /// shows is an `NSHostingController` with `sizingOptions = []`. That is the firewall keeping tab

--- a/TablePro/Core/Services/Infrastructure/WorkspacePanes.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspacePanes.swift
@@ -26,18 +26,24 @@ internal final class WorkspacePanes {
     internal let detail: NSHostingController<AnyView>
     internal let inspector: NSHostingController<AnyView>
     internal let sidebar: NSHostingController<AnyView>
+    /// The editor tab strip. It is a pane like the other three, built and kept alive per
+    /// connection, even though the window shows it in the titlebar accessory rather than in a
+    /// split item. Holding it here is what gives it the same `sizingOptions` firewall and the
+    /// same teardown as everything else the connection owns.
+    internal let tabStrip: NSHostingController<AnyView>
 
     internal init() {
         detail = NSHostingController(rootView: AnyView(Color.clear))
         inspector = NSHostingController(rootView: AnyView(Color.clear))
         sidebar = NSHostingController(rootView: AnyView(Color.clear))
+        tabStrip = NSHostingController(rootView: AnyView(Color.clear))
         for pane in panes {
             pane.sizingOptions = []
         }
     }
 
     private var panes: [NSHostingController<AnyView>] {
-        [detail, inspector, sidebar]
+        [detail, inspector, sidebar, tabStrip]
     }
 
     /// Empties every pane and unparents it. A hosting controller retains its SwiftUI tree, which

--- a/TablePro/Views/Main/EditorTabStrip.swift
+++ b/TablePro/Views/Main/EditorTabStrip.swift
@@ -257,6 +257,11 @@ private struct EditorTabStripItem: View {
         }
         .padding(.horizontal, EditorTabStripLayout.accessoryInset)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        /// The whole tab is the target, not the glyphs. A `Button` hit-tests the shape its label
+        /// draws, and this label is a short run of text between two clear spacers, so without a
+        /// shape of its own everything either side of a title like "Album" stops selecting the
+        /// tab: roughly 55pt of dead zone at each end of a 184pt tab.
+        .contentShape(Rectangle())
     }
 
     private var positionDescription: String {

--- a/TablePro/Views/Main/EditorTabStrip.swift
+++ b/TablePro/Views/Main/EditorTabStrip.swift
@@ -5,17 +5,25 @@
 
 import SwiftUI
 
-/// The editor tabs for one connection, built to the system tab bar's own geometry. Native window
-/// tabs cannot express this: a window belongs to exactly one tab group and a group's bar shows
-/// every window in it, so one window hosting several connections could only ever show all of
-/// their tabs interleaved.
+/// The editor tabs for one connection, drawn to the geometry of `NSTabBar`, the private control
+/// the system's own window tab bar is built from. Native window tabs cannot express this: a window
+/// belongs to exactly one tab group and a group's bar shows every window in it, so one window
+/// hosting several connections could only ever show all of their tabs interleaved.
 ///
-/// Glass is applied where the system applies it and nowhere else: the selected tab and the new-tab
-/// button, which is the one pane the system slides along its track. The track carries no fill of
-/// its own. The strip sits in the content view over plain window background rather than on toolbar
-/// material, and an alpha fill lands at very different strength on the two appearances there:
-/// `quaternarySystemFill` is a white wash over the dark chrome and a black one over the light
-/// chrome, which in dark mode reads as a raised panel no other part of the window has.
+/// The band is a titlebar accessory rather than a row in the content stack, so this view draws
+/// only what sits inside it: a filled track pinned to the band's top edge, and a new-tab button
+/// outside the track. `EditorTabStripAccessoryController` owns the band itself.
+///
+/// The track carries a surface, which is the whole difference between a tab bar and three loose
+/// pills. Without one the selected tab is a lone pane of glass over the content background, and
+/// glass draws itself there as a control floating above content, with the drop shadow to match:
+/// the tab ended up ringed in shadow where the system rings it in light. The two capsules are
+/// concentric at their ends, the selected one inset two points inside the track, which is why it
+/// never overruns the track's curve.
+///
+/// Track, selected tab and new-tab button are all glass, which is what the system does too. The
+/// increments are small because each one samples the glass beneath it, and that is the effect:
+/// the selection reads through its stroke and its label, not through a brighter fill.
 internal struct EditorTabStrip: View {
     internal let tabManager: QueryTabManager
     internal let onClose: (UUID) -> Void
@@ -27,17 +35,44 @@ internal struct EditorTabStrip: View {
     @Environment(\.controlActiveState) private var controlActiveState
 
     internal var body: some View {
-        HStack(spacing: EditorTabStripLayout.trackSpacing) {
-            track
-            EditorTabStripNewButton(action: onNewTab, isWindowActive: isWindowActive)
+        glassContainer {
+            HStack(spacing: EditorTabStripLayout.trackSpacing) {
+                track
+                EditorTabStripNewButton(action: onNewTab, isWindowActive: isWindowActive)
+            }
+            .frame(height: EditorTabStripLayout.trackHeight)
         }
-        .padding(EditorTabStripLayout.stripInset)
+        .padding(.horizontal, EditorTabStripLayout.stripInset)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .onChange(of: controlActiveState) { _, state in
             if state == .inactive { hoveredTabId = nil }
+        }
+        /// A closed tab leaves its id behind, and the tab that slides into its place would
+        /// otherwise light up under a pointer that never moved onto it.
+        .onChange(of: tabManager.tabs.map(\.id)) { _, ids in
+            if let hoveredTabId, !ids.contains(hoveredTabId) { self.hoveredTabId = nil }
         }
         .accessibilityElement(children: .contain)
         .accessibilityLabel(Text("Editor Tabs"))
         .accessibilityAddTraits(.isTabBar)
+    }
+
+    /// One container for every glass element in the strip. Glass cannot sample glass across
+    /// containers, so the track, the selected tab and the new-tab button light inconsistently
+    /// when they are not grouped, and the button sits only four points from the track's edge.
+    ///
+    /// `spacing` stays at zero. It is the proximity at which the container starts *merging*
+    /// neighbouring shapes into one, and the new-tab button flowing into the track is not wanted.
+    /// Note that grouping is not free: the container raises the glass it holds above the rest of
+    /// its content, which is why every control the tabs draw has to live inside its own glass
+    /// rather than beside it.
+    @ViewBuilder
+    private func glassContainer(@ViewBuilder content: () -> some View) -> some View {
+        if #available(macOS 26.0, *) {
+            GlassEffectContainer(spacing: 0) { content() }
+        } else {
+            content()
+        }
     }
 
     private var track: some View {
@@ -67,9 +102,13 @@ internal struct EditorTabStrip: View {
                 }
             }
             .frame(height: EditorTabStripLayout.tabHeight)
+            /// Clipped to the same capsule the tabs are drawn as, so a tab scrolled under the
+            /// track's rounded end is cut by that curve instead of squaring it off.
+            .clipShape(Capsule(style: .continuous))
             .padding(EditorTabStripLayout.trackPadding)
         }
         .frame(height: EditorTabStripLayout.trackHeight)
+        .trackSurface()
     }
 
     private func item(for tab: QueryTab, at index: Int) -> some View {
@@ -105,6 +144,23 @@ internal struct EditorTabStrip: View {
     }
 }
 
+/// Read off the system's own tab bar rather than chosen. Every value is a semantic `NSColor` so
+/// the light appearance inverts with the system instead of needing a second hand-tuned palette:
+/// a fill that lifts the track above dark chrome recesses it below light chrome, which is what a
+/// track is supposed to do in both.
+private enum EditorTabStripPalette {
+    /// Only reached before macOS 26, where there is no glass to stand in for the system's track
+    /// material. This is an opaque tone rather than an alpha wash for the same reason the material
+    /// is: measured at rgb(220) light and rgb(70) dark, against a system track of rgb(228) and
+    /// rgb(77), it is the closest system colour that stays lighter than the chrome in both.
+    static var trackFill: Color { Color(nsColor: .unemphasizedSelectedContentBackgroundColor) }
+    /// Half the weight of a separator. `separatorColor` was twice the measured edge and read as a
+    /// drawn outline rather than the lit rim the system puts there.
+    static var trackEdge: Color { Color(nsColor: .quinaryLabel) }
+    static var hoverFill: Color { Color(nsColor: .tertiarySystemFill) }
+    static var separator: Color { Color(nsColor: .separatorColor) }
+}
+
 private struct EditorTabStripItem: View {
     let tab: QueryTab
     let isSelected: Bool
@@ -122,45 +178,23 @@ private struct EditorTabStripItem: View {
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
-        Button(action: onSelect) {
-            ZStack {
-                if showsLeadingSeparator {
-                    HStack {
-                        Rectangle()
-                            .fill(Color(nsColor: .separatorColor))
-                            .frame(width: 1, height: EditorTabStripLayout.separatorHeight)
-                        Spacer()
-                    }
+        ZStack {
+            if showsLeadingSeparator {
+                HStack {
+                    Rectangle()
+                        .fill(EditorTabStripPalette.separator)
+                        .frame(
+                            width: EditorTabStripLayout.hairline,
+                            height: EditorTabStripLayout.separatorHeight
+                        )
+                    Spacer()
                 }
-
-                background
-
-                /// A spacer holds each end so the title stays optically centred. The close button
-                /// sits in the leading one as a sibling overlay rather than inside this label,
-                /// because a button nested in a button never receives the click.
-                HStack(spacing: 0) {
-                    Color.clear
-                        .frame(width: EditorTabStripLayout.accessoryWidth)
-                    Text(tab.title)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .italic(tab.isPreview)
-                        .font(.system(size: EditorTabStripLayout.fontSize))
-                        .foregroundStyle(titleColor)
-                        .frame(maxWidth: .infinity)
-                    Color.clear
-                        .frame(width: EditorTabStripLayout.accessoryWidth)
-                }
-                .padding(.horizontal, EditorTabStripLayout.accessoryInset)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .contentShape(Rectangle())
+
+            surface
         }
-        .buttonStyle(.plain)
-        .overlay(alignment: .leading) {
-            closeButton
-                .padding(.leading, EditorTabStripLayout.accessoryInset)
-        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .contentShape(Rectangle())
         .onHover(perform: onHover)
         .help(Text(tab.title))
         .contextMenu {
@@ -169,6 +203,7 @@ private struct EditorTabStripItem: View {
             Button(String(localized: "Close All Tabs"), action: onCloseAll)
         }
         .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
         .accessibilityIdentifier("editor-tab")
         .accessibilityLabel(Text(tab.title))
         .accessibilityValue(Text(positionDescription))
@@ -176,28 +211,66 @@ private struct EditorTabStripItem: View {
         .accessibilityAction(named: Text("Close Tab"), onClose)
     }
 
+    /// Everything the tab draws lives inside the glass, never over it. A `GlassEffectContainer`
+    /// raises the glass it holds above the rest of that container's content, so a sibling drawn
+    /// earlier in a `ZStack`, or an overlay attached outside, is painted over rather than under:
+    /// the title first measured dimmer than every unselected one, and the close button vanished
+    /// from the selected tab entirely.
+    ///
+    /// The two controls are siblings rather than nested, because a button inside another button's
+    /// label never receives the click.
+    private var surface: some View {
+        ZStack {
+            Button(action: onSelect) { title }
+                .buttonStyle(.plain)
+
+            HStack(spacing: 0) {
+                closeButton
+                Spacer(minLength: 0)
+            }
+            .padding(.leading, EditorTabStripLayout.accessoryInset)
+        }
+        .tabSurface(
+            isSelected: isSelected,
+            isHovered: isHovered,
+            isWindowActive: isWindowActive,
+            isLightAppearance: colorScheme == .light
+        )
+    }
+
+    /// A spacer holds each end so the title stays optically centred. The close button sits in the
+    /// leading one as a sibling overlay rather than inside this label, because a button nested in
+    /// a button never receives the click.
+    private var title: some View {
+        HStack(spacing: 0) {
+            Color.clear
+                .frame(width: EditorTabStripLayout.accessoryWidth)
+            Text(tab.title)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .italic(tab.isPreview)
+                .font(.system(size: EditorTabStripLayout.fontSize))
+                .foregroundStyle(titleColor)
+                .frame(maxWidth: .infinity)
+            Color.clear
+                .frame(width: EditorTabStripLayout.accessoryWidth)
+        }
+        .padding(.horizontal, EditorTabStripLayout.accessoryInset)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
     private var positionDescription: String {
         String(format: String(localized: "%1$d of %2$d"), position, count)
     }
 
+    /// The system draws both labels in the same face at the same size and separates them by colour
+    /// alone; measuring its bar shows identical glyph advances for a selected and an unselected
+    /// title, so weight carries no meaning here.
     private var titleColor: Color {
         guard isWindowActive else {
             return Color(nsColor: isSelected ? .secondaryLabelColor : .tertiaryLabelColor)
         }
         return Color(nsColor: isSelected ? .labelColor : .secondaryLabelColor)
-    }
-
-    /// The selected tab is the one pane of glass the system raises out of the track. An
-    /// unselected tab is not inert either: hovering fills it so the pointer has something to
-    /// land on, and a background window shows neither.
-    @ViewBuilder
-    private var background: some View {
-        if isSelected {
-            Color.clear.selectedTabSurface(isLightAppearance: colorScheme == .light, isWindowActive: isWindowActive)
-        } else if isHovered, isWindowActive {
-            Capsule(style: .continuous)
-                .fill(Color(nsColor: .quaternarySystemFill))
-        }
     }
 
     /// Shown for the tab in front at all times, and for any tab the pointer is over, so closing
@@ -276,6 +349,55 @@ private struct EditorTabStripNewButton: View {
 }
 
 private extension View {
+    /// The track is a material, not a wash. Sampling the system's own bar against three different
+    /// chrome colours shows it converging on a fixed tone rather than tinting whatever is behind
+    /// it: about 78 percent opaque over rgb(77) in dark, and 85 percent over rgb(228) in light. It
+    /// therefore reads *lighter* than the chrome in both appearances, which no alpha-based system
+    /// fill can do. `secondarySystemFill` is a white wash in dark and a black one in light, so it
+    /// lands within a few points of the system in dark and inverts in light, a track darker than
+    /// the titlebar it sits in. `glassEffect` is measured within six points of the system in both.
+    ///
+    /// The glass goes on the track's own content rather than behind it as a `.background`, because
+    /// a `GlassEffectContainer` raises the glass it holds above the container's other content: a
+    /// track drawn as a sibling layer paints over the tabs it is supposed to sit under.
+    @ViewBuilder
+    func trackSurface() -> some View {
+        if #available(macOS 26.0, *) {
+            glassEffect(.regular, in: Capsule(style: .continuous))
+        } else {
+            background(
+                Capsule(style: .continuous)
+                    .fill(EditorTabStripPalette.trackFill)
+                    .overlay(
+                        Capsule(style: .continuous)
+                            .strokeBorder(
+                                EditorTabStripPalette.trackEdge,
+                                lineWidth: EditorTabStripLayout.hairline
+                            )
+                    )
+            )
+        }
+    }
+
+    /// The selected tab is the one pane of glass the system raises out of the track. An unselected
+    /// tab is not inert either: hovering fills it so the pointer has something to land on, and a
+    /// background window shows neither.
+    @ViewBuilder
+    func tabSurface(
+        isSelected: Bool,
+        isHovered: Bool,
+        isWindowActive: Bool,
+        isLightAppearance: Bool
+    ) -> some View {
+        if isSelected {
+            selectedTabSurface(isLightAppearance: isLightAppearance, isWindowActive: isWindowActive)
+        } else if isHovered, isWindowActive {
+            background(Capsule(style: .continuous).fill(EditorTabStripPalette.hoverFill))
+        } else {
+            self
+        }
+    }
+
     /// Glass on macOS 26 and later, and the flat control fill that preceded it before that.
     /// `controlBackgroundColor` is not the fallback: it matches the window background exactly in
     /// dark mode, so the raised tab would read as a hole punched in its own track.

--- a/TablePro/Views/Main/EditorTabStripAccessoryController.swift
+++ b/TablePro/Views/Main/EditorTabStripAccessoryController.swift
@@ -64,8 +64,22 @@ internal final class EditorTabStripAccessoryController: NSTitlebarAccessoryViewC
 
     /// `hidden` collapses the band to zero height without taking it off the window, which is what
     /// keeps a connection's strip built while the window shows a pane that has no tabs to list.
+    ///
+    /// The band collapses under whatever had keyboard focus, so focus is let go on the way down.
+    /// Closing the second-to-last tab from the strip is enough to reach this: the button that was
+    /// clicked is inside the band that is now zero points tall, and a first responder in a view
+    /// with no size leaves Full Keyboard Access tabbing out of somewhere invisible.
     internal func setBandVisible(_ isVisible: Bool) {
         guard isHidden == isVisible else { return }
+        if !isVisible { resignFirstResponderInsideBand() }
         isHidden = !isVisible
+    }
+
+    private func resignFirstResponderInsideBand() {
+        guard let window = view.window,
+              let responder = window.firstResponder as? NSView,
+              responder.isDescendant(of: view)
+        else { return }
+        window.makeFirstResponder(nil)
     }
 }

--- a/TablePro/Views/Main/EditorTabStripAccessoryController.swift
+++ b/TablePro/Views/Main/EditorTabStripAccessoryController.swift
@@ -1,0 +1,71 @@
+//
+//  EditorTabStripAccessoryController.swift
+//  TablePro
+//
+
+import AppKit
+
+/// The window chrome band that holds the editor tab strip, in the same place the system puts its
+/// own: a bottom titlebar accessory, flush under the toolbar.
+///
+/// This is not a styling choice. A runtime probe of `NSTabBar`, the private control Finder's tab
+/// bar is built from, shows it hosted in exactly this way, and AppKit gives the placement two
+/// things a content-view mount cannot have. The accessory is inset past a `.sidebar` split item
+/// automatically, so the band starts where the content pane starts rather than at the window edge,
+/// with no sidebar-width tracking of our own. And the window's `contentLayoutRect` shrinks by the
+/// band, so the content below is laid out around it instead of being pushed by a stack.
+///
+/// Three properties have to be set together or the band misbehaves in ways that only show up in
+/// one state. `automaticallyAdjustsSize` defaults to true and would resize the view to the
+/// system's standard accessory height, discarding ours. `fullScreenMinHeight` defaults to zero,
+/// and the header is explicit that zero "will fully hide the view when the menu bar is hidden", so
+/// leaving it would make the tab strip vanish in full screen. `layoutAttribute` must be `.bottom`
+/// for either of the other two to apply at all.
+@MainActor
+internal final class EditorTabStripAccessoryController: NSTitlebarAccessoryViewController {
+    /// The strip belongs to one connection, the accessory belongs to the window, and a window
+    /// hosts several connections. The band therefore shows the selected workspace's own strip the
+    /// same way the split items show its panes, so every other connection's strip stays built.
+    private let paneHost = WorkspacePaneHost()
+
+    internal init() {
+        super.init(nibName: nil, bundle: nil)
+        layoutAttribute = .bottom
+        automaticallyAdjustsSize = false
+        fullScreenMinHeight = EditorTabStripLayout.bandHeight
+    }
+
+    @available(*, unavailable)
+    internal required init?(coder: NSCoder) {
+        fatalError("EditorTabStripAccessoryController does not support NSCoder init")
+    }
+
+    /// The width is a placeholder AppKit replaces with the pane's; only the height is ours, and
+    /// `NSTitlebarAccessoryViewController` observes it for changes.
+    override internal func loadView() {
+        let band = NSView(frame: NSRect(x: 0, y: 0, width: 1, height: EditorTabStripLayout.bandHeight))
+        view = band
+
+        addChild(paneHost)
+        let hosted = paneHost.view
+        hosted.translatesAutoresizingMaskIntoConstraints = false
+        band.addSubview(hosted)
+        NSLayoutConstraint.activate([
+            hosted.leadingAnchor.constraint(equalTo: band.leadingAnchor),
+            hosted.trailingAnchor.constraint(equalTo: band.trailingAnchor),
+            hosted.topAnchor.constraint(equalTo: band.topAnchor),
+            hosted.bottomAnchor.constraint(equalTo: band.bottomAnchor),
+        ])
+    }
+
+    internal func show(_ controller: NSViewController?) {
+        paneHost.show(controller)
+    }
+
+    /// `hidden` collapses the band to zero height without taking it off the window, which is what
+    /// keeps a connection's strip built while the window shows a pane that has no tabs to list.
+    internal func setBandVisible(_ isVisible: Bool) {
+        guard isHidden == isVisible else { return }
+        isHidden = !isVisible
+    }
+}

--- a/TablePro/Views/Main/EditorTabStripLayout.swift
+++ b/TablePro/Views/Main/EditorTabStripLayout.swift
@@ -7,8 +7,14 @@ import CoreGraphics
 import Foundation
 
 /// The geometry and visibility rules of the editor tab strip, kept apart from the view so they
-/// can be tested. Both rules were read off the system tab bar rather than designed.
+/// can be tested. Every number here was measured off `NSTabBar`, the private control Finder's own
+/// tab bar is built from, rather than designed: a runtime probe of its view tree on macOS 27 gives
+/// a 36pt titlebar accessory holding a 28pt bar, whose track is inset 8pt, then 4pt of gap, then a
+/// 28pt new-tab button, then 8pt to the trailing edge.
 internal enum EditorTabStripLayout {
+    /// The titlebar accessory's own height. The track is pinned to its top edge, flush against the
+    /// toolbar, and what remains below is the clearance the system leaves before the content.
+    internal static let bandHeight: CGFloat = 36
     internal static let trackHeight: CGFloat = 28
     internal static let tabHeight: CGFloat = 24
     internal static let trackPadding: CGFloat = 2
@@ -16,10 +22,16 @@ internal enum EditorTabStripLayout {
     internal static let trackSpacing: CGFloat = 4
     internal static let newTabButtonSize: CGFloat = 28
     internal static let minimumTabWidth: CGFloat = 120
-    internal static let separatorHeight: CGFloat = 18
+    internal static let separatorHeight: CGFloat = 16
     internal static let accessoryWidth: CGFloat = 16
     internal static let accessoryInset: CGFloat = 5
     internal static let fontSize: CGFloat = 11
+
+    /// One device pixel on the 2x displays this chrome is drawn for, which is what the system uses
+    /// for both the track's edge and the rule between two tabs.
+    internal static let hairline: CGFloat = 0.5
+
+    internal static var bandBottomClearance: CGFloat { bandHeight - trackHeight }
 
     /// Tabs share the track equally, and stop shrinking at a width that still fits a name so a
     /// long list scrolls instead of collapsing into slivers. The system staggers widths slightly

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -323,7 +323,7 @@ struct MainContentView: View {
     }
 
     private var bodyContentCore: some View {
-        editorTabStripAndContent
+        mainContentView
             .task {
                 let start = Date()
                 Self.lifecycleLogger.info(
@@ -387,28 +387,6 @@ struct MainContentView: View {
     }
 
     // MARK: - Main Content
-
-    /// These tabs belong to one connection's editor pane, not to the window, so they sit above the
-    /// pane the way Xcode places its editor tabs. The titlebar is where a window's own document
-    /// tabs go, and putting a pane-level strip there moves the window's base line below it and
-    /// paints the strip on titlebar material instead of the content background.
-    ///
-    /// The strip is hidden while a connection holds a single tab, so a window that behaves the
-    /// way it always did gains no chrome. It appears the moment a second tab exists.
-    private var editorTabStripAndContent: some View {
-        VStack(spacing: 0) {
-            if tabManager.tabs.count > 1 {
-                EditorTabStrip(
-                    tabManager: tabManager,
-                    onClose: { coordinator.commandActions?.closeTab(id: $0) },
-                    onCloseOthers: { coordinator.commandActions?.closeOtherTabs(anchoredOn: $0) },
-                    onCloseAll: { coordinator.commandActions?.closeAllTabs() },
-                    onNewTab: { coordinator.commandActions?.newTab() }
-                )
-            }
-            mainContentView
-        }
-    }
 
     @ViewBuilder
     private var mainContentView: some View {

--- a/TableProTests/Core/Services/Infrastructure/ConnectionWindowPaneResolverTests.swift
+++ b/TableProTests/Core/Services/Infrastructure/ConnectionWindowPaneResolverTests.swift
@@ -154,4 +154,27 @@ struct ConnectionWindowPaneResolverTests {
             }
         }
     }
+
+    @Test("The tab strip band appears only for content with more than one tab")
+    func tabStripBandFollowsContentAndTabCount() {
+        #expect(ConnectionWindowPaneResolver.showsTabStrip(for: .content, tabCount: 2))
+        #expect(ConnectionWindowPaneResolver.showsTabStrip(for: .content, tabCount: 9))
+
+        /// A single tab is the window every connection opens with, and it gained no chrome
+        /// before this band existed.
+        #expect(!ConnectionWindowPaneResolver.showsTabStrip(for: .content, tabCount: 1))
+        #expect(!ConnectionWindowPaneResolver.showsTabStrip(for: .content, tabCount: 0))
+    }
+
+    @Test("A pane with no session behind it shows no tab strip, whatever the stale tab count says")
+    func tabStripBandHiddenWithoutContent() {
+        for pane in [
+            ConnectionWindowPane.connecting,
+            .unavailable(.notConnected),
+            .unavailable(.failed(Self.failure)),
+            .empty,
+        ] {
+            #expect(!ConnectionWindowPaneResolver.showsTabStrip(for: pane, tabCount: 5))
+        }
+    }
 }

--- a/TableProTests/Views/Main/EditorTabStripAccessoryControllerTests.swift
+++ b/TableProTests/Views/Main/EditorTabStripAccessoryControllerTests.swift
@@ -1,0 +1,80 @@
+//
+//  EditorTabStripAccessoryControllerTests.swift
+//  TableProTests
+//
+
+import AppKit
+import Testing
+
+@testable import TablePro
+
+/// Three of these properties look like configuration and are really correctness. Probing a bottom
+/// titlebar accessory on macOS 27 shows `automaticallyAdjustsSize` resizing the band to the
+/// system's own height when left at its default, and `fullScreenMinHeight` clipping the band to a
+/// stale value in full screen while the windowed layout still looks right. `fullScreenMinHeight`
+/// left at its default of zero measured as zero drawn pixels once the menu bar auto-hid: the strip
+/// disappears on entering full screen and does not come back for the rest of the session.
+@Suite("Editor tab strip accessory")
+@MainActor
+struct EditorTabStripAccessoryControllerTests {
+    @Test("The band is configured as a bottom accessory that keeps its own height")
+    func bandConfiguration() {
+        let accessory = EditorTabStripAccessoryController()
+        _ = accessory.view
+
+        #expect(accessory.layoutAttribute == .bottom)
+        #expect(!accessory.automaticallyAdjustsSize)
+        #expect(accessory.view.frame.height == EditorTabStripLayout.bandHeight)
+    }
+
+    /// The header's rule is that a fully shown accessory sets this to the view's height, "and be
+    /// sure to update it if you ever change the view's height". Asserting the equality rather than
+    /// the literal is what makes a future height change fail here instead of in full screen.
+    @Test("Full screen keeps the whole band rather than clipping it")
+    func fullScreenMinHeightMatchesTheBand() {
+        let accessory = EditorTabStripAccessoryController()
+        _ = accessory.view
+
+        #expect(accessory.fullScreenMinHeight == accessory.view.frame.height)
+        #expect(accessory.fullScreenMinHeight > 0)
+    }
+
+    @Test("Hiding the band collapses it without taking it off the window")
+    func bandVisibilityToggles() {
+        let accessory = EditorTabStripAccessoryController()
+        _ = accessory.view
+
+        accessory.setBandVisible(false)
+        #expect(accessory.isHidden)
+
+        accessory.setBandVisible(true)
+        #expect(!accessory.isHidden)
+
+        /// Idempotent, because it is driven from every pane-chrome pass rather than from an edge.
+        accessory.setBandVisible(true)
+        #expect(!accessory.isHidden)
+    }
+
+    @Test("The band shows one connection's strip at a time and swaps rather than stacking")
+    func bandSwapsHostedStrip() {
+        let accessory = EditorTabStripAccessoryController()
+        _ = accessory.view
+
+        let first = NSViewController()
+        first.view = NSView()
+        let second = NSViewController()
+        second.view = NSView()
+
+        accessory.show(first)
+        #expect(first.view.superview != nil)
+
+        accessory.show(second)
+        #expect(second.view.superview != nil)
+        #expect(first.view.superview == nil)
+
+        /// A window with no connection selected shows no strip, rather than keeping the last one
+        /// on screen and through it the coordinator that strip retains.
+        accessory.show(nil)
+        #expect(second.view.superview == nil)
+    }
+}

--- a/TableProTests/Views/Main/EditorTabStripChromeTests.swift
+++ b/TableProTests/Views/Main/EditorTabStripChromeTests.swift
@@ -9,30 +9,63 @@ import Testing
 
 @testable import TablePro
 
-/// The strip sits in the content view over flat window background, so anything it fills behind the
-/// tabs is a second surface the rest of the window does not have. Sampling is symmetric about the
-/// band's centre so the assertions hold whichever way the hosting view flips its coordinates.
+/// What this suite can and cannot see is decided by Liquid Glass, not by the strip.
+///
+/// The track and the selected tab are both `glassEffect` surfaces, and glass is composited by the
+/// window server rather than drawn into a view's own context: `cacheDisplay`, `layer.render` and
+/// `dataWithPDF` all come back with zero non-transparent pixels for it, measured. So no assertion
+/// here can describe the track's material. That is checked by comparing the running app against
+/// the system's own tab bar, which is where the geometry in `EditorTabStripLayout` came from too.
+///
+/// What rasterises is everything drawn *on* the glass: the titles, the separators and the close
+/// button. That is the half worth guarding anyway, because it is the half that broke. A
+/// `GlassEffectContainer` raises the glass it holds above the container's other content, so the
+/// first two attempts at this strip painted the glass over the selected tab's own title and then
+/// over its close button, leaving a tab whose label was dimmer than its neighbours' and which had
+/// no visible way to close it. Both tests below fail if that returns.
 @Suite("Editor tab strip chrome")
 @MainActor
 struct EditorTabStripChromeTests {
     private static let width: CGFloat = 600
     private static let margin: CGFloat = 20
-    private static let bandHeight = EditorTabStripLayout.trackHeight + EditorTabStripLayout.stripInset * 2
+    private static let tabCount = 3
+    private static let bandHeight = EditorTabStripLayout.bandHeight
 
     private static var totalHeight: CGFloat { bandHeight + margin * 2 }
 
-    /// Two points inside the track's own padding, above and below every tab, where only a track
-    /// fill could ever paint.
-    private static var trackRows: [CGFloat] {
-        let trackTop = margin + EditorTabStripLayout.stripInset
-        let trackBottom = trackTop + EditorTabStripLayout.trackHeight
-        return [trackTop + 1, trackBottom - 1]
+    /// The row the titles and the close button sit on.
+    private static var contentRows: [CGFloat] {
+        let centre = margin + EditorTabStripLayout.trackHeight / 2
+        return Array(stride(from: centre - 4, through: centre + 4, by: 1))
     }
 
-    /// The same distance outside the band on each side, which is untouched window background.
     private static var backdropRows: [CGFloat] { [margin / 2, totalHeight - margin / 2] }
 
-    private static let sampleColumns: [CGFloat] = [200, 300, 400]
+    private static var trackWidth: CGFloat {
+        width - EditorTabStripLayout.stripInset * 2
+            - EditorTabStripLayout.newTabButtonSize - EditorTabStripLayout.trackSpacing
+    }
+
+    private static var tabWidth: CGFloat {
+        EditorTabStripLayout.tabWidth(forTrack: trackWidth, count: tabCount)
+    }
+
+    private static func tabOrigin(_ index: Int) -> CGFloat {
+        EditorTabStripLayout.stripInset + EditorTabStripLayout.trackPadding + tabWidth * CGFloat(index)
+    }
+
+    /// The close button sits `accessoryInset` in from its tab's leading edge and is
+    /// `accessoryWidth` across.
+    private static func closeGlyphColumns(ofTabAt index: Int) -> [CGFloat] {
+        let leading = tabOrigin(index) + EditorTabStripLayout.accessoryInset
+        return Array(stride(from: leading, to: leading + EditorTabStripLayout.accessoryWidth, by: 1))
+    }
+
+    /// The middle of a tab, where its title is centred and no accessory reaches.
+    private static func titleColumns(ofTabAt index: Int) -> [CGFloat] {
+        let centre = tabOrigin(index) + tabWidth / 2
+        return Array(stride(from: centre - 40, through: centre + 40, by: 2))
+    }
 
     private func makeHost(appearance: NSAppearance.Name) -> NSView {
         let manager = QueryTabManager()
@@ -51,7 +84,7 @@ struct EditorTabStripChromeTests {
             Color(nsColor: .windowBackgroundColor)
             VStack(spacing: 0) {
                 Color.clear.frame(height: Self.margin)
-                strip
+                strip.frame(height: Self.bandHeight)
                 Color.clear.frame(height: Self.margin)
             }
         }
@@ -79,14 +112,6 @@ struct EditorTabStripChromeTests {
         window.contentView?.layoutSubtreeIfNeeded()
     }
 
-    private func windowBackgroundBrightness(for appearance: NSAppearance.Name) -> CGFloat {
-        var brightness: CGFloat = 0
-        NSAppearance(named: appearance)?.performAsCurrentDrawingAppearance {
-            brightness = NSColor.windowBackgroundColor.usingColorSpace(.deviceRGB)?.brightnessComponent ?? 0
-        }
-        return brightness
-    }
-
     private func brightness(of view: NSView, rows: [CGFloat], columns: [CGFloat]) -> [CGFloat] {
         guard let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds) else { return [] }
         view.cacheDisplay(in: view.bounds, to: rep)
@@ -100,28 +125,70 @@ struct EditorTabStripChromeTests {
         }
     }
 
-    @Test("The strip paints no track behind the tabs", arguments: [NSAppearance.Name.aqua, .darkAqua])
-    func trackIsUnpainted(appearance: NSAppearance.Name) {
+    /// Ink, as distance from the surface the glyphs are drawn on, so the same assertion holds in
+    /// light where a label is darker than its background and in dark where it is lighter.
+    private func inkContrast(of view: NSView, columns: [CGFloat]) -> CGFloat {
+        let samples = brightness(of: view, rows: Self.contentRows, columns: columns)
+        guard let low = samples.min(), let high = samples.max() else { return 0 }
+        return high - low
+    }
+
+    @Test(
+        "The selected tab's close button is drawn on its glass, not buried under it",
+        arguments: [NSAppearance.Name.aqua, .darkAqua]
+    )
+    func selectedTabShowsItsCloseButton(appearance: NSAppearance.Name) {
         let host = makeHost(appearance: appearance)
 
-        let backdrop = brightness(of: host, rows: Self.backdropRows, columns: Self.sampleColumns)
-        let track = brightness(of: host, rows: Self.trackRows, columns: Self.sampleColumns)
+        let onSelected = inkContrast(of: host, columns: Self.closeGlyphColumns(ofTabAt: 0))
+        let onPlain = inkContrast(of: host, columns: Self.closeGlyphColumns(ofTabAt: 2))
+
+        /// A drawn glyph puts light pixels next to dark ones inside a box that is otherwise one
+        /// flat surface, so the spread is what proves it is there.
+        #expect(onSelected > 0.1)
+
+        /// The same box on a tab that is neither selected nor hovered carries no button, which is
+        /// what stops a stray highlight anywhere in the strip from satisfying the check above.
+        #expect(onPlain < 0.05)
+    }
+
+    /// The selected title is `labelColor` and the rest are `secondaryLabelColor`, so the selected
+    /// one always stands further from whatever it is drawn on. It went the other way when the
+    /// glass was painting over it, and the difference was large: the selected title measured a
+    /// peak of 121 against 166 for its neighbours, on a surface of 86.
+    @Test(
+        "The selected tab's title reads stronger than its neighbours, not weaker",
+        arguments: [NSAppearance.Name.aqua, .darkAqua]
+    )
+    func selectedTitleOutreadsTheOthers(appearance: NSAppearance.Name) {
+        let host = makeHost(appearance: appearance)
+
+        let selected = inkContrast(of: host, columns: Self.titleColumns(ofTabAt: 0))
+        let unselected = inkContrast(of: host, columns: Self.titleColumns(ofTabAt: 2))
+
+        #expect(selected > 0.1)
+        #expect(unselected > 0.1)
+        #expect(selected > unselected)
+    }
+
+    /// The band is 36pt and only its top 28 carry the track, so the strip must not paint the
+    /// clearance the system leaves between the tab bar and the content below it.
+    @Test("The band leaves its bottom clearance to the window", arguments: [NSAppearance.Name.aqua, .darkAqua])
+    func clearanceBelowTrackIsUnpainted(appearance: NSAppearance.Name) {
+        let host = makeHost(appearance: appearance)
+
+        let clearanceRow = Self.margin + EditorTabStripLayout.trackHeight
+            + EditorTabStripLayout.bandBottomClearance / 2
+        let columns = Self.titleColumns(ofTabAt: 1)
+
+        let backdrop = brightness(of: host, rows: Self.backdropRows, columns: columns)
+        let clearance = brightness(of: host, rows: [clearanceRow], columns: columns)
 
         guard let reference = backdrop.first else {
             Issue.record("The strip did not rasterise")
             return
         }
-        /// Anchored to the colour the band is supposed to be, so an all-black or otherwise empty
-        /// bitmap cannot satisfy the comparisons below by agreeing with itself.
-        #expect(abs(reference - windowBackgroundBrightness(for: appearance)) < 0.01)
-
-        #expect(track.count == backdrop.count)
-        #expect(backdrop.allSatisfy { abs($0 - reference) < 0.005 })
-        #expect(track.allSatisfy { abs($0 - reference) < 0.005 })
-
-        /// Without this, a strip that drew nothing at all would satisfy every assertion above.
-        let bandCentre = Self.margin + Self.bandHeight / 2
-        let ink = brightness(of: host, rows: [bandCentre], columns: Array(stride(from: 20, to: Self.width - 20, by: 4)))
-        #expect(ink.contains { abs($0 - reference) > 0.01 })
+        #expect(!clearance.isEmpty)
+        #expect(clearance.allSatisfy { abs($0 - reference) < 0.005 })
     }
 }

--- a/TableProTests/Views/Main/EditorTabStripChromeTests.swift
+++ b/TableProTests/Views/Main/EditorTabStripChromeTests.swift
@@ -112,6 +112,17 @@ struct EditorTabStripChromeTests {
         window.contentView?.layoutSubtreeIfNeeded()
     }
 
+    /// The colour the band is supposed to sit on, resolved independently of the bitmap. Every
+    /// comparison below is anchored to it so that an empty or all-black rasterisation cannot
+    /// satisfy the assertions by agreeing with itself.
+    private func windowBackgroundBrightness(for appearance: NSAppearance.Name) -> CGFloat {
+        var brightness: CGFloat = 0
+        NSAppearance(named: appearance)?.performAsCurrentDrawingAppearance {
+            brightness = NSColor.windowBackgroundColor.usingColorSpace(.deviceRGB)?.brightnessComponent ?? 0
+        }
+        return brightness
+    }
+
     private func brightness(of view: NSView, rows: [CGFloat], columns: [CGFloat]) -> [CGFloat] {
         guard let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds) else { return [] }
         view.cacheDisplay(in: view.bounds, to: rep)
@@ -188,6 +199,9 @@ struct EditorTabStripChromeTests {
             Issue.record("The strip did not rasterise")
             return
         }
+        /// Without this the two comparisons below would hold on a bitmap that rendered nothing at
+        /// all, because both sides would be reading the same blank.
+        #expect(abs(reference - windowBackgroundBrightness(for: appearance)) < 0.01)
         #expect(!clearance.isEmpty)
         #expect(clearance.allSatisfy { abs($0 - reference) < 0.005 })
     }

--- a/docs/features/tabs.mdx
+++ b/docs/features/tabs.mdx
@@ -3,7 +3,7 @@ title: Query Tabs
 description: Each tab keeps its own SQL, results, sorting, and filters, and comes back after a restart
 ---
 
-Every open connection lives in one window, and each connection has its own set of tabs. A tab strip appears above the editor as soon as a connection holds more than one tab, and lists only that connection's tabs. With a single tab there is no strip, so a window that behaves the way it always did gains no chrome.
+Every open connection lives in one window, and each connection has its own set of tabs. A tab strip appears in the window chrome, below the toolbar and lined up with the content pane, as soon as a connection holds more than one tab, and lists only that connection's tabs. With a single tab there is no strip, so a window that behaves the way it always did gains no chrome.
 
 Each tab keeps its own SQL, results, sorting, and filter state. Tabs persist across app restarts.
 
@@ -86,7 +86,7 @@ You can still have more than one window, for putting two connections side by sid
 | Move the current window out of its tab group | **Window > Move Tab to New Window** |
 | Gather every window into one tab group | **Window > Merge All Windows** |
 
-Both dim when the window is not part of a tab group. These are macOS window tabs, which is a different thing from the tab strip above the editor: window tabs hold whole windows, the strip holds one connection's editors.
+Both dim when the window is not part of a tab group. These are macOS window tabs, which is a different thing from the editor tab strip below the toolbar: window tabs hold whole windows, the strip holds one connection's editors.
 
 ### Disconnecting
 

--- a/docs/features/workspace-rail.mdx
+++ b/docs/features/workspace-rail.mdx
@@ -42,7 +42,7 @@ An entry goes away when its last tab closes and you are no longer browsing it. N
 
 Click an entry to go to it. Moving between two connections switches the window to that connection, returning you to the tab you last used there rather than an arbitrary one. Moving between two databases of one connection stays in the same window and moves what the sidebar lists.
 
-One window hosts every connection you have open. Each connection keeps its own set of tabs, and the tab strip above the editor lists only the tabs of the connection you are in. Switching reads as the window changing content, because that is what it is.
+One window hosts every connection you have open. Each connection keeps its own set of tabs, and the tab strip below the toolbar lists only the tabs of the connection you are in. Switching reads as the window changing content, because that is what it is.
 
 Open tabs are never closed or retargeted by a switch. A tab keeps the database it was opened against and keeps querying it, whichever entry you are in.
 


### PR DESCRIPTION
> Stacked on `feat/query-history-insights` (#2180), which is where this session started, so this PR is based on that branch rather than `main`. Merge #2180 first.

The editor tab strip did not look like the system's own. This moves it to where macOS puts its tab bar and draws it the way the system draws it, with every number taken from the real control rather than chosen.

## How the target was established

`NSTabBar`, the control Finder's tab bar is built from, is private, so it was measured three independent ways on macOS 27.0 (26A5406e): a runtime probe of its view tree, the Accessibility API on a live Finder window, and retina pixel scans of the rendered bar.

That produced a spec, and comparing it against `EditorTabStripLayout` gave a surprising result: **the geometry was already right**. `trackHeight 28`, `tabHeight 24`, `trackPadding 2`, `stripInset 8`, `trackSpacing 4`, `newTabButtonSize 28`, `minimumTabWidth 120`, `accessoryWidth 16`, `accessoryInset 5` and `fontSize 11` all match the system exactly, as do equal-width stretch, scroll-on-overflow and the separator suppression rule. Only the material and the mount point were wrong.

## Root cause

**The strip drew no track.** A source comment recorded the decision: the track "carries no fill of its own". The system's track is a filled capsule, so our selected tab was a lone pane of glass floating on the content background, and `glassEffect` rendered it as a control floating over content, complete with a dark drop shadow. Measured, dark appearance:

| | System | Before |
|---|---|---|
| Track vs the chrome behind it | `rgb(66,65,64)` on `rgb(49,46,45)`, **+17** | identical to its background, **+0** |
| Edge of the selected tab | **bright** `rgb(127,126,124)` | **dark** `rgb(24,23,23)` |
| Selected fill vs its track | +4 | +28, because there was no track |

**The strip was mounted in the content view.** The system's bar is a bottom `NSTitlebarAccessoryViewController`, 36pt tall with the 28pt bar pinned to its top edge, flush under the toolbar. Ours sat in a `VStack` with 8pt of padding above it.

## What changed

- The strip is now hosted in a bottom titlebar accessory (`EditorTabStripAccessoryController`). AppKit insets a bottom accessory past a `.sidebar` split item automatically, so the band lines up with the content pane with no sidebar-width tracking of our own.
- The track is drawn, as a `glassEffect` capsule. It is a material, not a wash: sampling the system bar against three different chrome colours shows it converging on a fixed tone rather than tinting what is behind it, about 78% opaque over `rgb(77)` in dark and 85% over `rgb(228)` in light. It therefore reads lighter than the chrome in **both** appearances, which no alpha-based system fill can do. `secondarySystemFill` lands within a few points in dark and inverts in light.
- With a track behind it, the selected tab's glass draws the bright stroke the system has instead of a dark shadow. No explicit stroke was needed; the dark rim was a symptom of the missing track.
- `separatorHeight` corrected from 18 to the measured 16, and the hover fill strengthened to sit on a track rather than on nothing.
- The band hides itself when the connection has one tab or no content behind it, through `ConnectionWindowPaneResolver.showsTabStrip(for:tabCount:)`.

## Two bugs found and fixed along the way

`GlassEffectContainer` raises the glass it holds above the container's other content. That is not in the header, and it bit twice: glass drawn as a `ZStack` sibling painted **over** the selected tab's title, which measured a peak of 121 against 166 for its unselected neighbours, the opposite of the system; and glass drawn behind an `.overlay` hid the selected tab's close button completely, leaving the visible tab with no way to close it by pointer. Both are fixed by putting the title and the close button inside the glass rather than beside it, and both now have tests.

## Verified

- `verify.sh build` PASS.
- `verify.sh test EditorTabStripChromeTests EditorTabStripAccessoryControllerTests ConnectionWindowPaneResolverTests EditorTabStripLayoutTests` PASS, 29 of 29.
- `verify.sh lint TablePro TableProTests` PASS, 0 violations, 258 docs references check out.
- `verify.sh uitest QueryHistoryActionsUITests`: the two cases that count `app.buttons` with identifier `editor-tab` both pass, which is what proves the strip is still reachable as a button now that it lives in the titlebar. `testReturnInTheListLoadsTheSelectedEntry` failed on `Failed to synthesize event: Timed out while synthesizing event`, an event-synthesis timeout caused by the machine being driven concurrently, not by an assertion.
- Full screen checked by hand, because `fullScreenMinHeight` defaults to 0 and the header is explicit that 0 "will fully hide the view when the menu bar is hidden". With it set to the band height the strip stays visible in full screen with the menu bar auto-hidden, still inset to the content pane.
- The running app was measured against Finder at retina resolution: the band sits at the toolbar's bottom edge, 36pt, inset to the content pane, and the track's lift over the chrome matches the system's +17 exactly.

## Found by the self-review, fixed in the second commit

- **The whole tab stopped being clickable.** Moving the strip's root from a `Button` to a `ZStack` left `.contentShape(Rectangle())` outside the button, so it hit-tested the glyph run of the title instead of the tab. Reproduced by clicking a blank part of a tab and watching the selection not move, then fixed and re-checked the same way. No automated test covers SwiftUI hit shapes, so this one is verified by hand.
- **The visibility observer accumulated arms.** `withObservationTracking` cannot be cancelled, and `applyTabStripVisibility()` runs on every phase change and every workspace switch, so each call left a live arm behind to be woken by the next tab change. It now registers only when there is none, or when the connection on screen changed and the live arm watches the previous tab manager.
- **Keyboard focus could end up inside a collapsed band.** Closing the second-to-last tab from the strip hides the band under the button that was just clicked. Focus is released on the way down.
- **The chrome suite lost its anti-vacuous anchor** in the rewrite, so `clearanceBelowTrackIsUnpainted` could have passed on a bitmap that rendered nothing. The appearance-resolved reference is back.

Two review findings were not acted on. The tab's accessibility role was flagged as possibly no longer a button, but the two UI cases that count `app.buttons` with identifier `editor-tab` pass, and one of them requires the count to *grow*, so the role is intact. A 4pt track overflow was reported from `tabWidth(forTrack: proxy.size.width, …)` using the outer width, but `tabWidth` already subtracts `trackPadding * 2` itself, so the value passed is correct.

## Not done, deliberately

The system slides its selection between tabs; this does not animate. The mechanism would be `glassEffectID` with a matched-geometry transition, and it is unverified across the strip's `ScrollView` and against tabs being added and removed mid-animation. A selection that animates wrongly is worse than one that does not, so it is left out rather than guessed at.

The track's own material cannot be covered by a pixel test. Liquid Glass is composited by the window server, and `cacheDisplay`, `layer.render` and `dataWithPDF` all return zero non-transparent pixels for it, measured. The suite therefore guards what does rasterise, which is also the half that broke: the titles, the separators and the close button.

`docs/images/tabs.png` and `tabs-dark.png` still show the old placement and need re-capturing.

https://claude.ai/code/session_01D5BJ4TrCpMKvVQtQuxwwmH
