### PR TITLE
refactor(tabs): drop the state ResultSet carries but nothing reads

### DIFF
--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
@@ -208,9 +208,6 @@ extension QueryExecutionCoordinator {
             rs.executionTime = tab.execution.executionTime
             rs.rowsAffected = tab.execution.rowsAffected
             rs.statusMessage = tab.execution.statusMessage
-            rs.tableName = tab.tableContext.tableName
-            rs.isEditable = tab.tableContext.isEditable
-            rs.metadataVersion = tab.metadataVersion
             rs.isTruncated = isTruncated
             rs.baseQuery = sql
 

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+MultiStatement.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+MultiStatement.swift
@@ -43,7 +43,6 @@ extension QueryExecutionCoordinator {
         resultSet.executionTime = result.executionTime
         resultSet.rowsAffected = result.rowsAffected
         resultSet.statusMessage = result.statusMessage
-        resultSet.tableName = tableName
         if !result.columns.isEmpty {
             resultSet.isTruncated = result.isTruncated
             resultSet.baseQuery = baseQuery

--- a/TablePro/Models/Query/ResultSet.swift
+++ b/TablePro/Models/Query/ResultSet.swift
@@ -9,6 +9,18 @@ import Foundation
 import Observation
 import os
 
+/// One execution's product: its rows, and the facts about how they were produced.
+///
+/// This is not where view state lives. A `ResultSet` is rebuilt with a fresh `id` on every table
+/// load, page turn, sort and re-execute, and `TabDisplayState.replaceUnpinnedResults(with:)` drops
+/// the one it replaces, so anything kept here is gone the first time the user turns a page.
+/// `QueryTab` owns what has to outlive a single result: sort, pagination, column layout, chart
+/// configuration and filters.
+///
+/// It used to mirror the first three of those, along with the tab's table name, editability and
+/// metadata version. Nothing read any of them, and having them here made this look like the
+/// established home for per-result view state, which is how the chart configuration nearly ended
+/// up here (#2243).
 @MainActor
 @Observable
 final class ResultSet: Identifiable {
@@ -19,16 +31,10 @@ final class ResultSet: Identifiable {
     var rowsAffected: Int = 0
     var errorMessage: String?
     var statusMessage: String?
-    var tableName: String?
-    var isEditable: Bool = false
     var isPinned: Bool = false
     var isTruncated: Bool = false
     var baseQuery: String?
     var baseQueryParameterValues: [String?]?
-    var metadataVersion: Int = 0
-    var sortState = SortState()
-    var pagination = PaginationState()
-    var columnLayout = ColumnLayoutState()
 
     /// An EXPLAIN result is a result set like any other, so it rides the same tab strip, pinning
     /// and history. It carries a plan instead of rows.

--- a/TableProTests/Models/Query/ResultSetOwnershipTests.swift
+++ b/TableProTests/Models/Query/ResultSetOwnershipTests.swift
@@ -1,0 +1,77 @@
+//
+//  ResultSetOwnershipTests.swift
+//  TableProTests
+//
+//  A `ResultSet` is replaced on every load, page turn, sort and re-execute, so view state kept on
+//  one dies at the first page turn. `QueryTab` owns that state. The boundary is easy to cross by
+//  accident because it is invisible in a diff: the chart configuration was nearly put on
+//  `ResultSet`, and the unread copies of the tab's own state it would have sat next to are what
+//  made that look right (#2243).
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("ResultSet ownership")
+struct ResultSetOwnershipTests {
+    @Test("ResultSet declares no stored property that QueryTab already owns")
+    func resultSetDoesNotMirrorTheTab() throws {
+        let shared = try Self.storedProperties(of: "ResultSet", in: "TablePro/Models/Query/ResultSet.swift")
+            .intersection(Self.storedProperties(of: "QueryTab", in: "TablePro/Models/Query/QueryTab.swift"))
+
+        #expect(
+            shared == ["id"],
+            """
+            A ResultSet is rebuilt on every load, page turn, sort and re-execute, so a copy of \
+            tab state kept here is read by nothing and discarded at the first page turn. Keep it \
+            on QueryTab: \(shared.subtracting(["id"]).sorted())
+            """
+        )
+    }
+
+    /// Stored properties are the `var`/`let` declarations at type scope, which the four-space house
+    /// indent pins exactly. A brace with no `=` ahead of it opens an accessor block, so the
+    /// declaration computes rather than stores; a brace after one is a default value or an
+    /// observer on something that does store.
+    ///
+    /// This compares names, so it catches a copy that keeps the name it had on `QueryTab` and
+    /// nothing else. State moved back under a new name still needs a reader to notice it.
+    private static func storedProperties(of type: String, in path: String) throws -> Set<String> {
+        let source = try String(contentsOf: repoRoot().appendingPathComponent(path), encoding: .utf8)
+        let lines = source.components(separatedBy: .newlines)
+        guard let start = lines.firstIndex(where: {
+            $0.contains("class \(type):") || $0.contains("struct \(type):")
+                || $0.contains("class \(type) {") || $0.contains("struct \(type) {")
+        }) else { throw CocoaError(.fileNoSuchFile) }
+
+        var names: Set<String> = []
+        for line in lines[(start + 1)...] {
+            if line == "}" { break }
+            guard line.hasPrefix("    "), !line.hasPrefix("     "), Self.stores(line) else { continue }
+            let words = line.split(separator: " ").map(String.init)
+            guard let keyword = words.firstIndex(where: { $0 == "var" || $0 == "let" }),
+                  keyword + 1 < words.count
+            else { continue }
+            let name = words[keyword + 1].prefix { $0 != ":" && $0 != "=" }
+            if !name.isEmpty { names.insert(String(name)) }
+        }
+        return names
+    }
+
+    private static func stores(_ line: String) -> Bool {
+        guard let brace = line.firstIndex(of: "{") else { return true }
+        return line[..<brace].contains("=")
+    }
+
+    private static func repoRoot() throws -> URL {
+        var directory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        for _ in 0 ..< 12 {
+            if FileManager.default.fileExists(atPath: directory.appendingPathComponent("project.yml").path) {
+                return directory
+            }
+            directory = directory.deletingLastPathComponent()
+        }
+        throw CocoaError(.fileNoSuchFile)
+    }
+}


### PR DESCRIPTION
## What this fixes

`ResultSet` carried six stored properties that nothing read. Three of them (`sortState`, `pagination`, `columnLayout`) were never even written. Three more (`tableName`, `isEditable`, `metadataVersion`) were written on every execution and read by nobody.

They came in whole with `7deb5b10e` (#512), the commit that created `ResultSet`. The intent then was for `ResultSet` to become the reference-type owner of per-result view state. The views were never repointed at it, `QueryTab` stayed canonical, and the copies have sat there since.

Leaving them is what makes them worth removing. A `ResultSet` is rebuilt with a fresh `id` on every table load, page turn, sort and re-execute, and `replaceUnpinnedResults(with:)` drops the one it replaces, so anything stored on it is discarded at the first page turn. The unread copies made this look like the established home for per-result view state, which is how the result-chart work in #2222 nearly put `chartConfiguration` here.

Fixes #2243.

## What changed

- Deleted the six properties, plus their four write sites in `QueryExecutionCoordinator+Helpers.swift` and `+MultiStatement.swift`. Deleting a property and leaving its write is a compile error, so they land together.
- Added a type-level doc comment saying what `ResultSet` is and what its lifetime means for anything stored on it. This is the shape `TabSession` got in #2064 after the same defect class.
- Added `ResultSetOwnershipTests`, a guard asserting `ResultSet` declares no stored property `QueryTab` already owns.

The deletion itself has no behaviour to test: the properties had no readers, so nothing observable changes. A passing Debug build is the real confirmation, and the guard is there to stop the state coming back.

## How the "nothing reads them" claim was checked

Every file mentioning `ResultSet` was read and each `.tableName` / `.isEditable` / `.metadataVersion` / `.sortState` / `.pagination` / `.columnLayout` hit was classified by receiver. Every read resolves to `QueryTab`, `InspectorViewState`, `StatusBarSnapshot` or `DataBrowserViewModel`. `ResultSet` conforms to `Identifiable` alone, has no extensions, is never encoded or persisted, and `TabDisplayState.==` compares only `resultSets.map(\.id)`, so no synthesized conformance reaches the fields either.

The guard was checked in both directions rather than assumed: re-adding `sortState` to `ResultSet` fails it, and the tree as it stands passes it. Against the pre-fix tree it reports `columnLayout, metadataVersion, pagination, sortState`. It compares names, so `tableName` and `isEditable` are outside its reach (`QueryTab` holds those under `tableContext`); those two rest on the receiver audit above.

## Scope note for whoever picks up the wrong-table-write bug

`tableName` and `isEditable` were not arbitrary duplicates. They held real per-result facts (`makeStatementResultSet` sets a distinct `tableName` per statement), and `switchActiveResultSet` already has the sync point that should have consumed them: it restores `baseQuery`, `baseQueryParameterValues` and load-more state from the incoming result, but never the table identity. That gap is a live data-corruption bug, reported separately, and its fix will need to re-capture per-result table identity. Removing these two keeps the code honest about what is actually read; it does not mean the facts are unwanted.

## Verification

Run in a worktree off `main` at `752019a6e`.

- `generate` PASS
- `build` (Debug, TablePro scheme) PASS
- `test` PASS, 46 cases: `ResultSetOwnershipTests`, `ResultChartConfigurationTests`, `ResultPinningTests`, `ClearQueryResultsTests`, `ResultTabBarPolicyTests`, `QueryPlanPresentationTests`. An earlier run over the same change also covered `PersistedTabRoundTripTests`, `MainContentCoordinatorTabSwitchTests`, `PaginationCoordinatorTests` and `DefaultSortInitialQueryTests`, 118 cases, all passing.
- `lint` 0 SwiftLint violations across all four changed files

No CHANGELOG entry: nothing here is user-facing, and a one-line entry naming a class would break the CHANGELOG rules. #2064, #1734 and #2066 are the precedent for internal removals of this kind. No docs change and no screenshots, for the same reason. No PluginKit surface is touched, so no ABI bump.
