### PR TITLE
fix(settings): write the execution audit log through the app's storage environment

### DIFF
--- a/TablePro/Core/Services/Execution/ExecutionAuditLog.swift
+++ b/TablePro/Core/Services/Execution/ExecutionAuditLog.swift
@@ -27,22 +27,19 @@ internal actor ExecutionAuditLog: ExecutionAuditLogging {
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "ExecutionAudit")
 
-    private let fileURL: URL?
+    private let fileURL: URL
     private var records: [ExecutionAuditRecord] = []
     private var loaded = false
 
-    internal init(fileURL: URL? = ExecutionAuditLog.defaultFileURL()) {
+    internal init(fileURL: URL = ExecutionAuditLog.defaultFileURL()) {
         self.fileURL = fileURL
     }
 
-    internal static func defaultFileURL() -> URL? {
-        guard let support = try? FileManager.default.url(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask,
-            appropriateFor: nil,
-            create: true
-        ) else { return nil }
-        let directory = support.appendingPathComponent("TablePro", isDirectory: true)
+    /// Resolved through `AppStorageEnvironment` like every other store, so a UI test appends to its
+    /// own sandbox. The chain is hash linked, which makes a foreign entry indistinguishable from a
+    /// real one rather than merely noise.
+    internal static func defaultFileURL() -> URL {
+        let directory = AppStorageEnvironment.shared.supportDirectory
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         return directory.appendingPathComponent("ExecutionAudit.json")
     }
@@ -104,7 +101,7 @@ internal actor ExecutionAuditLog: ExecutionAuditLogging {
     private func load() {
         guard !loaded else { return }
         loaded = true
-        guard let fileURL, let data = try? Data(contentsOf: fileURL) else { return }
+        guard let data = try? Data(contentsOf: fileURL) else { return }
         do {
             records = try JSONDecoder().decode([ExecutionAuditRecord].self, from: data)
         } catch {
@@ -115,7 +112,6 @@ internal actor ExecutionAuditLog: ExecutionAuditLogging {
     }
 
     private func persist() {
-        guard let fileURL else { return }
         do {
             let data = try JSONEncoder().encode(records)
             try data.write(to: fileURL, options: .atomic)

--- a/TableProTests/Core/Services/ExecutionAuditRecordTests.swift
+++ b/TableProTests/Core/Services/ExecutionAuditRecordTests.swift
@@ -189,4 +189,12 @@ struct ExecutionAuditLogTests {
         #expect(Set(entries.map(\.sequence)).count == 20)
         #expect(await log.verify() == .intact(count: 20))
     }
+
+    @Test("the default log lives inside the storage environment, so a UI test cannot append to the real chain")
+    func defaultLocationFollowsStorageEnvironment() {
+        let url = ExecutionAuditLog.defaultFileURL()
+        #expect(url.lastPathComponent == "ExecutionAudit.json")
+        #expect(url.deletingLastPathComponent() == AppStorageEnvironment.shared.supportDirectory)
+        #expect(url.path.hasPrefix(AppStorageEnvironment.shared.applicationSupportRoot.path))
+    }
 }


### PR DESCRIPTION
Fixes #2242.

`ExecutionAuditLog.defaultFileURL()` asked `FileManager` for Application Support directly instead of going through `AppStorageEnvironment.shared`, which is the one type allowed to resolve that directory.

Two things follow from that, and both are fixed here.

`swiftlint --strict` failed on `main`. The repo's own `storage_environment_directory` rule is `severity: error`, so the mandatory lint step was red for everyone on a violation they did not write. A gate that is always red teaches people to ignore it.

UI tests wrote to the developer's own audit log. `TableProUITests` launches the real app against a sandbox named in `TABLEPRO_UI_TEST_SANDBOX`, and every other store honours it. This path did not, so a test run appended to the log of whoever ran it. The log is hash chained, so those entries are not noise: they are indistinguishable from real decisions and they advance the chain.

## The change

`defaultFileURL()` now reads `AppStorageEnvironment.shared.supportDirectory`. It also drops to a non-optional `URL`: the old signature returned `URL?` only because `FileManager.url(for:create:)` could throw, and the environment cannot fail to name a root. That removes two unreachable `guard let fileURL` unwraps in `load()` and `persist()`.

The production path is unchanged, byte for byte. `AppStorageEnvironment.productionRoot()` resolves the same directory the old call did, so there is no migration and no existing log moves.

## Verification

- `swiftlint --strict` over the whole app target: exit 0, no output. It reports this exact violation on the unfixed tree, so that is a clean A/B.
- Debug build: PASS.
- `ExecutionAuditRecordTests`, `ExecutionAuditLogTests`, `AppStorageEnvironmentTests`: 20 executed, 20 passed. Log grepped for `Failing tests:` and `TEST FAILED`, 0 hits.

## Test added

`defaultLocationFollowsStorageEnvironment` asserts the log resolves inside `AppStorageEnvironment.shared.supportDirectory`. It is a narrow guard and the lint rule remains the primary one: this test catches a future relocation outside the sandboxed root, the lint rule catches a return to resolving the directory by hand.

## No CHANGELOG entry

Deliberate. CLAUDE.md asks for one-line user-facing entries, and this has no user-visible effect: same path, same contents, same behaviour. The bug only reaches someone running the test suite.

## Noted, not fixed here

`AppStorageEnvironment.supportDirectory` had zero readers before this commit. Fifteen storage classes hand-append `"TablePro"` to `applicationSupportRoot` instead, which is the duplication that property exists to remove. Mechanical to fix, but it touches fifteen files that other branches are editing, so it does not belong in a bug fix.
