### PR TITLE
style: satisfy the swiftlint strict gate in the operation reporting code

### DIFF
--- a/TablePro/Core/Coordinators/RowEditingCoordinator+SaveChanges.swift
+++ b/TablePro/Core/Coordinators/RowEditingCoordinator+SaveChanges.swift
@@ -391,11 +391,11 @@ extension RowEditingCoordinator {
     }
 }
 
-extension RowEditingCoordinator {
+fileprivate extension RowEditingCoordinator {
     /// The save is owned by the tab that started it, not by whichever tab is selected when it
     /// lands: `failSave` writes into the selected tab, so keying a completion off that would
     /// attribute a slow save to a tab the user switched to while waiting.
-    fileprivate func reportSaveFinished(
+    func reportSaveFinished(
         _ outcome: OperationOutcome,
         connection: DatabaseConnection,
         database: String?,

--- a/TablePro/Core/Services/Operations/OperationDurationFormatter.swift
+++ b/TablePro/Core/Services/Operations/OperationDurationFormatter.swift
@@ -13,8 +13,8 @@ import Foundation
 internal enum OperationDurationFormatter {
     internal static func string(from duration: Duration) -> String {
         let totalSeconds = max(0, Int(duration.components.seconds))
-        let hours = totalSeconds / 3600
-        let minutes = (totalSeconds % 3600) / 60
+        let hours = totalSeconds / 3_600
+        let minutes = (totalSeconds % 3_600) / 60
         let seconds = totalSeconds % 60
 
         if hours > 0 {


### PR DESCRIPTION
`swiftlint lint --strict` fails on `main` right now, on three violations that arrived with #2272:

```
TablePro/Core/Services/Operations/OperationDurationFormatter.swift:16:36: error: Number Separator Violation
TablePro/Core/Services/Operations/OperationDurationFormatter.swift:17:39: error: Number Separator Violation
TablePro/Core/Coordinators/RowEditingCoordinator+SaveChanges.swift:394:1: error: Extension Access Modifier Violation
```

That gate is the `lint` job in `build.yml`, and `release` needs it, so the next `v*` tag would have failed on this rather than on anything the tag introduced.

It merged unseen because PR CI never runs SwiftLint. `macos-tests.yml` builds and tests; only `build.yml` lints, and only on a tag. Worth closing separately, but this PR just clears the red.

## The fix

- `3600` becomes `3_600` in both places.
- `fileprivate` moves from `reportSaveFinished` onto the extension that holds it, which is what `extension_access_modifier` asks for and what `CLAUDE.md` specifies under Code Style. The extension has one member, so the effective access is unchanged.

No behaviour change, so no CHANGELOG entry.

## Verification

- `build` PASS
- `lint TablePro` PASS, 0 violations (was 3 errors)
- `test` PASS, 111 of 111 across the suites touching the coordinators involved
