### PR TITLE
fix(datagrid): keep staged structure and table-draft edits across a tab switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A tab with unsaved cell edits now shows the unsaved dot, so a tab is never marked clean and then asks to be saved.
 - Closing a tab used to leave its unsaved cell edits loaded behind it. The connection went on reporting unsaved changes with no tabs to show for it, and saving from there could write those edits to whichever database the sidebar had moved to.
 - A `.sql` file opened from a linked favorite can be opened again after its tab is closed. Opening it used to just bring the window forward and do nothing.
+- Staged structure changes survive switching tabs, and switching a table tab between Data and Structure. Adding a column or an index and then looking at anything else threw the pending change away, with no prompt and nothing in Undo.
+- A table definition in progress survives switching tabs. Naming a new table and defining its columns, then clicking any other tab, used to discard the whole definition.
+- Closing a tab with staged structure changes or an unfinished table definition asks before discarding them, and they count as unsaved work when you close the window or quit.
 
 ### Fixed
 

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -220,11 +220,7 @@ struct MainEditorContentView: View {
         case .table:
             tableTabContent(tab: tab)
         case .createTable:
-            CreateTableView(
-                connection: connection,
-                coordinator: coordinator,
-                selectionState: selectionState
-            )
+            createTableContent(tab: tab)
         case .erDiagram:
             erDiagramContent(tab: tab)
         case .serverDashboard:
@@ -563,6 +559,57 @@ struct MainEditorContentView: View {
         coordinator.scope(for: tab)
     }
 
+    /// A Create Table tab holds nothing but unsaved work, so its draft is cached here rather than
+    /// left in the view, which is destroyed the moment the tab is deselected.
+    @ViewBuilder
+    private func createTableContent(tab: QueryTab) -> some View {
+        Group {
+            if let draft = coordinator.createTableDrafts[tab.id] {
+                CreateTableView(
+                    connection: connection,
+                    coordinator: coordinator,
+                    selectionState: selectionState,
+                    draft: draft
+                )
+            } else {
+                Color.clear
+                    .onAppear { coordinator.createTableDrafts[tab.id] = CreateTableDraft() }
+            }
+        }
+        .id(tab.id)
+    }
+
+    /// The structure editor is rebuilt whenever the tab is deselected or switched to Data, so its
+    /// staged ALTERs live in a session cached here by tab, the same way the Users & Roles, ER
+    /// diagram and dashboard view models do. Creating it in `onAppear` rather than inline keeps the
+    /// write out of the view-update pass.
+    @ViewBuilder
+    private func structureContent(tab: QueryTab, tableName: String) -> some View {
+        let scope = structureScope(for: tab)
+        let identity = "\(scope?.qualifiedDescription ?? "").\(tableName)"
+        Group {
+            if let session = coordinator.structureSessions[tab.id], session.identity == identity {
+                TableStructureView(
+                    tableName: tableName,
+                    connection: connection,
+                    databaseName: scope?.database ?? "",
+                    schemaName: scope?.schema,
+                    toolbarState: coordinator.toolbarState,
+                    coordinator: coordinator,
+                    selectionState: selectionState,
+                    session: session
+                )
+                .id(identity)
+            } else {
+                Color.clear
+                    .onAppear {
+                        coordinator.structureSessions[tab.id] = StructureEditingSession(identity: identity)
+                    }
+            }
+        }
+        .frame(maxHeight: .infinity)
+    }
+
     @ViewBuilder
     private func resultsSection(tab: QueryTab) -> some View {
         VStack(spacing: 0) {
@@ -570,18 +617,7 @@ struct MainEditorContentView: View {
             switch tab.display.resultsViewMode {
             case .structure:
                 if let tableName = tab.tableContext.tableName {
-                    let scope = structureScope(for: tab)
-                    TableStructureView(
-                        tableName: tableName,
-                        connection: connection,
-                        databaseName: scope?.database ?? "",
-                        schemaName: scope?.schema,
-                        toolbarState: coordinator.toolbarState,
-                        coordinator: coordinator,
-                        selectionState: selectionState
-                    )
-                    .id("\(scope?.qualifiedDescription ?? "").\(tableName)")
-                    .frame(maxHeight: .infinity)
+                    structureContent(tab: tab, tableName: tableName)
                 }
             case .json:
                 resultTabBarSection(tab: tab)

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Protection.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Protection.swift
@@ -48,8 +48,14 @@ extension MainContentCoordinator {
     /// while `usersRolesActions` does not, so the staged principals survive a deselect even though
     /// nothing on the coordinator can still reach them.
     private func backgroundUnsavedWork(in tab: QueryTab) -> Bool {
-        if tab.tabType == .usersRoles { return tabsWithStagedPrincipals.contains(tab.id) }
-        return tab.pendingChanges.hasChanges
+        switch tab.tabType {
+        case .usersRoles:
+            return tabsWithStagedPrincipals.contains(tab.id)
+        case .createTable:
+            return hasTableDraftWork(in: tab)
+        default:
+            return tab.pendingChanges.hasChanges || hasStagedStructureEdits(in: tab)
+        }
     }
 
     private func liveUnsavedWork(in tab: QueryTab) -> Bool {
@@ -57,10 +63,23 @@ extension MainContentCoordinator {
         case .usersRoles:
             return usersRolesActions?.hasChanges() ?? tabsWithStagedPrincipals.contains(tab.id)
         case .createTable:
-            return toolbarState.hasCreateTablePending
+            return toolbarState.hasCreateTablePending || hasTableDraftWork(in: tab)
         default:
-            return changeManager.hasChanges || toolbarState.hasStructureChanges
+            return changeManager.hasChanges
+                || toolbarState.hasStructureChanges
+                || hasStagedStructureEdits(in: tab)
         }
+    }
+
+    /// Staged ALTERs read from the tab's own session rather than from `toolbarState`, which only
+    /// ever describes the tab on screen. A background tab keeps its session, so this is the only
+    /// answer that holds once the user has switched away from it.
+    private func hasStagedStructureEdits(in tab: QueryTab) -> Bool {
+        structureSessions[tab.id]?.changeManager.hasChanges ?? false
+    }
+
+    private func hasTableDraftWork(in tab: QueryTab) -> Bool {
+        createTableDrafts[tab.id]?.holdsWork ?? false
     }
 
     /// The dot on the tab and in the window's close button. Deliberately broader than

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TabClosing.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TabClosing.swift
@@ -42,6 +42,8 @@ extension MainContentCoordinator {
             WindowLifecycleMonitor.shared.unregisterSourceFile(url)
         }
         tabsWithStagedPrincipals.remove(tab.id)
+        structureSessions.removeValue(forKey: tab.id)
+        createTableDrafts.removeValue(forKey: tab.id)
         guard isSelectedTab(tab) else { return }
         changeManager.clearChangesAndUndoHistory()
         toolbarState.hasStructureChanges = false

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -145,6 +145,13 @@ final class MainContentCoordinator {
 
     weak var usersRolesActions: UsersRolesActionHandler?
 
+    /// Staged structure edits and table drafts, per tab. They belong here rather than in the view
+    /// for two reasons: the view is destroyed on every tab switch and on every switch between Data
+    /// and Structure, and the close gate has to be able to see the staged work of a tab the user is
+    /// not currently looking at.
+    var structureSessions: [UUID: StructureEditingSession] = [:]
+    var createTableDrafts: [UUID: CreateTableDraft] = [:]
+
     /// Tabs holding staged principal changes. `usersRolesActions` is nilled the moment the tab is
     /// deselected, but the view model behind it is cached per tab id and keeps the staged work, so
     /// without this record a background Users & Roles tab reports itself clean and closes silently.
@@ -511,6 +518,12 @@ final class MainContentCoordinator {
     func cleanupTabCaches(openTabIds: Set<UUID>) {
         if displayFormatsCache.keys.contains(where: { !openTabIds.contains($0) }) {
             displayFormatsCache = displayFormatsCache.filter { openTabIds.contains($0.key) }
+        }
+        if structureSessions.keys.contains(where: { !openTabIds.contains($0) }) {
+            structureSessions = structureSessions.filter { openTabIds.contains($0.key) }
+        }
+        if createTableDrafts.keys.contains(where: { !openTabIds.contains($0) }) {
+            createTableDrafts = createTableDrafts.filter { openTabIds.contains($0.key) }
         }
     }
 

--- a/TablePro/Views/Structure/CreateTableDraft.swift
+++ b/TablePro/Views/Structure/CreateTableDraft.swift
@@ -1,0 +1,29 @@
+//
+//  CreateTableDraft.swift
+//  TablePro
+//
+
+import Foundation
+import Observation
+
+/// A table definition in progress, held outside the view that edits it.
+///
+/// A Create Table tab's whole content is unsaved by definition: nothing exists on the server until
+/// the user presses Create. `MainEditorContentView` builds only the selected tab, so leaving the
+/// definition in the view's `@State` meant switching to any other tab and back threw away the table
+/// name, the options and every column the user had defined, with no prompt and nothing in Undo.
+@MainActor
+@Observable
+internal final class CreateTableDraft {
+    internal let changeManager = StructureChangeManager()
+
+    internal var tableName = ""
+    internal var tableOptions = CreateTableOptions()
+
+    /// Whether the draft holds anything worth losing. A tab that has only just opened does not: the
+    /// editor seeds one blank column so the grid has a row to show, which registers as a pending
+    /// change without the user having typed anything.
+    internal var holdsWork: Bool {
+        !tableName.isEmpty || changeManager.workingColumns.contains { !$0.name.isEmpty }
+    }
+}

--- a/TablePro/Views/Structure/CreateTableView.swift
+++ b/TablePro/Views/Structure/CreateTableView.swift
@@ -37,10 +37,14 @@ struct CreateTableView: View {
 
     @Environment(\.appServices) private var services
 
-    @State private var structureChangeManager: StructureChangeManager
+    /// The definition in progress. Held outside this view because the view is destroyed the moment
+    /// the tab is deselected, and nothing in a Create Table tab exists anywhere else yet.
+    @Bindable var draft: CreateTableDraft
+
     @State private var wrappedChangeManager: AnyChangeManager
-    @State private var tableName = ""
-    @State private var tableOptions = CreateTableOptions()
+
+    private var structureChangeManager: StructureChangeManager { draft.changeManager }
+
     @State private var selectedTab: CreateTableTab = .columns
     @State private var isCreating = false
     @State private var errorMessage: String?
@@ -57,14 +61,15 @@ struct CreateTableView: View {
     init(
         connection: DatabaseConnection,
         coordinator: MainContentCoordinator?,
-        selectionState: GridSelectionState
+        selectionState: GridSelectionState,
+        draft: CreateTableDraft
     ) {
         self.connection = connection
         self.coordinator = coordinator
         self.selectionState = selectionState
+        self.draft = draft
 
-        let manager = StructureChangeManager()
-        _structureChangeManager = State(wrappedValue: manager)
+        let manager = draft.changeManager
         _wrappedChangeManager = State(wrappedValue: AnyChangeManager(manager))
         _gridDelegate = State(wrappedValue: CreateTableGridDelegate(
             structureChangeManager: manager,
@@ -119,7 +124,7 @@ struct CreateTableView: View {
             Text("Table Name:")
                 .font(.body.weight(.medium))
 
-            TextField("Enter table name", text: $tableName)
+            TextField("Enter table name", text: $draft.tableName)
                 .textFieldStyle(.roundedBorder)
                 .autocorrectionDisabled(true)
                 .frame(maxWidth: 300)
@@ -128,22 +133,22 @@ struct CreateTableView: View {
                 Divider()
                     .frame(height: 20)
 
-                Picker("Engine:", selection: $tableOptions.engine) {
+                Picker("Engine:", selection: $draft.tableOptions.engine) {
                     ForEach(CreateTableOptions.engines, id: \.self) { engine in
                         Text(engine).tag(engine)
                     }
                 }
                 .fixedSize()
 
-                Picker("Charset:", selection: $tableOptions.charset) {
+                Picker("Charset:", selection: $draft.tableOptions.charset) {
                     ForEach(CreateTableOptions.charsets, id: \.self) { cs in
                         Text(cs).tag(cs)
                     }
                 }
                 .fixedSize()
 
-                Picker("Collation:", selection: $tableOptions.collation) {
-                    ForEach(CreateTableOptions.collations[tableOptions.charset] ?? [], id: \.self) { col in
+                Picker("Collation:", selection: $draft.tableOptions.collation) {
+                    ForEach(CreateTableOptions.collations[draft.tableOptions.charset] ?? [], id: \.self) { col in
                         Text(col).tag(col)
                     }
                 }
@@ -154,9 +159,9 @@ struct CreateTableView: View {
         }
         .padding()
         .background(Color(nsColor: .controlBackgroundColor))
-        .onChange(of: tableOptions.charset) { _, newCharset in
+        .onChange(of: draft.tableOptions.charset) { _, newCharset in
             if let first = CreateTableOptions.collations[newCharset]?.first {
-                tableOptions.collation = first
+                draft.tableOptions.collation = first
             }
         }
     }
@@ -212,7 +217,7 @@ struct CreateTableView: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(.accentColor)
-            .disabled(tableName.isEmpty || structureChangeManager.workingColumns.isEmpty || isCreating)
+            .disabled(draft.tableName.isEmpty || structureChangeManager.workingColumns.isEmpty || isCreating)
             .keyboardShortcut(.return, modifiers: .command)
         }
         .padding()
@@ -313,8 +318,8 @@ struct CreateTableView: View {
         }
         .onAppear { generatePreviewSQL() }
         .onChange(of: structureChangeManager.reloadVersion) { generatePreviewSQL() }
-        .onChange(of: tableName) { generatePreviewSQL() }
-        .onChange(of: tableOptions) { generatePreviewSQL() }
+        .onChange(of: draft.tableName) { generatePreviewSQL() }
+        .onChange(of: draft.tableOptions) { generatePreviewSQL() }
     }
 
     // Cell editing, row operations, undo/redo handled by CreateTableGridDelegate
@@ -336,7 +341,7 @@ struct CreateTableView: View {
         }
 
         let definition = PluginCreateTableDefinition(
-            tableName: tableName.isEmpty ? "untitled" : tableName,
+            tableName: draft.tableName.isEmpty ? "untitled" : draft.tableName,
             columns: columns.map { $0.toPlugin() },
             indexes: structureChangeManager.workingIndexes
                 .filter { !$0.name.isEmpty && !$0.columns.isEmpty }
@@ -345,10 +350,10 @@ struct CreateTableView: View {
                 .filter { !$0.name.isEmpty && !$0.columns.isEmpty && !$0.referencedTable.isEmpty }
                 .map { $0.toPlugin() },
             primaryKeyColumns: pkColumns,
-            engine: showMySQLOptions ? tableOptions.engine : nil,
-            charset: showMySQLOptions ? tableOptions.charset : nil,
-            collation: showMySQLOptions ? tableOptions.collation : nil,
-            ifNotExists: tableOptions.ifNotExists
+            engine: showMySQLOptions ? draft.tableOptions.engine : nil,
+            charset: showMySQLOptions ? draft.tableOptions.charset : nil,
+            collation: showMySQLOptions ? draft.tableOptions.collation : nil,
+            ifNotExists: draft.tableOptions.ifNotExists
         )
 
         let pluginDriver = (DatabaseManager.shared.driver(for: connection.id) as? PluginDriverAdapter)?.schemaPluginDriver
@@ -359,7 +364,7 @@ struct CreateTableView: View {
 
     private var isReadyToCreate: Bool {
         !isCreating
-            && !tableName.isEmpty
+            && !draft.tableName.isEmpty
             && structureChangeManager.workingColumns.contains { !$0.name.isEmpty && !$0.dataType.isEmpty }
     }
 
@@ -368,7 +373,7 @@ struct CreateTableView: View {
     }
 
     private func createTable() {
-        guard !isCreating, !tableName.isEmpty else { return }
+        guard !isCreating, !draft.tableName.isEmpty else { return }
         guard let sql = buildCreateTableSQL() else {
             errorMessage = String(localized: "Add at least one column with a name and type")
             showError = true
@@ -423,7 +428,7 @@ struct CreateTableView: View {
                 )
 
                 if let coordinator {
-                    coordinator.openTableTab(tableName)
+                    coordinator.openTableTab(draft.tableName)
                 }
 
                 AppCommands.shared.refreshData.send(DataRefreshRequest(connectionId: connection.id))

--- a/TablePro/Views/Structure/StructureEditingSession.swift
+++ b/TablePro/Views/Structure/StructureEditingSession.swift
@@ -1,0 +1,46 @@
+//
+//  StructureEditingSession.swift
+//  TablePro
+//
+
+import Foundation
+import Observation
+import TableProPluginKit
+
+/// The staged structure edits for one table, held outside the view that presents them.
+///
+/// `MainEditorContentView` builds only the selected tab's content, and the results view mode is a
+/// `switch` inside that, so switching tabs and switching a tab between Data and Structure both tear
+/// the view down and take its `@State` with it. Staged ALTERs are the user's work and have to
+/// outlive that, the same way a table tab's data-grid edits already do.
+///
+/// The loaded schema travels with them, and not as an optimisation. `StructureChangeManager`
+/// adopts a new baseline through `loadSchema`, which clears every pending change, the validation
+/// errors and the undo stack, so a rebuild that refetched the schema would discard the edits on its
+/// way back in. Holding the baseline here is what lets the rebuild skip the fetch, and skipping the
+/// fetch is the only version of this that keeps the edits.
+@MainActor
+@Observable
+internal final class StructureEditingSession {
+    /// The scope and table this session was opened against. A tab retargeted to another table gets
+    /// a new session rather than inheriting edits staged against the old one.
+    internal let identity: String
+
+    internal let changeManager = StructureChangeManager()
+
+    internal var columns: [ColumnInfo] = []
+    internal var indexes: [IndexInfo] = []
+    internal var foreignKeys: [ForeignKeyInfo] = []
+    internal var triggers: [TriggerInfo] = []
+    internal var ddlStatement: String = ""
+    internal var tabData = StructureTabDataState()
+
+    /// Whether the opening fetch has already run. True only after a real load, so a rebuild adopts
+    /// what is here instead of refetching, while a genuine refresh still goes through
+    /// `onRefreshData`, which asks before discarding.
+    internal var hasLoaded = false
+
+    internal init(identity: String) {
+        self.identity = identity
+    }
+}

--- a/TablePro/Views/Structure/TableStructureView+DataLoading.swift
+++ b/TablePro/Views/Structure/TableStructureView+DataLoading.swift
@@ -15,12 +15,24 @@ import UniformTypeIdentifiers
 // MARK: - Data Loading
 
 extension TableStructureView {
+    /// Runs once per session, not once per view. The view is rebuilt whenever the tab is deselected
+    /// or switched to Data and back, and `loadSchemaForEditing` re-baselines the change manager,
+    /// which clears every staged edit, its validation errors and its undo stack. So a rebuild reads
+    /// what the session already holds rather than fetching over the top of the user's work.
+    ///
+    /// A genuine refresh still refetches, through `onRefreshData`, which asks before discarding.
     @Sendable
     func loadInitialData() async {
+        guard !session.hasLoaded else {
+            isInitialLoading = false
+            isLoading = false
+            return
+        }
         await loadColumns()
         await loadTabDataIfNeeded(.indexes)
         await loadTabDataIfNeeded(.foreignKeys)
         loadSchemaForEditing()
+        session.hasLoaded = true
         isInitialLoading = false
     }
 

--- a/TablePro/Views/Structure/TableStructureView.swift
+++ b/TablePro/Views/Structure/TableStructureView.swift
@@ -44,19 +44,52 @@ struct TableStructureView: View {
         TableStructureLoader(scope: scope, tableName: tableName)
     }
 
+    /// Everything the user has staged, plus the baseline it is staged against. Held outside this
+    /// view because the view is destroyed whenever the tab is deselected or switched to Data.
+    let session: StructureEditingSession
+
     @State var selectedTab: StructureTab = .columns
-    @State var columns: [ColumnInfo] = []
-    @State var indexes: [IndexInfo] = []
-    @State var foreignKeys: [ForeignKeyInfo] = []
-    @State var triggers: [TriggerInfo] = []
-    @State var ddlStatement: String = ""
+
+    /// The loaded schema, forwarded to the session so a rebuild adopts it instead of refetching.
+    /// Refetching would re-baseline `structureChangeManager` and clear the staged edits.
+    var columns: [ColumnInfo] {
+        get { session.columns }
+        nonmutating set { session.columns = newValue }
+    }
+
+    var indexes: [IndexInfo] {
+        get { session.indexes }
+        nonmutating set { session.indexes = newValue }
+    }
+
+    var foreignKeys: [ForeignKeyInfo] {
+        get { session.foreignKeys }
+        nonmutating set { session.foreignKeys = newValue }
+    }
+
+    var triggers: [TriggerInfo] {
+        get { session.triggers }
+        nonmutating set { session.triggers = newValue }
+    }
+
+    var ddlStatement: String {
+        get { session.ddlStatement }
+        nonmutating set { session.ddlStatement = newValue }
+    }
+
+    var tabData: StructureTabDataState {
+        get { session.tabData }
+        nonmutating set { session.tabData = newValue }
+    }
+
+    var structureChangeManager: StructureChangeManager { session.changeManager }
+
     @AppStorage("structureCodeFontSize", store: AppStorageEnvironment.shared.defaults) var ddlFontSize: Double = 13
     @State var showCopyConfirmation = false
     @State var copyResetTask: Task<Void, Never>?
     @State var isLoading = true
     @State var isInitialLoading = true
     @State var errorMessage: String?
-    @State var tabData = StructureTabDataState()
     @State var partsReloadToken = 0
     @State var isReloadingAfterSave = false  // Prevent onChange loops during save reload
     @State var lastSaveTime: Date?
@@ -68,7 +101,6 @@ struct TableStructureView: View {
     @State var displayVersion: Int = 0
 
     // DataGridView state
-    @State var structureChangeManager: StructureChangeManager
     @State var wrappedChangeManager: AnyChangeManager
     @State var selectedRows: Set<Int> = []
     @State var sortState = SortState()
@@ -85,8 +117,8 @@ struct TableStructureView: View {
         toolbarState: ConnectionToolbarState,
         coordinator: MainContentCoordinator?,
         selectionState: GridSelectionState,
-        initialSelectedTab: StructureTab = .columns,
-        initialTabData: StructureTabDataState = StructureTabDataState()
+        session: StructureEditingSession,
+        initialSelectedTab: StructureTab = .columns
     ) {
         self.tableName = tableName
         self.connection = connection
@@ -95,11 +127,10 @@ struct TableStructureView: View {
         self.toolbarState = toolbarState
         self.coordinator = coordinator
         self.selectionState = selectionState
+        self.session = session
         _selectedTab = State(initialValue: initialSelectedTab)
-        _tabData = State(initialValue: initialTabData)
 
-        let manager = StructureChangeManager()
-        _structureChangeManager = State(wrappedValue: manager)
+        let manager = session.changeManager
         _wrappedChangeManager = State(wrappedValue: AnyChangeManager(manager))
         _gridDelegate = State(wrappedValue: StructureGridDelegate(
             structureChangeManager: manager,
@@ -520,7 +551,8 @@ struct TableStructureView: View {
         schemaName: nil,
         toolbarState: ConnectionToolbarState(),
         coordinator: nil,
-        selectionState: GridSelectionState()
+        selectionState: GridSelectionState(),
+        session: StructureEditingSession(identity: "test.users")
     )
     .frame(width: 800, height: 600)
 }

--- a/TableProTests/Views/Main/TabCloseProtectionTests.swift
+++ b/TableProTests/Views/Main/TabCloseProtectionTests.swift
@@ -170,6 +170,87 @@ struct TabCloseProtectionTests {
         #expect(coordinator.hasUnsavedWork(in: tab))
     }
 
+    // MARK: - Structure and Create Table
+
+    /// Staged ALTERs used to live in the structure view's own `@State`, so a tab switch destroyed
+    /// them outright. They live in a per-tab session now, which is also what lets the close gate see
+    /// them once the user has switched away from the tab holding them.
+    @Test("A background table tab reports its staged structure edits")
+    func backgroundStructureEditsAreGated() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        var tab = QueryTab(query: "")
+        tab.tabType = .table
+        tab.tableContext.tableName = "users"
+
+        let session = StructureEditingSession(identity: "db_a.users")
+        coordinator.structureSessions[tab.id] = session
+        #expect(!coordinator.hasUnsavedWork(in: tab))
+
+        session.changeManager.loadSchema(
+            tableName: "users",
+            columns: [],
+            indexes: [],
+            foreignKeys: [],
+            primaryKey: []
+        )
+        session.changeManager.addNewColumn()
+
+        #expect(session.changeManager.hasChanges)
+        #expect(coordinator.hasUnsavedWork(in: tab))
+    }
+
+    /// A session survives being read back, which is the whole point: the view is rebuilt on every
+    /// tab switch and on every switch between Data and Structure, and re-baselining the manager is
+    /// what would clear the staged edits.
+    @Test("A structure session keeps its staged edits across a rebuild")
+    func structureSessionSurvivesRebuild() {
+        let session = StructureEditingSession(identity: "db_a.users")
+        session.changeManager.loadSchema(
+            tableName: "users", columns: [], indexes: [], foreignKeys: [], primaryKey: []
+        )
+        session.changeManager.addNewColumn()
+        session.hasLoaded = true
+
+        #expect(session.hasLoaded)
+        #expect(session.changeManager.hasChanges)
+    }
+
+    /// A freshly opened Create Table tab seeds one blank column so the grid has a row. That is not
+    /// the user's work, and treating it as unsaved would prompt on every empty tab the user closes.
+    @Test("An untouched Create Table draft is not gated")
+    func untouchedTableDraftIsNotGated() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        var tab = QueryTab(query: "")
+        tab.tabType = .createTable
+
+        let draft = CreateTableDraft()
+        draft.changeManager.addNewColumn()
+        coordinator.createTableDrafts[tab.id] = draft
+
+        #expect(!draft.holdsWork)
+        #expect(!coordinator.hasUnsavedWork(in: tab))
+    }
+
+    @Test("A named Create Table draft is gated in the background")
+    func namedTableDraftIsGated() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        var tab = QueryTab(query: "")
+        tab.tabType = .createTable
+
+        let draft = CreateTableDraft()
+        draft.tableName = "invoices"
+        coordinator.createTableDrafts[tab.id] = draft
+
+        #expect(draft.holdsWork)
+        #expect(coordinator.hasUnsavedWork(in: tab))
+    }
+
     // MARK: - The dot agrees with the prompt
 
     /// Anything that would raise the save prompt is marked before the user reaches for the close
@@ -267,6 +348,25 @@ struct TabCloseProtectionTests {
         coordinator.closeTabsByUser(ids: [id])
 
         #expect(!coordinator.tabsWithStagedPrincipals.contains(id))
+    }
+
+    @Test("Closing a tab drops its structure session and table draft")
+    func closingDropsStructureAndDraftState() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.teardown() }
+
+        coordinator.tabManager.addTab(initialQuery: "", databaseName: "db_a")
+        guard let id = coordinator.tabManager.selectedTabId else {
+            Issue.record("expected a selected tab")
+            return
+        }
+        coordinator.structureSessions[id] = StructureEditingSession(identity: "db_a.users")
+        coordinator.createTableDrafts[id] = CreateTableDraft()
+
+        coordinator.closeTabsByUser(ids: [id])
+
+        #expect(coordinator.structureSessions[id] == nil)
+        #expect(coordinator.createTableDrafts[id] == nil)
     }
 
     /// A closed tab's file registration used to outlive it, and `TabRouter.openSQLFile` trusts that

--- a/docs/features/table-structure.mdx
+++ b/docs/features/table-structure.mdx
@@ -66,6 +66,10 @@ Structure edits queue locally; nothing runs until you save. See [Change Tracking
 - **Save Changes** (`Cmd+S` or the toolbar checkmark) applies the queued changes. Changes that can lose data (dropping a column, changing a type, adding NOT NULL, changing the primary key) first show a confirmation that lists each risky change.
 - **Preview SQL** (`Cmd+Shift+P`) shows the generated DDL statements without executing them.
 
+Queued changes stay queued while you look at something else. Switching to another tab, or switching the same tab between Data and Structure, leaves them alone, and so does coming back. They are only discarded when you discard them: closing the tab, closing the window or quitting asks first, and **Refresh** asks before replacing them with what is on the server.
+
+The same holds for a table you are still defining in a Create Table tab. The name, the options and every column you have added survive switching away and back.
+
 <Frame caption="Generated DDL preview">
   <img className="block dark:hidden" src="/images/schema-change-preview.png" alt="Schema change preview with ALTER TABLE statements" />
   <img className="hidden dark:block" src="/images/schema-change-preview-dark.png" alt="Schema change preview with ALTER TABLE statements" />


### PR DESCRIPTION
Stacked on #2238. Review that one first; this PR's base is its branch.

Found while investigating #2238. Staged structure changes and an in-progress table definition were destroyed by an ordinary tab switch, with no prompt and nothing in Undo. No close-path gate can catch this, which is why it could not ship with #2238.

## Root cause

`MainEditorContentView` builds only the selected tab's content (`MainEditorContentView.swift:101`), and the results view mode is a `switch` inside that. Both are `_ConditionalContent` branches, so switching tabs, and switching a table tab between Data and Structure, tear the view down and take its `@State` with it. `TableStructureView` held `structureChangeManager` there, and `CreateTableView` held the whole definition there.

The reload made it worse rather than better. `StructureChangeManager.loadSchema` is what adopts a new baseline, and it clears every pending change, the validation errors and the undo stack (`StructureChangeManager.swift:95-98`). So a rebuild that refetched the schema would have discarded the edits on the way back in even if the manager had survived.

## The fix

The same shape the file already uses for the Users & Roles, ER diagram, dashboard and Query Insights view models: per-tab state cached outside the view.

- **`StructureEditingSession`** holds the change manager plus the loaded baseline it is staged against. The baseline travels with it deliberately: holding it is what lets a rebuild skip the fetch, and skipping the fetch is the only version of this that keeps the edits. `loadInitialData` now runs once per session rather than once per view.
- **`CreateTableDraft`** holds the table name, the options and the change manager. A Create Table tab is unsaved by definition, since nothing exists on the server until Create is pressed.
- Both live on `MainContentCoordinator` next to the existing per-tab `displayFormatsCache`, and are pruned by the same `cleanupTabCaches`. That placement is load-bearing rather than tidiness: the close gate from #2238 has to see the staged work of a tab the user is not looking at, and view `@State` is invisible to it.
- The unsaved-work predicate reads them, so closing a tab, closing the window or quitting now asks about staged structure edits and unfinished table definitions instead of discarding them.
- `CreateTableDraft.holdsWork` deliberately ignores the blank column the editor seeds so the grid has a row. Counting it would prompt on every empty Create Table tab the user closes.

A genuine refresh still refetches, through `onRefreshData`, which already asks before discarding.

`TableStructureView`'s moved properties became forwarding computed properties with `nonmutating set`, so all ~105 references across the view and its two extensions are unchanged. Nothing took a binding projection on them, which is what made that safe.

## Verification

- `verify.sh build`: **PASS**
- `verify.sh test TabCloseProtectionTests CommandActionsBulkCloseTests QueryTabProtectionTests ConnectionCloseActionTests MainContentCoordinatorTabSwitchTests`: **PASS**, 70 executed, 70 passed, 0 failed
- `swiftlint --strict` over every changed file: clean

Six new cases cover a background table tab reporting its staged ALTERs, a session keeping them across a rebuild, an untouched Create Table draft staying unprompted, a named one being gated, and a closed tab dropping both.

No `TableProUITests` automation: driving this needs a live connection with a real table to open the Structure tab against, which the suite has no fixture for.

## Before / After

No screenshot: the change is that state stops disappearing. The visible difference is a Structure tab that still shows a pending column after you visit another tab, where it previously showed none.
