### PR TITLE
feat(plugin-duckdb): open Parquet, CSV, TSV and JSON files as a connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Double-click a table in the object browser, or press `Return` on it, to keep its tab. Clicking a table opens it in a preview tab that the next click reuses, and until now nothing said "keep this one", so browsing several tables left them all fighting over the first tab. Keeping a tab means the next table you click opens in its own, and double-clicking a table that is already open switches back to its tab rather than making a second one. (#2235)
 - Redis Sentinel and Redis Cluster connections. Pick a Connection Mode in the connection form. Sentinel asks the quorum which node is the primary, learns the other Sentinels so a lookup still works when the one you listed is down, and re-checks the address on every health check so a failover moves the connection with it. Cluster reads the shard map, opens a connection to every primary, routes each command to the shard that owns its key, follows MOVED and ASK redirects, splits multi-key commands across shards and sums key counts cluster-wide. Pointing a mode at the wrong kind of server now says which field to change instead of failing on the first command. (#1021)
 - **View > Result View** switches the results pane between Data, Structure, JSON and Chart from the menu bar. JSON and Chart mode used to be reachable by mouse alone.
+- A DuckDB connection can point at a Parquet, CSV, TSV, JSON or NDJSON file, not only a `.duckdb` database. DuckDB opens the file read-only as two views over it and never writes back, so the file on disk is left exactly as it was.
 
 ### Changed
 
@@ -40,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Save in the "Do you want to save changes?" prompt now closes what you asked to close once the save lands. Closing a group of tabs, or closing a connection, used to save and then leave everything open.
 - A column value filter survives switching result mode and switching tabs, instead of being dropped the moment the grid left the screen. Running a query, turning a page, refreshing, or moving to another result of the same script still clears it, because the values you picked came from the rows being replaced. (#2251)
 
+- The connection form's Browse button offers the file kinds the driver actually opens instead of every file on disk. It used to allow any file, so picking one the driver could not read looked fine until the connection failed.
+
 ### Fixed
 
 - Plugins installed from the registry are notarized, so macOS stops refusing to load them. Gatekeeper had been showing "could not verify this is free of malware" and blocking the driver, which read as a database TablePro could not connect to, and reinstalling made no difference. Every plugin needs to be published again to pick this up.
@@ -53,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opening a table no longer puts up a "Switch Failed" alert on an engine that has no databases. Dameng, Oracle, BigQuery, Elasticsearch and etcd browse schemas or indexes instead, and every click asked the driver to switch to a database with no name, which it refused. Clicking a table on those connections now just opens it. (#2262)
 - Switching schema on Dameng, Oracle, BigQuery, Snowflake and Trino no longer reloads the whole object list. The switch re-read every schema you had expanded, one after another, on the same connection the table you clicked was waiting for, so opening a table took an extra round trip per expanded schema. Only the stored procedures and functions are re-read now, which are the only things a schema switch can change. (#2262)
 - Open Quickly lists each schema once on Dameng, Oracle and BigQuery. It showed every schema twice, once labelled Database, and choosing that copy failed with an error.
+- A mistyped Parquet or CSV path in a DuckDB connection says the file is missing. DuckDB used to create an empty database under that name, which connected successfully to nothing.
 - The Settings window is titled after the pane you are on. Switching panes used to leave it reading "Untitled" until the window was closed and reopened.
 - The Settings window refuses to be resized smaller than a pane can draw. It had no minimum, so it could be shrunk until the controls were cut off.
 - Redis Sentinel and Cluster connections show their nodes in the connection list. Because those modes leave Host blank, the list showed nothing but the word "Redis". A connection that names its servers in a host list now shows the first one and how many others there are, and it follows the list the connection's current mode actually uses.

--- a/Plugins/DuckDBDriverPlugin/DuckDBFileKinds.swift
+++ b/Plugins/DuckDBDriverPlugin/DuckDBFileKinds.swift
@@ -1,0 +1,32 @@
+//
+//  DuckDBFileKinds.swift
+//  DuckDBDriverPlugin
+//
+//  The file kinds a DuckDB connection can open, split by whether opening one can
+//  create it. Extracted so the connection form's Browse panel and the driver's own
+//  path handling read the same list, and so both can be tested without the bundle.
+//
+
+import Foundation
+
+enum DuckDBFileKinds {
+    /// DuckDB's own storage format. Opening a path that does not exist creates the
+    /// database there, which is what the connection form's file field offers.
+    static let database = ["duckdb", "ddb"]
+
+    /// DuckDB 1.5 opens these as a database too: it starts an in-memory catalog and
+    /// creates two read-only views over the file, `file` and the file stem. Nothing is
+    /// written back, and the file on disk is left byte for byte identical.
+    static let readOnlyData = ["parquet", "csv", "tsv", "json", "ndjson"]
+
+    /// Database formats lead so the file field's placeholder reads
+    /// `/path/to/database.duckdb` rather than naming a format you cannot create.
+    static let all = database + readOnlyData
+
+    /// A missing `.duckdb` path is a request to create a database. A missing `.parquet`
+    /// or `.csv` path is a typo, and DuckDB would answer it by creating an empty database
+    /// under that name, which reads as a working connection to nothing.
+    static func canBeCreated(atPath path: String) -> Bool {
+        !readOnlyData.contains((path as NSString).pathExtension.lowercased())
+    }
+}

--- a/Plugins/DuckDBDriverPlugin/DuckDBPlugin.swift
+++ b/Plugins/DuckDBDriverPlugin/DuckDBPlugin.swift
@@ -81,7 +81,7 @@ final class DuckDBPlugin: NSObject, TableProPlugin, DriverPlugin {
             visibleWhen: FieldVisibilityRule(fieldId: "duckdbMode", values: ["remote"])
         )
     ]
-    static let fileExtensions: [String] = ["duckdb", "ddb"]
+    static let fileExtensions: [String] = DuckDBFileKinds.all
     static let brandColorHex = "#FFD900"
     static let parameterStyle: ParameterStyle = .dollar
 
@@ -247,6 +247,11 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         let path = expandPath(rawPath)
 
         if !FileManager.default.fileExists(atPath: path) {
+            guard DuckDBFileKinds.canBeCreated(atPath: path) else {
+                throw DuckDBPluginError.connectionFailed(
+                    String(format: String(localized: "No file at %@"), path)
+                )
+            }
             let directory = (path as NSString).deletingLastPathComponent
             if !directory.isEmpty {
                 try? FileManager.default.createDirectory(

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
@@ -732,7 +732,7 @@ extension PluginMetadataRegistry {
                     immutableColumns: [],
                     systemDatabaseNames: ["system", "temp"],
                     systemSchemaNames: [],
-                    fileExtensions: ["duckdb", "ddb"],
+                    fileExtensions: ["duckdb", "ddb", "parquet", "csv", "tsv", "json", "ndjson"],
                     databaseGroupingStrategy: .bySchema,
                     structureColumnFields: [.name, .type, .nullable, .defaultValue, .autoIncrement, .comment]
                 ),

--- a/TablePro/Core/Utilities/File/DatabaseFileTypes.swift
+++ b/TablePro/Core/Utilities/File/DatabaseFileTypes.swift
@@ -1,0 +1,36 @@
+//
+//  DatabaseFileTypes.swift
+//  TablePro
+//
+
+import Foundation
+import UniformTypeIdentifiers
+
+/// Turns a driver's declared file extensions into the content types its Browse panel offers.
+///
+/// The panel used to allow `[.database, .data]`, which is every file on disk, so a DuckDB
+/// connection let you pick a `.png` and a SQLite connection let you pick a `.parquet`. The
+/// driver is the only thing that knows what it can open, and it already declares that list.
+enum DatabaseFileTypes {
+    /// Most database extensions are not registered system types, so
+    /// `UTType(filenameExtension:)` alone returns nil for them. Declaring conformance to
+    /// `.data` makes the system mint a dynamic type, which the panel filters on by extension.
+    ///
+    /// Two extensions can resolve to one type, and whether they do depends on what is
+    /// installed: a Mac with the DuckDB CLI resolves both `duckdb` and `ddb` to
+    /// `org.duckdb.duckdb-database`, and a Mac without it mints a separate dynamic type for
+    /// each. Duplicates are dropped so the panel's format list does not repeat itself, and
+    /// the first occurrence keeps its place so the driver's own ordering survives.
+    static func contentTypes(forExtensions extensions: [String]) -> [UTType] {
+        var seen: Set<UTType> = []
+        let types = extensions.compactMap { rawExtension -> UTType? in
+            let trimmed = rawExtension.trimmingCharacters(in: CharacterSet(charactersIn: ". "))
+            guard !trimmed.isEmpty,
+                  let type = UTType(filenameExtension: trimmed, conformingTo: .data),
+                  seen.insert(type).inserted
+            else { return nil }
+            return type
+        }
+        return types.isEmpty ? [.data] : types
+    }
+}

--- a/TablePro/Views/ConnectionForm/Panes/GeneralPaneView.swift
+++ b/TablePro/Views/ConnectionForm/Panes/GeneralPaneView.swift
@@ -385,21 +385,26 @@ struct GeneralPaneView: View {
     }
 
     private func browseForFile() {
-        presentFilePanel { path in
+        let types = DatabaseFileTypes.contentTypes(
+            forExtensions: PluginManager.shared.fileExtensions(for: type)
+        )
+        presentFilePanel(contentTypes: types) { path in
             coordinator.network.database = path
         }
     }
 
+    /// Certificates, keys and identity files are not the driver's own file kinds, so this
+    /// panel stays open to any file.
     private func browseForAuthFile(field: ConnectionField) {
-        presentFilePanel { path in
+        presentFilePanel(contentTypes: [.data]) { path in
             coordinator.auth.additionalFieldValues[field.id] = path
         }
     }
 
-    private func presentFilePanel(onSelect: @escaping (String) -> Void) {
+    private func presentFilePanel(contentTypes: [UTType], onSelect: @escaping (String) -> Void) {
         guard let window = NSApp.keyWindow else { return }
         let panel = NSOpenPanel()
-        panel.allowedContentTypes = [.database, .data]
+        panel.allowedContentTypes = contentTypes
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
 

--- a/TableProTests/Core/Utilities/DatabaseFileTypesTests.swift
+++ b/TableProTests/Core/Utilities/DatabaseFileTypesTests.swift
@@ -1,0 +1,70 @@
+//
+//  DatabaseFileTypesTests.swift
+//  TableProTests
+//
+//  Whether an extension resolves to a registered type or a minted dynamic one depends on
+//  what is installed on the machine: a Mac with the DuckDB CLI resolves `duckdb` and `ddb`
+//  to one shared `org.duckdb.duckdb-database`, a Mac without it mints a dynamic type for
+//  each. These assert what holds either way, so they mean the same thing on CI.
+//
+
+import Foundation
+import Testing
+import UniformTypeIdentifiers
+
+@testable import TablePro
+
+@Suite("Database file types")
+struct DatabaseFileTypesTests {
+    private func accepts(_ types: [UTType], _ fileExtension: String) -> Bool {
+        types.contains { type in
+            type.tags[.filenameExtension]?.contains(fileExtension) ?? false
+        }
+    }
+
+    @Test("Every declared extension is accepted, including ones with no registered type")
+    func everyExtensionIsAccepted() {
+        let extensions = ["duckdb", "ddb", "parquet", "csv", "tsv", "json", "ndjson"]
+        let types = DatabaseFileTypes.contentTypes(forExtensions: extensions)
+
+        for fileExtension in extensions {
+            #expect(accepts(types, fileExtension), "the panel would reject .\(fileExtension)")
+        }
+    }
+
+    @Test("An unregistered extension still produces a type that conforms to data")
+    func unregisteredExtensionsStillResolve() {
+        let types = DatabaseFileTypes.contentTypes(forExtensions: ["duckdb", "ddb"])
+        #expect(!types.isEmpty)
+        #expect(types.allSatisfy { $0.conforms(to: .data) })
+        #expect(accepts(types, "duckdb"))
+        #expect(accepts(types, "ddb"))
+    }
+
+    @Test("Extensions that share one system type are listed once")
+    func sharedTypesAreDeduplicated() {
+        let types = DatabaseFileTypes.contentTypes(forExtensions: ["csv", "csv", "json"])
+        #expect(types.count == Set(types).count)
+        #expect(types.count == 2)
+    }
+
+    @Test("The first extension keeps its place, so the panel's default format is the driver's")
+    func orderIsPreserved() {
+        let types = DatabaseFileTypes.contentTypes(forExtensions: ["parquet", "csv"])
+        #expect(types.first?.tags[.filenameExtension]?.contains("parquet") == true)
+    }
+
+    @Test("A leading dot or stray whitespace is tolerated")
+    func extensionsAreTrimmed() {
+        let types = DatabaseFileTypes.contentTypes(forExtensions: [".parquet", " csv "])
+        #expect(accepts(types, "parquet"))
+        #expect(accepts(types, "csv"))
+    }
+
+    /// A driver that declares nothing must not end up with a panel that allows nothing.
+    @Test("A driver with no declared extensions falls back to any file")
+    func emptyListFallsBackToData() {
+        #expect(DatabaseFileTypes.contentTypes(forExtensions: []) == [.data])
+        #expect(DatabaseFileTypes.contentTypes(forExtensions: ["", ".", "  "]) == [.data])
+    }
+}

--- a/TableProTests/Plugins/DuckDBFileKindsTests.swift
+++ b/TableProTests/Plugins/DuckDBFileKindsTests.swift
@@ -1,0 +1,50 @@
+//
+//  DuckDBFileKindsTests.swift
+//  TableProTests
+//
+//  Tests for DuckDBFileKinds (compiled via project.yml from DuckDBDriverPlugin).
+//
+
+import Foundation
+import Testing
+
+@Suite("DuckDB file kinds")
+struct DuckDBFileKindsTests {
+    @Test("The database formats lead, so the file field's placeholder names one")
+    func databaseFormatsComeFirst() {
+        #expect(DuckDBFileKinds.all.first == "duckdb")
+        #expect(DuckDBFileKinds.all.prefix(2) == ["duckdb", "ddb"])
+    }
+
+    @Test("Every kind DuckDB can open is offered, with no duplicates")
+    func allCoversBothGroups() {
+        #expect(DuckDBFileKinds.all == DuckDBFileKinds.database + DuckDBFileKinds.readOnlyData)
+        #expect(Set(DuckDBFileKinds.all).count == DuckDBFileKinds.all.count)
+        for kind in ["parquet", "csv", "tsv", "json"] {
+            #expect(DuckDBFileKinds.all.contains(kind))
+        }
+    }
+
+    @Test("A missing database path may be created, because that is how you make a new one")
+    func databasePathsCanBeCreated() {
+        #expect(DuckDBFileKinds.canBeCreated(atPath: "/tmp/new.duckdb"))
+        #expect(DuckDBFileKinds.canBeCreated(atPath: "/tmp/new.ddb"))
+        #expect(DuckDBFileKinds.canBeCreated(atPath: "/tmp/new"))
+        #expect(DuckDBFileKinds.canBeCreated(atPath: ":memory:"))
+    }
+
+    @Test("A missing data-file path is a typo, not a request to create an empty database")
+    func dataFilePathsAreNotCreated() {
+        #expect(!DuckDBFileKinds.canBeCreated(atPath: "/tmp/sales.parquet"))
+        #expect(!DuckDBFileKinds.canBeCreated(atPath: "/tmp/sales.csv"))
+        #expect(!DuckDBFileKinds.canBeCreated(atPath: "/tmp/sales.tsv"))
+        #expect(!DuckDBFileKinds.canBeCreated(atPath: "/tmp/sales.json"))
+        #expect(!DuckDBFileKinds.canBeCreated(atPath: "/tmp/sales.ndjson"))
+    }
+
+    @Test("The extension check ignores case")
+    func extensionMatchIgnoresCase() {
+        #expect(!DuckDBFileKinds.canBeCreated(atPath: "/tmp/Sales.PARQUET"))
+        #expect(!DuckDBFileKinds.canBeCreated(atPath: "/tmp/Sales.Csv"))
+    }
+}

--- a/docs/databases/duckdb.mdx
+++ b/docs/databases/duckdb.mdx
@@ -15,6 +15,8 @@ DuckDB is an embedded analytical database built for OLAP workloads. TablePro ope
     Click **Browse...** to select an existing `.duckdb` file, or enter a path to create a new database.
 
     Enter `:memory:` instead of a path for an in-memory database. It holds nothing on disk, so everything in it is gone when you disconnect.
+
+    Browse also accepts a `.parquet`, `.csv`, `.tsv`, `.json` or `.ndjson` file. DuckDB opens it read-only: you get an in-memory database holding two views over the file, one named `file` and one named after the file, and the file on disk is never written to. Creating a database at a path that does not exist only works for `.duckdb` and `.ddb`, so a mistyped data-file path is reported instead of turning into an empty database.
   </Step>
   <Step title="Connect">
     Click **Save & Connect** to open the database.

--- a/project.yml
+++ b/project.yml
@@ -326,6 +326,7 @@ targets:
       - Plugins/ClickHouseDriverPlugin/ClickHouseTableOperations.swift
       - Plugins/DamengDriverPlugin/DamengParameterBinder.swift
       - Plugins/DamengDriverPlugin/DamengStatementClassifier.swift
+      - Plugins/DuckDBDriverPlugin/DuckDBFileKinds.swift
       - Plugins/DuckDBDriverPlugin/DuckDBPositionParser.swift
       - Plugins/DuckDBDriverPlugin/DuckDBSchemaQueries.swift
       - Plugins/DuckDBDriverPlugin/DuckDBTypeRendering.swift


### PR DESCRIPTION
The DuckDB report that opened #2285 also said Parquet and CSV files could not be connected. They never could: the driver declared `["duckdb", "ddb"]` and the docs said to query those formats with SQL instead. But the Browse panel offered every file on disk, so the product invited the attempt and then failed it.

## What was wrong

`GeneralPaneView.presentFilePanel` set `allowedContentTypes = [.database, .data]`, which matches anything. That is one shared panel for the database file and for certificates and key files, so every driver got the same "any file" filter. `PluginManager.fileExtensions(for:)` already existed and already knew the answer; only the placeholder text used it.

And a path that does not exist is a request to create a database, which is right for `.duckdb` and wrong for everything else. Typing `~/data/sales.parquet` with one letter off made DuckDB create an empty database at that name, and the connection then succeeded against nothing. Measured against the shipped library: `duckdb_open_ext` on a missing `.parquet` path creates a new empty database file there.

## What changed

**Browse offers what the driver opens.** The panel's content types come from `PluginManager.fileExtensions(for:)` through a new `DatabaseFileTypes`. The auth-file panel keeps "any file", because a certificate is not one of the driver's own formats.

Most database extensions have no registered system type, so `UTType(filenameExtension:)` returns nil for them; declaring conformance to `.data` mints a dynamic type the panel filters on. Whether an extension resolves to a registered type is machine-dependent, which is worth knowing:

```
duckdb  -> org.duckdb.duckdb-database   (registered here, tags: duckdb, ddb)
ddb     -> org.duckdb.duckdb-database   (the same type)
parquet -> dyn.ah62d4rv4ge81a2pwsf40n7a (dynamic)
csv     -> public.comma-separated-values-text
```

Two extensions can therefore land on one type, so the list is de-duplicated with its order kept.

**DuckDB declares the formats it can actually open.** DuckDB 1.5 opens a Parquet, CSV, TSV, JSON or NDJSON file as a database (duckdb/duckdb#17415): it starts an in-memory catalog and creates two read-only views over the file, `file` and the file stem. Measured against the shipped library with no extensions available:

```
open('test.parquet') -> catalog "test", views: file (VIEW), test (VIEW)
open('test.csv')     -> catalog "test", views: file (VIEW), test (VIEW)
```

The file is left byte for byte identical afterwards, writes are rejected by the engine and `CHECKPOINT` is a no-op, so this cannot damage a user's data. Reading a Parquet file still needs the `parquet` extension, which DuckDB downloads on first use; listing the views does not.

`duckdb` and `ddb` stay first in the list so the file field's placeholder still reads `/path/to/database.duckdb`.

**A missing data-file path is an error, not a new database.** `DuckDBFileKinds.canBeCreated(atPath:)` allows creation for `.duckdb`, `.ddb` and extensionless paths, which is what the connection form offers, and refuses it for the read-only formats.

## Verified

- `DuckDBFileKindsTests` and `DatabaseFileTypesTests`, both new.
- The type-resolution assertions are written to hold whether or not a machine has the DuckDB CLI installed, after a first draft that passed locally for the wrong reason.

## Follows #2287

Both change `connectLocal` in the same place, so this was written on top of #2287 and rebased onto `main` after it merged.
