### PR TITLE
fix(release): stop plugin builds from taking the latest release, and add a switching guide

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -372,6 +372,7 @@ jobs:
           gh release create "$TAG" \
             --title "$DISPLAY_NAME v$VERSION" \
             --notes "$RELEASE_BODY" \
+            --latest=false \
             build/Plugins/${BUNDLE_NAME}-arm64.zip \
             build/Plugins/${BUNDLE_NAME}-x86_64.zip
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -38,7 +38,7 @@
         "groups": [
           {
             "group": "Getting Started",
-            "pages": ["index", "quickstart", "installation", "changelog"]
+            "pages": ["index", "quickstart", "installation", "switching", "changelog"]
           },
           {
             "group": "Database Connections",

--- a/docs/switching.mdx
+++ b/docs/switching.mdx
@@ -1,0 +1,119 @@
+---
+title: Switching to TablePro
+description: Move your connections from TablePlus, Sequel Ace, DBeaver, DataGrip, Beekeeper Studio or Navicat, what comes across, what does not, and how to get your shortcuts back.
+---
+
+Most of a migration is one dialog. **File** > **Import from Other App...** reads the connections your current client already has, including groups and folders, and the source app does not need to be running.
+
+This page covers the rest: what does not come across, and what to do about it.
+
+## Import your connections
+
+<Steps>
+  <Step title="Open the importer">
+    **File** > **Import from Other App...**
+  </Step>
+  <Step title="Pick your current client">
+    Navicat is the one exception: export first with **File** > **Export Connections** in Navicat, with **Export Password** turned on, then point TablePro at the `.ncx` file.
+  </Step>
+  <Step title="Review and import">
+    Uncheck anything you don't want, resolve duplicates, click **Import**.
+  </Step>
+</Steps>
+
+<Frame caption="Pick the client you're coming from">
+  <img className="block dark:hidden" src="/images/import-from-app-picker.png" alt="Import from other app, source picker" />
+  <img className="hidden dark:block" src="/images/import-from-app-picker-dark.png" alt="Import from other app, source picker" />
+</Frame>
+
+<Frame caption="Review before anything is saved">
+  <img className="block dark:hidden" src="/images/connection-import-preview.png" alt="Import preview listing the connections found" />
+  <img className="hidden dark:block" src="/images/connection-import-preview-dark.png" alt="Import preview listing the connections found" />
+</Frame>
+
+| Coming from | Databases | Passwords |
+|-------------|-----------|-----------|
+| TablePlus | MySQL, PostgreSQL, MongoDB, SQLite, Redis, and more | From Keychain |
+| Sequel Ace | MySQL | From Keychain |
+| DBeaver | MySQL, PostgreSQL, SQLite, SQL Server, Oracle, and more | Decrypted from config file |
+| DataGrip | MySQL, PostgreSQL, SQLite, SQL Server, Oracle, and more | From Keychain or `c.kdbx` |
+| Beekeeper Studio | MySQL, PostgreSQL, SQLite, SQL Server, Oracle, and more | Decrypted from its `app.db` store |
+| Navicat | MySQL, MariaDB, PostgreSQL, SQLite, SQL Server, Oracle, MongoDB | Decrypted from `.ncx` file |
+
+SSH tunnel and SSL settings come across with the connection. See [Connection Sharing](/features/connection-sharing) for the full detail on each source.
+
+## About passwords
+
+This is the part of any migration that goes wrong, so it is worth knowing which case you are in before you start.
+
+**Passwords in a file.** DBeaver, Beekeeper Studio and Navicat keep credentials in their own encrypted store. TablePro decrypts it and the import runs start to finish with nothing to click.
+
+**Passwords in the macOS Keychain.** TablePlus, Sequel Ace and DataGrip store each password as a separate Keychain item, and macOS asks permission per item. On a large connection list that is a lot of prompts. Choose **Always Allow** rather than **Allow** and the run finishes without asking again.
+
+A DataGrip project protected by a master password cannot be read at all. Import those connections and set their passwords in TablePro.
+
+## What does not come across
+
+Be aware of these before you delete the old app.
+
+| Not imported | What to do |
+|--------------|------------|
+| Saved queries and snippets | Re-save the ones you actually use as [Favorites](/features/favorites) with `Cmd+D`. To keep a whole folder of `.sql` files in sync instead, including one tracked in git, [Linked Folders](/features/connection-sharing) does that and needs a Starter license |
+| Query history | Starts fresh. TablePro records history per connection from the first query you run, searchable with `Cmd+Y` |
+| Column widths, sort order and per-table filters | Rebuilt as you browse. TablePro saves these per table on its own |
+| Keyboard shortcuts | See below |
+
+## Getting your shortcuts back
+
+TablePro follows macOS conventions, so a good number of chords already match whatever you were using: `Cmd+N`, `Cmd+W`, `Cmd+S`, `Cmd+O`, `Cmd+Q`, `Cmd+F`, and `Cmd+Enter` to run a query.
+
+Where yours differ, rebind them in **Settings** > **Keyboard** (`Cmd+,`). Record the chord you are used to and TablePro warns you if something else already claims it.
+
+<Frame caption="Settings > Keyboard, where every rebindable shortcut lives">
+  <img className="block dark:hidden" src="/images/settings-keyboard.png" alt="Keyboard settings with the shortcut recorder" />
+  <img className="hidden dark:block" src="/images/settings-keyboard-dark.png" alt="Keyboard settings with the shortcut recorder" />
+</Frame>
+
+These are the ones worth setting up on your first day, because they are the jobs you do constantly:
+
+| Job | TablePro |
+|-----|----------|
+| Run the statement under the cursor | `Cmd+Enter` |
+| Run every statement | `Cmd+Shift+Enter` |
+| Jump to any table, database or saved query by name | `Cmd+Shift+O` |
+| Switch database | `Cmd+K` |
+| Query history | `Cmd+Y` |
+| Cancel a running query | `Cmd+.` |
+| Format the query | `Cmd+Shift+L` |
+| Explain the query | `Cmd+Option+E` |
+| Save the query as a favorite | `Cmd+D` |
+
+A few cannot be reassigned, so it is better to learn them than to fight them: editor built-ins such as `Cmd+/` for comment, `Cmd+[` and `Cmd+]` for indent, tab selection `Cmd+1` through `Cmd+9`, text size `Cmd+=` and `Cmd+-`, and `Cmd+F` for find. The recorder tells you when you hit one.
+
+If you use Vim bindings, turn on [Vim Mode](/features/vim-mode) in **Settings** > **Editor** and most of this section stops mattering.
+
+The full list is in [Keyboard Shortcuts](/features/keyboard-shortcuts).
+
+## Coming from a client TablePro cannot import
+
+Two other routes exist.
+
+**A connection URL.** **Add from Existing** > **Import from URL** takes a `postgres://`, `mysql://` or similar URL and fills in the form. Fastest path when you only have a handful of connections.
+
+<Frame caption="Import from URL">
+  <img className="block dark:hidden" src="/images/import-from-url.png" alt="Import a connection from a database URL" />
+  <img className="hidden dark:block" src="/images/import-from-url-dark.png" alt="Import a connection from a database URL" />
+</Frame>
+
+**A project folder.** [Open Project Folder](/features/project-folder-import) reads the database settings out of a project's config files, so a repository with a `.env`, `docker-compose.yml` or framework config becomes a connection without you typing a host.
+
+## If your database is not supported yet
+
+TablePro ships 14 drivers inside the app and installs 17 more from the plugin registry on demand, so a database missing from the connection form may still be one click away in **Settings** > **Plugins** > **Browse**.
+
+<Frame caption="Settings > Plugins > Browse">
+  <img className="block dark:hidden" src="/images/settings-plugins-browse.png" alt="Plugin registry browser" />
+  <img className="hidden dark:block" src="/images/settings-plugins-browse-dark.png" alt="Plugin registry browser" />
+</Frame>
+
+If it is genuinely not there, open a request on [GitHub](https://github.com/TableProApp/TablePro/issues). Driver coverage is tracked in the open, and the [supported database list](/databases/overview) is the current answer.


### PR DESCRIPTION
Two fixes to the path a new user actually walks, found while auditing where people who reach the project drop off.

## `releases/latest` served a plugin, not the app

`gh release create` in the plugin workflow never passed `--latest=false`, so whichever plugin shipped most recently took the latest spot. `releases/latest` resolved to `plugin-oracle-v1.2.20`, a two-hash install note, for anyone landing on the releases page or scripting an install. 162 of the repo's releases are plugin builds, so this was the normal state rather than an edge case.

One flag stops it recurring. The current release was re-pointed to v0.65.0 by hand, since the workflow only affects future runs.

`build.yml` is deliberately untouched: it pins `softprops/action-gh-release@v1` by SHA and `make_latest` only exists from v2, so adding the input there would risk the release job for no gain. With no plugin release claiming latest, app releases hold it on their own.

## No page for people switching from another client

The importer reads six other clients and that is documented, but only inside Connection Sharing, which nobody searching for how to move off their current tool would open. `docs/switching.mdx` is that page, in Getting Started after Installation.

It covers the parts a migration actually trips on:

- Which client maps to which databases, and where each one keeps its passwords
- The Keychain versus file split, and choosing **Always Allow** so a large import does not turn into one prompt per connection
- What does not come across: saved queries, query history, column widths, shortcuts, with what to do about each
- The shortcuts worth setting up on day one, and the ones that cannot be rebound
- Routes for clients the importer does not read: connection URL, project folder

Screenshots reuse the existing image set. Every image path and internal link was checked to exist.

No CHANGELOG entry: documentation-only, plus a CI change with no user-visible app behaviour.
