### PR TITLE
fix(hig): drop the em dash from five on-screen strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Five bits of on-screen text dropped the em dash they were punctuated with: the JSON and PHP viewer window titles, the expired-license banner in **Settings** > **Account**, the empty foreign key preview, and the warning line in the connection import list. The JSON viewer title can also be translated now, which it never could before.
 - The Quick Switcher is now called **Open Quickly** and lives in the **File** menu under Open File, the name and place macOS uses for jumping straight to something by name. The keyboard shortcut is unchanged at `Cmd+Shift+O`, and it is still rebindable in **Settings** > **Keyboard**. (#2185)
 - `Cmd+Return` opens the selected item in a new tab in Open Quickly, alongside the `Option+Return` that already did. (#2185)
 - When a connection fails because a sign-in expired, TablePro now offers to sign in again and reconnects for you, instead of leaving you on an error screen whose only button repeats the same failure. This covers Microsoft Entra ID and AWS SSO, on the connection itself as well as in the connection form's Test button.

--- a/TablePro/Views/Connection/ImportFromApp/ConnectionImportPreviewList.swift
+++ b/TablePro/Views/Connection/ImportFromApp/ConnectionImportPreviewList.swift
@@ -109,7 +109,7 @@ struct ConnectionImportPreviewList: View {
     @ViewBuilder
     private func warningText(for status: ImportItemStatus) -> some View {
         if case .warnings(let messages) = status, let first = messages.first {
-            Text(" — \(first)")
+            Text(", \(first)")
                 .foregroundStyle(.orange)
         }
     }

--- a/TablePro/Views/Results/ForeignKeyPreviewView.swift
+++ b/TablePro/Views/Results/ForeignKeyPreviewView.swift
@@ -93,7 +93,7 @@ struct ForeignKeyPreviewView: View {
     @ViewBuilder
     private var content: some View {
         if cellValue == nil {
-            Text("NULL — no referenced row")
+            Text("NULL, no referenced row")
                 .foregroundStyle(.secondary)
                 .font(.callout)
                 .frame(maxWidth: .infinity, alignment: .center)

--- a/TablePro/Views/Results/JSONViewerWindowController.swift
+++ b/TablePro/Views/Results/JSONViewerWindowController.swift
@@ -47,7 +47,11 @@ final class JSONViewerWindowController {
             defer: false
         )
         window.identifier = NSUserInterfaceItemIdentifier("json-viewer")
-        window.title = columnName.map { "JSON — \($0)" } ?? String(localized: "JSON Viewer")
+        if let columnName {
+            window.title = String(format: String(localized: "JSON: %@"), columnName)
+        } else {
+            window.title = String(localized: "JSON Viewer")
+        }
         window.isReleasedWhenClosed = false
         window.minSize = Self.minSize
         window.collectionBehavior = [.fullScreenPrimary]

--- a/TablePro/Views/Results/PhpViewerWindowController.swift
+++ b/TablePro/Views/Results/PhpViewerWindowController.swift
@@ -30,7 +30,7 @@ final class PhpViewerWindowController {
         )
         window.identifier = NSUserInterfaceItemIdentifier("php-viewer")
         if let columnName {
-            window.title = String(format: String(localized: "PHP — %@"), columnName)
+            window.title = String(format: String(localized: "PHP: %@"), columnName)
         } else {
             window.title = String(localized: "PHP Viewer")
         }

--- a/TablePro/Views/Settings/AccountSettingsView.swift
+++ b/TablePro/Views/Settings/AccountSettingsView.swift
@@ -29,7 +29,7 @@ struct AccountSettingsView: View {
             HStack {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundStyle(.orange)
-                Text(String(localized: "Sync paused — Pro license expired"))
+                Text(String(localized: "Sync paused, Pro license expired"))
                     .font(.callout)
                 Spacer()
                 Link(String(localized: "Renew License..."), destination: LicenseConstants.pricingURL)

--- a/TableProTests/Views/UserFacingEmDashGuardTests.swift
+++ b/TableProTests/Views/UserFacingEmDashGuardTests.swift
@@ -1,0 +1,148 @@
+//
+//  UserFacingEmDashGuardTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+/// CLAUDE.md's writing style bans the em dash from anything a user reads, and a review only catches
+/// it when someone happens to look at the right line. Five had accumulated in shipped UI strings,
+/// including two window titles, so this reads the source instead.
+///
+/// Two uses are deliberate and stay. A quoted em dash on its own is the macOS convention for "no
+/// value", the one Finder and Activity Monitor use in list columns, and it is a glyph rather than a
+/// sentence to rewrite. Log messages are not user-facing. The JetBrains keychain service names need
+/// no exemption: they spell the character `\u{2014}`, so the literal never appears in the source.
+@Suite("User-facing strings carry no em dash")
+struct UserFacingEmDashGuardTests {
+    private static let emDash: Character = "\u{2014}"
+    private static let placeholderGlyph = "\"\u{2014}\""
+
+    @Test("No em dash reaches a string literal in the app target")
+    func appTargetStringLiteralsAreClean() throws {
+        let offenders = try Self.offenders()
+
+        #expect(
+            offenders.isEmpty,
+            """
+            An em dash reached a user-facing string. Use a comma, period, colon, or rewrite it. \
+            The house style is the comma; see "Truncated, read only" and "License expired, sync paused".
+            \(offenders.joined(separator: "\n"))
+            """
+        )
+    }
+
+    private static func offenders() throws -> [String] {
+        let root = try repoRoot().appendingPathComponent("TablePro", isDirectory: true)
+        guard let enumerator = FileManager.default.enumerator(at: root, includingPropertiesForKeys: nil) else {
+            throw GuardError.sourceTreeNotFound
+        }
+
+        var found: [String] = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            let text = try String(contentsOf: url, encoding: .utf8)
+            let lines = text.components(separatedBy: .newlines)
+            var previous = ""
+            for (index, line) in lines.enumerated() {
+                defer { if !line.trimmingCharacters(in: .whitespaces).isEmpty { previous = line } }
+                guard carriesProseEmDash(line: line, previous: previous) else { continue }
+                found.append("\(url.lastPathComponent):\(index + 1): \(line.trimmingCharacters(in: .whitespaces))")
+            }
+        }
+        return found.sorted()
+    }
+
+    /// A line offends when an em dash survives inside a double-quoted span after the placeholder
+    /// glyph is removed, and neither it nor the call it continues is a comment or a log message.
+    static func carriesProseEmDash(line: String, previous: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.hasPrefix("//") else { return false }
+        guard !isLogging(trimmed), !isLogging(previous.trimmingCharacters(in: .whitespaces)) else { return false }
+
+        let withoutPlaceholders = trimmed.replacingOccurrences(of: placeholderGlyph, with: "")
+        guard withoutPlaceholders.contains(emDash) else { return false }
+        return quotedSpansContainEmDash(withoutPlaceholders)
+    }
+
+    private static func isLogging(_ line: String) -> Bool {
+        let markers = ["logger.", "Logger(", "os_log", ".debug(", ".info(", ".notice(", ".warning(", ".fault("]
+        return markers.contains { line.contains($0) }
+    }
+
+    private static func quotedSpansContainEmDash(_ line: String) -> Bool {
+        var insideQuotes = false
+        var escaped = false
+        for character in line {
+            if escaped {
+                escaped = false
+                continue
+            }
+            if character == "\\" {
+                escaped = true
+                continue
+            }
+            if character == "\"" {
+                insideQuotes.toggle()
+                continue
+            }
+            if insideQuotes, character == emDash {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func repoRoot() throws -> URL {
+        var directory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        for _ in 0 ..< 12 {
+            if FileManager.default.fileExists(atPath: directory.appendingPathComponent("TablePro.xcodeproj").path) {
+                return directory
+            }
+            directory = directory.deletingLastPathComponent()
+        }
+        throw GuardError.repoRootNotFound
+    }
+
+    private enum GuardError: Error {
+        case repoRootNotFound
+        case sourceTreeNotFound
+    }
+}
+
+@Suite("Em dash guard classifies lines correctly")
+struct UserFacingEmDashClassifierTests {
+    private func offends(_ line: String, previous: String = "") -> Bool {
+        UserFacingEmDashGuardTests.carriesProseEmDash(line: line, previous: previous)
+    }
+
+    @Test("Prose inside a string literal offends")
+    func proseOffends() {
+        #expect(offends("Text(\"NULL \u{2014} no referenced row\")"))
+        #expect(offends("window.title = String(format: String(localized: \"PHP \u{2014} %@\"), name)"))
+    }
+
+    @Test("The no-value placeholder glyph is allowed")
+    func placeholderGlyphIsAllowed() {
+        #expect(!offends("Text(verbatim: \"\u{2014}\").foregroundStyle(.tertiary)"))
+        #expect(!offends("guard let bytes else { return \"\u{2014}\" }"))
+    }
+
+    @Test("Comments and log messages are out of scope")
+    func commentsAndLogsAreAllowed() {
+        #expect(!offends("// counts newlines \u{2014} uses a fast NSString search"))
+        #expect(!offends("/// Returns nil when absent \u{2014} the caller retries"))
+        #expect(!offends("logger.warning(\"failed \u{2014} \\(error)\")"))
+        #expect(!offends("\"Startup failed: \\(statement) \u{2014} \\(error)\"", previous: "Self.startupLogger.warning("))
+    }
+
+    @Test("An em dash outside any quoted span is not a string literal")
+    func unquotedEmDashIsIgnored() {
+        #expect(!offends("let separator = someValue \u{2014} other"))
+    }
+
+    @Test("An escaped unicode spelling is not the literal character")
+    func escapedSpellingIsIgnored() {
+        #expect(!offends("\"IntelliJ Platform DB \\u{2014} \\(uuid)\""))
+    }
+}


### PR DESCRIPTION
Follow-up to #2194, which reported this while working nearby.

`CLAUDE.md` bans the em dash from anything a user reads. Five on-screen strings still had one:

| Where | Was | Now |
| --- | --- | --- |
| JSON viewer window title | `JSON — <column>` | `JSON: <column>` |
| PHP viewer window title | `PHP — <column>` | `PHP: <column>` |
| **Settings** > **Account**, expired-license banner | `Sync paused — Pro license expired` | `Sync paused, Pro license expired` |
| Foreign key preview, NULL cell | `NULL — no referenced row` | `NULL, no referenced row` |
| Connection import list, warning line | ` — <warning>` | `, <warning>` |

## Why the comma, and why the colon

The comma is the house style, not a guess. The repo has already migrated four identical em dashes and every one became a comma: `Truncated, read only`, `License expired, sync paused`, and both `~/.pgpass found, ...` strings. `License expired, sync paused` matters most here, because it is the live sibling of the Account banner. A colon there would punctuate the same fact two different ways on two adjacent surfaces.

The colon stays for the two window titles, where the left side is a bare label rather than a clause.

The import list is the one place a colon would have been actively wrong. The subtitle immediately before it is `\(host):\(port)`, rendered in an `HStack(spacing: 0)` under `lineLimit(1)`, so a colon would produce `localhost:5432: Some values are set outside this file`: two colons, two meanings, one line.

## The JSON title was also unlocalized

It was built as `columnName.map { "JSON — \($0)" }`, raw interpolation with no `String(localized:)`, so the key never reached the catalog and the title was English in every locale. It now uses `String(format: String(localized: "JSON: %@"), columnName)`, the shape `CLAUDE.md` requires and the one the PHP twin already used, so it is translatable for the first time.

## What was deliberately left alone

- **`JetBrainsCredentialStore.swift:44,48,52`.** Three Keychain service names embed an em dash because they mirror IntelliJ's own `generateServiceName` format, `IntelliJ Platform <subsystem> — <key>`. They are lookup keys, not prose, and rewriting them would break JetBrains credential import. They spell the character as `\u{2014}`, so a literal-character grep does not surface them, which is exactly how a blanket sweep would have broken this.
- **Nine "no value" placeholder glyphs** (`Text(verbatim: "—")`, `?? "—"`) in the integrations panes and the metadata models. A bare em dash meaning "empty" is the macOS convention Finder and Activity Monitor use. It is a glyph, not a sentence to rewrite.
- **Log messages, comments, released `CHANGELOG` sections, and `appcast.xml`.** Not user-facing, or a frozen record of what already shipped. `[Unreleased]` had none, and `docs/` is already clean.

## Translations

The catalog is compiler-extracted, and a command-line `xcodebuild` does not write back to it: I measured the file hash before and after a full build and it did not move. So the four renamed keys keep their old translations and the new keys are absent, which means these five strings fall back to their English source in `tr`, `vi`, `zh-Hans` and `zh-Hant` until the catalog is regenerated in Xcode and refilled.

No em dash reaches any user either way, because the fallback is the fixed English. This also matches what the repo already does: `decd6952e` renamed strings the same way and `627a03a34` refilled the translations a month later.

Five values are worth carrying over when that happens. The rest of the old values are verbatim English copies with nothing to preserve.

| Old key | Language | Value to re-key, with the mark swapped |
| --- | --- | --- |
| `NULL — no referenced row` | tr | `NULL, referans satır yok` |
| `NULL — no referenced row` | vi | `NULL, không có dòng tham chiếu` |
| `NULL — no referenced row` | zh-Hans | `NULL，无引用行` |
| `Sync paused — Pro license expired` | vi | `Tạm dừng đồng bộ, giấy phép Pro đã hết hạn` |
| `Sync paused — Pro license expired` | zh-Hans | `同步已暂停 - Pro 许可证已过期` (already has no em dash) |

`zh-Hant` already reads `NULL，沒有參照的列` and `同步已暫停，Pro 授權已過期`, so both are correct as they stand.

I did not hand-edit `Localizable.xcstrings`: the repo hook warns it is shared and frequently dirty from other work, and hand-writing 2.4 MB of catalog to save five values is the riskier trade.

## The guard

`UserFacingEmDashGuardTests` reads the app sources and fails on an em dash inside a string literal. It exempts the placeholder glyph, comments and log messages, and needs no exemption for the JetBrains names because those spell the character as an escape.

A guard test that cannot fail is worse than none, so I checked this one bites: reintroducing `Text("NULL — no referenced row")` fails it. A companion suite tests the classifier directly on each case it has to get right, including the escaped spelling and the multi-line log call.

## Verification

- `generate`: PASS
- `build` (Debug): PASS
- `test` UserFacingEmDashGuardTests, UserFacingEmDashClassifierTests: PASS, 6 executed, 6 passed
- Mutation check: reintroducing one em dash fails the guard
- `swiftlint` over `TablePro` and `TableProTests`: 0 violations

No UI automation: these are static strings with no flow to drive, and the source-scanning guard covers them more directly than a UI test could.
