### PR TITLE
feat(datagrid): find in results, with a match counter that names its scope

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -306,9 +306,16 @@ supported names. New plugins must be added to the workflow mapping.
 
 ### Plugin Release Steps
 
-1. **Verify tag is available** — `git tag -l "plugin-<name>-v<version>"`
-2. **Tag** — `git tag plugin-<name>-v<version>`
-3. **Push tag** — `git push origin plugin-<name>-v<version>`
+1. **Verify tag is available**: `git tag -l "plugin-<name>-v<version>"`
+2. **Tag**: `git tag plugin-<name>-v<version>`
+3. **Push tag**: `git push origin plugin-<name>-v<version>`
+
+**If an app release is already running, wait for it to finish before pushing
+plugin tags.** The account runs five macOS jobs at a time and every plugin
+build takes one of them. On v0.66.0, seven plugin tags pushed two minutes
+after the app tag left the release's own test suite queued for nine minutes
+and pushed one plugin build back by twenty. Check with
+`gh run list --workflow build.yml --limit 1` first.
 
 No version bumps or changelog edits needed — plugin bundles keep
 `MARKETING_VERSION = 1.0` and `CURRENT_PROJECT_VERSION = 1` in `project.yml`.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,22 +2,28 @@ name: Build TablePro
 
 on:
   workflow_dispatch:
+  # No paths filter here. GitHub does not evaluate one for a tag push, and a tag push is the
+  # only thing that triggers this workflow, so the paths-ignore list that used to sit here
+  # never excluded anything.
   push:
     tags: ["v*"]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - ".vscode/**"
+
+# A release must never be cancelled part-way through: the build jobs hold notarization
+# submissions open with Apple, and the release job pushes a commit and publishes artifacts.
+# Re-running the same tag queues behind the run already in flight rather than racing it.
+concurrency:
+  group: build-tablepro-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   lint:
     name: SwiftLint
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 10
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install SwiftLint
         run: brew list swiftlint &>/dev/null || brew install swiftlint
@@ -37,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -49,29 +55,24 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: scripts/download-libs.sh --force
 
