### PR TITLE
ci(release): stop running the macOS suite twice per release and drop the unused Homebrew setup

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -306,9 +306,16 @@ supported names. New plugins must be added to the workflow mapping.
 
 ### Plugin Release Steps
 
-1. **Verify tag is available** — `git tag -l "plugin-<name>-v<version>"`
-2. **Tag** — `git tag plugin-<name>-v<version>`
-3. **Push tag** — `git push origin plugin-<name>-v<version>`
+1. **Verify tag is available**: `git tag -l "plugin-<name>-v<version>"`
+2. **Tag**: `git tag plugin-<name>-v<version>`
+3. **Push tag**: `git push origin plugin-<name>-v<version>`
+
+**If an app release is already running, wait for it to finish before pushing
+plugin tags.** The account runs five macOS jobs at a time and every plugin
+build takes one of them. On v0.66.0, seven plugin tags pushed two minutes
+after the app tag left the release's own test suite queued for nine minutes
+and pushed one plugin build back by twenty. Check with
+`gh run list --workflow build.yml --limit 1` first.
 
 No version bumps or changelog edits needed — plugin bundles keep
 `MARKETING_VERSION = 1.0` and `CURRENT_PROJECT_VERSION = 1` in `project.yml`.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,22 +2,28 @@ name: Build TablePro
 
 on:
   workflow_dispatch:
+  # No paths filter here. GitHub does not evaluate one for a tag push, and a tag push is the
+  # only thing that triggers this workflow, so the paths-ignore list that used to sit here
+  # never excluded anything.
   push:
     tags: ["v*"]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - ".vscode/**"
+
+# A release must never be cancelled part-way through: the build jobs hold notarization
+# submissions open with Apple, and the release job pushes a commit and publishes artifacts.
+# Re-running the same tag queues behind the run already in flight rather than racing it.
+concurrency:
+  group: build-tablepro-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   lint:
     name: SwiftLint
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 10
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install SwiftLint
         run: brew list swiftlint &>/dev/null || brew install swiftlint
@@ -37,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -49,29 +55,24 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: scripts/download-libs.sh --force
 
