### PR TITLE
fix(settings): title the Settings window after the pane it is showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Settings window is titled after the pane you are on. Switching panes used to leave it reading "Untitled" until the window was closed and reopened.
+- The Settings window refuses to be resized smaller than a pane can draw. It had no minimum, so it could be shrunk until the controls were cut off.
 - Redis Sentinel and Cluster connections show their nodes in the connection list. Because those modes leave Host blank, the list showed nothing but the word "Redis". A connection that names its servers in a host list now shows the first one and how many others there are, and it follows the list the connection's current mode actually uses.
 - Redis Cluster routes `OBJECT`, `MEMORY`, `SORT`, `GEORADIUS`, `ZUNIONSTORE` and `ZINTERSTORE` to the right shard on servers that do not report command tips, which is every Redis 6. The built-in routing table used as the fallback there disagreed with Redis on 32 counts: it hashed a container command on the name of its subcommand, treated the argument count of a store operation as a key, and marked `MSETNX` splittable when splitting it across shards would set some of its keys and not the others.
 - Floating point values show the shortest digits that still identify the stored number exactly. A value inside a sub-document or an array picked up binary floating point noise, so a stored `0.1` read as `0.10000000000000001`, and a top level value that needed 17 digits was cut to 16, so the grid could show a number that was not the one on the server. Affects MongoDB, Elasticsearch, ClickHouse, Snowflake, DynamoDB and Beancount results, and values brought in through JSON import.

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -78,7 +78,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         WindowOpener.shared.setWelcomePresenter { WelcomeWindowController.present() }
         WindowOpener.shared.setConnectionFormPresenter { ConnectionFormWindowController.present($0) }
         WindowOpener.shared.setIntegrationsActivityPresenter { IntegrationsActivityWindowController.present() }
-        WindowOpener.shared.setSettingsPresenter { SettingsWindowController.present() }
+        WindowOpener.shared.setSettingsPresenter { SettingsWindowController.present(pane: $0) }
         KeyRepeatFilter.shared.install()
         let syncSettings = AppSettingsStorage.shared.loadSync()
         let passwordSyncExpected = syncSettings.enabled && syncSettings.syncConnections && syncSettings.syncPasswords

