### PR TITLE
fix(tabs): ask before closing a tab that holds unsaved work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The PHP serialized viewer's tree filter now behaves like the JSON one. Both ignore accents, so `cafe` finds `café`. (#2204)
 - Picking a database in the connections strip returns you to the tab you last used in it, the way picking a connection already returns you to that connection's tab. A database with nothing open just moves the object browser, as before. (#2217)
 - Two tabs showing objects with the same name from different databases now carry the database in their names, so two tabs called `orders` read as `app.orders` and `staging.orders`. A name no other tab uses stays short. Hovering a tab, or reading it with VoiceOver, always names its database. (#2217)
+- Save in the "Do you want to save changes?" prompt now closes what you asked to close once the save lands. Closing a group of tabs, or closing a connection, used to save and then leave everything open.
 
 ### Fixed
 
@@ -52,6 +53,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A tree filter that finds nothing now says so instead of showing an empty list, and says when the value was too large to load in full. (#2204)
 - Filtering a tree now searches the whole of a long string value instead of only the shortened form shown in the row. (#2204)
 - Copy Value on a JSON object or array now copies that part of the document instead of a summary like `{3 keys}`, and long strings copy in full. (#2204)
+- Closing a tab holding unsaved work asks before it goes, instead of discarding the work in silence. This covers unsaved cell edits in a table tab, a `.sql` file that differs from what is on disk, staged structure and Create Table changes, and staged user and role changes. Cell edits were the worst case: nothing brought them back, not even Reopen Closed Tab. Tabs holding only typed query text still close without asking, because that text comes back.
+- A tab with unsaved cell edits now shows the unsaved dot, so a tab is never marked clean and then asks to be saved.
+- Closing a tab used to leave its unsaved cell edits loaded behind it. The connection went on reporting unsaved changes with no tabs to show for it, and saving from there could write those edits to whichever database the sidebar had moved to.
+- A `.sql` file opened from a linked favorite can be opened again after its tab is closed. Opening it used to just bring the window forward and do nothing.
 
 ## [0.66.0] - 2026-08-19
 

--- a/TablePro/Core/Services/Infrastructure/ConnectionCloseAction.swift
+++ b/TablePro/Core/Services/Infrastructure/ConnectionCloseAction.swift
@@ -49,7 +49,10 @@ internal enum ConnectionCloseAction {
             window: presentingWindow
         ) {
         case .save:
-            coordinator?.commandActions?.saveChanges()
+            /// Save closes too, once the save has actually landed. It used to start the save and
+            /// stop there, so the connection the user asked to close stayed open.
+            guard await coordinator?.commandActions?.saveSelectedTabWork() == true else { break }
+            WindowManager.shared.closeWindow(for: connectionId)
         case .dontSave:
             WindowManager.shared.closeWindow(for: connectionId)
         case .cancel:

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -264,7 +264,7 @@ struct MainEditorContentView: View {
     private func usersRolesContent(tab: QueryTab) -> some View {
         Group {
             if let vm = usersRolesViewModels[tab.id] {
-                UsersRolesTabView(viewModel: vm, coordinator: coordinator)
+                UsersRolesTabView(viewModel: vm, coordinator: coordinator, tabID: tab.id)
             } else {
                 ProgressView(String(localized: "Loading users and roles..."))
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -502,7 +502,7 @@ struct MainEditorContentView: View {
                 guard tabId == tabManager.selectedTabId,
                       let index = tabManager.tabs.firstIndex(where: { $0.id == tabId }),
                       let window = coordinator.contentWindow else { return }
-                let showsIndicator = tabManager.tabs[index].showsUnsavedIndicator
+                let showsIndicator = coordinator.showsUnsavedIndicator(for: tabManager.tabs[index])
                 Task { @MainActor in
                     window.isDocumentEdited = showsIndicator
                 }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Protection.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Protection.swift
@@ -13,29 +13,70 @@ extension MainContentCoordinator {
         rightPanelState?.editState.hasEdits ?? false
     }
 
-    /// Work that is only recoverable by saving it. A scratch query tab is deliberately absent:
-    /// its text is persisted with the tab and comes back on relaunch, so it needs no alert.
-    /// Closing a tab also files it in `RecentlyClosedTabStore`; quitting does not, which is why
-    /// the tab-state write must never be skipped or cleared on an empty in-memory tab list.
-    func hasUnsavedWork(in tab: QueryTab?) -> Bool {
-        guard let tab else { return false }
-        if tab.tabType == .usersRoles {
-            return usersRolesActions?.hasChanges() ?? false
-        }
-        return tab.content.isFileDirty || tab.pendingChanges.hasChanges
+    /// Only the selected tab's editors are mounted, so only the selected tab has live state on the
+    /// coordinator to read.
+    func isSelectedTab(_ tab: QueryTab) -> Bool {
+        tabManager.selectedTabId == tab.id
     }
 
-    func hasUnsavedWorkInSelectedTab() -> Bool {
-        changeManager.hasChanges
-            || hasPendingDestructiveTableOps
-            || hasSidebarEdits
-            || hasUnsavedWork(in: tabManager.selectedTab)
+    /// Work in one tab that only saving can recover.
+    ///
+    /// Where that work lives depends on whether the tab is selected, because a tab's editors are
+    /// mounted only while it is. The selected tab's live edits sit on the coordinator, in
+    /// `changeManager` and `toolbarState`; a background tab carries whatever was snapshotted into
+    /// `pendingChanges` the last time it was switched away from. Reading the snapshot for the
+    /// selected tab answers "no" for the gesture users make most, editing a cell and closing the
+    /// tab they are looking at, because nothing has switched away to write the snapshot yet.
+    ///
+    /// Connection-scoped work is deliberately absent. A staged TRUNCATE or an unsaved sidebar edit
+    /// belongs to the connection rather than to any one tab, so letting it gate a tab's close would
+    /// pose a question neither Save nor Don't Save could answer for the tab being closed.
+    ///
+    /// A scratch query tab is absent too, and that one is a decision rather than an omission: its
+    /// text is persisted with the tab and filed in `RecentlyClosedTabStore` on close, so it comes
+    /// back. Grid edits do not. `TabChangeSnapshot` is not `Codable` and `PersistedTab` carries no
+    /// change fields, so closing a table tab is the one gesture that destroys them for good.
+    func hasUnsavedWork(in tab: QueryTab?) -> Bool {
+        guard let tab else { return false }
+        if tab.content.isFileDirty { return true }
+        guard isSelectedTab(tab) else { return backgroundUnsavedWork(in: tab) }
+        return liveUnsavedWork(in: tab)
+    }
+
+    /// A deselected tab left its editors behind, so the answer is whatever they wrote down before
+    /// they went. Users and roles keeps its own record because its view model outlives the view
+    /// while `usersRolesActions` does not, so the staged principals survive a deselect even though
+    /// nothing on the coordinator can still reach them.
+    private func backgroundUnsavedWork(in tab: QueryTab) -> Bool {
+        if tab.tabType == .usersRoles { return tabsWithStagedPrincipals.contains(tab.id) }
+        return tab.pendingChanges.hasChanges
+    }
+
+    private func liveUnsavedWork(in tab: QueryTab) -> Bool {
+        switch tab.tabType {
+        case .usersRoles:
+            return usersRolesActions?.hasChanges() ?? tabsWithStagedPrincipals.contains(tab.id)
+        case .createTable:
+            return toolbarState.hasCreateTablePending
+        default:
+            return changeManager.hasChanges || toolbarState.hasStructureChanges
+        }
+    }
+
+    /// The dot on the tab and in the window's close button. Deliberately broader than
+    /// `hasUnsavedWork(in:)`: a scratch query tab shows the dot because its text is unsaved, yet
+    /// closing it asks nothing because the text comes back. It is never narrower, so anything that
+    /// would raise the save prompt is marked before the user reaches for the close button.
+    func showsUnsavedIndicator(for tab: QueryTab) -> Bool {
+        tab.showsUnsavedIndicator || hasUnsavedWork(in: tab)
     }
 
     func hasAnyUnsavedWork() -> Bool {
         changeManager.hasChanges
             || hasPendingDestructiveTableOps
             || hasSidebarEdits
+            || toolbarState.hasStructureChanges
+            || toolbarState.hasCreateTablePending
             || tabManager.tabs.contains { hasUnsavedWork(in: $0) }
     }
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TabClosing.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TabClosing.swift
@@ -13,14 +13,39 @@ extension MainContentCoordinator {
     ///
     /// Closing tabs never closes the window: the window hosts every open connection now, so the
     /// connection is simply left on its empty state.
+    ///
+    /// Consent to close is not consent to lose work. Callers that can reach a tab holding unsaved
+    /// work ask first, through `MainContentCommandActions.closeTabAwaiting(id:)`.
     func closeTabsByUser(ids: [UUID]) {
         dataTabDelegate?.tableViewCoordinator?.flushPendingColumnLayoutPersistence()
         for id in ids {
             guard let tab = tabManager.tabs.first(where: { $0.id == id }) else { continue }
             RecentlyClosedTabStore.shared.push(tab: tab, connection: connection)
+            releaseResources(of: tab)
             tabManager.closeTab(id: id)
         }
         guard tabManager.tabs.isEmpty else { return }
         persistence.clearForUserClosedAllTabs()
+    }
+
+    /// A closed tab has to take its coordinator-side state with it, and this is the only place that
+    /// can: `handleTabChange` snapshots a tab by looking it up in `tabManager.tabs`, and by the time
+    /// it runs the tab is already gone. So it must happen before `tabManager.closeTab(id:)`, which
+    /// is also what makes the selected-tab test meaningful, since that call reassigns the selection.
+    ///
+    /// Left behind, the change manager keeps the closed tab's edits and the table name they were
+    /// written against. Nothing clears it, so the connection goes on reporting unsaved work with no
+    /// tabs to show for it, and the next Save resolves its scope through `browseScope` and runs
+    /// those statements against whatever database the sidebar has since moved to.
+    private func releaseResources(of tab: QueryTab) {
+        if let url = tab.content.sourceFileURL {
+            WindowLifecycleMonitor.shared.unregisterSourceFile(url)
+        }
+        tabsWithStagedPrincipals.remove(tab.id)
+        guard isSelectedTab(tab) else { return }
+        changeManager.clearChangesAndUndoHistory()
+        toolbarState.hasStructureChanges = false
+        toolbarState.hasCreateTablePending = false
+        toolbarState.hasPrincipalChanges = false
     }
 }

--- a/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Setup.swift
@@ -245,7 +245,7 @@ extension MainContentView {
             connectionId: connection.id
         )
         viewWindow?.representedURL = selectedTab?.content.sourceFileURL
-        viewWindow?.isDocumentEdited = selectedTab?.showsUnsavedIndicator ?? false
+        viewWindow?.isDocumentEdited = selectedTab.map(coordinator.showsUnsavedIndicator) ?? false
     }
 
     /// Configure the hosting NSWindow — called by WindowAccessor when the window is available.
@@ -270,7 +270,7 @@ extension MainContentView {
 
         // Native proxy icon (Cmd+click shows path in Finder) and dirty dot
         window.representedURL = tabManager.selectedTab?.content.sourceFileURL
-        window.isDocumentEdited = tabManager.selectedTab?.showsUnsavedIndicator ?? false
+        window.isDocumentEdited = tabManager.selectedTab.map(coordinator.showsUnsavedIndicator) ?? false
 
         commandActions?.window = window
 

--- a/TablePro/Views/Main/MainContentCommandActions+BulkClose.swift
+++ b/TablePro/Views/Main/MainContentCommandActions+BulkClose.swift
@@ -78,7 +78,13 @@ extension MainContentCommandActions {
 
     /// A partial close leaves the window open, so it cannot lean on the window's own prompt.
     /// Unsaved work is tracked for the connection rather than per tab, so the question is asked
-    /// once for the batch.
+    /// once for the batch rather than once per tab, which is also what keeps the sheets from
+    /// queueing: `NSWindow.beginSheet` queues a second sheet behind the first rather than
+    /// presenting it, so N prompts would be answered one at a time with no way to see why.
+    ///
+    /// Save goes on to close. This used to save and then return false, which left the batch
+    /// standing after a successful save and made Save mean "cancel" on this path while it meant
+    /// "close" on the window path.
     func confirmDiscardingUnsavedWork() async -> Bool {
         guard hasUnsavedWorkInConnection else { return true }
 
@@ -87,8 +93,7 @@ extension MainContentCommandActions {
             window: closeAnchorWindow
         ) {
         case .save:
-            saveChanges()
-            return false
+            return await saveSelectedTabWork()
         case .dontSave:
             return true
         case .cancel:

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -496,7 +496,61 @@ final class MainContentCommandActions {
     /// in right after connecting. The window hosts every open connection now, so closing it here
     /// would take the other connections' tabs and their unsaved edits with it.
     func closeTab(id: UUID) {
-        coordinator?.closeTabsByUser(ids: [id])
+        Task { await closeTabAwaiting(id: id) }
+    }
+
+    /// A tab holding work only a save can recover asks before it goes, which is what the window
+    /// close and the batch closes already do and what the HIG requires of an app that does not
+    /// autosave: "present a save dialog when people choose to close the document, quit your app,
+    /// log out, or restart".
+    ///
+    /// Save proceeds with the close, per `NSDocument.canCloseDocumentWithDelegate`: "shouldClose
+    /// will be YES if ... the user chose to discard modifications, or chose to save and the saving
+    /// was successful". `saveSelectedTabWork` returns false for the one case where saving cannot
+    /// finish on its own, staged principals, whose review sheet is now up and owns the decision.
+    func closeTabAwaiting(id: UUID) async {
+        guard let coordinator,
+              let tab = coordinator.tabManager.tabs.first(where: { $0.id == id }) else { return }
+        guard coordinator.hasUnsavedWork(in: tab) else {
+            coordinator.closeTabsByUser(ids: [id])
+            return
+        }
+        guard coordinator.tabClosesInFlight.insert(id).inserted else { return }
+        defer { coordinator.tabClosesInFlight.remove(id) }
+
+        let previousSelection = coordinator.tabManager.selectedTabId
+        revealTab(id)
+
+        switch await AlertHelper.confirmSaveChanges(
+            message: String(localized: "Your changes will be lost if you don't save them."),
+            window: closeAnchorWindow
+        ) {
+        case .save:
+            guard await saveSelectedTabWork() else { return }
+            coordinator.closeTabsByUser(ids: [id])
+        case .dontSave:
+            coordinator.closeTabsByUser(ids: [id])
+        case .cancel:
+            restoreSelection(previousSelection)
+        }
+    }
+
+    /// Shown, then asked. The save and discard machinery reads the selected tab, so the tab being
+    /// closed has to be the selected one before the question is put; naming work the user cannot
+    /// see would also ask them to decide about something they have no way to look at first.
+    private func revealTab(_ id: UUID) {
+        guard let coordinator, coordinator.tabManager.selectedTabId != id else { return }
+        coordinator.tabManager.selectedTabId = id
+    }
+
+    /// Cancel puts everything back, including a selection that only moved so the sheet had
+    /// somewhere honest to point.
+    private func restoreSelection(_ id: UUID?) {
+        guard let coordinator,
+              let id,
+              coordinator.tabManager.selectedTabId != id,
+              coordinator.tabManager.tabs.contains(where: { $0.id == id }) else { return }
+        coordinator.tabManager.selectedTabId = id
     }
 
     /// Cmd+W closes the tab in front. Pressed again with no tabs left it closes the connection,
@@ -613,15 +667,15 @@ final class MainContentCommandActions {
         coordinator.toolbarState.isTableTab = false
     }
 
-    private func saveAndClose(asBatchSurvivor: Bool?) async -> Bool {
-        guard let coordinator = coordinator else {
-            finish(asBatchSurvivor: asBatchSurvivor)
-            return true
-        }
+    /// The save half of a close, shared by the tab close, the window close and the batch close so
+    /// the three cannot drift on what Save means. Returns whether the caller may go on to close.
+    ///
+    /// False comes back for exactly one case: user and role changes can only be applied after the
+    /// SQL is reviewed, so Save opens the review sheet and stands the close down. Falling through
+    /// there would close over the sheet and destroy every staged change.
+    func saveSelectedTabWork() async -> Bool {
+        guard let coordinator = coordinator else { return true }
 
-        // User and role changes can only be applied after the SQL is reviewed, so Save opens the
-        // review sheet and cancels the close. Falling through here would close the window and
-        // destroy every staged change.
         if isUsersRolesTab, coordinator.usersRolesActions?.hasChanges() == true {
             coordinator.usersRolesActions?.reviewAndApply()
             return false
@@ -630,7 +684,6 @@ final class MainContentCommandActions {
         // Structure view saves via direct coordinator call
         if coordinator.tabManager.selectedTab?.display.resultsViewMode == .structure {
             coordinator.structureActions?.saveChanges?()
-            finish(asBatchSurvivor: asBatchSurvivor)
             return true
         }
 
@@ -639,30 +692,33 @@ final class MainContentCommandActions {
             || !pendingTruncates.wrappedValue.isEmpty
             || !pendingDeletes.wrappedValue.isEmpty
         if hasDataChanges {
-            let saved = await withCheckedContinuation { continuation in
+            return await withCheckedContinuation { continuation in
                 coordinator.saveCompletionContinuation = continuation
                 saveChanges()
             }
-            if saved {
-                finish(asBatchSurvivor: asBatchSurvivor)
-            }
-            return saved
         }
 
         // Sidebar-only edits (made directly in the inspector panel)
         if rightPanelState.editState.hasEdits {
             rightPanelState.onSave?()
-            finish(asBatchSurvivor: asBatchSurvivor)
             return true
         }
 
         // File save (query editor with source file)
         if coordinator.tabManager.selectedTab?.content.isFileDirty == true {
             saveFileToSourceURL()
-            finish(asBatchSurvivor: asBatchSurvivor)
             return true
         }
 
+        return true
+    }
+
+    private func saveAndClose(asBatchSurvivor: Bool?) async -> Bool {
+        guard coordinator != nil else {
+            finish(asBatchSurvivor: asBatchSurvivor)
+            return true
+        }
+        guard await saveSelectedTabWork() else { return false }
         finish(asBatchSurvivor: asBatchSurvivor)
         return true
     }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -145,6 +145,16 @@ final class MainContentCoordinator {
 
     weak var usersRolesActions: UsersRolesActionHandler?
 
+    /// Tabs holding staged principal changes. `usersRolesActions` is nilled the moment the tab is
+    /// deselected, but the view model behind it is cached per tab id and keeps the staged work, so
+    /// without this record a background Users & Roles tab reports itself clean and closes silently.
+    @ObservationIgnored internal var tabsWithStagedPrincipals: Set<UUID> = []
+
+    /// Tabs whose close confirmation is already on screen. `saveCompletionContinuation` is a single
+    /// slot, so a second gesture arriving before the first sheet resolves would overwrite the
+    /// continuation the first one is suspended on and leave that task waiting forever.
+    @ObservationIgnored internal var tabClosesInFlight: Set<UUID> = []
+
     /// Published capability/labels for the structure-mode footer in the bottom status bar.
     /// `TableStructureView` writes to this; `MainStatusBarView` reads from it.
     let structureFooterState = StructureFooterState()

--- a/TablePro/Views/UsersRoles/UsersRolesTabView.swift
+++ b/TablePro/Views/UsersRoles/UsersRolesTabView.swift
@@ -5,6 +5,7 @@ import TableProPluginKit
 struct UsersRolesTabView: View {
     @Bindable var viewModel: UsersRolesViewModel
     let coordinator: MainContentCoordinator?
+    let tabID: UUID
 
     @State private var actions = UsersRolesActionHandler()
 
@@ -47,7 +48,7 @@ struct UsersRolesTabView: View {
         .onAppear { install() }
         .onDisappear { teardown() }
         .onChange(of: viewModel.changeCount) { _, _ in
-            coordinator?.toolbarState.hasPrincipalChanges = viewModel.hasChanges
+            publishChangeState()
         }
     }
 
@@ -127,7 +128,21 @@ struct UsersRolesTabView: View {
             Task { await viewModel.load(forceReload: true) }
         }
         coordinator?.usersRolesActions = actions
-        coordinator?.toolbarState.hasPrincipalChanges = viewModel.hasChanges
+        publishChangeState()
+    }
+
+    /// The toolbar flag describes the tab on screen, so deselecting clears it. The per-tab record
+    /// must not follow it down: this view goes away on deselect but `UsersRolesViewModel` is cached
+    /// by tab id and keeps the staged principals, so clearing here would report a tab that still
+    /// holds real work as clean and let it close without asking.
+    private func publishChangeState() {
+        guard let coordinator else { return }
+        coordinator.toolbarState.hasPrincipalChanges = viewModel.hasChanges
+        if viewModel.hasChanges {
+            coordinator.tabsWithStagedPrincipals.insert(tabID)
+        } else {
+            coordinator.tabsWithStagedPrincipals.remove(tabID)
+        }
     }
 
     private func teardown() {

--- a/TableProTests/Views/Main/TabCloseProtectionTests.swift
+++ b/TableProTests/Views/Main/TabCloseProtectionTests.swift
@@ -1,0 +1,294 @@
+//
+//  TabCloseProtectionTests.swift
+//  TableProTests
+//
+//  Covers the per-tab unsaved-work predicate that gates closing a single tab, and the
+//  coordinator state a closed tab has to take with it.
+//
+
+import AppKit
+import Foundation
+import SwiftUI
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@MainActor @Suite("Tab close protection")
+struct TabCloseProtectionTests {
+    private static let columns = ["id", "name", "email"]
+    private static let originalRow: [PluginCellValue] = [.text("1"), .text("ada"), .text("ada@example.com")]
+
+    private func makeCoordinator(database: String = "db_a") -> MainContentCoordinator {
+        let connection = TestFixtures.makeConnection(database: database)
+        return SessionStateFactory.create(connection: connection, payload: nil).coordinator
+    }
+
+    /// Puts a real pending change in the coordinator's change manager, the same way an inline cell
+    /// edit does, so the predicate is exercised against live state rather than a hand-built stub.
+    private func stageCellEdit(on coordinator: MainContentCoordinator, table: String = "users") {
+        coordinator.changeManager.configureForTable(
+            tableName: table,
+            columns: Self.columns,
+            primaryKeyColumns: ["id"],
+            databaseType: .mysql
+        )
+        coordinator.changeManager.recordRowDeletion(rowIndex: 0, originalRow: Self.originalRow)
+    }
+
+    // MARK: - The reported bug
+
+    /// The case the user reported, and the reason the old predicate could not answer it. Live grid
+    /// edits sit in the coordinator's change manager until a tab switch snapshots them into
+    /// `pendingChanges`, so a table tab edited and closed without ever leaving it had an empty
+    /// snapshot and reported itself clean.
+    @Test("The selected tab reports its live cell edits with no tab switch")
+    func selectedTabSeesLiveGridEdits() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        coordinator.tabManager.addTab(initialQuery: "", databaseName: "db_a")
+        guard let tab = coordinator.tabManager.selectedTab else {
+            Issue.record("expected a selected tab")
+            return
+        }
+        #expect(!coordinator.hasUnsavedWork(in: tab))
+
+        stageCellEdit(on: coordinator)
+
+        #expect(!tab.pendingChanges.hasChanges)
+        #expect(coordinator.hasUnsavedWork(in: tab))
+    }
+
+    /// The other half of the same rule: a tab the user is not looking at has no live state on the
+    /// coordinator, so its own snapshot is the only honest answer. Reading the live manager here
+    /// would report the selected tab's edits against a tab that does not own them, and would ask
+    /// about work the user cannot see on the tab they are closing.
+    @Test("A background tab reports its own snapshot, not the selected tab's live edits")
+    func backgroundTabReadsItsOwnSnapshot() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        coordinator.tabManager.addTab(initialQuery: "", databaseName: "db_a")
+        guard let background = coordinator.tabManager.selectedTab else {
+            Issue.record("expected a selected tab")
+            return
+        }
+        coordinator.tabManager.addTab(initialQuery: "", databaseName: "db_a")
+        stageCellEdit(on: coordinator)
+
+        #expect(coordinator.tabManager.selectedTabId != background.id)
+        #expect(coordinator.changeManager.hasChanges)
+        #expect(!coordinator.hasUnsavedWork(in: background))
+
+        var carriesSnapshot = background
+        carriesSnapshot.pendingChanges = coordinator.changeManager.saveState()
+        #expect(carriesSnapshot.pendingChanges.hasChanges)
+        #expect(coordinator.hasUnsavedWork(in: carriesSnapshot))
+    }
+
+    /// Work the connection holds must not gate an unrelated tab. Neither Save nor Don't Save could
+    /// answer for the tab being closed, so the question would be unanswerable by construction.
+    @Test("Connection-level unsaved work does not gate a clean tab")
+    func connectionLevelWorkDoesNotGateACleanTab() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        coordinator.tabManager.addTab(initialQuery: "", databaseName: "db_a")
+        guard let clean = coordinator.tabManager.selectedTab else {
+            Issue.record("expected a selected tab")
+            return
+        }
+        coordinator.tabManager.addTab(initialQuery: "", databaseName: "db_a")
+        stageCellEdit(on: coordinator)
+
+        #expect(coordinator.hasAnyUnsavedWork())
+        #expect(!coordinator.hasUnsavedWork(in: clean))
+    }
+
+    // MARK: - Deliberate exclusions
+
+    /// Scratch text is persisted with the tab and filed in `RecentlyClosedTabStore` on close, so it
+    /// comes back. Prompting for it is the over-prompting comparable clients deliberately avoid.
+    @Test("A scratch query tab holding text still closes without asking")
+    func scratchQueryTabIsNotGated() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        coordinator.tabManager.addTab(initialQuery: "SELECT 1", databaseName: "db_a")
+        guard let tab = coordinator.tabManager.selectedTab else {
+            Issue.record("expected a selected tab")
+            return
+        }
+
+        #expect(tab.hasQueryText)
+        #expect(!coordinator.hasUnsavedWork(in: tab))
+    }
+
+    // MARK: - File-backed tabs
+
+    @Test("A file-backed tab that diverges from disk is gated even in the background")
+    func dirtyFileTabIsGated() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        var tab = QueryTab(query: "SELECT 2")
+        tab.content.sourceFileURL = URL(fileURLWithPath: "/tmp/report.sql")
+        tab.content.savedFileContent = "SELECT 1"
+
+        #expect(coordinator.tabManager.selectedTabId != tab.id)
+        #expect(coordinator.hasUnsavedWork(in: tab))
+    }
+
+    @Test("A file-backed tab matching disk is not gated")
+    func cleanFileTabIsNotGated() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        var tab = QueryTab(query: "SELECT 1")
+        tab.content.sourceFileURL = URL(fileURLWithPath: "/tmp/report.sql")
+        tab.content.savedFileContent = "SELECT 1"
+
+        #expect(!coordinator.hasUnsavedWork(in: tab))
+    }
+
+    // MARK: - Users and roles
+
+    /// `usersRolesActions` is nilled the moment the tab is deselected, but the view model behind it
+    /// is cached per tab id and keeps the staged principals. Without the per-tab record a background
+    /// Users & Roles tab reported itself clean and closed silently.
+    @Test("A background Users & Roles tab reports its staged principals")
+    func backgroundUsersRolesTabIsGated() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        var tab = QueryTab(query: "")
+        tab.tabType = .usersRoles
+
+        #expect(!coordinator.hasUnsavedWork(in: tab))
+
+        coordinator.tabsWithStagedPrincipals.insert(tab.id)
+        #expect(coordinator.hasUnsavedWork(in: tab))
+    }
+
+    // MARK: - The dot agrees with the prompt
+
+    /// Anything that would raise the save prompt is marked before the user reaches for the close
+    /// button. The dot is deliberately broader: a scratch tab shows it without being gated.
+    @Test("A tab that would be gated always shows the unsaved indicator")
+    func indicatorCoversEverythingTheGateCovers() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        coordinator.tabManager.addTab(initialQuery: "", databaseName: "db_a")
+        guard let tab = coordinator.tabManager.selectedTab else {
+            Issue.record("expected a selected tab")
+            return
+        }
+        #expect(!coordinator.showsUnsavedIndicator(for: tab))
+
+        stageCellEdit(on: coordinator)
+
+        #expect(coordinator.hasUnsavedWork(in: tab))
+        #expect(coordinator.showsUnsavedIndicator(for: tab))
+    }
+
+    @Test("A scratch tab shows the dot without being gated")
+    func scratchTabShowsTheDotOnly() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        coordinator.tabManager.addTab(initialQuery: "SELECT 1", databaseName: "db_a")
+        guard let tab = coordinator.tabManager.selectedTab else {
+            Issue.record("expected a selected tab")
+            return
+        }
+
+        #expect(coordinator.showsUnsavedIndicator(for: tab))
+        #expect(!coordinator.hasUnsavedWork(in: tab))
+    }
+
+    // MARK: - A closed tab takes its state with it
+
+    /// Nothing else can clear the change manager on this path: `handleTabChange` snapshots a tab by
+    /// looking it up in `tabManager.tabs`, and by the time it runs the tab is gone. Left behind, the
+    /// edits outlive their tab and the next Save runs them under whatever scope the sidebar moved to.
+    @Test("Closing the selected tab clears the change manager it was using")
+    func closingClearsTheOrphanedChangeManager() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        coordinator.tabManager.addTab(initialQuery: "", databaseName: "db_a")
+        guard let id = coordinator.tabManager.selectedTabId else {
+            Issue.record("expected a selected tab")
+            return
+        }
+        stageCellEdit(on: coordinator)
+        #expect(coordinator.changeManager.hasChanges)
+
+        coordinator.closeTabsByUser(ids: [id])
+
+        #expect(coordinator.tabManager.tabs.isEmpty)
+        #expect(!coordinator.changeManager.hasChanges)
+        #expect(!coordinator.hasAnyUnsavedWork())
+    }
+
+    /// A background tab's close must not reach into the selected tab's live editors.
+    @Test("Closing a background tab leaves the selected tab's edits alone")
+    func closingABackgroundTabKeepsLiveEdits() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        coordinator.tabManager.addTab(initialQuery: "", databaseName: "db_a")
+        guard let backgroundId = coordinator.tabManager.selectedTabId else {
+            Issue.record("expected a selected tab")
+            return
+        }
+        coordinator.tabManager.addTab(initialQuery: "", databaseName: "db_a")
+        stageCellEdit(on: coordinator)
+
+        coordinator.closeTabsByUser(ids: [backgroundId])
+
+        #expect(coordinator.tabManager.tabs.count == 1)
+        #expect(coordinator.changeManager.hasChanges)
+    }
+
+    @Test("Closing a tab drops its staged-principal record")
+    func closingDropsThePrincipalRecord() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        coordinator.tabManager.addTab(initialQuery: "", databaseName: "db_a")
+        guard let id = coordinator.tabManager.selectedTabId else {
+            Issue.record("expected a selected tab")
+            return
+        }
+        coordinator.tabsWithStagedPrincipals.insert(id)
+
+        coordinator.closeTabsByUser(ids: [id])
+
+        #expect(!coordinator.tabsWithStagedPrincipals.contains(id))
+    }
+
+    /// A closed tab's file registration used to outlive it, and `TabRouter.openSQLFile` trusts that
+    /// registry without re-checking, so the file could not be reopened while the window lived.
+    @Test("Closing a file-backed tab releases its source-file registration")
+    func closingReleasesTheSourceFileRegistration() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        let url = URL(fileURLWithPath: "/tmp/tabclose-\(UUID().uuidString).sql")
+        let windowId = UUID()
+        coordinator.windowId = windowId
+        coordinator.tabManager.addTab(initialQuery: "SELECT 1", databaseName: "db_a")
+        guard let id = coordinator.tabManager.selectedTabId else {
+            Issue.record("expected a selected tab")
+            return
+        }
+        coordinator.tabManager.mutate(tabId: id) { $0.content.sourceFileURL = url }
+        WindowLifecycleMonitor.shared.registerSourceFile(url, windowId: windowId)
+
+        coordinator.closeTabsByUser(ids: [id])
+
+        #expect(WindowLifecycleMonitor.shared.window(forSourceFile: url) == nil)
+    }
+}

--- a/docs/features/tabs.mdx
+++ b/docs/features/tabs.mdx
@@ -50,7 +50,13 @@ Closing the last tab leaves the connection open on its empty state rather than c
 
 **Close Tabs for Other Databases** closes only tabs opened against a database other than the one the connection is on now. It never touches the tab you are looking at, and it is limited to the current connection. Tabs from different databases are meant to coexist, so switching databases never closes anything on its own. On engines that switch schemas instead of databases, such as BigQuery and Oracle, the command reads **Close Tabs for Other Schemas**.
 
-Closing a query tab keeps its SQL in Recently Closed, so an accidental close costs nothing, including when you close a whole group at once. TablePro asks before closing only when unsaved work would be lost, such as pending data edits, pending structure changes, or unsaved edits to a `.sql` file on disk. A bulk close asks once, and cancelling stops the rest.
+Closing a query tab keeps its SQL in Recently Closed, so an accidental close costs nothing, including when you close a whole group at once. That is why a tab holding only typed query text closes without asking: the text comes back.
+
+TablePro asks before closing when unsaved work would be lost, and the prompt offers Save, Cancel and Don't Save. It covers unsaved cell edits in a table tab, a `.sql` file that differs from what is on disk, staged structure and Create Table changes, and staged user and role changes. Save closes the tab once the save lands, except for user and role changes, where Save opens the review sheet instead and leaves the tab open until you execute or discard there. A bulk close asks once, and cancelling stops the rest.
+
+Closing a tab you are not looking at selects it first, so the prompt is about work you can see before you answer it.
+
+A tab whose work would raise that prompt shows an unsaved dot on the tab, so nothing is ever marked clean and then asks to be saved.
 
 <Note>
 Tabs cannot be pinned or dragged to reorder. Pinning exists for result tabs inside a query tab (`Cmd+Option+P`, see [Keyboard Shortcuts](/features/keyboard-shortcuts)).


### PR DESCRIPTION
Closing a single tab destroyed unsaved work with no confirmation. Reported for two cases, both reproduced: a `.sql` file tab with unsaved edits, and a table tab with edited cells.

## Root cause

Two defects that compose.

**No gate.** Every single-tab-close gesture funnels through `MainContentCommandActions.closeTab(id:)`, which called `MainContentCoordinator.closeTabsByUser(ids:)` directly. Window close (`closeWindowAwaiting`) and the batch closes (`runBatchClose`) both gate on unsaved work; the single-tab path gated on nothing.

**The per-tab predicate was blind to live edits.** `hasUnsavedWork(in:)` read `tab.pendingChanges`, which is only written on switch-*away* (`MainContentCoordinator+TabSwitch.swift:30-37`). The selected tab's live grid edits sit in the coordinator's `DataChangeManager`. So even a gate using the existing predicate would still have missed the reported table-tab case, because nothing has switched away to write the snapshot.

Grid edits were the worst case: `TabChangeSnapshot` is not `Codable` and `PersistedTab` carries no change fields, so `RecentlyClosedTabStore` and tab persistence both drop them. Nothing brought them back.

## The fix

Refactored the predicate layer rather than patching the call site, because the existing one is stale by design for the selected tab and its only selected-tab helper (`hasUnsavedWorkInSelectedTab`) was dead and mis-scoped.

- **One tab-scoped predicate.** `hasUnsavedWork(in:)` resolves live coordinator state when the tab is selected and its own snapshot when it is not, plus `isFileDirty` either way. It now also covers structure changes and a staged Create Table, which `hasAnyUnsavedWork()` was missing entirely, so window close and Quit were silently destroying staged DDL too.
- **Connection-scoped work stays out of it.** A staged TRUNCATE or an unsaved sidebar edit belongs to the connection, so it must not gate an unrelated tab: neither Save nor Don't Save could answer for the tab being closed.
- **Scratch query text stays unprompted.** It is persisted with the tab and filed in `RecentlyClosedTabStore`, so it comes back. Postico, Sequel Ace and DataGrip all make the same distinction.
- **The gate itself.** `closeTabAwaiting(id:)` presents `AlertHelper.confirmSaveChanges` as a window-modal sheet. Save proceeds with the close, per `NSDocument.canCloseDocumentWithDelegate`: "shouldClose will be YES if ... the user chose to discard modifications, or chose to save and the saving was successful". Closing a background tab selects it first, so the question is about work the user can see, and Cancel puts the selection back.
- **Reentrancy guard.** `saveCompletionContinuation` is a single slot, so a second Cmd+W arriving before the first sheet resolved would overwrite the continuation the first was suspended on and hang that task.

### Also fixed, because the primary fix is unsafe or incoherent without them

- **Orphaned change manager (blocking).** Closing a tab never consumed the coordinator's `DataChangeManager`. `handleTabChange` cannot snapshot a tab that is already removed, and nothing else cleared it, so the edits outlived their tab: the connection went on reporting unsaved work with no tabs, and a later Save resolved its scope through `browseScope` and would run those statements against whatever database the sidebar had since moved to. Without this, Don't Save would have converted silent loss into a wrong-database write.
- **Save aborting the close.** `confirmDiscardingUnsavedWork` and `ConnectionCloseAction.close` both called `saveChanges()` and then returned without closing. The save half is now `saveSelectedTabWork()`, shared by all three close paths so they cannot drift again. It keeps the one deliberate exception: user and role changes can only be applied after review, so Save opens the review sheet and stands the close down.
- **The unsaved dot.** `showsUnsavedIndicator` ignored grid edits, so a table tab with pending cell edits was marked clean and would then ask to be saved. The dot now covers everything the gate covers, and stays deliberately broader (a scratch tab shows the dot without being gated).
- **Stale source-file registration.** `closeTabsByUser` never unregistered the tab's source file, so a `.sql` file opened from a linked favorite could not be reopened while its window lived: `TabRouter.openSQLFile` trusts that registry without re-checking and just raised the window.

## Before / After

There is no "before" screenshot to show: the defect is that no UI appeared at all. The "after" is the existing `AlertHelper.confirmSaveChanges` sheet already shipped for window close and batch close, now presented on one more path, so this introduces no new visual design.

## Verification

Built and tested locally against the real app target.

- `verify.sh build`: **PASS**
- `verify.sh test TabCloseProtectionTests CommandActionsBulkCloseTests QueryTabProtectionTests ConnectionCloseActionTests MainContentCoordinatorTabSwitchTests`: **PASS**, 64 executed, 64 passed, 0 failed
- `swiftlint --strict` over every changed file: clean

`TabCloseProtectionTests` is new and pins the reported bug directly: a selected table tab with live cell edits and no tab switch must report unsaved work while its `pendingChanges` snapshot is still empty. It also pins the background-tab case, the scratch-tab exclusion, the connection-scoped exclusion, the dot agreeing with the gate, and the three pieces of coordinator state a closed tab has to take with it.

No `TableProUITests` automation: the three sheet arms run through `AlertHelper.run(_:in:)`, which has no injection seam, and the suite has no existing coverage of this sheet even for the already-gated window-close path. The predicate and the state cleanup, which is where the defect actually lived, are covered by unit tests.
