### PR TITLE
fix(ci): untrack the Dameng lib symlink that breaks every runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,7 +168,10 @@ Libs/ios/
 # lockfile is the only one cargo writes. lib/ holds the staticlib slices build-dameng.sh
 # links into the plugin; they stay out of Libs/, which download-libs.sh checksum-verifies.
 Native/DamengBridge/**/target/
-Native/DamengBridge/lib/
+# No trailing slash: a pattern ending in one matches a directory only, so a symlink named `lib`
+# slipped past it and was committed, pointing at one machine's absolute path. Every checkout
+# elsewhere then got a dangling link and `mkdir -p` in build-dameng.sh failed on it.
+Native/DamengBridge/lib
 
 # Issue analysis blueprints (local only)
 .analysis/

--- a/Native/DamengBridge/lib
+++ b/Native/DamengBridge/lib
@@ -1,1 +1,0 @@
-/Users/ngoquocdat/Workspaces/TablePro/Native/DamengBridge/lib


### PR DESCRIPTION
`main` is red, and so is every open pull request. This fixes it.

## What happened

`Native/DamengBridge/lib` is a build output directory, but it is tracked in git as a **symlink** whose content is one machine's absolute path:

```
120000 blob 762ab315b27c    Native/DamengBridge/lib
  -> /Users/ngoquocdat/Workspaces/TablePro/Native/DamengBridge/lib
```

Every checkout that is not that machine gets a dangling link. `scripts/build-dameng.sh:38` runs `mkdir -p "$LIBS_DIR"`, which follows the link, finds the target's parent missing, and fails. The `-p` does not help: it applies to missing parents of the path you asked for, not to a broken symlink standing where that path should be.

Reproduced exactly, outside the repo:

```
$ ln -sfn /Users/nonexistent-runner/.../lib bridge/lib
$ mkdir -p bridge/lib
mkdir: bridge/lib: No such file or directory     # exit 1, byte for byte the CI error

$ rm -f bridge/lib && mkdir -p bridge/lib        # exit 0
```

## Why it slipped in

`.gitignore` had `Native/DamengBridge/lib/`. A pattern with a trailing slash matches a directory and **not** a symlink, so the entry never covered the symlink and a broad `git add` swept it in.

It arrived with an unrelated change (`22ee96c58`, the Redis Sentinel PR), which is what you would expect from a stray `git add -A` rather than anything deliberate.

## The fix

- Untrack `Native/DamengBridge/lib`. Nothing should have tracked it; it is written by `build-dameng.sh`.
- Drop the trailing slash so the pattern matches the symlink too, and say why in a comment so it does not get re-added.

Verified locally: with the new pattern, a symlink created at that path does not appear in `git status` at all.

## Note for the same trap elsewhere

`Libs/dylibs` and `Libs/ios` are ignored by the same trailing-slash style and are symlinks in every worktree, so they can be committed the same way. They are untouched here because they are not currently tracked, but the pattern is worth the same treatment before someone stages one.