--- a/TablePro/Core/Services/Infrastructure/WindowOpener.swift
+++ b/TablePro/Core/Services/Infrastructure/WindowOpener.swift
@@ -17,7 +17,7 @@ internal final class WindowOpener {
     @ObservationIgnored private var openWelcomeAction: (() -> Void)?
     @ObservationIgnored private var openConnectionFormAction: ((ConnectionFormRequest) -> Void)?
     @ObservationIgnored private var openIntegrationsActivityAction: (() -> Void)?
-    @ObservationIgnored private var openSettingsAction: (() -> Void)?
+    @ObservationIgnored private var openSettingsAction: ((SettingsPane?) -> Void)?
     @ObservationIgnored private var stagedDraftId: UUID?
     @ObservationIgnored private var pendingCalls: [() -> Void] = []
 
@@ -35,12 +35,9 @@ internal final class WindowOpener {
     }
 
     internal func openSettings(tab: SettingsPane? = nil) {
-        if let tab {
-            AppStorageEnvironment.shared.defaults.set(tab.rawValue, forKey: PreferenceKeys.selectedSettingsPane.name)
-        }
         perform { opener in
             guard let present = opener.openSettingsAction else { return false }
-            present()
+            present(tab)
             return true
         }
     }
@@ -119,7 +116,7 @@ internal final class WindowOpener {
         drainPendingCalls()
     }
 
-    internal func setSettingsPresenter(_ present: @escaping () -> Void) {
+    internal func setSettingsPresenter(_ present: @escaping (SettingsPane?) -> Void) {
         openSettingsAction = present
         drainPendingCalls()
     }

--- a/TablePro/Core/Utilities/UI/AlertHelper.swift
+++ b/TablePro/Core/Utilities/UI/AlertHelper.swift
@@ -143,9 +143,8 @@ final class AlertHelper {
         let fitted = host.sizeThatFits(in: NSSize(width: 520, height: CGFloat.greatestFiniteMagnitude))
         host.view.frame = NSRect(origin: .zero, size: fitted)
 
-        let sheetWindow = NSWindow(contentViewController: host)
+        let sheetWindow = NSWindow.titled(String(localized: "Approve Integration"), contentViewController: host)
         sheetWindow.styleMask = [.titled, .closable]
-        sheetWindow.title = String(localized: "Approve Integration")
         sheetWindow.isReleasedWhenClosed = false
 
         guard let parent = resolveWindow(nil) else {

--- a/TablePro/Extensions/NSWindow+ContentTitle.swift
+++ b/TablePro/Extensions/NSWindow+ContentTitle.swift
@@ -1,0 +1,17 @@
+//
+//  NSWindow+ContentTitle.swift
+//  TablePro
+//
+
+import AppKit
+
+internal extension NSWindow {
+    /// `NSWindow(contentViewController:)` binds the window title to that controller's `title`
+    /// with "Untitled" as its null placeholder, so a window built that way is titled through its
+    /// content view controller. Writing `window.title` afterwards holds only until the binding
+    /// next fires, and the placeholder is what a controller with no title publishes.
+    static func titled(_ title: String, contentViewController: NSViewController) -> NSWindow {
+        contentViewController.title = title
+        return NSWindow(contentViewController: contentViewController)
+    }
+}

--- a/TablePro/Views/Acknowledgements/AcknowledgementsWindowController.swift
+++ b/TablePro/Views/Acknowledgements/AcknowledgementsWindowController.swift
@@ -27,16 +27,12 @@ internal final class AcknowledgementsWindowController: NSWindowController {
         )
         hosting.preferredContentSize = Self.windowSize
 
-        let window = NSWindow(contentViewController: hosting)
-        window.title = String(localized: "Acknowledgements")
+        let window = NSWindow.titled(String(localized: "Acknowledgements"), contentViewController: hosting)
         window.identifier = NSUserInterfaceItemIdentifier(WindowIdentifier.acknowledgements)
         window.styleMask = [.titled, .closable, .resizable, .miniaturizable]
         window.isRestorable = false
         window.setContentSize(Self.windowSize)
-        window.setFrameAutosaveName(WindowIdentifier.acknowledgements)
-        if !window.setFrameUsingName(WindowIdentifier.acknowledgements) {
-            window.center()
-        }
+        window.applyAutosaveName(WindowIdentifier.acknowledgements)
         self.init(window: window)
     }
 }

--- a/TablePro/Views/Connection/WelcomeWindowController.swift
+++ b/TablePro/Views/Connection/WelcomeWindowController.swift
@@ -32,8 +32,7 @@ internal final class WelcomeWindowController: NSWindowController {
         /// split pane's host, where the same minimum would pin the window's dividers.
         hosting.sizingOptions = [.minSize]
 
-        let window = NSWindow(contentViewController: hosting)
-        window.title = String(localized: "Welcome to TablePro")
+        let window = NSWindow.titled(String(localized: "Welcome to TablePro"), contentViewController: hosting)
         window.identifier = NSUserInterfaceItemIdentifier(WindowIdentifier.welcome)
         window.styleMask = [.titled, .closable, .miniaturizable, .fullSizeContentView]
         window.titlebarAppearsTransparent = true

--- a/TablePro/Views/ConnectionForm/ConnectionFormWindowController.swift
+++ b/TablePro/Views/ConnectionForm/ConnectionFormWindowController.swift
@@ -46,8 +46,7 @@ internal final class ConnectionFormWindowController: NSWindowController, NSWindo
         /// split pane's host, where the same minimum would pin the window's dividers.
         hosting.sizingOptions = [.minSize]
 
-        let window = NSWindow(contentViewController: hosting)
-        window.title = Self.initialTitle(for: request)
+        let window = NSWindow.titled(Self.initialTitle(for: request), contentViewController: hosting)
         window.identifier = NSUserInterfaceItemIdentifier(WindowIdentifier.connectionForm)
         window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
         window.isRestorable = false

--- a/TablePro/Views/Integrations/IntegrationsActivityWindowController.swift
+++ b/TablePro/Views/Integrations/IntegrationsActivityWindowController.swift
@@ -29,8 +29,7 @@ internal final class IntegrationsActivityWindowController: NSWindowController {
         /// split pane's host, where the same minimum would pin the window's dividers.
         hosting.sizingOptions = [.minSize]
 
-        let window = NSWindow(contentViewController: hosting)
-        window.title = String(localized: "Integrations Activity")
+        let window = NSWindow.titled(String(localized: "Integrations Activity"), contentViewController: hosting)
         window.identifier = NSUserInterfaceItemIdentifier(WindowIdentifier.integrationsActivity)
         window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
         window.setContentSize(NSSize(width: 960, height: 600))

--- a/TablePro/Views/Settings/SettingsView.swift
+++ b/TablePro/Views/Settings/SettingsView.swift
@@ -5,7 +5,7 @@
 
 import SwiftUI
 
-enum SettingsPane: String {
+enum SettingsPane: String, CaseIterable {
     case general, appearance, editor, data, keyboard, ai, mcp, plugins, account
 
     var title: String {

--- a/TablePro/Views/Settings/SettingsWindowController.swift
+++ b/TablePro/Views/Settings/SettingsWindowController.swift
@@ -4,6 +4,7 @@
 //
 
 import AppKit
+import os
 import SwiftUI
 
 /// Hosts the settings panes in an AppKit window so the app no longer needs a SwiftUI `Settings`
@@ -13,10 +14,10 @@ import SwiftUI
 internal final class SettingsWindowController: NSWindowController {
     private static var shared: SettingsWindowController?
 
-    internal static func present() {
+    internal static func present(pane: SettingsPane? = nil) {
         let controller = shared ?? SettingsWindowController()
         shared = controller
-        controller.paneController?.selectPersistedPane()
+        controller.paneController?.select(pane)
         controller.showWindow(nil)
         controller.window?.makeKeyAndOrderFront(nil)
         NSApp.activate()
@@ -26,24 +27,22 @@ internal final class SettingsWindowController: NSWindowController {
         contentViewController as? SettingsPaneTabViewController
     }
 
-    private convenience init() {
+    internal convenience init() {
         let panes = SettingsPaneTabViewController(nibName: nil, bundle: nil)
 
+        /// `NSWindow(contentViewController:)` binds the window title to the content view
+        /// controller's own title, so the selected pane publishes the title and nothing writes
+        /// `window.title` directly.
         let window = NSWindow(contentViewController: panes)
-        window.title = String(localized: "Settings")
         window.identifier = NSUserInterfaceItemIdentifier(WindowIdentifier.settings)
         window.styleMask = [.titled, .closable, .resizable]
         window.toolbarStyle = .preference
         window.isRestorable = false
+        window.contentMinSize = SettingsPaneTabViewController.paneSize
         window.setContentSize(SettingsPaneTabViewController.paneSize)
-        window.setFrameAutosaveName(WindowIdentifier.settings)
-        /// A programmatic window keeps whatever origin AppKit gave it, so the first launch
-        /// after the SwiftUI scene is gone has no saved frame to restore.
-        if !window.setFrameUsingName(WindowIdentifier.settings) {
-            window.center()
-        }
-        /// A frame saved before the window became resizable can be smaller than any pane can
-        /// draw, so a restored frame is grown back to the pane minimum.
+        window.applyAutosaveName(WindowIdentifier.settings)
+        /// `contentMinSize` only constrains a user drag, so a frame saved before the window had
+        /// a minimum is grown back to the pane minimum on restore.
         window.setContentSize(
             NSSize(
                 width: max(window.contentLayoutRect.width, SettingsPaneTabViewController.paneSize.width),
@@ -54,12 +53,11 @@ internal final class SettingsWindowController: NSWindowController {
     }
 }
 
-private final class SettingsPaneTabViewController: NSTabViewController {
-    fileprivate static let paneSize = NSSize(width: 720, height: 500)
+internal final class SettingsPaneTabViewController: NSTabViewController {
+    internal static let paneSize = NSSize(width: 720, height: 500)
+    internal static let paneOrder: [SettingsPane] = SettingsPane.allCases
 
-    private static let paneOrder: [SettingsPane] = [
-        .general, .appearance, .editor, .data, .keyboard, .ai, .mcp, .plugins, .account,
-    ]
+    private static let logger = Logger(subsystem: "com.TablePro", category: "SettingsWindow")
 
     private var persistedPane: SettingsPane {
         let stored = AppStorageEnvironment.shared.defaults.string(forKey: PreferenceKeys.selectedSettingsPane.name)
@@ -67,9 +65,14 @@ private final class SettingsPaneTabViewController: NSTabViewController {
         return pane
     }
 
-    fileprivate func selectPersistedPane() {
+    internal func select(_ pane: SettingsPane?) {
         loadViewIfNeeded()
-        select(persistedPane)
+        let wanted = pane ?? persistedPane
+        guard let index = Self.paneOrder.firstIndex(of: wanted) else {
+            Self.logger.error("Settings pane \(wanted.rawValue, privacy: .public) has no tab and cannot be shown")
+            return
+        }
+        selectedTabViewItemIndex = index
     }
 
     override func viewDidLoad() {
@@ -89,13 +92,6 @@ private final class SettingsPaneTabViewController: NSTabViewController {
         guard let identifier = tabViewItem?.identifier as? String,
               let pane = SettingsPane(rawValue: identifier) else { return }
         AppStorageEnvironment.shared.defaults.set(pane.rawValue, forKey: PreferenceKeys.selectedSettingsPane.name)
-        view.window?.title = pane.title
-    }
-
-    private func select(_ pane: SettingsPane) {
-        guard let index = Self.paneOrder.firstIndex(of: pane) else { return }
-        selectedTabViewItemIndex = index
-        view.window?.title = pane.title
     }
 
     private func makeTabViewItem(for pane: SettingsPane) -> NSTabViewItem {
@@ -109,9 +105,11 @@ private final class SettingsPaneTabViewController: NSTabViewController {
             .environment(UpdaterBridge.shared)
             .environment(\.appServices, .live)
         let hosting = NSHostingController(rootView: content)
-        /// A standalone window wants the content's minimum to become the window's, unlike a
-        /// split pane's host, where the same minimum would pin the window's dividers.
-        hosting.sizingOptions = [.minSize]
+        /// A tab child publishes no size to the window, which owns its minimum through
+        /// `contentMinSize`. Its title does travel: `NSTabViewController` mirrors the selected
+        /// child's title into its own, and the window's title is bound to that.
+        hosting.sizingOptions = []
+        hosting.title = pane.title
 
         let item = NSTabViewItem(viewController: hosting)
         item.label = pane.title

--- a/TableProTests/Core/Services/Infrastructure/WindowOpenerTests.swift
+++ b/TableProTests/Core/Services/Infrastructure/WindowOpenerTests.swift
@@ -9,17 +9,21 @@ import XCTest
 @MainActor
 final class WindowOpenerTests: XCTestCase {
     private var openedRequests: [ConnectionFormRequest] = []
+    private var openedSettingsPanes: [SettingsPane?] = []
 
     override func setUp() {
         super.setUp()
         _ = WelcomeRouter.shared.consumePendingRequest()
         openedRequests = []
+        openedSettingsPanes = []
         WindowOpener.shared.setWelcomePresenter {}
         WindowOpener.shared.setConnectionFormPresenter { [weak self] request in
             self?.openedRequests.append(request)
         }
         WindowOpener.shared.setIntegrationsActivityPresenter {}
-        WindowOpener.shared.setSettingsPresenter {}
+        WindowOpener.shared.setSettingsPresenter { [weak self] pane in
+            self?.openedSettingsPanes.append(pane)
+        }
     }
 
     override func tearDown() {
@@ -153,6 +157,32 @@ final class WindowOpenerTests: XCTestCase {
         opener.setConnectionFormPresenter { opened.append($0) }
 
         XCTAssertEqual(opened, [.edit(connectionId: connectionId)])
+    }
+
+    func testTheRequestedSettingsPaneReachesThePresenter() {
+        WindowOpener.shared.openSettings(tab: .plugins)
+
+        XCTAssertEqual(openedSettingsPanes, [.plugins])
+    }
+
+    func testOpeningSettingsWithoutAPaneAsksForNone() {
+        WindowOpener.shared.openSettings()
+
+        XCTAssertEqual(openedSettingsPanes, [SettingsPane?.none])
+    }
+
+    /// The pane used to travel through UserDefaults, so a call made before the presenter existed
+    /// wrote the preference and then opened on whatever was stored.
+    func testASettingsCallQueuedBeforeItsPresenterKeepsItsPane() {
+        let opener = WindowOpener()
+        var opened: [SettingsPane?] = []
+
+        opener.openSettings(tab: .ai)
+        XCTAssertTrue(opened.isEmpty, "No presenter yet, so the call has to wait")
+
+        opener.setSettingsPresenter { opened.append($0) }
+
+        XCTAssertEqual(opened, [.ai])
     }
 
     func testEditingTheSameConnectionTwiceRequestsTheSameWindow() {

--- a/TableProTests/Views/Settings/SettingsWindowTitleTests.swift
+++ b/TableProTests/Views/Settings/SettingsWindowTitleTests.swift
@@ -1,0 +1,97 @@
+//
+//  SettingsWindowTitleTests.swift
+//  TableProTests
+//
+
+import AppKit
+@testable import TablePro
+import XCTest
+
+@MainActor
+final class SettingsWindowTitleTests: XCTestCase {
+    private var storedPane: String?
+    private var windows: [NSWindow] = []
+
+    override func setUp() {
+        super.setUp()
+        storedPane = AppStorageEnvironment.shared.defaults.string(forKey: PreferenceKeys.selectedSettingsPane.name)
+    }
+
+    override func tearDown() {
+        for window in windows {
+            window.contentViewController = nil
+            window.close()
+        }
+        windows = []
+        if let storedPane {
+            AppStorageEnvironment.shared.defaults.set(storedPane, forKey: PreferenceKeys.selectedSettingsPane.name)
+        } else {
+            AppStorageEnvironment.shared.defaults.removeObject(forKey: PreferenceKeys.selectedSettingsPane.name)
+        }
+        super.tearDown()
+    }
+
+    private func makePanes() -> (SettingsPaneTabViewController, NSWindow) {
+        let panes = SettingsPaneTabViewController(nibName: nil, bundle: nil)
+        let window = NSWindow(contentViewController: panes)
+        window.isReleasedWhenClosed = false
+        windows.append(window)
+        return (panes, window)
+    }
+
+    func testEveryPaneIsReachableAndCarriesItsOwnTitle() {
+        let (panes, _) = makePanes()
+        panes.loadViewIfNeeded()
+
+        XCTAssertEqual(SettingsPaneTabViewController.paneOrder, SettingsPane.allCases)
+        XCTAssertEqual(panes.tabViewItems.count, SettingsPane.allCases.count)
+        for (item, pane) in zip(panes.tabViewItems, SettingsPane.allCases) {
+            XCTAssertEqual(item.viewController?.title, pane.title)
+            XCTAssertEqual(item.label, pane.title)
+        }
+    }
+
+    /// `NSWindow(contentViewController:)` binds the window title to that controller's title and
+    /// substitutes "Untitled" whenever it is nil, so a pane switch used to erase the title.
+    func testTheWindowTitleFollowsTheSelectedPane() {
+        let (panes, window) = makePanes()
+
+        for pane in SettingsPane.allCases {
+            panes.select(pane)
+            XCTAssertEqual(window.title, pane.title)
+        }
+    }
+
+    func testAFreshControllerOpensOnThePersistedPane() {
+        AppStorageEnvironment.shared.defaults.set(
+            SettingsPane.keyboard.rawValue,
+            forKey: PreferenceKeys.selectedSettingsPane.name
+        )
+
+        let (_, window) = makePanes()
+
+        XCTAssertEqual(window.title, SettingsPane.keyboard.title)
+    }
+
+    func testAskingForNoPaneReadsTheStoredPaneRatherThanStayingPut() {
+        let (panes, window) = makePanes()
+        panes.select(.plugins)
+        XCTAssertEqual(window.title, SettingsPane.plugins.title)
+
+        AppStorageEnvironment.shared.defaults.set(
+            SettingsPane.editor.rawValue,
+            forKey: PreferenceKeys.selectedSettingsPane.name
+        )
+        panes.select(nil)
+
+        XCTAssertEqual(window.title, SettingsPane.editor.title)
+    }
+
+    func testTheWindowRefusesToShrinkBelowAPane() {
+        let controller = SettingsWindowController()
+        guard let window = controller.window else { return XCTFail("The controller must build a window") }
+        windows.append(window)
+
+        XCTAssertEqual(window.contentMinSize, SettingsPaneTabViewController.paneSize)
+    }
+}

--- a/TableProUITests/SettingsWindowTitleUITests.swift
+++ b/TableProUITests/SettingsWindowTitleUITests.swift
@@ -1,0 +1,28 @@
+import XCTest
+
+final class SettingsWindowTitleUITests: UITestCase {
+    /// The window is found by its accessibility identifier, never by its title: the title is the
+    /// thing under test, so matching on it would pass without the window ever being retitled.
+    func testTheSettingsWindowTitleFollowsTheSelectedPane() throws {
+        let app = try launchApp()
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+
+        let settingsMenuItem = app.menuBars.menuItems["Settings..."]
+        XCTAssertTrue(settingsMenuItem.waitForExistence(timeout: 10))
+        settingsMenuItem.click()
+
+        let settingsWindow = app.windows["settings"]
+        XCTAssertTrue(settingsWindow.waitForExistence(timeout: 10))
+
+        for pane in ["Keyboard", "Appearance", "Plugins", "Editor", "General"] {
+            let paneButton = app.toolbars.buttons[pane]
+            XCTAssertTrue(paneButton.waitForExistence(timeout: 10))
+            paneButton.click()
+
+            XCTAssertTrue(
+                waitForPredicate(timeout: 5) { settingsWindow.title == pane },
+                "The settings window has to be titled \(pane), it is titled \(settingsWindow.title)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## What was wrong

Switching panes in the Settings window left the title reading **"Untitled"**, and it stayed that way until the window was closed and reopened.

## Root cause

`NSWindow(contentViewController:)` does not just install a content view controller. It calls `-[NSWindow _bindTitleToContentViewController]`, which **binds** `window.title` to that controller's `title` through KVO, with `NSNullPlaceholder = "Untitled"`. Dumped from the live window:

```
infoForBinding("title") = [
    NSObservedKeyPath: title,
    NSObservedObject: <SettingsPaneTabViewController>,
    NSOptions: { NSNullPlaceholder = Untitled; ... }
]
```

`NSTabViewController` mirrors the **selected child's** `title` into its own. The settings panes are `NSHostingController`s whose `title` was never set, so the bound value was always nil and the binding wrote its null placeholder. `tabView(_:didSelect:)` wrote `view.window?.title = pane.title` by hand, which the binding then overwrote on the next fire. The first open looked correct only because that manual write landed after the binding's initial fire; the first pane click made it "Untitled" for good.

Captured under lldb against a Debug build:

```
-[NSWindow setTitle:]
-[NSWindowTitleBinder _observeValueForKeyPath:ofObject:context:]
-[NSObject(NSKeyValueBindingCreation) bind:toObject:withKeyPath:options:]
-[NSWindow _bindTitleToContentViewController]
+[NSWindow _windowWithContentViewController:styleMask:]
SettingsWindowController.init() at SettingsWindowController.swift:32
```

## The fix

Write the title to the object AppKit actually reads. Each pane's hosting controller carries `title = pane.title`, `NSTabViewController` mirrors it, and the binding drives the window title. All three manual `window.title` writes are gone.

The other five windows built with `NSWindow(contentViewController:)` (Welcome, Connection Form, Acknowledgements, Integrations Activity, the pairing approval sheet) go through a new `NSWindow.titled(_:contentViewController:)` that titles the controller before the window is built. Their titles were already correct, because their content controllers' titles never change after creation and the manual write happened to be the last word, but each still opened as "Untitled" for the moment between the binding firing and that write. The helper carries the AppKit rule in one place, next to `applyAutosaveName`, rather than in five copies.

## Also fixed

- **The Settings window had no minimum size.** `hosting.sizingOptions = [.minSize]` does nothing for a controller that is a *tab child* rather than the window's own content view controller: `window.contentMinSize` measured `(0, 0)`, and the live window accepted 420x320 against a 720x500 pane minimum, cutting off the controls. The window now sets `contentMinSize`.
- **`WindowOpener.openSettings(tab:)` passed the requested pane through UserDefaults**, because `setSettingsPresenter` took no argument. It writes the preference before the window exists, so a call queued ahead of the presenter opened on whatever was stored rather than on the pane asked for. The presenter now takes the pane, matching `setConnectionFormPresenter` right above it.
- The Settings and Acknowledgements windows hand-rolled the frame restore that `NSWindow.applyAutosaveName(_:)` already does.
- `SettingsPane` is now `CaseIterable` and the tab order is derived from it, instead of a hand-copied list a new pane could be left out of. A pane with no tab is logged rather than silently swallowed.

## Verification

- `verify.sh build`: PASS
- `verify.sh test SettingsWindowTitleTests WindowOpenerTests`: PASS, 20/20
- `verify.sh uitest SettingsWindowTitleUITests AuxiliaryWindowCloseUITests`: PASS, 8/8
- `verify.sh lint TablePro TableProTests TableProUITests`: PASS, 0 violations
- Two probes compiled with `swiftc` against the real AppKit pin the mechanism: one shows a manual `window.title` surviving until the bound key path changes and then being replaced, and shows `NSWindow(contentRect:)` + assigning `contentViewController` installs no binding at all; the other shows the fix, with the window title tracking pane selection and no manual writes.
- Driven live against a Debug build before and after: `after clicking General: Untitled` becomes `after clicking General: General`.

## Tests

- `SettingsWindowTitleTests` asserts every pane is reachable and carries its own title, that the window title follows the selected pane through all nine, that a fresh controller opens on the persisted pane, that asking for no pane re-reads the store rather than staying put, and that the window carries the pane minimum. It saves and restores the pane preference so a run does not rewrite the developer's own.
- `WindowOpenerTests` gains three cases for the pane reaching the presenter, including one queued before the presenter is registered.
- `SettingsWindowTitleUITests` clicks through the settings toolbar and asserts the window's title each time, finding the window by its accessibility identifier rather than by the title under test.

## Before / After

Captured from a Debug build with the Integrations pane selected in both cases. The images are not attached here because `gh` cannot upload them; the window titles were read straight off the accessibility tree, which is the same string the title bar draws.

| | Selected pane | Window title |
| --- | --- | --- |
| Before | Integrations | `Untitled` |
| After | Integrations | `Integrations` |

Clicking through the panes on the fixed build, in order: `General`, `Keyboard`, `Plugins`, `Appearance`. Every one of those read `Untitled` before.

Resize floor, same build, forcing the window to 420x320 through the accessibility API: before it became 420x320, after it stays 720x588 (720x500 of pane plus the title bar and preference toolbar).
