### PR TITLE
fix(sidebar): stack the empty Favorites actions so the view fits the sidebar on macOS 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The empty Favorites sidebar fits its width on macOS 15. The description and the New Favorite, New Folder and Link a Folder buttons ran past both edges of the sidebar and were cut off, so the buttons could not be read or reached. They now wrap and stack inside the sidebar.
 - Table favorites and saved queries sync through iCloud. Their record types had never been created in the iCloud schema, so every one was rejected on upload, and Account settings reported the same sync error again on every attempt because the rejected items were retried forever.
 - An SSH profile that uses a jump host syncs. iCloud rejected the jump host list, and that stopped the whole profile from uploading.
 - A connection carries its favorite mark, every tag assigned to it, and its AI rules and always-allowed tools to your other Macs. These were held back from upload, so they stayed on the Mac that set them, and a connection with several tags arrived with only the first one.

--- a/TablePro/Views/Sidebar/FavoritesTabView.swift
+++ b/TablePro/Views/Sidebar/FavoritesTabView.swift
@@ -468,20 +468,26 @@ internal struct FavoritesTabView: View {
 
     /// An empty list has no row to right-click, so the commands the background menu carries have to
     /// be here too. They used to live in a bar at the bottom of the sidebar.
+    ///
+    /// The actions are stacked, not left to `ContentUnavailableView`'s default row. On macOS 15 the
+    /// row of three buttons is wider than the sidebar, and the view sizes its whole content to that
+    /// row, so the description and the buttons ran past both edges and were cut off.
     private var emptyState: some View {
         ContentUnavailableView {
             Label(String(localized: "No Favorites"), systemImage: "star")
         } description: {
             Text("Save frequently used queries, or link a folder of .sql files to share with your team.")
         } actions: {
-            Button(String(localized: "New Favorite...")) {
-                viewModel.createFavorite()
-            }
-            Button(String(localized: "New Folder")) {
-                viewModel.createFolder()
-            }
-            Button(String(localized: "Link a Folder...")) {
-                addLinkedFolder()
+            VStack(spacing: 8) {
+                Button(String(localized: "New Favorite...")) {
+                    viewModel.createFavorite()
+                }
+                Button(String(localized: "New Folder")) {
+                    viewModel.createFolder()
+                }
+                Button(String(localized: "Link a Folder...")) {
+                    addLinkedFolder()
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
On macOS 15 the empty Favorites sidebar does not fit its own width. The description and the three action buttons run past both edges and are cut off, so "New Favorite..." and "Link a Folder..." cannot be read (TablePro 0.66.0, macOS 15.6.1, sidebar at its default width):

<img src="https://raw.githubusercontent.com/manfad/TablePro/assets/favorites-empty-state/app-before.png" width="283" alt="Empty Favorites sidebar on macOS 15 with the description and buttons clipped on both sides">

## Root cause

`ContentUnavailableView` lays its `actions` out in a row. Three buttons side by side are wider than the sidebar, and on macOS 15 the view sizes its whole content to that row instead of the width it was given, so the description wraps at the row's width and the entire block overflows. It is not the description that is too wide: with the buttons stacked, the same text wraps inside 220 pt.

## Change

`FavoritesTabView.emptyState` wraps the three buttons in a `VStack(spacing: 8)`. That is the only layout change; the view stays a stock `ContentUnavailableView` like the other sidebar empty states, and the strings and actions are untouched. A doc comment on the property records why the actions are stacked, so it is not "simplified" back into a row.

## Before / after

Same view code, rendered at sidebar widths of 260 pt and 220 pt on macOS 15.6.1:

<img src="https://raw.githubusercontent.com/manfad/TablePro/assets/favorites-empty-state/before-after-260.png" width="540" alt="Before and after at 260 pt: buttons stacked, description wraps inside the width">

<img src="https://raw.githubusercontent.com/manfad/TablePro/assets/favorites-empty-state/before-after-220.png" width="460" alt="Before and after at 220 pt">

## Verification

- The after renders above are from a small standalone SwiftUI harness on macOS 15.6.1 that hosts the exact `emptyState` body (literal strings, no-op actions) in a 260 pt and a 220 pt window and snapshots the view. Its "before" reproduces the clipping in the app screenshot pixel for pixel. I could not build TablePro itself here (Xcode 16.4, the project needs Xcode 26), so please give it a run on a Mac with Xcode 26; the diff is a plain `VStack` wrapper and should not behave differently.
- `swiftlint lint --strict` is clean on `FavoritesTabView.swift`.
- `CHANGELOG.md` has an entry under `[Unreleased] > Fixed`.
- No tests: pure layout, no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
