### PR TITLE
fix(settings): derive license gating from the signed payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **File > Save As...** stayed available on a table, structure or diagram tab, and **File > Export > Export Results...** stayed available with no rows to export. Both did nothing when chosen. They are dimmed now until they can run.
 - Clearing query history from the drawer promised to delete the connection's history while the source filter was quietly sparing table browsing, row edits, imports and AI queries. The confirmation now says what it will actually delete, and clearing itself is unchanged.
 - A query history database TablePro cannot open showed as "No Query History", which reads as though nothing had ever been recorded. The drawer now says the store could not be opened and that your history is still on disk.
+- A license the server reports as suspended, expired, or no longer activated on this Mac now pauses Pro features at that check, instead of running on for up to a month because the reply was treated as if the server could not be reached. **Check Status** in **Settings > Account** says what the server replied, rather than appearing to do nothing.
+- A license bought with an email address containing a slash could never be activated, and said to update the app, which never helped.
 
 ### Changed
 
@@ -66,6 +68,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Settings > Data no longer lists every saved table layout and filter. TablePro still remembers both. Reset columns from the table's Columns popover, and remove saved filters from the filter panel.
+
+### Security
+
+- Licensing reads every entitlement from the signed license itself, so an edited or copied local copy cannot unlock paid features. TablePro also honours a machine binding when the license server includes one. (#2181)
 
 ## [0.65.0] - 2026-08-16
 

--- a/TablePro/Core/Services/Licensing/LicenseAPIClient.swift
+++ b/TablePro/Core/Services/Licensing/LicenseAPIClient.swift
@@ -111,6 +111,11 @@ final class LicenseAPIClient {
             }
 
         case 404:
+            // Only a body this API produced counts as the server rejecting the key. A captive
+            // portal or proxy answering 404 is a transport failure, not a revoked license.
+            guard (try? decoder.decode(LicenseAPIErrorResponse.self, from: data)) != nil else {
+                throw LicenseError.serverError(404, "Not Found")
+            }
             throw LicenseError.invalidKey
 
         case 409:

--- a/TablePro/Core/Services/Licensing/LicenseManager.swift
+++ b/TablePro/Core/Services/Licensing/LicenseManager.swift
@@ -10,6 +10,27 @@ import Foundation
 import Observation
 import os
 
+/// Why a cached license blob was not adopted at launch.
+internal enum CachedLicenseRejection: Equatable {
+    case cachedForAnotherMachine
+    case boundToAnotherMachine
+    case signatureInvalid
+
+    var logDescription: String {
+        switch self {
+        case .cachedForAnotherMachine: return "cached for another machine"
+        case .boundToAnotherMachine: return "signed for another machine"
+        case .signatureInvalid: return "signature invalid"
+        }
+    }
+}
+
+/// Outcome of checking a cached license blob before trusting it.
+internal enum CachedLicenseResolution: Equatable {
+    case accepted(License)
+    case rejected(CachedLicenseRejection)
+}
+
 /// Manages the app's license state with offline-first verification
 @MainActor @Observable
 final class LicenseManager {
@@ -39,6 +60,17 @@ final class LicenseManager {
     /// Grace period: 30 days without server contact before forcing re-validation
     private let gracePeriodDays = 30
 
+    /// What the server last told us about this license, when that was a rejection rather than a
+    /// new payload. Deliberately not persisted: it can only take entitlement away, and writing it
+    /// to disk would put licensing state back outside the signature.
+    private var serverRejection: LicenseStatus?
+
+    /// When the server last confirmed this license, measured by this Mac's clock. Held in memory
+    /// only, so nothing on disk can forge it and a relaunch falls back to the signed issue date.
+    /// It exists so a server clock far behind the Mac cannot expire the grace period on a license
+    /// the server has just approved.
+    private var lastServerContact: Date?
+
     @ObservationIgnored private var revalidationTask: Task<Void, Never>?
 
     private init() {
@@ -58,29 +90,62 @@ final class LicenseManager {
             return
         }
 
-        // Verify license belongs to this machine (prevents backup/restore cross-machine use)
-        guard cached.machineId == storage.machineId else {
-            Self.logger.warning("Cached license machineId mismatch, clearing")
-            storage.clearAll()
-            status = .unlicensed
-            return
-        }
+        let resolution = Self.resolveCachedLicense(
+            cached,
+            currentMachineId: storage.machineId,
+            verify: verifier.verify(payload:)
+        )
 
-        // Re-verify signature offline with embedded public key
-        do {
-            _ = try verifier.verify(payload: cached.signedPayload)
-
-            license = cached
+        switch resolution {
+        case .accepted(let accepted):
+            license = accepted
             evaluateStatus()
-
-            Self.logger.trace("Loaded cached license for \(cached.email)")
-        } catch {
-            // Signature invalid — clear everything
-            Self.logger.error("Cached license signature invalid, clearing")
+            Self.logger.trace("Loaded cached license for \(accepted.email)")
+        case .rejected(let reason):
+            Self.logger.error("Cached license rejected (\(reason.logDescription)), clearing")
             storage.clearAll()
             license = nil
             status = .unlicensed
         }
+    }
+
+    /// Verify a signed payload and refuse one the server minted for a different Mac.
+    /// Every path that trusts a payload goes through here.
+    private func verifiedPayload(from signed: SignedLicensePayload) throws -> LicensePayloadData {
+        let data = try verifier.verify(payload: signed)
+
+        guard Self.acceptsMachine(data.machineId, current: storage.machineId) else {
+            throw LicenseError.machineMismatch
+        }
+
+        return data
+    }
+
+    /// A payload without a signed machine binding predates the binding and is accepted.
+    nonisolated static func acceptsMachine(_ bound: String?, current: String) -> Bool {
+        guard let bound else { return true }
+        return bound == current
+    }
+
+    /// Whether a cached blob may be adopted, decided without touching storage so it can be tested.
+    nonisolated static func resolveCachedLicense(
+        _ cached: License,
+        currentMachineId: String,
+        verify: (SignedLicensePayload) throws -> LicensePayloadData
+    ) -> CachedLicenseResolution {
+        guard cached.cachedOnMachineId == currentMachineId else {
+            return .rejected(.cachedForAnotherMachine)
+        }
+
+        guard let verified = try? verify(cached.signedPayload) else {
+            return .rejected(.signatureInvalid)
+        }
+
+        guard acceptsMachine(verified.machineId, current: currentMachineId) else {
+            return .rejected(.boundToAnotherMachine)
+        }
+
+        return .accepted(cached)
     }
 
     /// Start periodic re-validation. Call from AppDelegate.applicationDidFinishLaunching.
@@ -89,7 +154,7 @@ final class LicenseManager {
         revalidationTask = Task { [weak self] in
             // Check if revalidation is needed right now
             if let self, let license = self.license,
-               license.daysSinceLastValidation >= Int(self.revalidationInterval / 86_400) {
+               (license.daysSinceLastValidation ?? .max) >= Int(self.revalidationInterval / 86_400) {
                 await self.revalidate()
             }
 
@@ -146,19 +211,15 @@ final class LicenseManager {
         do {
             let signedPayload = try await apiClient.activate(request: request)
 
-            let payloadData = try verifier.verify(payload: signedPayload)
+            let payloadData = try verifiedPayload(from: signedPayload)
 
-            let newLicense = License.from(
-                payload: payloadData,
-                signedPayload: signedPayload,
-                machineId: storage.machineId
-            )
+            let newLicense = License(signedPayload: signedPayload, cachedOnMachineId: storage.machineId)
 
             storage.saveLicenseKey(trimmedKey)
             storage.saveLicense(newLicense)
 
             license = newLicense
-            evaluateStatus()
+            acceptServerConfirmation()
 
             Self.logger.info("License activated for \(payloadData.email)")
         } catch let error as LicenseError {
@@ -193,19 +254,15 @@ final class LicenseManager {
         do {
             let signedPayload = try await apiClient.acceptInvite(request: request)
 
-            let payloadData = try verifier.verify(payload: signedPayload)
+            let payloadData = try verifiedPayload(from: signedPayload)
 
-            let newLicense = License.from(
-                payload: payloadData,
-                signedPayload: signedPayload,
-                machineId: storage.machineId
-            )
+            let newLicense = License(signedPayload: signedPayload, cachedOnMachineId: storage.machineId)
 
             storage.saveLicenseKey(newLicense.key)
             storage.saveLicense(newLicense)
 
             license = newLicense
-            evaluateStatus()
+            acceptServerConfirmation()
 
             Self.logger.info("Joined team via invitation for \(payloadData.email)")
         } catch let error as LicenseError {
@@ -244,6 +301,8 @@ final class LicenseManager {
 
         storage.clearAll()
         self.license = nil
+        serverRejection = nil
+        lastServerContact = nil
         status = .deactivated
 
         revalidationTask?.cancel()
@@ -281,31 +340,62 @@ final class LicenseManager {
 
         do {
             let signedPayload = try await apiClient.validate(request: request)
-            let payloadData = try verifier.verify(payload: signedPayload)
+            _ = try verifiedPayload(from: signedPayload)
 
-            let updatedLicense = License.from(
-                payload: payloadData,
-                signedPayload: signedPayload,
-                machineId: storage.machineId
-            )
+            let updatedLicense = License(signedPayload: signedPayload, cachedOnMachineId: storage.machineId)
 
             storage.saveLicense(updatedLicense)
             self.license = updatedLicense
-            evaluateStatus()
+            lastError = nil
+            acceptServerConfirmation()
 
             await TeamLibrarySyncCoordinator.shared.pullIfNeeded()
 
             Self.logger.trace("License re-validated successfully")
         } catch {
-            // Network failure — use grace period
-            Self.logger.warning("Re-validation failed: \(error.localizedDescription)")
+            let licenseError = error as? LicenseError ?? .networkError(error)
 
-            if license.daysSinceLastValidation > gracePeriodDays {
-                self.status = .validationFailed
-                Self.logger.error("Grace period exceeded (\(license.daysSinceLastValidation) days)")
+            if let rejection = Self.revocationStatus(for: licenseError) {
+                Self.logger.error("License rejected by server: \(licenseError.localizedDescription)")
+                serverRejection = rejection
+            } else {
+                Self.logger.warning("Re-validation failed: \(licenseError.localizedDescription)")
             }
-            // Otherwise keep using cached license (still within grace period)
+
+            lastError = licenseError
+            evaluateStatus()
         }
+    }
+
+    /// The status the server's own rejection implies, or nil when the request simply did not
+    /// reach it. Only a rejection the server actually spoke changes entitlement; a transport
+    /// failure falls through to the offline grace period.
+    nonisolated static func revocationStatus(for error: LicenseError) -> LicenseStatus? {
+        switch error {
+        case .licenseSuspended:
+            return .suspended
+        case .licenseExpired:
+            return .expired
+        case .notActivated, .machineMismatch:
+            return .deactivated
+        case .invalidKey:
+            return .unlicensed
+        default:
+            return nil
+        }
+    }
+
+    private func acceptServerConfirmation() {
+        serverRejection = nil
+        lastServerContact = Date()
+        evaluateStatus()
+    }
+
+    /// Whether this Mac has heard from the server recently enough to keep the license running,
+    /// which covers a freshly issued payload whose signed issue date looks stale to us.
+    private var isWithinLocalGracePeriod: Bool {
+        guard let lastServerContact else { return false }
+        return Date().timeIntervalSince(lastServerContact) <= Double(gracePeriodDays) * 86_400
     }
 
     // MARK: - Status Evaluation
@@ -320,34 +410,47 @@ final class LicenseManager {
             return
         }
 
-        // Check server-reported status
-        switch license.status {
-        case .suspended:
-            status = .suspended
-            return
-        case .expired:
-            status = .expired
-            return
-        case .deactivated:
-            status = .deactivated
-            return
-        default:
-            break
+        status = Self.resolveStatus(
+            signedStatus: license.status,
+            isExpired: license.isExpired,
+            daysSinceValidation: license.daysSinceLastValidation,
+            gracePeriodDays: gracePeriodDays,
+            serverRejection: serverRejection,
+            hasRecentServerContact: isWithinLocalGracePeriod
+        )
+    }
+
+    /// Pure resolution of the effective status. Kept static and side-effect free so the whole grid
+    /// can be tested without constructing a LicenseManager, the same way `resolveAccess` is.
+    /// Only a signed `active` may go on to be treated as active, so a status this build does not
+    /// recognise withholds access rather than granting it.
+    nonisolated static func resolveStatus(
+        signedStatus: LicenseStatus,
+        isExpired: Bool,
+        daysSinceValidation: Int?,
+        gracePeriodDays: Int,
+        serverRejection: LicenseStatus?,
+        hasRecentServerContact: Bool
+    ) -> LicenseStatus {
+        if let serverRejection {
+            return serverRejection
         }
 
-        // Check local expiration
-        if license.isExpired {
-            status = .expired
-            return
+        guard signedStatus == .active else {
+            return signedStatus
         }
 
-        // Check grace period
-        if license.daysSinceLastValidation > gracePeriodDays {
-            status = .validationFailed
-            return
+        if isExpired {
+            return .expired
         }
 
-        status = .active
+        // An unreadable issue date is left to the revalidation scheduler, which treats it as due,
+        // rather than counted against a license that may be fine.
+        if (daysSinceValidation ?? 0) > gracePeriodDays, !hasRecentServerContact {
+            return .validationFailed
+        }
+
+        return .active
     }
 
     private func notifyIfChanged(from previousStatus: LicenseStatus) {

--- a/TablePro/Core/Services/Licensing/LicenseSignatureVerifier.swift
+++ b/TablePro/Core/Services/Licensing/LicenseSignatureVerifier.swift
@@ -32,9 +32,11 @@ final class LicenseSignatureVerifier {
             throw LicenseError.signatureInvalid
         }
 
-        // Encode the data portion as canonical JSON (same as server)
+        // Encode the data portion as canonical JSON (same as server). The server signs
+        // json_encode($data, JSON_UNESCAPED_SLASHES) over a ksort'ed array, so the slash must
+        // stay raw here or a signed field containing one never verifies.
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
         let dataJSON = try encoder.encode(payload.data)
 
         guard let signatureData = Data(base64Encoded: payload.signature) else {

--- a/TablePro/Core/Storage/LicenseStorage.swift
+++ b/TablePro/Core/Storage/LicenseStorage.swift
@@ -50,9 +50,7 @@ final class LicenseStorage {
     /// Save cached license (including signed payload) to UserDefaults
     func saveLicense(_ license: License) {
         do {
-            let encoder = JSONEncoder()
-            encoder.dateEncodingStrategy = .iso8601
-            let data = try encoder.encode(license)
+            let data = try JSONEncoder().encode(license)
             defaults.set(data, forKey: Keys.licensePayload)
         } catch {
             Self.logger.error("Failed to encode license: \(error.localizedDescription)")
@@ -66,9 +64,7 @@ final class LicenseStorage {
         }
 
         do {
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            return try decoder.decode(License.self, from: data)
+            return try JSONDecoder().decode(License.self, from: data)
         } catch {
             Self.logger.error("Failed to decode license: \(error.localizedDescription)")
             return nil

--- a/TablePro/Models/Settings/License.swift
+++ b/TablePro/Models/Settings/License.swift
@@ -47,6 +47,7 @@ struct LicensePayloadData: Codable, Equatable {
     let tier: String
     let teamId: String?
     let role: String?
+    let machineId: String?
 
     init(
         billingCycle: String?,
@@ -57,7 +58,8 @@ struct LicensePayloadData: Codable, Equatable {
         issuedAt: String,
         tier: String,
         teamId: String? = nil,
-        role: String? = nil
+        role: String? = nil,
+        machineId: String? = nil
     ) {
         self.billingCycle = billingCycle
         self.licenseKey = licenseKey
@@ -68,6 +70,7 @@ struct LicensePayloadData: Codable, Equatable {
         self.tier = tier
         self.teamId = teamId
         self.role = role
+        self.machineId = machineId
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -80,15 +83,16 @@ struct LicensePayloadData: Codable, Equatable {
         case tier
         case teamId = "team_id"
         case role
+        case machineId = "machine_id"
     }
 
     /// Custom encode to explicitly write null for nil optionals.
     /// The auto-synthesized Codable uses encodeIfPresent which omits nil keys,
     /// but PHP's json_encode includes null values — the signed JSON must match exactly.
     ///
-    /// `team_id` and `role` are the exception: the server omits them for non-Team licenses, so
-    /// they use encodeIfPresent (dropped when nil). This keeps a payload signed before teams
-    /// existed verifying byte-for-byte against a build that knows about the new keys.
+    /// `team_id`, `role` and `machine_id` are the exception: the server omits them unless they
+    /// apply, so they use encodeIfPresent (dropped when nil). This keeps a payload signed before
+    /// those keys existed verifying byte-for-byte against a build that knows about them.
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         if let billingCycle {
@@ -108,6 +112,7 @@ struct LicensePayloadData: Codable, Equatable {
         try container.encode(tier, forKey: .tier)
         try container.encodeIfPresent(teamId, forKey: .teamId)
         try container.encodeIfPresent(role, forKey: .role)
+        try container.encodeIfPresent(machineId, forKey: .machineId)
     }
 }
 
@@ -224,17 +229,51 @@ internal struct ListActivationsResponse: Codable {
 
 // MARK: - Cached License
 
-/// Local cached license with metadata for offline use
+/// Cache envelope around the server's signed payload.
+///
+/// Every field that drives gating is computed from `signedPayload.data`, so a forged value has
+/// nowhere to live: the RSA signature covers all of it. `cachedOnMachineId` is the one locally
+/// written field and it is not a security control, only the tripwire that drops a cache restored
+/// from another Mac's backup. The binding that holds against tampering is `boundMachineId`,
+/// which the server signs.
 struct License: Codable, Equatable {
-    var key: String
-    var email: String
-    var status: LicenseStatus
-    var expiresAt: Date?
-    var lastValidatedAt: Date
-    var machineId: String
     var signedPayload: SignedLicensePayload
-    var tier: String
-    var billingCycle: String?
+    var cachedOnMachineId: String
+
+    private enum CodingKeys: String, CodingKey {
+        case signedPayload
+        case cachedOnMachineId = "machineId"
+    }
+
+    private var payload: LicensePayloadData { signedPayload.data }
+
+    var key: String { payload.licenseKey }
+
+    var email: String { payload.email }
+
+    var tier: String { payload.tier }
+
+    var billingCycle: String? { payload.billingCycle }
+
+    var boundMachineId: String? { payload.machineId }
+
+    var status: LicenseStatus {
+        switch payload.status {
+        case "active": .active
+        case "expired": .expired
+        case "suspended": .suspended
+        default: .validationFailed
+        }
+    }
+
+    var expiresAt: Date? {
+        payload.expiresAt.flatMap { Self.iso8601Formatter.date(from: $0) }
+    }
+
+    /// When the server signed this payload, which is when it last confirmed the license.
+    var issuedAt: Date? {
+        Self.iso8601Formatter.date(from: payload.issuedAt)
+    }
 
     /// Whether the license has expired based on expiration date
     var isExpired: Bool {
@@ -248,9 +287,11 @@ struct License: Codable, Equatable {
         return Calendar.current.dateComponents([.day], from: Date(), to: expiresAt).day
     }
 
-    /// Days since last successful server validation
-    var daysSinceLastValidation: Int {
-        Calendar.current.dateComponents([.day], from: lastValidatedAt, to: Date()).day ?? 0
+    /// Days since the server last confirmed this license, or nil when the payload does not say.
+    /// A clock behind the server reads as zero rather than as a license from the future.
+    var daysSinceLastValidation: Int? {
+        guard let issuedAt else { return nil }
+        return max(0, Calendar.current.dateComponents([.day], from: issuedAt, to: Date()).day ?? 0)
     }
 
     private static let iso8601Formatter: ISO8601DateFormatter = {
@@ -258,33 +299,6 @@ struct License: Codable, Equatable {
         formatter.formatOptions = [.withInternetDateTime]
         return formatter
     }()
-
-    /// Create a License from a verified server payload
-    static func from(
-        payload: LicensePayloadData,
-        signedPayload: SignedLicensePayload,
-        machineId: String
-    ) -> License {
-        let expiresAt = payload.expiresAt.flatMap { iso8601Formatter.date(from: $0) }
-        let status: LicenseStatus = switch payload.status {
-        case "active": .active
-        case "expired": .expired
-        case "suspended": .suspended
-        default: .validationFailed
-        }
-
-        return License(
-            key: payload.licenseKey,
-            email: payload.email,
-            status: status,
-            expiresAt: expiresAt,
-            lastValidatedAt: Date(),
-            machineId: machineId,
-            signedPayload: signedPayload,
-            tier: payload.tier,
-            billingCycle: payload.billingCycle
-        )
-    }
 }
 
 // MARK: - License Error
@@ -293,6 +307,7 @@ struct License: Codable, Equatable {
 enum LicenseError: LocalizedError {
     case invalidKey
     case signatureInvalid
+    case machineMismatch
     case publicKeyNotFound
     case publicKeyInvalid
     case activationLimitReached
@@ -309,6 +324,8 @@ enum LicenseError: LocalizedError {
             return String(localized: "The license key is invalid.")
         case .signatureInvalid:
             return String(localized: "License signature verification failed.")
+        case .machineMismatch:
+            return String(localized: "This license was issued for a different Mac.")
         case .publicKeyNotFound:
             return String(localized: "License public key not found in app bundle.")
         case .publicKeyInvalid:
@@ -350,6 +367,8 @@ enum LicenseError: LocalizedError {
             return String(format: String(localized: "Something went wrong (error %d). Try again in a moment."), code)
         case .signatureInvalid, .publicKeyNotFound, .publicKeyInvalid:
             return String(localized: "License verification failed. Try updating the app to the latest version.")
+        case .machineMismatch:
+            return String(localized: "This license was activated on a different Mac. Activate it here to use Pro features.")
         case .notActivated:
             return String(localized: "This machine is not activated for this license.")
         case .decodingError:

--- a/TablePro/Views/Settings/Sections/LicenseSection.swift
+++ b/TablePro/Views/Settings/Sections/LicenseSection.swift
@@ -54,8 +54,8 @@ struct LicenseSection: View {
             }
 
             LabeledContent("Status:") {
-                Text(license.status.displayName)
-                    .foregroundStyle(license.status.isValid ? .green : .red)
+                Text(licenseManager.status.displayName)
+                    .foregroundStyle(licenseManager.status.isValid ? .green : .red)
             }
 
             if let expiresAt = license.expiresAt {
@@ -134,6 +134,12 @@ struct LicenseSection: View {
                     Task { await licenseManager.revalidate() }
                 }
                 .disabled(licenseManager.isValidating)
+            }
+
+            if let lastError = licenseManager.lastError {
+                Label(lastError.friendlyDescription, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.callout)
             }
 
             LabeledContent("Remove license from this machine") {

--- a/TableProTests/Models/LicenseManagerDecisionTests.swift
+++ b/TableProTests/Models/LicenseManagerDecisionTests.swift
@@ -1,0 +1,223 @@
+//
+//  LicenseManagerDecisionTests.swift
+//  TablePro
+//
+//  Tests for the pure licensing decisions: adopting a cached blob, the signed machine binding,
+//  and what a server rejection means
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("LicenseManagerDecision")
+struct LicenseManagerDecisionTests {
+    private static let thisMachine = "9f86d081884c7d659a2feaa0c55ad015"
+    private static let otherMachine = "0000000000000000000000000000dead"
+
+    private static func payload(machineId: String? = nil, tier: String = "starter") -> LicensePayloadData {
+        LicensePayloadData(
+            billingCycle: nil,
+            licenseKey: "AAAAA-BBBBB-CCCCC-DDDDD-EEEEE",
+            email: "user@example.com",
+            status: "active",
+            expiresAt: nil,
+            issuedAt: "2026-08-18T10:00:00+00:00",
+            tier: tier,
+            machineId: machineId
+        )
+    }
+
+    private static func license(
+        _ payload: LicensePayloadData,
+        cachedOn machineId: String = thisMachine
+    ) -> License {
+        License(
+            signedPayload: SignedLicensePayload(data: payload, signature: "sig"),
+            cachedOnMachineId: machineId
+        )
+    }
+
+    private static func validSignature(_ signed: SignedLicensePayload) throws -> LicensePayloadData {
+        signed.data
+    }
+
+    private static func badSignature(_: SignedLicensePayload) throws -> LicensePayloadData {
+        throw LicenseError.signatureInvalid
+    }
+
+    // MARK: - acceptsMachine
+
+    @Test("A payload with no signed machine binding is accepted")
+    func acceptsUnboundPayload() {
+        #expect(LicenseManager.acceptsMachine(nil, current: Self.thisMachine))
+    }
+
+    @Test("A payload bound to this machine is accepted")
+    func acceptsMatchingMachine() {
+        #expect(LicenseManager.acceptsMachine(Self.thisMachine, current: Self.thisMachine))
+    }
+
+    @Test("A payload bound to another machine is refused")
+    func refusesOtherMachine() {
+        #expect(LicenseManager.acceptsMachine(Self.otherMachine, current: Self.thisMachine) == false)
+    }
+
+    // MARK: - resolveCachedLicense
+
+    @Test("A cached blob with a valid signature on this machine is adopted")
+    func adoptsValidCachedLicense() {
+        let cached = Self.license(Self.payload())
+        let resolution = LicenseManager.resolveCachedLicense(
+            cached,
+            currentMachineId: Self.thisMachine,
+            verify: Self.validSignature
+        )
+        #expect(resolution == .accepted(cached))
+    }
+
+    @Test("A cached blob copied from another Mac's backup is rejected before the signature check")
+    func rejectsCacheFromAnotherMachine() {
+        let cached = Self.license(Self.payload(), cachedOn: Self.otherMachine)
+        let resolution = LicenseManager.resolveCachedLicense(
+            cached,
+            currentMachineId: Self.thisMachine,
+            verify: { signed in
+                Issue.record("Signature must not be checked for another machine's cache")
+                return signed.data
+            }
+        )
+        #expect(resolution == .rejected(.cachedForAnotherMachine))
+    }
+
+    @Test("A payload the server bound to another Mac is rejected even when the envelope claims this one")
+    func rejectsPayloadBoundElsewhere() {
+        let cached = Self.license(Self.payload(machineId: Self.otherMachine))
+        let resolution = LicenseManager.resolveCachedLicense(
+            cached,
+            currentMachineId: Self.thisMachine,
+            verify: Self.validSignature
+        )
+        #expect(resolution == .rejected(.boundToAnotherMachine))
+    }
+
+    @Test("A payload the server bound to this Mac is adopted")
+    func adoptsPayloadBoundHere() {
+        let cached = Self.license(Self.payload(machineId: Self.thisMachine))
+        let resolution = LicenseManager.resolveCachedLicense(
+            cached,
+            currentMachineId: Self.thisMachine,
+            verify: Self.validSignature
+        )
+        #expect(resolution == .accepted(cached))
+    }
+
+    @Test("A cached blob with a bad signature is rejected")
+    func rejectsBadSignature() {
+        let cached = Self.license(Self.payload())
+        let resolution = LicenseManager.resolveCachedLicense(
+            cached,
+            currentMachineId: Self.thisMachine,
+            verify: Self.badSignature
+        )
+        #expect(resolution == .rejected(.signatureInvalid))
+    }
+
+    // MARK: - revocationStatus
+
+    @Test("A suspended license reported by the server suspends it here")
+    func mapsSuspended() {
+        #expect(LicenseManager.revocationStatus(for: .licenseSuspended) == .suspended)
+    }
+
+    @Test("An expired license reported by the server expires it here")
+    func mapsExpired() {
+        #expect(LicenseManager.revocationStatus(for: .licenseExpired) == .expired)
+    }
+
+    @Test("A machine the server no longer has an activation for is deactivated here")
+    func mapsNotActivated() {
+        #expect(LicenseManager.revocationStatus(for: .notActivated) == .deactivated)
+    }
+
+    @Test("A payload minted for another machine is deactivated here")
+    func mapsMachineMismatch() {
+        #expect(LicenseManager.revocationStatus(for: .machineMismatch) == .deactivated)
+    }
+
+    @Test("A license key the server no longer knows leaves this Mac unlicensed")
+    func mapsInvalidKey() {
+        #expect(LicenseManager.revocationStatus(for: .invalidKey) == .unlicensed)
+    }
+
+    @Test("A transport failure is not a revocation, so the offline grace period still applies")
+    func transportFailuresAreNotRevocations() {
+        #expect(LicenseManager.revocationStatus(for: .networkError(URLError(.notConnectedToInternet))) == nil)
+        #expect(LicenseManager.revocationStatus(for: .serverError(500, "Internal Server Error")) == nil)
+        #expect(LicenseManager.revocationStatus(for: .serverError(404, "Not Found")) == nil)
+        #expect(LicenseManager.revocationStatus(for: .signatureInvalid) == nil)
+        #expect(LicenseManager.revocationStatus(for: .activationLimitReached) == nil)
+    }
+
+    // MARK: - resolveStatus
+
+    private static func resolve(
+        signedStatus: LicenseStatus = .active,
+        isExpired: Bool = false,
+        daysSinceValidation: Int? = 0,
+        serverRejection: LicenseStatus? = nil,
+        hasRecentServerContact: Bool = false
+    ) -> LicenseStatus {
+        LicenseManager.resolveStatus(
+            signedStatus: signedStatus,
+            isExpired: isExpired,
+            daysSinceValidation: daysSinceValidation,
+            gracePeriodDays: 30,
+            serverRejection: serverRejection,
+            hasRecentServerContact: hasRecentServerContact
+        )
+    }
+
+    @Test("A signed, unexpired, recently validated license is active")
+    func resolvesActive() {
+        #expect(Self.resolve() == .active)
+    }
+
+    @Test("A server rejection outranks everything the payload says")
+    func serverRejectionWins() {
+        #expect(Self.resolve(serverRejection: .suspended) == .suspended)
+        #expect(Self.resolve(signedStatus: .active, serverRejection: .deactivated) == .deactivated)
+        #expect(Self.resolve(serverRejection: .expired, hasRecentServerContact: true) == .expired)
+    }
+
+    @Test("A signed status this build does not recognise withholds access instead of granting it")
+    func unrecognisedSignedStatusFailsClosed() {
+        #expect(Self.resolve(signedStatus: .validationFailed) == .validationFailed)
+        #expect(Self.resolve(signedStatus: .unlicensed) == .unlicensed)
+        #expect(Self.resolve(signedStatus: .suspended) == .suspended)
+        #expect(Self.resolve(signedStatus: .expired) == .expired)
+        #expect(Self.resolve(signedStatus: .deactivated) == .deactivated)
+    }
+
+    @Test("A license past its signed expiry is expired")
+    func resolvesExpiry() {
+        #expect(Self.resolve(isExpired: true) == .expired)
+    }
+
+    @Test("Grace runs out 30 days after the signed issue date, and not before")
+    func resolvesGracePeriod() {
+        #expect(Self.resolve(daysSinceValidation: 30) == .active)
+        #expect(Self.resolve(daysSinceValidation: 31) == .validationFailed)
+    }
+
+    @Test("A server that answered this session keeps a stale-looking issue date from failing grace")
+    func recentContactSuppressesStaleIssueDate() {
+        #expect(Self.resolve(daysSinceValidation: 400, hasRecentServerContact: true) == .active)
+        #expect(Self.resolve(daysSinceValidation: 400, hasRecentServerContact: false) == .validationFailed)
+    }
+
+    @Test("An unreadable signed issue date does not by itself fail the grace period")
+    func unreadableIssueDateDoesNotFailGrace() {
+        #expect(Self.resolve(daysSinceValidation: nil) == .active)
+    }
+}

--- a/TableProTests/Models/LicenseTests.swift
+++ b/TableProTests/Models/LicenseTests.swift
@@ -12,6 +12,48 @@ import Testing
 
 @Suite("License")
 struct LicenseTests {
+    private static let machineId = "9f86d081884c7d659a2feaa0c55ad015"
+
+    private static func payload(
+        status: String = "active",
+        tier: String = "starter",
+        expiresAt: String? = nil,
+        issuedAt: String = "2024-01-01T00:00:00Z",
+        email: String = "test@test.com",
+        licenseKey: String = "test-key",
+        billingCycle: String? = nil,
+        teamId: String? = nil,
+        role: String? = nil,
+        machineId: String? = nil
+    ) -> LicensePayloadData {
+        LicensePayloadData(
+            billingCycle: billingCycle,
+            licenseKey: licenseKey,
+            email: email,
+            status: status,
+            expiresAt: expiresAt,
+            issuedAt: issuedAt,
+            tier: tier,
+            teamId: teamId,
+            role: role,
+            machineId: machineId
+        )
+    }
+
+    private static func license(_ payload: LicensePayloadData) -> License {
+        License(
+            signedPayload: SignedLicensePayload(data: payload, signature: "sig"),
+            cachedOnMachineId: machineId
+        )
+    }
+
+    private static func isoString(daysAgo: Int) throws -> String {
+        let date = try #require(Calendar.current.date(byAdding: .day, value: -daysAgo, to: Date()))
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: date)
+    }
+
     // MARK: - LicenseStatus.isValid Tests
 
     @Test("LicenseStatus.isValid returns true for active status")
@@ -34,224 +76,142 @@ struct LicenseTests {
 
     // MARK: - License.isExpired Tests
 
-    @Test("isExpired returns false when expiresAt is nil")
+    @Test("isExpired returns false when the signed payload has no expiry")
     func isExpiredNilExpiresAt() {
-        let license = License(
-            key: "test-key",
-            email: "test@test.com",
-            status: .active,
-            expiresAt: nil,
-            lastValidatedAt: Date(),
-            machineId: "machine1",
-            signedPayload: SignedLicensePayload(
-                data: LicensePayloadData(
-                    billingCycle: nil,
-                    licenseKey: "test-key",
-                    email: "test@test.com",
-                    status: "active",
-                    expiresAt: nil,
-                    issuedAt: "2024-01-01T00:00:00Z",
-                    tier: "starter"
-                ),
-                signature: "sig"
-            ),
-            tier: "starter"
-        )
+        #expect(Self.license(Self.payload()).isExpired == false)
+    }
+
+    @Test("isExpired returns false when the signed expiry is in the future")
+    func isExpiredFutureDate() throws {
+        let license = Self.license(Self.payload(expiresAt: try Self.isoString(daysAgo: -30)))
         #expect(license.isExpired == false)
     }
 
-    @Test("isExpired returns false when expiresAt is in the future")
-    func isExpiredFutureDate() {
-        let futureDate = Date().addingTimeInterval(86_400 * 30)
-        let license = License(
-            key: "test-key",
-            email: "test@test.com",
-            status: .active,
-            expiresAt: futureDate,
-            lastValidatedAt: Date(),
-            machineId: "machine1",
-            signedPayload: SignedLicensePayload(
-                data: LicensePayloadData(
-                    billingCycle: nil,
-                    licenseKey: "test-key",
-                    email: "test@test.com",
-                    status: "active",
-                    expiresAt: "2025-01-01T00:00:00Z",
-                    issuedAt: "2024-01-01T00:00:00Z",
-                    tier: "starter"
-                ),
-                signature: "sig"
-            ),
-            tier: "starter"
-        )
-        #expect(license.isExpired == false)
-    }
-
-    @Test("isExpired returns true when expiresAt is in the past")
-    func isExpiredPastDate() {
-        let pastDate = Date().addingTimeInterval(-86_400 * 30)
-        let license = License(
-            key: "test-key",
-            email: "test@test.com",
-            status: .expired,
-            expiresAt: pastDate,
-            lastValidatedAt: Date(),
-            machineId: "machine1",
-            signedPayload: SignedLicensePayload(
-                data: LicensePayloadData(
-                    billingCycle: nil,
-                    licenseKey: "test-key",
-                    email: "test@test.com",
-                    status: "expired",
-                    expiresAt: "2024-01-01T00:00:00Z",
-                    issuedAt: "2023-01-01T00:00:00Z",
-                    tier: "starter"
-                ),
-                signature: "sig"
-            ),
-            tier: "starter"
-        )
+    @Test("isExpired returns true when the signed expiry is in the past")
+    func isExpiredPastDate() throws {
+        let license = Self.license(Self.payload(expiresAt: try Self.isoString(daysAgo: 30)))
         #expect(license.isExpired == true)
     }
 
     // MARK: - License.daysSinceLastValidation Tests
 
-    @Test("daysSinceLastValidation returns 0 when lastValidatedAt is today")
-    func daysSinceLastValidationToday() {
-        let license = License(
-            key: "test-key",
-            email: "test@test.com",
-            status: .active,
-            expiresAt: nil,
-            lastValidatedAt: Date(),
-            machineId: "machine1",
-            signedPayload: SignedLicensePayload(
-                data: LicensePayloadData(
-                    billingCycle: nil,
-                    licenseKey: "test-key",
-                    email: "test@test.com",
-                    status: "active",
-                    expiresAt: nil,
-                    issuedAt: "2024-01-01T00:00:00Z",
-                    tier: "starter"
-                ),
-                signature: "sig"
-            ),
-            tier: "starter"
-        )
+    @Test("daysSinceLastValidation returns 0 when the payload was issued today")
+    func daysSinceLastValidationToday() throws {
+        let license = Self.license(Self.payload(issuedAt: try Self.isoString(daysAgo: 0)))
         #expect(license.daysSinceLastValidation == 0)
     }
 
-    @Test("daysSinceLastValidation returns correct days when lastValidatedAt is 5 days ago")
-    func daysSinceLastValidationFiveDaysAgo() {
-        guard let fiveDaysAgo = Calendar.current.date(byAdding: .day, value: -5, to: Date()) else {
-            Issue.record("Failed to create date 5 days ago")
-            return
-        }
-        let license = License(
-            key: "test-key",
-            email: "test@test.com",
-            status: .active,
-            expiresAt: nil,
-            lastValidatedAt: fiveDaysAgo,
-            machineId: "machine1",
-            signedPayload: SignedLicensePayload(
-                data: LicensePayloadData(
-                    billingCycle: nil,
-                    licenseKey: "test-key",
-                    email: "test@test.com",
-                    status: "active",
-                    expiresAt: nil,
-                    issuedAt: "2024-01-01T00:00:00Z",
-                    tier: "starter"
-                ),
-                signature: "sig"
-            ),
-            tier: "starter"
-        )
+    @Test("daysSinceLastValidation counts from the signed issue date, not from local state")
+    func daysSinceLastValidationFiveDaysAgo() throws {
+        let license = Self.license(Self.payload(issuedAt: try Self.isoString(daysAgo: 5)))
         #expect(license.daysSinceLastValidation == 5)
     }
 
-    // MARK: - License.from Status Mapping Tests
-
-    @Test("License.from maps active status correctly")
-    func licenseFromMapsActiveStatus() {
-        let payloadData = LicensePayloadData(
-            billingCycle: nil,
-            licenseKey: "test-key",
-            email: "test@test.com",
-            status: "active",
-            expiresAt: nil,
-            issuedAt: "2024-01-01T00:00:00Z",
-            tier: "starter"
-        )
-        let signedPayload = SignedLicensePayload(data: payloadData, signature: "sig")
-        let license = License.from(
-            payload: payloadData,
-            signedPayload: signedPayload,
-            machineId: "machine1"
-        )
-        #expect(license.status == .active)
+    @Test("daysSinceLastValidation reads a payload issued in the future as 0, not as negative")
+    func daysSinceLastValidationClampsFutureIssueDate() throws {
+        let license = Self.license(Self.payload(issuedAt: try Self.isoString(daysAgo: -10)))
+        #expect(license.daysSinceLastValidation == 0)
     }
 
-    @Test("License.from maps expired status correctly")
-    func licenseFromMapsExpiredStatus() {
-        let payloadData = LicensePayloadData(
-            billingCycle: "monthly",
-            licenseKey: "test-key",
-            email: "test@test.com",
-            status: "expired",
-            expiresAt: "2024-01-01T00:00:00Z",
-            issuedAt: "2023-01-01T00:00:00Z",
-            tier: "starter"
-        )
-        let signedPayload = SignedLicensePayload(data: payloadData, signature: "sig")
-        let license = License.from(
-            payload: payloadData,
-            signedPayload: signedPayload,
-            machineId: "machine1"
-        )
-        #expect(license.status == .expired)
+    @Test("daysSinceLastValidation is nil when the signed issue date cannot be read")
+    func daysSinceLastValidationUnparseableIssueDate() {
+        let license = Self.license(Self.payload(issuedAt: "not-a-date"))
+        #expect(license.daysSinceLastValidation == nil)
     }
 
-    @Test("License.from maps suspended status correctly")
-    func licenseFromMapsSuspendedStatus() {
-        let payloadData = LicensePayloadData(
-            billingCycle: nil,
-            licenseKey: "test-key",
-            email: "test@test.com",
-            status: "suspended",
-            expiresAt: nil,
-            issuedAt: "2024-01-01T00:00:00Z",
-            tier: "starter"
-        )
-        let signedPayload = SignedLicensePayload(data: payloadData, signature: "sig")
-        let license = License.from(
-            payload: payloadData,
-            signedPayload: signedPayload,
-            machineId: "machine1"
-        )
-        #expect(license.status == .suspended)
+    // MARK: - Status Mapping Tests
+
+    @Test("License maps the signed active status")
+    func licenseMapsActiveStatus() {
+        #expect(Self.license(Self.payload(status: "active")).status == .active)
     }
 
-    @Test("License.from maps unknown status to validationFailed")
-    func licenseFromMapsUnknownStatusToValidationFailed() {
-        let payloadData = LicensePayloadData(
-            billingCycle: nil,
-            licenseKey: "test-key",
-            email: "test@test.com",
-            status: "unknown",
-            expiresAt: nil,
-            issuedAt: "2024-01-01T00:00:00Z",
-            tier: "starter"
-        )
-        let signedPayload = SignedLicensePayload(data: payloadData, signature: "sig")
-        let license = License.from(
-            payload: payloadData,
-            signedPayload: signedPayload,
-            machineId: "machine1"
-        )
-        #expect(license.status == .validationFailed)
+    @Test("License maps the signed expired status")
+    func licenseMapsExpiredStatus() {
+        #expect(Self.license(Self.payload(status: "expired")).status == .expired)
+    }
+
+    @Test("License maps the signed suspended status")
+    func licenseMapsSuspendedStatus() {
+        #expect(Self.license(Self.payload(status: "suspended")).status == .suspended)
+    }
+
+    @Test("License maps an unknown signed status to validationFailed")
+    func licenseMapsUnknownStatusToValidationFailed() {
+        #expect(Self.license(Self.payload(status: "unknown")).status == .validationFailed)
+    }
+
+    // MARK: - Gating Reads Only the Signed Payload
+
+    @Test("A cached blob whose outer fields claim Team over a signed Starter payload stays Starter")
+    func forgedOuterFieldsAreIgnored() throws {
+        let signed = Self.payload(status: "active", tier: "starter", expiresAt: "2024-01-01T00:00:00Z")
+        let encoded = try JSONEncoder().encode(signed)
+        let payloadJSON = try #require(String(data: encoded, encoding: .utf8))
+
+        let forged = """
+        {
+            "key": "FORGED-KEY",
+            "email": "attacker@example.com",
+            "status": "active",
+            "expiresAt": null,
+            "lastValidatedAt": "2999-01-01T00:00:00Z",
+            "machineId": "\(Self.machineId)",
+            "tier": "team",
+            "billingCycle": "lifetime",
+            "signedPayload": { "data": \(payloadJSON), "signature": "sig" }
+        }
+        """
+
+        let data = try #require(forged.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(License.self, from: data)
+
+        #expect(decoded.tier == "starter")
+        #expect(decoded.key == "test-key")
+        #expect(decoded.email == "test@test.com")
+        #expect(decoded.expiresAt != nil)
+        #expect(decoded.isExpired == true)
+        #expect(LicenseTier(rawValue: decoded.tier) == .starter)
+    }
+
+    @Test("A blob written by an older build still decodes and derives its values from the payload")
+    func legacyBlobDecodes() throws {
+        let signed = Self.payload(tier: "team", billingCycle: "yearly", teamId: "01JXYZ", role: "owner")
+        let encoded = try JSONEncoder().encode(signed)
+        let payloadJSON = try #require(String(data: encoded, encoding: .utf8))
+
+        let legacy = """
+        {
+            "key": "test-key",
+            "email": "test@test.com",
+            "status": "active",
+            "lastValidatedAt": "2024-01-01T00:00:00Z",
+            "machineId": "\(Self.machineId)",
+            "tier": "team",
+            "billingCycle": "yearly",
+            "signedPayload": { "data": \(payloadJSON), "signature": "sig" }
+        }
+        """
+
+        let data = try #require(legacy.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(License.self, from: data)
+
+        #expect(decoded.cachedOnMachineId == Self.machineId)
+        #expect(decoded.tier == "team")
+        #expect(decoded.billingCycle == "yearly")
+        #expect(decoded.status == .active)
+        #expect(decoded.boundMachineId == nil)
+    }
+
+    @Test("A saved envelope round-trips through the same two keys an older blob used")
+    func envelopeRoundTrips() throws {
+        let original = Self.license(Self.payload())
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(License.self, from: data) == original)
+
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let keys = try #require(object).keys.sorted()
+        #expect(keys == ["machineId", "signedPayload"])
     }
 
     // MARK: - LicensePayloadData Encoding Tests
@@ -380,5 +340,109 @@ struct LicenseTests {
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(LicensePayloadData.self, from: data)
         #expect(decoded == original)
+    }
+
+    // MARK: - Signed Byte Contract
+
+    /// The bytes the app verifies must be the bytes the server signed. The server does
+    /// `ksort($data)` then `json_encode($data, JSON_UNESCAPED_SLASHES)`, so the key order is
+    /// alphabetical and a forward slash stays raw. These are real outputs from that signer.
+    private static func canonicalJSON(_ payload: LicensePayloadData) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        let encoded = try encoder.encode(payload)
+        return try #require(String(data: encoded, encoding: .utf8))
+    }
+
+    private static let slashPayload = LicensePayloadData(
+        billingCycle: "yearly",
+        licenseKey: "AAAAA-BBBBB-CCCCC-DDDDD-EEEEE",
+        email: "dev/ops@example.com",
+        status: "active",
+        expiresAt: "2027-01-01T00:00:00+00:00",
+        issuedAt: "2026-08-18T10:00:00+00:00",
+        tier: "team",
+        teamId: "01JXYZ",
+        role: "owner"
+    )
+
+    @Test("A signed field containing a slash encodes to the same bytes the server signed")
+    func canonicalEncodingKeepsSlashesRaw() throws {
+        let expected = "{\"billing_cycle\":\"yearly\",\"email\":\"dev/ops@example.com\","
+            + "\"expires_at\":\"2027-01-01T00:00:00+00:00\",\"issued_at\":\"2026-08-18T10:00:00+00:00\","
+            + "\"license_key\":\"AAAAA-BBBBB-CCCCC-DDDDD-EEEEE\",\"role\":\"owner\",\"status\":\"active\","
+            + "\"team_id\":\"01JXYZ\",\"tier\":\"team\"}"
+
+        #expect(try Self.canonicalJSON(Self.slashPayload) == expected)
+    }
+
+    @Test("A payload bound to a machine encodes machine_id in the server's sorted position")
+    func canonicalEncodingIncludesBoundMachine() throws {
+        let bound = LicensePayloadData(
+            billingCycle: "yearly",
+            licenseKey: "AAAAA-BBBBB-CCCCC-DDDDD-EEEEE",
+            email: "dev/ops@example.com",
+            status: "active",
+            expiresAt: "2027-01-01T00:00:00+00:00",
+            issuedAt: "2026-08-18T10:00:00+00:00",
+            tier: "team",
+            teamId: "01JXYZ",
+            role: "owner",
+            machineId: "9f86d081884c7d659a2feaa0c55ad015"
+        )
+
+        let expected = "{\"billing_cycle\":\"yearly\",\"email\":\"dev/ops@example.com\","
+            + "\"expires_at\":\"2027-01-01T00:00:00+00:00\",\"issued_at\":\"2026-08-18T10:00:00+00:00\","
+            + "\"license_key\":\"AAAAA-BBBBB-CCCCC-DDDDD-EEEEE\","
+            + "\"machine_id\":\"9f86d081884c7d659a2feaa0c55ad015\",\"role\":\"owner\",\"status\":\"active\","
+            + "\"team_id\":\"01JXYZ\",\"tier\":\"team\"}"
+
+        #expect(try Self.canonicalJSON(bound) == expected)
+    }
+
+    @Test("An unbound payload omits machine_id so a payload signed before binding still verifies")
+    func payloadDataOmitsMachineIdWhenNil() throws {
+        let data = try JSONEncoder().encode(Self.slashPayload)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let keys = try #require(object)
+
+        #expect(keys["machine_id"] == nil)
+        #expect(keys.keys.count == 9)
+    }
+
+    @Test("A bound payload carries machine_id as a tenth key")
+    func payloadDataEncodesMachineId() throws {
+        let bound = LicensePayloadData(
+            billingCycle: nil,
+            licenseKey: "ABC-123",
+            email: "user@example.com",
+            status: "active",
+            expiresAt: nil,
+            issuedAt: "2026-01-01T00:00:00Z",
+            tier: "starter",
+            machineId: "abc123"
+        )
+        let data = try JSONEncoder().encode(bound)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let keys = try #require(object)
+
+        #expect(keys["machine_id"] as? String == "abc123")
+        #expect(keys.keys.count == 8)
+    }
+
+    @Test("machine_id round-trips through Codable")
+    func payloadDataRoundTripsMachineId() throws {
+        let original = LicensePayloadData(
+            billingCycle: nil,
+            licenseKey: "ABC-123",
+            email: "user@example.com",
+            status: "active",
+            expiresAt: nil,
+            issuedAt: "2026-01-01T00:00:00Z",
+            tier: "starter",
+            machineId: "abc123"
+        )
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(LicensePayloadData.self, from: data) == original)
     }
 }

--- a/docs/features/licensing.mdx
+++ b/docs/features/licensing.mdx
@@ -44,9 +44,10 @@ To move the license to another Mac, click **Deactivate...** in **Settings > Acco
 
 Activation stores a signed license on your Mac. The license key goes in the macOS Keychain.
 
-- On every launch, TablePro re-verifies the license signature offline. No network needed.
+- On every launch, TablePro re-verifies the license signature offline. No network needed. Your tier, status, and expiry all come from the signed license, so editing the copy on disk changes nothing.
 - Every 7 days, the app re-validates with the license server in the background.
 - If the server is unreachable, the license keeps working for 30 days after the last successful validation. After that, the status changes to Validation Failed and Pro features pause until a validation succeeds.
+- If the server replies that the license is suspended, expired, or no longer activated on this Mac, Pro features pause at that check. The offline grace period only covers a server TablePro could not reach. Reopening the app runs on the signed license again until the next check, which is never more than a week after the last successful validation.
 
 **Check Status** in **Settings > Account** re-validates on demand, and gated screens offer **Retry Validation**. When a license expires within 7 days, the Account tab shows a renewal warning with a link to tablepro.app.
 


### PR DESCRIPTION
Fixes #2181.

## Root cause

`LicenseManager.loadCachedLicense()` verified the cached signed payload and then threw the result away (`_ = try verifier.verify(...)`), adopting the whole cached `License` struct instead. `License` stored `status`, `tier`, `expiresAt`, `lastValidatedAt`, `key`, `email`, `billingCycle` and `machineId` as ordinary properties in one UserDefaults blob, and every gating decision read those. Only `signedPayload` was covered by a signature.

The structural cause is that `License` was two things at once: an envelope around the server's signed payload, and an independent mutable second copy of the same facts. The signature authenticated the first copy; gating read the second. `machineId` lived in the same blob, so that guard was defeated by editing it.

## The fix

`License` now has exactly two stored properties, `signedPayload` and `cachedOnMachineId`. Every gating field is computed from the RSA-verified payload, so a forged value has nowhere to live. `cachedOnMachineId` stays as the tripwire that drops a cache restored from another Mac's backup, and the code says plainly that it is not a security control.

Three things follow from that:

- **The grace clock moves onto the signed `issued_at`.** The server sets `issued_at = now()` on every sign and only activate, validate and accept-invite sign anything, so it is the time of the last successful server contact and it is signed. That deletes `lastValidatedAt`, the last locally writable field that granted entitlement.
- **Signed machine binding.** `LicensePayloadData` gains an optional `machineId`, and `verifiedPayload(from:)` is now the single funnel every payload passes through before it is trusted. This is stage 2 of the rollout already specified in the license server's `docs/machine-binding-rollout.md`; `encodeIfPresent` keeps payloads issued before stage 1 verifying byte for byte, and a nil binding is accepted so nobody is locked out.
- **A server rejection is no longer treated as a network outage.** `revalidate()` had one untyped `catch`, so a 403 "License has been suspended" and dropped Wi-Fi took the same path: the app logged a warning, kept `status = .active`, and never set `lastError`, so **Check Status** reported nothing. Suspension, expiry, an activation removed for this Mac, and an unknown key now each map to a status. This ships here rather than separately because after the primary fix `revalidate()` is the only thing that refreshes the payload gating depends on.

Two smaller repairs in the same path:

- `.withoutEscapingSlashes` on the verifier's encoder. The server signs `json_encode($data, JSON_UNESCAPED_SLASHES)`; Swift was escaping the slash, so a license whose email contains one could never be activated and the error told the user to update the app, which never helped.
- The 404 branch in `LicenseAPIClient` now decodes the error body before mapping to `.invalidKey`, matching what the 403 branch already did, so a captive portal answering 404 is a transport failure rather than a revoked license.

## Proof

A harness signs a payload with PHP `openssl_sign` exactly as the license server does, then verifies it with the verbatim body of `verify()`, before and after:

```
=== 1. Byte contract: a signed field containing '/'
   email signed by the server: dev/ops@example.com
   BEFORE (.sortedKeys only)                 verify = false
   AFTER  (+ .withoutEscapingSlashes)        verify = true

=== 2. Forged cache: genuine Starter payload, outer fields claim Team
   signature on the payload is genuine:       true
   BEFORE  tier used for gating =             team   key = FORGED
   AFTER   tier used for gating =             starter   key = AAAAA-BBBBB-CCCCC-DDDDD-EEEEE
```

The ASCII control passes on both sides, which is what isolates the cause in the first case.

## Migration

An existing blob carries `signedPayload` and `machineId` plus five keys that are now unknown and are ignored, so it decodes and keeps working with no shim. A new blob writes only the two keys. Rolling back to an older build loses the cache and needs a re-activation, which the server handles idempotently for a machine that is already activated, so no seat is burned.

## Built and tested

Run through `verify.sh` in an isolated worktree, all against Debug:

| step | verdict |
| --- | --- |
| `generate` | PASS |
| `build TablePro` | PASS |
| `test LicenseTests LicenseTierTests LicenseManagerDecisionTests TeamLibrarySyncCoordinatorTests` | PASS, 70 executed, 70 passed |
| `lint TablePro TableProTests` | PASS, 0 violations |

70 cases against 70 declared `@Test` functions, so nothing was silently skipped by the suite filter.

New coverage, on top of the rewritten model tests:

- The regression test for this issue: a legacy-shaped blob whose outer fields say active/team over a signed payload that says active/starter resolves to Starter.
- A blob written by an older build still decodes, and the envelope round-trips through the same two keys.
- Golden bytes: the canonical encoding of a payload whose email contains `/` equals the exact string the real PHP signer produces, with and without `machine_id`.
- `resolveCachedLicense`, `acceptsMachine`, `revocationStatus` and `resolveStatus` are `nonisolated static` pure functions, following the existing `resolveAccess` precedent, and each is tested over its grid.

No `TableProUITests`. The flow needs a forged UserDefaults blob plus a genuinely signed payload, and `AppDelegate` skips startup under XCTest, so it cannot run deterministically. No screenshots: the only visible change is the Settings > Account status row now reading the resolved status, and a warning line under **Check Status** when the server replied with a rejection.

## Reviews

`security-review` found no exploitable findings, and confirmed that every value reaching a gating decision traces back to the verified payload, that neither new in-memory field can grant entitlement, and that the client half of the machine binding fails closed in both directions. It did surface a pre-existing fail-open in the switch this PR edits: a signed status the app does not recognise fell through `default: break` and resolved to active. That is closed here, and `resolveStatus` now only lets a signed `active` proceed.

`code-review` flagged that passing the MainActor-isolated `verifiedPayload` into a `nonisolated static` function compiles under Swift 5 but blocks Swift 6 migration. `resolveCachedLicense` now takes the plain `verifier.verify` and does the machine check itself, which removes the conversion and puts the binding logic under that function's own tests.

## Scope

Not done here, deliberately:

- Stage 3 of the machine binding (`LICENSE_MACHINE_BINDING_REQUIRED=true`) and setting `MIN_APP_VERSION`. Both are server side and adoption gated, and the rollout doc sequences them after this app release.
- Making verification tolerant of unknown server keys. Stage 2 works without it, and doing it properly needs a server change, because the server re-encodes for the HTTP response and so never sends the bytes it signed.
- The non-ASCII half of the encoder divergence. PHP escapes to `\uXXXX` and Swift emits raw UTF-8, so a license whose email holds a non-ASCII character never verifies. It fails closed, and the fix is `JSON_UNESCAPED_UNICODE` in the license repo.

A server rejection is held in memory rather than persisted, so quitting the app runs on the signed license again until the next check. That check is never more than about a week after the last successful validation, because a rejection does not advance the signed `issued_at`. Persisting it would put licensing state back outside the signature, which is the shape of the bug being fixed.
https://claude.ai/code/session_01DZmrNHvcGbCUdh8RFSA29z
