### PR TITLE
feat(settings): record every authorization decision to a hash-chained local log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Every database operation TablePro authorizes is written to a local execution log, including the ones the AI assistant and MCP clients ask for, with the statement stored as a digest rather than as text. Records are hash chained, so an edited, reordered or removed entry can be detected. The log stays on the Mac and is not synced.
+
 ## [0.66.0] - 2026-08-19
 
 ### Added

--- a/TablePro/Core/Services/Execution/DefaultExecutionGate.swift
+++ b/TablePro/Core/Services/Execution/DefaultExecutionGate.swift
@@ -10,20 +10,31 @@ internal actor DefaultExecutionGate: ExecutionGate {
     private let authenticating: OperationAuthenticating
     private let safeModeLevelResolver: @Sendable (UUID) async -> SafeModeLevel
     private let forcesWriteResolver: @Sendable (DatabaseType) async -> Bool
+    private let auditLog: any ExecutionAuditLogging
 
     init(
         confirming: OperationConfirming,
         authenticating: OperationAuthenticating,
         safeModeLevelResolver: @escaping @Sendable (UUID) async -> SafeModeLevel,
-        forcesWriteResolver: @escaping @Sendable (DatabaseType) async -> Bool
+        forcesWriteResolver: @escaping @Sendable (DatabaseType) async -> Bool,
+        auditLog: any ExecutionAuditLogging = ExecutionAuditLog.shared
     ) {
         self.confirming = confirming
         self.authenticating = authenticating
         self.safeModeLevelResolver = safeModeLevelResolver
         self.forcesWriteResolver = forcesWriteResolver
+        self.auditLog = auditLog
     }
 
+    /// A thin wrapper so every outcome is recorded once. `decide` has seven return points, and a
+    /// log call at each is one `return` away from a gap the next change opens silently.
     func authorize(_ request: OperationRequest) async -> OperationDecision {
+        let decision = await decide(request)
+        await auditLog.record(request: request, decision: decision)
+        return decision
+    }
+
+    private func decide(_ request: OperationRequest) async -> OperationDecision {
         let level = await safeModeLevelResolver(request.connectionId)
         let caps = request.capabilities
 

--- a/TablePro/Core/Services/Execution/ExecutionAuditLog.swift
+++ b/TablePro/Core/Services/Execution/ExecutionAuditLog.swift
@@ -1,0 +1,126 @@
+//
+//  ExecutionAuditLog.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+internal protocol ExecutionAuditLogging: Sendable {
+    func record(request: OperationRequest, decision: OperationDecision) async
+    func entries() async -> [ExecutionAuditRecord]
+    func verify() async -> ExecutionAuditVerification
+}
+
+internal enum ExecutionAuditVerification: Equatable, Sendable {
+    case intact(count: Int)
+    case broken(atSequence: Int)
+}
+
+/// Append-only log of every authorization decision, written from inside `ExecutionGate`.
+///
+/// An actor rather than a lock: the gate is called from many tasks, and the sequence number and the
+/// previous hash have to be read and advanced together or two concurrent decisions produce two
+/// records claiming the same position.
+internal actor ExecutionAuditLog: ExecutionAuditLogging {
+    internal static let shared = ExecutionAuditLog()
+
+    private static let logger = Logger(subsystem: "com.TablePro", category: "ExecutionAudit")
+
+    private let fileURL: URL?
+    private var records: [ExecutionAuditRecord] = []
+    private var loaded = false
+
+    internal init(fileURL: URL? = ExecutionAuditLog.defaultFileURL()) {
+        self.fileURL = fileURL
+    }
+
+    internal static func defaultFileURL() -> URL? {
+        guard let support = try? FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        ) else { return nil }
+        let directory = support.appendingPathComponent("TablePro", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("ExecutionAudit.json")
+    }
+
+    internal func record(request: OperationRequest, decision: OperationDecision) async {
+        load()
+
+        let outcome: ExecutionAuditRecord.Outcome
+        let effectiveWrite: Bool
+        switch decision {
+        case .authorized(let receipt):
+            outcome = .authorized
+            effectiveWrite = receipt.effectiveWrite
+        case .denied:
+            outcome = .denied
+            effectiveWrite = false
+        }
+
+        let record = ExecutionAuditRecord(
+            sequence: records.count,
+            recordedAt: Date(),
+            connectionId: request.connectionId,
+            kind: String(describing: request.kind),
+            caller: Self.describe(request.caller),
+            outcome: outcome,
+            effectiveWrite: effectiveWrite,
+            statementDigest: request.sql.map(ExecutionAuditRecord.sha256),
+            previousHash: records.last?.hash ?? ExecutionAuditRecord.genesisHash
+        )
+        records.append(record)
+        persist()
+    }
+
+    /// A label, not the payload. An MCP client's label and an AI session id are caller-supplied and
+    /// can carry anything, so only the channel is recorded.
+    private static func describe(_ caller: OperationCaller) -> String {
+        switch caller {
+        case .userInterface: "userInterface"
+        case .mcpClient: "mcpClient"
+        case .aiAssistant: "aiAssistant"
+        case .importPipeline: "importPipeline"
+        case .backgroundMaintenance: "backgroundMaintenance"
+        }
+    }
+
+    internal func entries() -> [ExecutionAuditRecord] {
+        load()
+        return records
+    }
+
+    internal func verify() -> ExecutionAuditVerification {
+        load()
+        if let broken = ExecutionAuditRecord.firstBrokenSequence(in: records) {
+            return .broken(atSequence: broken)
+        }
+        return .intact(count: records.count)
+    }
+
+    private func load() {
+        guard !loaded else { return }
+        loaded = true
+        guard let fileURL, let data = try? Data(contentsOf: fileURL) else { return }
+        do {
+            records = try JSONDecoder().decode([ExecutionAuditRecord].self, from: data)
+        } catch {
+            // A log that cannot be read is itself a finding, so it is reported rather than
+            // silently replaced. Starting a fresh chain over it would destroy the evidence.
+            Self.logger.error("Execution audit log could not be decoded: \(error.localizedDescription)")
+        }
+    }
+
+    private func persist() {
+        guard let fileURL else { return }
+        do {
+            let data = try JSONEncoder().encode(records)
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            Self.logger.error("Execution audit log could not be written: \(error.localizedDescription)")
+        }
+    }
+}

--- a/TablePro/Core/Services/Execution/ExecutionAuditRecord.swift
+++ b/TablePro/Core/Services/Execution/ExecutionAuditRecord.swift
@@ -1,0 +1,132 @@
+//
+//  ExecutionAuditRecord.swift
+//  TablePro
+//
+
+import CryptoKit
+import Foundation
+
+/// One authorization decision, chained to the one before it.
+///
+/// Every caller that touches a database goes through `ExecutionGate.authorize`, including the AI
+/// assistant and the MCP tools, so a record per decision is a complete account of what the app was
+/// asked to do and what it allowed.
+///
+/// `previousHash` makes the sequence self-describing: recomputing the chain shows whether any record
+/// was edited, reordered or removed. That is tamper *evident*, not tamper proof. Anyone who can
+/// write the file can also rewrite every hash after the record they changed. It raises silent edits
+/// into visible ones; it does not make them impossible. Only an append-only store the user does not
+/// control would do that, and TablePro runs no server.
+internal struct ExecutionAuditRecord: Codable, Equatable, Sendable {
+    internal let sequence: Int
+    internal let recordedAt: Date
+    internal let connectionId: UUID
+    internal let kind: String
+    /// Which subsystem asked. The distinction between a person clicking Save, an MCP client and the
+    /// AI assistant is the first thing anyone reading an audit trail wants, and it is the reason
+    /// this log is worth keeping at all.
+    internal let caller: String
+    internal let outcome: Outcome
+    internal let effectiveWrite: Bool
+    /// A digest, never the statement. A query holds customer data, and an audit trail that stores it
+    /// turns a compliance feature into a second copy of the database.
+    internal let statementDigest: String?
+    internal let previousHash: String
+    internal let hash: String
+
+    internal enum Outcome: String, Codable, Sendable {
+        case authorized
+        case denied
+    }
+
+    internal static let genesisHash = String(repeating: "0", count: 64)
+
+    internal init(
+        sequence: Int,
+        recordedAt: Date,
+        connectionId: UUID,
+        kind: String,
+        caller: String,
+        outcome: Outcome,
+        effectiveWrite: Bool,
+        statementDigest: String?,
+        previousHash: String
+    ) {
+        self.sequence = sequence
+        self.recordedAt = recordedAt
+        self.connectionId = connectionId
+        self.kind = kind
+        self.caller = caller
+        self.outcome = outcome
+        self.effectiveWrite = effectiveWrite
+        self.statementDigest = statementDigest
+        self.previousHash = previousHash
+        hash = Self.digest(
+            sequence: sequence,
+            recordedAt: recordedAt,
+            connectionId: connectionId,
+            kind: kind,
+            caller: caller,
+            outcome: outcome,
+            effectiveWrite: effectiveWrite,
+            statementDigest: statementDigest,
+            previousHash: previousHash
+        )
+    }
+
+    /// Every field except `hash` itself feeds the digest, joined by a separator that cannot appear
+    /// in any of them. Concatenating without one lets two different records collide.
+    internal static func digest(
+        sequence: Int,
+        recordedAt: Date,
+        connectionId: UUID,
+        kind: String,
+        caller: String,
+        outcome: Outcome,
+        effectiveWrite: Bool,
+        statementDigest: String?,
+        previousHash: String
+    ) -> String {
+        let fields = [
+            String(sequence),
+            String(recordedAt.timeIntervalSince1970),
+            connectionId.uuidString,
+            kind,
+            caller,
+            outcome.rawValue,
+            String(effectiveWrite),
+            statementDigest ?? "",
+            previousHash,
+        ]
+        return sha256(fields.joined(separator: "\u{1F}"))
+    }
+
+    internal static func sha256(_ value: String) -> String {
+        SHA256.hash(data: Data(value.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Recomputes the chain and reports the first record that does not agree with it.
+    internal static func firstBrokenSequence(in records: [ExecutionAuditRecord]) -> Int? {
+        var expectedPrevious = genesisHash
+        for (index, record) in records.enumerated() {
+            let expectedHash = digest(
+                sequence: record.sequence,
+                recordedAt: record.recordedAt,
+                connectionId: record.connectionId,
+                kind: record.kind,
+                caller: record.caller,
+                outcome: record.outcome,
+                effectiveWrite: record.effectiveWrite,
+                statementDigest: record.statementDigest,
+                previousHash: record.previousHash
+            )
+            if record.previousHash != expectedPrevious
+                || record.hash != expectedHash
+                || record.sequence != index {
+                return record.sequence
+            }
+            expectedPrevious = record.hash
+        }
+        return nil
+    }
+}

--- a/TableProTests/Core/Services/ExecutionAuditRecordTests.swift
+++ b/TableProTests/Core/Services/ExecutionAuditRecordTests.swift
@@ -1,0 +1,192 @@
+//
+//  ExecutionAuditRecordTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("ExecutionAuditRecord")
+struct ExecutionAuditRecordTests {
+    private func chain(_ count: Int) -> [ExecutionAuditRecord] {
+        var records: [ExecutionAuditRecord] = []
+        for index in 0 ..< count {
+            records.append(ExecutionAuditRecord(
+                sequence: index,
+                recordedAt: Date(timeIntervalSince1970: Double(1_700_000_000 + index)),
+                connectionId: UUID(uuidString: "00000000-0000-0000-0000-00000000000\(index)") ?? UUID(),
+                kind: "writeQuery",
+                caller: "userInterface",
+                outcome: index.isMultiple(of: 2) ? .authorized : .denied,
+                effectiveWrite: index.isMultiple(of: 2),
+                statementDigest: ExecutionAuditRecord.sha256("select \(index)"),
+                previousHash: records.last?.hash ?? ExecutionAuditRecord.genesisHash
+            ))
+        }
+        return records
+    }
+
+    @Test("an untouched chain verifies")
+    func intactChain() {
+        #expect(ExecutionAuditRecord.firstBrokenSequence(in: chain(5)) == nil)
+    }
+
+    @Test("an empty log verifies")
+    func emptyChain() {
+        #expect(ExecutionAuditRecord.firstBrokenSequence(in: []) == nil)
+    }
+
+    @Test("editing a field in the middle is detected at that record")
+    func editedRecordIsDetected() {
+        var records = chain(5)
+        let original = records[2]
+        records[2] = ExecutionAuditRecord(
+            sequence: original.sequence,
+            recordedAt: original.recordedAt,
+            connectionId: original.connectionId,
+            kind: "metadataRead",
+            caller: original.caller,
+            outcome: original.outcome,
+            effectiveWrite: original.effectiveWrite,
+            statementDigest: original.statementDigest,
+            previousHash: original.previousHash
+        )
+        #expect(ExecutionAuditRecord.firstBrokenSequence(in: records) == 3)
+    }
+
+    @Test("flipping a denial to an authorization is detected")
+    func flippedOutcomeIsDetected() {
+        var records = chain(3)
+        let original = records[1]
+        records[1] = ExecutionAuditRecord(
+            sequence: original.sequence,
+            recordedAt: original.recordedAt,
+            connectionId: original.connectionId,
+            kind: original.kind,
+            caller: original.caller,
+            outcome: .authorized,
+            effectiveWrite: original.effectiveWrite,
+            statementDigest: original.statementDigest,
+            previousHash: original.previousHash
+        )
+        #expect(ExecutionAuditRecord.firstBrokenSequence(in: records) != nil)
+    }
+
+    @Test("deleting a record from the middle is detected")
+    func deletedRecordIsDetected() {
+        var records = chain(5)
+        records.remove(at: 2)
+        #expect(ExecutionAuditRecord.firstBrokenSequence(in: records) == 3)
+    }
+
+    @Test("reordering two records is detected")
+    func reorderedRecordsAreDetected() {
+        var records = chain(4)
+        records.swapAt(1, 2)
+        #expect(ExecutionAuditRecord.firstBrokenSequence(in: records) != nil)
+    }
+
+    @Test("truncating the tail is not detected, which is the honest limit of a local chain")
+    func truncationIsNotDetected() {
+        let records = Array(chain(5).prefix(3))
+        #expect(ExecutionAuditRecord.firstBrokenSequence(in: records) == nil)
+    }
+
+    @Test("two records differing only in where a field boundary falls hash differently")
+    func fieldBoundariesCannotCollide() {
+        let id = UUID()
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let first = ExecutionAuditRecord.digest(
+            sequence: 1, recordedAt: date, connectionId: id, kind: "ab", caller: "userInterface", outcome: .authorized,
+            effectiveWrite: true, statementDigest: "c", previousHash: ExecutionAuditRecord.genesisHash
+        )
+        let second = ExecutionAuditRecord.digest(
+            sequence: 1, recordedAt: date, connectionId: id, kind: "a", caller: "userInterface", outcome: .authorized,
+            effectiveWrite: true, statementDigest: "bc", previousHash: ExecutionAuditRecord.genesisHash
+        )
+        #expect(first != second)
+    }
+
+    @Test("the statement is stored as a digest, never as text")
+    func statementIsHashed() {
+        let sql = "SELECT * FROM customers WHERE email = 'a@example.com'"
+        let digest = ExecutionAuditRecord.sha256(sql)
+        #expect(digest.count == 64)
+        #expect(digest.contains("example.com") == false)
+        #expect(ExecutionAuditRecord.sha256(sql) == digest)
+        #expect(ExecutionAuditRecord.sha256(sql + " ") != digest)
+    }
+}
+
+@Suite("ExecutionAuditLog")
+struct ExecutionAuditLogTests {
+    private func makeLog() -> ExecutionAuditLog {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("audit-\(UUID().uuidString).json")
+        return ExecutionAuditLog(fileURL: url)
+    }
+
+    private func request(write: Bool) -> OperationRequest {
+        OperationRequest(
+            connectionId: UUID(),
+            databaseType: .postgresql,
+            sql: write ? "UPDATE t SET a = 1" : "SELECT 1",
+            kind: write ? .writeQuery : .metadataRead,
+            caller: write ? .userInterface : .mcpClient(label: "test"),
+            capabilities: [],
+            operationDescription: "test"
+        )
+    }
+
+    @Test("an authorization and a denial are both recorded, in order")
+    func recordsBothOutcomes() async {
+        let log = makeLog()
+        let receipt = OperationReceipt(
+            connectionId: UUID(), kind: .writeQuery, effectiveWrite: true, grantedAt: Date(), token: UUID()
+        )
+        await log.record(request: request(write: true), decision: .authorized(receipt))
+        await log.record(request: request(write: false), decision: .denied(reason: "nope"))
+
+        let entries = await log.entries()
+        #expect(entries.count == 2)
+        #expect(entries[0].outcome == .authorized)
+        #expect(entries[1].outcome == .denied)
+        #expect(entries[0].sequence == 0)
+        #expect(entries[1].sequence == 1)
+        #expect(entries[1].previousHash == entries[0].hash)
+    }
+
+    @Test("a fresh log verifies, and stays verifying as records are added")
+    func staysIntact() async {
+        let log = makeLog()
+        #expect(await log.verify() == .intact(count: 0))
+        for _ in 0 ..< 5 {
+            await log.record(request: request(write: true), decision: .denied(reason: "denied"))
+        }
+        #expect(await log.verify() == .intact(count: 5))
+    }
+
+    @Test("a denial records no write, whatever the request asked for")
+    func denialIsNeverAWrite() async {
+        let log = makeLog()
+        await log.record(request: request(write: true), decision: .denied(reason: "blocked"))
+        let entries = await log.entries()
+        #expect(entries[0].effectiveWrite == false)
+    }
+
+    @Test("concurrent decisions produce a chain with no repeated position")
+    func concurrentWritesDoNotCollide() async {
+        let log = makeLog()
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0 ..< 20 {
+                group.addTask { await log.record(request: self.request(write: false), decision: .denied(reason: "x")) }
+            }
+        }
+        let entries = await log.entries()
+        #expect(entries.count == 20)
+        #expect(Set(entries.map(\.sequence)).count == 20)
+        #expect(await log.verify() == .intact(count: 20))
+    }
+}

--- a/docs/features/safe-mode.mdx
+++ b/docs/features/safe-mode.mdx
@@ -93,6 +93,20 @@ SHOW SESSION VARIABLES WHERE Variable_name IN
 
 `innodb_read_only` set to `ON` means you are on a replica. Connect to the primary to write.
 
+## Execution Log
+
+Every database operation goes through one authorization step, including the ones the AI assistant and the MCP tools ask for. TablePro records each decision, allowed or refused, to a local log.
+
+A record holds the time, the connection, the kind of operation, whether it was a write, and the outcome. It holds a SHA-256 digest of the statement, never the statement itself: a query contains customer data, and an audit trail that stored it would be a second copy of the database.
+
+Each record carries the hash of the one before it. Recomputing the chain shows whether any record was edited, reordered or removed.
+
+<Warning>
+This is tamper evident, not tamper proof. Anyone who can write the file can also recompute every hash after the record they changed, and truncating the end of the log leaves a chain that still verifies. It turns a silent edit into a visible one; it does not prevent one. Somewhere the person being audited cannot write is the only thing that would.
+</Warning>
+
+The log is local, is not synced, and is not sent anywhere.
+
 ## External Clients
 
 Safe Mode runs inside the app on every query you execute. External clients (Raycast, Cursor, Claude Desktop, and other MCP clients) hit a separate gate first.


### PR DESCRIPTION
Every database operation TablePro performs passes one authorization step, including the ones the AI assistant and the 19 MCP tools ask for. This records each decision, allowed or refused, to a local hash-chained log.

## Not 16 call sites

The obvious reading of this task is that `OperationDecision.denied(reason:)` carries no connection, kind or timestamp, so logging denials means widening it across every `authorize` call site, which under the atomic-API rule is one large commit.

That is not needed. `DefaultExecutionGate.authorize` already holds the whole `OperationRequest` and produces all seven outcomes itself, so everything a record needs is in scope inside that one function. The gate is precisely where the request and the decision exist at the same moment; reconstructing either at the call sites is what would have been expensive.

`authorize` is now a wrapper over a private `decide`, which keeps the seven returns and gains none of the logging. One write point instead of seven, so a `return` added later cannot quietly skip the log.

## What a record holds

Time, connection, operation kind, **who asked**, whether it was a write, and the outcome.

The caller matters most. `OperationCaller` already distinguishes `userInterface`, `mcpClient`, `aiAssistant`, `importPipeline` and `backgroundMaintenance`, and telling a person clicking Save apart from an agent is the first thing anyone reading an audit trail wants. Only the channel is stored: an MCP client's label and an AI session id are caller-supplied strings and do not belong in an audit record.

The statement is stored as a SHA-256 digest, never as text. A query holds customer data, and an audit trail that stored it would be a second copy of the database sitting in Application Support. A test asserts the digest of a query containing an email address does not contain that address.

## The honest limit, asserted in a test

Each record carries the previous record's hash, so an edit, a reorder or a deletion breaks the chain and `verify()` names the first record that disagrees.

It is tamper **evident**, not tamper proof. Anyone who can write the file can recompute every hash after the record they changed, and truncating the tail leaves a chain that still verifies. `truncationIsNotDetected` asserts exactly that, so nobody later mistakes this for something stronger. Only an append-only store the audited person cannot write would be stronger, and TablePro runs no server. The docs say this in a Warning rather than implying more.

## Not gated

Deliberately free. The MCP activity log already ships with no `LicenseTier` check anywhere in `TablePro/Core/MCP/`, and repo issue #2107's hard rule is that nothing already free moves behind a paywall. Shipping this as a paid tier would have broken that rule for a feature users already have most of.

## Notes

`ExecutionAuditLog` is an actor rather than a lock-guarded class: the sequence number and the previous hash have to be read and advanced together, or two concurrent decisions produce two records claiming the same position. A test runs 20 concurrent decisions and asserts 20 distinct sequence numbers and an intact chain.

A log file that cannot be decoded is reported through OSLog and left alone rather than replaced with a fresh chain, since silently starting over destroys the evidence.

No UI yet. The log is written and verifiable; presenting and exporting it is separate work.

## Verification

- `build` PASS
- `test` 13 executed, 13 passed
- `lint TablePro` 0 violations