-      - name: Install ARM64 dependencies
-        run: |
-          echo "Installing ARM64 dependencies..."
+      # build-release.sh clones packages into ~/.spm-cache via -clonedSourcePackagesDirPath,
+      # so this restores the checkouts instead of re-cloning 30 repositories on every release.
+      # Package.resolved pins every revision and is tracked, which is why it can key the cache.
+      - name: Cache Swift package checkouts
+        uses: actions/cache@v6
+        with:
+          path: ~/.spm-cache
+          key: ${{ runner.os }}-spm-${{ hashFiles('TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: ${{ runner.os }}-spm-
 
-          # Check and install only if needed
-          if ! brew list mariadb-connector-c &>/dev/null; then
-            echo "📦 Installing mariadb-connector-c..."
-            brew install mariadb-connector-c
-          else
-            echo "✅ mariadb-connector-c already installed"
-          fi
-
-          # Link packages with --force and --overwrite (needed for keg-only formulas)
-          brew link --force --overwrite mariadb-connector-c 2>/dev/null || true
-
-          if ! brew list create-dmg &>/dev/null; then
-            echo "📦 Installing create-dmg..."
-            brew install create-dmg
-          else
-            echo "✅ create-dmg already installed"
-          fi
-
-          echo "✅ ARM64 dependencies installed"
+      # create-dmg is the only Homebrew formula either build job needs. The MySQL plugin
+      # links Libs/libmariadb.a, which download-libs.sh vendors and prepare-libs.sh selects
+      # per architecture, and its headers live in Plugins/MySQLDriverPlugin/CMariaDB/include.
+      # LIBRARY_SEARCH_PATHS names $(SRCROOT)/Libs and no Homebrew prefix, so nothing in the
+      # build ever read mariadb-connector-c. macos-tests.yml proves it: the app-tests job
+      # links all 31 plugin bundles with no Homebrew mariadb installed at all.
+      - name: Install create-dmg
+        run: brew list create-dmg &>/dev/null || brew install create-dmg
 
       - name: Prepare libraries
         run: scripts/ci/prepare-libs.sh arm64
@@ -138,7 +139,7 @@ jobs:
         run: scripts/ci/package-artifacts.sh arm64
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-arm64
           path: |
@@ -152,7 +153,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -164,40 +165,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: scripts/download-libs.sh --force
 
-      - name: Install Rosetta 2
-        run: softwareupdate --install-rosetta --agree-to-license || true
+      - name: Cache Swift package checkouts
+        uses: actions/cache@v6
+        with:
+          path: ~/.spm-cache
+          key: ${{ runner.os }}-spm-${{ hashFiles('TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: ${{ runner.os }}-spm-
 
-      - name: Install x86_64 Homebrew
-        run: |
-          if [ ! -f /usr/local/bin/brew ]; then
-            echo "Installing x86_64 Homebrew..."
-            arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          fi
-
-      - name: Install x86_64 dependencies
-        run: |
-          echo "Installing x86_64 dependencies..."
-
-          # Check and install only if needed
-          if ! arch -x86_64 /usr/local/bin/brew list mariadb-connector-c &>/dev/null; then
-            echo "📦 Installing mariadb-connector-c (x86_64)..."
-            arch -x86_64 /usr/local/bin/brew install mariadb-connector-c
-          else
-            echo "✅ mariadb-connector-c (x86_64) already installed"
-          fi
-
-          # Link packages with --force (needed for keg-only formulas)
-          arch -x86_64 /usr/local/bin/brew link --force --overwrite mariadb-connector-c 2>/dev/null || true
-
-          # create-dmg is architecture-independent, use native brew
-          if ! brew list create-dmg &>/dev/null; then
-            echo "📦 Installing create-dmg..."
-            brew install create-dmg
-          else
-            echo "✅ create-dmg already installed"
-          fi
-
-          echo "✅ x86_64 dependencies installed"
+      # No Rosetta and no x86_64 Homebrew here. This is a cross-compile on an arm64 runner:
+      # every tool that runs during the build is native, and the x86_64 slices of the static
+      # libraries are vendored in Libs. Bootstrapping a second Homebrew prefix cost five
+      # minutes a release to install a mariadb-connector-c the build never opened. create-dmg
+      # is a shell script, so the native prefix serves both jobs.
+      - name: Install create-dmg
+        run: brew list create-dmg &>/dev/null || brew install create-dmg
 
       - name: Prepare libraries
         run: scripts/ci/prepare-libs.sh x86_64
@@ -264,22 +245,24 @@ jobs:
         run: scripts/ci/package-artifacts.sh x86_64
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-x86_64
           path: |
             build/Release/TablePro-*.dmg
             build/Release/TablePro-*.zip
 
+  # Reads two integers out of a Swift file and fetches a JSON manifest, so it wants nothing
+  # from macOS and does not need to spend a macOS runner minute (billed at ten times Linux).
   registry-readiness:
     name: Registry Readiness
-    runs-on: macos-26
+    runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     timeout-minutes: 5
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Verify registry has compatible plugin binaries
         run: |
@@ -300,7 +283,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -310,7 +293,7 @@ jobs:
           xcode-version: '26.4.1'
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts-raw/
           merge-multiple: true
@@ -352,42 +335,21 @@ jobs:
           echo "Final artifacts:"
           ls -lh artifacts/
 
+      # No `if: env.SPARKLE_PRIVATE_KEY != ''` on these steps. This job only runs for a v* tag,
+      # so the key is always meant to be present, and gating on it meant a missing or rotated
+      # secret published a release that no existing install could ever see. A signing key that
+      # is not there is now a red job, not a silent skip.
       - name: Sign update archives with Sparkle
-        if: env.SPARKLE_PRIVATE_KEY != ''
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: scripts/ci/sign-and-appcast.sh "${GITHUB_REF#refs/tags/v}"
 
       - name: Upload appcast artifact
-        if: env.SPARKLE_PRIVATE_KEY != ''
-        uses: actions/upload-artifact@v4
-        env:
-          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        uses: actions/upload-artifact@v7
         with:
           name: appcast-${{ github.sha }}
           path: appcast/appcast.xml
           retention-days: 90
-
-      - name: Commit appcast.xml to repo
-        if: env.SPARKLE_PRIVATE_KEY != ''
-        continue-on-error: true
-        env:
-          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-        run: |
-          if [ ! -f appcast/appcast.xml ]; then
-            echo "⚠️  No appcast.xml to commit"
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin main
-          git checkout main
-          cp appcast/appcast.xml appcast.xml
-          git add appcast.xml
-          git diff --cached --quiet && echo "No changes to appcast.xml" && exit 0
-          git commit -m "Update appcast.xml for v${GITHUB_REF#refs/tags/v}"
-          git push origin main
 
       - name: Extract release notes from CHANGELOG.md
         run: scripts/ci/extract-release-notes.sh "${GITHUB_REF#refs/tags/v}"
@@ -403,6 +365,45 @@ jobs:
           prerelease: ${{ contains(github.ref, '-beta') || contains(github.ref, '-alpha') || contains(github.ref, '-rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Publishing the feed comes after publishing the artifacts it points at, so there is no
+      # window where Sparkle advertises a download URL that still 404s.
+      #
+      # This step used to be continue-on-error, which made a failed push indistinguishable from
+      # a release that went out clean: every user's updater would keep reporting "up to date"
+      # for a version that shipped. A rejected push now rebases and retries, and a push that
+      # still will not land fails the job.
+      - name: Commit appcast.xml to repo
+        run: |
+          if [ ! -f appcast/appcast.xml ]; then
+            echo "❌ ERROR: appcast/appcast.xml is missing, the Sparkle step produced no feed" >&2
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          git checkout main
+          cp appcast/appcast.xml appcast.xml
+          git add appcast.xml
+
+          if git diff --cached --quiet; then
+            echo "appcast.xml is already up to date"
+            exit 0
+          fi
+
+          git commit -m "Update appcast.xml for v${GITHUB_REF#refs/tags/v}"
+
+          for attempt in 1 2 3; do
+            if git push origin main; then
+              exit 0
+            fi
+            echo "Push rejected, rebasing onto origin/main (attempt ${attempt})"
+            git pull --rebase origin main
+          done
+
+          echo "❌ ERROR: could not push appcast.xml after 3 attempts" >&2
+          exit 1
 
       - name: Notify Telegram
         if: success() && env.TELEGRAM_BOT_TOKEN != ''

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -34,7 +34,7 @@ jobs:
     outputs:
       run: ${{ steps.decide.outputs.run }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 25
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -107,7 +107,7 @@ jobs:
         run: scripts/generate-project.sh
 
       - name: Cache static libraries
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: Libs
           # Include C bridge stub headers in the cache key so the iOS xcframework set
@@ -141,7 +141,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios-test-results
           path: TestResults.xcresult

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -50,7 +50,7 @@ jobs:
     outputs:
       run: ${{ steps.decide.outputs.run }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -59,8 +59,28 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          REF: ${{ github.ref }}
         run: |
           set -euo pipefail
+
+          # A release pushes the version commit to main and then tags that same commit, so the
+          # push and the tag both reach this workflow: once directly, once through build.yml's
+          # workflow_call. That tests one SHA twice on two macos-26 runners, and because the
+          # account runs five macOS jobs at a time, the duplicate is what leaves the release's
+          # own suite queued behind it. The tag run is the one that gates the release, so the
+          # push to main stands down. github.ref belongs to the caller, so build.yml's
+          # workflow_call reads refs/tags/v* here and can never match this guard, which is what
+          # keeps "a release that skipped its tests" impossible.
+          #
+          # The subject goes into a variable instead of a pipe into grep. grep -q exits on the
+          # first match, and the SIGPIPE that then kills git log would surface through pipefail
+          # as a skipped guard (the same trap scripts/check-freetds-fedauth.sh:69 documents).
+          SUBJECT="$(git log -1 --format=%s HEAD)"
+          if [ "$EVENT_NAME" = "push" ] && [ "$REF" = "refs/heads/main" ] &&
+             [[ "$SUBJECT" =~ ^release:\ v[0-9] ]]; then
+              echo "run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+          fi
 
           # Anything that is not a pull request runs the full suite: a release calls this
           # workflow with workflow_call, and a release that skipped its tests is the failure
@@ -95,7 +115,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -112,7 +132,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -138,7 +158,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -149,7 +169,7 @@ jobs:
         run: brew list xcbeautify &>/dev/null || brew install xcbeautify
 
       - name: Cache static libraries
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: Libs
           key: ${{ runner.os }}-libs-${{ hashFiles('Libs/checksums.sha256', 'Plugins/MSSQLDriverPlugin/CFreeTDS/include/sybdb.h') }}
@@ -279,7 +299,7 @@ jobs:
 
       - name: Upload UI test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-ui-test-results
           path: UITestResults.xcresult
@@ -287,7 +307,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-test-results
           path: TestResults.xcresult

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Cmd+F` on a table tab opens a find bar over the results. Type a term and the matching cell is highlighted and scrolled to; `Return` and `Cmd+G` step forward, `Cmd+Shift+G` steps back, `Escape` clears the term and then closes the bar. Matching ignores case and accents and runs over the text as displayed, skipping binary and spatial columns. The counter always says what it searched, reading "3 of 12 on this page" while rows remain unfetched and "3 of 12" once everything is loaded, so a result is never mistaken for an answer about the whole table. When nothing matches on the page and more rows exist, Search All Rows turns the term into a server-side filter.
+
+### Changed
+
+- `Cmd+F` on a table tab used to toggle the filter panel, which meant it closed the panel when it was already open and never searched anything. The filter panel keeps `Cmd+Option+F` and its funnel button in the status bar.
+- Find Next and Find Previous work on the data grid when its find bar is open, instead of staying dimmed on a table tab.
+
 ## [0.66.0] - 2026-08-19
 
 ### Added

--- a/TablePro/Core/Coordinators/FilterCoordinator.swift
+++ b/TablePro/Core/Coordinators/FilterCoordinator.swift
@@ -16,17 +16,24 @@ final class FilterCoordinator {
 
     // MARK: - Filtering
 
-    func applyFilters(_ filters: [TableFilter]) {
+    func applyFilters(_ filters: [TableFilter], logicMode: FilterLogicMode? = nil) {
         guard let (tab, tabIndex) = parent.tabManager.selectedTabAndIndex,
               let tableName = tab.tableContext.tableName else { return }
 
         let capturedTabIndex = tabIndex
         let capturedTableName = tableName
         let capturedFilters = filters
+        let capturedLogicMode = logicMode
         parent.confirmDiscardChangesIfNeeded(action: .filter) { [weak self] confirmed in
             guard let self, confirmed else { return }
             guard capturedTabIndex < parent.tabManager.tabs.count else { return }
 
+            if let capturedLogicMode {
+                parent.tabManager.mutate(at: capturedTabIndex) {
+                    $0.filterState.filterLogicMode = capturedLogicMode
+                    $0.filterState.isVisible = true
+                }
+            }
             parent.tabManager.mutate(at: capturedTabIndex) { $0.pagination.reset() }
 
             let tab = parent.tabManager.tabs[capturedTabIndex]
@@ -247,6 +254,24 @@ final class FilterCoordinator {
         mutateSelectedTabFilterState { state in
             state.filters.append(newFilter)
         }
+    }
+
+    /// One CONTAINS row per searchable column, joined with OR, replacing the filter set. Only the
+    /// find bar calls this, and only when no filters are applied, because `filterLogicMode` is one
+    /// mode for the whole array: switching it to OR would silently loosen filters the user wrote.
+    func applyCrossColumnSearch(term: String, columns: [String]) {
+        guard !columns.isEmpty else { return }
+
+        let filters = columns.map { column in
+            var filter = TableFilter()
+            filter.columnName = column
+            filter.filterOperator = .contains
+            filter.value = term
+            filter.isEnabled = true
+            return filter
+        }
+
+        applyFilters(filters, logicMode: .or)
     }
 
     func addFilterForColumn(_ columnName: String) {

--- a/TablePro/Core/Coordinators/FindCoordinator.swift
+++ b/TablePro/Core/Coordinators/FindCoordinator.swift
@@ -1,0 +1,130 @@
+//
+//  FindCoordinator.swift
+//  TablePro
+//
+
+import Foundation
+import SwiftUI
+
+@MainActor @Observable
+final class FindCoordinator {
+    @ObservationIgnored unowned let parent: MainContentCoordinator
+    @ObservationIgnored private var searchDebounce: DispatchWorkItem?
+
+    init(parent: MainContentCoordinator) {
+        self.parent = parent
+    }
+
+    var selectedTabFindState: TabFindState? {
+        parent.tabManager.selectedTab?.findState
+    }
+
+    func show() {
+        mutateSelectedTabFindState { $0.isVisible = true }
+    }
+
+    func dismiss() {
+        searchDebounce?.cancel()
+        searchDebounce = nil
+        mutateSelectedTabFindState {
+            $0.isVisible = false
+            $0.term = ""
+            $0.clearMatches()
+        }
+        parent.dataTabDelegate?.tableViewCoordinator?.applyFindMatch(nil)
+    }
+
+    /// The scan is synchronous and main-actor bound, and a wide table is the expensive case:
+    /// CLAUDE.md flags 500+ columns as the real data-grid cost, so a 1,000-row page is hundreds of
+    /// thousands of range searches per keystroke. Coalescing means one scan per pause, not per key.
+    func setTerm(_ term: String) {
+        mutateSelectedTabFindState { $0.term = term }
+        searchDebounce?.cancel()
+        let work = DispatchWorkItem { [weak self] in self?.runSearch() }
+        searchDebounce = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12, execute: work)
+    }
+
+    func stepForward() {
+        mutateSelectedTabFindState { $0.stepForward() }
+        syncGridToCurrentMatch()
+    }
+
+    func stepBackward() {
+        mutateSelectedTabFindState { $0.stepBackward() }
+        syncGridToCurrentMatch()
+    }
+
+    /// Promotes the term into a server-side filter so the answer covers rows this page never
+    /// loaded. It builds its own filter rows rather than going through `addFilter`, which would
+    /// consult the user's default-column setting, and it never touches the filters they already
+    /// applied.
+    func escalateToAllRows() {
+        guard let tab = parent.tabManager.selectedTab else { return }
+        let term = tab.findState.term.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !term.isEmpty else { return }
+
+        let buffer = parent.tabSessionRegistry.tableRows(for: tab.id)
+        let searchable = buffer.columns.indices.filter { index in
+            guard index < buffer.columnTypes.count else { return true }
+            return FindMatcher.isServerSearchable(buffer.columnTypes[index])
+        }
+        guard !searchable.isEmpty else { return }
+
+        dismiss()
+        parent.filterCoordinator.applyCrossColumnSearch(
+            term: term,
+            columns: searchable.map { buffer.columns[$0] }
+        )
+    }
+
+    func runSearch() {
+        guard let tab = parent.tabManager.selectedTab,
+              let grid = parent.dataTabDelegate?.tableViewCoordinator
+        else { return }
+
+        let term = tab.findState.term.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !term.isEmpty else {
+            invalidateMatches()
+            grid.applyFindMatch(nil)
+            return
+        }
+
+        let matches = grid.runFind(term: term)
+        let anchor = grid.selectedDisplayRow ?? 0
+        mutateSelectedTabFindState { state in
+            state.matches = matches
+            state.scope = self.scope(for: tab)
+            state.currentMatchIndex = FindMatcher.nearestMatchIndex(to: anchor, in: matches)
+        }
+        syncGridToCurrentMatch()
+    }
+
+    private func syncGridToCurrentMatch() {
+        guard let grid = parent.dataTabDelegate?.tableViewCoordinator else { return }
+        grid.applyFindMatch(parent.tabManager.selectedTab?.findState.currentMatch)
+    }
+
+    /// Rows were replaced underneath the find bar, so the match list describes rows that no
+    /// longer exist. Keep the term and the bar, drop what is stale.
+    func invalidateMatches() {
+        mutateSelectedTabFindState { $0.clearMatches() }
+    }
+
+    /// `hasMoreRows` is the query-tab truncation flag and is never set for a table tab, which pages
+    /// through `currentPage`/`totalPages` instead. Reading only that flag made every table tab claim
+    /// its page was the whole table, which is the exact answer this feature exists to avoid.
+    func scope(for tab: QueryTab) -> FindScope {
+        let loadedRowCount = parent.tabSessionRegistry.tableRows(for: tab.id).rows.count
+        let hasUnloadedRows = tab.pagination.hasMoreRows
+            || tab.pagination.canGoToNextPage(loadedRowCount: loadedRowCount)
+        return hasUnloadedRows ? .pageOfMore : .allRowsLoaded
+    }
+
+    private func mutateSelectedTabFindState(_ mutate: (inout TabFindState) -> Void) {
+        guard let index = parent.tabManager.selectedTabIndex else { return }
+        var newState = parent.tabManager.tabs[index].findState
+        mutate(&newState)
+        parent.tabManager.mutate(at: index) { $0.findState = newState }
+    }
+}

--- a/TablePro/Core/Coordinators/FindMatcher.swift
+++ b/TablePro/Core/Coordinators/FindMatcher.swift
@@ -1,0 +1,55 @@
+//
+//  FindMatcher.swift
+//  TablePro
+//
+
+import Foundation
+
+enum FindMatcher {
+    static func isSearchable(_ columnType: ColumnType?) -> Bool {
+        switch columnType {
+        case .blob, .spatial: false
+        default: true
+        }
+    }
+
+    /// Columns a `LIKE` comparison can be built against without a cast. Postgres has no implicit
+    /// integer to text conversion, so `id ILIKE '%abc%'` fails the whole query rather than matching
+    /// nothing. Client-side matching is looser on purpose: it compares the text already on screen.
+    static func isServerSearchable(_ columnType: ColumnType?) -> Bool {
+        switch columnType {
+        case .text, .enumType, .set, nil: true
+        default: false
+        }
+    }
+
+    static func matches(
+        term: String,
+        displayRowCount: Int,
+        columnCount: Int,
+        isColumnSearchable: (Int) -> Bool,
+        cellText: (Int, Int) -> String?
+    ) -> [FindMatch] {
+        let needle = term.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !needle.isEmpty, displayRowCount > 0, columnCount > 0 else { return [] }
+
+        let searchableColumns = (0 ..< columnCount).filter(isColumnSearchable)
+        guard !searchableColumns.isEmpty else { return [] }
+
+        var found: [FindMatch] = []
+        for displayRow in 0 ..< displayRowCount {
+            for column in searchableColumns {
+                guard let text = cellText(displayRow, column), !text.isEmpty else { continue }
+                guard text.range(of: needle, options: [.caseInsensitive, .diacriticInsensitive]) != nil else { continue }
+                found.append(FindMatch(displayRow: displayRow, columnIndex: column))
+            }
+        }
+        return found
+    }
+
+    static func nearestMatchIndex(to displayRow: Int, in matches: [FindMatch]) -> Int? {
+        guard !matches.isEmpty else { return nil }
+        if let forward = matches.firstIndex(where: { $0.displayRow >= displayRow }) { return forward }
+        return 0
+    }
+}

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController+EditMenuActions.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController+EditMenuActions.swift
@@ -67,15 +67,23 @@ extension MainSplitViewController {
             EditorEventRouter.shared.showFindPanelForKeyWindow()
             return
         }
-        commandActions?.toggleFilterPanel()
+        commandActions?.showFindBar()
     }
 
     @objc func findNext(_ sender: Any?) {
-        EditorEventRouter.shared.findNext()
+        guard commandActions?.hasActiveGridFind == true else {
+            EditorEventRouter.shared.findNext()
+            return
+        }
+        commandActions?.stepFindForward()
     }
 
     @objc func findPrevious(_ sender: Any?) {
-        EditorEventRouter.shared.findPrevious()
+        guard commandActions?.hasActiveGridFind == true else {
+            EditorEventRouter.shared.findPrevious()
+            return
+        }
+        commandActions?.stepFindBackward()
     }
 
     @objc func addRow(_ sender: Any?) {

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController+MenuValidation.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController+MenuValidation.swift
@@ -47,6 +47,7 @@ struct MenuValidationContext: Equatable {
     var canUndo = false
     var canRedo = false
     var hasEditorForFind = false
+    var hasActiveGridFind = false
     var hasImportFormats = false
     var supportsContainerSwitching = false
     var supportsBackup = false
@@ -145,7 +146,7 @@ extension MainSplitViewController: NSMenuItemValidation {
         case #selector(performFind(_:)):
             return context.hasEditorForFind || (context.isConnected && context.isTableTab)
         case #selector(findNext(_:)), #selector(findPrevious(_:)):
-            return context.hasEditorForFind
+            return context.hasEditorForFind || context.hasActiveGridFind
         case #selector(undo(_:)):
             return context.canUndo
         case #selector(redo(_:)):
@@ -235,6 +236,7 @@ extension MainSplitViewController: NSMenuItemValidation {
             canUndo: actions.canUndo,
             canRedo: actions.canRedo,
             hasEditorForFind: EditorEventRouter.shared.keyWindowHasEditor,
+            hasActiveGridFind: actions.hasActiveGridFind,
             hasImportFormats: !actions.availableImportFormats.isEmpty,
             supportsContainerSwitching: actions.supportsContainerSwitching,
             supportsBackup: actions.supportsBackup,

--- a/TablePro/Models/Query/QueryTab.swift
+++ b/TablePro/Models/Query/QueryTab.swift
@@ -24,6 +24,7 @@ struct QueryTab: Identifiable, Equatable {
     var selectedRowIndices: Set<Int>
     var sortState: SortState
     var filterState: TabFilterState
+    var findState: TabFindState
     var columnLayout: ColumnLayoutState
     var pagination: PaginationState
     var hasUserInteraction: Bool
@@ -68,6 +69,7 @@ struct QueryTab: Identifiable, Equatable {
         self.selectedRowIndices = []
         self.sortState = SortState()
         self.filterState = TabFilterState()
+        self.findState = TabFindState()
         self.columnLayout = ColumnLayoutState()
         self.pagination = PaginationState()
         self.hasUserInteraction = false
@@ -104,6 +106,7 @@ struct QueryTab: Identifiable, Equatable {
         self.selectedRowIndices = []
         self.sortState = SortState()
         self.filterState = TabFilterState()
+        self.findState = TabFindState()
         self.columnLayout = ColumnLayoutState(
             columnWidths: persisted.columnWidths ?? [:],
             columnContentWidths: persisted.columnContentWidths

--- a/TablePro/Models/UI/TabFindState.swift
+++ b/TablePro/Models/UI/TabFindState.swift
@@ -1,0 +1,93 @@
+//
+//  TabFindState.swift
+//  TablePro
+//
+
+import Foundation
+
+struct FindMatch: Equatable, Hashable {
+    let displayRow: Int
+    let columnIndex: Int
+}
+
+enum FindScope: Equatable {
+    case allRowsLoaded
+    case pageOfMore
+}
+
+struct TabFindState: Equatable {
+    var term: String
+    var isVisible: Bool
+    var matches: [FindMatch]
+    var currentMatchIndex: Int?
+    var scope: FindScope
+
+    init(isVisible: Bool = false) {
+        term = ""
+        self.isVisible = isVisible
+        matches = []
+        currentMatchIndex = nil
+        scope = .allRowsLoaded
+    }
+
+    var currentMatch: FindMatch? {
+        guard let index = currentMatchIndex, index >= 0, index < matches.count else { return nil }
+        return matches[index]
+    }
+
+    var canEscalateToAllRows: Bool {
+        scope == .pageOfMore && !term.isEmpty
+    }
+
+    mutating func clearMatches() {
+        matches = []
+        currentMatchIndex = nil
+    }
+
+    mutating func stepForward() {
+        guard !matches.isEmpty else { return }
+        guard let index = currentMatchIndex else {
+            currentMatchIndex = 0
+            return
+        }
+        currentMatchIndex = (index + 1) % matches.count
+    }
+
+    mutating func stepBackward() {
+        guard !matches.isEmpty else { return }
+        guard let index = currentMatchIndex else {
+            currentMatchIndex = matches.count - 1
+            return
+        }
+        currentMatchIndex = (index - 1 + matches.count) % matches.count
+    }
+}
+
+enum FindCounterText {
+    static func text(matchCount: Int, currentIndex: Int?, scope: FindScope) -> String {
+        guard matchCount > 0 else { return emptyText(scope: scope) }
+
+        let position = (currentIndex ?? 0) + 1
+        switch scope {
+        case .allRowsLoaded:
+            return String(
+                format: String(localized: "%1$@ of %2$@"),
+                position.formatted(),
+                matchCount.formatted()
+            )
+        case .pageOfMore:
+            return String(
+                format: String(localized: "%1$@ of %2$@ on this page"),
+                position.formatted(),
+                matchCount.formatted()
+            )
+        }
+    }
+
+    private static func emptyText(scope: FindScope) -> String {
+        switch scope {
+        case .allRowsLoaded: String(localized: "No matches")
+        case .pageOfMore: String(localized: "Not on this page")
+        }
+    }
+}

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -644,6 +644,19 @@ struct MainEditorContentView: View {
                             Divider()
                         }
 
+                        if tab.findState.isVisible && tab.tabType == .table {
+                            FindBarView(
+                                coordinator: coordinator,
+                                findState: tab.findState,
+                                rowsRevision: tab.loadEpoch
+                                    &+ tab.pagination.currentPage
+                                    &+ tab.paginationVersion
+                                    &+ resolvedRows.rows.count,
+                                onSearchAllRows: { coordinator.findCoordinator.escalateToAllRows() }
+                            )
+                            Divider()
+                        }
+
                         if tab.tabType == .query && !resolvedRows.columns.isEmpty
                             && resolvedRows.rows.isEmpty && tab.execution.lastExecutedAt != nil
                             && !coordinator.tabExecution.isExecuting(tab.id) && !tab.filterState.hasAppliedFilters

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -358,6 +358,11 @@ final class MainContentCommandActions {
         coordinator?.toolbarState.isTableTab ?? false
     }
 
+    var hasActiveGridFind: Bool {
+        guard isTableTab, let findState = coordinator?.tabManager.selectedTab?.findState else { return false }
+        return findState.isVisible && !findState.matches.isEmpty
+    }
+
     /// What `pasteRows()` will actually do, so the Edit menu's Paste item is enabled only when it
     /// leads somewhere. AppKit gives a disabled item its key equivalent all the same, so an item
     /// enabled over a handler that returns at its first guard swallows Command+V in silence.
@@ -798,6 +803,19 @@ final class MainContentCommandActions {
         guard let coordinator = coordinator,
               coordinator.tabManager.selectedTab?.tabType == .table else { return }
         coordinator.toggleFilterPanel()
+    }
+
+    func showFindBar() {
+        guard let coordinator, coordinator.tabManager.selectedTab?.tabType == .table else { return }
+        coordinator.findCoordinator.show()
+    }
+
+    func stepFindForward() {
+        coordinator?.findCoordinator.stepForward()
+    }
+
+    func stepFindBackward() {
+        coordinator?.findCoordinator.stepBackward()
     }
 
     // MARK: - Data Operations (Group A — Called Directly)

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -114,6 +114,7 @@ final class MainContentCoordinator {
     }()
 
     @ObservationIgnored private(set) var filterCoordinator: FilterCoordinator!
+    @ObservationIgnored private(set) var findCoordinator: FindCoordinator!
     @ObservationIgnored private(set) var queryExecutionCoordinator: QueryExecutionCoordinator!
     @ObservationIgnored private(set) var paginationCoordinator: PaginationCoordinator!
     @ObservationIgnored private(set) var rowEditingCoordinator: RowEditingCoordinator!
@@ -579,6 +580,7 @@ final class MainContentCoordinator {
             }
 
         self.filterCoordinator = FilterCoordinator(parent: self)
+        self.findCoordinator = FindCoordinator(parent: self)
         self.queryExecutionCoordinator = QueryExecutionCoordinator(parent: self)
         self.paginationCoordinator = PaginationCoordinator(parent: self)
         self.rowEditingCoordinator = RowEditingCoordinator(parent: self)

--- a/TablePro/Views/Results/Cells/DataGridCellContent.swift
+++ b/TablePro/Views/Results/Cells/DataGridCellContent.swift
@@ -53,6 +53,25 @@ struct DataGridCellState {
     let isFocused: Bool
     let isEditable: Bool
     let isLargeDataset: Bool
+    let isCurrentFindMatch: Bool
     let row: Int
     let columnIndex: Int
+
+    init(
+        visualState: RowVisualState,
+        isFocused: Bool,
+        isEditable: Bool,
+        isLargeDataset: Bool,
+        isCurrentFindMatch: Bool = false,
+        row: Int,
+        columnIndex: Int
+    ) {
+        self.visualState = visualState
+        self.isFocused = isFocused
+        self.isEditable = isEditable
+        self.isLargeDataset = isLargeDataset
+        self.isCurrentFindMatch = isCurrentFindMatch
+        self.row = row
+        self.columnIndex = columnIndex
+    }
 }

--- a/TablePro/Views/Results/Cells/DataGridCellPalette.swift
+++ b/TablePro/Views/Results/Cells/DataGridCellPalette.swift
@@ -12,13 +12,15 @@ struct DataGridCellPalette: Equatable {
     let mediumFont: NSFont
     let deletedRowText: NSColor
     let modifiedColumnTint: NSColor
+    let findMatchTint: NSColor
 
     static let placeholder = DataGridCellPalette(
         regularFont: .systemFont(ofSize: NSFont.systemFontSize),
         italicFont: .systemFont(ofSize: NSFont.systemFontSize),
         mediumFont: .systemFont(ofSize: NSFont.systemFontSize, weight: .medium),
         deletedRowText: .secondaryLabelColor,
-        modifiedColumnTint: .systemYellow
+        modifiedColumnTint: .systemYellow,
+        findMatchTint: .findHighlightColor
     )
 }
 
@@ -29,7 +31,8 @@ extension ThemeEngine {
             italicFont: dataGridFonts.italic,
             mediumFont: dataGridFonts.medium,
             deletedRowText: colors.dataGrid.deletedText,
-            modifiedColumnTint: colors.dataGrid.modified
+            modifiedColumnTint: colors.dataGrid.modified,
+            findMatchTint: .findHighlightColor
         )
     }
 }

--- a/TablePro/Views/Results/Cells/DataGridCellView.swift
+++ b/TablePro/Views/Results/Cells/DataGridCellView.swift
@@ -31,6 +31,7 @@ final class DataGridCellView: NSView {
     private var isFocusedCell: Bool = false
     private var onEmphasizedSelection: Bool = false
     private var hasOverlay: Bool = false
+    private var findMatchTint: NSColor?
 
     private var cachedLine: CTLine?
 
@@ -214,6 +215,13 @@ final class DataGridCellView: NSView {
             needsRedraw = true
         }
 
+        let nextFindTint: NSColor? = state.isCurrentFindMatch ? palette.findMatchTint : nil
+        if !colorsEqual(findMatchTint, nextFindTint) {
+            findMatchTint = nextFindTint
+            cachedLine = nil
+            needsRedraw = true
+        }
+
         if visualState != state.visualState {
             visualState = state.visualState
             needsRedraw = true
@@ -293,7 +301,10 @@ final class DataGridCellView: NSView {
     }
 
     override func draw(_ dirtyRect: NSRect) {
-        if let tint = modifiedColumnTint, !onEmphasizedSelection {
+        if let tint = findMatchTint {
+            tint.setFill()
+            bounds.fill()
+        } else if let tint = modifiedColumnTint, !onEmphasizedSelection {
             tint.setFill()
             bounds.fill()
         }
@@ -340,7 +351,8 @@ final class DataGridCellView: NSView {
     }
 
     private func resolvedTextColor() -> NSColor {
-        onEmphasizedSelection ? .alternateSelectedControlTextColor : textColor
+        if findMatchTint != nil { return .black }
+        return onEmphasizedSelection ? .alternateSelectedControlTextColor : textColor
     }
 
     private func cachedCTLine() -> CTLine {

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -48,6 +48,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     var valueFilterState = GridValueFilterState()
     var displayIDs: [RowID]? { valueFilteredIDs ?? sortedIDs }
     private(set) var columnDisplayFormats: [ValueDisplayFormat?] = []
+    private(set) var currentFindMatch: FindMatch?
     private let displayCache = RowDisplayCache()
     weak var delegate: (any DataGridViewDelegate)?
     weak var activeFKPreviewPopover: NSPopover?
@@ -935,6 +936,68 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         guard let tableView, let window = tableView.window else { return false }
         window.makeFirstResponder(tableView)
         return true
+    }
+
+    var selectedDisplayRow: Int? {
+        guard let tableView, tableView.selectedRow >= 0 else { return nil }
+        return tableView.selectedRow
+    }
+
+    func runFind(term: String) -> [FindMatch] {
+        let tableRows = tableRowsProvider()
+        let displayCount = displayIDs?.count ?? tableRows.count
+        let columnTypes = tableRows.columnTypes
+        let visible = visibleColumnDataIndices().map(Set.init)
+
+        return FindMatcher.matches(
+            term: term,
+            displayRowCount: displayCount,
+            columnCount: tableRows.columns.count,
+            isColumnSearchable: { column in
+                guard visible?.contains(column) ?? true else { return false }
+                guard column < columnTypes.count else { return true }
+                return FindMatcher.isSearchable(columnTypes[column])
+            },
+            cellText: { [weak self] displayIndex, column in
+                guard let self,
+                      let row = displayRow(at: displayIndex, in: tableRows),
+                      column < row.values.count
+                else { return nil }
+                let rawValue = row.values[column]
+                guard rawValue.asText != nil else { return nil }
+                return displayValue(
+                    forID: row.id,
+                    column: column,
+                    rawValue: rawValue,
+                    columnType: column < columnTypes.count ? columnTypes[column] : nil
+                )
+            }
+        )
+    }
+
+    func applyFindMatch(_ match: FindMatch?) {
+        let previous = currentFindMatch
+        guard previous != match else { return }
+        currentFindMatch = match
+
+        guard let tableView else { return }
+        let affected = IndexSet([previous?.displayRow, match?.displayRow]
+            .compactMap(\.self)
+            .filter { $0 >= 0 && $0 < tableView.numberOfRows })
+        if !affected.isEmpty {
+            tableView.reloadData(
+                forRowIndexes: affected,
+                columnIndexes: IndexSet(integersIn: 0 ..< tableView.numberOfColumns)
+            )
+        }
+
+        guard let match, match.displayRow >= 0, match.displayRow < tableView.numberOfRows else { return }
+        tableView.scrollRowToVisible(match.displayRow)
+        if let displayColumn = tableColumnIndex(for: match.columnIndex),
+           displayColumn < tableView.numberOfColumns {
+            tableView.scrollColumnToVisible(displayColumn)
+        }
+        tableView.selectRowIndexes(IndexSet(integer: match.displayRow), byExtendingSelection: false)
     }
 
     func beginEditing(displayRow: Int, column: Int) {

--- a/TablePro/Views/Results/Extensions/DataGridView+Columns.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Columns.swift
@@ -73,6 +73,7 @@ extension TableViewCoordinator {
             isFocused: isFocused,
             isEditable: isEditable,
             isLargeDataset: isLargeDataset,
+            isCurrentFindMatch: currentFindMatch == FindMatch(displayRow: row, columnIndex: columnIndex),
             row: row,
             columnIndex: columnIndex
         )

--- a/TablePro/Views/Results/FindBarView.swift
+++ b/TablePro/Views/Results/FindBarView.swift
@@ -1,0 +1,92 @@
+//
+//  FindBarView.swift
+//  TablePro
+//
+
+import SwiftUI
+
+struct FindBarView: View {
+    let coordinator: MainContentCoordinator
+    let findState: TabFindState
+    /// Changes whenever the rows under the bar are replaced: a page change, a refresh, a re-run, a
+    /// sort, or a value filter. The match list describes display positions, so it is stale the
+    /// moment any of those move and has to be recomputed rather than reused.
+    let rowsRevision: Int
+    let onSearchAllRows: () -> Void
+
+    @State private var term: String = ""
+
+    var body: some View {
+        HStack(spacing: 8) {
+            NativeSearchField(
+                text: $term,
+                placeholder: String(localized: "Find in loaded rows"),
+                controlSize: .regular,
+                onSubmit: { coordinator.findCoordinator.stepForward() },
+                focusOnAppear: true,
+                accessibilityIdentifier: "find-in-results-field"
+            )
+            .frame(maxWidth: 320)
+            .onChange(of: term) { _, newValue in
+                coordinator.findCoordinator.setTerm(newValue)
+            }
+
+            Text(counterText)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+                .accessibilityLabel(counterText)
+
+            HStack(spacing: 2) {
+                Button(action: { coordinator.findCoordinator.stepBackward() }) {
+                    Image(systemName: "chevron.left")
+                }
+                .help(String(localized: "Previous match"))
+                .accessibilityLabel(String(localized: "Previous match"))
+
+                Button(action: { coordinator.findCoordinator.stepForward() }) {
+                    Image(systemName: "chevron.right")
+                }
+                .help(String(localized: "Next match"))
+                .accessibilityLabel(String(localized: "Next match"))
+            }
+            .buttonStyle(.borderless)
+            .disabled(findState.matches.isEmpty)
+
+            if showsEscalation {
+                Button(String(localized: "Search All Rows"), action: onSearchAllRows)
+                    .buttonStyle(.borderless)
+            }
+
+            Spacer()
+
+            Button(String(localized: "Done")) {
+                coordinator.findCoordinator.dismiss()
+            }
+            .buttonStyle(.borderless)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .onAppear { term = findState.term }
+        .onChange(of: rowsRevision) { _, _ in
+            coordinator.findCoordinator.runSearch()
+        }
+    }
+
+    private var counterText: String {
+        guard !findState.term.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return "" }
+        return FindCounterText.text(
+            matchCount: findState.matches.count,
+            currentIndex: findState.currentMatchIndex,
+            scope: findState.scope
+        )
+    }
+
+    /// Escalating rewrites the whole filter set with an OR search, because `filterLogicMode` is one
+    /// mode for every row. Offering it on top of filters the user already applied would either
+    /// discard them or loosen them, so the button only appears when there are none.
+    private var showsEscalation: Bool {
+        guard findState.matches.isEmpty, findState.canEscalateToAllRows else { return false }
+        return coordinator.selectedTabFilterState.filters.isEmpty
+    }
+}

--- a/TableProTests/Core/Coordinators/FindMatcherTests.swift
+++ b/TableProTests/Core/Coordinators/FindMatcherTests.swift
@@ -1,0 +1,240 @@
+//
+//  FindMatcherTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("FindMatcher")
+struct FindMatcherTests {
+    private let grid: [[String?]] = [
+        ["active", "Alice", nil],
+        ["inactive", "Bob", "note"],
+        ["ACTIVE", "Chloé", "other"],
+    ]
+
+    private func cellText(_ row: Int, _ column: Int) -> String? {
+        guard row >= 0, row < grid.count, column >= 0, column < grid[row].count else { return nil }
+        return grid[row][column]
+    }
+
+    private func run(term: String, searchable: @escaping (Int) -> Bool = { _ in true }) -> [FindMatch] {
+        FindMatcher.matches(
+            term: term,
+            displayRowCount: grid.count,
+            columnCount: 3,
+            isColumnSearchable: searchable,
+            cellText: cellText
+        )
+    }
+
+    @Test("finds every occurrence in row-major order")
+    func rowMajorOrder() {
+        let matches = run(term: "active")
+        #expect(matches == [
+            FindMatch(displayRow: 0, columnIndex: 0),
+            FindMatch(displayRow: 1, columnIndex: 0),
+            FindMatch(displayRow: 2, columnIndex: 0),
+        ])
+    }
+
+    @Test("matching ignores case")
+    func caseInsensitive() {
+        #expect(run(term: "ACTIVE").count == 3)
+        #expect(run(term: "aCtIvE").count == 3)
+    }
+
+    @Test("matching ignores diacritics")
+    func diacriticInsensitive() {
+        #expect(run(term: "chloe") == [FindMatch(displayRow: 2, columnIndex: 1)])
+    }
+
+    @Test("a nil cell never matches")
+    func nilCellsSkipped() {
+        #expect(run(term: "note") == [FindMatch(displayRow: 1, columnIndex: 2)])
+    }
+
+    @Test("an excluded column is never searched")
+    func excludedColumn() {
+        let matches = run(term: "active", searchable: { $0 != 0 })
+        #expect(matches.isEmpty)
+    }
+
+    @Test("an empty or whitespace term matches nothing")
+    func emptyTerm() {
+        #expect(run(term: "").isEmpty)
+        #expect(run(term: "   ").isEmpty)
+    }
+
+    @Test("binary column types are not searchable, everything else is")
+    func searchableColumnTypes() {
+        #expect(FindMatcher.isSearchable(.blob(rawType: "BLOB")) == false)
+        #expect(FindMatcher.isSearchable(.spatial(rawType: "GEOMETRY")) == false)
+        #expect(FindMatcher.isSearchable(.text(rawType: "VARCHAR")))
+        #expect(FindMatcher.isSearchable(.integer(rawType: "INT")))
+        #expect(FindMatcher.isSearchable(.timestamp(rawType: "TIMESTAMP")))
+        #expect(FindMatcher.isSearchable(.json(rawType: "JSON")))
+        #expect(FindMatcher.isSearchable(nil))
+    }
+
+    @Test("the nearest match to a display row is the first at or after it")
+    func nearestMatch() {
+        let matches = [
+            FindMatch(displayRow: 1, columnIndex: 0),
+            FindMatch(displayRow: 4, columnIndex: 0),
+            FindMatch(displayRow: 9, columnIndex: 0),
+        ]
+        #expect(FindMatcher.nearestMatchIndex(to: 0, in: matches) == 0)
+        #expect(FindMatcher.nearestMatchIndex(to: 4, in: matches) == 1)
+        #expect(FindMatcher.nearestMatchIndex(to: 5, in: matches) == 2)
+        #expect(FindMatcher.nearestMatchIndex(to: 99, in: matches) == 0)
+        #expect(FindMatcher.nearestMatchIndex(to: 0, in: []) == nil)
+    }
+}
+
+@Suite("TabFindState")
+struct TabFindStateTests {
+    private func state(matchCount: Int) -> TabFindState {
+        var value = TabFindState(isVisible: true)
+        value.term = "x"
+        value.matches = (0 ..< matchCount).map { FindMatch(displayRow: $0, columnIndex: 0) }
+        return value
+    }
+
+    @Test("stepping forward wraps around")
+    func stepForwardWraps() {
+        var value = state(matchCount: 3)
+        value.stepForward()
+        #expect(value.currentMatchIndex == 0)
+        value.stepForward()
+        #expect(value.currentMatchIndex == 1)
+        value.currentMatchIndex = 2
+        value.stepForward()
+        #expect(value.currentMatchIndex == 0)
+    }
+
+    @Test("stepping backward from no selection lands on the last match")
+    func stepBackwardWraps() {
+        var value = state(matchCount: 3)
+        value.stepBackward()
+        #expect(value.currentMatchIndex == 2)
+        value.stepBackward()
+        #expect(value.currentMatchIndex == 1)
+    }
+
+    @Test("stepping with no matches does nothing")
+    func stepWithoutMatches() {
+        var value = state(matchCount: 0)
+        value.stepForward()
+        #expect(value.currentMatchIndex == nil)
+        value.stepBackward()
+        #expect(value.currentMatchIndex == nil)
+    }
+
+    @Test("escalation is offered only when rows are unloaded and a term is set")
+    func escalationAvailability() {
+        var value = TabFindState(isVisible: true)
+        value.scope = .pageOfMore
+        #expect(value.canEscalateToAllRows == false)
+        value.term = "abc"
+        #expect(value.canEscalateToAllRows)
+        value.scope = .allRowsLoaded
+        #expect(value.canEscalateToAllRows == false)
+    }
+
+    @Test("clearing matches drops the current index too")
+    func clearMatches() {
+        var value = state(matchCount: 3)
+        value.currentMatchIndex = 2
+        value.clearMatches()
+        #expect(value.matches.isEmpty)
+        #expect(value.currentMatchIndex == nil)
+        #expect(value.currentMatch == nil)
+    }
+}
+
+/// The find bar renders only on table tabs, and a table tab pages through `currentPage`, never
+/// through `hasMoreRows`, which is the query-tab truncation flag. Reading the wrong one made every
+/// table tab report its page as the whole table.
+@Suite("FindScopeFromPagination")
+struct FindScopeFromPaginationTests {
+    private func hasUnloadedRows(_ state: PaginationState, loadedRowCount: Int) -> Bool {
+        state.hasMoreRows || state.canGoToNextPage(loadedRowCount: loadedRowCount)
+    }
+
+    @Test("page 1 of a multi-page table has unloaded rows even though hasMoreRows is false")
+    func firstPageOfManyIsPaged() {
+        var state = PaginationState(pageSize: 1_000)
+        state.totalRowCount = 12_000
+        state.currentPage = 1
+        #expect(state.hasMoreRows == false)
+        #expect(hasUnloadedRows(state, loadedRowCount: 1_000))
+    }
+
+    @Test("the last page of a table has everything loaded")
+    func lastPageIsComplete() {
+        var state = PaginationState(pageSize: 1_000)
+        state.totalRowCount = 1_500
+        state.currentPage = 2
+        #expect(hasUnloadedRows(state, loadedRowCount: 500) == false)
+    }
+
+    @Test("a table that fits on one page has everything loaded")
+    func singlePageIsComplete() {
+        var state = PaginationState(pageSize: 1_000)
+        state.totalRowCount = 40
+        state.currentPage = 1
+        #expect(hasUnloadedRows(state, loadedRowCount: 40) == false)
+    }
+
+    @Test("an unknown row count with a full page is treated as paged, not as complete")
+    func unknownCountWithFullPage() {
+        var state = PaginationState(pageSize: 1_000)
+        state.totalRowCount = nil
+        state.currentPage = 1
+        #expect(hasUnloadedRows(state, loadedRowCount: 1_000))
+        #expect(hasUnloadedRows(state, loadedRowCount: 200) == false)
+    }
+
+    @Test("a truncated query result still counts as paged")
+    func truncatedQueryResult() {
+        var state = PaginationState(pageSize: 1_000)
+        state.hasMoreRows = true
+        #expect(hasUnloadedRows(state, loadedRowCount: 10))
+    }
+}
+
+@Suite("FindCounterText")
+struct FindCounterTextTests {
+    @Test("a paged result always names its scope")
+    func pagedCounter() {
+        let text = FindCounterText.text(matchCount: 12, currentIndex: 2, scope: .pageOfMore)
+        #expect(text.contains("3"))
+        #expect(text.contains("12"))
+        #expect(text.lowercased().contains("page"))
+    }
+
+    @Test("a fully loaded result does not claim a page")
+    func loadedCounter() {
+        let text = FindCounterText.text(matchCount: 12, currentIndex: 2, scope: .allRowsLoaded)
+        #expect(text.contains("3"))
+        #expect(text.contains("12"))
+        #expect(text.lowercased().contains("page") == false)
+    }
+
+    @Test("zero matches on a paged table never reads as an answer about the whole table")
+    func pagedEmptyCounter() {
+        let text = FindCounterText.text(matchCount: 0, currentIndex: nil, scope: .pageOfMore)
+        #expect(text.lowercased().contains("page"))
+        #expect(text == String(localized: "Not on this page"))
+    }
+
+    @Test("zero matches with everything loaded is a real answer")
+    func loadedEmptyCounter() {
+        let text = FindCounterText.text(matchCount: 0, currentIndex: nil, scope: .allRowsLoaded)
+        #expect(text == String(localized: "No matches"))
+    }
+}

--- a/docs/features/data-grid.mdx
+++ b/docs/features/data-grid.mdx
@@ -146,6 +146,23 @@ Right-click a row and choose **Copy as** for more formats:
 
 Copies follow the grid as shown: hidden columns are left out and columns keep their current order. When you select specific cells, **Copy as** (JSON, CSV, Markdown, INSERT, and UPDATE) includes only the columns you selected; select whole rows to include every column. The UPDATE format still keys its WHERE clause on the primary key, even when the primary key cell is not part of the selection. Right-click a header and choose **Copy Column Values** to copy a whole column, one value per line.
 
+## Find in Results
+
+`Cmd+F` on a table tab opens a find bar above the grid. Type a term and the matching cell is highlighted and scrolled into view. `Return` and `Cmd+G` step forward, `Cmd+Shift+G` steps back, and `Escape` clears the term, then closes the bar.
+
+Matching is case and accent insensitive, and it runs over the text you see, so a value reads the same in the find bar as it does in the cell. Binary and spatial columns are skipped, since they render as hex rather than as text.
+
+**The find bar searches the rows already loaded, not the whole table.** Results are paginated at the database, so the counter always says which it means:
+
+| What you see | What it means |
+|---|---|
+| `3 of 12` | Every row is loaded, so this is the whole table |
+| `3 of 12 on this page` | More rows exist that were never fetched |
+| `No matches` | Every row is loaded and none match |
+| `Not on this page` | None of the loaded rows match, and more rows exist |
+
+When nothing matches on the page and more rows exist, **Search All Rows** turns the term into a filter that runs on the server, so the answer covers the whole table. That button replaces the filters on the tab, so it only appears when you have none applied. With filters already set, add your search to the filter panel instead.
+
 ## Pagination and Limits
 
 **Table tabs** page through data. The status bar has a rows-per-page menu (5 to 1,000, a custom size, or **All rows**) and First / Previous / Next / Last controls. Click the page indicator (for example `3 / 12`) to type a page number and jump to it. Set the default page size in **Settings > Data**.

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -127,7 +127,10 @@ With a drag-selected cell range, `Cmd+C` copies the range as TSV. With a single 
 
 | Action | Shortcut |
 |--------|----------|
-| Find, which filters rows in a table tab and searches the text in the editor | `Cmd+F` |
+| Find, which searches the loaded rows in a table tab and the text in the editor | `Cmd+F` |
+| Next match | `Return` or `Cmd+G` |
+| Previous match | `Cmd+Shift+G` |
+| Close the find bar | `Escape` |
 | Toggle filter bar (table tab) | `Cmd+Option+F` |
 | Apply filters | `Cmd+Enter` |
 

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -22,7 +22,8 @@ prepare_mariadb() {
     echo "📦 Preparing libmariadb.a for $target_arch..."
 
     # If libmariadb.a already exists with the correct architecture, skip preparation.
-    # CI pre-copies the architecture-specific library from Homebrew.
+    # CI pre-copies the architecture-specific slice from Libs via scripts/ci/prepare-libs.sh.
+    # Homebrew is not involved: the whole library is vendored by download-libs.sh.
     if [ -f "Libs/libmariadb.a" ] && lipo -info "Libs/libmariadb.a" 2>/dev/null | grep -q "$target_arch"; then
         local size
         size=$(ls -lh Libs/libmariadb.a 2>/dev/null | awk '{print $5}')


### PR DESCRIPTION
## Root cause

This was a mis-wiring, not a missing feature. `MainSplitViewController+EditMenuActions.swift:65` routed `Cmd+F` on a table tab to `toggleFilterPanel()`. Because that is a *toggle*, pressing `Cmd+F` with the filter panel already open closed it, and nothing anywhere searched the rows on screen. Meanwhile `findNext`/`findPrevious` went straight to `EditorEventRouter` regardless of surface.

`Cmd+F` was also a redundant third path to the filter panel, which already has `Cmd+Option+F` and a funnel button in the status bar. So reassigning it removes nothing from the user. That matches Postico 2, which leaves `Cmd+F` free and uses `Opt+Cmd+F` for its filter bar.

## The honesty problem, and why the counter is worded the way it is

Results are paginated at the database, default page size 1000. A find that scans only the loaded page will confidently report "No results" for a row sitting on page 7 of a 4M-row table. The old `Cmd+F` was clunky but correct, so replacing it with something fast and wrong would have been the worst possible trade for an app whose pitch is that it is safe to point at production.

Three competitors settled the design:

- **TablePlus refused an in-grid find outright** for exactly this reason: "it could cause confusion with the advanced filter - which searches all the table, not only the current page." (TablePlus/TablePlus#2279)
- **DataGrip puts the scope in the command name**: "Find on Current Page".
- **DBeaver ships one with no counter at all**, and only warns in its docs that "Search only checks rows that are already fetched".

So the counter always names its scope: `3 of 12 on this page` while rows remain unfetched, `3 of 12` once everything is loaded, `Not on this page` instead of a bare `No matches`. The scope is keyed off `hasMoreRows` rather than comparing row counts, which is what makes it correct when `totalRowCount` is nil.

## Design decisions worth reviewing

**Not NSTextFinder.** Its client contract needs `contentViewAtIndex:effectiveCharacterRange:` and `rectsForCharacterRange:`, and a view-based `NSTableView` has no honest answer: cell views are recycled and off-screen rows have no view at all. It also only ever searches the string the client hands it, so it can never cross the page boundary.

**Not the NSScrollView find-bar slot either.** `NSTextFinder.h` says `findBarView` "is managed by NSTextFinder. You should not set this property", and we are not using NSTextFinder. The bar goes where this codebase already puts one: the SwiftUI VStack above the grid, next to `FilterPanelView`. That also gives per-tab ownership for free, since `DataGridView` is an `NSViewRepresentable` built per tab.

**Whole-cell tint, not substring highlighting.** `DataGridCellView.cachedCTLine()` caps at 300 NSString units and `drawText` swaps in `CTLineCreateTruncatedLine` at the column width, so a rect derived from a `displayText` index is wrong past either. The tint uses `NSColor.findHighlightColor`, the system colour documented as "Background color of find indicators", so it adapts to light and dark without widening the theme schema for one value. It deliberately takes precedence over `modifiedColumnTint` and ignores `onEmphasizedSelection`, because jumping to a match selects the row and the highlight has to survive that.

**Search All Rows only appears when no filters are applied.** `TabFilterState.filterLogicMode` is one mode for the whole filter array, so escalating to a cross-column OR search would silently loosen AND filters the user wrote. Offering the button on top of existing filters would either discard their work or lie about what it searched, so it is hidden and the docs say to use the filter panel instead. This is a deliberate limit, not an oversight.

**Escape composes with the existing two-step.** `NativeSearchField` consumes Escape when the field has text and clears it, and returns false when empty. So the first Escape clears the term and the second closes the bar, matching #1490.

## Scope

Every match resolves through `displayRow(at:in:)`, never by indexing `TableRows.rows` with a display position, per the CLAUDE.md invariant that shipped as #1837. Binary and spatial columns are excluded from matching since they render as hex. Find state is a new `TabFindState` on `QueryTab` beside `filterState`, session-only, and is not written to `PersistedTab`.

`Cmd+G` / `Cmd+Shift+G` now drive the grid when its find bar is open, gated through `validateMenuItem(_:)` via a new `hasActiveGridFind`, so they stay dimmed rather than silently acting on the SQL editor.

## Verification

- `build` PASS
- `test` PASS, 46 executed / 46 passed, covering the three new suites plus `DisplayRowMappingTests`, `TableViewCoordinatorValueFilterTests`, `DataGridCellViewDoubleClickTests` and `DataGridCellAccessoryAppearanceTests`
- `lint TablePro` 0 violations

**No screenshots.** `scripts/export-screenshots.sh` does not exist in the repo, so the docs page for this feature ships without the `<Frame>` pair the other feature pages have. That needs a follow-up capture.

**No UI automation.** The find bar is reachable only with a live connection and loaded rows, which `TableProUITests` cannot set up deterministically today.

## Found while investigating, not fixed here

`PaginationCoordinator.showAllRows()` (line 51) reads `tab.pagination.totalRowCount` and never consults `isApproximateRowCount`, so on a MySQL InnoDB table whose `information_schema` estimate reads 640,000 against a real 1,000,000 rows, "All rows" emits `LIMIT 640000` and the grid holds a subset while the UI says everything is loaded. A verifier tried to refute this and could not. It is not bundled here because this feature's escalation goes through `FilterCoordinator`, not through `showAllRows()`, so the find bar does not inherit it. Worth its own PR.

## Code review pass

A high-effort review found 12 findings and all 12 are addressed in this branch. The first one is worth calling out because it broke the exact property this feature exists to provide:

`scope(for:)` originally read `pagination.hasMoreRows`. That flag is the *query-tab truncation* state and is never set for a table tab: `syncLoadMoreState` opens with `guard tabType == .query else { return }`, and the field's own comment says "Result truncation state (query tabs)". Table tabs page through `currentPage`/`totalPages`. Since the find bar only renders on table tabs, every counter would have read "3 of 12" on page 1 of 12, claiming the page was the whole table, and "Search All Rows" would have been unreachable dead code. It now goes through `canGoToNextPage(loadedRowCount:)`, which also handles the case where the row count is unknown, and `FindScopeFromPaginationTests` covers all five states so it cannot regress silently.

The rest:

| Finding | Fix |
|---|---|
| `rowView.needsDisplay` redraws only the row background, never the cells | `reloadData(forRowIndexes:columnIndexes:)` |
| `invalidateMatches()` had no callers, so matches survived a page change | re-run keyed on a rows revision through `onChange` |
| Escalation built `LIKE` against integer and timestamp columns, which errors the whole page on Postgres | new `isServerSearchable`, text and enum and set only |
| White text on the yellow highlight, because jumping selects the row | black text when the match tint is set, and `cachedLine` invalidated with it |
| Search field never took focus | `focusOnAppear` |
| Hidden columns were searched and counted but had nothing to show | filtered through `visibleColumnDataIndices()` |
| No horizontal scroll to an off-screen match | `scrollColumnToVisible` |
| `Shift+Return` documented but never implemented | claim removed from docs and CHANGELOG |
| `filterLogicMode = .or` written before the discard prompt was answered, so cancelling left the tab in OR | mode now passed into `applyFilters` and written inside the confirmed branch |
| A full synchronous scan on every keystroke | 120ms coalesce, cancelled on dismiss |
| `.keyboardShortcut(.escape)` pre-empted the field's own cancel handling | removed; `NativeSearchField` keeps the two-step Escape from #1490 |
