### PR TITLE
fix(localization): refine Korean Save & Connect label

### DIFF
--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -98294,7 +98294,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "저장 및 연결"
+            "value" : "저장 후 연결"
           }
         },
         "tr" : {


### PR DESCRIPTION
## 목적

Improve the clarity of the Korean primary action label in the connection form.

## 내용(의도 포함)

- Refine the Korean copy for the save-and-connect action.
- Leave the underlying behavior and other localizations unchanged.

## 성공기준

- Localization verification and strict lint pass.
- The Korean localization test suite passes on macOS.
- The label renders without wrapping or clipping in the connection form.