### PR TITLE
docs: stop requiring a CLA that was removed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,10 +128,6 @@ Open a [GitHub issue](https://github.com/TableProApp/TablePro/issues) with:
 - Reproduction steps
 - Database type and version (for database-specific bugs)
 
-## CLA
-
-Sign the Contributor License Agreement on your first PR. The CLA bot walks you through it. One-time thing.
-
 ## License
 
 Contributions are licensed under [AGPLv3](LICENSE).

--- a/README.md
+++ b/README.md
@@ -174,4 +174,3 @@ Thanks to these amazing people for supporting TablePro:
 
 This project is licensed under the [GNU Affero General Public License v3.0 (AGPLv3)](LICENSE).
 
-Contributions require signing a Contributor License Agreement (CLA). See [CLA.md](CLA.md) for details.

--- a/README.vi.md
+++ b/README.vi.md
@@ -141,4 +141,3 @@ Cảm ơn những người tuyệt vời đã ủng hộ TablePro:
 
 Dự án này cấp phép theo [GNU Affero General Public License v3.0 (AGPLv3)](LICENSE).
 
-Đóng góp cần ký Contributor License Agreement (CLA). Xem [CLA.md](CLA.md) để biết chi tiết.

--- a/README.zh.md
+++ b/README.zh.md
@@ -140,4 +140,3 @@ brew install --cask tablepro
 
 本项目采用 [GNU Affero General Public License v3.0 (AGPLv3)](LICENSE) 许可。
 
-贡献者需签署贡献者许可协议(CLA)。详见 [CLA.md](CLA.md)。


### PR DESCRIPTION
All three READMEs say "Contributions require signing a Contributor License Agreement (CLA). See [CLA.md](CLA.md) for details." That link is a 404: commit `5ea49b7b3` ("Remove CLA", 22 Jun 2026) deleted `CLA.md`, `.github/workflows/cla.yml` and `signatures/cla.json`, 303 lines in total.

So the licence statement asks contributors to sign a document that does not exist, and the workflow that used to check it is gone too. This drops the sentence from the English, Vietnamese and Chinese READMEs.

Nothing else changes. The project stays AGPL-3.0.

## Why this matters beyond the dead link

Whether to run a CLA is worth deciding deliberately rather than leaving as a stale sentence, because it is the thing that decides who can change the licence later.

Without a CLA, the maintainer cannot relicense other people's contributions. That is already concrete: `Plugins/TableProPluginKit/` has 10,065 lines, and 188 of them belong to three outside contributors:

| Contributor | Lines | Covered by the old CLA? |
|---|---|---|
| Nguyen Van Thang | 136 | No, committed 2026-08-18, after the CLA was removed |
| Santiago Montoya A. | 40 | Yes |
| Henry | 12 | No |

That matters if TableProPluginKit is ever put under a permissive licence so third parties can write drivers without their driver becoming AGPL, which is the shape Grafana and MongoDB both use. Doing that needs permission from those two contributors, or a rewrite of their 148 lines. It gets harder with every plugin PR merged under no CLA.

This PR does not decide that. It only stops the README claiming a requirement the project does not have.
