### PR TITLE
fix(tabs): restore hidden columns and the caret on every tab, not just the front one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Every restored tab hides the columns you hid for its table, not just the tab that was in front. The others came back showing every column, and hiding one there wrote that single column over the table's saved set, losing the rest.
+- A query tab reopens with the caret where you left it, even if it was not the tab in front when you quit. The position was recorded only for the selected tab, so switching to another tab threw away the position that was already saved, and looking at a restored tab was enough to lose it.
 - Reopening a session keeps the sort and the page number on every restored tab, not just the one that was in front. The others held their saved sort and page until you clicked them, and the next save wrote the tab out without either, so a tab you did not visit lost them for good.
 - A restored tab reopens on the rows it was showing. The page number was saved without the page size it was counted in, so a tab left on page 12 of 100 rows came back as page 12 of the default 1,000 and landed 11,000 rows further down, usually on an empty grid.
 - Scrolling a result with hundreds of columns is no longer slow. Every column built a cell for every row on screen whether or not it was anywhere near the viewport, so a 500-column table carried about 18,000 live cells and laid all of them out on each frame. Only the columns near the viewport are built now, and the rest keep their width so the horizontal scroller still spans the whole result. (#1219)

--- a/TablePro/Core/Services/Infrastructure/TabPersistenceCoordinator.swift
+++ b/TablePro/Core/Services/Infrastructure/TabPersistenceCoordinator.swift
@@ -173,6 +173,11 @@ internal final class TabPersistenceCoordinator {
         let defaultPageSize = AppSettingsManager.shared.dataGrid.defaultPageSize
         var restoredTabs = state.tabs.map { QueryTab(from: $0, defaultPageSize: defaultPageSize) }
         FileTabBaseline.hydrate(&restoredTabs)
+        RestoredHiddenColumns.hydrate(
+            &restoredTabs,
+            connectionId: connectionId,
+            persister: FileColumnLayoutPersister.shared
+        )
         return RestoreResult(
             tabs: restoredTabs,
             selectedTabId: state.selectedTabId,

--- a/TablePro/Models/Query/RestoredHiddenColumns.swift
+++ b/TablePro/Models/Query/RestoredHiddenColumns.swift
@@ -1,0 +1,49 @@
+//
+//  RestoredHiddenColumns.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Puts each restored table tab's hidden columns back on the tab.
+///
+/// Hidden columns are not part of the tab record: they live in the per-table layout store, keyed by
+/// connection, database, schema and table. Only the tab selected at launch used to read them, so
+/// every other restored tab came back showing columns the user had hidden, and the first hide there
+/// wrote that near-empty set over the table's stored one and took the rest with it.
+///
+/// This runs at restore rather than at first load on purpose. A tab whose first load fails never
+/// auto-loads again, and the manual re-run skips the first-load path entirely, so a restore keyed
+/// to that path would miss exactly the tab the user is trying to recover.
+@MainActor
+internal enum RestoredHiddenColumns {
+    internal static func hydrate(
+        _ tabs: inout [QueryTab],
+        connectionId: UUID,
+        persister: any ColumnLayoutPersisting
+    ) {
+        for index in tabs.indices {
+            hydrate(&tabs[index], connectionId: connectionId, persister: persister)
+        }
+    }
+
+    internal static func hydrate(
+        _ tab: inout QueryTab,
+        connectionId: UUID,
+        persister: any ColumnLayoutPersisting
+    ) {
+        guard tab.tabType == .table,
+              tab.columnLayout.hiddenColumns.isEmpty,
+              let tableName = tab.tableContext.tableName, !tableName.isEmpty else { return }
+
+        let key = ColumnLayoutTableKey(
+            connectionId: connectionId,
+            databaseName: tab.tableContext.databaseName,
+            schemaName: tab.tableContext.schemaName,
+            tableName: tableName
+        )
+        let restored = persister.loadHiddenColumns(for: key)
+        guard !restored.isEmpty else { return }
+        tab.columnLayout.hiddenColumns = restored
+    }
+}

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
@@ -6,6 +6,7 @@
 //  to keep the main class body within SwiftLint limits.
 //
 
+import CodeEditSourceEditor
 import Foundation
 import os
 
@@ -34,6 +35,25 @@ extension MainContentCoordinator {
             if changeManager.hasChanges {
                 let savedState = changeManager.saveState()
                 tabManager.mutate(at: oldIndex) { $0.pendingChanges = savedState }
+            }
+            // One editor serves every query tab, so `cursorPositions` describes the outgoing tab
+            // only until the switch completes. Persistence writes the live caret for the selected
+            // tab alone, so a caret not captured here is gone once the editor has consumed the
+            // tab's restored value.
+            //
+            // Only a tab whose own restored caret is already consumed can be written, because the
+            // query editor subtree has no `.id(tab.id)`: selecting a restored tab reuses the same
+            // editor without re-installing it, so `cursorPositions` can still describe the tab
+            // before it. Overwriting there would destroy the very caret this is meant to keep.
+            let outgoing = tabManager.tabs[oldIndex]
+            if outgoing.tabType == .query,
+               outgoing.restoredCursorOffset == nil,
+               outgoing.restoredCursorLength == nil,
+               let range = cursorPositions.first?.range {
+                tabManager.mutate(at: oldIndex) {
+                    $0.restoredCursorOffset = range.location
+                    $0.restoredCursorLength = range.length
+                }
             }
             if let tableName = tabManager.tabs[oldIndex].tableContext.tableName {
                 FilterSettingsStorage.shared.saveLastFilters(

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -398,10 +398,13 @@ final class MainContentCoordinator {
                 return named
             }
         }
-        if tab.tabType == .query, tab.id == tabManager.selectedTabId {
-            let range = cursorPositions.first?.range
-            enriched.restoredCursorOffset = range?.location
-            enriched.restoredCursorLength = range.map(\.length)
+        // Only when there is a live caret to write. `cursorPositions` starts empty and is fed by
+        // the editor's own change events, so a tab whose editor never became first responder has
+        // none, and writing that absence over the tab's saved caret discards it.
+        if tab.tabType == .query, tab.id == tabManager.selectedTabId,
+           let range = cursorPositions.first?.range {
+            enriched.restoredCursorOffset = range.location
+            enriched.restoredCursorLength = range.length
         }
         return enriched
     }

--- a/TableProTests/Models/RestoredHiddenColumnsTests.swift
+++ b/TableProTests/Models/RestoredHiddenColumnsTests.swift
@@ -1,0 +1,118 @@
+//
+//  RestoredHiddenColumnsTests.swift
+//  TableProTests
+//
+//  Hidden columns live in the per-table layout store, not in the tab record, and only the tab
+//  selected at launch used to read them. Every other restored tab came back showing columns the
+//  user had hidden, and its first hide wrote that near-empty set over the table's stored one.
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@MainActor
+private final class StubColumnLayoutPersister: ColumnLayoutPersisting {
+    var hidden: [String: Set<String>] = [:]
+
+    func load(for key: ColumnLayoutTableKey) -> ColumnLayoutState? { nil }
+    func save(_ layout: ColumnLayoutState, for key: ColumnLayoutTableKey) {}
+    func clear(for key: ColumnLayoutTableKey) {}
+
+    func loadHiddenColumns(for key: ColumnLayoutTableKey) -> Set<String> {
+        hidden[key.tableName] ?? []
+    }
+
+    func saveHiddenColumns(_ hidden: Set<String>, for key: ColumnLayoutTableKey) {
+        self.hidden[key.tableName] = hidden
+    }
+}
+
+@Suite("Restored hidden columns")
+@MainActor
+struct RestoredHiddenColumnsTests {
+    private let connectionId = UUID()
+
+    private func tableTab(_ tableName: String) -> QueryTab {
+        QueryTab(
+            title: tableName,
+            query: "SELECT * FROM \(tableName)",
+            tabType: .table,
+            tableName: tableName
+        )
+    }
+
+    @Test("A restored table tab picks up the columns hidden for its table")
+    func hydratesATableTab() {
+        let persister = StubColumnLayoutPersister()
+        persister.hidden["users"] = ["email"]
+        var tabs = [tableTab("users")]
+
+        RestoredHiddenColumns.hydrate(&tabs, connectionId: connectionId, persister: persister)
+
+        #expect(tabs[0].columnLayout.hiddenColumns == ["email"])
+    }
+
+    /// The reported failure: three tabs, only the one in front came back correct.
+    @Test("Every restored tab is hydrated, not just the first")
+    func hydratesEveryTab() {
+        let persister = StubColumnLayoutPersister()
+        persister.hidden["users"] = ["email"]
+        persister.hidden["orders"] = ["total"]
+        persister.hidden["products"] = ["sku"]
+        var tabs = [tableTab("users"), tableTab("orders"), tableTab("products")]
+
+        RestoredHiddenColumns.hydrate(&tabs, connectionId: connectionId, persister: persister)
+
+        #expect(tabs[0].columnLayout.hiddenColumns == ["email"])
+        #expect(tabs[1].columnLayout.hiddenColumns == ["total"])
+        #expect(tabs[2].columnLayout.hiddenColumns == ["sku"])
+    }
+
+    @Test("A tab that already carries hidden columns is left alone")
+    func leavesAPopulatedTabAlone() {
+        let persister = StubColumnLayoutPersister()
+        persister.hidden["users"] = ["email"]
+        var tabs = [tableTab("users")]
+        tabs[0].columnLayout.hiddenColumns = ["notes"]
+
+        RestoredHiddenColumns.hydrate(&tabs, connectionId: connectionId, persister: persister)
+
+        #expect(tabs[0].columnLayout.hiddenColumns == ["notes"])
+    }
+
+    @Test("A table with nothing stored stays empty")
+    func nothingStoredStaysEmpty() {
+        var tabs = [tableTab("users")]
+
+        RestoredHiddenColumns.hydrate(
+            &tabs,
+            connectionId: connectionId,
+            persister: StubColumnLayoutPersister()
+        )
+
+        #expect(tabs[0].columnLayout.hiddenColumns.isEmpty)
+    }
+
+    @Test("A query tab is not touched")
+    func skipsQueryTabs() {
+        let persister = StubColumnLayoutPersister()
+        persister.hidden["users"] = ["email"]
+        var tabs = [QueryTab(title: "Query 1", query: "SELECT 1", tabType: .query)]
+
+        RestoredHiddenColumns.hydrate(&tabs, connectionId: connectionId, persister: persister)
+
+        #expect(tabs[0].columnLayout.hiddenColumns.isEmpty)
+    }
+
+    @Test("A table tab with no table name is skipped")
+    func skipsATabWithoutATableName() {
+        let persister = StubColumnLayoutPersister()
+        persister.hidden[""] = ["email"]
+        var tabs = [QueryTab(title: "untitled", query: "", tabType: .table)]
+
+        RestoredHiddenColumns.hydrate(&tabs, connectionId: connectionId, persister: persister)
+
+        #expect(tabs[0].columnLayout.hiddenColumns.isEmpty)
+    }
+}

--- a/TableProTests/Views/Main/MainContentCoordinatorTabSwitchTests.swift
+++ b/TableProTests/Views/Main/MainContentCoordinatorTabSwitchTests.swift
@@ -4,6 +4,7 @@
 //
 
 import AppKit
+import CodeEditSourceEditor
 import Foundation
 import SwiftUI
 import TableProPluginKit
@@ -890,5 +891,63 @@ struct MainContentCoordinatorTabSwitchTests {
             return
         }
         #expect(tabManager.tabs[index].columnLayout.hiddenColumns == ["email", "phone"])
+    }
+
+    // MARK: - The caret of the tab being left
+
+    /// One editor serves every query tab, so the live caret describes the outgoing tab only until
+    /// the switch completes. Persistence writes it for the selected tab alone, and the tab's own
+    /// restored value was already cleared when its editor consumed it, so a caret not captured on
+    /// the way out is simply gone.
+    @Test("Switching away from a query tab keeps its caret on the tab")
+    func switchingAwayCapturesTheCaret() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let first = addQueryTab(to: tabManager, title: "A", query: String(repeating: "SELECT 1;\n", count: 200))
+        let second = addQueryTab(to: tabManager, title: "B")
+
+        coordinator.cursorPositions = [CursorPosition(range: NSRange(location: 120, length: 8))]
+        tabManager.selectedTabId = second
+        coordinator.handleTabChange(from: first, to: second, tabs: tabManager.tabs)
+
+        guard let index = tabManager.tabs.firstIndex(where: { $0.id == first }) else {
+            Issue.record("Expected tab to exist")
+            return
+        }
+        #expect(tabManager.tabs[index].restoredCursorOffset == 120)
+        #expect(tabManager.tabs[index].restoredCursorLength == 8)
+    }
+
+    @Test("A captured caret survives into the persisted record")
+    func capturedCaretIsPersisted() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let first = addQueryTab(to: tabManager, title: "A", query: String(repeating: "SELECT 1;\n", count: 200))
+        let second = addQueryTab(to: tabManager, title: "B")
+
+        coordinator.cursorPositions = [CursorPosition(range: NSRange(location: 90, length: 0))]
+        tabManager.selectedTabId = second
+        coordinator.handleTabChange(from: first, to: second, tabs: tabManager.tabs)
+
+        guard let index = tabManager.tabs.firstIndex(where: { $0.id == first }) else {
+            Issue.record("Expected tab to exist")
+            return
+        }
+        #expect(tabManager.tabs[index].toPersistedTab().cursorOffset == 90)
+    }
+
+    @Test("Leaving a table tab records no caret")
+    func tableTabRecordsNoCaret() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let table = addTableTab(to: tabManager, tableName: "users")
+        let query = addQueryTab(to: tabManager, title: "B")
+
+        coordinator.cursorPositions = [CursorPosition(range: NSRange(location: 42, length: 0))]
+        tabManager.selectedTabId = query
+        coordinator.handleTabChange(from: table, to: query, tabs: tabManager.tabs)
+
+        guard let index = tabManager.tabs.firstIndex(where: { $0.id == table }) else {
+            Issue.record("Expected tab to exist")
+            return
+        }
+        #expect(tabManager.tabs[index].restoredCursorOffset == nil)
     }
 }