-      - name: Install ARM64 dependencies
-        run: |
-          echo "Installing ARM64 dependencies..."
+      # build-release.sh clones packages into ~/.spm-cache via -clonedSourcePackagesDirPath,
+      # so this restores the checkouts instead of re-cloning 30 repositories on every release.
+      # Package.resolved pins every revision and is tracked, which is why it can key the cache.
+      - name: Cache Swift package checkouts
+        uses: actions/cache@v6
+        with:
+          path: ~/.spm-cache
+          key: ${{ runner.os }}-spm-${{ hashFiles('TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: ${{ runner.os }}-spm-
 
-          # Check and install only if needed
-          if ! brew list mariadb-connector-c &>/dev/null; then
-            echo "📦 Installing mariadb-connector-c..."
-            brew install mariadb-connector-c
-          else
-            echo "✅ mariadb-connector-c already installed"
-          fi
-
-          # Link packages with --force and --overwrite (needed for keg-only formulas)
-          brew link --force --overwrite mariadb-connector-c 2>/dev/null || true
-
-          if ! brew list create-dmg &>/dev/null; then
-            echo "📦 Installing create-dmg..."
-            brew install create-dmg
-          else
-            echo "✅ create-dmg already installed"
-          fi
-
-          echo "✅ ARM64 dependencies installed"
+      # create-dmg is the only Homebrew formula either build job needs. The MySQL plugin
+      # links Libs/libmariadb.a, which download-libs.sh vendors and prepare-libs.sh selects
+      # per architecture, and its headers live in Plugins/MySQLDriverPlugin/CMariaDB/include.
+      # LIBRARY_SEARCH_PATHS names $(SRCROOT)/Libs and no Homebrew prefix, so nothing in the
+      # build ever read mariadb-connector-c. macos-tests.yml proves it: the app-tests job
+      # links all 31 plugin bundles with no Homebrew mariadb installed at all.
+      - name: Install create-dmg
+        run: brew list create-dmg &>/dev/null || brew install create-dmg
 
       - name: Prepare libraries
         run: scripts/ci/prepare-libs.sh arm64
@@ -138,7 +139,7 @@ jobs:
         run: scripts/ci/package-artifacts.sh arm64
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-arm64
           path: |
@@ -152,7 +153,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -164,40 +165,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: scripts/download-libs.sh --force
 
-      - name: Install Rosetta 2
-        run: softwareupdate --install-rosetta --agree-to-license || true
+      - name: Cache Swift package checkouts
+        uses: actions/cache@v6
+        with:
+          path: ~/.spm-cache
+          key: ${{ runner.os }}-spm-${{ hashFiles('TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: ${{ runner.os }}-spm-
 
-      - name: Install x86_64 Homebrew
-        run: |
-          if [ ! -f /usr/local/bin/brew ]; then
-            echo "Installing x86_64 Homebrew..."
-            arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          fi
-
-      - name: Install x86_64 dependencies
-        run: |
-          echo "Installing x86_64 dependencies..."
-
-          # Check and install only if needed
-          if ! arch -x86_64 /usr/local/bin/brew list mariadb-connector-c &>/dev/null; then
-            echo "📦 Installing mariadb-connector-c (x86_64)..."
-            arch -x86_64 /usr/local/bin/brew install mariadb-connector-c
-          else
-            echo "✅ mariadb-connector-c (x86_64) already installed"
-          fi
-
-          # Link packages with --force (needed for keg-only formulas)
-          arch -x86_64 /usr/local/bin/brew link --force --overwrite mariadb-connector-c 2>/dev/null || true
-
-          # create-dmg is architecture-independent, use native brew
-          if ! brew list create-dmg &>/dev/null; then
-            echo "📦 Installing create-dmg..."
-            brew install create-dmg
-          else
-            echo "✅ create-dmg already installed"
-          fi
-
-          echo "✅ x86_64 dependencies installed"
+      # No Rosetta and no x86_64 Homebrew here. This is a cross-compile on an arm64 runner:
+      # every tool that runs during the build is native, and the x86_64 slices of the static
+      # libraries are vendored in Libs. Bootstrapping a second Homebrew prefix cost five
+      # minutes a release to install a mariadb-connector-c the build never opened. create-dmg
+      # is a shell script, so the native prefix serves both jobs.
+      - name: Install create-dmg
+        run: brew list create-dmg &>/dev/null || brew install create-dmg
 
       - name: Prepare libraries
         run: scripts/ci/prepare-libs.sh x86_64
@@ -264,22 +245,24 @@ jobs:
         run: scripts/ci/package-artifacts.sh x86_64
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-x86_64
           path: |
             build/Release/TablePro-*.dmg
             build/Release/TablePro-*.zip
 
+  # Reads two integers out of a Swift file and fetches a JSON manifest, so it wants nothing
+  # from macOS and does not need to spend a macOS runner minute (billed at ten times Linux).
   registry-readiness:
     name: Registry Readiness
-    runs-on: macos-26
+    runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     timeout-minutes: 5
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Verify registry has compatible plugin binaries
         run: |
@@ -300,7 +283,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -310,7 +293,7 @@ jobs:
           xcode-version: '26.4.1'
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts-raw/
           merge-multiple: true
@@ -352,42 +335,21 @@ jobs:
           echo "Final artifacts:"
           ls -lh artifacts/
 
+      # No `if: env.SPARKLE_PRIVATE_KEY != ''` on these steps. This job only runs for a v* tag,
+      # so the key is always meant to be present, and gating on it meant a missing or rotated
+      # secret published a release that no existing install could ever see. A signing key that
+      # is not there is now a red job, not a silent skip.
       - name: Sign update archives with Sparkle
-        if: env.SPARKLE_PRIVATE_KEY != ''
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: scripts/ci/sign-and-appcast.sh "${GITHUB_REF#refs/tags/v}"
 
       - name: Upload appcast artifact
-        if: env.SPARKLE_PRIVATE_KEY != ''
-        uses: actions/upload-artifact@v4
-        env:
-          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        uses: actions/upload-artifact@v7
         with:
           name: appcast-${{ github.sha }}
           path: appcast/appcast.xml
           retention-days: 90
-
-      - name: Commit appcast.xml to repo
-        if: env.SPARKLE_PRIVATE_KEY != ''
-        continue-on-error: true
-        env:
-          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-        run: |
-          if [ ! -f appcast/appcast.xml ]; then
-            echo "⚠️  No appcast.xml to commit"
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin main
-          git checkout main
-          cp appcast/appcast.xml appcast.xml
-          git add appcast.xml
-          git diff --cached --quiet && echo "No changes to appcast.xml" && exit 0
-          git commit -m "Update appcast.xml for v${GITHUB_REF#refs/tags/v}"
-          git push origin main
 
       - name: Extract release notes from CHANGELOG.md
         run: scripts/ci/extract-release-notes.sh "${GITHUB_REF#refs/tags/v}"
@@ -403,6 +365,45 @@ jobs:
           prerelease: ${{ contains(github.ref, '-beta') || contains(github.ref, '-alpha') || contains(github.ref, '-rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Publishing the feed comes after publishing the artifacts it points at, so there is no
+      # window where Sparkle advertises a download URL that still 404s.
+      #
+      # This step used to be continue-on-error, which made a failed push indistinguishable from
+      # a release that went out clean: every user's updater would keep reporting "up to date"
+      # for a version that shipped. A rejected push now rebases and retries, and a push that
+      # still will not land fails the job.
+      - name: Commit appcast.xml to repo
+        run: |
+          if [ ! -f appcast/appcast.xml ]; then
+            echo "❌ ERROR: appcast/appcast.xml is missing, the Sparkle step produced no feed" >&2
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          git checkout main
+          cp appcast/appcast.xml appcast.xml
+          git add appcast.xml
+
+          if git diff --cached --quiet; then
+            echo "appcast.xml is already up to date"
+            exit 0
+          fi
+
+          git commit -m "Update appcast.xml for v${GITHUB_REF#refs/tags/v}"
+
+          for attempt in 1 2 3; do
+            if git push origin main; then
+              exit 0
+            fi
+            echo "Push rejected, rebasing onto origin/main (attempt ${attempt})"
+            git pull --rebase origin main
+          done
+
+          echo "❌ ERROR: could not push appcast.xml after 3 attempts" >&2
+          exit 1
 
       - name: Notify Telegram
         if: success() && env.TELEGRAM_BOT_TOKEN != ''

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -34,7 +34,7 @@ jobs:
     outputs:
       run: ${{ steps.decide.outputs.run }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 25
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -107,7 +107,7 @@ jobs:
         run: scripts/generate-project.sh
 
       - name: Cache static libraries
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: Libs
           # Include C bridge stub headers in the cache key so the iOS xcframework set
@@ -141,7 +141,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios-test-results
           path: TestResults.xcresult

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -50,7 +50,7 @@ jobs:
     outputs:
       run: ${{ steps.decide.outputs.run }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -59,8 +59,28 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          REF: ${{ github.ref }}
         run: |
           set -euo pipefail
+
+          # A release pushes the version commit to main and then tags that same commit, so the
+          # push and the tag both reach this workflow: once directly, once through build.yml's
+          # workflow_call. That tests one SHA twice on two macos-26 runners, and because the
+          # account runs five macOS jobs at a time, the duplicate is what leaves the release's
+          # own suite queued behind it. The tag run is the one that gates the release, so the
+          # push to main stands down. github.ref belongs to the caller, so build.yml's
+          # workflow_call reads refs/tags/v* here and can never match this guard, which is what
+          # keeps "a release that skipped its tests" impossible.
+          #
+          # The subject goes into a variable instead of a pipe into grep. grep -q exits on the
+          # first match, and the SIGPIPE that then kills git log would surface through pipefail
+          # as a skipped guard (the same trap scripts/check-freetds-fedauth.sh:69 documents).
+          SUBJECT="$(git log -1 --format=%s HEAD)"
+          if [ "$EVENT_NAME" = "push" ] && [ "$REF" = "refs/heads/main" ] &&
+             [[ "$SUBJECT" =~ ^release:\ v[0-9] ]]; then
+              echo "run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+          fi
 
           # Anything that is not a pull request runs the full suite: a release calls this
           # workflow with workflow_call, and a release that skipped its tests is the failure
@@ -95,7 +115,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -112,7 +132,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -138,7 +158,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -149,7 +169,7 @@ jobs:
         run: brew list xcbeautify &>/dev/null || brew install xcbeautify
 
       - name: Cache static libraries
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: Libs
           key: ${{ runner.os }}-libs-${{ hashFiles('Libs/checksums.sha256', 'Plugins/MSSQLDriverPlugin/CFreeTDS/include/sybdb.h') }}
@@ -279,7 +299,7 @@ jobs:
 
       - name: Upload UI test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-ui-test-results
           path: UITestResults.xcresult
@@ -287,7 +307,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-test-results
           path: TestResults.xcresult

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -22,7 +22,8 @@ prepare_mariadb() {
     echo "📦 Preparing libmariadb.a for $target_arch..."
 
     # If libmariadb.a already exists with the correct architecture, skip preparation.
-    # CI pre-copies the architecture-specific library from Homebrew.
+    # CI pre-copies the architecture-specific slice from Libs via scripts/ci/prepare-libs.sh.
+    # Homebrew is not involved: the whole library is vendored by download-libs.sh.
     if [ -f "Libs/libmariadb.a" ] && lipo -info "Libs/libmariadb.a" 2>/dev/null | grep -q "$target_arch"; then
         local size
         size=$(ls -lh Libs/libmariadb.a 2>/dev/null | awk '{print $5}')


### PR DESCRIPTION
Cleanup of the release pipeline, from profiling the v0.66.0 run ([32167949766](https://github.com/TableProApp/TablePro/actions/runs/32167949766)). That run took ~50 minutes against 40m35s for v0.65.0.

## Speed

**The macOS suite ran twice on the same commit.** `/release` pushes the version commit to main and then tags it, so `macos-tests.yml` fires once directly and once through `build.yml`'s `workflow_call`. Both ran SHA `8cd3514`. The concurrency group is keyed on `github.ref`, so `refs/heads/main` and `refs/tags/v0.66.0` never collided. The duplicate is also what left the release's own `app-tests` queued for 8m51s, since the account runs five macOS jobs at a time. The `changes` job now stands down for a push to main whose subject is a release commit, and the tag run does the work.

I did not merge the concurrency groups, which was the first thing I tried. Whichever run enters the group second cancels the other, and that ordering is not guaranteed if the two pushes are ever combined. Losing the tag run means the release dies. The guard here fails toward running twice instead.

**The x86_64 job spent 5m15s on Homebrew for a library it never opened.** `prepare-libs.sh` copies `Libs/libmariadb_x86_64.a`, `project.yml` force-loads `$(SRCROOT)/Libs/libmariadb.a`, the headers are vendored under `Plugins/MySQLDriverPlugin/CMariaDB/include`, and `LIBRARY_SEARCH_PATHS` names no Homebrew prefix. `app-tests` already proves it: that job links all 31 plugin bundles with no Homebrew mariadb installed. Rosetta went with it, since nothing x86_64 executes during a cross-compile. `create-dmg` is the only formula either job needs.

Also: `registry-readiness` moves to `ubuntu-latest` (it reads two integers and fetches a JSON manifest), the build jobs cache the `~/.spm-cache` checkouts that `build-release.sh` already clones into, and `lint` moves to `macos-26` so the workflow stops straddling two runner images.

## Correctness of the release

Two steps could fail without failing the release:

- The Sparkle steps were gated on `if: env.SPARKLE_PRIVATE_KEY != ''`. This job only runs for a `v*` tag, so a missing or rotated key was never legitimate, and it published a release no installed copy could see under a green check. Gate removed.
- `Commit appcast.xml to repo` was `continue-on-error: true`, which made a failed push indistinguishable from a clean release: every updater keeps reporting "up to date" for a version that shipped. It now rebases and retries up to three times, and fails the job if the push still will not land.

That step also moved after `Create GitHub Release`, so the feed never advertises a download URL that still 404s.

## Hygiene

- Dropped `paths-ignore` from the tag trigger. GitHub does not evaluate path filters for tag pushes, so it never excluded anything.
- Added `concurrency` with `cancel-in-progress: false`, so a re-tag queues instead of cancelling a run mid-notarization.
- Cleared the Node 20 deprecation: checkout v4 to v7, upload-artifact v4 to v7, download-artifact v4 to v8, cache v4 to v6, across `build.yml`, `macos-tests.yml` and `ios-tests.yml`. I read each new major's `action.yml` and release notes first. Every input in use survives, and the breaking changes are opt-in (`archive`, `skip-decompress`) or wanted here (v8 errors on a download digest mismatch instead of warning).
- Fixed the comment at `scripts/build-release.sh:25` claiming CI pre-copies libmariadb "from Homebrew". It comes from `Libs`. That sentence is most likely why the Homebrew step existed.
- `.claude/skills/release/SKILL.md` now says to wait for the app release before pushing plugin tags. On v0.66.0 seven plugin tags pushed two minutes after the app tag, and one plugin build did not start for 20 minutes.

## Testing

No unit tests: every change is workflow configuration. Verification was:

- `actionlint` on all three workflows. The only findings are 4 pre-existing SC2086 infos in the keychain steps, identical on the HEAD versions.
- The new skip guard was run against 7 event/ref/subject combinations. It skips only `push` + `refs/heads/main` + a `release: v<digit>` subject. The `refs/tags/v*` path that `workflow_call` sees still returns `run=true`, as do `workflow_dispatch` on main and a prose subject like `release: verify the funnel`.
- Action inputs checked against each new major's `action.yml`.

What cannot be exercised without a real tag is the release job's new step order and the appcast retry. `gh workflow run build.yml --ref ci/release-pipeline-cleanup` covers both build jobs, and so the Homebrew removal and the SPM cache, without publishing anything: `registry-readiness` and `release` are both gated on `refs/tags/v`.

## Not done

DerivedData caching. For release builds a stale cache can yield a subtly wrong binary that then gets signed, notarized and shipped, and at multi-GB against a 10GB repo budget shared with the `Libs` cache it would likely cost more in restore and save time than it returns. The 15-minute compile needs a real fix, not a cache.

`build-plugin.yml` still uses `checkout@v4`. It had uncommitted changes in the working tree while I was editing, so I left it alone.
