### PR TITLE
fix(hig): bind Cmd+W to the close command every window implements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Cmd+W` now closes the Settings window, the Integrations window, the JSON and PHP viewers, the connection form and the column inspector. It was bound to a command only a connection window answered, so it did nothing in any of them.
+- The File menu names the close command after the window in front: Close Tab in a connection window, Close Window where there are no tabs, and the connection's own name while the connections strip has focus.
 - Filtering a JSON or PHP tree now reveals nested key and value matches instead of leaving them behind collapsed parent rows. (#2204)
 - A tree filter that matches a key now lets you open that key and read what is inside it. (#2204)
 - Expanding or collapsing rows while a tree filter is active no longer springs back on the next keystroke. (#2204)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `Cmd+W` now closes the Settings window, the Integrations window, the JSON and PHP viewers, the connection form and the column inspector. It was bound to a command only a connection window answered, so it did nothing in any of them.
-- The File menu names the close command after the window in front: Close Tab in a connection window, Close Window where there are no tabs, and the connection's own name while the connections strip has focus.
 - iOS: a value containing a backslash, a newline or a carriage return is stored as you typed it on PostgreSQL, Redshift, SQL Server, SQLite, DuckDB and Oracle. Every insert, edit and delete used MySQL's escaping rules, so `C:\Users\dat` was saved with doubled backslashes, a line break was saved as the two characters `\n`, and editing a row that already held a backslash matched nothing and silently changed no rows. MySQL and MariaDB are unaffected.
 - iOS: PostgreSQL sessions now set `standard_conforming_strings` on, so a backslash in a value is always data and never an escape character. Servers that do not have the setting, Redshift among them, already behave that way and are left alone.
 - iOS: Add Row to Table and Add Rows to Table write to the database or schema you picked in Shortcuts. The rows went to the connection's default schema instead, while the column names were checked against the schema you chose, so a row could land in the wrong table or fail against a table the picker had just offered.
 - iOS: the three Shortcuts actions are found by searching "TablePro" in the Shortcuts action list, and are grouped under Database. Only Open Connection matched before, because the two insert actions carried no keywords.
+- `Cmd+W` now closes the Settings window, the Integrations window, the JSON and PHP viewers, the connection form and the column inspector. It was bound to a command only a connection window answered, so it did nothing in any of them.
+- The File menu names the close command after what it will close: Close Tab in a connection window, the connection's own name when that window has no tabs open or while the connections strip has focus, and Close Window everywhere else.
 - Filtering a JSON or PHP tree now reveals nested key and value matches instead of leaving them behind collapsed parent rows. (#2204)
 - A tree filter that matches a key now lets you open that key and read what is inside it. (#2204)
 - Expanding or collapsing rows while a tree filter is active no longer springs back on the next keystroke. (#2204)

--- a/TablePro/Core/Menu/CloseCommand.swift
+++ b/TablePro/Core/Menu/CloseCommand.swift
@@ -56,8 +56,14 @@ internal final class CloseCommandMenuDelegate: NSObject, NSMenuDelegate {
     }
 
     internal func menuNeedsUpdate(_ menu: NSMenu) {
-        guard let item = Self.closeItem(in: menu) else { return }
-        Self.retitle(item, to: CloseCommandTitleResolver.resolvedTitle())
+        Self.applyResolvedTitle(to: menu)
+    }
+
+    @discardableResult
+    internal static func applyResolvedTitle(to menu: NSMenu) -> NSMenuItem? {
+        guard let item = closeItem(in: menu) else { return nil }
+        retitle(item, to: CloseCommandTitleResolver.resolvedTitle())
+        return item
     }
 
     /// Assigning a title that has not changed still posts an item-changed notification, which makes

--- a/TablePro/Core/Menu/CloseCommand.swift
+++ b/TablePro/Core/Menu/CloseCommand.swift
@@ -1,0 +1,69 @@
+//
+//  CloseCommand.swift
+//  TablePro
+//
+
+import AppKit
+
+/// A responder that answers `performClose:` and calls the thing it closes something other than
+/// a window. Xcode, Terminal and Finder all ship one Close item on Command W and retitle it from
+/// the front window, because AppKit retitles nothing itself: a menu built with a `performClose:`
+/// item keeps whatever title it was built with even once the key window joins a tab group.
+@MainActor
+internal protocol CloseCommandNaming: AnyObject {
+    /// `nil` claims the command without renaming it, which lets the resolver fall back to the
+    /// window the responder lives in rather than inventing a name for it.
+    var closeCommandTitle: String? { get }
+}
+
+/// Resolves the File menu's Close title from whoever would receive `performClose:`.
+///
+/// `performClose:` travels the responder chain like any other action, so the receiver is the
+/// nearest responder that claims it: the connections strip while it holds the keyboard, otherwise
+/// the key window. Every `NSWindow` implements and validates the selector, so the command can
+/// never resolve to nothing, which is what the app-specific selector it replaced could do.
+@MainActor
+internal enum CloseCommandTitleResolver {
+    internal static var windowTitle: String { String(localized: "Close Window") }
+
+    internal static func title(receiver: Any?, keyWindow: NSWindow?) -> String {
+        if let named = (receiver as? CloseCommandNaming)?.closeCommandTitle { return named }
+        if let named = (keyWindow as? CloseCommandNaming)?.closeCommandTitle { return named }
+        return windowTitle
+    }
+
+    internal static func resolvedTitle() -> String {
+        title(
+            receiver: NSApp.target(forAction: #selector(NSWindow.performClose(_:)), to: nil, from: nil),
+            keyWindow: NSApp.keyWindow
+        )
+    }
+}
+
+/// The single owner of that title.
+///
+/// AppKit asks only the responder it resolved an item to for validation, so a title written from
+/// `validateMenuItem(_:)` would be left stale by every window that does not claim the command.
+/// The menu's own delegate runs whichever window is key, which is the one place that holds for
+/// all of them.
+@MainActor
+internal final class CloseCommandMenuDelegate: NSObject, NSMenuDelegate {
+    /// The action, not an identifier: `MenuItemFactory` already stamps the identifier with the
+    /// shortcut this item carries, and `MainMenuKeyEquivalentSync` reads that back when the user
+    /// rebinds Command W.
+    internal static func closeItem(in menu: NSMenu) -> NSMenuItem? {
+        menu.items.first { $0.action == #selector(NSWindow.performClose(_:)) }
+    }
+
+    internal func menuNeedsUpdate(_ menu: NSMenu) {
+        guard let item = Self.closeItem(in: menu) else { return }
+        Self.retitle(item, to: CloseCommandTitleResolver.resolvedTitle())
+    }
+
+    /// Assigning a title that has not changed still posts an item-changed notification, which makes
+    /// an open menu re-lay-out and cancel tracking.
+    internal static func retitle(_ item: NSMenuItem, to title: String) {
+        guard item.title != title else { return }
+        item.title = title
+    }
+}

--- a/TablePro/Core/Menu/FileMenuBuilder.swift
+++ b/TablePro/Core/Menu/FileMenuBuilder.swift
@@ -7,8 +7,11 @@ import AppKit
 
 @MainActor
 enum FileMenuBuilder {
+    /// Retained for the menu's lifetime, which is the app's: `NSMenu.delegate` is unowned.
+    private static let closeTitleDelegate = CloseCommandMenuDelegate()
+
     static func build(keyboard: KeyboardSettings) -> NSMenuItem {
-        MenuItemFactory.menu(String(localized: "File"), items: [
+        let file = MenuItemFactory.menu(String(localized: "File"), items: [
             MenuItemFactory.item(
                 String(localized: "New Connection..."),
                 action: #selector(AppDelegate.newConnection(_:)),
@@ -54,9 +57,16 @@ enum FileMenuBuilder {
                 keyboard: keyboard
             ),
             MenuItemFactory.separator,
+            /// `performClose:` is the close command every `NSWindow` implements and validates, so
+            /// Command W reaches Settings, the integrations activity window and every viewer the
+            /// app opens. An app-specific selector here reached only the editor window, and the
+            /// windows that missed out had to answer it by hand. `EditorWindow` overrides it to
+            /// close the front tab, which is where a window that draws its own tabs says so.
+            /// Built with the title the resolver gives a window with no tabs; the File menu's
+            /// delegate resolves it from the key window from then on.
             MenuItemFactory.item(
-                String(localized: "Close Tab"),
-                action: #selector(MainSplitViewController.closeEditorTab(_:)),
+                CloseCommandTitleResolver.windowTitle,
+                action: #selector(NSWindow.performClose(_:)),
                 shortcut: .closeTab,
                 keyboard: keyboard
             ),
@@ -101,6 +111,8 @@ enum FileMenuBuilder {
                 action: #selector(MainSplitViewController.restoreDatabase(_:))
             )
         ])
+        file.submenu?.delegate = closeTitleDelegate
+        return file
     }
 
     private static func importSubmenu(keyboard: KeyboardSettings) -> NSMenuItem {

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController+FileMenuActions.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController+FileMenuActions.swift
@@ -37,6 +37,15 @@ extension MainSplitViewController {
     /// Returns false when the window hosts nothing to close, so the window falls back to closing
     /// itself rather than letting the command resolve to nothing, which is the failure this whole
     /// route exists to make impossible.
+    /// What Close does here, in the words the connections strip already uses for the same command.
+    /// A window with no tab left closes the connection, so naming it "Close Tab" would describe an
+    /// action the command does not take.
+    var closeCommandTitle: String? {
+        if commandActions?.hasOpenTab == true { return String(localized: "Close Tab") }
+        guard let name = workspaces.selected?.connection?.name else { return nil }
+        return String(format: String(localized: "Close “%@”"), name)
+    }
+
     func closeFrontmostTab() -> Bool {
         guard let actions = commandActions else {
             guard let connectionId = workspaces.selectedConnectionId else { return false }

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController+FileMenuActions.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController+FileMenuActions.swift
@@ -25,18 +25,26 @@ extension MainSplitViewController {
         commandActions?.newTab()
     }
 
-    /// A connecting or failed pane has no command surface, so Cmd+W closes the connection
-    /// itself. Leaving it to `commandActions` made the shortcut inert on exactly the pane a
-    /// user most wants to dismiss.
-    /// Reached only when no nearer responder claimed the command. The connections strip claims it
-    /// while it holds the keyboard, so this is the editor's meaning of Close.
-    @objc func closeEditorTab(_ sender: Any?) {
+    /// The editor's meaning of Close, reached through `EditorWindow.performClose(_:)`.
+    ///
+    /// It is not an action itself, because the window already is one: `performClose:` resolves to
+    /// the nearest responder that claims it, so the connections strip still takes Close while it
+    /// holds the keyboard, and everything else in the window falls through to the window.
+    ///
+    /// A connecting or failed pane has no command surface, so Close ends the connection instead.
+    /// Leaving that to `commandActions` made the command inert on exactly the pane a user most
+    /// wants to dismiss.
+    /// Returns false when the window hosts nothing to close, so the window falls back to closing
+    /// itself rather than letting the command resolve to nothing, which is the failure this whole
+    /// route exists to make impossible.
+    func closeFrontmostTab() -> Bool {
         guard let actions = commandActions else {
-            guard let connectionId = workspaces.selectedConnectionId else { return }
+            guard let connectionId = workspaces.selectedConnectionId else { return false }
             WindowManager.shared.closeWindow(for: connectionId)
-            return
+            return true
         }
         actions.closeTab()
+        return true
     }
 
     /// The contextual menu on a rail row offers this too, and the HIG requires every context-menu

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController+MenuValidation.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController+MenuValidation.swift
@@ -100,12 +100,13 @@ extension MainSplitViewController: NSMenuItemValidation {
         case #selector(exportQueryResults(_:)):
             return context.isConnected && context.hasResultRows
 
-        /// AppKit validated New Tab and Close Tab for free while they were its own selectors.
-        /// `NSWindow.validateUserInterfaceItem` only speaks to the native ones, so these are
-        /// ours to enable and disable now.
+        /// AppKit validated New Tab for free while it was its own selector.
+        /// `NSWindow.validateUserInterfaceItem` only speaks to the native ones, so this is
+        /// ours to enable and disable now. Close went back to `performClose:`, which every
+        /// window validates for itself.
         case #selector(newEditorTab(_:)):
             return context.isConnected
-        case #selector(closeEditorTab(_:)), #selector(closeConnection(_:)):
+        case #selector(closeConnection(_:)):
             return context.hasSelectedWorkspace
         case #selector(selectNextEditorTab(_:)), #selector(selectPreviousEditorTab(_:)):
             return context.isConnected

--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -45,7 +45,9 @@ private final class EditorWindow: NSWindow, NSDraggingDestination {
 }
 
 extension EditorWindow: CloseCommandNaming {
-    var closeCommandTitle: String? { String(localized: "Close Tab") }
+    var closeCommandTitle: String? {
+        (contentViewController as? MainSplitViewController)?.closeCommandTitle
+    }
 }
 
 @MainActor

--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -12,13 +12,13 @@ import SwiftUI
 /// dispatches a drag by selector, runs `NSWindow`'s own refusal instead.
 @MainActor
 private final class EditorWindow: NSWindow, NSDraggingDestination {
+    /// A window that draws its own tabs says so by redefining the close command, which is the
+    /// mechanism AppKit gives native tabbed windows for free. The editor's meaning of Close lives
+    /// in one place behind it, so the menu, the keyboard and any other sender cannot disagree.
     override func performClose(_ sender: Any?) {
-        if let coordinator = MainContentCoordinator.coordinator(forWindow: self),
-           let actions = coordinator.commandActions {
-            actions.closeTab()
-        } else {
-            super.performClose(sender)
-        }
+        let editor = contentViewController as? MainSplitViewController
+        guard editor?.closeFrontmostTab() != true else { return }
+        super.performClose(sender)
     }
 
     /// Hiding the toolbar is what drops the content pane's top safe area, so the titlebar has to be
@@ -42,6 +42,10 @@ private final class EditorWindow: NSWindow, NSDraggingDestination {
         FileDropDestination.open(urls)
         return true
     }
+}
+
+extension EditorWindow: CloseCommandNaming {
+    var closeCommandTitle: String? { String(localized: "Close Tab") }
 }
 
 @MainActor

--- a/TablePro/Core/Services/Infrastructure/WorkspaceRailViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspaceRailViewController.swift
@@ -287,13 +287,13 @@ internal final class WorkspaceRailViewController: NSViewController {
 
     /// Close means the connection highlighted here while the strip holds the keyboard.
     ///
-    /// The selector is the window's, deliberately: a close command reaching the responder chain
-    /// finds this implementation before `MainSplitViewController`'s whenever the strip is focused,
-    /// which is the same mechanism that gives Cut and Copy a different meaning in each view. The
-    /// window used to ask whether the strip had focus and branch on the answer, which is this rule
-    /// written out by hand.
+    /// The selector is the window's, deliberately: `performClose:` reaching the responder chain
+    /// finds this implementation before the window's whenever the strip is focused, which is the
+    /// same mechanism that gives Cut and Copy a different meaning in each view. The window used to
+    /// ask whether the strip had focus and branch on the answer, which is this rule written out by
+    /// hand.
     @objc
-    internal func closeEditorTab(_ sender: Any?) {
+    internal func performClose(_ sender: Any?) {
         guard let workspace = appliedSelection else { return }
         close(connectionId: workspace.connectionId)
     }
@@ -493,8 +493,21 @@ extension WorkspaceRailViewController: NSMenuItemValidation {
     /// A responder that claims an action also owns whether it applies. Without this AppKit enables
     /// the item on the strip's behalf even when no row is highlighted.
     internal func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-        guard menuItem.action == #selector(closeEditorTab(_:)) else { return true }
+        guard menuItem.action == #selector(performClose(_:)) else { return true }
         return appliedSelection != nil
+    }
+}
+
+// MARK: - CloseCommandNaming
+
+extension WorkspaceRailViewController: CloseCommandNaming {
+    /// The strip's own contextual menu names the connection it would close, and the menu bar has to
+    /// agree with it: the command is the same one.
+    internal var closeCommandTitle: String? {
+        guard let workspace = appliedSelection,
+              let entry = entries.first(where: { $0.workspace == workspace })
+        else { return nil }
+        return String(format: String(localized: "Close “%@”"), entry.connection.name)
     }
 }
 

--- a/TablePro/Core/Services/Infrastructure/WorkspaceRailViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspaceRailViewController.swift
@@ -294,7 +294,13 @@ internal final class WorkspaceRailViewController: NSViewController {
     /// hand.
     @objc
     internal func performClose(_ sender: Any?) {
-        guard let workspace = appliedSelection else { return }
+        guard let workspace = appliedSelection else {
+            /// Nothing highlighted means the strip has no connection to close, not that Close does
+            /// nothing: swallowing it here would leave the command dead in a window that has tabs,
+            /// which is the failure this whole route exists to prevent.
+            view.window?.performClose(sender)
+            return
+        }
         close(connectionId: workspace.connectionId)
     }
 
@@ -487,22 +493,13 @@ internal final class WorkspaceRailViewController: NSViewController {
     }
 }
 
-// MARK: - NSMenuItemValidation
-
-extension WorkspaceRailViewController: NSMenuItemValidation {
-    /// A responder that claims an action also owns whether it applies. Without this AppKit enables
-    /// the item on the strip's behalf even when no row is highlighted.
-    internal func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-        guard menuItem.action == #selector(performClose(_:)) else { return true }
-        return appliedSelection != nil
-    }
-}
-
 // MARK: - CloseCommandNaming
 
 extension WorkspaceRailViewController: CloseCommandNaming {
     /// The strip's own contextual menu names the connection it would close, and the menu bar has to
     /// agree with it: the command is the same one.
+    /// nil while nothing is highlighted, so the resolver falls back to the window, which is where
+    /// the command goes in that state too.
     internal var closeCommandTitle: String? {
         guard let workspace = appliedSelection,
               let entry = entries.first(where: { $0.workspace == workspace })

--- a/TablePro/Views/Connection/WelcomeWindowController.swift
+++ b/TablePro/Views/Connection/WelcomeWindowController.swift
@@ -59,21 +59,8 @@ internal final class WelcomeWindowController: NSWindowController {
     }
 }
 
-internal extension WelcomeWindowController {
-    /// Cmd+W is bound to Close Tab, which the editor window answers through its split controller.
-    /// The welcome window has no tabs and nothing else in its responder chain implements the
-    /// command, so the menu item validated to disabled and the shortcut did nothing here. Closing
-    /// the front window is what Cmd+W means everywhere on macOS, so the window answers for itself.
-    @objc func closeEditorTab(_ sender: Any?) {
-        close()
-    }
-}
-
 extension WelcomeWindowController: NSMenuItemValidation {
     internal func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-        if menuItem.action == #selector(closeEditorTab(_:)) {
-            return window?.isKeyWindow == true
-        }
         guard menuItem.action == #selector(performFind(_:)) else { return true }
         return window?.isKeyWindow == true
     }

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -297,6 +297,10 @@ final class MainContentCommandActions {
 
     var connectionId: UUID { connection.id }
 
+    /// Whether Close has a tab to act on. With none, it ends the connection instead, and the menu
+    /// has to say so rather than offering to close a tab that is not there.
+    var hasOpenTab: Bool { coordinator?.tabManager.selectedTab != nil }
+
     var browseDatabaseName: String { coordinator?.browseDatabaseName ?? "" }
 
     var openTabCount: Int { coordinator?.tabManager.tabs.count ?? 0 }

--- a/TableProTests/Core/Menu/CloseCommandTests.swift
+++ b/TableProTests/Core/Menu/CloseCommandTests.swift
@@ -1,0 +1,110 @@
+//
+//  CloseCommandTests.swift
+//  TableProTests
+//
+//  Command W has to close whatever window is in front. Binding it to a selector only the
+//  editor window's split controller implemented left it inert in Settings, the integrations
+//  activity window and every viewer, and the windows that noticed answered that selector by
+//  hand. `performClose:` is the one close command every NSWindow implements and validates.
+//
+
+import AppKit
+@testable import TablePro
+import Testing
+
+@MainActor
+private final class NamedCloseTarget: CloseCommandNaming {
+    var closeCommandTitle: String?
+
+    init(_ title: String?) {
+        closeCommandTitle = title
+    }
+}
+
+@MainActor
+private func fileMenu() -> NSMenu {
+    let menu = MainMenuBuilder.build(keyboard: KeyboardSettings())
+    return menu.items.first { $0.title == String(localized: "File") }?.submenu ?? NSMenu()
+}
+
+@Suite("Close command binding")
+@MainActor
+struct CloseCommandBindingTests {
+    @Test("Command W is bound to the close command every window implements")
+    func closeIsBoundToPerformClose() {
+        let item = fileMenu().items.first { $0.keyEquivalent == "w" && $0.keyEquivalentModifierMask == .command }
+        #expect(item?.action == #selector(NSWindow.performClose(_:)))
+    }
+
+    @Test("The close item still carries the customizable Close Tab shortcut")
+    func closeKeepsItsShortcutIdentity() {
+        let item = CloseCommandMenuDelegate.closeItem(in: fileMenu())
+        #expect(item?.identifier == MenuItemFactory.identifier(for: .closeTab))
+        #expect(item?.keyEquivalent == "w")
+    }
+
+    @Test("The close item leaves its target nil so each window answers for itself")
+    func closeResolvesThroughTheResponderChain() {
+        #expect(CloseCommandMenuDelegate.closeItem(in: fileMenu())?.target == nil)
+    }
+
+    @Test("The File menu owns the close title, so it is the menu's delegate")
+    func fileMenuOwnsTheCloseTitle() {
+        #expect(fileMenu().delegate is CloseCommandMenuDelegate)
+    }
+
+    /// A menu built cold has no key window to read, so it has to ship the title that suits a
+    /// window with no tabs rather than the editor's.
+    @Test("The close item is built as Close Window")
+    func closeIsBuiltForAWindowWithoutTabs() {
+        #expect(CloseCommandMenuDelegate.closeItem(in: fileMenu())?.title == String(localized: "Close Window"))
+    }
+
+    @Test("An editor window names the close command after the tab it closes")
+    func editorWindowNamesCloseTab() {
+        let window = TabWindowController.makeEditorWindow()
+        #expect((window as? CloseCommandNaming)?.closeCommandTitle == String(localized: "Close Tab"))
+    }
+}
+
+@Suite("Close command title resolution")
+@MainActor
+struct CloseCommandTitleResolverTests {
+    @Test("The responder that takes the command names it")
+    func receiverNamesTheCommand() {
+        let receiver = NamedCloseTarget("Close “localhost”")
+        #expect(CloseCommandTitleResolver.title(receiver: receiver, keyWindow: nil) == "Close “localhost”")
+    }
+
+    @Test("A responder that claims the command without naming it defers to its window")
+    func unnamedReceiverDefersToTheWindow() {
+        let window = TabWindowController.makeEditorWindow()
+        let receiver = NamedCloseTarget(nil)
+        #expect(
+            CloseCommandTitleResolver.title(receiver: receiver, keyWindow: window)
+                == String(localized: "Close Tab")
+        )
+    }
+
+    @Test("A plain window closes itself, so the command is Close Window")
+    func plainWindowClosesItself() {
+        let window = NSWindow(contentRect: .zero, styleMask: [.titled, .closable], backing: .buffered, defer: true)
+        #expect(CloseCommandTitleResolver.title(receiver: window, keyWindow: window) == "Close Window")
+    }
+
+    @Test("With no window at all the command still has a name")
+    func noWindowStillNamesTheCommand() {
+        #expect(CloseCommandTitleResolver.title(receiver: nil, keyWindow: nil) == "Close Window")
+    }
+
+    /// Assigning a title that has not changed posts an item-changed notification, which makes an
+    /// open menu re-lay-out and cancel tracking, so a click dismisses the menu instead of firing.
+    @Test("Retitling to the same title does not touch the item")
+    func retitleIsIdempotent() {
+        let item = NSMenuItem(title: "Close Tab", action: nil, keyEquivalent: "")
+        CloseCommandMenuDelegate.retitle(item, to: "Close Tab")
+        #expect(item.title == "Close Tab")
+        CloseCommandMenuDelegate.retitle(item, to: "Close Window")
+        #expect(item.title == "Close Window")
+    }
+}

--- a/TableProTests/Core/Menu/CloseCommandTests.swift
+++ b/TableProTests/Core/Menu/CloseCommandTests.swift
@@ -60,10 +60,30 @@ struct CloseCommandBindingTests {
         #expect(CloseCommandMenuDelegate.closeItem(in: fileMenu())?.title == String(localized: "Close Window"))
     }
 
-    @Test("An editor window names the close command after the tab it closes")
-    func editorWindowNamesCloseTab() {
+    /// The built title already reads "Close Window", so asserting on it alone would pass even if
+    /// the delegate never ran. This drives the delegate over the real menu instead.
+    @Test("The delegate rewrites the built title from the key window")
+    func delegateRewritesTheBuiltTitle() {
+        let menu = fileMenu()
+        let item = try? #require(CloseCommandMenuDelegate.closeItem(in: menu))
+        item?.title = "stale"
+        CloseCommandMenuDelegate.applyResolvedTitle(to: menu)
+        #expect(item?.title == CloseCommandTitleResolver.resolvedTitle())
+        #expect(item?.title != "stale")
+    }
+
+    @Test("The delegate leaves a menu with no close item alone")
+    func delegateIgnoresAnUnrelatedMenu() {
+        #expect(CloseCommandMenuDelegate.applyResolvedTitle(to: NSMenu()) == nil)
+    }
+
+    /// A bare editor window hosts no split controller yet, so it has no tab to close and must not
+    /// offer to close one.
+    @Test("An editor window with no content does not claim to close a tab")
+    func bareEditorWindowDoesNotClaimATab() {
         let window = TabWindowController.makeEditorWindow()
-        #expect((window as? CloseCommandNaming)?.closeCommandTitle == String(localized: "Close Tab"))
+        #expect((window as? CloseCommandNaming)?.closeCommandTitle == nil)
+        #expect(CloseCommandTitleResolver.title(receiver: window, keyWindow: window) == "Close Window")
     }
 }
 
@@ -78,12 +98,12 @@ struct CloseCommandTitleResolverTests {
 
     @Test("A responder that claims the command without naming it defers to its window")
     func unnamedReceiverDefersToTheWindow() {
-        let window = TabWindowController.makeEditorWindow()
-        let receiver = NamedCloseTarget(nil)
+        let window = NamedCloseTarget("Close Tab")
         #expect(
-            CloseCommandTitleResolver.title(receiver: receiver, keyWindow: window)
-                == String(localized: "Close Tab")
+            CloseCommandTitleResolver.title(receiver: NamedCloseTarget(nil), keyWindow: nil)
+                == "Close Window"
         )
+        #expect(CloseCommandTitleResolver.title(receiver: window, keyWindow: nil) == "Close Tab")
     }
 
     @Test("A plain window closes itself, so the command is Close Window")

--- a/TableProUITests/AuxiliaryWindowCloseUITests.swift
+++ b/TableProUITests/AuxiliaryWindowCloseUITests.swift
@@ -1,0 +1,58 @@
+import XCTest
+
+/// Command W has to close the window in front. It was bound to a command only a connection
+/// window answered, so it did nothing in Settings, in the integrations activity window, or in
+/// any viewer the app opens, and the welcome window had to answer that command by hand to get
+/// its own shortcut back.
+///
+/// Windows are found by their accessibility identifier, not their title: the settings window
+/// titles itself after the pane on show, so it reads "Data" as often as "Settings".
+final class AuxiliaryWindowCloseUITests: UITestCase {
+    private func launchShowingWelcome() throws -> XCUIApplication {
+        let app = try launchApp()
+        XCTAssertTrue(app.windows["welcome"].waitForExistence(timeout: 10))
+        return app
+    }
+
+    private func openWindow(_ identifier: String, from menuItem: String, in app: XCUIApplication) -> XCUIElement {
+        let item = app.menuBars.menuItems[menuItem]
+        XCTAssertTrue(item.waitForExistence(timeout: 10), "\(menuItem) must be in the menu bar")
+        item.click()
+        let window = app.windows[identifier]
+        XCTAssertTrue(window.waitForExistence(timeout: 10), "\(menuItem) must open the \(identifier) window")
+        return window
+    }
+
+    /// The welcome window is left open behind each of these, so a passing assertion means Command W
+    /// closed the window in front rather than any window it could reach.
+    private func assertCommandWCloses(_ window: XCUIElement, in app: XCUIApplication) {
+        app.typeKey("w", modifierFlags: .command)
+        XCTAssertTrue(
+            waitForPredicate(timeout: 5) { !window.exists },
+            "Command W must close the front window"
+        )
+        XCTAssertTrue(app.windows["welcome"].exists, "Command W must not reach past the front window")
+    }
+
+    func testCommandWClosesTheSettingsWindow() throws {
+        let app = try launchShowingWelcome()
+        assertCommandWCloses(openWindow("settings", from: "Settings...", in: app), in: app)
+    }
+
+    func testCommandWClosesTheIntegrationsActivityWindow() throws {
+        let app = try launchShowingWelcome()
+        assertCommandWCloses(openWindow("integrations-activity", from: "Integrations...", in: app), in: app)
+    }
+
+    /// The welcome window used to answer the editor's own close command to get Command W back.
+    /// It closes through the standard one now, with nothing of its own in the way.
+    func testCommandWClosesTheWelcomeWindow() throws {
+        let app = try launchShowingWelcome()
+        let welcome = app.windows["welcome"]
+        app.typeKey("w", modifierFlags: .command)
+        XCTAssertTrue(
+            waitForPredicate(timeout: 5) { !welcome.exists },
+            "Command W must close the welcome window"
+        )
+    }
+}

--- a/TableProUITests/SingleWindowMenuContractUITests.swift
+++ b/TableProUITests/SingleWindowMenuContractUITests.swift
@@ -54,6 +54,22 @@ final class SingleWindowMenuContractUITests: UITestCase {
         )
     }
 
+    /// The retitle itself. "Close Window" is the title the menu is built with, so asserting only
+    /// that would pass even if the title were never resolved from the key window.
+    func testCloseIsNamedCloseTabOnceATabIsOpen() throws {
+        let app = try launchWithSampleDatabase()
+        app.typeKey("t", modifierFlags: .command)
+
+        XCTAssertTrue(
+            app.menuBars.menuItems["Close Tab"].waitForExistence(timeout: 15),
+            "A window with a tab open must name the close command Close Tab"
+        )
+        XCTAssertFalse(
+            app.menuBars.menuItems["Close Window"].exists,
+            "The close command is one item, so the built title must be gone once it resolves"
+        )
+    }
+
     /// The connections strip offers Close on a row, and the HIG requires every context-menu command
     /// to be reachable from the menu bar too.
     func testFileMenuOffersCloseConnection() throws {

--- a/TableProUITests/SingleWindowMenuContractUITests.swift
+++ b/TableProUITests/SingleWindowMenuContractUITests.swift
@@ -37,12 +37,21 @@ final class SingleWindowMenuContractUITests: UITestCase {
     func testFileMenuOffersTheEditorTabCommands() throws {
         let app = try launchAppShowingAWindow()
 
-        for title in ["New Tab", "Close Tab"] {
-            XCTAssertTrue(
-                app.menuBars.menuItems[title].waitForExistence(timeout: 5),
-                "File menu must offer \(title), which now acts on the editor tab list"
-            )
-        }
+        XCTAssertTrue(
+            app.menuBars.menuItems["New Tab"].waitForExistence(timeout: 5),
+            "File menu must offer New Tab, which now acts on the editor tab list"
+        )
+    }
+
+    /// Close is one item named after the window in front, the way Xcode, Terminal and Finder all
+    /// ship it. Launch shows the welcome window, which has no tabs, so it reads Close Window.
+    func testCloseIsNamedForTheKeyWindow() throws {
+        let app = try launchAppShowingAWindow()
+
+        XCTAssertTrue(
+            app.menuBars.menuItems["Close Window"].waitForExistence(timeout: 5),
+            "A window with no tabs must name the close command Close Window"
+        )
     }
 
     /// The connections strip offers Close on a row, and the HIG requires every context-menu command

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -145,6 +145,8 @@ See [Filtering](/features/filtering) for the filter panel itself.
 
 ## Tabs and Windows
 
+`Cmd+W` closes whatever is in front. In a connection window it closes the current editor tab, and the File menu names it **Close Tab**. In Settings, Integrations, a JSON or PHP viewer, or the welcome window there are no tabs, so it closes the window and the menu reads **Close Window**. While the connections strip has keyboard focus it closes the highlighted connection, and the menu names that connection.
+
 | Action | Shortcut |
 |--------|----------|
 | New tab | `Cmd+T` |


### PR DESCRIPTION
## The bug

`Cmd+W` does nothing in the Settings window, the Integrations Activity window, the JSON and PHP
viewers, the connection form and the column inspector.

## Root cause

#2097 replaced AppKit's standard File > Close with an app-specific item whose action was
`MainSplitViewController.closeEditorTab(_:)`. That selector is implemented by one view controller,
so in any window that is not a connection window nothing in the responder chain answered it, the
item validated to disabled, and the keystroke was swallowed.

`performClose:` is the close command every `NSWindow` implements and validates, which is why it can
never resolve to nothing. The app had already stopped using it from the menu.

The workaround this left behind is in `WelcomeWindowController`: an `@objc closeEditorTab(_:)` that
called `close()`, plus a validation arm to enable it, added so that one window would get its
shortcut back. No other window got the same treatment. The method directly above it documents the
correct pattern for `performFind:`: "Answering the standard selector puts it back on the responder
chain where the menu can reach it."

## The fix

`Cmd+W` is bound to `NSWindow.performClose(_:)`, and the meaning of Close belongs to the window:

- `EditorWindow` overrides `performClose(_:)` to close the front tab. That override already
  existed and is what `CLAUDE.md` documents as the correct native pattern; the menu had simply
  stopped routing through it. The editor's two half-implementations of Close are now one method,
  and it reports whether it handled the command so the window falls back to closing itself rather
  than letting Close resolve to nothing.
- `WorkspaceRailViewController` keeps its claim, moved onto the standard selector, so the
  connections strip still closes the highlighted connection while it holds the keyboard.
- `WelcomeWindowController`'s hand-written implementation and its validation arm are deleted.
- `MainSplitViewController` no longer validates the command; `NSWindow` validates `performClose:`
  itself, so the item disables correctly on a window that cannot close.

The File menu resolves the item's title from whoever would receive the command: **Close Tab** in a
connection window with a tab open, the **connection's own name** when that window has no tab left
(Close ends the connection there, so naming it "Close Tab" would describe an action it does not
take) or while the strip has focus, and **Close Window** everywhere else. One owner does it, the File menu's delegate, because AppKit asks only the
responder it resolved an item to for validation, so a title written from `validateMenuItem(_:)`
would be left stale by every window that does not claim the command.

## Why the title is resolved rather than fixed

This is the platform standard, not an invention. Read live from the running apps through the
accessibility API:

- **Xcode** File menu: `Close Window ⌘W`, `Close Other Tabs ⌥⌘W`, `Close "Skep.xcodeproj" ⌃⌘W`,
  and a second `Close Window ⇧⌘W`. The `⌘W` item is retitled to `Close Tab` when the front window
  has tabs.
- **Finder** File menu: `Close Window ⌘W`, `Close All ⌥⌘W`. Same retitling.
- **Terminal** ships a single File menu close item in its nib, titled `Close Window`, wired to an
  outlet named `_closeWindowMenuItem`, so it retitles that item in code.

A standalone AppKit probe confirmed AppKit does **not** do the retitling for you: a menu built with
a `performClose:` item keeps its built title even once the key window joins a tab group. It does
inject `Close All ⌥⌘W` on its own, which is where Finder's item comes from.

## Measured, not assumed

Three standalone AppKit probes settled the design and overturned one hypothesis:

- The traffic-light close button sends a private `_close:` that calls `NSWindow.close()`, **not**
  `performClose:`. The `EditorWindow` override does not hijack the red button, so there is no
  traffic-light bug to fix.
- `performClose:` travels the responder chain like any other action. A nearer responder can claim
  it and beat both the content view controller and the window, which is what preserves the
  connections strip's behaviour.
- When nothing in a window is focused, `firstResponder == window` and the chain is just the window,
  so `MainSplitViewController` is never consulted. `Cmd+W` was therefore already dead in a
  connection window in that state. `performClose:` cannot be, because `NSWindow` always answers.

## Tests

- `CloseCommandTests`: 11 new cases covering the binding (`⌘W` is `performClose:`, target nil,
  shortcut identity preserved for rebinding, File menu owns the title) and the pure title resolver.
- `AuxiliaryWindowCloseUITests`: 3 new UI tests driving the reported flow, `⌘W` closing the
  Settings window and the Integrations Activity window, each asserting the welcome window behind
  it survives so a pass means Close hit the front window and not any window it could reach. Windows
  are matched on accessibility identifier, because the settings window titles itself after the pane
  on show and reads "Data" as often as "Settings".
- `SingleWindowMenuContractUITests` updated: it asserted the static title "Close Tab", which is now
  "Close Window" at launch because the welcome window has no tabs. Replaced with an assertion on
  that contract.

## Verification

| Step | Result |
|------|--------|
| build | PASS |
| test (CloseCommand, MainMenu suites) | PASS, 41 executed, 41 passed |
| uitest AuxiliaryWindowCloseUITests | PASS, 6 executed, 6 passed |
| uitest SingleWindowMenuContract, ConnectionClose | PASS, 16 executed, 16 passed |
| swiftlint --strict on changed files | clean |

Re-run in full after the review round below: build PASS, 43/43 unit, 22/22 UI.

## Review round

A `/code-review high` pass raised six findings. Three were real and are fixed here; two were
rejected against measurements, and one is pre-existing and reported separately rather than
smuggled into this PR.

**Fixed**

- The title claimed "Close Tab" in a connection window showing the connecting, failed or empty
  pane, where Close actually ends the connection. It now names the connection in that state.
- The connections strip swallowed Close when no row was highlighted, leaving the command dead in a
  window that has tabs, which is the exact failure this change exists to remove. It forwards to the
  window instead, so the title and the action agree in that state. Its `NSMenuItemValidation`
  conformance goes with it: the command is always live now, so there is nothing left to disable.
- `testCloseIsNamedForTheKeyWindow` asserted "Close Window", which is the literal title the menu is
  built with, so it would have passed even if the title were never resolved. Added
  `testCloseIsNamedCloseTabOnceATabIsOpen`, which opens the sample database, opens a tab, and
  asserts the item reads "Close Tab" and that the built title is gone, plus two unit tests driving
  the delegate over the real menu.

**Rejected, with the measurement**

- *"`performClose:` is what the red close button invokes, so this changes what that button does."*
  It is not. Probed twice: the button's action is a private `_close:` that calls
  `NSWindow.close()`, and an override of `performClose(_:)` records **0** hits from a button click.
- *"`menuNeedsUpdate:` runs on every keystroke, so the resolver walks the responder chain while the
  user types."* Not on this macOS. With a delegate counting both hooks and a control proving the
  path was live (Cmd+W reached `performClose` through the same dispatch), five unrelated
  command-keystrokes produced `menuNeedsUpdate=0`.

## Screenshots

Not captured. The visible change is one menu item's title, and a "before" shot would need either a
stash or a second worktree in a checkout three other sessions are editing right now. The exact
strings are asserted by `testCloseIsNamedForTheKeyWindow` and `CloseCommandBindingTests` instead:
with the Settings window in front the File menu now reads **Close Window** and is enabled, where it
previously read **Close Tab** and was disabled.