### PR DESCRIPTION
Two more pieces of a restored tab's view state that only the tab in front ever kept. Same family as #2255, different mechanisms. Both were found and verified while investigating #2234.

## Hidden columns came back on every tab but one

Hidden columns are not part of the tab record. They live in the per-table layout store, and one function reads them: `restoreLastHiddenColumnsForTable`, which operates on `tabManager.selectedTab`. Its call sites are launch, opening a table, following a foreign key, and reopening a closed tab. **Tab switching is not among them**, and `QueryTab.init(from:)` fills `columnLayout` with widths only.

So a restored tab that was not selected at launch started with an empty hidden set. Selecting it ran the first load, which rebuilt the browse query from that empty set, and every column you had hidden came back. Worse, hiding one column there wrote the tab's whole set, now a single column, over the table's stored one, taking the rest with it.

Each restored tab now picks its table's hidden set up at restore, beside the existing `FileTabBaseline` hydration. Self-review ruled out the first version of this, which hung the restore off `prepareTableTabFirstLoad`: a tab whose first load *fails* has `lastExecutedAt` set, so it never auto-loads again, and the user's manual re-run goes through `executeTableTabQueryDirectly` and skips the first-load path entirely. The tab a user is actively trying to recover would have been the one still losing its columns.

Doing it at restore also made it a pure function over the tabs and an injected persister, so it is tested directly rather than through a coordinator. It only fills a set that is empty, so it can never overwrite what a tab already has, and it is a no-op for a table with nothing stored.

