### PR TITLE
test(hig): skip the inspector toolbar placement test on a screen too narrow to host it

### DIFF
--- a/TableProUITests/InspectorToolbarPlacementUITests.swift
+++ b/TableProUITests/InspectorToolbarPlacementUITests.swift
@@ -8,6 +8,7 @@
 //  is why the identifier-order unit tests are not enough on their own.
 //
 
+import AppKit
 import XCTest
 
 final class InspectorToolbarPlacementUITests: UITestCase {
@@ -21,16 +22,27 @@ final class InspectorToolbarPlacementUITests: UITestCase {
 
     /// The window size is pinned because the measurement is a distance from the window's trailing
     /// edge: a restored frame narrow enough to overflow the toolbar would move the last item for
-    /// reasons that have nothing to do with the inspector. The language is pinned because the only
-    /// handle on the toggle is the label AppKit gives its own standard item, which is localized.
+    /// reasons that have nothing to do with the inspector.
+    private let pinnedWindowSize = CGSize(width: 1512, height: 861)
+
     private var pinnedEnvironment: [String: String] {
-        ["TABLEPRO_SCREENSHOT_FRAME": "1512x861", "AppleLanguages": "(en)"]
+        ["TABLEPRO_SCREENSHOT_FRAME": "\(Int(pinnedWindowSize.width))x\(Int(pinnedWindowSize.height))"]
     }
+
+    /// The only handle on the toggle is the label AppKit gives its own standard item, which is
+    /// localized, so the app has to run in a known language. `AppleLanguages` is a defaults key
+    /// rather than an environment variable, and this test used to pass it in the environment, where
+    /// nothing reads it: the match worked only because both machines happened to be English.
+    private let pinnedArguments = ["-AppleLanguages", "(en)"]
 
     /// The inspector remembers whether it was open, so the starting state is whatever the previous
     /// launch left. Both directions are asserted rather than assuming one.
     func testTheInspectorToggleHoldsTheTrailingEdgeThroughBothTransitions() throws {
-        let app = try launchWithSampleDatabase(environment: pinnedEnvironment)
+        try skipUnlessTheScreenFitsThePinnedWindow()
+        let app = try launchWithSampleDatabase(
+            environment: pinnedEnvironment,
+            arguments: pinnedArguments
+        )
         let window = try mainWindow(of: app)
         let toggle = try inspectorToggle(in: window)
 
@@ -69,6 +81,25 @@ final class InspectorToolbarPlacementUITests: UITestCase {
     }
 
     // MARK: - Helpers
+
+    /// A window pinned wider than the screen is placed partly off it, and its toolbar collapses the
+    /// trailing items into the overflow menu, so there is no toggle in the toolbar to measure at
+    /// all. That is unmeasurable rather than wrong, and it is what the CI runner is: a 1024x768
+    /// virtual machine, where this reported "No inspector toggle in the toolbar" on every run while
+    /// passing on any real display.
+    private func skipUnlessTheScreenFitsThePinnedWindow() throws {
+        /// Width only, and against the screen's own frame rather than its visible one. The failure
+        /// this guards is horizontal, and the menu bar and Dock take height, not toolbar room.
+        let width = NSScreen.main?.frame.width ?? 0
+        try XCTSkipUnless(
+            width >= pinnedWindowSize.width,
+            """
+            Needs a screen at least \(Int(pinnedWindowSize.width))pt wide to hold the pinned window; \
+            this one is \(Int(width))pt. Anything narrower overflows the toolbar's trailing items \
+            into its menu, and the toggle is then not in the toolbar to measure.
+            """
+        )
+    }
 
     private func mainWindow(of app: XCUIApplication) throws -> XCUIElement {
         let window = app.windows.matching(NSPredicate(format: "identifier != %@", "welcome")).firstMatch

--- a/TableProUITests/Support/UITestCase.swift
+++ b/TableProUITests/Support/UITestCase.swift
@@ -82,7 +82,14 @@ internal class UITestCase: XCTestCase {
         }
     }
 
-    internal func launchApp(environment: [String: String] = [:]) throws -> XCUIApplication {
+    /// `arguments` is separate from `environment` because the two are not interchangeable. A
+    /// defaults override such as `-AppleLanguages` only takes effect as a launch argument: passed
+    /// in the environment it is an ordinary variable nothing reads, so the pin silently does
+    /// nothing and the test passes only on a machine that was already in that language.
+    internal func launchApp(
+        environment: [String: String] = [:],
+        arguments: [String] = []
+    ) throws -> XCUIApplication {
         let root = try XCTUnwrap(sandboxRoot, "setUpWithError did not prepare a sandbox")
         let app = XCUIApplication()
         app.launchEnvironment["TABLEPRO_UI_TESTING"] = "1"
@@ -90,6 +97,7 @@ internal class UITestCase: XCTestCase {
         for (key, value) in environment {
             app.launchEnvironment[key] = value
         }
+        app.launchArguments.append(contentsOf: arguments)
         app.launch()
         launchedApps.append(app)
         return app
@@ -103,8 +111,11 @@ internal class UITestCase: XCTestCase {
     /// menu during menu traversal"; XCUITest then falls back to hovering and resolves the item to an
     /// unhittable zero-size frame. That failed every suite this helper serves.
     @discardableResult
-    internal func launchWithSampleDatabase(environment: [String: String] = [:]) throws -> XCUIApplication {
-        let app = try launchApp(environment: environment)
+    internal func launchWithSampleDatabase(
+        environment: [String: String] = [:],
+        arguments: [String] = []
+    ) throws -> XCUIApplication {
+        let app = try launchApp(environment: environment, arguments: arguments)
         let menuBar = app.menuBars.firstMatch
         XCTAssertTrue(menuBar.waitForExistence(timeout: 10))
         let openSample = menuBar.menuItems["Open Sample Database"]


### PR DESCRIPTION
## What this fixes

`InspectorToolbarPlacementUITests` fails on every CI run with "No inspector toggle in the toolbar", and has never passed there. It arrived with #2221, whose own and only CI run failed on it, and it has failed on every pull request since, including ones that do not touch the toolbar. It passes on a real display.

## Root cause

Measured from the runner's own element tree, exported from the `macos-ui-test-results` artifact of run 32221079561 rather than inferred:

- The runner is a virtual machine with a **1024x768** screen: `MenuBar, {{0.0, 0.0}, {1024.0, 30.0}}`.
- The test pins the window to **1512x861**, which does not fit, so AppKit places it at `x = -244`: `Toolbar, {{-244.0, 31.0}, {1512.0, 52.0}}`.
- The toolbar's trailing items collapse into the overflow menu. Its last visible children are `Button label: 'Open Quickly'` and then `PopUpButton label: 'more toolbar items'`.
- The whole tree contains exactly one "Inspector": `MenuItem, identifier: 'shortcut.toggleInspector', title: 'Show Inspector'`, which is the View menu. There is no toggle in the toolbar to find.

So the pin meant to stop the toolbar overflowing is what causes it, because it is wider than the screen it runs on. The test's own comment anticipated the failure mode ("a restored frame narrow enough to overflow the toolbar would move the last item") without noticing that pinning a frame the screen cannot hold produces exactly that.

## The fix

Skip when the screen cannot hold the pinned window. The requirement is derived from the same constant that builds the pin, so the two cannot drift, and it is width only: the failure is horizontal, and the menu bar and Dock take height rather than toolbar room. On a display wide enough the test runs exactly as before; on the CI runner it reports a skip that says what it needs and why.

This is a precondition, not a quarantine: nothing is added to `.github/macos-ui-test-quarantine.txt`, and the test starts running again by itself the day the runner gets a wider screen.

## Also fixed: the language pin never worked

The test pinned `AppleLanguages` because the only handle on the toggle is the label AppKit gives its own standard item, which is localized. It passed it in `launchEnvironment`, where nothing reads it: `AppleLanguages` is a defaults key and only takes effect as a launch argument. The match worked only because both machines happened to be running in English.

`UITestCase.launchApp` and `launchWithSampleDatabase` now take `arguments:` alongside `environment:`, and the test passes `-AppleLanguages (en)` there. Both parameters default to empty, so no other suite changes.

## Verified

- `verify.sh uitest InspectorToolbarPlacementUITests` on unmodified `origin/main`: PASS, 2 cases. That is the measurement behind "runner-only".
- Same after the change: PASS, 2 cases, with `-AppleLanguages` now actually applied.
- The skip path was exercised rather than assumed: an intermediate version required the screen's *visible* frame to fit, which this display misses by two points in height, and the run reported `Test skipped - Needs a screen that fits a 1512x861 window; this one is 1512x859`. That is what showed the height half of the check was wrong, and it is now width only.
- `verify.sh test AppStorageEnvironmentTests MainWindowToolbarLayoutTests`: PASS, 9 cases. The first is the guard that scans `TableProUITests` sources for suites that bypass `UITestCase`, which the signature change had to keep satisfying.
- `swiftlint --strict` over both changed files: clean.

No CHANGELOG entry: this changes test preconditions only, and nothing about it is user-facing.
