### PR TITLE
fix(tabs): keep the sort and page of a restored tab you never opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reopening a session keeps the sort and the page number on every restored tab, not just the one that was in front. The others held their saved sort and page until you clicked them, and the next save wrote the tab out without either, so a tab you did not visit lost them for good.
+- A restored tab reopens on the rows it was showing. The page number was saved without the page size it was counted in, so a tab left on page 12 of 100 rows came back as page 12 of the default 1,000 and landed 11,000 rows further down, usually on an empty grid.
 - Scrolling a result with hundreds of columns is no longer slow. Every column built a cell for every row on screen whether or not it was anywhere near the viewport, so a 500-column table carried about 18,000 live cells and laid all of them out on each frame. Only the columns near the viewport are built now, and the rest keep their width so the horizontal scroller still spans the whole result. (#1219)
 - A column you hid keeps its place in the column order. The order was saved from the columns the query returned, and a hidden column is left out of that query, so its position was erased and Show All put it back at the far right of a grid you had arranged.
 - A row you are inserting shows empty values in JSON result mode for the columns the server fills in, instead of printing TablePro's internal marker for them as though it were data.

--- a/TablePro/Models/Query/QueryTab.swift
+++ b/TablePro/Models/Query/QueryTab.swift
@@ -59,6 +59,10 @@ struct QueryTab: Identifiable, Equatable {
 
     var pendingRestoredSort: [PersistedSortColumn]?
     var restoredPage: Int?
+    /// The page size `restoredPage` was measured in. A page index means nothing without it: the
+    /// offset is recomputed as `(page - 1) * pageSize`, so reading the index in a different size
+    /// lands the tab on rows it was never showing.
+    var restoredPageSize: Int?
     var restoredCursorOffset: Int?
     var restoredCursorLength: Int?
 
@@ -104,6 +108,7 @@ struct QueryTab: Identifiable, Equatable {
         self.loadEpoch = 0
         self.pendingRestoredSort = nil
         self.restoredPage = nil
+        self.restoredPageSize = nil
         self.restoredCursorOffset = nil
         self.restoredCursorLength = nil
     }
@@ -145,6 +150,8 @@ struct QueryTab: Identifiable, Equatable {
         self.loadEpoch = 0
         self.pendingRestoredSort = persisted.sortColumns
         self.restoredPage = persisted.restoredPage.map { max(1, $0) }
+        self.restoredPageSize = persisted.restoredPageSize
+            .map { $0.clamped(to: SettingsValidationRules.defaultPageSizeRange) }
         self.restoredCursorOffset = Self.clampedCursorOffset(persisted.cursorOffset, in: persisted.query)
         self.restoredCursorLength = Self.clampedCursorLength(
             persisted.cursorLength,
@@ -202,15 +209,37 @@ struct QueryTab: Identifiable, Equatable {
     func toPersistedTab() -> PersistedTab {
         let persistedQuery = content.query
 
+        // A restored tab holds its saved sort and page in the pending fields until it is selected,
+        // because only the selected tab runs the first load that consumes them. Every save maps
+        // every tab through here, so re-emitting what has not been consumed yet is what keeps an
+        // unactivated tab's view state alive. `cursorOffset` and `columnWidths` already do this.
+        //
+        // The fallback holds only until the tab has actually run. After that the live state is the
+        // truth, and a pending value that outranked it would pin a page the user has since left
+        // with no way to correct it.
+        let carriesPendingState = tabType == .table && execution.lastExecutedAt == nil
+
         let persistedSort: [PersistedSortColumn]? = {
             let resolved = sortState.columns.compactMap { column -> PersistedSortColumn? in
                 guard let name = column.columnName else { return nil }
                 return PersistedSortColumn(columnName: name, direction: column.direction)
             }
-            return resolved.isEmpty ? nil : resolved
+            guard resolved.isEmpty else { return resolved }
+            return carriesPendingState ? pendingRestoredSort : nil
         }()
 
-        let restoredPage = (tabType == .table && pagination.currentPage > 1) ? pagination.currentPage : nil
+        let restoredPage: Int?
+        let restoredPageSize: Int?
+        if tabType == .table, pagination.currentPage > 1 {
+            restoredPage = pagination.currentPage
+            restoredPageSize = pagination.pageSize
+        } else if carriesPendingState, let pending = self.restoredPage {
+            restoredPage = pending
+            restoredPageSize = self.restoredPageSize
+        } else {
+            restoredPage = nil
+            restoredPageSize = nil
+        }
         let widths = columnLayout.columnWidths.isEmpty ? nil : columnLayout.columnWidths
         let contentWidths = columnLayout.columnContentWidths?.isEmpty == false
             ? columnLayout.columnContentWidths
@@ -230,6 +259,7 @@ struct QueryTab: Identifiable, Equatable {
             queryParameters: content.queryParameters.isEmpty ? nil : content.queryParameters,
             sortColumns: persistedSort,
             restoredPage: restoredPage,
+            restoredPageSize: restoredPageSize,
             cursorOffset: Self.clampedCursorOffset(restoredCursorOffset, in: persistedQuery),
             cursorLength: Self.clampedCursorLength(
                 restoredCursorLength,

--- a/TablePro/Models/Query/QueryTabManager.swift
+++ b/TablePro/Models/Query/QueryTabManager.swift
@@ -408,6 +408,12 @@ final class QueryTabManager {
         tab.filterState = TabFilterState()
         tab.columnLayout = ColumnLayoutState()
         tab.pagination = PaginationState(pageSize: pageSize)
+        // Retargeting points the tab at a different table, so a restore that has not been consumed
+        // yet describes rows this tab no longer shows. Left behind, it is persisted against the new
+        // table and applied to it on the next launch.
+        tab.pendingRestoredSort = nil
+        tab.restoredPage = nil
+        tab.restoredPageSize = nil
         tab.tableContext.databaseName = databaseName
         tab.tableContext.schemaName = schemaName
         tab.isPreview = isPreview

--- a/TablePro/Models/Query/QueryTabState.swift
+++ b/TablePro/Models/Query/QueryTabState.swift
@@ -37,6 +37,7 @@ struct PersistedTab: Codable {
     var queryParameters: [QueryParameter]?
     var sortColumns: [PersistedSortColumn]?
     var restoredPage: Int?
+    var restoredPageSize: Int?
     var cursorOffset: Int?
     var cursorLength: Int?
     var columnWidths: [String: CGFloat]?
@@ -60,6 +61,7 @@ struct PersistedTab: Codable {
         queryParameters: [QueryParameter]? = nil,
         sortColumns: [PersistedSortColumn]? = nil,
         restoredPage: Int? = nil,
+        restoredPageSize: Int? = nil,
         cursorOffset: Int? = nil,
         cursorLength: Int? = nil,
         columnWidths: [String: CGFloat]? = nil,
@@ -79,6 +81,7 @@ struct PersistedTab: Codable {
         self.queryParameters = queryParameters
         self.sortColumns = sortColumns
         self.restoredPage = restoredPage
+        self.restoredPageSize = restoredPageSize
         self.cursorOffset = cursorOffset
         self.cursorLength = cursorLength
         self.columnWidths = columnWidths
@@ -89,7 +92,8 @@ struct PersistedTab: Codable {
     private enum CodingKeys: String, CodingKey {
         case id, title, query, tabType, tableName, isView, databaseName, schemaName
         case sourceFileURL, erDiagramSchemaKey, queryParameters
-        case sortColumns, restoredPage, cursorOffset, cursorLength, columnWidths, columnContentWidths, windowGroupIndex
+        case sortColumns, restoredPage, restoredPageSize, cursorOffset, cursorLength
+        case columnWidths, columnContentWidths, windowGroupIndex
         case overflowFileName
     }
 
@@ -108,6 +112,7 @@ struct PersistedTab: Codable {
         queryParameters = try container.decodeIfPresent([QueryParameter].self, forKey: .queryParameters)
         sortColumns = try container.decodeIfPresent([PersistedSortColumn].self, forKey: .sortColumns)
         restoredPage = try container.decodeIfPresent(Int.self, forKey: .restoredPage)
+        restoredPageSize = try container.decodeIfPresent(Int.self, forKey: .restoredPageSize)
         cursorOffset = try container.decodeIfPresent(Int.self, forKey: .cursorOffset)
         cursorLength = try container.decodeIfPresent(Int.self, forKey: .cursorLength)
         columnWidths = try container.decodeIfPresent([String: CGFloat].self, forKey: .columnWidths)

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TableFirstLoad.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TableFirstLoad.swift
@@ -95,12 +95,15 @@ extension MainContentCoordinator {
             tab.pendingRestoredSort ?? [],
             in: effectiveResultColumns(for: tab)
         )
-        let pageSize = AppSettingsManager.shared.dataGrid.defaultPageSize
+        // The persisted page index counts pages of the size it was taken in, so reading it in
+        // today's default would land the tab on rows it was never showing.
+        let pageSize = tab.restoredPageSize ?? AppSettingsManager.shared.dataGrid.defaultPageSize
         let page = max(1, tab.restoredPage ?? 1)
 
         tabManager.mutate(at: index) { tab in
             tab.pendingRestoredSort = nil
             tab.restoredPage = nil
+            tab.restoredPageSize = nil
             if !resolvedSort.isEmpty {
                 tab.sortState = SortState(columns: resolvedSort, source: .user)
             }

--- a/TableProTests/Core/Services/PersistedTabRoundTripTests.swift
+++ b/TableProTests/Core/Services/PersistedTabRoundTripTests.swift
@@ -78,6 +78,179 @@ struct PersistedTabRoundTripTests {
         #expect(tab.toPersistedTab().restoredPage == nil)
     }
 
+    // MARK: - A tab that is restored but never selected
+
+    /// Only the selected tab runs the first load that consumes the pending sort and page, but every
+    /// save maps every tab through toPersistedTab. Re-deriving from live state wrote nil for the
+    /// others, so their sort and page were gone by the third launch without the user touching them.
+    @Test("An unactivated tab re-emits the sort it has not consumed yet")
+    func unconsumedSortSurvivesResave() {
+        var tab = tableTab()
+        tab.sortState = SortState(
+            columns: [SortColumn(columnIndex: 0, direction: .descending, columnName: "created_at")],
+            source: .user
+        )
+
+        let restored = QueryTab(from: tab.toPersistedTab(), defaultPageSize: 1_000)
+        let resaved = restored.toPersistedTab()
+
+        #expect(resaved.sortColumns?.count == 1)
+        #expect(resaved.sortColumns?[0].columnName == "created_at")
+        #expect(resaved.sortColumns?[0].direction == .descending)
+    }
+
+    @Test("An unactivated tab re-emits the page it has not consumed yet")
+    func unconsumedPageSurvivesResave() {
+        var tab = tableTab()
+        tab.pagination.currentPage = 7
+
+        let restored = QueryTab(from: tab.toPersistedTab(), defaultPageSize: 1_000)
+        let resaved = restored.toPersistedTab()
+
+        #expect(resaved.restoredPage == 7)
+    }
+
+    @Test("Repeated saves without activation keep the state indefinitely")
+    func stateSurvivesRepeatedResaves() {
+        var tab = tableTab()
+        tab.pagination.currentPage = 4
+        tab.sortState = SortState(
+            columns: [SortColumn(columnIndex: 0, direction: .ascending, columnName: "id")],
+            source: .user
+        )
+
+        var persisted = tab.toPersistedTab()
+        for _ in 0..<3 {
+            persisted = QueryTab(from: persisted, defaultPageSize: 1_000).toPersistedTab()
+        }
+
+        #expect(persisted.restoredPage == 4)
+        #expect(persisted.sortColumns?[0].columnName == "id")
+    }
+
+    // MARK: - The page size the page index was counted in
+
+    /// A page index means nothing on its own: the offset is recomputed as (page - 1) * pageSize.
+    /// Reading a page counted in 50s as pages of 1000 lands the tab on rows it never showed.
+    @Test("A persisted page carries the page size it was counted in")
+    func persistedPageCarriesItsPageSize() {
+        var tab = tableTab()
+        tab.pagination.pageSize = 50
+        tab.pagination.currentPage = 20
+
+        let persisted = tab.toPersistedTab()
+
+        #expect(persisted.restoredPage == 20)
+        #expect(persisted.restoredPageSize == 50)
+        #expect(QueryTab(from: persisted, defaultPageSize: 1_000).restoredPageSize == 50)
+    }
+
+    @Test("Page 1 carries no page size, so Show All never restores a huge page")
+    func pageOneCarriesNoPageSize() {
+        var tab = tableTab()
+        tab.pagination.pageSize = 5_000_000
+        tab.pagination.currentPage = 1
+
+        let persisted = tab.toPersistedTab()
+
+        #expect(persisted.restoredPage == nil)
+        #expect(persisted.restoredPageSize == nil)
+    }
+
+    @Test("An unactivated tab re-emits its page size along with its page")
+    func unconsumedPageSizeSurvivesResave() {
+        var tab = tableTab()
+        tab.pagination.pageSize = 50
+        tab.pagination.currentPage = 20
+
+        let restored = QueryTab(from: tab.toPersistedTab(), defaultPageSize: 1_000)
+        let resaved = restored.toPersistedTab()
+
+        #expect(resaved.restoredPage == 20)
+        #expect(resaved.restoredPageSize == 50)
+    }
+
+    // MARK: - The fallback must not outlive the restore it stands in for
+
+    /// The pending values stand in for a restore that has not happened yet. Once the tab has run,
+    /// the live state is the truth, or a page the user has since left would be pinned forever with
+    /// nothing able to correct it.
+    @Test("Once the tab has run, live state wins over an unconsumed page")
+    func executedTabPrefersLiveState() {
+        var tab = tableTab()
+        tab.pagination.currentPage = 12
+        let restored = QueryTab(from: tab.toPersistedTab(), defaultPageSize: 1_000)
+
+        var paged = restored
+        paged.execution.lastExecutedAt = Date()
+        paged.pagination.currentPage = 1
+
+        #expect(paged.restoredPage == 12)
+        #expect(paged.toPersistedTab().restoredPage == nil)
+    }
+
+    @Test("Once the tab has run, clearing the sort clears it in persistence too")
+    func executedTabDropsUnconsumedSort() {
+        var tab = tableTab()
+        tab.sortState = SortState(
+            columns: [SortColumn(columnIndex: 0, direction: .ascending, columnName: "id")],
+            source: .user
+        )
+        var restored = QueryTab(from: tab.toPersistedTab(), defaultPageSize: 1_000)
+        restored.execution.lastExecutedAt = Date()
+
+        #expect(restored.toPersistedTab().sortColumns == nil)
+    }
+
+    /// Consumption is gated on table tabs, so a query tab would never clear a pending sort and it
+    /// would reappear in the persisted record after the user cleared it.
+    @Test("A query tab does not carry a pending sort forward")
+    func queryTabDropsPendingSort() {
+        var tab = tableTab()
+        tab.sortState = SortState(
+            columns: [SortColumn(columnIndex: 0, direction: .ascending, columnName: "id")],
+            source: .user
+        )
+        var restored = QueryTab(from: tab.toPersistedTab(), defaultPageSize: 1_000)
+        restored.tabType = .query
+
+        #expect(restored.toPersistedTab().sortColumns == nil)
+    }
+
+    @Test("A restored page size outside the supported range is clamped")
+    func restoredPageSizeIsClamped() {
+        let absurd = PersistedTab(
+            id: UUID(),
+            title: "users",
+            query: "SELECT * FROM users",
+            tabType: .table,
+            tableName: "users",
+            restoredPage: 2,
+            restoredPageSize: 5_000_000
+        )
+
+        let restored = QueryTab(from: absurd, defaultPageSize: 1_000)
+
+        #expect(restored.restoredPageSize == SettingsValidationRules.defaultPageSizeRange.upperBound)
+    }
+
+    @Test("A tab saved before page sizes were persisted still restores its page")
+    func legacyTabWithoutPageSizeStillRestores() {
+        let legacy = PersistedTab(
+            id: UUID(),
+            title: "users",
+            query: "SELECT * FROM users",
+            tabType: .table,
+            tableName: "users",
+            restoredPage: 3
+        )
+
+        let restored = QueryTab(from: legacy, defaultPageSize: 1_000)
+
+        #expect(restored.restoredPage == 3)
+        #expect(restored.restoredPageSize == nil)
+    }
+
     @Test("Cursor offset round-trips for query tabs")
     func cursorOffsetRoundTrip() {
         var tab = QueryTab(id: UUID(), title: "Q", query: "SELECT * FROM users", tabType: .query)


### PR DESCRIPTION
Two defects in how a restored tab's view state round-trips. Found while investigating #2234; the second is why the first could not ship alone.

## A tab you never clicked loses its sort and page

Restore parks a tab's saved sort and page in `pendingRestoredSort` / `restoredPage` rather than applying them, because applying needs the schema. Only `applyPendingRestoredViewState` consumes them, and it is reachable solely through `prepareTableTabFirstLoad`, whose first guard is `tabManager.selectedTabId == tabId`. So only the tab in front ever consumes its own state.

Every save maps **every** tab through `toPersistedTab()`, which re-derived the sort from `sortState.columns` and the page from `pagination.currentPage`. Both are still empty on a tab that has not been activated, so the very next autosave wrote `nil` over each of them.

Leave five tabs sorted and on page 3, quit, relaunch, and only the selected tab keeps its state. Wait 30 seconds for the periodic save, or just quit again, and the other four have lost it permanently, without the user having touched them.

`toPersistedTab()` now falls back to the pending values when the live ones are empty, which is exactly what `restoredCursorOffset` and `columnWidths` already do. The consumption side is untouched: `applyPendingRestoredViewState` stays the only consumer.

## A restored page index was read in the wrong page size

This is why the first fix could not ship on its own. Restoring the page number makes the page restore actually happen, and the offset is recomputed as `(page - 1) * pageSize` against `AppSettingsManager.shared.dataGrid.defaultPageSize`, not against the size the page was counted in. `PersistedTab` had no page size at all.

Set a tab to 100 rows per page, go to page 12 (rows 1101-1200), quit. It comes back as page 12 of the 1,000 default: offset 11,000, an empty grid, and a pager reading 12 of 2. Fixing the loss alone would have taken this from rare to routine, which is what made it scope rather than a follow-up.

`PersistedTab` gains `restoredPageSize`, and restore reads the page index in the size it was counted in.

Two things fall out of that framing, and both are deliberate:

- The size is persisted **only as the unit for a persisted page index**, never as "remember the user's page size". A tab on page 1 persists neither.
- That is also what keeps **Show All** safe. It puts the whole result on one page, so `currentPage` is 1, so no page size is written and relaunching never re-fetches a million rows.

It also preserves the existing contract. `PersistedTabRoundTripTests.paginationSeedsFromLivePageSize` pins that a restored tab seeds its page size from the live default rather than from the persisted query text, and that test has a tab on page 1: no page size is persisted, the default still applies, and it passes unchanged. The new field is an explicit, trustworthy value rather than a parse of the query string, which is what that test was guarding against.

`restoredPageSize` is decoded with `decodeIfPresent`, so a tab written by an older build restores its page exactly as before.

## Keeping the fallback from outliving the restore

Making the pending values survive a re-save means they now outlive a single activation, and three paths relied on them being transient. Self-review caught all three:

- **A stale page must not outrank live truth.** The fallback holds only while `execution.lastExecutedAt == nil`. Without that, a user who pages back to 1 and quits reopens on page 12 forever, and nothing can correct it: the only code that clears the pending fields is the first-load path.
- **Retargeting a tab clears them.** `replaceTabContent` already resets sort, pagination, filters and layout when a tab is pointed at a different table, which is what clicking a sidebar table during a restored tab's schema load does. The pending fields now reset with them, or `orders`' page 12 and sort get persisted against `customers` and applied to it next launch.
- **Only table tabs carry a pending sort.** Consumption is gated on `tabType == .table`, so a query tab would never clear one and a sort the user cleared would reappear in the persisted record permanently.

`restoredPageSize` is also clamped to `SettingsValidationRules.defaultPageSizeRange` on decode, so a hand-edited or out-of-range value cannot make a restored tab issue an enormous first fetch.

## Verification

Run through `verify.sh` in an isolated worktree on `752019a6e`.

- `generate` PASS, `build` PASS
- `test` PASS, **46 of 46**: PersistedTabRoundTripTests, DefaultSortInitialQueryTests, TabPersistenceTests, QueryTabManagerTests
- `swiftlint --strict` clean over every touched file

The new tests pin the parts that failed silently: an unactivated tab re-emits its sort and its page, three consecutive save/restore cycles keep both, a persisted page carries the size it was counted in, page 1 carries no size (the Show All guard), and a tab written before the field existed still restores its page.

No UI automation. The flow is quit, relaunch and restore across three launches, driven by an autosave timer, which does not run deterministically in `TableProUITests`. The behaviour is covered at the round-trip boundary instead, which is where both causes live.