## Looking at a restored query tab threw away its caret

One editor serves every query tab, so `cursorPositions` is a single coordinator property describing whichever tab is mounted. `enrichedForPersistence` writes the live caret only for the selected tab, and the tab's own `restoredCursorOffset` is cleared as soon as its editor consumes it.

That makes the failure the act of looking. Restore a session with query tabs A and B, click A so its saved caret is applied and then cleared, click B, quit. A's caret is now `null` on disk. Next launch A opens at offset 0 in a query thousands of lines long, and the position that had been saved is gone because you visited the tab.

The caret is now captured onto the outgoing tab in `handleTabChange`, beside the pending changes and filters that are already saved there on deselect. `toPersistedTab` serializes those fields already, so the tab carries its own last-known caret whether it is selected at quit or not. Leaving a table tab records nothing, since the caret does not belong to it.

The capture only writes to a tab whose own restored caret has already been consumed, and that guard is load-bearing. The query editor subtree carries no `.id(tab.id)`, so selecting a restored tab reuses the same editor without re-installing it: `scheduleCursorRestore` returns early and `clearRestoredCursor` never fires, which leaves `cursorPositions` still describing the tab before it. Without the guard, leaving that tab would overwrite its saved caret with the previous tab's, destroying exactly what this is meant to keep.

