### PR TITLE
perf(datagrid): mount only the columns near the viewport on a wide result

### DIFF
--- a/.claude/skills/fix-issue/scripts/worktree.sh
+++ b/.claude/skills/fix-issue/scripts/worktree.sh
@@ -62,10 +62,12 @@ for archive in "$MAIN_ROOT"/Libs/*.a; do
 done
 link "$MAIN_ROOT/Libs/dylibs" "$DIR/Libs/dylibs"
 link "$MAIN_ROOT/Libs/ios" "$DIR/Libs/ios"
+link "$MAIN_ROOT/Native/DamengBridge/lib" "$DIR/Native/DamengBridge/lib"
 
 missing=""
 [ -e "$DIR/Secrets.xcconfig" ] || missing="$missing Secrets.xcconfig"
 [ -e "$DIR/Libs/dylibs" ] || missing="$missing Libs/dylibs"
+[ -e "$DIR/Native/DamengBridge/lib" ] || missing="$missing Native/DamengBridge/lib"
 ls "$DIR"/Libs/*.a > /dev/null 2>&1 || missing="$missing Libs/*.a"
 if [ -n "$missing" ]; then
     echo "warning: not linked, the main checkout does not have them:$missing" >&2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Scrolling a result with hundreds of columns is no longer slow. Every column built a cell for every row on screen whether or not it was anywhere near the viewport, so a 500-column table carried about 18,000 live cells and laid all of them out on each frame. Only the columns near the viewport are built now, and the rest keep their width so the horizontal scroller still spans the whole result. (#1219)
+- A column you hid keeps its place in the column order. The order was saved from the columns the query returned, and a hidden column is left out of that query, so its position was erased and Show All put it back at the far right of a grid you had arranged.
+- A row you are inserting shows empty values in JSON result mode for the columns the server fills in, instead of printing TablePro's internal marker for them as though it were data.
 - `Cmd+F` no longer opens a find bar in JSON result mode. It searched the data grid's cells through the grid, which is not mounted there, so it always reported no matches whatever you typed. The Tree view keeps its own search field. (#2244)
 - The Filters button and `Cmd+Option+F` now open the filter panel in JSON result mode, where they used to flip a switch and draw nothing. Applying a filter re-runs the query, so the JSON shows the filtered rows. (#2244)
 - Add Row, Duplicate Row, Paste and Delete no longer collapse the JSON view to the single row they touched. Each command selected that row so the grid could scroll to it, and JSON mode reads the same selection as "show only these rows", so the document appeared to empty out. (#2244)

--- a/TablePro/Core/Storage/ColumnLayoutPersister.swift
+++ b/TablePro/Core/Storage/ColumnLayoutPersister.swift
@@ -67,7 +67,10 @@ final class FileColumnLayoutPersister: ColumnLayoutPersisting {
         )
         entry.columnWidths = layout.columnWidths
         entry.columnContentWidths = layout.columnContentWidths
-        entry.columnOrder = layout.columnOrder
+        entry.columnOrder = ColumnLayoutState.mergedColumnOrder(
+            current: entry.columnOrder,
+            incoming: layout.columnOrder
+        )
         entries[key.storageKey] = entry
         cache[key.connectionId] = entries
         writeEntries(entries, for: key.connectionId)

--- a/TablePro/Core/Utilities/SQL/JsonRowConverter.swift
+++ b/TablePro/Core/Utilities/SQL/JsonRowConverter.swift
@@ -40,7 +40,7 @@ internal struct JsonRowConverter {
                 }
 
                 let cell = row[colIdx]
-                if cell.isNull {
+                if cell.isNull || cell.isDefaultMarker {
                     result.append("null")
                     appendPropertySuffix(to: &result, colIdx: colIdx)
                     continue

--- a/TablePro/Extensions/PluginCellValue+DefaultMarker.swift
+++ b/TablePro/Extensions/PluginCellValue+DefaultMarker.swift
@@ -1,0 +1,22 @@
+//
+//  PluginCellValue+DefaultMarker.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+internal extension PluginCellValue {
+    /// The sentinel a pending inserted row carries for a column the server fills in, written by
+    /// `RowOperationsManager` and stripped again by `SQLStatementGenerator`.
+    ///
+    /// It is an internal marker, never a value, so every view that renders a cell has to recognise
+    /// it. The grid shows it as a placeholder; anything that renders the same rows some other way
+    /// has to agree, or the marker leaks out as literal text.
+    static let defaultMarkerText = "__DEFAULT__"
+
+    var isDefaultMarker: Bool {
+        guard case .text(let value) = self else { return false }
+        return value == Self.defaultMarkerText
+    }
+}

--- a/TablePro/Models/Query/QueryTabState.swift
+++ b/TablePro/Models/Query/QueryTabState.swift
@@ -339,10 +339,51 @@ struct ColumnLayoutState: Equatable {
     var columnOrder: [String]?
     var hiddenColumns: Set<String> = []
 
+    /// Splices a captured order into the stored one, keeping names the capture never saw.
+    ///
+    /// A capture only lists the columns the query returned, and hiding a column takes it out of
+    /// that projection. Overwriting with the capture therefore drops the hidden column's position,
+    /// and showing it again appends it at the end, which reorders a grid the user never touched.
+    /// Names the capture does cover take its order; the rest hold their slots.
+    static func mergedColumnOrder(current: [String]?, incoming: [String]?) -> [String]? {
+        guard let incoming else { return current }
+        guard let current, !current.isEmpty else { return incoming }
+
+        let incomingSet = Set(incoming)
+        // Only a narrowing of the same column set is a partial capture worth splicing. Anything
+        // else is a different result, and merging there would accumulate names from a table the
+        // layout no longer describes.
+        guard incomingSet.isSubset(of: Set(current)) else { return incoming }
+        var remaining = incoming.makeIterator()
+        var merged: [String] = []
+        merged.reserveCapacity(max(current.count, incoming.count))
+
+        for name in current {
+            if incomingSet.contains(name) {
+                guard let next = remaining.next() else { continue }
+                merged.append(next)
+            } else {
+                merged.append(name)
+            }
+        }
+
+        let placed = Set(merged)
+        merged.append(contentsOf: incoming.filter { !placed.contains($0) })
+        return merged
+    }
+
     mutating func applyGeometry(from other: ColumnLayoutState) {
         columnWidths = other.columnWidths
         columnContentWidths = other.columnContentWidths
-        columnOrder = other.columnOrder
+        columnOrder = Self.mergedColumnOrder(current: columnOrder, incoming: other.columnOrder)
+    }
+
+    /// Drops the geometry outright. Reset is not a capture, so it must not go through the merge,
+    /// which deliberately keeps a stored order when a capture carries none.
+    mutating func resetGeometry() {
+        columnWidths = [:]
+        columnContentWidths = nil
+        columnOrder = nil
     }
 
     func mergingWidths(_ liveWidths: [String: CGFloat]) -> ColumnLayoutState {

--- a/TablePro/Models/UI/ColumnIdentitySchema.swift
+++ b/TablePro/Models/UI/ColumnIdentitySchema.swift
@@ -7,7 +7,20 @@ import AppKit
 
 struct ColumnIdentitySchema: Equatable {
     static let rowNumberIdentifier = NSUserInterfaceItemIdentifier("__rowNumber__")
+
+    /// Stand-ins for the columns the window leaves unmounted, holding their width so the document
+    /// keeps its full extent and the horizontal scroller still spans the whole result.
+    ///
+    /// Deliberately outside `dataColumnPrefix`: every loop that walks `tableView.tableColumns`
+    /// resolves a data index through `dataIndex(from:)` first, so a spacer is skipped by all of
+    /// them without any of those call sites learning about it.
+    static let leadingSpacerIdentifier = NSUserInterfaceItemIdentifier("__leadingSpacer__")
+    static let trailingSpacerIdentifier = NSUserInterfaceItemIdentifier("__trailingSpacer__")
     static let dataColumnPrefix = "dataColumn-"
+
+    static func isSpacer(_ identifier: NSUserInterfaceItemIdentifier) -> Bool {
+        identifier == leadingSpacerIdentifier || identifier == trailingSpacerIdentifier
+    }
 
     let identifiers: [NSUserInterfaceItemIdentifier]
     let columnNames: [String]

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ColumnVisibility.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ColumnVisibility.swift
@@ -89,7 +89,7 @@ extension MainContentCoordinator {
         guard let index = tabManager.tabs.firstIndex(where: { $0.id == target.tabId }),
               columnLayoutTableKey(for: tabManager.tabs[index]) == target.tableKey else { return }
         tabManager.mutate(at: index) { tab in
-            tab.columnLayout.applyGeometry(from: ColumnLayoutState())
+            tab.columnLayout.resetGeometry()
         }
     }
 

--- a/TablePro/Views/Results/Cells/DataGridCellContent.swift
+++ b/TablePro/Views/Results/Cells/DataGridCellContent.swift
@@ -22,7 +22,7 @@ struct DataGridCellContent {
         case .null:
             return .null
         case .text(let value):
-            if value == "__DEFAULT__" { return .defaultMarker }
+            if value == PluginCellValue.defaultMarkerText { return .defaultMarker }
             return value.isEmpty ? .empty : nil
         case .bytes:
             return nil

--- a/TablePro/Views/Results/ColumnWindowResolver.swift
+++ b/TablePro/Views/Results/ColumnWindowResolver.swift
@@ -1,0 +1,110 @@
+//
+//  ColumnWindowResolver.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Chooses which columns a wide result keeps mounted.
+///
+/// `NSTableView` virtualises rows but never columns: a prepared row builds one cell view for every
+/// column that is not hidden, whatever the horizontal viewport shows. At 500 columns that is
+/// ~18,000 live views, and every scroll frame lays out and draws all of them. Hidden columns cost
+/// almost nothing, so the fix is to keep only the columns near the viewport unhidden and give the
+/// document its full width back through a spacer at each end.
+///
+/// Pure on purpose: the geometry is the part worth testing, and it needs no table view to decide.
+internal enum ColumnWindowResolver {
+    /// Columns kept mounted on each side of the viewport, so a small scroll does not re-window.
+    internal static let overscan = 10
+
+    /// Columns of headroom that must remain between the viewport and the edge of the mounted range
+    /// before the window is left alone.
+    ///
+    /// Must stay below `overscan`, or the margin can never be satisfied and every scroll re-windows.
+    /// Sliding per column put the re-window tile inside the scroll frame and traded a steady cost
+    /// for an intermittent stall, so the window holds until this headroom is spent and then jumps
+    /// by a whole overscan.
+    internal static let slideMargin = 3
+
+    internal struct Window: Equatable {
+        let range: Range<Int>
+        let leadingWidth: CGFloat
+        let trailingWidth: CGFloat
+
+        internal static let empty = Window(range: 0..<0, leadingWidth: 0, trailingWidth: 0)
+    }
+
+    /// - Parameter current: the mounted range, so an unchanged decision returns it verbatim and the
+    ///   caller can skip the tile entirely.
+    internal static func resolve(
+        columnWidths: [CGFloat],
+        viewportMinX: CGFloat,
+        viewportWidth: CGFloat,
+        current: Range<Int>?
+    ) -> Window {
+        guard !columnWidths.isEmpty else { return .empty }
+        guard viewportWidth > 0 else {
+            return window(for: 0..<min(columnWidths.count, overscan * 2), columnWidths: columnWidths)
+        }
+
+        let visible = visibleRange(
+            columnWidths: columnWidths,
+            viewportMinX: max(0, viewportMinX),
+            viewportWidth: viewportWidth
+        )
+        let desired = padded(visible, count: columnWidths.count)
+
+        if let current, current.lowerBound <= visible.lowerBound, current.upperBound >= visible.upperBound {
+            let leadingSlack = visible.lowerBound - current.lowerBound
+            let trailingSlack = current.upperBound - visible.upperBound
+            let atStart = current.lowerBound == 0
+            let atEnd = current.upperBound == columnWidths.count
+            if (leadingSlack >= slideMargin || atStart) && (trailingSlack >= slideMargin || atEnd) {
+                return window(for: current, columnWidths: columnWidths)
+            }
+        }
+
+        return window(for: desired, columnWidths: columnWidths)
+    }
+
+    /// The columns the viewport actually intersects. Always at least one column, so a viewport
+    /// narrower than a single column still mounts the one under it.
+    private static func visibleRange(
+        columnWidths: [CGFloat],
+        viewportMinX: CGFloat,
+        viewportWidth: CGFloat
+    ) -> Range<Int> {
+        let viewportMaxX = viewportMinX + viewportWidth
+        var offset: CGFloat = 0
+        var first: Int?
+        var last = columnWidths.count - 1
+
+        for (index, width) in columnWidths.enumerated() {
+            let columnMaxX = offset + width
+            if first == nil, columnMaxX > viewportMinX {
+                first = index
+            }
+            if offset >= viewportMaxX {
+                last = max(index - 1, first ?? 0)
+                break
+            }
+            offset = columnMaxX
+        }
+
+        let lower = first ?? max(columnWidths.count - 1, 0)
+        return lower..<min(max(last + 1, lower + 1), columnWidths.count)
+    }
+
+    private static func padded(_ range: Range<Int>, count: Int) -> Range<Int> {
+        let lower = max(0, range.lowerBound - overscan)
+        let upper = min(count, range.upperBound + overscan)
+        return lower..<upper
+    }
+
+    private static func window(for range: Range<Int>, columnWidths: [CGFloat]) -> Window {
+        let leading = columnWidths[0..<range.lowerBound].reduce(0, +)
+        let trailing = columnWidths[range.upperBound...].reduce(0, +)
+        return Window(range: range, leadingWidth: leading, trailingWidth: trailing)
+    }
+}

--- a/TablePro/Views/Results/DataGridColumnPool.swift
+++ b/TablePro/Views/Results/DataGridColumnPool.swift
@@ -10,17 +10,60 @@ final class DataGridColumnPool {
     private var pooledColumns: [NSTableColumn] = []
     private weak var attachedTableView: NSTableView?
 
+    /// Columns the user hid, kept apart from the ones the window unmounts so a window slide can
+    /// never bring a hidden column back.
+    private var userHiddenIdentifiers: Set<NSUserInterfaceItemIdentifier> = []
+    /// Slots the current result actually uses. The pool only grows, so the surplus slots past the
+    /// result's column count stay attached and hidden, and windowing must never mount one.
+    private var activeIdentifiers: Set<NSUserInterfaceItemIdentifier> = []
+    private var windowedRange: Range<Int>?
+
+    private lazy var leadingSpacer = Self.makeSpacer(ColumnIdentitySchema.leadingSpacerIdentifier)
+    private lazy var trailingSpacer = Self.makeSpacer(ColumnIdentitySchema.trailingSpacerIdentifier)
+
     var totalSlots: Int { pooledColumns.count }
+
+    private static func makeSpacer(_ identifier: NSUserInterfaceItemIdentifier) -> NSTableColumn {
+        let column = NSTableColumn(identifier: identifier)
+        column.minWidth = 0
+        column.maxWidth = .greatestFiniteMagnitude
+        column.width = 0
+        column.resizingMask = []
+        column.isEditable = false
+        column.isHidden = true
+        // The data grid header owns all of its own chrome (#2017): NSTableHeaderCell paints a fixed
+        // 28pt band with a divider and a rule that land mid-cell in this header's 42pt. A spacer is
+        // normally off screen, but it must not be the one cell that asks AppKit to paint.
+        column.headerCell = SortableHeaderCell(textCell: "")
+        return column
+    }
 
     func attach(to tableView: NSTableView) {
         attachedTableView = tableView
     }
 
+    /// Whether the result presents this column at all, which is a different question from whether
+    /// the window currently has it mounted.
+    ///
+    /// `isHidden` answers both at once, and everything that asks "which columns is the user
+    /// looking at" (copy, find, cell navigation, size-all) means this one. Reading `isHidden`
+    /// there silently narrows those to the columns near the viewport.
+    func presentsColumn(_ column: NSTableColumn) -> Bool {
+        activeIdentifiers.contains(column.identifier) && !userHiddenIdentifiers.contains(column.identifier)
+    }
+
+    var hasUserHiddenColumns: Bool { !userHiddenIdentifiers.isEmpty }
+
     func detachFromTableView() {
         guard let tableView = attachedTableView else { return }
-        for column in pooledColumns where tableView.tableColumns.contains(column) {
+        let attached = Set(tableView.tableColumns.map(\.identifier))
+        for column in pooledColumns where attached.contains(column.identifier) {
             tableView.removeTableColumn(column)
         }
+        for spacer in [leadingSpacer, trailingSpacer] where attached.contains(spacer.identifier) {
+            tableView.removeTableColumn(spacer)
+        }
+        windowedRange = nil
         attachedTableView = nil
     }
 
@@ -36,6 +79,7 @@ final class DataGridColumnPool {
     ) {
         attach(to: tableView)
         let visibleCount = schema.columnNames.count
+        activeIdentifiers = Set(schema.identifiers)
 
         growBackingPoolIfNeeded(to: visibleCount)
 
@@ -61,6 +105,11 @@ final class DataGridColumnPool {
                     isEditable: isEditable
                 )
                 let hidden = hiddenFromLayout.contains(columnName) || hiddenColumnNames.contains(columnName)
+                if hidden {
+                    userHiddenIdentifiers.insert(column.identifier)
+                } else {
+                    userHiddenIdentifiers.remove(column.identifier)
+                }
                 if column.isHidden != hidden {
                     column.isHidden = hidden
                 }
@@ -87,6 +136,94 @@ final class DataGridColumnPool {
             visibleCount: visibleCount,
             targetOrder: targetOrder
         )
+
+        windowedRange = nil
+        applyColumnWindow(in: tableView)
+    }
+
+    /// Unmounts the columns the viewport cannot reach and gives their width to the spacers.
+    ///
+    /// `NSTableView` builds a cell view per non-hidden column for every prepared row, so a 500
+    /// column result holds ~18,000 live views and lays all of them out on every scroll frame.
+    /// Hiding the far ones is measurably close to free; the spacers keep the document width and
+    /// therefore the scroll extent identical to mounting everything.
+    func applyColumnWindow(in tableView: NSTableView) {
+        let candidates = tableView.tableColumns.filter {
+            activeIdentifiers.contains($0.identifier) && !userHiddenIdentifiers.contains($0.identifier)
+        }
+        guard !candidates.isEmpty else {
+            hideSpacers()
+            return
+        }
+
+        let viewport = tableView.enclosingScrollView?.contentView.bounds ?? tableView.visibleRect
+        guard viewport.width > 0 else {
+            unmountNothing(candidates)
+            return
+        }
+
+        // The document starts at the row-number column, but the resolver measures from the first
+        // data column, so the viewport has to be rebased before it can index into these widths.
+        let leadingChrome = tableView.tableColumns
+            .prefix { $0.identifier != candidates[0].identifier }
+            .filter { !$0.isHidden }
+            .reduce(0) { $0 + $1.width + tableView.intercellSpacing.width }
+
+        // A mounted column contributes its width plus one intercell gap; a hidden one contributes
+        // nothing. A spacer standing in for N columns has to carry their gaps too, or the document
+        // ends up short and the last columns cannot be reached.
+        let spacing = tableView.intercellSpacing.width
+        let window = ColumnWindowResolver.resolve(
+            columnWidths: candidates.map { $0.width + spacing },
+            viewportMinX: viewport.minX - leadingChrome,
+            viewportWidth: viewport.width,
+            current: windowedRange
+        )
+        guard window.range != windowedRange else { return }
+        windowedRange = window.range
+
+        for (index, column) in candidates.enumerated() {
+            let mounted = window.range.contains(index)
+            if column.isHidden == mounted {
+                column.isHidden = !mounted
+            }
+        }
+        applySpacer(leadingSpacer, width: spacerWidth(window.leadingWidth, spacing: spacing), in: tableView)
+        applySpacer(trailingSpacer, width: spacerWidth(window.trailingWidth, spacing: spacing), in: tableView)
+    }
+
+    /// The resolver works in per-column slots that already include one gap each. A spacer is a
+    /// single column, so it keeps one gap of its own and absorbs the rest as width.
+    private func spacerWidth(_ slotWidth: CGFloat, spacing: CGFloat) -> CGFloat {
+        guard slotWidth > 0 else { return 0 }
+        return max(0, slotWidth - spacing)
+    }
+
+    /// A table that has not been laid out yet reports no viewport, and windowing against that would
+    /// hide every column. Mount everything until there is a real width to measure against.
+    private func unmountNothing(_ candidates: [NSTableColumn]) {
+        windowedRange = nil
+        for column in candidates where column.isHidden {
+            column.isHidden = false
+        }
+        hideSpacers()
+    }
+
+    private func applySpacer(_ spacer: NSTableColumn, width: CGFloat, in tableView: NSTableView) {
+        if spacer.width != width {
+            spacer.width = width
+        }
+        let hidden = width <= 0
+        if spacer.isHidden != hidden {
+            spacer.isHidden = hidden
+        }
+    }
+
+    private func hideSpacers() {
+        for spacer in [leadingSpacer, trailingSpacer] where !spacer.isHidden {
+            spacer.isHidden = true
+            spacer.width = 0
+        }
     }
 
     private func growBackingPoolIfNeeded(to count: Int) {
@@ -145,6 +282,11 @@ final class DataGridColumnPool {
             attached.insert(pooledColumns[slot].identifier)
         }
 
+        for spacer in [leadingSpacer, trailingSpacer] where !attached.contains(spacer.identifier) {
+            tableView.addTableColumn(spacer)
+            attached.insert(spacer.identifier)
+        }
+
         NSAnimationContext.beginGrouping()
         NSAnimationContext.current.duration = 0
         NSAnimationContext.current.allowsImplicitAnimation = false
@@ -166,6 +308,22 @@ final class DataGridColumnPool {
             tableView.moveColumn(currentIndex, toColumn: desiredIndex)
             updateIndexMap(&indexByIdentifier, movedFrom: currentIndex, to: desiredIndex)
         }
+
+        positionSpacers(in: tableView, baseOffset: baseOffset)
+    }
+
+    /// The leading spacer stands in for everything scrolled off to the left, so it has to sit ahead
+    /// of the first data column; the trailing spacer holds the rest and sits last.
+    private func positionSpacers(in tableView: NSTableView, baseOffset: Int) {
+        move(leadingSpacer, to: baseOffset, in: tableView)
+        move(trailingSpacer, to: tableView.tableColumns.count - 1, in: tableView)
+    }
+
+    private func move(_ column: NSTableColumn, to index: Int, in tableView: NSTableView) {
+        guard let current = tableView.tableColumns.firstIndex(of: column) else { return }
+        let clamped = max(0, min(index, tableView.tableColumns.count - 1))
+        guard current != clamped else { return }
+        tableView.moveColumn(current, toColumn: clamped)
     }
 
     private func updateIndexMap(

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -102,10 +102,18 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         identitySchema.dataIndex(from: identifier)
     }
 
+    /// Whether the result presents this column, regardless of whether the window has it mounted.
+    func presentsColumn(_ column: NSTableColumn) -> Bool {
+        columnPool.presentsColumn(column)
+    }
+
+    /// The columns the user is looking at, which is every presented column and not merely the
+    /// mounted ones. Copy, find and size-all all read this, so narrowing it to the window would
+    /// silently drop the columns off screen from a copied row or a search.
     func visibleColumnDataIndices() -> [Int]? {
         guard let tableView else { return nil }
         return tableView.tableColumns
-            .filter { !$0.isHidden && $0.identifier != ColumnIdentitySchema.rowNumberIdentifier }
+            .filter { presentsColumn($0) }
             .compactMap { dataColumnIndex(from: $0.identifier) }
     }
 
@@ -709,7 +717,36 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
                 self?.schedulePrewarmResume()
             }
         }
-        scrollObservers = [start, end]
+        scrollView.contentView.postsBoundsChangedNotifications = true
+        let bounds = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.updateColumnWindow()
+            }
+        }
+        // A bounds change is scrolling; a frame change is the viewport resizing. Widening the
+        // window exposes area the window never covered, and only this fires for that.
+        scrollView.contentView.postsFrameChangedNotifications = true
+        let frame = NotificationCenter.default.addObserver(
+            forName: NSView.frameDidChangeNotification,
+            object: scrollView.contentView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.updateColumnWindow()
+            }
+        }
+        scrollObservers = [start, end, bounds, frame]
+    }
+
+    /// Re-mounts the columns the viewport can now reach. The resolver keeps the range stable while
+    /// the viewport stays inside its margin, so most scroll frames return without touching a column.
+    func updateColumnWindow() {
+        guard let tableView, !isRebuildingColumns else { return }
+        columnPool.applyColumnWindow(in: tableView)
     }
 
     private func detachScrollObservers() {

--- a/TablePro/Views/Results/Extensions/DataGridView+Sort.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Sort.swift
@@ -197,7 +197,7 @@ extension TableViewCoordinator {
         menu.addItem(hideItem)
 
         if delegate != nil,
-           tableView.tableColumns.contains(where: { $0.isHidden && $0.identifier != ColumnIdentitySchema.rowNumberIdentifier }) {
+           columnPool.hasUserHiddenColumns {
             let showAllItem = NSMenuItem(
                 title: String(localized: "Show All Columns"),
                 action: #selector(showAllColumns),
@@ -362,8 +362,7 @@ extension TableViewCoordinator {
 
         let tableRows = tableRowsProvider()
         for column in tableView.tableColumns {
-            guard !column.isHidden,
-                  column.identifier != ColumnIdentitySchema.rowNumberIdentifier,
+            guard presentsColumn(column),
                   let dataColumnIndex = dataColumnIndex(from: column.identifier),
                   dataColumnIndex < tableRows.columns.count else { continue }
 

--- a/TablePro/Views/Results/KeyHandlingTableView.swift
+++ b/TablePro/Views/Results/KeyHandlingTableView.swift
@@ -502,7 +502,7 @@ final class KeyHandlingTableView: NSTableView {
     private func isVisibleDataColumn(at index: Int) -> Bool {
         guard index >= 0, index < numberOfColumns else { return false }
         let column = tableColumns[index]
-        return !column.isHidden && column.identifier != ColumnIdentitySchema.rowNumberIdentifier
+        return coordinator?.presentsColumn(column) ?? !column.isHidden
     }
 
     /// `NSResponder` declares these two but does not implement them, so calling `super` raises

--- a/TableProTests/Core/Utilities/JsonRowConverterTests.swift
+++ b/TableProTests/Core/Utilities/JsonRowConverterTests.swift
@@ -371,4 +371,31 @@ struct JsonRowConverterTests {
         #expect(result.contains("\"\(expected)\""))
         #expect(!result.contains("null"))
     }
+
+    // MARK: - Default-value marker
+
+    /// A pending inserted row carries the default marker for columns the server fills in. The grid
+    /// draws it as a placeholder, so JSON has to agree instead of printing the internal token.
+    @Test("The default-value marker renders as null, not as literal text")
+    func defaultMarkerRendersAsNull() {
+        let converter = makeConverter(
+            columns: ["id", "name"],
+            columnTypes: [.integer(rawType: nil), .text(rawType: nil)]
+        )
+        let result = converter.generateJson(
+            rows: [[.text(PluginCellValue.defaultMarkerText), .text("Ada")]]
+        )
+
+        #expect(!result.contains(PluginCellValue.defaultMarkerText))
+        #expect(result.contains("\"id\": null"))
+        #expect(result.contains("\"Ada\""))
+    }
+
+    @Test("A value that merely resembles the marker is untouched")
+    func markerLookalikeIsPreserved() {
+        let converter = makeConverter(columns: ["name"], columnTypes: [.text(rawType: nil)])
+        let result = converter.generateJson(rows: [[.text("__DEFAULT")]])
+
+        #expect(result.contains("\"__DEFAULT\""))
+    }
 }

--- a/TableProTests/Models/ColumnOrderMergeTests.swift
+++ b/TableProTests/Models/ColumnOrderMergeTests.swift
@@ -1,0 +1,108 @@
+//
+//  ColumnOrderMergeTests.swift
+//  TableProTests
+//
+//  A captured column order only lists the columns the query returned, so hiding a column takes it
+//  out of the capture. Writing the capture over the stored order therefore erased the hidden
+//  column's position for good, and Show All appended it at the end of a grid the user had arranged.
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Column order merge")
+struct ColumnOrderMergeTests {
+    @Test("A column missing from the capture keeps its stored position")
+    func absentColumnKeepsItsSlot() {
+        let merged = ColumnLayoutState.mergedColumnOrder(
+            current: ["id", "notes", "name", "email"],
+            incoming: ["id", "name", "email"]
+        )
+        #expect(merged == ["id", "notes", "name", "email"])
+    }
+
+    @Test("The capture's own order wins for the columns it covers")
+    func captureReordersWhatItCovers() {
+        let merged = ColumnLayoutState.mergedColumnOrder(
+            current: ["id", "notes", "name", "email"],
+            incoming: ["email", "id", "name"]
+        )
+        #expect(merged == ["email", "notes", "id", "name"])
+    }
+
+    /// Only a narrowing of the same set is a partial capture. A capture naming a column the stored
+    /// order never had describes a different result, so it replaces rather than accumulating names
+    /// from a table this layout no longer describes.
+    @Test("A capture with a new column replaces the stored order")
+    func newColumnReplacesOrder() {
+        let merged = ColumnLayoutState.mergedColumnOrder(
+            current: ["id", "name"],
+            incoming: ["id", "name", "created_at"]
+        )
+        #expect(merged == ["id", "name", "created_at"])
+    }
+
+    @Test("A capture for a different table replaces the stored order outright")
+    func differentTableReplacesOrder() {
+        let merged = ColumnLayoutState.mergedColumnOrder(
+            current: ["id", "name"],
+            incoming: ["email"]
+        )
+        #expect(merged == ["email"])
+    }
+
+    @Test("No stored order adopts the capture wholesale")
+    func emptyCurrentAdoptsIncoming() {
+        #expect(ColumnLayoutState.mergedColumnOrder(current: nil, incoming: ["a", "b"]) == ["a", "b"])
+        #expect(ColumnLayoutState.mergedColumnOrder(current: [], incoming: ["a", "b"]) == ["a", "b"])
+    }
+
+    @Test("No capture leaves the stored order alone")
+    func nilIncomingKeepsCurrent() {
+        #expect(ColumnLayoutState.mergedColumnOrder(current: ["a", "b"], incoming: nil) == ["a", "b"])
+    }
+
+    /// The reported sequence: arrange the grid, hide a column, then drag another. The capture that
+    /// follows the drag omits the hidden column, and before the merge that dropped it permanently.
+    @Test("Hiding then reordering does not lose the hidden column's place")
+    func hideThenReorderKeepsHiddenColumn() {
+        let arranged = ["id", "notes", "name", "email", "created_at"]
+        let afterHidingNotesAndDraggingEmail = ["email", "id", "name", "created_at"]
+
+        let merged = ColumnLayoutState.mergedColumnOrder(
+            current: arranged,
+            incoming: afterHidingNotesAndDraggingEmail
+        )
+
+        #expect(merged?.contains("notes") == true)
+        #expect(merged?.firstIndex(of: "notes") == 1)
+    }
+
+    /// Reset is not a capture. Routing it through the merge made "clear the layout" a no-op, so a
+    /// DDL column reorder kept the order from before the change.
+    @Test("resetGeometry clears the order the merge would have kept")
+    func resetClearsOrder() {
+        var stored = ColumnLayoutState()
+        stored.columnOrder = ["id", "notes", "name"]
+        stored.columnWidths = ["id": 80]
+
+        stored.resetGeometry()
+
+        #expect(stored.columnOrder == nil)
+        #expect(stored.columnWidths.isEmpty)
+    }
+
+    @Test("applyGeometry merges rather than replacing the order")
+    func applyGeometryMerges() {
+        var stored = ColumnLayoutState()
+        stored.columnOrder = ["id", "notes", "name"]
+
+        var captured = ColumnLayoutState()
+        captured.columnOrder = ["name", "id"]
+
+        stored.applyGeometry(from: captured)
+
+        #expect(stored.columnOrder == ["name", "notes", "id"])
+    }
+}

--- a/TableProTests/Views/Results/ColumnWindowResolverTests.swift
+++ b/TableProTests/Views/Results/ColumnWindowResolverTests.swift
@@ -1,0 +1,156 @@
+//
+//  ColumnWindowResolverTests.swift
+//  TableProTests
+//
+//  NSTableView virtualises rows but never columns, so a 500-column result mounts a cell view per
+//  column per prepared row and every scroll frame lays all of them out. The window keeps the
+//  document's full width through spacers, so scroll extent has to survive every decision here.
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Column window resolver")
+struct ColumnWindowResolverTests {
+    private let wide = Array(repeating: CGFloat(100), count: 500)
+
+    private func totalWidth(_ window: ColumnWindowResolver.Window, widths: [CGFloat]) -> CGFloat {
+        let mounted = widths[window.range].reduce(0, +)
+        return window.leadingWidth + mounted + window.trailingWidth
+    }
+
+    @Test("No columns resolves to an empty window")
+    func emptyColumns() {
+        let window = ColumnWindowResolver.resolve(
+            columnWidths: [], viewportMinX: 0, viewportWidth: 800, current: nil
+        )
+        #expect(window == .empty)
+    }
+
+    @Test("A window mounts far fewer columns than the result has")
+    func windowIsSmall() {
+        let window = ColumnWindowResolver.resolve(
+            columnWidths: wide, viewportMinX: 0, viewportWidth: 800, current: nil
+        )
+        #expect(window.range.count < 50)
+        #expect(window.range.lowerBound == 0)
+    }
+
+    /// The spacers exist so the horizontal scroller still spans the whole result. If this drifts,
+    /// the grid silently loses columns the user can no longer reach.
+    @Test(
+        "Document width is preserved at every scroll position",
+        arguments: [CGFloat(0), 1_000, 24_950, 49_200]
+    )
+    func documentWidthPreserved(minX: CGFloat) {
+        let window = ColumnWindowResolver.resolve(
+            columnWidths: wide, viewportMinX: minX, viewportWidth: 800, current: nil
+        )
+        #expect(totalWidth(window, widths: wide) == 50_000)
+    }
+
+    @Test("Document width is preserved for 0, 1, 50 and 500 columns")
+    func documentWidthAcrossColumnCounts() {
+        for count in [1, 50, 500] {
+            let widths = Array(repeating: CGFloat(100), count: count)
+            let window = ColumnWindowResolver.resolve(
+                columnWidths: widths, viewportMinX: 0, viewportWidth: 800, current: nil
+            )
+            #expect(totalWidth(window, widths: widths) == CGFloat(count) * 100)
+        }
+    }
+
+    @Test("The window covers the columns under the viewport")
+    func windowCoversViewport() {
+        let window = ColumnWindowResolver.resolve(
+            columnWidths: wide, viewportMinX: 10_000, viewportWidth: 800, current: nil
+        )
+        #expect(window.range.contains(100))
+        #expect(window.range.contains(107))
+    }
+
+    @Test("Scrolled to the far end the window stops at the last column")
+    func windowClampsAtEnd() {
+        let window = ColumnWindowResolver.resolve(
+            columnWidths: wide, viewportMinX: 49_200, viewportWidth: 800, current: nil
+        )
+        #expect(window.range.upperBound == 500)
+        #expect(window.trailingWidth == 0)
+    }
+
+    // MARK: - Hysteresis
+
+    /// Re-windowing costs a tile, and doing it per column put that tile inside the scroll frame.
+    @Test("A small scroll inside the mounted range does not move the window")
+    func smallScrollKeepsWindow() {
+        let first = ColumnWindowResolver.resolve(
+            columnWidths: wide, viewportMinX: 10_000, viewportWidth: 800, current: nil
+        )
+        let second = ColumnWindowResolver.resolve(
+            columnWidths: wide, viewportMinX: 10_100, viewportWidth: 800, current: first.range
+        )
+        #expect(second.range == first.range)
+    }
+
+    @Test("Scrolling past the margin moves the window")
+    func largeScrollMovesWindow() {
+        let first = ColumnWindowResolver.resolve(
+            columnWidths: wide, viewportMinX: 10_000, viewportWidth: 800, current: nil
+        )
+        let second = ColumnWindowResolver.resolve(
+            columnWidths: wide, viewportMinX: 20_000, viewportWidth: 800, current: first.range
+        )
+        #expect(second.range != first.range)
+        #expect(second.range.contains(200))
+    }
+
+    /// The margin has to be smaller than the overscan, or it can never be satisfied and every
+    /// scroll re-windows. That is exactly what the first version of this did.
+    @Test("The slide margin leaves room to move inside the mounted window")
+    func marginFitsInsideOverscan() {
+        #expect(ColumnWindowResolver.slideMargin < ColumnWindowResolver.overscan)
+    }
+
+    @Test("A window already at the start does not slide just because there is no leading margin")
+    func atStartDoesNotThrash() {
+        let first = ColumnWindowResolver.resolve(
+            columnWidths: wide, viewportMinX: 0, viewportWidth: 800, current: nil
+        )
+        let second = ColumnWindowResolver.resolve(
+            columnWidths: wide, viewportMinX: 0, viewportWidth: 800, current: first.range
+        )
+        #expect(second.range == first.range)
+        #expect(second.leadingWidth == 0)
+    }
+
+    @Test("A viewport wider than the result mounts everything")
+    func viewportWiderThanResult() {
+        let widths = Array(repeating: CGFloat(100), count: 20)
+        let window = ColumnWindowResolver.resolve(
+            columnWidths: widths, viewportMinX: 0, viewportWidth: 5_000, current: nil
+        )
+        #expect(window.range == 0..<20)
+        #expect(window.leadingWidth == 0)
+        #expect(window.trailingWidth == 0)
+    }
+
+    @Test("Uneven column widths still preserve the document width")
+    func unevenWidths() {
+        let widths: [CGFloat] = (0..<200).map { CGFloat(40 + ($0 % 7) * 30) }
+        let expected = widths.reduce(0, +)
+        let window = ColumnWindowResolver.resolve(
+            columnWidths: widths, viewportMinX: 3_000, viewportWidth: 700, current: nil
+        )
+        #expect(totalWidth(window, widths: widths) == expected)
+    }
+
+    @Test("A zero-width viewport still mounts a usable window")
+    func zeroWidthViewport() {
+        let window = ColumnWindowResolver.resolve(
+            columnWidths: wide, viewportMinX: 0, viewportWidth: 0, current: nil
+        )
+        #expect(!window.range.isEmpty)
+        #expect(totalWidth(window, widths: wide) == 50_000)
+    }
+}

--- a/TableProTests/Views/Results/DataGridColumnPoolTests.swift
+++ b/TableProTests/Views/Results/DataGridColumnPoolTests.swift
@@ -14,6 +14,9 @@ import Testing
 struct DataGridColumnPoolTests {
     private func makeTableView() -> NSTableView {
         let tableView = NSTableView()
+        // Mirrors DataGridView. The default style redistributes column widths on resize, which
+        // would silently rewrite the widths these tests assert on.
+        tableView.columnAutoresizingStyle = .noColumnAutoresizing
         let rowNumberColumn = NSTableColumn(identifier: ColumnIdentitySchema.rowNumberIdentifier)
         rowNumberColumn.width = 40
         tableView.addTableColumn(rowNumberColumn)
@@ -29,7 +32,10 @@ struct DataGridColumnPoolTests {
     }
 
     private func dataColumns(in tableView: NSTableView) -> [NSTableColumn] {
-        tableView.tableColumns.filter { $0.identifier != ColumnIdentitySchema.rowNumberIdentifier }
+        tableView.tableColumns.filter {
+            $0.identifier != ColumnIdentitySchema.rowNumberIdentifier
+                && !ColumnIdentitySchema.isSpacer($0.identifier)
+        }
     }
 
     @Test("reconcile grows pool when column count exceeds capacity")
@@ -635,5 +641,172 @@ struct DataGridColumnPoolTests {
         )
         #expect(dataColumns(in: tableView).count == 3)
         #expect(pool.totalSlots == 3)
+    }
+
+    // MARK: - Column windowing (#1219)
+
+    private func makeScrolledTableView(viewportWidth: CGFloat) -> (NSScrollView, NSTableView) {
+        let tableView = makeTableView()
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: viewportWidth, height: 600))
+        scrollView.documentView = tableView
+        scrollView.hasHorizontalScroller = true
+        scrollView.layoutSubtreeIfNeeded()
+        return (scrollView, tableView)
+    }
+
+    private func reconcileWide(
+        _ pool: DataGridColumnPool,
+        tableView: NSTableView,
+        count: Int,
+        hidden: Set<String> = []
+    ) {
+        let names = (0..<count).map { "c\($0)" }
+        pool.reconcile(
+            tableView: tableView,
+            schema: ColumnIdentitySchema(columns: names),
+            columnTypes: makeColumnTypes(count: count),
+            savedLayout: nil,
+            isEditable: true,
+            hiddenColumnNames: hidden,
+            widthCalculator: defaultWidthCalculator
+        )
+    }
+
+    private func spacerWidth(in tableView: NSTableView) -> CGFloat {
+        tableView.tableColumns
+            .filter { ColumnIdentitySchema.isSpacer($0.identifier) }
+            .reduce(0) { $0 + $1.width }
+    }
+
+    /// NSTableView builds a cell view per non-hidden column for every prepared row, so the whole
+    /// point is that a wide result leaves most columns unmounted.
+    @Test("A wide result mounts far fewer columns than it has")
+    func wideResultMountsAWindow() {
+        let pool = DataGridColumnPool()
+        let (_, tableView) = makeScrolledTableView(viewportWidth: 800)
+
+        reconcileWide(pool, tableView: tableView, count: 500)
+
+        let mounted = dataColumns(in: tableView).filter { !$0.isHidden }
+        #expect(mounted.count < 60)
+        #expect(!mounted.isEmpty)
+    }
+
+    /// The spacers exist so the horizontal scroller still spans the whole result. Lose this and the
+    /// user cannot reach the columns the window left out.
+    @Test("The spacers restore the width the window left out")
+    func spacersPreserveDocumentWidth() {
+        let pool = DataGridColumnPool()
+        let (_, tableView) = makeScrolledTableView(viewportWidth: 800)
+
+        reconcileWide(pool, tableView: tableView, count: 500)
+
+        // A visible column occupies its width plus one intercell gap; a hidden one occupies
+        // nothing. The spacers stand in for the unmounted columns, gaps included, so the two
+        // layouts have to come to the same total.
+        let gap = tableView.intercellSpacing.width
+        let columns = dataColumns(in: tableView)
+        let everyColumnSlot = columns.reduce(0) { $0 + $1.width + gap }
+        let occupied = tableView.tableColumns
+            .filter { !$0.isHidden && $0.identifier != ColumnIdentitySchema.rowNumberIdentifier }
+            .reduce(0) { $0 + $1.width + gap }
+
+        #expect(columns.count == 500)
+        #expect(spacerWidth(in: tableView) > 0)
+        #expect(columns.filter { !$0.isHidden }.count < columns.count)
+        #expect(occupied == everyColumnSlot)
+    }
+
+    @Test("A narrow result mounts every column and needs no spacer")
+    func narrowResultMountsEverything() {
+        let pool = DataGridColumnPool()
+        let (_, tableView) = makeScrolledTableView(viewportWidth: 800)
+
+        reconcileWide(pool, tableView: tableView, count: 4)
+
+        let allMounted = dataColumns(in: tableView).allSatisfy { !$0.isHidden }
+        #expect(allMounted)
+        #expect(spacerWidth(in: tableView) == 0)
+    }
+
+    /// A window slide must never bring back a column the user hid, which is the one way windowing
+    /// could corrupt the visible column set.
+    @Test("Windowing never un-hides a column the user hid")
+    func windowNeverUnhidesUserHiddenColumn() {
+        let pool = DataGridColumnPool()
+        let (scrollView, tableView) = makeScrolledTableView(viewportWidth: 800)
+
+        reconcileWide(pool, tableView: tableView, count: 500, hidden: ["c0", "c1", "c2"])
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: 0))
+        pool.applyColumnWindow(in: tableView)
+
+        let hiddenByUser = dataColumns(in: tableView).prefix(3)
+        let allStillHidden = hiddenByUser.allSatisfy { $0.isHidden }
+        #expect(allStillHidden)
+    }
+
+    @Test("A table with no laid-out viewport mounts everything rather than hiding it all")
+    func noViewportMountsEverything() {
+        let pool = DataGridColumnPool()
+        let tableView = makeTableView()
+
+        reconcileWide(pool, tableView: tableView, count: 120)
+
+        let allMounted = dataColumns(in: tableView).allSatisfy { !$0.isHidden }
+        #expect(allMounted)
+    }
+
+    /// Copy, Find, cell navigation and Size All Columns to Fit all ask "which columns is the user
+    /// looking at". Answering that with isHidden narrows them to the mounted window, which silently
+    /// drops the off-screen columns from a copied row and makes Find miss them entirely.
+    @Test("Every column the result shows is presented, even when the window unmounts it")
+    func unmountedColumnsAreStillPresented() {
+        let pool = DataGridColumnPool()
+        let (_, tableView) = makeScrolledTableView(viewportWidth: 800)
+
+        reconcileWide(pool, tableView: tableView, count: 500)
+
+        let columns = dataColumns(in: tableView)
+        let presented = columns.filter { pool.presentsColumn($0) }
+        let mounted = columns.filter { !$0.isHidden }
+
+        #expect(presented.count == 500)
+        #expect(mounted.count < presented.count)
+    }
+
+    @Test("A column the user hid is not presented")
+    func userHiddenColumnIsNotPresented() {
+        let pool = DataGridColumnPool()
+        let (_, tableView) = makeScrolledTableView(viewportWidth: 800)
+
+        reconcileWide(pool, tableView: tableView, count: 20, hidden: ["c3"])
+
+        let presented = dataColumns(in: tableView).filter { pool.presentsColumn($0) }
+        #expect(presented.count == 19)
+        #expect(pool.hasUserHiddenColumns)
+    }
+
+    @Test("A surplus slot from a wider result is not presented")
+    func surplusSlotIsNotPresented() {
+        let pool = DataGridColumnPool()
+        let (_, tableView) = makeScrolledTableView(viewportWidth: 800)
+
+        reconcileWide(pool, tableView: tableView, count: 40)
+        reconcileWide(pool, tableView: tableView, count: 5)
+
+        let presented = dataColumns(in: tableView).filter { pool.presentsColumn($0) }
+        #expect(presented.count == 5)
+    }
+
+    @Test("Detaching removes the spacers along with the pooled columns")
+    func detachRemovesSpacers() {
+        let pool = DataGridColumnPool()
+        let (_, tableView) = makeScrolledTableView(viewportWidth: 800)
+
+        reconcileWide(pool, tableView: tableView, count: 60)
+        pool.detachFromTableView()
+
+        let hasSpacer = tableView.tableColumns.contains(where: { ColumnIdentitySchema.isSpacer($0.identifier) })
+        #expect(!hasSpacer)
     }
 }

--- a/docs/features/data-grid.mdx
+++ b/docs/features/data-grid.mdx
@@ -60,7 +60,9 @@ Hide columns from the columns button in the status bar or the header menu. A hid
 
 On a schemaless store such as MongoDB, the popover lists every field the grid can draw, including ones that only turn up in later documents, so **Hide All** covers all of them.
 
-Column widths, order, and which columns are hidden are remembered per table, scoped to the connection, database, and schema. Click **Reset Columns** in the columns popover to put everything back to defaults.
+Column widths, order, and which columns are hidden are remembered per table, scoped to the connection, database, and schema. Hiding a column keeps its place in that order, so showing it again puts it back where it was. Click **Reset Columns** in the columns popover to put everything back to defaults.
+
+A result with hundreds of columns only builds the ones near the viewport, so scrolling stays smooth on very wide tables. The horizontal scroller still covers the whole result, and columns are built as you reach them.
 
 ### Display Format
 


### PR DESCRIPTION
Fixes #1219.

Three fixes in the data grid, plus a script line. Two came from investigating #2234; #1219 is the reported one.

## Scrolling a wide result (#1219)

`NSTableView` virtualises rows but never columns. A prepared row builds one cell view for every column that is not hidden, whatever the horizontal viewport actually shows, so a 500-column result holds roughly 18,000 live cell views and lays all of them out on every scroll frame. Neither #1726 nor #1742 touched this: both are per-row costs, and the cost here is per-column.

Only the columns near the viewport are mounted now. The rest are hidden, which is measurably close to free, and a spacer column at each end carries their width so the document keeps its full extent and the horizontal scroller still spans the whole result.

`ColumnWindowResolver` owns the geometry and is pure, because that is the part worth testing: which columns the viewport intersects, how much overscan to keep, and when the window is allowed to slide. The window holds while the viewport stays inside its margin, then jumps by a whole overscan. Sliding per column puts the re-window tile inside the scroll frame and trades a steady cost for an intermittent stall.

**`isHidden` could not carry this on its own.** It already meant "the user hid this column", and windowing would have overloaded it to also mean "not near the viewport". Six call sites read it and would have quietly changed meaning: Copy Row, Copy with Headers and Copy as JSON would have put only the mounted columns on the clipboard and silently dropped the rest of a 500-column row; `Cmd+F` would have reported no matches for a value in column 300 while scrolled to column 5; Shift-Tab and Left-arrow would have landed on the edge of the window instead of the real last column; Size All Columns to Fit would have fitted the window and persisted a half-fitted layout. `presentsColumn(_:)` is now the predicate those sites ask, and it answers "the result shows this column" independently of what is mounted.

Three more things made this safer than it looks:

- Every loop over `tableView.tableColumns` in the app already resolves a data index through `dataColumnIndex(from:)` or casts to `SortableHeaderCell` first. The spacers own identifiers outside `dataColumnPrefix`, so `captureColumnLayout`, the value-filter indicators, column selection and the sort indicators all skip them with no change at those call sites.
- Columns the user hid are tracked separately from columns the window unmounted, so a window slide can never bring a hidden column back.
- Only columns in the current result are windowed. The pool never shrinks, so the surplus slots from a previously wider result stay attached and hidden, and mounting one would resurrect a column that is not in this result.

Also fixed here: `detachFromTableView` was `O(columns^2)`, 250,000 identity comparisons at 500 columns.

## A hidden column lost its place in the column order

`captureColumnLayout` builds the order from the columns the query returned, and hiding a column takes it out of that query. Both sinks then wrote that partial order over the stored one: `ColumnLayoutState.applyGeometry` in memory and `FileColumnLayoutPersister.save` on disk. So hiding two columns and dragging a third erased the hidden columns' positions for good, and Show All appended them at the far right of a grid the user had arranged.

`mergedColumnOrder` splices a capture into the stored order, keeping names the capture never saw. It only splices when the capture is a **narrowing of the same column set**; a capture naming a column the stored order never had describes a different result and replaces it outright, which is what `FileColumnLayoutPersisterTests.saveOverwritesExistingEntry` already pinned. `applyGeometry` deliberately preserves `hiddenColumns` for the same reason, so this follows a precedent that was already there.

## JSON printed an internal marker as data

A pending inserted row carries `__DEFAULT__` for the columns the server fills in. The grid draws that as a placeholder; `JsonRowConverter` had no idea about it and printed the token as a string value. It renders as `null` now, and the sentinel has one named home shared with the grid's reader instead of a thirteenth string literal. Deliberately app-side rather than on `PluginCellValue` in PluginKit, so there is no ABI surface and no plugin re-release.

## worktree.sh

A fresh worktree could not build `AllPlugins`: `Native/DamengBridge/lib` is gitignored and was not among the paths the script links, so `DamengDriver` failed on a missing `libdameng_bridge.a` that reads like a broken change.

## Verification

Run through `verify.sh` in an isolated worktree rebased on `dfbdca780`.

- `generate` PASS, `build` PASS
- `test` PASS, **148 of 148**: ColumnWindowResolverTests, DataGridColumnPoolTests, ColumnOrderMergeTests, JsonRowConverterTests, ColumnLayoutStateTests, FileColumnLayoutPersisterTests, ColumnLayoutSyncTests, ResultsJsonViewTests, DataGridPerformanceTests, DataGridUpdateSnapshotTests
- `swiftlint --strict` clean over every touched file

New tests pin the parts that would break quietly: the document width is preserved at every scroll extreme and for 1, 50 and 500 columns; the window holds through a small scroll and moves through a large one; the slide margin stays below the overscan; a user-hidden column survives a window slide; a table with no laid-out viewport mounts everything rather than hiding it all; the spacers are removed on teardown; and a hidden column keeps its position through a capture.

**On the numbers, to be precise about what is and is not measured here.** The investigation measured the problem and prototyped the fix: 500 visible columns gave 7.24ms p50 and 37.8ms mean per vertical scroll frame with 18,000 live cell views, against 0.479ms p50 at 50 columns, and a windowing prototype brought that to 0.479ms p50, 1.293ms mean and 1,152 subviews. Those are the prototype's numbers, not this implementation's. I have no 500-column ClickHouse table to measure this branch against, and horizontal scrolling is not deterministic enough for a `TableProUITests` case, so what is verified here is the geometry and the pool behaviour, not a frame time. Worth a look on a real wide table before release.

The reporter last confirmed the lag on 0.39.1 and has not said which version they retested on, so their confirmation on a current build is still worth having either way.
