### PR TITLE
fix(connections): keep the hosts of a tunnelled MongoDB SRV connection

### DIFF
--- a/TablePro/Core/Database/DatabaseManager+Tunnel.swift
+++ b/TablePro/Core/Database/DatabaseManager+Tunnel.swift
@@ -51,8 +51,17 @@ extension DatabaseManager {
         let forwardEndpoint = connection.tunnelForwardEndpoint
         effectiveFields[DatabaseConnection.preTunnelHostKey] = forwardEndpoint.host
         effectiveFields[DatabaseConnection.preTunnelPortKey] = String(forwardEndpoint.port)
-        for fieldId in connection.hostListFieldIds {
-            effectiveFields[fieldId] = nil
+        /// A host list names the servers the driver would reach for itself, and behind a tunnel
+        /// there is one forwarded endpoint instead, so the list has to go. An SRV connection is
+        /// the exception: its host is a lookup name rather than a server to dial, the driver
+        /// resolves it and then connects through the forward anyway, and clearing it leaves the
+        /// driver with nothing to resolve. The rule used to live in the MongoDB branch below,
+        /// where the `!usesMongoSrv` guard protected it; generalising the clear to every host-list
+        /// field moved it above that guard and dropped the exception with it.
+        if !connection.usesMongoSrv {
+            for fieldId in connection.hostListFieldIds {
+                effectiveFields[fieldId] = nil
+            }
         }
         if connection.type.pluginTypeId == "MongoDB", !connection.usesMongoSrv {
             effectiveFields["mongoParam_directConnection"] = "true"


### PR DESCRIPTION
`main` is red on `DatabaseManagerTunnelTests/tunnelLeavesMongoSrvUntouched()`, and every open pull request inherits it. The test name states the contract that broke.

## What happened

`22ee96c58` generalised the tunnel host-list clear so Redis Sentinel and Cluster host lists get dropped behind a tunnel. That is correct on its own. The problem is where the new loop sits:

```diff
+        for fieldId in connection.hostListFieldIds {
+            effectiveFields[fieldId] = nil
+        }
         if connection.type.pluginTypeId == "MongoDB", !connection.usesMongoSrv {
-            effectiveFields["mongoHosts"] = nil
             effectiveFields["mongoParam_directConnection"] = "true"
         }
```

The old line cleared `mongoHosts` **only** when `!connection.usesMongoSrv`. That guard was the whole point: it kept the hosts for an SRV connection. The new loop runs above the guard and clears every host-list field unconditionally, and `mongoHosts` is a `.hostList` field, so the SRV exception was dropped along with the line that carried it.

## Why it matters beyond a red check

A host list names servers the driver would dial itself, and behind a tunnel there is one forwarded endpoint instead, so clearing it is right. An SRV connection is not that: its host is a name to resolve, not a server to dial. The driver resolves it and then connects through the forward anyway. Clearing it leaves the driver with nothing to resolve, so an SRV MongoDB connection over SSH loses its hosts.

## The fix

Put the SRV exception back, in front of the loop that swallowed it, with a comment saying why so the next generalisation does not remove it again.

Redis is unaffected: `usesMongoSrv` is `mongoUseSrv || host.hasSuffix(".mongodb.net")`, which is false for a Redis connection, so Sentinel and Cluster host lists are still cleared exactly as this loop intended.

## Verification

`DatabaseManagerTunnelTests`: 10 executed, 10 passed. It was 9 of 10 before the change, failing on `tunnelLeavesMongoSrvUntouched()`.

## One thing I did not do

The guard is a MongoDB-specific term gating a driver-agnostic loop, which is not lovely. The honest version of this rule is per-field: a host list holds names to resolve or servers to dial, and only the second kind should be cleared. That belongs in `hostListFieldIds` rather than at the call site, and it is more than a hotfix should carry while `main` is red. Worth doing when someone is next in this code.