One more path fed the same loss and is fixed here too: `enrichedForPersistence` wrote `restoredCursorOffset = range?.location` unconditionally, so a tab whose editor never became first responder had its perfectly good saved caret overwritten with nothing on the next save. It only writes when there is a live caret now.

## Verification

Run through `verify.sh` in an isolated worktree on `1cb902800`.

- `generate` PASS, `build` PASS
- `test` PASS, **97 of 97**: RestoredHiddenColumnsTests, MainContentCoordinatorTabSwitchTests, CoordinatorColumnVisibilityTests, PersistedTabRoundTripTests, DefaultSortInitialQueryTests
- `swiftlint --strict` clean over every touched file

The new tests pin what failed silently: every restored tab picks up its own table's hidden set rather than only the first, a tab that already has one is left alone, a table with nothing stored stays empty, query tabs and tabs with no table name are skipped, switching away from a query tab keeps its caret on the tab, that caret reaches the persisted record, and leaving a table tab records none.

Known and unchanged: the per-table store is shared by every tab on that table, so a tab reloaded after another tab changed the hidden set picks up the new one. That is how `restoreLastHiddenColumnsForTable` already behaves on navigation, and changing it would be a change to the feature's model rather than a fix.

No UI automation. Both flows are quit, relaunch and restore across launches, driven by an autosave timer, which does not run deterministically in `TableProUITests`. Both are covered at the boundary where the state is actually lost.
