### PR TITLE
fix(toolbar): anchor the inspector toggle to the window's trailing edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The inspector button stays at the right end of the toolbar when the inspector is open. It used to slide left and sit against the inspector's inner edge, so the button moved as soon as you used it.
+- The Tables and Favorites switch in the toolbar keeps following the sidebar after you open Customize Toolbar. It stopped responding until the window was closed and reopened.
+- Refresh, New Tab, Open Quickly, Export, Database, Results and Dashboard are dimmed in the toolbar's overflow menu when they cannot run. On a narrow window they looked available and did nothing.
 - Filtering a JSON or PHP tree now reveals nested key and value matches instead of leaving them behind collapsed parent rows. (#2204)
 - A tree filter that matches a key now lets you open that key and read what is inside it. (#2204)
 - Expanding or collapsing rows while a tree filter is active no longer springs back on the next keystroke. (#2204)

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Delegate.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Delegate.swift
@@ -18,13 +18,13 @@ extension MainWindowToolbar {
         )
         switch itemIdentifier {
         case Self.sidebarToggle:
-            return makeSidebarToggleItem()
+            return makeSidebarToggleItem(claimsSlot: Self.claimsItemSlot(willBeInsertedIntoToolbar: flag))
         case Self.connectionGroup:
             let group = makeGroup(
                 id: itemIdentifier,
                 label: String(localized: "Connection"),
                 subitems: [subitemConnection(), subitemDatabase()],
-                retainsController: Self.retainsHostingController(willBeInsertedIntoToolbar: flag),
+                retainsController: Self.claimsItemSlot(willBeInsertedIntoToolbar: flag),
                 content: HStack(spacing: 4) {
                     ConnectionToolbarSubjectButton(subject: subject)
                     DatabaseToolbarSubjectButton(subject: subject)
@@ -41,7 +41,7 @@ extension MainWindowToolbar {
                 action: nil,
                 keyEquivalent: "",
                 modifiers: [],
-                retainsController: Self.retainsHostingController(willBeInsertedIntoToolbar: flag),
+                retainsController: Self.claimsItemSlot(willBeInsertedIntoToolbar: flag),
                 content: ToolbarPrincipalSubjectContent(subject: subject)
             )
             item.visibilityPriority = .high
@@ -87,11 +87,6 @@ extension MainWindowToolbar {
                         : "rectangle.bottomhalf.inset.filled"
                 }
             )
-        case Self.inspector:
-            let item = NSToolbarItem(itemIdentifier: Self.inspector)
-            item.label = String(localized: "Inspector")
-            item.paletteLabel = String(localized: "Inspector")
-            return item
         case Self.dashboard:
             return menuOnlyItem(
                 id: itemIdentifier,

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Items.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Items.swift
@@ -100,6 +100,7 @@ extension MainWindowToolbar {
         menuItem.image = item.image
         menuItem.submenu = buildImportSubmenu()
         item.menuFormRepresentation = menuItem
+        bindMenuForm(action: #selector(performImportFormat(_:)), to: Self.importTables)
 
         bindShortcut(.importData, description: String(localized: "Import Data"), to: item)
         return item
@@ -151,6 +152,7 @@ extension MainWindowToolbar {
             item.target = self
             item.action = action
             item.autovalidates = true
+            bindMenuForm(action: action, to: id)
             let menuItem = NSMenuItem(title: label, action: action, keyEquivalent: keyEquivalent)
             menuItem.keyEquivalentModifierMask = modifiers
             menuItem.target = self
@@ -181,6 +183,7 @@ extension MainWindowToolbar {
         item.isBordered = true
         item.symbolAccessibilityDescription = label
         item.symbolProvider = symbolProvider ?? { symbol }
+        bindMenuForm(action: action, to: id)
 
         let menuItem = NSMenuItem(title: label, action: action, keyEquivalent: "")
         menuItem.target = self
@@ -231,8 +234,9 @@ extension MainWindowToolbar {
     /// AppKit asks the delegate again with `willBeInsertedIntoToolbar: false` to build the palette
     /// copies shown by Customize Toolbar, and letting those overwrite the slot released the
     /// controllers whose views were on screen. `NSToolbarItem` does not retain its controller, so
-    /// the live items collapsed to zero width the moment the panel opened.
-    static func retainsHostingController(willBeInsertedIntoToolbar: Bool) -> Bool {
+    /// the live items collapsed to zero width the moment the panel opened. The sidebar segmented
+    /// control keeps its live group in a slot of the same shape, so both read this one predicate.
+    static func claimsItemSlot(willBeInsertedIntoToolbar: Bool) -> Bool {
         willBeInsertedIntoToolbar
     }
 

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Validation.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Validation.swift
@@ -76,21 +76,15 @@ extension MainWindowToolbar: NSToolbarItemValidation {
     }
 }
 
-/// AppKit validates toolbar overflow entries as menu items rather than visible toolbar items.
-/// Keep their state aligned with the predicates used by `validateToolbarItem(_:)`.
+/// AppKit validates toolbar overflow entries as menu items rather than visible toolbar items, so
+/// `validateToolbarItem(_:)` never sees them and every entry it does not answer for stays enabled.
+/// A hand-written selector list here only covered three of the twelve actions, which left Refresh,
+/// New Tab, Open Quickly, Export, Database, Results and Dashboard live in the overflow menu of a
+/// narrow window while the same buttons were disabled on a wide one, and clicking one did nothing.
+/// The mapping now comes from the factory that built the item, so it cannot fall behind again.
 extension MainWindowToolbar: NSMenuItemValidation {
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-        let itemIdentifier: NSToolbarItem.Identifier
-        switch menuItem.action {
-        case #selector(performSaveChanges(_:)):
-            itemIdentifier = Self.saveChanges
-        case #selector(performPreviewSQL(_:)):
-            itemIdentifier = Self.previewSQL
-        case #selector(performImportFormat(_:)):
-            itemIdentifier = Self.importTables
-        default:
-            return true
-        }
+        guard let itemIdentifier = itemIdentifier(forMenuFormAction: menuItem.action) else { return true }
         guard let context = validationContext() else { return false }
         return Self.isEnabled(itemIdentifier: itemIdentifier, context: context)
     }

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -33,6 +33,13 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
     /// receives both, so this is not a second list anyone has to keep in step by hand.
     private var shortcutBindings: [NSToolbarItem.Identifier: ToolbarShortcutBinding] = [:]
 
+    /// Which item an overflow-menu entry stands for. AppKit validates an overflowed item as a menu
+    /// item rather than as a toolbar item, so `validateToolbarItem(_:)` never runs for it and the
+    /// entry stayed enabled while the same button was disabled on a wider window. Recorded by the
+    /// factory that already receives both the identifier and the action, for the same reason
+    /// `shortcutBindings` is: a second hand-written table drifts.
+    private var menuFormIdentifiers: [Selector: NSToolbarItem.Identifier] = [:]
+
     /// How a hosted item answers "how wide are you". `.intrinsicContentSize` only overrides the
     /// hosting view's `intrinsicContentSize`, and AppKit measures a view-backed item when it is
     /// inserted and never reads that value again. Repointing the subject then left the item at the
@@ -87,6 +94,16 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
             description: description
         )
         applyShortcutBinding(to: item)
+    }
+
+    /// Records which item an overflow-menu action belongs to, so validation can reach it.
+    internal func bindMenuForm(action: Selector, to itemIdentifier: NSToolbarItem.Identifier) {
+        menuFormIdentifiers[action] = itemIdentifier
+    }
+
+    /// Nil for a menu item this toolbar did not build, which is nobody else's item to validate.
+    internal func itemIdentifier(forMenuFormAction action: Selector?) -> NSToolbarItem.Identifier? {
+        action.flatMap { menuFormIdentifiers[$0] }
     }
 
     /// Re-words an item whose description follows the connection, keeping its shortcut hint. Setting
@@ -206,6 +223,14 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
 
     /// Items ahead of `.sidebarTrackingSeparator` lay out in the sidebar's own titlebar strip,
     /// so the control that switches what the sidebar shows sits over the pane it drives.
+    ///
+    /// A tracking separator divides the toolbar into pane-aligned sections; it does not align the
+    /// items inside one. Everything after `.inspectorTrackingSeparator` therefore lays out from
+    /// that section's leading edge, which is the inspector divider, so the toggle walked inward as
+    /// the pane opened and only looked right while the inspector was closed. The `.flexibleSpace`
+    /// is what anchors it to the window's trailing edge, and it is the order Apple ships in
+    /// WWDC23 session 10054. Keep the toggle last: ahead of the separator it lands in the content
+    /// section and is wrong in both states.
     internal static let defaultItemIdentifiers: [NSToolbarItem.Identifier] = [
         sidebarToggle,
         .sidebarTrackingSeparator,
@@ -217,6 +242,7 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
         newTab,
         previewSQL,
         .inspectorTrackingSeparator,
+        .flexibleSpace,
         inspector,
     ]
 
@@ -268,15 +294,25 @@ extension MainWindowToolbar {
         return group
     }
 
-    internal func makeSidebarToggleItem() -> NSToolbarItem {
+    /// `sidebarGroup` is the one handle `syncSidebarSelection()` has on the live control, so only
+    /// the item actually going into the toolbar may claim it. A Customize Toolbar palette copy
+    /// that took the slot left every later sync writing into a discarded group, and the segments
+    /// stopped following the sidebar until the window was reopened.
+    internal func makeSidebarToggleItem(claimsSlot: Bool) -> NSToolbarItem {
         let group = Self.makeSidebarSegmentGroup(target: self, action: #selector(sidebarSegmentChanged(_:)))
+        bindMenuForm(action: #selector(sidebarSegmentChanged(_:)), to: Self.sidebarToggle)
+        guard claimsSlot else { return group }
         sidebarGroup = group
         syncSidebarSelection()
         return group
     }
 
-    @objc fileprivate func sidebarSegmentChanged(_ sender: NSToolbarItemGroup) {
-        let index = sender.selectedIndex
+    /// `@objc` does not type-check the sender, and this action is reachable from the overflow menu
+    /// as well as from the control, where AppKit sends an `NSMenuItem`. A typed parameter would
+    /// read `selectedIndex` off it and trap on `doesNotRecognizeSelector`.
+    @objc fileprivate func sidebarSegmentChanged(_ sender: Any?) {
+        guard let group = sender as? NSToolbarItemGroup else { return }
+        let index = group.selectedIndex
         guard Self.sidebarSegmentTabs.indices.contains(index) else { return }
         coordinator?.splitViewController?.setSidebarTab(Self.sidebarSegmentTabs[index])
     }

--- a/TableProTests/Services/MainWindowToolbarLayoutTests.swift
+++ b/TableProTests/Services/MainWindowToolbarLayoutTests.swift
@@ -34,6 +34,153 @@ struct MainWindowToolbarLayoutTests {
     }
 }
 
+/// A tracking separator divides the toolbar into pane-aligned sections and leaves the items inside
+/// one leading-aligned, so the toggle rode the inspector divider inward as the pane opened and only
+/// looked right while the inspector was closed. Measured on macOS 27 in a 1400pt window with a
+/// 270pt inspector: the toggle sat at x=1135 open and x=1352 closed, and the flexible space holds
+/// it at x=1352 in both. This suite pins the order Apple ships in WWDC23 session 10054.
+@MainActor
+struct MainWindowToolbarInspectorPlacementTests {
+    @Test("The inspector toggle is the trailing-most item")
+    func inspectorToggleIsTrailingMost() {
+        #expect(MainWindowToolbar.defaultItemIdentifiers.last == MainWindowToolbar.inspector)
+    }
+
+    @Test("A flexible space anchors the inspector toggle to the window edge")
+    func flexibleSpaceSeparatesTheTrackingSeparatorFromTheToggle() throws {
+        let identifiers = MainWindowToolbar.defaultItemIdentifiers
+        let separatorIndex = try #require(identifiers.firstIndex(of: .inspectorTrackingSeparator))
+        let toggleIndex = try #require(identifiers.firstIndex(of: MainWindowToolbar.inspector))
+        #expect(separatorIndex < toggleIndex)
+        #expect(Array(identifiers[(separatorIndex + 1) ..< toggleIndex]) == [.flexibleSpace])
+    }
+
+    /// Ahead of the separator the toggle lands in the content section, which measured wrong in both
+    /// the open and the closed state.
+    @Test("The inspector toggle stays behind its tracking separator")
+    func toggleNeverPrecedesItsTrackingSeparator() throws {
+        let identifiers = MainWindowToolbar.defaultItemIdentifiers
+        let separatorIndex = try #require(identifiers.firstIndex(of: .inspectorTrackingSeparator))
+        #expect(!identifiers[..<separatorIndex].contains(MainWindowToolbar.inspector))
+    }
+
+    @Test("The inspector item is AppKit's standard toggle, not a private identifier")
+    func inspectorIsTheStandardIdentifier() {
+        #expect(MainWindowToolbar.inspector == NSToolbarItem.Identifier.toggleInspector)
+    }
+
+    /// `NSToolbarItem.h`: AppKit creates the standard identifiers itself and "the delegate method
+    /// will not be called for these items". A delegate arm for one is dead code that can only ever
+    /// be worse than the item AppKit builds, which already carries the label, the state-aware
+    /// tooltip, the `toggleInspector:` action and a menu form.
+    @Test("The delegate builds none of AppKit's standard items")
+    func delegateDoesNotAnswerForStandardIdentifiers() {
+        let owner = MainWindowToolbar()
+        let standard = MainWindowToolbar.allowedItemIdentifiers.filter { $0.rawValue.hasPrefix("NSToolbar") }
+
+        #expect(standard.contains(MainWindowToolbar.inspector))
+        for identifier in standard {
+            let item = owner.toolbar(
+                owner.managedToolbar,
+                itemForItemIdentifier: identifier,
+                willBeInsertedIntoToolbar: true
+            )
+            #expect(item == nil, "\(identifier.rawValue) must be left to AppKit")
+        }
+    }
+}
+
+/// AppKit validates an overflowed toolbar item as a menu item, so `validateToolbarItem(_:)` never
+/// runs for it. Every action therefore has to resolve back to the identifier whose predicate gates
+/// it, or the overflow entry stays enabled while the same button is disabled.
+@MainActor
+struct MainWindowToolbarOverflowValidationTests {
+    private func vendedItems() -> (MainWindowToolbar, [NSToolbarItem]) {
+        let owner = MainWindowToolbar()
+        let items = MainWindowToolbar.allowedItemIdentifiers
+            .compactMap {
+                owner.toolbar(owner.managedToolbar, itemForItemIdentifier: $0, willBeInsertedIntoToolbar: true)
+            }
+            .flatMap { item -> [NSToolbarItem] in
+                guard let group = item as? NSToolbarItemGroup else { return [item] }
+                return [item] + group.subitems
+            }
+        return (owner, items)
+    }
+
+    /// Scoped to the items this toolbar targets, because those are exactly the ones AppKit routes
+    /// back to `validateMenuItem(_:)`. A menu entry AppKit synthesizes with a selector of its own
+    /// is not ours to answer for, and whether it exists at all depends on when AppKit builds it.
+    @Test("Every action the toolbar owns resolves to the item it stands for")
+    func everyOwnedActionResolvesToAnIdentifier() {
+        let (owner, items) = vendedItems()
+        let owned = items.filter { $0.target === owner }.compactMap(\.action)
+
+        #expect(!owned.isEmpty)
+        for action in owned {
+            #expect(
+                owner.itemIdentifier(forMenuFormAction: action) != nil,
+                "\(NSStringFromSelector(action)) has no toolbar item to validate against"
+            )
+        }
+    }
+
+    /// The gap this closed: seven of the twelve actions had no entry, so their overflow entries
+    /// stayed enabled with no session while the same buttons were disabled.
+    @Test("Connection-scoped actions all reach the session predicate")
+    func connectionScopedActionsAreAllMapped() {
+        let (owner, _) = vendedItems()
+        let expected: [Selector: NSToolbarItem.Identifier] = [
+            #selector(MainWindowToolbar.performRefresh(_:)): MainWindowToolbar.refresh,
+            #selector(MainWindowToolbar.performNewTab(_:)): MainWindowToolbar.newTab,
+            #selector(MainWindowToolbar.performOpenQuickSwitcher(_:)): MainWindowToolbar.quickSwitcher,
+            #selector(MainWindowToolbar.performExport(_:)): MainWindowToolbar.exportTables,
+            #selector(MainWindowToolbar.performOpenDatabaseSwitcher(_:)): MainWindowToolbar.database,
+            #selector(MainWindowToolbar.performToggleResults(_:)): MainWindowToolbar.results,
+            #selector(MainWindowToolbar.performShowDashboard(_:)): MainWindowToolbar.dashboard,
+        ]
+
+        for (action, identifier) in expected {
+            #expect(
+                owner.itemIdentifier(forMenuFormAction: action) == identifier,
+                "\(NSStringFromSelector(action)) must validate as \(identifier.rawValue)"
+            )
+        }
+    }
+
+    /// The import control carries no action of its own; its submenu entries do.
+    @Test("The import submenu validates as the import item")
+    func importSubmenuResolvesToTheImportItem() {
+        let owner = MainWindowToolbar()
+        _ = owner.subitemImport()
+        #expect(
+            owner.itemIdentifier(forMenuFormAction: #selector(MainWindowToolbar.performImportFormat(_:)))
+                == MainWindowToolbar.importTables
+        )
+    }
+
+    /// With no connection the toolbar disables these, so the overflow menu must too.
+    @Test("A menu item with no session is disabled, not silently inert")
+    func connectionScopedEntriesAreDisabledWithoutASession() {
+        let owner = MainWindowToolbar()
+        let menuItem = NSMenuItem(
+            title: "Refresh",
+            action: #selector(MainWindowToolbar.performRefresh(_:)),
+            keyEquivalent: ""
+        )
+        _ = owner.subitemRefresh()
+        #expect(!owner.validateMenuItem(menuItem))
+    }
+
+    /// A menu item this toolbar never built is not its to judge.
+    @Test("An unrelated menu item is left alone")
+    func unrelatedMenuItemsValidateTrue() {
+        let owner = MainWindowToolbar()
+        let menuItem = NSMenuItem(title: "Unrelated", action: #selector(NSView.layout), keyEquivalent: "")
+        #expect(owner.validateMenuItem(menuItem))
+    }
+}
+
 @MainActor
 struct MainWindowToolbarCustomizationTests {
     /// Opening Customize Toolbar makes AppKit ask the delegate again, with the flag off, for the
@@ -41,8 +188,41 @@ struct MainWindowToolbarCustomizationTests {
     /// whose views were on screen, and the connection group and status item collapsed to nothing.
     @Test("Only the item going into the toolbar claims the retained controller")
     func paletteCopiesDoNotClaimTheSlot() {
-        #expect(MainWindowToolbar.retainsHostingController(willBeInsertedIntoToolbar: true))
-        #expect(!MainWindowToolbar.retainsHostingController(willBeInsertedIntoToolbar: false))
+        #expect(MainWindowToolbar.claimsItemSlot(willBeInsertedIntoToolbar: true))
+        #expect(!MainWindowToolbar.claimsItemSlot(willBeInsertedIntoToolbar: false))
+    }
+
+    /// The sidebar segmented control keeps a slot of the same shape, and it never read the guard.
+    /// A palette copy took the slot, so every later `syncSidebarSelection()` wrote into a discarded
+    /// group and the segments stopped following the sidebar until the window was reopened.
+    @Test("A palette copy does not take over the live sidebar control")
+    func paletteCopyDoesNotClaimTheSidebarGroup() throws {
+        let owner = MainWindowToolbar()
+        let live = try #require(owner.makeSidebarToggleItem(claimsSlot: true) as? NSToolbarItemGroup)
+        #expect(owner.sidebarGroup === live)
+
+        let palette = try #require(owner.makeSidebarToggleItem(claimsSlot: false) as? NSToolbarItemGroup)
+        #expect(palette !== live)
+        #expect(owner.sidebarGroup === live)
+    }
+
+    /// The delegate is the path Customize Toolbar actually takes.
+    @Test("Vending a palette item through the delegate leaves the live control alone")
+    func delegatePaletteVendLeavesTheSidebarGroupIntact() throws {
+        let owner = MainWindowToolbar()
+        _ = owner.toolbar(
+            owner.managedToolbar,
+            itemForItemIdentifier: MainWindowToolbar.sidebarToggle,
+            willBeInsertedIntoToolbar: true
+        )
+        let live = try #require(owner.sidebarGroup)
+
+        _ = owner.toolbar(
+            owner.managedToolbar,
+            itemForItemIdentifier: MainWindowToolbar.sidebarToggle,
+            willBeInsertedIntoToolbar: false
+        )
+        #expect(owner.sidebarGroup === live)
     }
 
     /// The identifier is the autosave name. Changing it silently discards every user's arrangement,

--- a/TableProUITests/InspectorToolbarPlacementUITests.swift
+++ b/TableProUITests/InspectorToolbarPlacementUITests.swift
@@ -1,0 +1,86 @@
+//
+//  InspectorToolbarPlacementUITests.swift
+//  TableProUITests
+//
+//  The inspector toggle used to ride the inspector's divider: a tracking separator splits the
+//  toolbar into pane-aligned sections and leaves the items inside one leading-aligned, so opening
+//  the pane walked the button inward by the width of the pane. Only geometry catches that, which
+//  is why the identifier-order unit tests are not enough on their own.
+//
+
+import XCTest
+
+final class InspectorToolbarPlacementUITests: UITestCase {
+    /// The button is 44pt wide and the toolbar insets the trailing edge by a few points. The
+    /// inspector is 270pt, so anything near that is the pane's width rather than padding.
+    private let trailingEdgeTolerance: CGFloat = 80
+
+    /// How far the grid has to narrow or widen before the pane counts as having changed state.
+    /// The inspector's minimum thickness is 270pt.
+    private let paneTravel: CGFloat = 100
+
+    /// The window size is pinned because the measurement is a distance from the window's trailing
+    /// edge: a restored frame narrow enough to overflow the toolbar would move the last item for
+    /// reasons that have nothing to do with the inspector. The language is pinned because the only
+    /// handle on the toggle is the label AppKit gives its own standard item, which is localized.
+    private var pinnedEnvironment: [String: String] {
+        ["TABLEPRO_SCREENSHOT_FRAME": "1512x861", "AppleLanguages": "(en)"]
+    }
+
+    /// The inspector remembers whether it was open, so the starting state is whatever the previous
+    /// launch left. Both directions are asserted rather than assuming one.
+    func testTheInspectorToggleHoldsTheTrailingEdgeThroughBothTransitions() throws {
+        let app = try launchWithSampleDatabase(environment: pinnedEnvironment)
+        let window = try mainWindow(of: app)
+        let toggle = try inspectorToggle(in: window)
+
+        let initialGap = window.frame.maxX - toggle.frame.maxX
+        XCTAssertLessThan(
+            initialGap,
+            trailingEdgeTolerance,
+            "The inspector toggle must start at the window's trailing edge"
+        )
+
+        let grid = window.tables.matching(identifier: "data-grid").firstMatch
+        XCTAssertTrue(grid.waitForExistence(timeout: 30), "The sample database produced no data grid")
+
+        for transition in 1 ... 2 {
+            let widthBefore = grid.frame.width
+            app.typeKey("i", modifierFlags: [.command, .option])
+
+            XCTAssertTrue(
+                waitForPredicate(timeout: 15) { abs(grid.frame.width - widthBefore) > self.paneTravel },
+                "Transition \(transition): Command Option I did not move the inspector"
+            )
+
+            let gap = window.frame.maxX - toggle.frame.maxX
+            XCTAssertLessThan(
+                gap,
+                trailingEdgeTolerance,
+                "Transition \(transition): the toggle drifted in from the window's trailing edge"
+            )
+            XCTAssertEqual(
+                gap,
+                initialGap,
+                accuracy: 1,
+                "Transition \(transition): moving the inspector must not move its own toggle"
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func mainWindow(of app: XCUIApplication) throws -> XCUIElement {
+        let window = app.windows.matching(NSPredicate(format: "identifier != %@", "welcome")).firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 60), "The sample database produced no window")
+        return window
+    }
+
+    /// AppKit builds this item itself and labels it "Inspector"; the app never vends it, so there
+    /// is no accessibility identifier of ours to match on.
+    private func inspectorToggle(in window: XCUIElement) throws -> XCUIElement {
+        let toggle = window.toolbars.buttons["Inspector"].firstMatch
+        XCTAssertTrue(toggle.waitForExistence(timeout: 20), "No inspector toggle in the toolbar")
+        return toggle
+    }
+}

--- a/TableProUITests/Support/UITestCase.swift
+++ b/TableProUITests/Support/UITestCase.swift
@@ -103,8 +103,8 @@ internal class UITestCase: XCTestCase {
     /// menu during menu traversal"; XCUITest then falls back to hovering and resolves the item to an
     /// unhittable zero-size frame. That failed every suite this helper serves.
     @discardableResult
-    internal func launchWithSampleDatabase() throws -> XCUIApplication {
-        let app = try launchApp()
+    internal func launchWithSampleDatabase(environment: [String: String] = [:]) throws -> XCUIApplication {
+        let app = try launchApp(environment: environment)
         let menuBar = app.menuBars.firstMatch
         XCTAssertTrue(menuBar.waitForExistence(timeout: 10))
         let openSample = menuBar.menuItems["Open Sample Database"]

--- a/docs/features/data-grid.mdx
+++ b/docs/features/data-grid.mdx
@@ -114,7 +114,7 @@ There is no discard button. Undo your edits, or let the confirmation prompt drop
 
 ## Inspector
 
-Toggle the inspector with `Cmd+Option+I`. With a row selected, it lists every column value with full editors for long text and JSON; see [Cell and Row Viewers](/features/json-viewer) for details. Turn on **Settings > Data > Auto-show inspector on row select** to open it automatically.
+Toggle the inspector with `Cmd+Option+I`, or with the button at the right end of the toolbar. With a row selected, it lists every column value with full editors for long text and JSON; see [Cell and Row Viewers](/features/json-viewer) for details. Turn on **Settings > Data > Auto-show inspector on row select** to open it automatically.
 
 With no row selected, it shows table statistics: data, index, and total size, row count, average row size, engine, collation, and created and updated dates (fields vary by database).
 


### PR DESCRIPTION
## Root cause

`NSTrackingSeparatorToolbarItem` divides the toolbar into pane-aligned **sections**. It does not align the items *inside* one. Everything listed after `.inspectorTrackingSeparator` lays out from that section's leading edge, which is the inspector divider, so the toggle walked inward by the width of the pane the moment the pane opened. The app ships the inspector collapsed, which is why the button looked correct until you used it.

`defaultItemIdentifiers` ended `previewSQL, .inspectorTrackingSeparator, inspector` with nothing to push the toggle across its own section. WWDC23 session 10054 spells out the missing ingredient: "add the new inspector tracking separator **and a flexible space** before your toggle inspector item".

This shipped in 0.65.0 as intended behaviour: *"The titlebar breaks at the inspector divider, so the inspector toggle sits over the inspector pane."* An earlier attempt (`3308b9fdc`) fixed the symptom by deleting the tracking separator instead of completing it; #2097 restored the separator and the misplacement with it.

## Measurements

Standalone AppKit probe on macOS 27, reproducing this exact identifier list against a three-pane `NSSplitViewController`. Window 1400pt, inspector 270pt, toggle frame in window coordinates:

| order | inspector closed | inspector open |
| --- | --- | --- |
| before | x=1352 | **x=1135** |
| `.inspectorTrackingSeparator, .flexibleSpace, .toggleInspector` | x=1352 | **x=1352** |
| toggle ahead of the separator | x=1083 | x=1181 |
| no tracking separator at all | x=1352 | x=1352, but the titlebar loses its section break |

In the app, measured by the new UI test: **221.0pt** in from the trailing edge before, **4pt** after.

## Before / After

<img width="1512" height="859" alt="before-real" src="https://github.com/user-attachments/assets/8ce9da06-42ae-45eb-910a-3620ba508c04" />

<img width="1512" height="859" alt="after-real" src="https://github.com/user-attachments/assets/fc4a4b17-1ebc-4edd-a5e7-497272615f29" />

## The fix

- Insert `.flexibleSpace` between `.inspectorTrackingSeparator` and the toggle, which is Apple's own order and is unchanged API since macOS 14, so it behaves the same on the 14.0 deployment target.
- Delete the delegate arm for `.toggleInspector`. `NSToolbarItem.h` states that AppKit creates the standard identifiers itself and "the delegate method will not be called for these items", so the hand-built bare `NSToolbarItem` was dead code. AppKit's own item already supplies the label, a state-aware "Hide Inspector" tooltip, the `toggleInspector:` action and a menu form.

No toolbar autosave identifier bump: the saved configuration holds only display and size keys until a user actually customizes, so bumping would discard every existing customization for nothing.

## Also fixed, found while investigating

Both are in the same file and were verified against the code, then adversarially checked.

- **The Customize Toolbar palette copy hijacked the live sidebar control.** `sidebarGroup` is the only handle `syncSidebarSelection()` has, and the delegate ignored `willBeInsertedIntoToolbar`, so the palette copy took the slot. After opening that sheet once, the Tables/Favorites segments stopped following the sidebar until the window was reopened. This is the hazard `retainsHostingController(willBeInsertedIntoToolbar:)` already existed to prevent; it is now one predicate, renamed `claimsItemSlot`, read by both slots.
- **The overflow menu validated three of twelve actions.** AppKit validates an overflowed item as a menu item, so `validateToolbarItem(_:)` never runs for it, and a hand-written selector list covered only Save, Preview and Import. On a narrow window Refresh, New Tab, Open Quickly, Export, Database, Results and Dashboard rendered enabled with no session and clicked into a no-op. The mapping is now recorded by the factory that builds the item, the same shape `shortcutBindings` uses, so it cannot fall behind again.

`sidebarSegmentChanged(_:)` also took a typed `NSToolbarItemGroup` sender under `@objc`, which does no sender check. It now takes `Any?` and guards the cast.

## Tests

- `MainWindowToolbarInspectorPlacementTests`: pins the tail as separator, then flexible space, then toggle; asserts the toggle is last and is AppKit's standard identifier; asserts the delegate answers `nil` for every standard identifier so the dead arm cannot come back.
- `MainWindowToolbarOverflowValidationTests`: every action the toolbar targets resolves to an identifier, the seven connection-scoped actions map to the right ones, and a menu item the toolbar never built is left alone.
- `MainWindowToolbarCustomizationTests`: a palette copy, vended both directly and through the delegate, leaves the live sidebar group alone.
- `InspectorToolbarPlacementUITests`: drives the sample database and measures the toggle's distance from the window's trailing edge across both transitions, using the data grid's width to confirm the pane actually moved. It fails on the unfixed build with `("221.0") is not less than ("80.0")` and passes on the fix. The window size and language are pinned because the assertion is a distance from the window edge and the only handle on the toggle is AppKit's own localized label.

## Verification

- `xcodebuild build`: BUILD SUCCEEDED.
- Toolbar unit suites, 51 cases: all pass.
- `InspectorToolbarPlacementUITests`: passes, and fails on the unfixed build as above.
- `swiftlint` over `TablePro`, `TableProTests`, `TableProUITests`: no violation in any changed file. The run reports a pre-existing `storage_environment_directory` error in `ExecutionAuditLog.swift`, which this branch does not touch.
