### PR TITLE
build: adopt the Swift 6 language mode across the app, plugins and packages

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -2,7 +2,7 @@
 # https://github.com/nicklockwood/SwiftFormat
 
 # Swift version
---swiftversion 5.9
+--swiftversion 6.0
 
 # File options
 --exclude DerivedData,.build,Packages,Pods,Carthage,vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A column value filter survives switching result mode and switching tabs, instead of being dropped the moment the grid left the screen. Running a query, turning a page, refreshing, or moving to another result of the same script still clears it, because the values you picked came from the rows being replaced. (#2251)
 
 - The connection form's Browse button offers the file kinds the driver actually opens instead of every file on disk. It used to allow any file, so picking one the driver could not read looked fine until the connection failed.
+- TablePro is built in the Swift 6 language mode. The Mac app, the iPhone and iPad app, all 31 plugin bundles and the shared packages are now checked for data races by the compiler rather than by review, which closes off a class of crash that only turned up under load.
+
 ### Removed
 
 - MCP remote access is gone. The server binds to this Mac only. The certificate it used named only localhost, so no other device could ever have verified it, and opening a database client to the network is not worth the risk.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ These govern every decision about code, architecture, tooling and process:
 
 ## Project Overview
 
-TablePro is a native macOS database client (SwiftUI + AppKit), a fast, lightweight alternative to TablePlus. macOS 14.0+, `SWIFT_VERSION = 5.0` (`Configs/Base.xcconfig`), Universal Binary (arm64 + x86_64).
+TablePro is a native macOS database client (SwiftUI + AppKit), a fast, lightweight alternative to TablePlus. macOS 14.0+, `SWIFT_VERSION = 6.0` (`Configs/Base.xcconfig`), Universal Binary (arm64 + x86_64).
 
 - **Source**: `TablePro/` holds `Core/` (business logic, services), `Views/` (UI), `Models/` (data structures), `ViewModels/`, `Extensions/` and `Theme/`
 - **Plugins**: `Plugins/` holds the `.tableplugin` bundles plus the `TableProPluginKit` shared framework.
@@ -27,6 +27,7 @@ TablePro is a native macOS database client (SwiftUI + AppKit), a fast, lightweig
 - **C bridges**: Each plugin contains its own C bridge module (e.g., `Plugins/MySQLDriverPlugin/CMariaDB/`, `Plugins/PostgreSQLDriverPlugin/CLibPQ/`)
 - **Static libs**: `Libs/` holds pre-built `.a` files and `Libs/ios/` holds the iOS xcframeworks. Both are downloaded by `scripts/download-libs.sh` and are not in git.
 - **SPM deps**: declared in `project.yml`. Vendored local packages under `LocalPackages/` (CodeEditSourceEditor, CodeEditTextView, CodeEditLanguages) and `Packages/` (TableProCore, TableProOracle); remote packages are Sparkle, swift-certificates and Yams. Revisions are pinned by the tracked `Package.resolved` inside each generated `.xcodeproj`.
+    - `SWIFT_VERSION` in `Configs/Base.xcconfig` sets the language mode for the Xcode-native targets only. A SwiftPM package takes its mode from its own manifest, so `Packages/TableProCore` and `Packages/TableProOracle` carry `swift-tools-version: 6.0` of their own. The vendored `LocalPackages/` forks stay on 5.9 so they can still take upstream changes, and a remote dependency keeps whatever its own manifest says. Never pass `SWIFT_VERSION=` on an `xcodebuild` command line to test a language-mode change: the override reaches the package targets too and reports their errors as yours.
 
 ## Build & Development Commands
 

--- a/Configs/Base.xcconfig
+++ b/Configs/Base.xcconfig
@@ -46,7 +46,7 @@ GCC_WARN_UNUSED_VARIABLE = YES
 LOCALIZATION_PREFERS_STRING_CATALOGS = YES
 MTL_FAST_MATH = YES
 STRING_CATALOG_GENERATE_SYMBOLS = YES
-SWIFT_VERSION = 5.0
+SWIFT_VERSION = 6.0
 CODE_SIGN_STYLE = Automatic
 
 // Signing knobs. Only the two app targets read them, so plugin bundles and the helper

--- a/Packages/TableProCore/Package.swift
+++ b/Packages/TableProCore/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 
 import PackageDescription
 

--- a/Packages/TableProCore/Sources/TableProImport/ConnectionExportEnvelope.swift
+++ b/Packages/TableProCore/Sources/TableProImport/ConnectionExportEnvelope.swift
@@ -43,7 +43,7 @@ public enum ConnectionExportError: LocalizedError {
 
 // MARK: - Export Envelope
 
-public struct ConnectionExportEnvelope: Codable {
+public struct ConnectionExportEnvelope: Codable, Sendable {
     public let formatVersion: Int
     public let exportedAt: Date
     public let appVersion: String
@@ -73,7 +73,7 @@ public struct ConnectionExportEnvelope: Codable {
 
 // MARK: - Exportable Connection
 
-public struct ExportableConnection: Codable {
+public struct ExportableConnection: Codable, Sendable {
     public let name: String
     public let host: String
     public let port: Int
@@ -198,7 +198,7 @@ public extension ExportableConnection {
 
 // MARK: - SSH Config
 
-public struct ExportableSSHConfig: Codable {
+public struct ExportableSSHConfig: Codable, Sendable {
     public let enabled: Bool
     public let host: String
     public let port: Int?
@@ -241,7 +241,7 @@ public struct ExportableSSHConfig: Codable {
     }
 }
 
-public struct ExportableJumpHost: Codable {
+public struct ExportableJumpHost: Codable, Sendable {
     public let host: String
     public let port: Int?
     public let username: String
@@ -259,7 +259,7 @@ public struct ExportableJumpHost: Codable {
 
 // MARK: - SSL Config
 
-public struct ExportableSSLConfig: Codable {
+public struct ExportableSSLConfig: Codable, Sendable {
     public let mode: String
     public let caCertificatePath: String?
     public let clientCertificatePath: String?
@@ -275,7 +275,7 @@ public struct ExportableSSLConfig: Codable {
 
 // MARK: - Group & Tag
 
-public struct ExportableGroup: Codable {
+public struct ExportableGroup: Codable, Sendable {
     public let name: String
     public let color: String?
 
@@ -285,7 +285,7 @@ public struct ExportableGroup: Codable {
     }
 }
 
-public struct ExportableTag: Codable {
+public struct ExportableTag: Codable, Sendable {
     public let name: String
     public let color: String?
 
@@ -297,7 +297,7 @@ public struct ExportableTag: Codable {
 
 // MARK: - Credentials
 
-public struct ExportableCredentials: Codable {
+public struct ExportableCredentials: Codable, Sendable {
     public let password: String?
     public let sshPassword: String?
     public let keyPassphrase: String?

--- a/Packages/TableProCore/Sources/TableProImport/ConnectionImportTypes.swift
+++ b/Packages/TableProCore/Sources/TableProImport/ConnectionImportTypes.swift
@@ -2,13 +2,13 @@ import Foundation
 
 // MARK: - Import Preview Types
 
-public enum ImportItemStatus {
+public enum ImportItemStatus: Sendable {
     case ready
     case duplicate(existingId: UUID, existingName: String)
     case warnings([String])
 }
 
-public struct ImportItem: Identifiable {
+public struct ImportItem: Identifiable, Sendable {
     public let id = UUID()
     public let connection: ExportableConnection
     public let status: ImportItemStatus
@@ -19,14 +19,14 @@ public struct ImportItem: Identifiable {
     }
 }
 
-public enum ImportResolution: Hashable {
+public enum ImportResolution: Hashable, Sendable {
     case importNew
     case skip
     case replace(existingId: UUID)
     case importAsCopy
 }
 
-public struct ConnectionImportPreview {
+public struct ConnectionImportPreview: Sendable {
     public let envelope: ConnectionExportEnvelope
     public let items: [ImportItem]
 
@@ -36,7 +36,7 @@ public struct ConnectionImportPreview {
     }
 }
 
-public struct ConnectionDuplicateCandidate {
+public struct ConnectionDuplicateCandidate: Sendable {
     public let id: UUID
     public let name: String
     public let host: String

--- a/Packages/TableProCore/Sources/TableProMSSQLCore/MSSQLConnectCancellation.swift
+++ b/Packages/TableProCore/Sources/TableProMSSQLCore/MSSQLConnectCancellation.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public final class SingleResumeGate<Value>: @unchecked Sendable {
+public final class SingleResumeGate<Value: Sendable>: @unchecked Sendable {
     private let lock = NSLock()
     private var continuation: CheckedContinuation<Value, Error>?
     private var outcome: Result<Value, Error>?

--- a/Packages/TableProCore/Sources/TableProModels/Cell.swift
+++ b/Packages/TableProCore/Sources/TableProModels/Cell.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 public enum Cell: Sendable {
     case null
@@ -15,9 +16,9 @@ public extension Cell {
         case .text(let value):
             return value
         case .truncatedText(let head, let total, _):
-            return head + "... (\(byteCountFormatter.string(fromByteCount: Int64(total))))"
+            return head + "... (\(formattedByteCount(total)))"
         case .binary(let count, _):
-            return "[BLOB \(byteCountFormatter.string(fromByteCount: Int64(count)))]"
+            return "[BLOB \(formattedByteCount(count))]"
         }
     }
 
@@ -105,9 +106,13 @@ public extension Cell {
     }
 }
 
-private let byteCountFormatter: ByteCountFormatter = {
+private let byteCountFormatter = OSAllocatedUnfairLock(uncheckedState: {
     let formatter = ByteCountFormatter()
     formatter.allowedUnits = [.useBytes, .useKB, .useMB, .useGB]
     formatter.countStyle = .binary
     return formatter
-}()
+}())
+
+private func formattedByteCount(_ byteCount: Int) -> String {
+    byteCountFormatter.withLock { $0.string(fromByteCount: Int64(byteCount)) }
+}

--- a/Packages/TableProCore/Sources/TableProTeradataCore/TeradataTLSTransport.swift
+++ b/Packages/TableProCore/Sources/TableProTeradataCore/TeradataTLSTransport.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Network
+import os
 import Security
 
 final class TeradataTLSTransport: TeradataTransport {
@@ -46,11 +47,11 @@ final class TeradataTLSTransport: TeradataTransport {
         connection = NWConnection(host: NWEndpoint.Host(host), port: endpointPort, using: parameters)
 
         let ready = DispatchSemaphore(value: 0)
-        var failure: Error?
+        let failureBox = OSAllocatedUnfairLock<NWError?>(initialState: nil)
         connection.stateUpdateHandler = { state in
             switch state {
             case .ready: ready.signal()
-            case .failed(let error): failure = error; ready.signal()
+            case .failed(let error): failureBox.withLock { $0 = error }; ready.signal()
             case .cancelled: ready.signal()
             default: break
             }
@@ -60,7 +61,7 @@ final class TeradataTLSTransport: TeradataTransport {
             connection.cancel()
             throw TeradataWireError.connectionFailed("TLS handshake to \(host):\(options.httpsPort) timed out")
         }
-        if let failure {
+        if let failure = failureBox.withLock({ $0 }) {
             connection.cancel()
             throw TeradataWireError.connectionFailed("TLS handshake failed: \(failure)")
         }

--- a/Packages/TableProCore/Tests/TableProMSSQLCoreTests/MSSQLConnectCancellationTests.swift
+++ b/Packages/TableProCore/Tests/TableProMSSQLCoreTests/MSSQLConnectCancellationTests.swift
@@ -36,7 +36,7 @@ struct MSSQLConnectCancellationTests {
     @Test("Cancel returns promptly and the late result is discarded, not adopted")
     func cancelDiscardsLateResult() async {
         let queue = DispatchQueue(label: "test.cancel")
-        let workStarted = DispatchSemaphore(value: 0)
+        let workStarted = FlagBox()
         let release = DispatchSemaphore(value: 0)
         let discarded = FlagBox()
 
@@ -44,7 +44,7 @@ struct MSSQLConnectCancellationTests {
             try await runCancellableBlocking(
                 on: queue,
                 work: { () -> Int in
-                    workStarted.signal()
+                    workStarted.mark()
                     release.wait()
                     return 7
                 },
@@ -52,7 +52,7 @@ struct MSSQLConnectCancellationTests {
             )
         }
 
-        workStarted.wait()
+        await pollUntil { workStarted.value }
         task.cancel()
 
         let result = await task.result

--- a/Packages/TableProCore/Tests/TableProPluginKitTests/CSVTypeInferrerTests.swift
+++ b/Packages/TableProCore/Tests/TableProPluginKitTests/CSVTypeInferrerTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import TableProPluginKit
+
+final class CSVTypeInferrerTests: XCTestCase {
+    func testInfersInteger() {
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["1", "-42", "0"]), .integer)
+    }
+
+    func testInfersRealWhenNotEveryValueIsWhole() {
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["1", "2.5", "-0.25"]), .real)
+    }
+
+    func testInfersBooleanFromEitherSpelling() {
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["true", "FALSE", "Yes", "n", "T"]), .boolean)
+    }
+
+    func testInfersDateFromInternetDateTime() {
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["2026-08-20T12:34:56Z"]), .date)
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["2026-08-20T12:34:56+02:00"]), .date)
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["2026-08-20T12:34:56-0700"]), .date)
+    }
+
+    func testInfersDateFromFractionalSeconds() {
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["2026-08-20T12:34:56.123Z"]), .date)
+    }
+
+    func testInfersDateFromCalendarDay() {
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["2026-08-20", "1999-01-01", "0001-01-01"]), .date)
+    }
+
+    func testInfersDateFromLeapDay() {
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["2024-02-29"]), .date)
+    }
+
+    func testInfersDateFromTheLenientFormsTheFormatterAccepts() {
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["  2026-08-20"]), .date)
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["2026/08/20"]), .date)
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["-0001-01-01"]), .date)
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["2023-02-29"]), .date)
+    }
+
+    func testRejectsImpossibleCalendarDay() {
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["2026-13-45"]), .text)
+    }
+
+    func testRejectsBasicFormatDate() {
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["20260820"]), .integer)
+    }
+
+    func testFallsBackToTextForMixedValues() {
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["2026-08-20", "not a date"]), .text)
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["hello"]), .text)
+    }
+
+    func testEmptyValuesAreSkippedAndAnEmptyColumnIsText() {
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["", "7", ""]), .integer)
+        XCTAssertEqual(CSVTypeInferrer.infer(column: ["", ""]), .text)
+        XCTAssertEqual(CSVTypeInferrer.infer(column: []), .text)
+    }
+
+    func testInferColumnsHandlesRaggedRows() {
+        let rows = [
+            ["1", "true", "2026-08-20"],
+            ["2", "no"],
+            ["3", "yes", "1999-01-01", "extra"]
+        ]
+        XCTAssertEqual(
+            CSVTypeInferrer.inferColumns(rows: rows, columnCount: 3),
+            [.integer, .boolean, .date]
+        )
+    }
+
+    func testOnlyTheFirstSampleSizeValuesAreRead() {
+        let values = Array(repeating: "1", count: CSVTypeInferrer.sampleSize) + ["not a number"]
+        XCTAssertEqual(CSVTypeInferrer.infer(column: values), .integer)
+    }
+}

--- a/Packages/TableProOracle/Package.swift
+++ b/Packages/TableProOracle/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 
 import PackageDescription
 

--- a/Packages/TableProOracle/Sources/TableProOracleCore/OracleCellFormatting.swift
+++ b/Packages/TableProOracle/Sources/TableProOracleCore/OracleCellFormatting.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 public enum OracleCellFormatting {
     public static let maxHexBytes = 4_096
@@ -17,18 +18,18 @@ public enum OracleCellFormatting {
         return formatter
     }()
 
-    private static let utcFormatter: ISO8601DateFormatter = {
+    private static let utcFormatter: OSAllocatedUnfairLock<ISO8601DateFormatter> = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        return formatter
+        return OSAllocatedUnfairLock(uncheckedState: formatter)
     }()
 
-    private static let localFormatter: ISO8601DateFormatter = {
+    private static let localFormatter: OSAllocatedUnfairLock<ISO8601DateFormatter> = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         formatter.timeZone = .current
-        return formatter
+        return OSAllocatedUnfairLock(uncheckedState: formatter)
     }()
 
     private static let zonedFormatter: DateFormatter = {
@@ -46,9 +47,9 @@ public enum OracleCellFormatting {
     public static func formatTimestamp(_ date: Date, style: TimestampStyle) -> String {
         switch style {
         case .utc:
-            return utcFormatter.string(from: date)
+            return utcFormatter.withLockUnchecked { $0.string(from: date) }
         case .local:
-            return localFormatter.string(from: date)
+            return localFormatter.withLockUnchecked { $0.string(from: date) }
         case .zoned:
             return zonedFormatter.string(from: date)
         }

--- a/Plugins/BeancountDriverPlugin/BeancountPluginDriver+Projection.swift
+++ b/Plugins/BeancountDriverPlugin/BeancountPluginDriver+Projection.swift
@@ -58,7 +58,7 @@ private final class BeancountProjectionWriter {
     }
 }
 
-struct BeancountProjectionRows {
+struct BeancountProjectionRows: @unchecked Sendable {
     var transactions: [[String: Any]] = []
     var postings: [[String: Any]] = []
     var accounts: [[String: Any]] = []

--- a/Plugins/BeancountDriverPlugin/BeancountPluginDriver.swift
+++ b/Plugins/BeancountDriverPlugin/BeancountPluginDriver.swift
@@ -5,6 +5,7 @@
 
 import Dispatch
 import Foundation
+import os
 import OSLog
 import SQLite3
 import TableProNumberFormatting
@@ -93,8 +94,7 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     private static let closesQuery =
         "SELECT account, close FROM #accounts WHERE close IS NOT NULL ORDER BY close, account"
     private static let logger = Logger(subsystem: "com.TablePro", category: "BeancountPluginDriver")
-    private static let rledgerCapabilityLock = NSLock()
-    private static var rledgerNoCacheSupport: [String: Bool] = [:]
+    private static let rledgerNoCacheSupport = OSAllocatedUnfairLock(initialState: [String: Bool]())
 
     private static let workQueue = DispatchQueue(
         label: "com.TablePro.BeancountDriver",
@@ -756,12 +756,9 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     private static func rledgerSupportsNoCache(executablePath: String) -> Bool {
-        rledgerCapabilityLock.lock()
-        if let cached = rledgerNoCacheSupport[executablePath] {
-            rledgerCapabilityLock.unlock()
+        if let cached = rledgerNoCacheSupport.withLock({ $0[executablePath] }) {
             return cached
         }
-        rledgerCapabilityLock.unlock()
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executablePath)
@@ -784,9 +781,7 @@ final class BeancountPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             supports = false
         }
 
-        rledgerCapabilityLock.withLock {
-            rledgerNoCacheSupport[executablePath] = supports
-        }
+        rledgerNoCacheSupport.withLock { $0[executablePath] = supports }
         return supports
     }
 

--- a/Plugins/BigQueryDriverPlugin/BigQueryTypeMapper.swift
+++ b/Plugins/BigQueryDriverPlugin/BigQueryTypeMapper.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import os
 import TableProPluginKit
 
 internal struct BigQueryTypeMapper {
@@ -87,11 +88,15 @@ internal struct BigQueryTypeMapper {
         }
     }
 
-    private static let timestampFormatter: ISO8601DateFormatter = {
-        let f = ISO8601DateFormatter()
-        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return f
+    private static let lockedTimestampFormatter: OSAllocatedUnfairLock<ISO8601DateFormatter> = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return OSAllocatedUnfairLock(uncheckedState: formatter)
     }()
+
+    private static func timestampString(from date: Date) -> String {
+        lockedTimestampFormatter.withLockUnchecked { $0.string(from: date) }
+    }
 
     private static func convertScalarString(_ str: String, type: String) -> String? {
         switch type.uppercased() {
@@ -99,7 +104,7 @@ internal struct BigQueryTypeMapper {
             // BigQuery returns timestamps as epoch-seconds strings like "1.617235200E9"
             if let epochSeconds = Double(str) {
                 let date = Date(timeIntervalSince1970: epochSeconds)
-                return timestampFormatter.string(from: date)
+                return timestampString(from: date)
             }
             return str
 

--- a/Plugins/CSVExportPlugin/CSVExportPlugin.swift
+++ b/Plugins/CSVExportPlugin/CSVExportPlugin.swift
@@ -8,7 +8,7 @@ import SwiftUI
 import TableProPluginKit
 
 @Observable
-final class CSVExportPlugin: ExportFormatPlugin, SettablePlugin {
+final class CSVExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Sendable {
     static let pluginName = "CSV Export"
     static let pluginVersion = "1.0.0"
     static let pluginDescription = "Export data to CSV format"
@@ -29,6 +29,7 @@ final class CSVExportPlugin: ExportFormatPlugin, SettablePlugin {
 
     required init() { loadSettings() }
 
+    @MainActor
     func settingsView() -> AnyView? {
         AnyView(CSVExportOptionsView(plugin: self))
     }

--- a/Plugins/CSVImportPlugin/CSVImportPlugin.swift
+++ b/Plugins/CSVImportPlugin/CSVImportPlugin.swift
@@ -8,7 +8,7 @@ import SwiftUI
 import TableProPluginKit
 
 @Observable
-final class CSVImportPlugin: ImportFormatPlugin, SettablePlugin {
+final class CSVImportPlugin: ImportFormatPlugin, SettablePlugin, @unchecked Sendable {
     static let pluginName = "CSV Import"
     static let pluginVersion = "1.0.0"
     static let pluginDescription = "Import data from CSV and TSV files"
@@ -29,6 +29,7 @@ final class CSVImportPlugin: ImportFormatPlugin, SettablePlugin {
 
     required init() { loadSettings() }
 
+    @MainActor
     func settingsView() -> AnyView? {
         AnyView(CSVImportOptionsView(plugin: self))
     }

--- a/Plugins/CassandraDriverPlugin/CassandraConnection.swift
+++ b/Plugins/CassandraDriverPlugin/CassandraConnection.swift
@@ -97,15 +97,18 @@ actor CassandraConnectionActor {
             let trimmedClientCertPath = sslClientCertPath?.trimmingCharacters(in: .whitespaces) ?? ""
             let trimmedClientKeyPath = sslClientKeyPath?.trimmingCharacters(in: .whitespaces) ?? ""
             if !trimmedClientCertPath.isEmpty || !trimmedClientKeyPath.isEmpty {
-                try applyClientCertificate(
-                    to: ssl,
-                    certPath: trimmedClientCertPath,
-                    keyPath: trimmedClientKeyPath,
-                    keyPassphrase: sslClientKeyPassphrase
-                ) {
+                do {
+                    try applyClientCertificate(
+                        to: ssl,
+                        certPath: trimmedClientCertPath,
+                        keyPath: trimmedClientKeyPath,
+                        keyPassphrase: sslClientKeyPassphrase
+                    )
+                } catch {
                     cass_ssl_free(ssl)
                     cass_cluster_free(cluster)
                     self.cluster = nil
+                    throw error
                 }
             }
 
@@ -165,38 +168,31 @@ actor CassandraConnectionActor {
         to ssl: OpaquePointer,
         certPath: String,
         keyPath: String,
-        keyPassphrase: String?,
-        cleanup: () -> Void
+        keyPassphrase: String?
     ) throws {
         guard !certPath.isEmpty else {
-            cleanup()
             throw SSLHandshakeError.clientCertRequired(serverMessage: "A client certificate is required when a client key is set")
         }
         guard !keyPath.isEmpty else {
-            cleanup()
             throw SSLHandshakeError.clientCertRequired(serverMessage: "A client key is required when a client certificate is set")
         }
 
         guard let certData = FileManager.default.contents(atPath: certPath),
               let certString = String(data: certData, encoding: .utf8) else {
-            cleanup()
             throw SSLHandshakeError.clientCertRequired(serverMessage: "Could not read client certificate at \(certPath)")
         }
         let certResult = cass_ssl_set_cert(ssl, certString)
         if certResult != CASS_OK {
-            cleanup()
             throw SSLHandshakeError.clientCertRequired(serverMessage: "Client certificate at \(certPath) is not a valid PEM")
         }
 
         guard let keyData = FileManager.default.contents(atPath: keyPath),
               let keyString = String(data: keyData, encoding: .utf8) else {
-            cleanup()
             throw SSLHandshakeError.clientKeyInvalid(serverMessage: "Could not read client key at \(keyPath)")
         }
         let passphrase = keyPassphrase?.isEmpty == false ? keyPassphrase : nil
         let keyResult = cass_ssl_set_private_key(ssl, keyString, passphrase)
         if keyResult != CASS_OK {
-            cleanup()
             throw CassandraClientKeyClassifier.privateKeyLoadError(keyPEM: keyString, hasPassphrase: passphrase != nil, keyPath: keyPath)
         }
     }

--- a/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
+++ b/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
@@ -189,15 +189,11 @@ internal final class CassandraPluginDriver: PluginDatabaseDriver, @unchecked Sen
         )
 
         if let keyspace {
-            stateLock.lock()
-            _currentKeyspace = keyspace
-            stateLock.unlock()
+            stateLock.withLock { _currentKeyspace = keyspace }
         }
 
         if let version = try? await connectionActor.serverVersion() {
-            stateLock.lock()
-            _cachedVersion = version
-            stateLock.unlock()
+            stateLock.withLock { _cachedVersion = version }
         }
 
         let caps = CassandraCapabilities(
@@ -537,9 +533,7 @@ internal final class CassandraPluginDriver: PluginDatabaseDriver, @unchecked Sen
 
     func switchDatabase(to database: String) async throws {
         try await connectionActor.switchKeyspace(database)
-        stateLock.lock()
-        _currentKeyspace = database
-        stateLock.unlock()
+        stateLock.withLock { _currentKeyspace = database }
     }
 
     // MARK: - Schemas (Cassandra uses keyspaces, not schemas)

--- a/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
+++ b/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
@@ -204,21 +204,21 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         urlConfig.timeoutIntervalForRequest = HttpQueryTimeout.sessionBootstrapRequestTimeout
         urlConfig.timeoutIntervalForResource = HttpQueryTimeout.sessionResourceTimeout
 
-        lock.lock()
-        if let delegate = ClickHouseTLSDelegate.make(for: config.ssl) {
-            session = URLSession(configuration: urlConfig, delegate: delegate, delegateQueue: nil)
-        } else {
-            session = URLSession(configuration: urlConfig)
+        lock.withLock {
+            if let delegate = ClickHouseTLSDelegate.make(for: config.ssl) {
+                session = URLSession(configuration: urlConfig, delegate: delegate, delegateQueue: nil)
+            } else {
+                session = URLSession(configuration: urlConfig)
+            }
         }
-        lock.unlock()
 
         do {
             _ = try await executeRaw("SELECT 1")
         } catch {
-            lock.lock()
-            session?.invalidateAndCancel()
-            session = nil
-            lock.unlock()
+            lock.withLock {
+                session?.invalidateAndCancel()
+                session = nil
+            }
             Self.logger.error("Connection test failed: \(error.localizedDescription)")
             if let sslError = ClickHouseSSLClassifier.classifySSLError(error) {
                 throw sslError
@@ -433,9 +433,7 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     // MARK: - Database Switching
 
     func switchDatabase(to database: String) async throws {
-        lock.lock()
-        _currentDatabase = database
-        lock.unlock()
+        lock.withLock { _currentDatabase = database }
     }
 
     // MARK: - EXPLAIN
@@ -503,13 +501,10 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         query: String,
         continuation: AsyncThrowingStream<PluginStreamElement, Error>.Continuation
     ) async throws {
-        lock.lock()
-        guard let session = self.session else {
-            lock.unlock()
-            throw ClickHouseError.notConnected
+        let (session, database) = try lock.withLock { () throws -> (URLSession, String) in
+            guard let session = self.session else { throw ClickHouseError.notConnected }
+            return (session, _currentDatabase)
         }
-        let database = _currentDatabase
-        lock.unlock()
 
         var trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
         while trimmedQuery.hasSuffix(";") {

--- a/Plugins/ClickHouseDriverPlugin/ClickHousePluginDriver+Http.swift
+++ b/Plugins/ClickHouseDriverPlugin/ClickHousePluginDriver+Http.swift
@@ -11,16 +11,14 @@ extension ClickHousePluginDriver {
     // MARK: - Private HTTP Layer
 
     func executeRaw(_ query: String, queryId: String? = nil) async throws -> CHQueryResult {
-        lock.lock()
-        guard let session = self.session else {
-            lock.unlock()
-            throw ClickHouseError.notConnected
+        let (session, database) = try lock.withLock { () throws -> (URLSession, String) in
+            guard let session = self.session else { throw ClickHouseError.notConnected }
+            let database = _currentDatabase
+            if let queryId {
+                _lastQueryId = queryId
+            }
+            return (session, database)
         }
-        let database = _currentDatabase
-        if let queryId {
-            _lastQueryId = queryId
-        }
-        lock.unlock()
 
         var request = try buildRequest(query: query, database: database, queryId: queryId)
         request.timeoutInterval = _queryTimeout.requestTimeoutInterval
@@ -28,16 +26,14 @@ extension ClickHousePluginDriver {
     }
 
     func executeRawWithParams(_ query: String, params: [String: String?], queryId: String? = nil) async throws -> CHQueryResult {
-        lock.lock()
-        guard let session = self.session else {
-            lock.unlock()
-            throw ClickHouseError.notConnected
+        let (session, database) = try lock.withLock { () throws -> (URLSession, String) in
+            guard let session = self.session else { throw ClickHouseError.notConnected }
+            let database = _currentDatabase
+            if let queryId {
+                _lastQueryId = queryId
+            }
+            return (session, database)
         }
-        let database = _currentDatabase
-        if let queryId {
-            _lastQueryId = queryId
-        }
-        lock.unlock()
 
         var request = try buildRequest(query: query, database: database, queryId: queryId, params: params)
         request.timeoutInterval = _queryTimeout.requestTimeoutInterval
@@ -47,9 +43,7 @@ extension ClickHousePluginDriver {
     private func perform(request: URLRequest, session: URLSession) async throws -> CHQueryResult {
         let (data, response) = try await send(request: request, session: session)
 
-        lock.lock()
-        currentTask = nil
-        lock.unlock()
+        lock.withLock { currentTask = nil }
 
         let httpResponse = response as? HTTPURLResponse
         if let httpResponse, httpResponse.statusCode >= 400 {

--- a/Plugins/CloudflareD1DriverPlugin/CloudflareD1PluginDriver.swift
+++ b/Plugins/CloudflareD1DriverPlugin/CloudflareD1PluginDriver.swift
@@ -85,11 +85,11 @@ final class CloudflareD1PluginDriver: PluginDatabaseDriver, @unchecked Sendable 
             }
             databaseId = match.uuid
 
-            lock.lock()
-            for db in databases {
-                databaseNameToUuid[db.name] = db.uuid
+            lock.withLock {
+                for db in databases {
+                    databaseNameToUuid[db.name] = db.uuid
+                }
             }
-            lock.unlock()
         }
 
         let client = D1HttpClient(accountId: accountId, apiToken: apiToken, databaseId: databaseId)
@@ -97,18 +97,14 @@ final class CloudflareD1PluginDriver: PluginDatabaseDriver, @unchecked Sendable 
 
         do {
             let details = try await client.getDatabaseDetails()
-            lock.lock()
-            _serverVersion = details.version ?? "D1"
-            lock.unlock()
+            lock.withLock { _serverVersion = details.version ?? "D1" }
         } catch {
             client.invalidateSession()
             Self.logger.error("Connection test failed: \(error.localizedDescription)")
             throw CloudflareD1Error(message: String(localized: "Failed to connect to Cloudflare D1"))
         }
 
-        lock.lock()
-        httpClient = client
-        lock.unlock()
+        lock.withLock { httpClient = client }
 
         Self.logger.debug("Connected to Cloudflare D1 database: \(databaseName)")
     }
@@ -183,9 +179,7 @@ final class CloudflareD1PluginDriver: PluginDatabaseDriver, @unchecked Sendable 
     }
 
     func applyQueryTimeout(_ seconds: Int) async throws {
-        lock.lock()
-        let client = httpClient
-        lock.unlock()
+        let client = lock.withLock { httpClient }
         client?.setQueryTimeout(seconds)
     }
 
@@ -528,12 +522,12 @@ final class CloudflareD1PluginDriver: PluginDatabaseDriver, @unchecked Sendable 
 
         let databases = try await client.listDatabases()
 
-        lock.lock()
-        databaseNameToUuid.removeAll()
-        for db in databases {
-            databaseNameToUuid[db.name] = db.uuid
+        lock.withLock {
+            databaseNameToUuid.removeAll()
+            for db in databases {
+                databaseNameToUuid[db.name] = db.uuid
+            }
         }
-        lock.unlock()
 
         return databases.map(\.name)
     }
@@ -553,9 +547,7 @@ final class CloudflareD1PluginDriver: PluginDatabaseDriver, @unchecked Sendable 
 
         let newDb = try await client.createDatabase(name: request.name)
 
-        lock.lock()
-        databaseNameToUuid[newDb.name] = newDb.uuid
-        lock.unlock()
+        lock.withLock { databaseNameToUuid[newDb.name] = newDb.uuid }
     }
 
     func dropDatabase(name: String) async throws {
@@ -563,9 +555,7 @@ final class CloudflareD1PluginDriver: PluginDatabaseDriver, @unchecked Sendable 
             throw CloudflareD1Error.notConnected
         }
 
-        lock.lock()
-        let uuid = databaseNameToUuid[name]
-        lock.unlock()
+        let uuid = lock.withLock { databaseNameToUuid[name] }
 
         guard let databaseId = uuid ?? (isUuid(name) ? name : nil) else {
             throw CloudflareD1Error(message: String(format: String(localized: "Database '%@' not found"), name))
@@ -573,15 +563,11 @@ final class CloudflareD1PluginDriver: PluginDatabaseDriver, @unchecked Sendable 
 
         try await client.deleteDatabase(databaseId: databaseId)
 
-        lock.lock()
-        databaseNameToUuid.removeValue(forKey: name)
-        lock.unlock()
+        lock.withLock { _ = databaseNameToUuid.removeValue(forKey: name) }
     }
 
     func switchDatabase(to database: String) async throws {
-        lock.lock()
-        var uuid = databaseNameToUuid[database]
-        lock.unlock()
+        var uuid = lock.withLock { databaseNameToUuid[database] }
 
         if uuid == nil && isUuid(database) {
             uuid = database
@@ -594,13 +580,13 @@ final class CloudflareD1PluginDriver: PluginDatabaseDriver, @unchecked Sendable 
 
             let databases = try await client.listDatabases()
 
-            lock.lock()
-            databaseNameToUuid.removeAll()
-            for db in databases {
-                databaseNameToUuid[db.name] = db.uuid
+            uuid = lock.withLock {
+                databaseNameToUuid.removeAll()
+                for db in databases {
+                    databaseNameToUuid[db.name] = db.uuid
+                }
+                return databaseNameToUuid[database]
             }
-            uuid = databaseNameToUuid[database]
-            lock.unlock()
         }
 
         guard let resolvedUuid = uuid else {
@@ -609,9 +595,7 @@ final class CloudflareD1PluginDriver: PluginDatabaseDriver, @unchecked Sendable 
             )
         }
 
-        lock.lock()
-        httpClient?.databaseId = resolvedUuid
-        lock.unlock()
+        lock.withLock { httpClient?.databaseId = resolvedUuid }
     }
 
     // MARK: - Identifier Quoting

--- a/Plugins/CloudflareD1DriverPlugin/D1HttpClient.swift
+++ b/Plugins/CloudflareD1DriverPlugin/D1HttpClient.swift
@@ -304,12 +304,9 @@ final class D1HttpClient: @unchecked Sendable {
     }
 
     private func performRequest(url: URL, method: String, body: Data?) async throws -> Data {
-        lock.lock()
-        guard let session else {
-            lock.unlock()
+        guard let session = lock.withLock({ self.session }) else {
             throw D1HttpError(message: String(localized: "Not connected to database"))
         }
-        lock.unlock()
 
         var request = URLRequest(url: url)
         request.httpMethod = method
@@ -348,9 +345,7 @@ final class D1HttpClient: @unchecked Sendable {
             self.lock.unlock()
         }
 
-        lock.lock()
-        currentTask = nil
-        lock.unlock()
+        lock.withLock { currentTask = nil }
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw D1HttpError(message: "Invalid response from server")

--- a/Plugins/DuckDBDriverPlugin/DuckDBConnection.swift
+++ b/Plugins/DuckDBDriverPlugin/DuckDBConnection.swift
@@ -8,6 +8,12 @@ import Foundation
 import os
 import TableProPluginKit
 
+/// Hands the open connection pointer out of the actor so a cancel can interrupt the query that is
+/// running on it. libduckdb documents `duckdb_interrupt` as the one call safe from another thread.
+struct InterruptHandle: @unchecked Sendable {
+    let connection: duckdb_connection?
+}
+
 actor DuckDBConnectionActor {
     private static let logger = Logger(subsystem: "com.TablePro", category: "DuckDBConnectionActor")
 
@@ -16,7 +22,7 @@ actor DuckDBConnectionActor {
 
     var isConnected: Bool { connection != nil }
 
-    var connectionHandleForInterrupt: duckdb_connection? { connection }
+    var connectionHandleForInterrupt: InterruptHandle { InterruptHandle(connection: connection) }
 
     func open(path: String) throws {
         var db: duckdb_database?

--- a/Plugins/DuckDBDriverPlugin/DuckDBPlugin.swift
+++ b/Plugins/DuckDBDriverPlugin/DuckDBPlugin.swift
@@ -305,10 +305,10 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         try await connectionActor.executeQuery(QuackConnectBuilder.attachSQL(host: host, port: port, alias: alias))
         try await connectionActor.executeQuery(QuackConnectBuilder.useSQL(alias: alias))
 
-        stateLock.lock()
-        _currentSchema = "main"
-        _currentDatabase = alias
-        stateLock.unlock()
+        stateLock.withLock {
+            _currentSchema = "main"
+            _currentDatabase = alias
+        }
 
         await captureInterruptHandle()
     }
@@ -325,10 +325,10 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         let position = try await readPosition()
         let catalog = try await resolveOpenedCatalog(named: position.catalog)
 
-        stateLock.lock()
-        _currentDatabase = catalog
-        if let schema = position.schema { _currentSchema = schema }
-        stateLock.unlock()
+        stateLock.withLock {
+            _currentDatabase = catalog
+            if let schema = position.schema { _currentSchema = schema }
+        }
     }
 
     /// Nothing has run `USE` yet at connect, so `search_path` is usually empty and the catalog
@@ -385,7 +385,7 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     private func captureInterruptHandle() async {
-        if let conn = await connectionActor.connectionHandleForInterrupt {
+        if let conn = await connectionActor.connectionHandleForInterrupt.connection {
             setInterruptHandle(conn)
         }
     }
@@ -749,9 +749,7 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func switchSchema(to schema: String) async throws {
         _ = try await execute(query: DuckDBSchemaQueries.useSchema(schema, in: currentDatabase))
-        stateLock.lock()
-        _currentSchema = schema
-        stateLock.unlock()
+        stateLock.withLock { _currentSchema = schema }
     }
 
     // MARK: - Database Operations
@@ -773,10 +771,10 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         _ = try await execute(query: DuckDBSchemaQueries.useDatabase(database))
         let canonical = await canonicalCatalogName(matching: database) ?? database
         let landedSchema = try? await readPosition().schema
-        stateLock.lock()
-        _currentDatabase = canonical
-        _currentSchema = landedSchema.flatMap { $0 } ?? "main"
-        stateLock.unlock()
+        stateLock.withLock {
+            _currentDatabase = canonical
+            _currentSchema = landedSchema.flatMap { $0 } ?? "main"
+        }
     }
 
     private func canonicalCatalogName(matching database: String) async -> String? {

--- a/Plugins/EtcdDriverPlugin/EtcdHttpClient.swift
+++ b/Plugins/EtcdDriverPlugin/EtcdHttpClient.swift
@@ -371,28 +371,28 @@ internal final class EtcdHttpClient: @unchecked Sendable {
             delegate = nil
         }
 
-        lock.lock()
-        if let delegate {
-            session = URLSession(configuration: urlConfig, delegate: delegate, delegateQueue: nil)
-        } else {
-            session = URLSession(configuration: urlConfig)
+        lock.withLock {
+            if let delegate {
+                session = URLSession(configuration: urlConfig, delegate: delegate, delegateQueue: nil)
+            } else {
+                session = URLSession(configuration: urlConfig)
+            }
         }
-        lock.unlock()
 
         do {
             try await detectApiPrefix()
         } catch let etcdError as EtcdError {
-            lock.lock()
-            session?.invalidateAndCancel()
-            session = nil
-            lock.unlock()
+            lock.withLock {
+                session?.invalidateAndCancel()
+                session = nil
+            }
             Self.logger.error("Connection test failed: \(etcdError.localizedDescription)")
             throw etcdError
         } catch {
-            lock.lock()
-            session?.invalidateAndCancel()
-            session = nil
-            lock.unlock()
+            lock.withLock {
+                session?.invalidateAndCancel()
+                session = nil
+            }
             Self.logger.error("Connection test failed: \(error.localizedDescription)")
             throw EtcdError.connectionFailed(error.localizedDescription)
         }
@@ -401,10 +401,10 @@ internal final class EtcdHttpClient: @unchecked Sendable {
             do {
                 try await authenticate()
             } catch {
-                lock.lock()
-                session?.invalidateAndCancel()
-                session = nil
-                lock.unlock()
+                lock.withLock {
+                    session?.invalidateAndCancel()
+                    session = nil
+                }
                 throw error
             }
         }
@@ -438,12 +438,10 @@ internal final class EtcdHttpClient: @unchecked Sendable {
     private func detectApiPrefix() async throws {
         let candidates = ["v3", "v3beta", "v3alpha"]
 
-        lock.lock()
-        guard let session else {
-            lock.unlock()
-            throw EtcdError.notConnected
+        let session = try lock.withLock { () -> URLSession in
+            guard let session else { throw EtcdError.notConnected }
+            return session
         }
-        lock.unlock()
 
         for candidate in candidates {
             guard let url = URL(string: "\(baseUrl)/\(candidate)/maintenance/status") else {
@@ -471,17 +469,13 @@ internal final class EtcdHttpClient: @unchecked Sendable {
             case 404:
                 continue
             case 200:
-                lock.lock()
-                apiPrefix = candidate
-                lock.unlock()
+                lock.withLock { apiPrefix = candidate }
                 Self.logger.debug("Detected etcd API prefix: \(candidate)")
                 return
             case 401 where !config.username.isEmpty:
                 // Auth required but credentials are configured — prefix is valid,
                 // authenticate() will run after detection
-                lock.lock()
-                apiPrefix = candidate
-                lock.unlock()
+                lock.withLock { apiPrefix = candidate }
                 Self.logger.debug("Detected etcd API prefix: \(candidate) (auth required)")
                 return
             case 401:
@@ -545,14 +539,10 @@ internal final class EtcdHttpClient: @unchecked Sendable {
     // MARK: - Watch
 
     func watch(key: String, prefix: Bool, timeout: TimeInterval) async throws -> [EtcdWatchEvent] {
-        lock.lock()
-        guard session != nil else {
-            lock.unlock()
-            throw EtcdError.notConnected
+        let (token, generation) = try lock.withLock { () -> (String?, UInt64) in
+            guard session != nil else { throw EtcdError.notConnected }
+            return (authToken, sessionGeneration)
         }
-        let token = authToken
-        let generation = sessionGeneration
-        lock.unlock()
 
         let b64Key = Self.base64Encode(key)
         var createReq = EtcdWatchCreateRequest(key: b64Key)
@@ -573,6 +563,7 @@ internal final class EtcdHttpClient: @unchecked Sendable {
             request.setValue(token, forHTTPHeaderField: "Authorization")
         }
         request.httpBody = try JSONEncoder().encode(watchReq)
+        let watchRequest = request
 
         return try await withThrowingTaskGroup(of: [EtcdWatchEvent].self) { group in
             let collectedData = DataCollector()
@@ -583,7 +574,7 @@ internal final class EtcdHttpClient: @unchecked Sendable {
                         guard self.sessionGeneration == generation, let currentSession = self.session else {
                             return nil
                         }
-                        let dataTask = currentSession.dataTask(with: request) { data, _, error in
+                        let dataTask = currentSession.dataTask(with: watchRequest) { data, _, error in
                             if let error {
                                 // URLError.cancelled is expected when we cancel after timeout
                                 if (error as? URLError)?.code == .cancelled {
@@ -708,14 +699,10 @@ internal final class EtcdHttpClient: @unchecked Sendable {
     }
 
     private func performRequest<Req: Encodable>(path: String, body: Req, allowReauth: Bool = true) async throws -> Data {
-        lock.lock()
-        guard let session else {
-            lock.unlock()
-            throw EtcdError.notConnected
+        let (token, generation) = try lock.withLock { () -> (String?, UInt64) in
+            guard session != nil else { throw EtcdError.notConnected }
+            return (authToken, sessionGeneration)
         }
-        let token = authToken
-        let generation = sessionGeneration
-        lock.unlock()
 
         guard let url = URL(string: "\(baseUrl)/\(path)") else {
             throw EtcdError.serverError("Invalid URL: \(baseUrl)/\(path)")
@@ -761,9 +748,7 @@ internal final class EtcdHttpClient: @unchecked Sendable {
             self.lock.unlock()
         }
 
-        lock.lock()
-        currentTask = nil
-        lock.unlock()
+        lock.withLock { currentTask = nil }
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EtcdError.serverError("Invalid response type")
@@ -771,9 +756,7 @@ internal final class EtcdHttpClient: @unchecked Sendable {
 
         if httpResponse.statusCode == 401 {
             // Attempt token refresh if not already authenticating and credentials are available
-            lock.lock()
-            let alreadyAuthenticating = _isAuthenticating
-            lock.unlock()
+            let alreadyAuthenticating = lock.withLock { _isAuthenticating }
 
             if allowReauth, !alreadyAuthenticating, !config.username.isEmpty {
                 try await authenticate()
@@ -798,22 +781,16 @@ internal final class EtcdHttpClient: @unchecked Sendable {
     // MARK: - Authentication
 
     private func authenticate() async throws {
-        lock.lock()
-        guard session != nil else {
-            lock.unlock()
-            throw EtcdError.notConnected
+        let startedAuthenticating = try lock.withLock { () -> Bool in
+            guard session != nil else { throw EtcdError.notConnected }
+            guard !_isAuthenticating else { return false }
+            _isAuthenticating = true
+            return true
         }
-        if _isAuthenticating {
-            lock.unlock()
-            return
-        }
-        _isAuthenticating = true
-        lock.unlock()
+        guard startedAuthenticating else { return }
 
         defer {
-            lock.lock()
-            _isAuthenticating = false
-            lock.unlock()
+            lock.withLock { _isAuthenticating = false }
         }
 
         let authReq = EtcdAuthRequest(name: config.username, password: config.password)
@@ -827,13 +804,10 @@ internal final class EtcdHttpClient: @unchecked Sendable {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONEncoder().encode(authReq)
 
-        lock.lock()
-        guard session != nil else {
-            lock.unlock()
-            throw EtcdError.notConnected
+        let generation = try lock.withLock { () -> UInt64 in
+            guard session != nil else { throw EtcdError.notConnected }
+            return sessionGeneration
         }
-        let generation = sessionGeneration
-        lock.unlock()
 
         let (data, response) = try await withCheckedThrowingContinuation {
             (continuation: CheckedContinuation<(Data, URLResponse), Error>) in
@@ -872,9 +846,7 @@ internal final class EtcdHttpClient: @unchecked Sendable {
             throw EtcdError.authFailed("No token in response")
         }
 
-        lock.lock()
-        authToken = token
-        lock.unlock()
+        lock.withLock { authToken = token }
 
         Self.logger.debug("Authenticated with etcd successfully")
     }

--- a/Plugins/JSONExportPlugin/JSONExportPlugin.swift
+++ b/Plugins/JSONExportPlugin/JSONExportPlugin.swift
@@ -8,7 +8,7 @@ import SwiftUI
 import TableProPluginKit
 
 @Observable
-final class JSONExportPlugin: ExportFormatPlugin, SettablePlugin {
+final class JSONExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Sendable {
     static let pluginName = "JSON Export"
     static let pluginVersion = "1.0.0"
     static let pluginDescription = "Export data to JSON format"
@@ -26,6 +26,7 @@ final class JSONExportPlugin: ExportFormatPlugin, SettablePlugin {
 
     required init() { loadSettings() }
 
+    @MainActor
     func settingsView() -> AnyView? {
         AnyView(JSONExportOptionsView(plugin: self))
     }

--- a/Plugins/JSONImportPlugin/JSONImportPlugin.swift
+++ b/Plugins/JSONImportPlugin/JSONImportPlugin.swift
@@ -8,7 +8,7 @@ import SwiftUI
 import TableProPluginKit
 
 @Observable
-final class JSONImportPlugin: ImportFormatPlugin, SettablePlugin {
+final class JSONImportPlugin: ImportFormatPlugin, SettablePlugin, @unchecked Sendable {
     static let pluginName = "JSON Import"
     static let pluginVersion = "1.0.0"
     static let pluginDescription = "Import data from JSON files"
@@ -27,6 +27,7 @@ final class JSONImportPlugin: ImportFormatPlugin, SettablePlugin {
 
     required init() { loadSettings() }
 
+    @MainActor
     func settingsView() -> AnyView? {
         AnyView(JSONImportOptionsView(plugin: self))
     }

--- a/Plugins/LibSQLDriverPlugin/HranaHttpClient.swift
+++ b/Plugins/LibSQLDriverPlugin/HranaHttpClient.swift
@@ -208,12 +208,10 @@ final class HranaHttpClient: @unchecked Sendable {
     }
 
     private func performRequest(url: URL, body: Data) async throws -> Data {
-        lock.lock()
+        let session = lock.withLock { self.session }
         guard let session else {
-            lock.unlock()
             throw HranaHttpError(message: String(localized: "Not connected to database"))
         }
-        lock.unlock()
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -254,9 +252,7 @@ final class HranaHttpClient: @unchecked Sendable {
             self.lock.unlock()
         }
 
-        lock.lock()
-        currentTask = nil
-        lock.unlock()
+        lock.withLock { currentTask = nil }
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw HranaHttpError(message: "Invalid response from server")

--- a/Plugins/LibSQLDriverPlugin/LibSQLPluginDriver.swift
+++ b/Plugins/LibSQLDriverPlugin/LibSQLPluginDriver.swift
@@ -94,11 +94,11 @@ final class LibSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         let versionResult = try await localBackend.executeQuery("SELECT sqlite_version()")
         let version = versionResult.rows.first?.first?.asText ?? "SQLite"
 
-        lock.lock()
-        _dbHandleForInterrupt = rawHandle != 0 ? OpaquePointer(bitPattern: rawHandle) : nil
-        _serverVersion = version
-        backend = .local(localBackend)
-        lock.unlock()
+        lock.withLock {
+            _dbHandleForInterrupt = rawHandle != 0 ? OpaquePointer(bitPattern: rawHandle) : nil
+            _serverVersion = version
+            backend = .local(localBackend)
+        }
 
         Self.logger.debug("Connected to local libSQL database file")
     }
@@ -126,18 +126,14 @@ final class LibSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 ?? sqliteVersion.rows.first?.first?.stringValue
                 ?? "libSQL"
 
-            lock.lock()
-            _serverVersion = version
-            lock.unlock()
+            lock.withLock { _serverVersion = version }
         } catch {
             client.invalidateSession()
             Self.logger.error("Connection test failed: \(error.localizedDescription)")
             throw LibSQLError(message: String(localized: "Failed to connect to libSQL database"))
         }
 
-        lock.lock()
-        backend = .remote(client)
-        lock.unlock()
+        lock.withLock { backend = .remote(client) }
 
         Self.logger.debug("Connected to libSQL database: \(normalized)")
     }

--- a/Plugins/MQLExportPlugin/MQLExportPlugin.swift
+++ b/Plugins/MQLExportPlugin/MQLExportPlugin.swift
@@ -8,7 +8,7 @@ import SwiftUI
 import TableProPluginKit
 
 @Observable
-final class MQLExportPlugin: ExportFormatPlugin, SettablePlugin {
+final class MQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Sendable {
     static let pluginName = "MQL Export"
     static let pluginVersion = "1.0.0"
     static let pluginDescription = "Export data to MongoDB Query Language format"
@@ -41,6 +41,7 @@ final class MQLExportPlugin: ExportFormatPlugin, SettablePlugin {
         optionValues.contains(true)
     }
 
+    @MainActor
     func settingsView() -> AnyView? {
         AnyView(MQLExportOptionsView(plugin: self))
     }

--- a/Plugins/MSSQLDriverPlugin/FreeTDSConnection.swift
+++ b/Plugins/MSSQLDriverPlugin/FreeTDSConnection.swift
@@ -15,51 +15,57 @@ import Foundation
 import os
 import TableProMSSQLCore
 
-private let freetdsLogger = Logger(subsystem: "com.TablePro", category: "FreeTDSConnection")
+nonisolated private let freetdsLogger = Logger(subsystem: "com.TablePro", category: "FreeTDSConnection")
 
-private let freetdsErrorLock = NSLock()
-private var freetdsConnectionErrors: [UnsafeRawPointer: String] = [:]
-private var freetdsGlobalError = ""
-
-private func freetdsGetError(for dbproc: UnsafeMutablePointer<DBPROCESS>?) -> String {
-    freetdsErrorLock.lock()
-    defer { freetdsErrorLock.unlock() }
-    if let dbproc {
-        return freetdsConnectionErrors[UnsafeRawPointer(dbproc)] ?? freetdsGlobalError
-    }
-    return freetdsGlobalError
+private struct FreeTDSErrorState {
+    var perConnection: [UInt: String] = [:]
+    var global = ""
 }
 
-private func freetdsClearError(for dbproc: UnsafeMutablePointer<DBPROCESS>?) {
-    freetdsErrorLock.lock()
-    defer { freetdsErrorLock.unlock() }
-    if let dbproc {
-        freetdsConnectionErrors[UnsafeRawPointer(dbproc)] = nil
-    } else {
-        freetdsGlobalError = ""
+nonisolated private let freetdsErrors = OSAllocatedUnfairLock(initialState: FreeTDSErrorState())
+
+nonisolated private func freetdsConnectionKey(_ dbproc: UnsafeMutablePointer<DBPROCESS>) -> UInt {
+    UInt(bitPattern: UnsafeRawPointer(dbproc))
+}
+
+nonisolated private func freetdsGetError(for dbproc: UnsafeMutablePointer<DBPROCESS>?) -> String {
+    let key = dbproc.map(freetdsConnectionKey)
+    return freetdsErrors.withLock { state in
+        guard let key else { return state.global }
+        return state.perConnection[key] ?? state.global
     }
 }
 
-private func freetdsSetError(_ msg: String, for dbproc: UnsafeMutablePointer<DBPROCESS>?, overwrite: Bool = false) {
-    freetdsErrorLock.lock()
-    defer { freetdsErrorLock.unlock() }
-    if let dbproc {
-        let key = UnsafeRawPointer(dbproc)
-        if overwrite || (freetdsConnectionErrors[key]?.isEmpty ?? true) {
-            freetdsConnectionErrors[key] = msg
+nonisolated private func freetdsClearError(for dbproc: UnsafeMutablePointer<DBPROCESS>?) {
+    let key = dbproc.map(freetdsConnectionKey)
+    freetdsErrors.withLock { state in
+        guard let key else {
+            state.global = ""
+            return
         }
-    } else if overwrite || freetdsGlobalError.isEmpty {
-        freetdsGlobalError = msg
+        state.perConnection[key] = nil
     }
 }
 
-private func freetdsUnregister(_ dbproc: UnsafeMutablePointer<DBPROCESS>) {
-    freetdsErrorLock.lock()
-    defer { freetdsErrorLock.unlock() }
-    freetdsConnectionErrors.removeValue(forKey: UnsafeRawPointer(dbproc))
+nonisolated private func freetdsSetError(_ msg: String, for dbproc: UnsafeMutablePointer<DBPROCESS>?, overwrite: Bool = false) {
+    let key = dbproc.map(freetdsConnectionKey)
+    freetdsErrors.withLock { state in
+        guard let key else {
+            if overwrite || state.global.isEmpty { state.global = msg }
+            return
+        }
+        if overwrite || (state.perConnection[key]?.isEmpty ?? true) {
+            state.perConnection[key] = msg
+        }
+    }
 }
 
-private let freetdsInitOnce: Void = {
+nonisolated private func freetdsUnregister(_ dbproc: UnsafeMutablePointer<DBPROCESS>) {
+    let key = freetdsConnectionKey(dbproc)
+    freetdsErrors.withLock { $0.perConnection[key] = nil }
+}
+
+nonisolated private let freetdsInitOnce: Void = {
     _ = dbinit()
     _ = dberrhandle { dbproc, _, dberr, _, dberrstr, oserrstr in
         var msg = "db-lib error \(dberr)"
@@ -82,7 +88,7 @@ private let freetdsInitOnce: Void = {
     }
 }()
 
-private func freetdsDispatchAsync<T: Sendable>(
+nonisolated private func freetdsDispatchAsync<T: Sendable>(
     on queue: DispatchQueue,
     execute work: @escaping @Sendable () throws -> T
 ) async throws -> T {
@@ -98,7 +104,7 @@ private func freetdsDispatchAsync<T: Sendable>(
     }
 }
 
-private func freetdsDispatchAsync(
+nonisolated private func freetdsDispatchAsync(
     on queue: DispatchQueue,
     execute work: @escaping @Sendable () throws -> Void
 ) async throws {
@@ -667,7 +673,7 @@ nonisolated final class FreeTDSConnection: @unchecked Sendable {
     }
 }
 
-private extension MSSQLLoginField {
+nonisolated private extension MSSQLLoginField {
     var dbsetName: Int32 {
         switch self {
         case .user: return Int32(DBSETUSER)

--- a/Plugins/MSSQLDriverPlugin/MSSQLKerberosCredentials.swift
+++ b/Plugins/MSSQLDriverPlugin/MSSQLKerberosCredentials.swift
@@ -1,5 +1,5 @@
 import Foundation
-import GSS
+@preconcurrency import GSS
 import TableProMSSQLCore
 
 enum MSSQLKerberosCredentials {

--- a/Plugins/MSSQLDriverPlugin/MSSQLKerberosRealmResolver.swift
+++ b/Plugins/MSSQLDriverPlugin/MSSQLKerberosRealmResolver.swift
@@ -1,5 +1,5 @@
 import Foundation
-import GSS
+@preconcurrency import GSS
 import TableProMSSQLCore
 
 /// Resolves the canonical SQL Server Kerberos service (host + realm) for a connection host.

--- a/Plugins/MSSQLDriverPlugin/MSSQLLoginParameters.swift
+++ b/Plugins/MSSQLDriverPlugin/MSSQLLoginParameters.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum MSSQLLoginField: Equatable {
+nonisolated enum MSSQLLoginField: Equatable {
     case user
     case password
     case application
@@ -10,12 +10,12 @@ enum MSSQLLoginField: Equatable {
     case database
 }
 
-struct MSSQLLoginParameter: Equatable {
+nonisolated struct MSSQLLoginParameter: Equatable {
     let field: MSSQLLoginField
     let value: String
 }
 
-enum MSSQLLoginParameters {
+nonisolated enum MSSQLLoginParameters {
     static let nationalLanguage = "us_english"
     static let charset = "UTF-8"
 

--- a/Plugins/MSSQLDriverPlugin/MSSQLPluginDriver+Schema.swift
+++ b/Plugins/MSSQLDriverPlugin/MSSQLPluginDriver+Schema.swift
@@ -105,9 +105,7 @@ extension MSSQLPluginDriver {
                 extra: isIdentity ? "IDENTITY" : nil
             )
         }
-        identityCacheLock.lock()
-        identityColumnsByTable[table] = identityColumns
-        identityCacheLock.unlock()
+        identityCacheLock.withLock { identityColumnsByTable[table] = identityColumns }
         return columns
     }
 

--- a/Plugins/MongoDBDriverPlugin/BsonDocumentFlattener.swift
+++ b/Plugins/MongoDBDriverPlugin/BsonDocumentFlattener.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import os
 import TableProNumberFormatting
 import TableProPluginKit
 
@@ -148,7 +149,7 @@ struct BsonDocumentFlattener {
         case let num as NSNumber:
             return displayString(for: num)
         case let date as Date:
-            return iso8601Formatter.string(from: date)
+            return iso8601Text(for: date)
         case let objectId as MongoDBObjectId:
             return objectId.hex
         case let decimal as MongoDBDecimal128:
@@ -218,7 +219,7 @@ struct BsonDocumentFlattener {
         case let data as Data:
             return MongoDBUuidCodec.binaryText(for: MongoDBBinaryValue(data: data, subtype: 0))
         case let date as Date:
-            return iso8601Formatter.string(from: date)
+            return iso8601Text(for: date)
         case is NSNull:
             return value
         case let str as String:
@@ -230,7 +231,11 @@ struct BsonDocumentFlattener {
         }
     }
 
-    private static let iso8601Formatter = ISO8601DateFormatter()
+    private static let iso8601Formatter = OSAllocatedUnfairLock(uncheckedState: ISO8601DateFormatter())
+
+    private static func iso8601Text(for date: Date) -> String {
+        iso8601Formatter.withLockUnchecked { $0.string(from: date) }
+    }
 
     private static func displayString(for num: NSNumber) -> String {
         if isBoolean(num) {

--- a/Plugins/MongoDBDriverPlugin/MongoDBConnection.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBConnection.swift
@@ -36,6 +36,12 @@ extension MongoDBError: PluginDriverError {
 
 // MARK: - Connection Class
 
+/// Hands a BSON pointer or a decoded document between the serial queue and the awaiting caller.
+/// Only one of the two touches it at a time, which is what the compiler cannot see through `Any`.
+private struct QueueTransfer<Value>: @unchecked Sendable {
+    let value: Value
+}
+
 /// Thread-safe MongoDB connection using libmongoc.
 /// All blocking C calls are dispatched to a dedicated serial queue.
 /// Async entry points use `queue.async` + continuations. Synchronous entry points
@@ -407,7 +413,9 @@ final class MongoDBConnection: @unchecked Sendable {
     /// libmongoc call at this point, so the `killSessions` command needs its own client.
     private func killSession(lsid: OpaquePointer) {
         let uriString = buildUri()
+        let session = QueueTransfer(value: lsid)
         controlQueue.async {
+            let lsid = session.value
             defer { bson_destroy(lsid) }
             guard let controlClient = mongoc_client_new(uriString) else { return }
             defer { mongoc_client_destroy(controlClient) }
@@ -511,8 +519,8 @@ final class MongoDBConnection: @unchecked Sendable {
             try checkCancelled()
             let result = try runCommandSync(client: client, command: command, database: database)
             try checkCancelled()
-            return result
-        }
+            return QueueTransfer(value: result)
+        }.value
         #else
         throw MongoDBError.libmongocUnavailable
         #endif
@@ -536,11 +544,11 @@ final class MongoDBConnection: @unchecked Sendable {
                 throw MongoDBError.notConnected
             }
             try checkCancelled()
-            return try findSync(
+            return try QueueTransfer(value: findSync(
                 client: client, database: database, collection: collection,
                 filter: filter, sort: sort, projection: projection, skip: skip, limit: limit
-            )
-        }
+            ))
+        }.value
         #else
         throw MongoDBError.libmongocUnavailable
         #endif
@@ -554,10 +562,10 @@ final class MongoDBConnection: @unchecked Sendable {
                 throw MongoDBError.notConnected
             }
             try checkCancelled()
-            return try aggregateSync(
+            return try QueueTransfer(value: aggregateSync(
                 client: client, database: database, collection: collection, pipeline: pipeline
-            )
-        }
+            ))
+        }.value
         #else
         throw MongoDBError.libmongocUnavailable
         #endif
@@ -710,10 +718,10 @@ final class MongoDBConnection: @unchecked Sendable {
                 throw MongoDBError.notConnected
             }
             try checkCancelled()
-            return try listIndexesSync(
+            return try QueueTransfer(value: listIndexesSync(
                 client: client, database: database, collection: collection
-            )
-        }
+            ))
+        }.value
         #else
         throw MongoDBError.libmongocUnavailable
         #endif

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver+Principals.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver+Principals.swift
@@ -127,6 +127,8 @@ extension MySQLPluginDriver: PluginPrincipalManagement {
             try await columns(in: database, table: table)
         case .server, .schema, .column:
             []
+        @unknown default:
+            []
         }
     }
 
@@ -238,6 +240,8 @@ extension MySQLPluginDriver: PluginPrincipalManagement {
             "\(quoteIdentifier(database)).\(quoteIdentifier(table))"
         case let .column(database, _, table, _):
             "\(quoteIdentifier(database)).\(quoteIdentifier(table))"
+        @unknown default:
+            nil
         }
     }
 

--- a/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
@@ -184,9 +184,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
     // MARK: - Connection Management
 
     func connect(reportingStage report: @escaping ConnectionStageReporter = { _ in }) async throws {
-        stateLock.lock()
-        _isConnectCancelled = false
-        stateLock.unlock()
+        stateLock.withLock { _isConnectCancelled = false }
 
         try await withTaskCancellationHandler {
             try await pluginDispatchAsyncCancellable(

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+PrincipalSQL.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+PrincipalSQL.swift
@@ -114,6 +114,8 @@ extension PostgreSQLPluginDriver {
             } else {
                 "TABLE \(quoteIdentifier(table))"
             }
+        @unknown default:
+            nil
         }
     }
 

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Principals.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Principals.swift
@@ -103,6 +103,8 @@ extension PostgreSQLPluginDriver: PluginPrincipalManagement {
             return try await columns(in: database, schema: schema, table: table)
         case .server, .column:
             return []
+        @unknown default:
+            return []
         }
     }
 

--- a/Plugins/RedisDriverPlugin/RedisAuthCommand.swift
+++ b/Plugins/RedisDriverPlugin/RedisAuthCommand.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum RedisAuthCommand {
+nonisolated enum RedisAuthCommand {
     enum Failure: Equatable, Sendable {
         case rejectedCredentials
         case rejectedWithoutUsername

--- a/Plugins/RedisDriverPlugin/RedisDatabaseIndex.swift
+++ b/Plugins/RedisDriverPlugin/RedisDatabaseIndex.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum RedisDatabaseIndex {
+nonisolated enum RedisDatabaseIndex {
     static let fieldName = "redisDatabase"
 
     static func resolve(additionalFields: [String: String], database: String) -> Int {

--- a/Plugins/SQLExportPlugin/SQLExportPlugin.swift
+++ b/Plugins/SQLExportPlugin/SQLExportPlugin.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import TableProPluginKit
 
 @Observable
-final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin {
+final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Sendable {
     static let pluginName = "SQL Export"
     static let pluginVersion = "1.0.0"
     static let pluginDescription = "Export data to SQL format"
@@ -51,6 +51,7 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin {
         settings.compressWithGzip ? "sql.gz" : "sql"
     }
 
+    @MainActor
     func settingsView() -> AnyView? {
         AnyView(SQLExportOptionsView(plugin: self))
     }

--- a/Plugins/SQLImportPlugin/SQLImportPlugin.swift
+++ b/Plugins/SQLImportPlugin/SQLImportPlugin.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import TableProPluginKit
 
 @Observable
-final class SQLImportPlugin: ImportFormatPlugin, SettablePlugin {
+final class SQLImportPlugin: ImportFormatPlugin, SettablePlugin, @unchecked Sendable {
     private static let logger = Logger(subsystem: "com.TablePro", category: "SQLImportPlugin")
 
     static let pluginName = "SQL Import"
@@ -29,6 +29,7 @@ final class SQLImportPlugin: ImportFormatPlugin, SettablePlugin {
 
     required init() { loadSettings() }
 
+    @MainActor
     func settingsView() -> AnyView? {
         AnyView(SQLImportOptionsView(plugin: self))
     }

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeIdTokenStore.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeIdTokenStore.swift
@@ -13,30 +13,29 @@ import os
 import Security
 
 enum SnowflakeIdTokenStore {
-    private static let lock = NSLock()
-    private static var cache: [String: String] = [:]
+    private static let cache = OSAllocatedUnfairLock(initialState: [String: String]())
     private static let service = "com.TablePro.SnowflakeDriverPlugin.idToken"
     private static let logger = Logger(subsystem: "com.TablePro", category: "SnowflakeIdTokenStore")
 
     static func token(account: String, user: String) -> String? {
         let key = cacheKey(account: account, user: user)
-        if let cached = lock.withLock({ cache[key] }) {
+        if let cached = cache.withLock({ $0[key] }) {
             return cached
         }
         guard let stored = readKeychain(key: key) else { return nil }
-        lock.withLock { cache[key] = stored }
+        cache.withLock { $0[key] = stored }
         return stored
     }
 
     static func store(_ token: String, account: String, user: String) {
         let key = cacheKey(account: account, user: user)
-        lock.withLock { cache[key] = token }
+        cache.withLock { $0[key] = token }
         writeKeychain(token, key: key)
     }
 
     static func clear(account: String, user: String) {
         let key = cacheKey(account: account, user: user)
-        _ = lock.withLock { cache.removeValue(forKey: key) }
+        cache.withLock { $0[key] = nil }
         deleteKeychain(key: key)
     }
 

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeMFATokenStore.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeMFATokenStore.swift
@@ -12,30 +12,34 @@ import os
 import Security
 
 enum SnowflakeMFATokenStore {
-    private static let lock = NSLock()
-    private static var cache: [String: String] = [:]
+    private struct TokenState {
+        var cache: [String: String] = [:]
+        var rejectedPasscodes: [String: Date] = [:]
+    }
+
+    private static let state = OSAllocatedUnfairLock(initialState: TokenState())
     private static let service = "com.TablePro.SnowflakeDriverPlugin.mfaToken"
     private static let logger = Logger(subsystem: "com.TablePro", category: "SnowflakeMFATokenStore")
 
     static func token(account: String, user: String) -> String? {
         let key = cacheKey(account: account, user: user)
-        if let cached = lock.withLock({ cache[key] }) {
+        if let cached = state.withLock({ $0.cache[key] }) {
             return cached
         }
         guard let stored = readKeychain(key: key) else { return nil }
-        lock.withLock { cache[key] = stored }
+        state.withLock { $0.cache[key] = stored }
         return stored
     }
 
     static func store(_ token: String, account: String, user: String) {
         let key = cacheKey(account: account, user: user)
-        lock.withLock { cache[key] = token }
+        state.withLock { $0.cache[key] = token }
         writeKeychain(token, key: key)
     }
 
     static func clear(account: String, user: String) {
         let key = cacheKey(account: account, user: user)
-        _ = lock.withLock { cache.removeValue(forKey: key) }
+        state.withLock { $0.cache[key] = nil }
         deleteKeychain(key: key)
     }
 
@@ -44,22 +48,22 @@ enum SnowflakeMFATokenStore {
     static func markPasscodeRejected(_ passcode: String, account: String, user: String) {
         guard !passcode.isEmpty else { return }
         let key = "\(cacheKey(account: account, user: user)):\(passcode)"
-        lock.withLock {
-            rejectedPasscodes = rejectedPasscodes.filter { Date().timeIntervalSince($0.value) < rejectedPasscodeLifetime }
-            rejectedPasscodes[key] = Date()
+        state.withLock { state in
+            state.rejectedPasscodes = state.rejectedPasscodes.filter {
+                Date().timeIntervalSince($0.value) < rejectedPasscodeLifetime
+            }
+            state.rejectedPasscodes[key] = Date()
         }
     }
 
     static func isPasscodeRejected(_ passcode: String, account: String, user: String) -> Bool {
         guard !passcode.isEmpty else { return false }
         let key = "\(cacheKey(account: account, user: user)):\(passcode)"
-        return lock.withLock {
-            guard let rejectedAt = rejectedPasscodes[key] else { return false }
+        return state.withLock {
+            guard let rejectedAt = $0.rejectedPasscodes[key] else { return false }
             return Date().timeIntervalSince(rejectedAt) < rejectedPasscodeLifetime
         }
     }
-
-    private static var rejectedPasscodes: [String: Date] = [:]
 
     private static func cacheKey(account: String, user: String) -> String {
         "\(SnowflakeAccount.issuerAccountName(forAccount: account)).\(user.uppercased())"

--- a/Plugins/TableProPluginKit/CSVTypeInferrer.swift
+++ b/Plugins/TableProPluginKit/CSVTypeInferrer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 public struct CSVTypeInferrer {
     public typealias InferredType = InspectorColumnType
@@ -9,16 +10,16 @@ public struct CSVTypeInferrer {
         "true", "false", "yes", "no", "t", "f", "y", "n"
     ]
 
-    private static let isoFormatter: ISO8601DateFormatter = {
+    private static let isoFormatter: OSAllocatedUnfairLock<ISO8601DateFormatter> = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
-        return formatter
+        return OSAllocatedUnfairLock(uncheckedState: formatter)
     }()
 
-    private static let dateOnlyFormatter: ISO8601DateFormatter = {
+    private static let dateOnlyFormatter: OSAllocatedUnfairLock<ISO8601DateFormatter> = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withFullDate]
-        return formatter
+        return OSAllocatedUnfairLock(uncheckedState: formatter)
     }()
 
     public static func infer(column values: [String]) -> InferredType {
@@ -53,8 +54,8 @@ public struct CSVTypeInferrer {
     }
 
     private static func isDate(_ value: String) -> Bool {
-        if isoFormatter.date(from: value) != nil { return true }
-        if dateOnlyFormatter.date(from: value) != nil { return true }
+        if isoFormatter.withLockUnchecked({ $0.date(from: value) }) != nil { return true }
+        if dateOnlyFormatter.withLockUnchecked({ $0.date(from: value) }) != nil { return true }
         return false
     }
 }

--- a/Plugins/TableProPluginKit/ExportFormatPlugin.swift
+++ b/Plugins/TableProPluginKit/ExportFormatPlugin.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-public protocol ExportFormatPlugin: TableProPlugin {
+public protocol ExportFormatPlugin: TableProPlugin, Sendable {
     static var formatId: String { get }
     static var formatDisplayName: String { get }
     static var defaultFileExtension: String { get }

--- a/Plugins/TableProPluginKit/ImportFormatPlugin.swift
+++ b/Plugins/TableProPluginKit/ImportFormatPlugin.swift
@@ -6,7 +6,7 @@
 import Foundation
 import SwiftUI
 
-public protocol ImportFormatPlugin: TableProPlugin {
+public protocol ImportFormatPlugin: TableProPlugin, Sendable {
     static var formatId: String { get }
     static var formatDisplayName: String { get }
     static var acceptedFileExtensions: [String] { get }

--- a/Plugins/TableProPluginKit/SettablePlugin.swift
+++ b/Plugins/TableProPluginKit/SettablePlugin.swift
@@ -8,6 +8,7 @@ import SwiftUI
 
 /// Type-erased witness for runtime discovery (needed because SettablePlugin has associated type).
 public protocol SettablePluginDiscoverable: AnyObject {
+    @MainActor
     func settingsView() -> AnyView?
     func snapshotSettingsData() -> Data?
     func restoreSettingsData(_ data: Data)
@@ -34,6 +35,7 @@ public protocol SettablePlugin: SettablePluginDiscoverable {
 }
 
 public extension SettablePlugin {
+    @MainActor
     func settingsView() -> AnyView? { nil }
 
     func snapshotSettingsData() -> Data? {

--- a/Plugins/XLSXExportPlugin/XLSXExportPlugin.swift
+++ b/Plugins/XLSXExportPlugin/XLSXExportPlugin.swift
@@ -8,7 +8,7 @@ import SwiftUI
 import TableProPluginKit
 
 @Observable
-final class XLSXExportPlugin: ExportFormatPlugin, SettablePlugin {
+final class XLSXExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Sendable {
     static let pluginName = "XLSX Export"
     static let pluginVersion = "1.0.0"
     static let pluginDescription = "Export data to Excel format"
@@ -26,6 +26,7 @@ final class XLSXExportPlugin: ExportFormatPlugin, SettablePlugin {
 
     required init() { loadSettings() }
 
+    @MainActor
     func settingsView() -> AnyView? {
         AnyView(XLSXExportOptionsView(plugin: self))
     }
@@ -164,9 +165,7 @@ final class XLSXExportPlugin: ExportFormatPlugin, SettablePlugin {
 
         }
 
-        try await Task.detached(priority: .userInitiated) {
-            try writer.write(to: destination)
-        }.value
+        try await writer.write(to: destination)
 
         progress.finalizeTable()
 

--- a/Plugins/XLSXExportPlugin/XLSXWriter.swift
+++ b/Plugins/XLSXExportPlugin/XLSXWriter.swift
@@ -142,7 +142,15 @@ final class XLSXWriter {
     }
 
     /// Write the XLSX file to the given URL
-    func write(to url: URL) throws {
+    func write(to url: URL) async throws {
+        let entries = archiveEntries()
+        try await Task.detached(priority: .userInitiated) {
+            let zipData = try ZipBuilder.build(entries: entries)
+            try zipData.write(to: url, options: .atomic)
+        }.value
+    }
+
+    private func archiveEntries() -> [ZipFileEntry] {
         var entries: [ZipFileEntry] = []
 
         entries.append(ZipFileEntry(path: "[Content_Types].xml", data: contentTypesXML()))
@@ -158,8 +166,7 @@ final class XLSXWriter {
             ))
         }
 
-        let zipData = try ZipBuilder.build(entries: entries)
-        try zipData.write(to: url, options: .atomic)
+        return entries
     }
 
     // MARK: - Row XML Generation

--- a/TablePro/AppDelegate.swift
+++ b/TablePro/AppDelegate.swift
@@ -11,8 +11,8 @@ import UserNotifications
 
 @MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "AppDelegate")
-    static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "AppDelegate")
+    nonisolated static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
 
     private var hasRunPostLaunchActivation = false
 
@@ -270,14 +270,27 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 }
 
+/// Carries a UserNotifications callback from the delegate thread to the main actor.
+/// UNUserNotificationCenter hands each one over exactly once and keeps no reference.
+private struct NotificationDelivery<Payload>: @unchecked Sendable {
+    let payload: Payload
+    let complete: () -> Void
+}
+
+private struct NotificationPresentationRequest: @unchecked Sendable {
+    let notification: UNNotification
+    let respond: (UNNotificationPresentationOptions) -> Void
+}
+
 extension AppDelegate: UNUserNotificationCenterDelegate {
     nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
+        let request = NotificationPresentationRequest(notification: notification, respond: completionHandler)
         Task { @MainActor in
-            completionHandler(NotificationRouter.shared.presentationOptions(for: notification))
+            request.respond(NotificationRouter.shared.presentationOptions(for: request.notification))
         }
     }
 
@@ -286,9 +299,10 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
+        let delivery = NotificationDelivery(payload: response, complete: completionHandler)
         Task { @MainActor in
-            defer { completionHandler() }
-            NotificationRouter.shared.handle(response)
+            defer { delivery.complete() }
+            NotificationRouter.shared.handle(delivery.payload)
         }
     }
 }

--- a/TablePro/Core/AI/Chat/ChatToolRegistry.swift
+++ b/TablePro/Core/AI/Chat/ChatToolRegistry.swift
@@ -10,7 +10,7 @@ import os
 final class ChatToolRegistry {
     static let shared = ChatToolRegistry()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "ChatToolRegistry")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ChatToolRegistry")
 
     private var tools: [String: any ChatTool] = [:]
 

--- a/TablePro/Core/AI/Chat/ToolApprovalCenter.swift
+++ b/TablePro/Core/AI/Chat/ToolApprovalCenter.swift
@@ -16,7 +16,7 @@ enum ToolApprovalDecision: Sendable {
 final class ToolApprovalCenter {
     static let shared = ToolApprovalCenter()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "ToolApprovalCenter")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ToolApprovalCenter")
 
     private var pending: [String: CheckedContinuation<ToolApprovalDecision, Never>] = [:]
 

--- a/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexService.swift
+++ b/TablePro/Core/AI/ChatGPTCodex/ChatGPTCodexService.swift
@@ -11,7 +11,7 @@ import os
 final class ChatGPTCodexService {
     static let shared = ChatGPTCodexService()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "ChatGPTCodexService")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ChatGPTCodexService")
 
     enum AuthState: Sendable, Equatable {
         case signedOut

--- a/TablePro/Core/AI/ClaudeAgent/ClaudeAgentService.swift
+++ b/TablePro/Core/AI/ClaudeAgent/ClaudeAgentService.swift
@@ -23,7 +23,7 @@ final class ClaudeAgentService {
 
     static let shared = ClaudeAgentService()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "ClaudeAgentService")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ClaudeAgentService")
 
     private(set) var state: InstallState = .unknown
     private(set) var isRefreshing = false

--- a/TablePro/Core/AI/Copilot/CopilotAuthManager.swift
+++ b/TablePro/Core/AI/Copilot/CopilotAuthManager.swift
@@ -9,7 +9,7 @@ import os
 
 @MainActor
 final class CopilotAuthManager {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "CopilotAuth")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "CopilotAuth")
 
     struct SignInResult {
         let userCode: String

--- a/TablePro/Core/AI/Copilot/CopilotChatProvider.swift
+++ b/TablePro/Core/AI/Copilot/CopilotChatProvider.swift
@@ -6,7 +6,7 @@
 import Foundation
 import os
 
-final class CopilotChatProvider: ChatTransport {
+final class CopilotChatProvider: ChatTransport, @unchecked Sendable {
     private static let logger = Logger(subsystem: "com.TablePro", category: "CopilotChatProvider")
 
     private var conversationId: String?

--- a/TablePro/Core/AI/Copilot/CopilotDocumentSync.swift
+++ b/TablePro/Core/AI/Copilot/CopilotDocumentSync.swift
@@ -10,7 +10,7 @@ import os
 /// to all document text sent to the server.
 @MainActor
 final class CopilotDocumentSync {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "CopilotDocumentSync")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "CopilotDocumentSync")
 
     private let documentManager = LSPDocumentManager()
     let preambleBuilder = CopilotPreambleBuilder()

--- a/TablePro/Core/AI/Copilot/CopilotInlineSource.swift
+++ b/TablePro/Core/AI/Copilot/CopilotInlineSource.swift
@@ -8,7 +8,7 @@ import os
 
 @MainActor
 final class CopilotInlineSource: InlineSuggestionSource {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "CopilotInlineSource")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "CopilotInlineSource")
 
     private let documentSync: CopilotDocumentSync
     private var pendingCommands: [UUID: LSPCommand] = [:]

--- a/TablePro/Core/AI/Copilot/CopilotPreambleBuilder.swift
+++ b/TablePro/Core/AI/Copilot/CopilotPreambleBuilder.swift
@@ -9,7 +9,7 @@ import TableProPluginKit
 
 @MainActor
 final class CopilotPreambleBuilder {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "CopilotPreambleBuilder")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "CopilotPreambleBuilder")
 
     static let contextDirectory: URL = {
         let appSupport = AppStorageEnvironment.shared.applicationSupportRoot

--- a/TablePro/Core/AI/Copilot/CopilotService.swift
+++ b/TablePro/Core/AI/Copilot/CopilotService.swift
@@ -8,7 +8,7 @@ import os
 
 @MainActor @Observable
 final class CopilotService {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "CopilotService")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "CopilotService")
     static let shared = CopilotService()
 
     enum Status: Sendable, Equatable {

--- a/TablePro/Core/AI/Cursor/CursorAgentService.swift
+++ b/TablePro/Core/AI/Cursor/CursorAgentService.swift
@@ -10,7 +10,7 @@ import os
 final class CursorAgentService {
     static let shared = CursorAgentService()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "CursorAgentService")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "CursorAgentService")
 
     enum AuthState: Sendable, Equatable {
         case notInstalled

--- a/TablePro/Core/AI/Images/ChatImageConverter.swift
+++ b/TablePro/Core/AI/Images/ChatImageConverter.swift
@@ -10,6 +10,12 @@ import ImageIO
 import os
 import UniformTypeIdentifiers
 
+/// Carries an object NSItemProvider decoded on its own queue back to the awaiting caller.
+/// The provider hands it over and keeps no reference, so nothing else can touch it in flight.
+private struct LoadedObject<Value>: @unchecked Sendable {
+    let value: Value
+}
+
 enum ChatImageConverterError: Error, LocalizedError {
     case unsupportedFormat
     case decodingFailed
@@ -142,7 +148,7 @@ enum ChatImageConverter {
     }
 
     private static func loadObject<T: NSItemProviderReading>(itemProvider: NSItemProvider) async throws -> T {
-        try await withCheckedThrowingContinuation { continuation in
+        let loaded: LoadedObject<T> = try await withCheckedThrowingContinuation { continuation in
             itemProvider.loadObject(ofClass: T.self) { object, error in
                 if let error {
                     continuation.resume(throwing: error)
@@ -152,9 +158,10 @@ enum ChatImageConverter {
                     continuation.resume(throwing: ChatImageConverterError.decodingFailed)
                     return
                 }
-                continuation.resume(returning: typed)
+                continuation.resume(returning: LoadedObject(value: typed))
             }
         }
+        return loaded.value
     }
 
     private static func loadData(itemProvider: NSItemProvider, typeIdentifier: String) async throws -> Data {

--- a/TablePro/Core/AI/InlineSuggestion/AIChatInlineSource.swift
+++ b/TablePro/Core/AI/InlineSuggestion/AIChatInlineSource.swift
@@ -8,7 +8,7 @@ import os
 
 @MainActor
 final class AIChatInlineSource: InlineSuggestionSource {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "AIChatInlineSource")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "AIChatInlineSource")
 
     private weak var schemaProvider: SQLSchemaProvider?
     var connectionPolicy: AIConnectionPolicy?

--- a/TablePro/Core/AI/InlineSuggestion/GhostTextRenderer.swift
+++ b/TablePro/Core/AI/InlineSuggestion/GhostTextRenderer.swift
@@ -10,16 +10,16 @@ import os
 
 @MainActor
 final class GhostTextRenderer {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "GhostTextRenderer")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "GhostTextRenderer")
 
     private weak var controller: TextViewController?
     private var ghostLayer: CATextLayer?
     private var currentText: String?
     private var currentOffset: Int = 0
-    private let _scrollObserver = OSAllocatedUnfairLock<Any?>(initialState: nil)
+    private let _scrollObserver = OSAllocatedUnfairLock<Any?>(uncheckedState: nil)
 
     deinit {
-        if let observer = _scrollObserver.withLock({ $0 }) { NotificationCenter.default.removeObserver(observer) }
+        if let observer = _scrollObserver.withLockUnchecked({ $0 }) { NotificationCenter.default.removeObserver(observer) }
     }
 
     func install(controller: TextViewController) {
@@ -84,11 +84,11 @@ final class GhostTextRenderer {
     // MARK: - Scroll Observer
 
     private func installScrollObserver() {
-        guard _scrollObserver.withLock({ $0 }) == nil else { return }
+        guard _scrollObserver.withLockUnchecked({ $0 }) == nil else { return }
         guard let scrollView = controller?.scrollView else { return }
         let contentView = scrollView.contentView
 
-        _scrollObserver.withLock {
+        _scrollObserver.withLockUnchecked {
             $0 = NotificationCenter.default.addObserver(
                 forName: NSView.boundsDidChangeNotification,
                 object: contentView,
@@ -102,7 +102,7 @@ final class GhostTextRenderer {
     }
 
     private func removeScrollObserver() {
-        _scrollObserver.withLock {
+        _scrollObserver.withLockUnchecked {
             if let observer = $0 {
                 NotificationCenter.default.removeObserver(observer)
             }

--- a/TablePro/Core/AI/InlineSuggestion/InlineSuggestionManager.swift
+++ b/TablePro/Core/AI/InlineSuggestion/InlineSuggestionManager.swift
@@ -12,7 +12,7 @@ import os
 final class InlineSuggestionManager {
     // MARK: - Properties
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "InlineSuggestion")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "InlineSuggestion")
 
     private weak var controller: TextViewController?
     private let renderer = GhostTextRenderer()
@@ -21,12 +21,12 @@ final class InlineSuggestionManager {
     private var suggestionOffset: Int = 0
     private var debounceTask: Task<Void, Never>?
     private var requestTask: Task<Void, Never>?
-    private let _keyEventMonitor = OSAllocatedUnfairLock<Any?>(initialState: nil)
+    private let _keyEventMonitor = OSAllocatedUnfairLock<Any?>(uncheckedState: nil)
     private(set) var isEditorFocused = false
     private var isUninstalled = false
 
     deinit {
-        if let monitor = _keyEventMonitor.withLock({ $0 }) { NSEvent.removeMonitor(monitor) }
+        if let monitor = _keyEventMonitor.withLockUnchecked({ $0 }) { NSEvent.removeMonitor(monitor) }
     }
 
     // MARK: - Install / Uninstall
@@ -208,37 +208,38 @@ final class InlineSuggestionManager {
 
     private func installKeyEventMonitor() {
         removeKeyEventMonitor()
-        _keyEventMonitor.withLock { $0 = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] nsEvent in
+        let monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] nsEvent in
             nonisolated(unsafe) let event = nsEvent
-            return MainActor.assumeIsolated {
-                guard let self, self.isEditorFocused else { return event }
+            let acceptsSuggestion = MainActor.assumeIsolated { () -> Bool in
+                guard let self, self.isEditorFocused else { return false }
 
-                guard self.currentSuggestion != nil else { return event }
+                guard self.currentSuggestion != nil else { return false }
 
                 guard let textView = self.controller?.textView,
                       event.window === textView.window,
-                      textView.window?.firstResponder === textView else { return event }
+                      textView.window?.firstResponder === textView else { return false }
 
                 switch event.keyCode {
                 case 48:
                     self.acceptSuggestion()
-                    return nil
+                    return true
 
                 case 53:
                     self.dismissSuggestion()
-                    return event
+                    return false
 
                 default:
                     self.dismissSuggestion()
-                    return event
+                    return false
                 }
             }
+            return acceptsSuggestion ? nil : nsEvent
         }
-        }
+        _keyEventMonitor.withLockUnchecked { $0 = monitor }
     }
 
     private func removeKeyEventMonitor() {
-        _keyEventMonitor.withLock {
+        _keyEventMonitor.withLockUnchecked {
             if let monitor = $0 { NSEvent.removeMonitor(monitor) }
             $0 = nil
         }

--- a/TablePro/Core/AI/XAI/XAIService.swift
+++ b/TablePro/Core/AI/XAI/XAIService.swift
@@ -11,7 +11,7 @@ import os
 final class XAIService {
     static let shared = XAIService()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "XAIService")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "XAIService")
 
     enum AuthState: Sendable, Equatable {
         case signedOut

--- a/TablePro/Core/ChangeTracking/DataChangeManager.swift
+++ b/TablePro/Core/ChangeTracking/DataChangeManager.swift
@@ -39,7 +39,7 @@ struct UndoResult {
 /// when multiple queries complete simultaneously (e.g., rapid sorting over SSH tunnel)
 @MainActor @Observable
 final class DataChangeManager: ChangeManaging {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "DataChangeManager")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "DataChangeManager")
 
     private(set) var pending = PendingChanges()
     var hasChanges: Bool = false

--- a/TablePro/Core/ChangeTracking/SQLStatementGenerator.swift
+++ b/TablePro/Core/ChangeTracking/SQLStatementGenerator.swift
@@ -11,7 +11,7 @@ import os
 import TableProPluginKit
 
 /// A parameterized SQL statement with placeholders and bound values
-struct ParameterizedStatement {
+struct ParameterizedStatement: @unchecked Sendable {
     let sql: String
     let parameters: [Any?]
 }

--- a/TablePro/Core/Concurrency/OnceTask.swift
+++ b/TablePro/Core/Concurrency/OnceTask.swift
@@ -43,7 +43,7 @@ actor OnceTask<Key: Hashable & Sendable, Value: Sendable> {
         inFlight.removeValue(forKey: key)
     }
 
-    func cancel(where predicate: (Key) -> Bool) {
+    func cancel(where predicate: @Sendable (Key) -> Bool) {
         for key in inFlight.keys where predicate(key) {
             inFlight[key]?.task.cancel()
             inFlight.removeValue(forKey: key)

--- a/TablePro/Core/Coordinators/PaginationCoordinator.swift
+++ b/TablePro/Core/Coordinators/PaginationCoordinator.swift
@@ -299,7 +299,6 @@ final class PaginationCoordinator {
             do {
                 let start = CFAbsoluteTimeGetCurrent()
                 progressLog.info("[fetchAll] executing full query: \(baseQuery.prefix(100), privacy: .public)")
-                let anyParams: [Any?]? = storedParamValues.map { $0.map { $0 as Any? } }
                 let result = try await DatabaseManager.shared.withScopedDriver(
                     scope: scope,
                     route: route,
@@ -308,7 +307,7 @@ final class PaginationCoordinator {
                     try await driver.executeUserQuery(
                         query: baseQuery,
                         rowCap: nil,
-                        parameters: anyParams
+                        parameters: storedParamValues.map { $0.map { $0 as Any? } }
                     )
                 }
                 let fetchTime = CFAbsoluteTimeGetCurrent() - start

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+Parameters.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+Parameters.swift
@@ -11,7 +11,13 @@ private let paramLog = Logger(subsystem: "com.TablePro", category: "QueryParamet
 
 /// One statement of a multi-statement run, resolved before the transaction opens so the
 /// lease holds nothing but driver work.
-private struct PreparedStatement {
+/// Carries the driver-bound parameter values into the scoped-driver closure. The values are
+/// handed to the driver and never touched again by the caller, which is what `[Any?]` hides.
+private struct BoundParameterValues: @unchecked Sendable {
+    let values: [Any?]
+}
+
+private struct PreparedStatement: @unchecked Sendable {
     let originalSQL: String
     let executableSQL: String
     let parameterValues: [Any?]?
@@ -121,6 +127,7 @@ extension QueryExecutionCoordinator {
             needsMetadataFetch = false
         }
 
+        let boundValues = BoundParameterValues(values: parameters)
         let parameterizedTask = Task { [weak self, parent] in
             guard let self else { return }
 
@@ -136,11 +143,11 @@ extension QueryExecutionCoordinator {
                     scope: scope,
                     route: DatabaseManager.shared.executionRoute(for: scope),
                     cancellation: .cancellableRead
-                ) { [queryExecutor = parent.queryExecutor] driver in
+                ) { [queryExecutor = parent.queryExecutor, boundValues] driver in
                     try await queryExecutor.executeQuery(
                         driver: driver,
                         sql: sql,
-                        parameters: parameters,
+                        parameters: boundValues.values,
                         rowCap: rowCap
                     )
                 }

--- a/TablePro/Core/Database/DatabaseDriver.swift
+++ b/TablePro/Core/Database/DatabaseDriver.swift
@@ -502,7 +502,7 @@ extension DatabaseDriver {
 /// Factory for creating database drivers via plugin lookup
 @MainActor
 enum DatabaseDriverFactory {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "DatabaseDriverFactory")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "DatabaseDriverFactory")
 
     /// Async variant that awaits background plugin loading instead of blocking the main thread.
     /// Preferred for all call sites that are already in an async context.

--- a/TablePro/Core/Database/DatabaseManager.swift
+++ b/TablePro/Core/Database/DatabaseManager.swift
@@ -15,7 +15,7 @@ import TableProPluginKit
 @MainActor @Observable
 final class DatabaseManager {
     static let shared = DatabaseManager()
-    internal static let logger = Logger(subsystem: "com.TablePro", category: "DatabaseManager")
+    nonisolated internal static let logger = Logger(subsystem: "com.TablePro", category: "DatabaseManager")
 
     @ObservationIgnored internal let connectionStorage: ConnectionStorage
     @ObservationIgnored internal let appSettingsStorage: AppSettingsStorage

--- a/TablePro/Core/Database/FilterSQLGenerator.swift
+++ b/TablePro/Core/Database/FilterSQLGenerator.swift
@@ -369,6 +369,8 @@ struct FilterSQLGenerator {
             return booleanText(isTrue: true)
         case .isFalse:
             return booleanText(isTrue: false)
+        @unknown default:
+            return nil
         }
     }
 

--- a/TablePro/Core/Database/PostgresDumpService.swift
+++ b/TablePro/Core/Database/PostgresDumpService.swift
@@ -361,7 +361,7 @@ private extension String {
 
 // MARK: - Real Process Runner
 
-final class ProcessPostgresDumpRunner: PostgresDumpRunner {
+final class ProcessPostgresDumpRunner: PostgresDumpRunner, @unchecked Sendable {
     private let process = Process()
     private let stderrPipe = Pipe()
     private let stateLock = NSLock()

--- a/TablePro/Core/Database/SignIn/ConnectionSignInProvider.swift
+++ b/TablePro/Core/Database/SignIn/ConnectionSignInProvider.swift
@@ -12,17 +12,17 @@ enum ConnectionSignInKind: String, Equatable, CaseIterable {
 /// provider says which failures it recognises and what to run to recover, so both the connection
 /// form and the real connect path can offer the same recovery without either knowing which driver
 /// is involved.
-struct ConnectionSignInProvider {
+struct ConnectionSignInProvider: Sendable {
     let kind: ConnectionSignInKind
 
     /// Whether this provider recognises the failure. Kept free of UI so it stays testable.
-    let claims: (Error, [String: String]) -> Bool
+    let claims: @Sendable (Error, [String: String]) -> Bool
 
     let title: String
-    let message: ([String: String]) -> String
+    let message: @Sendable ([String: String]) -> String
     let signedInMessage: String
     let failureTitle: String
-    let signIn: @MainActor ([String: String], NSWindow?) async throws -> Void
+    let signIn: @MainActor @Sendable ([String: String], NSWindow?) async throws -> Void
 }
 
 enum ConnectionSignInRegistry {

--- a/TablePro/Core/Database/TableOperationSQLBuilder.swift
+++ b/TablePro/Core/Database/TableOperationSQLBuilder.swift
@@ -8,7 +8,7 @@ import os
 
 @MainActor
 struct TableOperationSQLBuilder {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "TableOperationSQLBuilder")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "TableOperationSQLBuilder")
 
     let connectionId: UUID
     let databaseType: DatabaseType

--- a/TablePro/Core/Database/TriggerEditing.swift
+++ b/TablePro/Core/Database/TriggerEditing.swift
@@ -41,7 +41,7 @@ enum TriggerApplyStrategy: Equatable {
 
 @MainActor
 enum TriggerEditing {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "TriggerEditing")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "TriggerEditing")
 
     static func apply(
         connection: DatabaseConnection,

--- a/TablePro/Core/KeyboardHandling/KeyCode.swift
+++ b/TablePro/Core/KeyboardHandling/KeyCode.swift
@@ -30,7 +30,7 @@ import AppKit
 ///     }
 /// }
 /// ```
-public enum KeyCode: UInt16 {
+public enum KeyCode: UInt16, Sendable {
     // MARK: - Special Keys
 
     /// Escape key (ESC)

--- a/TablePro/Core/KeyboardHandling/KeyRepeatFilter.swift
+++ b/TablePro/Core/KeyboardHandling/KeyRepeatFilter.swift
@@ -23,14 +23,14 @@ final class KeyRepeatFilter {
         guard monitor == nil else { return }
         monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { nsEvent in
             nonisolated(unsafe) let event = nsEvent
-            return MainActor.assumeIsolated {
-                guard event.isARepeat else { return event }
+            let suppress = MainActor.assumeIsolated { () -> Bool in
+                guard event.isARepeat else { return false }
                 let keyboard = AppSettingsManager.shared.keyboard
-                let suppress = Self.nonRepeatingActions.contains {
+                return Self.nonRepeatingActions.contains {
                     keyboard.shortcut(for: $0)?.matches(event) == true
                 }
-                return suppress ? nil : event
             }
+            return suppress ? nil : nsEvent
         }
     }
 }

--- a/TablePro/Core/MCP/Lifecycle/MCPHandshakeFile.swift
+++ b/TablePro/Core/MCP/Lifecycle/MCPHandshakeFile.swift
@@ -243,7 +243,7 @@ public final class MCPServerInstanceIdentity: Sendable {
 
 @MainActor
 internal final class MCPHandshakeFile {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "MCP.Handshake")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "MCP.Handshake")
 
     private let directory: URL
     private let fileManager: FileManager

--- a/TablePro/Core/MCP/Lifecycle/MCPServerManager.swift
+++ b/TablePro/Core/MCP/Lifecycle/MCPServerManager.swift
@@ -26,7 +26,7 @@ internal final class MCPServerManager {
         let expiresAt: Date
     }
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "MCPServerManager")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "MCPServerManager")
     private static let bridgeTokenLifetime: TimeInterval = 60 * 60
     private static let bridgeTokenRenewalLead: TimeInterval = 15 * 60
     private static let clientRefreshInterval: Duration = .seconds(5)

--- a/TablePro/Core/MCP/MCPAuditLogStorage.swift
+++ b/TablePro/Core/MCP/MCPAuditLogStorage.swift
@@ -47,36 +47,45 @@ actor MCPAuditLogStorage {
         NSClassFromString("XCTestCase") != nil
     }
 
-    private var db: OpaquePointer?
+    private struct DatabaseHandle: @unchecked Sendable {
+        var pointer: OpaquePointer?
+    }
+
+    private var dbHandle = DatabaseHandle()
+
+    private var db: OpaquePointer? {
+        if !isPrepared {
+            isPrepared = true
+            setupDatabase()
+            prune(olderThan: Self.retentionDays)
+            loadChainHead()
+        }
+        return dbHandle.pointer
+    }
     private var dbPath: String?
     private let testDatabaseSuffix: String?
     private var nextSequence: Int = 0
     private var lastHash: String = MCPAuditChainLink.genesisHash
+    private var isPrepared = false
 
     init() {
         self.testDatabaseSuffix = nil
-        setupDatabase()
-        prune(olderThan: Self.retentionDays)
-        loadChainHead()
     }
 
     #if DEBUG
     init(isolatedForTesting: Bool) {
         self.testDatabaseSuffix = isolatedForTesting ? "_\(UUID().uuidString)" : nil
-        setupDatabase()
-        prune(olderThan: Self.retentionDays)
-        loadChainHead()
     }
 
     var databaseFilePaths: [String] {
-        guard let dbPath else { return [] }
+        guard db != nil, let dbPath else { return [] }
         return [dbPath, dbPath + "-wal", dbPath + "-shm"]
     }
     #endif
 
     deinit {
-        if let db {
-            sqlite3_close(db)
+        if let pointer = dbHandle.pointer {
+            sqlite3_close(pointer)
         }
         if Self.isRunningTests, let dbPath {
             try? FileManager.default.removeItem(atPath: dbPath)
@@ -112,7 +121,7 @@ actor MCPAuditLogStorage {
         }
         Self.restrict(path: path, to: 0o600)
 
-        if sqlite3_open(path, &db) != SQLITE_OK {
+        if sqlite3_open(path, &dbHandle.pointer) != SQLITE_OK {
             Self.logger.error("Error opening MCP audit database")
             return
         }

--- a/TablePro/Core/MCP/MCPAuditLogger.swift
+++ b/TablePro/Core/MCP/MCPAuditLogger.swift
@@ -19,9 +19,7 @@ final class MCPAuditWriteQueue: @unchecked Sendable {
     }
 
     func flush() async {
-        lock.lock()
-        let pending = tail
-        lock.unlock()
+        let pending = lock.withLock { tail }
         await pending?.value
     }
 }

--- a/TablePro/Core/MCP/MCPConnectionBridge+Schema.swift
+++ b/TablePro/Core/MCP/MCPConnectionBridge+Schema.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import TableProPluginKit
 
 extension MCPConnectionBridge {
@@ -256,8 +257,8 @@ extension MCPConnectionBridge {
         if let value = metadata.comment { fields["comment"] = .string(value) }
         if let value = metadata.engine { fields["engine"] = .string(value) }
         if let value = metadata.collation { fields["collation"] = .string(value) }
-        if let value = metadata.createTime { fields["created_at"] = .string(Self.iso8601.string(from: value)) }
-        if let value = metadata.updateTime { fields["updated_at"] = .string(Self.iso8601.string(from: value)) }
+        if let value = metadata.createTime { fields["created_at"] = .string(Self.iso8601.withLockUnchecked { $0.string(from: value) }) }
+        if let value = metadata.updateTime { fields["updated_at"] = .string(Self.iso8601.withLockUnchecked { $0.string(from: value) }) }
         return .object(fields)
     }
 

--- a/TablePro/Core/MCP/MCPConnectionBridge+Server.swift
+++ b/TablePro/Core/MCP/MCPConnectionBridge+Server.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import TableProPluginKit
 
 extension MCPConnectionBridge {
@@ -327,6 +328,8 @@ extension MCPConnectionBridge {
             return [database, schema, table].compactMap { $0 }.joined(separator: ".")
         case .column(let database, let schema, let table, let column):
             return [database, schema, table, column].compactMap { $0 }.joined(separator: ".")
+        @unknown default:
+            return "*"
         }
     }
 
@@ -339,7 +342,7 @@ extension MCPConnectionBridge {
             "database_type": .string(entry.databaseType.rawValue),
             "source": .string(entry.source.rawValue),
             "statement_type": .string(entry.statementType.rawValue),
-            "executed_at": .string(iso8601.string(from: entry.executedAt)),
+            "executed_at": .string(iso8601.withLockUnchecked { $0.string(from: entry.executedAt) }),
             "execution_time_ms": .double(entry.executionTime * 1_000),
             "row_count": .int(entry.rowCount),
             "was_successful": .bool(entry.wasSuccessful)

--- a/TablePro/Core/MCP/MCPConnectionBridge.swift
+++ b/TablePro/Core/MCP/MCPConnectionBridge.swift
@@ -143,8 +143,8 @@ public actor MCPConnectionBridge {
             "status": .string(statusString),
             "connection_id": .string(connectionId.uuidString),
             "current_database": .string(snapshot.database),
-            "connected_at": .string(Self.iso8601.string(from: snapshot.connectedAt)),
-            "last_active_at": .string(Self.iso8601.string(from: snapshot.lastActiveAt))
+            "connected_at": .string(Self.iso8601.withLockUnchecked { $0.string(from: snapshot.connectedAt) }),
+            "last_active_at": .string(Self.iso8601.withLockUnchecked { $0.string(from: snapshot.lastActiveAt) })
         ]
         if let schema = snapshot.schema {
             result["current_schema"] = .string(schema)
@@ -308,7 +308,7 @@ public actor MCPConnectionBridge {
         }
     }
 
-    static let iso8601 = ISO8601DateFormatter()
+    static let iso8601 = OSAllocatedUnfairLock(uncheckedState: ISO8601DateFormatter())
 
     func resolveDriver(_ connectionId: UUID) async throws -> (DatabaseDriver, DatabaseType) {
         let pending: DatabaseConnection? = await MainActor.run {

--- a/TablePro/Core/MCP/MCPPairingService.swift
+++ b/TablePro/Core/MCP/MCPPairingService.swift
@@ -98,7 +98,7 @@ actor PairingExchangeStore {
 final class MCPPairingService {
     static let shared = MCPPairingService()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "MCPPairingService")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "MCPPairingService")
     private static let pruneInterval: Duration = .seconds(60)
     static let exchangeRateLimitPolicy = MCPRateLimitPolicy(
         maxFailedAttempts: 5,

--- a/TablePro/Core/MCP/Protocol/Tools/ExportDataTool.swift
+++ b/TablePro/Core/MCP/Protocol/Tools/ExportDataTool.swift
@@ -299,6 +299,8 @@ public struct ExportDataTool: MCPToolImplementation {
             return "SELECT * FROM \(quotedTable) LIMIT \(limit)"
         case .none:
             return "SELECT * FROM \(quotedTable)"
+        @unknown default:
+            return "SELECT * FROM \(quotedTable)"
         }
     }
 

--- a/TablePro/Core/MCP/Protocol/Tools/MCPExportWriters.swift
+++ b/TablePro/Core/MCP/Protocol/Tools/MCPExportWriters.swift
@@ -56,6 +56,7 @@ struct MCPSqlExportDialect: Sendable {
         switch booleanStyle {
         case .truefalse: return value ? "TRUE" : "FALSE"
         case .numeric: return value ? "1" : "0"
+        @unknown default: return value ? "TRUE" : "FALSE"
         }
     }
 }

--- a/TablePro/Core/MCP/Subscriptions/MCPSubscriptionEventSource.swift
+++ b/TablePro/Core/MCP/Subscriptions/MCPSubscriptionEventSource.swift
@@ -4,7 +4,7 @@ import os
 
 @MainActor
 public final class MCPSubscriptionEventSource {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "MCP.Subscriptions")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "MCP.Subscriptions")
 
     private weak var registry: MCPSubscriptionRegistry?
     private var cancellables: Set<AnyCancellable> = []

--- a/TablePro/Core/Plugins/ImportTypeMapper.swift
+++ b/TablePro/Core/Plugins/ImportTypeMapper.swift
@@ -29,6 +29,7 @@ enum ImportTypeMapper {
         case .boolean: return "BOOLEAN"
         case .json: return "JSONB"
         case .text: return "TEXT"
+        @unknown default: return "TEXT"
         }
     }
 
@@ -39,6 +40,7 @@ enum ImportTypeMapper {
         case .boolean: return "TINYINT(1)"
         case .json: return "JSON"
         case .text: return "TEXT"
+        @unknown default: return "TEXT"
         }
     }
 
@@ -48,6 +50,7 @@ enum ImportTypeMapper {
         case .real: return "REAL"
         case .boolean: return "INTEGER"
         case .json, .text: return "TEXT"
+        @unknown default: return "TEXT"
         }
     }
 
@@ -57,6 +60,7 @@ enum ImportTypeMapper {
         case .real: return "FLOAT"
         case .boolean: return "BIT"
         case .json, .text: return "NVARCHAR(MAX)"
+        @unknown default: return "NVARCHAR(MAX)"
         }
     }
 
@@ -66,6 +70,7 @@ enum ImportTypeMapper {
         case .real: return "DOUBLE PRECISION"
         case .boolean: return "BOOLEAN"
         case .json, .text: return "TEXT"
+        @unknown default: return "TEXT"
         }
     }
 }

--- a/TablePro/Core/Plugins/InspectorDocumentController.swift
+++ b/TablePro/Core/Plugins/InspectorDocumentController.swift
@@ -9,7 +9,7 @@ import TableProPluginKit
 
 @MainActor
 final class InspectorDocumentController: NSDocumentController {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "CSVInspector")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "CSVInspector")
 
     override init() {
         super.init()

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -73,11 +73,13 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable, DatabaseRepor
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "PluginDriverAdapter")
 
-    private static let iso8601Formatter: ISO8601DateFormatter = {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return formatter
-    }()
+    private static let iso8601Formatter = OSAllocatedUnfairLock(
+        uncheckedState: {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            return formatter
+        }()
+    )
 
     static func cellValue(for parameter: Any?) -> PluginCellValue {
         guard let parameter else { return .null }
@@ -105,7 +107,7 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable, DatabaseRepor
         case let f as any BinaryFloatingPoint:
             return NumberText.text(for: Double(f))
         case let d as Date:
-            return Self.iso8601Formatter.string(from: d)
+            return Self.iso8601Formatter.withLockUnchecked { $0.string(from: d) }
         case let data as Data:
             return data.hexEncoded
         case let uuid as UUID:

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -14,9 +14,9 @@ import TableProPluginKit
 @MainActor @Observable
 final class PluginManager {
     static let shared = PluginManager()
-    static let currentPluginKitVersion = 19
-    static let minimumCompatiblePluginKitVersion = 19
-    static let currentInspectorKitVersion = 1
+    nonisolated static let currentPluginKitVersion = 19
+    nonisolated static let minimumCompatiblePluginKitVersion = 19
+    nonisolated static let currentInspectorKitVersion = 1
     private static let disabledPluginsKey = "com.TablePro.disabledPlugins"
     private static let legacyDisabledPluginsKey = "disabledPlugins"
 
@@ -100,7 +100,7 @@ final class PluginManager {
         set { defaults.set(Array(newValue), forKey: Self.disabledPluginsKey) }
     }
 
-    static let logger = Logger(subsystem: "com.TablePro", category: "PluginManager")
+    nonisolated static let logger = Logger(subsystem: "com.TablePro", category: "PluginManager")
 
     private var pendingPluginURLs: [(url: URL, source: PluginSource)] = []
 

--- a/TablePro/Core/Plugins/Registry/DownloadCountService.swift
+++ b/TablePro/Core/Plugins/Registry/DownloadCountService.swift
@@ -13,7 +13,7 @@ final class DownloadCountService {
     private var counts: [String: Int] = [:]
     private var lastFetchDate: Date?
     private static let cooldown: TimeInterval = 300 // 5 minutes
-    private static let logger = Logger(subsystem: "com.TablePro", category: "DownloadCountService")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "DownloadCountService")
 
     private static let releasesURL = URL(string: "https://api.github.com/repos/TableProApp/TablePro/releases?per_page=100")!
 

--- a/TablePro/Core/Plugins/Registry/RegistryClient.swift
+++ b/TablePro/Core/Plugins/Registry/RegistryClient.swift
@@ -16,7 +16,7 @@ final class RegistryClient {
 
     let session: URLSession
     static let supportedSchemaVersion = 2
-    private static let logger = Logger(subsystem: "com.TablePro", category: "RegistryClient")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "RegistryClient")
     private static let manifestFreshnessWindow: TimeInterval = 300
 
     private static let defaultRegistryURL = URL(string:
@@ -47,7 +47,7 @@ final class RegistryClient {
         return Self.defaultRegistryURL
     }
 
-    private static let manifestCacheFileName = "registry-manifest.json"
+    nonisolated private static let manifestCacheFileName = "registry-manifest.json"
 
     init(
         userDefaults: UserDefaults = .standard,

--- a/TablePro/Core/Process/LoopbackPort.swift
+++ b/TablePro/Core/Process/LoopbackPort.swift
@@ -42,7 +42,7 @@ enum LoopbackPort {
         return await withCheckedContinuation { continuation in
             let connection = NWConnection(host: NWEndpoint.Host(host), port: nwPort, using: .tcp)
             let resumed = OSAllocatedUnfairLock(initialState: false)
-            let complete: (Bool) -> Void = { value in
+            let complete: @Sendable (Bool) -> Void = { value in
                 let shouldResume = resumed.withLock { done -> Bool in
                     guard !done else { return false }
                     done = true

--- a/TablePro/Core/Process/SupervisedProcessRunner.swift
+++ b/TablePro/Core/Process/SupervisedProcessRunner.swift
@@ -10,7 +10,7 @@ struct SubprocessTermination: Sendable, Equatable {
     let wasRequested: Bool
 }
 
-protocol SupervisedProcessRunner: AnyObject {
+protocol SupervisedProcessRunner: AnyObject, Sendable {
     func start(binaryPath: String, arguments: [String], environment: [String: String]) throws
     func stop()
     var processIdentifier: Int32? { get }

--- a/TablePro/Core/SOCKS/SOCKSProxyManager.swift
+++ b/TablePro/Core/SOCKS/SOCKSProxyManager.swift
@@ -279,7 +279,7 @@ actor SOCKSProxyManager: TunnelManaging {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int, Error>) in
                 let resumed = OSAllocatedUnfairLock(initialState: false)
                 let existingHandler = listener.stateUpdateHandler
-                let finish: (Result<Int, Error>) -> Void = { result in
+                let finish: @Sendable (Result<Int, Error>) -> Void = { result in
                     let shouldResume = resumed.withLock { done -> Bool in
                         guard !done else { return false }
                         done = true
@@ -323,7 +323,7 @@ actor SOCKSProxyManager: TunnelManaging {
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 let resumed = OSAllocatedUnfairLock(initialState: false)
-                let finish: (Result<Void, Error>) -> Void = { result in
+                let finish: @Sendable (Result<Void, Error>) -> Void = { result in
                     let shouldResume = resumed.withLock { done -> Bool in
                         guard !done else { return false }
                         done = true

--- a/TablePro/Core/SSH/Auth/PromptKeyboardInteractiveProvider.swift
+++ b/TablePro/Core/SSH/Auth/PromptKeyboardInteractiveProvider.swift
@@ -63,7 +63,7 @@ internal final class PromptKeyboardInteractiveProvider: KeyboardInteractivePromp
         alert.window.initialFirstResponder = fields.first
 
         guard alert.runModal() == .alertFirstButtonReturn else { return nil }
-        return fields.map(\.stringValue)
+        return fields.map { $0.stringValue }
     }
 
     private func informativeText(for challenge: KeyboardInteractiveChallenge, attempt: Int) -> String {

--- a/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
+++ b/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
@@ -786,6 +786,13 @@ internal enum LibSSH2TunnelFactory {
         return channel
     }
 
+    /// The libssh2 handles the relay task takes ownership of. The relay is the only thing that
+    /// touches them once it starts, which is what the compiler cannot see through an OpaquePointer.
+    private struct RelayHandles: @unchecked Sendable {
+        let channel: OpaquePointer
+        let session: OpaquePointer
+    }
+
     /// Start a relay task that copies data between a channel and a socketpair fd.
     /// libssh2 calls use `sessionQueue.sync` for thread safety; I/O loop runs on a concurrent queue.
     private static func startChannelRelay(
@@ -799,6 +806,7 @@ internal enum LibSSH2TunnelFactory {
             label: "com.TablePro.ssh.hop-relay",
             qos: .utility
         )
+        let handles = RelayHandles(channel: channel, session: session)
         return Task.detached {
             await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
                 relayQueue.async {
@@ -806,8 +814,8 @@ internal enum LibSSH2TunnelFactory {
                         localFD: socketFD,
                         transportFD: sshSocketFD,
                         channelIO: LibSSH2ChannelIO(
-                            channel: channel,
-                            session: session,
+                            channel: handles.channel,
+                            session: handles.session,
                             sessionQueue: sessionQueue
                         ),
                         bufferSize: 32_768,

--- a/TablePro/Core/Services/AppServices.swift
+++ b/TablePro/Core/Services/AppServices.swift
@@ -67,7 +67,7 @@ struct AppServices {
     )
 }
 
-private struct AppServicesEnvironmentKey: EnvironmentKey {
+private struct AppServicesEnvironmentKey: @preconcurrency EnvironmentKey {
     @MainActor static var defaultValue: AppServices { .live }
 }
 

--- a/TablePro/Core/Services/ColumnTypeClassifier.swift
+++ b/TablePro/Core/Services/ColumnTypeClassifier.swift
@@ -106,8 +106,8 @@ struct ColumnTypeClassifier {
 
     // MARK: - Type Lookup Table
 
-    private static let typeLookup: [String: (String) -> ColumnType] = {
-        var map: [String: (String) -> ColumnType] = [:]
+    private static let typeLookup: [String: @Sendable (String) -> ColumnType] = {
+        var map: [String: @Sendable (String) -> ColumnType] = [:]
 
         for key in ["BOOL", "BOOLEAN", "BIT"] {
             map[key] = { .boolean(rawType: $0) }

--- a/TablePro/Core/Services/Export/ConnectionExportService.swift
+++ b/TablePro/Core/Services/Export/ConnectionExportService.swift
@@ -29,7 +29,7 @@ struct PreparedConnectionImport {
 
 @MainActor
 enum ConnectionExportService {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "ConnectionExportService")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ConnectionExportService")
     private static let currentFormatVersion = 1
 
     // MARK: - Export

--- a/TablePro/Core/Services/Export/ExportService.swift
+++ b/TablePro/Core/Services/Export/ExportService.swift
@@ -57,7 +57,7 @@ struct ExportState {
 
 @MainActor @Observable
 final class ExportService {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "ExportService")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ExportService")
 
     var state = ExportState()
 

--- a/TablePro/Core/Services/Export/ForeignApp/DBeaverImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/DBeaverImporter.swift
@@ -36,7 +36,7 @@ struct DBeaverImporter: ForeignAppImporter {
     var dbeaverDataRoot: URL = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent("Library/DBeaverData")
 
-    var resolveAppURL: (_ bundleIdentifier: String) -> URL? = {
+    var resolveAppURL: @Sendable (_ bundleIdentifier: String) -> URL? = {
         NSWorkspace.shared.urlForApplication(withBundleIdentifier: $0)
     }
 

--- a/TablePro/Core/Services/Export/ForeignApp/ForeignAppImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/ForeignAppImporter.swift
@@ -12,7 +12,7 @@ import UniformTypeIdentifiers
 
 // MARK: - Protocol
 
-protocol ForeignAppImporter {
+protocol ForeignAppImporter: Sendable {
     var id: String { get }
     var displayName: String { get }
     var symbolName: String { get }
@@ -124,7 +124,7 @@ enum KeychainReadResult {
     case cancelled
 }
 
-typealias ForeignKeychainRead = (_ service: String, _ account: String) -> KeychainReadResult
+typealias ForeignKeychainRead = @Sendable (_ service: String, _ account: String) -> KeychainReadResult
 
 enum ForeignKeychainReader {
     private static let logger = Logger(subsystem: "com.TablePro", category: "ForeignKeychainReader")

--- a/TablePro/Core/Services/Export/ForeignApp/TablePlusImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/TablePlusImporter.swift
@@ -26,8 +26,8 @@ struct TablePlusImporter: ForeignAppImporter {
     ]
 
     var readKeychain: ForeignKeychainRead = ForeignKeychainReader.readPassword
-    var keyFileExists: (_ path: String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
-    var resolveAppURL: (_ bundleIdentifier: String) -> URL? = {
+    var keyFileExists: @Sendable (_ path: String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
+    var resolveAppURL: @Sendable (_ bundleIdentifier: String) -> URL? = {
         NSWorkspace.shared.urlForApplication(withBundleIdentifier: $0)
     }
 

--- a/TablePro/Core/Services/Export/ImportService.swift
+++ b/TablePro/Core/Services/Export/ImportService.swift
@@ -27,7 +27,7 @@ struct ImportState {
 
 @MainActor @Observable
 final class ImportService {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "ImportService")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ImportService")
 
     var state = ImportState()
 

--- a/TablePro/Core/Services/Export/LinkedFolderWatcher.swift
+++ b/TablePro/Core/Services/Export/LinkedFolderWatcher.swift
@@ -12,7 +12,7 @@ import Foundation
 import os
 import TableProImport
 
-struct LinkedConnection: Identifiable {
+struct LinkedConnection: Identifiable, Sendable {
     let id: UUID
     let connection: ExportableConnection
     let folderId: UUID
@@ -23,7 +23,7 @@ struct LinkedConnection: Identifiable {
 @Observable
 final class LinkedFolderWatcher {
     static let shared = LinkedFolderWatcher()
-    private static let logger = Logger(subsystem: "com.TablePro", category: "LinkedFolderWatcher")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "LinkedFolderWatcher")
 
     private(set) var linkedConnections: [LinkedConnection] = []
     private var watchSources: [UUID: DispatchSourceFileSystemObject] = [:]

--- a/TablePro/Core/Services/Formatting/ValueDisplayFormatService.swift
+++ b/TablePro/Core/Services/Formatting/ValueDisplayFormatService.swift
@@ -13,7 +13,7 @@ import os
 final class ValueDisplayFormatService {
     static let shared = ValueDisplayFormatService()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "ValueDisplayFormat")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ValueDisplayFormat")
 
     private let storage: ValueDisplayFormatStorage
     private var autoDetectedFormats: [String: ValueDisplayFormat] = [:]

--- a/TablePro/Core/Services/Infrastructure/AppLaunchCoordinator.swift
+++ b/TablePro/Core/Services/Infrastructure/AppLaunchCoordinator.swift
@@ -13,7 +13,7 @@ import os
 internal final class AppLaunchCoordinator {
     internal static let shared = AppLaunchCoordinator()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "AppLaunchCoordinator")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "AppLaunchCoordinator")
     internal static let collectionWindow: Duration = .milliseconds(150)
 
     private(set) var phase: LaunchPhase = .launching

--- a/TablePro/Core/Services/Infrastructure/CommandLineToolInstaller.swift
+++ b/TablePro/Core/Services/Infrastructure/CommandLineToolInstaller.swift
@@ -43,7 +43,7 @@ internal protocol CommandLineToolInstalling {
 internal final class CommandLineToolInstaller: CommandLineToolInstalling {
     internal static let shared = CommandLineToolInstaller()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "CommandLineToolInstaller")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "CommandLineToolInstaller")
     private static let toolName = "tablepro"
     private static let marker = "# TablePro command line tool"
     private static let scriptContents = """

--- a/TablePro/Core/Services/Infrastructure/ConnectionWorkspaceRegistry.swift
+++ b/TablePro/Core/Services/Infrastructure/ConnectionWorkspaceRegistry.swift
@@ -10,7 +10,7 @@ import os
 /// answer this with its own identity, which could only ever name one connection.
 @MainActor
 internal final class ConnectionWorkspaceRegistry {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "ConnectionWorkspace")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ConnectionWorkspace")
 
     private var workspacesById: [UUID: ConnectionWorkspace] = [:]
     private(set) var order: [UUID] = []

--- a/TablePro/Core/Services/Infrastructure/DatabaseFileWatcher.swift
+++ b/TablePro/Core/Services/Infrastructure/DatabaseFileWatcher.swift
@@ -12,7 +12,7 @@ import os
 
 @MainActor
 final class DatabaseFileWatcher {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "DatabaseFileWatcher")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "DatabaseFileWatcher")
 
     private var activeSources: [UUID: DispatchSourceFileSystemObject] = [:]
     private var debounceTasks: [UUID: Task<Void, Never>] = [:]

--- a/TablePro/Core/Services/Infrastructure/EditorTabOpener.swift
+++ b/TablePro/Core/Services/Infrastructure/EditorTabOpener.swift
@@ -11,7 +11,7 @@ import os
 /// connection is being created for it or has been open for hours.
 @MainActor
 internal enum EditorTabOpener {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "EditorTabOpener")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "EditorTabOpener")
 
     internal static func apply(
         _ payload: EditorTabPayload,

--- a/TablePro/Core/Services/Infrastructure/LaunchIntentRouter.swift
+++ b/TablePro/Core/Services/Infrastructure/LaunchIntentRouter.swift
@@ -11,7 +11,7 @@ import os
 internal final class LaunchIntentRouter {
     internal static let shared = LaunchIntentRouter()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "LaunchIntentRouter")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "LaunchIntentRouter")
 
     private init() {}
 

--- a/TablePro/Core/Services/Infrastructure/MacAnalyticsProvider.swift
+++ b/TablePro/Core/Services/Infrastructure/MacAnalyticsProvider.swift
@@ -11,7 +11,7 @@ import TableProAnalytics
 final class MacAnalyticsProvider: AnalyticsEnvironmentProvider {
     static let shared = MacAnalyticsProvider()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "MacAnalyticsProvider")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "MacAnalyticsProvider")
 
     private let defaults: UserDefaults
 

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -15,7 +15,7 @@ import SwiftUI
 
 @MainActor
 internal final class MainSplitViewController: NSSplitViewController, InspectorVisibilityProxy {
-    private static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
+    nonisolated private static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
 
     // MARK: - Payload & Session
 

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -12,7 +12,7 @@ import TableProPluginKit
 
 @MainActor
 internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
-    internal static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
+    nonisolated internal static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
 
     internal static let toolbarIdentifier = NSToolbar.Identifier("com.TablePro.main.toolbar.v2")
 

--- a/TablePro/Core/Services/Infrastructure/PrivilegedShell.swift
+++ b/TablePro/Core/Services/Infrastructure/PrivilegedShell.swift
@@ -27,7 +27,7 @@ internal protocol PrivilegedShellRunning {
 
 @MainActor
 internal struct OSAScriptPrivilegedShell: PrivilegedShellRunning {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "PrivilegedShell")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "PrivilegedShell")
 
     internal static func quote(_ value: String) -> String {
         "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"

--- a/TablePro/Core/Services/Infrastructure/SampleDatabaseService.swift
+++ b/TablePro/Core/Services/Infrastructure/SampleDatabaseService.swift
@@ -34,7 +34,7 @@ internal final class SampleDatabaseService {
         connectionInspector: DatabaseManagerSampleConnectionInspector()
     )
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "SampleDatabaseService")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "SampleDatabaseService")
 
     private let bundledFileResolver: () -> URL?
     private let fileManager: FileManager

--- a/TablePro/Core/Services/Infrastructure/TabPersistenceCoordinator.swift
+++ b/TablePro/Core/Services/Infrastructure/TabPersistenceCoordinator.swift
@@ -22,7 +22,7 @@ internal struct RestoreResult {
 
 @MainActor @Observable
 internal final class TabPersistenceCoordinator {
-    internal static let logger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
+    nonisolated internal static let logger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
     let connectionId: UUID
 
     @ObservationIgnored private var saveTask: Task<Void, Never>?

--- a/TablePro/Core/Services/Infrastructure/TabRouter.swift
+++ b/TablePro/Core/Services/Infrastructure/TabRouter.swift
@@ -35,7 +35,7 @@ internal enum TabRouterError: Error, LocalizedError {
 internal final class TabRouter {
     internal static let shared = TabRouter()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "TabRouter")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "TabRouter")
 
     private let externalConnectionGate: ExternalConnectionGate
 

--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -52,7 +52,7 @@ extension EditorWindow: CloseCommandNaming {
 
 @MainActor
 internal final class TabWindowController: NSWindowController, NSWindowDelegate {
-    private static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
+    nonisolated private static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
 
     internal static let frameAutosaveName: NSWindow.FrameAutosaveName = "MainEditorWindow"
 

--- a/TablePro/Core/Services/Infrastructure/WindowLifecycleMonitor.swift
+++ b/TablePro/Core/Services/Infrastructure/WindowLifecycleMonitor.swift
@@ -14,11 +14,11 @@ import OSLog
 
 @MainActor
 internal final class WindowLifecycleMonitor {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "WindowLifecycleMonitor")
-    private static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "WindowLifecycleMonitor")
+    nonisolated private static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
     internal static let shared = WindowLifecycleMonitor()
 
-    private struct Entry {
+    private struct Entry: @unchecked Sendable {
         let connectionId: UUID
         weak var window: NSWindow?
         var observers: [NSObjectProtocol]

--- a/TablePro/Core/Services/Infrastructure/WindowManager.swift
+++ b/TablePro/Core/Services/Infrastructure/WindowManager.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 @MainActor
 internal final class WindowManager {
-    private static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
+    nonisolated private static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
 
     internal static let shared = WindowManager()
 

--- a/TablePro/Core/Services/Infrastructure/WindowOpener.swift
+++ b/TablePro/Core/Services/Infrastructure/WindowOpener.swift
@@ -12,7 +12,7 @@ import os
 internal final class WindowOpener {
     internal static let shared = WindowOpener()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "WindowOpener")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "WindowOpener")
 
     @ObservationIgnored private var openWelcomeAction: (() -> Void)?
     @ObservationIgnored private var openConnectionFormAction: ((ConnectionFormRequest) -> Void)?

--- a/TablePro/Core/Services/Infrastructure/WorkspaceRailViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspaceRailViewController.swift
@@ -6,6 +6,7 @@
 import AppKit
 import Combine
 import Observation
+import os
 import OSLog
 
 /// The window a rail belongs to. A window hosts several connections and shows one at a time, so
@@ -42,7 +43,7 @@ internal final class WorkspaceRailTableView: NSTableView {
 
 @MainActor
 internal final class WorkspaceRailViewController: NSViewController {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "WorkspaceRail")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "WorkspaceRail")
     private static let reorderType = NSPasteboard.PasteboardType("com.TablePro.workspaceRailEntry")
 
     internal var onLayoutChange: ((WorkspaceRailMetrics.Layout) -> Void)?
@@ -62,7 +63,7 @@ internal final class WorkspaceRailViewController: NSViewController {
     private var entries: [WorkspaceRailEntry] = []
     private var layout: WorkspaceRailMetrics.Layout = WorkspaceRailMetrics.medium
     private var changeCancellable: AnyCancellable?
-    private var activationObserver: (any NSObjectProtocol)?
+    private let activationObserver = OSAllocatedUnfairLock<(any NSObjectProtocol)?>(uncheckedState: nil)
     private var contentTopConstraint: NSLayoutConstraint?
 
     /// What the rail last put on screen as selected, which after every `applySelection` is the
@@ -145,11 +146,12 @@ internal final class WorkspaceRailViewController: NSViewController {
         /// Changing the Appearance setting means leaving TablePro and coming back, and AppKit
         /// publishes that. `effectiveRowSizeStyle` is then re-read, which is the documented way to
         /// ask what the system resolved. The undocumented defaults key this used to observe is gone.
-        activationObserver = NotificationCenter.default.addObserver(
+        let observer = NotificationCenter.default.addObserver(
             forName: NSApplication.didBecomeActiveNotification, object: nil, queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated { self?.refreshLayoutIfNeeded() }
         }
+        activationObserver.withLockUnchecked { $0 = observer }
         observeRowSizePreference()
         reload()
     }
@@ -161,8 +163,8 @@ internal final class WorkspaceRailViewController: NSViewController {
     }
 
     deinit {
-        if let activationObserver {
-            NotificationCenter.default.removeObserver(activationObserver)
+        if let observer = activationObserver.withLockUnchecked({ $0 }) {
+            NotificationCenter.default.removeObserver(observer)
         }
     }
 

--- a/TablePro/Core/Services/Licensing/LicenseAPIClient.swift
+++ b/TablePro/Core/Services/Licensing/LicenseAPIClient.swift
@@ -9,7 +9,7 @@ import Foundation
 import os
 
 /// HTTP client for the TablePro license API
-final class LicenseAPIClient {
+final class LicenseAPIClient: Sendable {
     static let shared = LicenseAPIClient()
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "LicenseAPIClient")

--- a/TablePro/Core/Services/Licensing/LicenseManager.swift
+++ b/TablePro/Core/Services/Licensing/LicenseManager.swift
@@ -36,7 +36,7 @@ internal enum CachedLicenseResolution: Equatable {
 final class LicenseManager {
     static let shared = LicenseManager()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "LicenseManager")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "LicenseManager")
 
     /// Current cached license (nil = unlicensed)
     private(set) var license: License?

--- a/TablePro/Core/Services/Licensing/LicenseSignatureVerifier.swift
+++ b/TablePro/Core/Services/Licensing/LicenseSignatureVerifier.swift
@@ -10,7 +10,7 @@ import os
 import Security
 
 /// Verifies RSA-SHA256 signatures on license payloads using the embedded public key
-final class LicenseSignatureVerifier {
+final class LicenseSignatureVerifier: @unchecked Sendable {
     static let shared = LicenseSignatureVerifier()
 
     private let publicKey: SecKey?

--- a/TablePro/Core/Services/Notifications/NotificationAuthorization.swift
+++ b/TablePro/Core/Services/Notifications/NotificationAuthorization.swift
@@ -20,7 +20,7 @@ internal final class NotificationAuthorization {
 
     internal static let options: UNAuthorizationOptions = [.alert, .sound]
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "Notifications")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "Notifications")
 
     private let presenter: any UserNotificationPresenting
     private var didRequest = false

--- a/TablePro/Core/Services/Notifications/PluginNotificationService.swift
+++ b/TablePro/Core/Services/Notifications/PluginNotificationService.swift
@@ -16,7 +16,7 @@ final class PluginNotificationService {
     static let openPluginSettingsActionId = "openPluginSettings"
     private static let updateFailedCategoryId = "com.TablePro.pluginUpdateFailed"
     private static let failedIdentifierPrefix = identifierPrefix + "failed."
-    private static let logger = Logger(subsystem: "com.TablePro", category: "PluginNotifications")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "PluginNotifications")
 
     private(set) var authorizationStatus: UNAuthorizationStatus = .notDetermined
 

--- a/TablePro/Core/Services/Notifications/UserNotificationPresenting.swift
+++ b/TablePro/Core/Services/Notifications/UserNotificationPresenting.swift
@@ -23,7 +23,7 @@ internal protocol UserNotificationPresenting: AnyObject {
 internal final class SystemNotificationPresenter: UserNotificationPresenting {
     internal static let shared = SystemNotificationPresenter()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "Notifications")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "Notifications")
 
     private init() {}
 

--- a/TablePro/Core/Services/Operations/OperationCompletionReporter.swift
+++ b/TablePro/Core/Services/Operations/OperationCompletionReporter.swift
@@ -17,7 +17,7 @@ import UserNotifications
 internal final class OperationCompletionReporter {
     internal static let shared = OperationCompletionReporter()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "OperationNotifications")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "OperationNotifications")
 
     private let presenter: any UserNotificationPresenting
     private let authorization: NotificationAuthorization

--- a/TablePro/Core/Services/Query/DatabaseTreeMetadataService.swift
+++ b/TablePro/Core/Services/Query/DatabaseTreeMetadataService.swift
@@ -42,7 +42,7 @@ final class DatabaseTreeMetadataService {
     @ObservationIgnored private let routinesDedup = OnceTask<ObjectsKey, [RoutineInfo]>()
     @ObservationIgnored private let partitionsDedup = OnceTask<PartitionsKey, [TableInfo]>()
 
-    @ObservationIgnored private static let logger = Logger(
+    @ObservationIgnored nonisolated private static let logger = Logger(
         subsystem: "com.TablePro", category: "SidebarTree"
     )
 
@@ -360,12 +360,12 @@ final class DatabaseTreeMetadataService {
         }
         await withTaskGroup(of: Void.self) { group in
             for key in keys {
-                group.addTask { @MainActor in
+                group.addTask {
                     await self.reloadTablesInPlace(key)
                 }
             }
             for key in loadedPartitionKeys {
-                group.addTask { @MainActor in
+                group.addTask {
                     await self.reloadPartitionsInPlace(key)
                 }
             }

--- a/TablePro/Core/Services/Query/ExternalSchemaTracker.swift
+++ b/TablePro/Core/Services/Query/ExternalSchemaTracker.swift
@@ -16,7 +16,7 @@ final class ExternalSchemaTracker {
         let database: String
     }
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "ExternalSchemaTracker")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ExternalSchemaTracker")
 
     private var namesByDatabase: [Key: Set<String>] = [:]
 

--- a/TablePro/Core/Services/Query/RowOperationsManager.swift
+++ b/TablePro/Core/Services/Query/RowOperationsManager.swift
@@ -5,7 +5,7 @@ import TableProPluginKit
 
 @MainActor
 final class RowOperationsManager {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "RowOperationsManager")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "RowOperationsManager")
 
     private static let maxClipboardRows = 50_000
 

--- a/TablePro/Core/Services/Query/SchemaForeignKeyStore.swift
+++ b/TablePro/Core/Services/Query/SchemaForeignKeyStore.swift
@@ -11,7 +11,7 @@ import os
 final class SchemaForeignKeyStore {
     static let shared = SchemaForeignKeyStore()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "SchemaForeignKeyStore")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "SchemaForeignKeyStore")
 
     private var entries: [String: [String: [ForeignKeyInfo]]] = [:]
     private var loads: [String: Task<Void, Never>] = [:]

--- a/TablePro/Core/Services/Query/SchemaProviderRegistry.swift
+++ b/TablePro/Core/Services/Query/SchemaProviderRegistry.swift
@@ -12,7 +12,7 @@ import os
 
 @MainActor
 final class SchemaProviderRegistry {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "SchemaProviderRegistry")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "SchemaProviderRegistry")
 
     static let shared = SchemaProviderRegistry()
 

--- a/TablePro/Core/Services/Query/SchemaRefreshService.swift
+++ b/TablePro/Core/Services/Query/SchemaRefreshService.swift
@@ -20,7 +20,7 @@ final class SchemaRefreshService {
         let database: String?
     }
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "SchemaRefreshService")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "SchemaRefreshService")
 
     private let schemaService: SchemaService
     private let treeMetadataService: DatabaseTreeMetadataService
@@ -85,8 +85,9 @@ final class SchemaRefreshService {
     func loadBrowseCatalogs(connectionIds: [UUID]) async -> Set<UUID> {
         await withTaskGroup(of: (UUID, Bool).self) { group in
             for connectionId in connectionIds {
-                group.addTask { @MainActor in
-                    (connectionId, await self.loadBrowseCatalog(connectionId: connectionId))
+                group.addTask {
+                    let didLoad = await self.loadBrowseCatalog(connectionId: connectionId)
+                    return (connectionId, didLoad)
                 }
             }
             var loaded: Set<UUID> = []

--- a/TablePro/Core/Services/Query/SchemaService.swift
+++ b/TablePro/Core/Services/Query/SchemaService.swift
@@ -55,7 +55,7 @@ final class SchemaService {
     @ObservationIgnored private var loadGenerations: [UUID: Int] = [:]
     @ObservationIgnored private var refreshWaiters: [UUID: [RefreshWaiter]] = [:]
     @ObservationIgnored private var nextLoadGeneration = 0
-    @ObservationIgnored private static let logger = Logger(subsystem: "com.TablePro", category: "SchemaService")
+    @ObservationIgnored nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "SchemaService")
 
     func state(for connectionId: UUID) -> SchemaState {
         states[connectionId] ?? .idle

--- a/TablePro/Core/Services/SQL/SQLFolderWatcher.swift
+++ b/TablePro/Core/Services/SQL/SQLFolderWatcher.swift
@@ -12,7 +12,7 @@ import os
 @Observable
 internal final class SQLFolderWatcher {
     static let shared = SQLFolderWatcher()
-    private static let logger = Logger(subsystem: "com.TablePro", category: "SQLFolderWatcher")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "SQLFolderWatcher")
 
     private(set) var lastScanCompletedAt: Date?
 

--- a/TablePro/Core/Services/TeamLibrary/LiveTeamLibraryAPIClient.swift
+++ b/TablePro/Core/Services/TeamLibrary/LiveTeamLibraryAPIClient.swift
@@ -10,7 +10,7 @@
 import Foundation
 import os
 
-final class LiveTeamLibraryAPIClient: TeamLibraryAPIClient {
+final class LiveTeamLibraryAPIClient: TeamLibraryAPIClient, Sendable {
     static let shared = LiveTeamLibraryAPIClient()
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "TeamLibraryAPIClient")

--- a/TablePro/Core/Services/TeamLibrary/TeamLibrarySyncCoordinator.swift
+++ b/TablePro/Core/Services/TeamLibrary/TeamLibrarySyncCoordinator.swift
@@ -17,7 +17,7 @@ import TableProImport
 final class TeamLibrarySyncCoordinator {
     static let shared = TeamLibrarySyncCoordinator()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "TeamLibrarySyncCoordinator")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "TeamLibrarySyncCoordinator")
 
     private let apiClient: TeamLibraryAPIClient
     private let store: TeamLibraryStore

--- a/TablePro/Core/Storage/AIKeyStorage.swift
+++ b/TablePro/Core/Storage/AIKeyStorage.swift
@@ -9,7 +9,7 @@
 import Foundation
 import os
 
-final class AIKeyStorage {
+final class AIKeyStorage: Sendable {
     static let shared = AIKeyStorage()
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "AIKeyStorage")

--- a/TablePro/Core/Storage/AppSettingsManager.swift
+++ b/TablePro/Core/Storage/AppSettingsManager.swift
@@ -275,7 +275,7 @@ final class AppSettingsManager {
         return migrated
     }
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "AppSettingsManager")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "AppSettingsManager")
 
     private func applyHistorySettingsImmediately() async {
         await queryHistoryManager.applySettingsChange()

--- a/TablePro/Core/Storage/AppSettingsStorage.swift
+++ b/TablePro/Core/Storage/AppSettingsStorage.swift
@@ -10,7 +10,7 @@ import Foundation
 import os
 
 /// Persistent storage for app settings
-final class AppSettingsStorage {
+final class AppSettingsStorage: Sendable {
     static let shared = AppSettingsStorage()
     private static let logger = Logger(subsystem: "com.TablePro", category: "AppSettingsStorage")
 

--- a/TablePro/Core/Storage/ColumnLayoutPersister.swift
+++ b/TablePro/Core/Storage/ColumnLayoutPersister.swift
@@ -15,7 +15,7 @@ final class FileColumnLayoutPersister: ColumnLayoutPersisting {
         return persister
     }()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "ColumnLayoutPersister")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ColumnLayoutPersister")
     private static let legacyUserDefaultsPrefix = "com.TablePro.columns.layout."
     private static let legacyVisibilityPrefix = "com.TablePro.columns.hiddenColumns."
     private static let scopeMigrationKey = "com.TablePro.columnLayoutSchemaScopeMigrationComplete"

--- a/TablePro/Core/Storage/ConnectionStorage.swift
+++ b/TablePro/Core/Storage/ConnectionStorage.swift
@@ -14,7 +14,7 @@ import TableProSyncTransport
 @MainActor
 final class ConnectionStorage {
     static let shared = ConnectionStorage()
-    private static let logger = Logger(subsystem: "com.TablePro", category: "ConnectionStorage")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ConnectionStorage")
 
     private let connectionsKey = "com.TablePro.connections"
     private let migratedToFileKey = "com.TablePro.connectionsMigratedToFile"

--- a/TablePro/Core/Storage/CustomSlashCommandStorage.swift
+++ b/TablePro/Core/Storage/CustomSlashCommandStorage.swift
@@ -29,7 +29,7 @@ final class CustomSlashCommandStorage {
 
     static let syncCategory = "customSlashCommands"
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "CustomSlashCommandStorage")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "CustomSlashCommandStorage")
     private static let defaultsKey = "ai.customSlashCommands.v1"
     private let defaults: UserDefaults
     private let syncTracker: SyncChangeTracker

--- a/TablePro/Core/Storage/ExternalConnectionTrustStore.swift
+++ b/TablePro/Core/Storage/ExternalConnectionTrustStore.swift
@@ -23,7 +23,7 @@ internal protocol ExternalConnectionTrustChecking {
 internal final class ExternalConnectionTrustStore: ExternalConnectionTrustChecking {
     internal static let shared = ExternalConnectionTrustStore()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "ExternalConnectionTrustStore")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ExternalConnectionTrustStore")
     private static let storageKey = "com.TablePro.externalConnectionTrust.entries"
 
     private let defaults: UserDefaults

--- a/TablePro/Core/Storage/FavoriteTablesStorage.swift
+++ b/TablePro/Core/Storage/FavoriteTablesStorage.swift
@@ -6,7 +6,7 @@ extension Notification.Name {
     static let favoriteTablesDidChange = Notification.Name("FavoriteTablesDidChange")
 }
 
-final class FavoriteTablesStorage {
+final class FavoriteTablesStorage: @unchecked Sendable {
     static let shared = FavoriteTablesStorage()
     private static let logger = Logger(subsystem: "com.TablePro", category: "FavoriteTablesStorage")
 

--- a/TablePro/Core/Storage/FilterSettingsStorage.swift
+++ b/TablePro/Core/Storage/FilterSettingsStorage.swift
@@ -77,7 +77,7 @@ struct FilterSettings: Codable, Equatable {
 @MainActor
 final class FilterSettingsStorage {
     static let shared = FilterSettingsStorage()
-    private static let logger = Logger(subsystem: "com.TablePro", category: "FilterSettingsStorage")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "FilterSettingsStorage")
 
     private static let legacyLastFiltersKeyPrefix = "com.TablePro.filter.lastFilters."
     private static let legacyKnownFilterKeysKey = "com.TablePro.filter.knownFilterKeys"

--- a/TablePro/Core/Storage/GroupStorage.swift
+++ b/TablePro/Core/Storage/GroupStorage.swift
@@ -11,7 +11,7 @@ import TableProSyncTransport
 @MainActor
 final class GroupStorage {
     static let shared = GroupStorage()
-    private static let logger = Logger(subsystem: "com.TablePro", category: "GroupStorage")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "GroupStorage")
 
     private let groupsKey = "com.TablePro.groups"
     private let defaults: UserDefaults

--- a/TablePro/Core/Storage/LastOpenConnectionsStorage.swift
+++ b/TablePro/Core/Storage/LastOpenConnectionsStorage.swift
@@ -14,7 +14,7 @@ import os
 final class LastOpenConnectionsStorage {
     static let shared = LastOpenConnectionsStorage()
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "LastOpenConnections")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "LastOpenConnections")
 
     private let fileURL: URL
 

--- a/TablePro/Core/Storage/LicenseStorage.swift
+++ b/TablePro/Core/Storage/LicenseStorage.swift
@@ -10,7 +10,7 @@ import IOKit
 import os
 
 /// Persists license data using Keychain (secrets) and UserDefaults (metadata)
-final class LicenseStorage {
+final class LicenseStorage: Sendable {
     static let shared = LicenseStorage()
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "LicenseStorage")
@@ -81,9 +81,16 @@ final class LicenseStorage {
 
     /// Hardware UUID from IOKit, SHA256-hashed for privacy.
     /// Stable across OS reinstalls (tied to hardware).
-    private lazy var _machineId: String = Self.computeMachineId(defaults: defaults)
+    private let cachedMachineId = OSAllocatedUnfairLock<String?>(initialState: nil)
 
-    var machineId: String { _machineId }
+    var machineId: String {
+        cachedMachineId.withLock { cached in
+            if let cached { return cached }
+            let computed = Self.computeMachineId(defaults: defaults)
+            cached = computed
+            return computed
+        }
+    }
 
     private static func computeMachineId(defaults: UserDefaults) -> String {
         let platformExpert = IOServiceGetMatchingService(

--- a/TablePro/Core/Storage/LinkedFolderStorage.swift
+++ b/TablePro/Core/Storage/LinkedFolderStorage.swift
@@ -21,7 +21,7 @@ struct LinkedFolder: Codable, Identifiable, Hashable {
     }
 }
 
-final class LinkedFolderStorage {
+final class LinkedFolderStorage: Sendable {
     static let shared = LinkedFolderStorage()
 
     private let store: CodableListPreferenceStore<LinkedFolder>

--- a/TablePro/Core/Storage/LinkedSQLIndex.swift
+++ b/TablePro/Core/Storage/LinkedSQLIndex.swift
@@ -11,9 +11,23 @@ internal actor LinkedSQLIndex {
     static let shared = LinkedSQLIndex()
     private static let logger = Logger(subsystem: "com.TablePro", category: "LinkedSQLIndex")
 
-    private var db: OpaquePointer?
+    private struct DatabaseHandle: @unchecked Sendable {
+        var pointer: OpaquePointer?
+    }
+
+    private var dbHandle = DatabaseHandle()
+
     private let databaseURL: URL
     private let removeDatabaseOnDeinit: Bool
+    private var isPrepared = false
+
+    private var db: OpaquePointer? {
+        if !isPrepared {
+            isPrepared = true
+            setupDatabase()
+        }
+        return dbHandle.pointer
+    }
 
     init(
         databaseURL: URL = LinkedSQLIndex.defaultDatabaseURL(),
@@ -21,7 +35,6 @@ internal actor LinkedSQLIndex {
     ) {
         self.databaseURL = databaseURL
         self.removeDatabaseOnDeinit = removeDatabaseOnDeinit
-        setupDatabase()
     }
 
     static func defaultDatabaseURL() -> URL {
@@ -32,8 +45,8 @@ internal actor LinkedSQLIndex {
     }
 
     deinit {
-        if let db = db {
-            sqlite3_close_v2(db)
+        if let pointer = dbHandle.pointer {
+            sqlite3_close_v2(pointer)
         }
         if removeDatabaseOnDeinit {
             let path = databaseURL.path(percentEncoded: false)
@@ -49,7 +62,7 @@ internal actor LinkedSQLIndex {
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
 
         let dbPath = databaseURL.path(percentEncoded: false)
-        if sqlite3_open(dbPath, &db) != SQLITE_OK {
+        if sqlite3_open(dbPath, &dbHandle.pointer) != SQLITE_OK {
             Self.logger.error("Error opening linked SQL index database")
             return
         }

--- a/TablePro/Core/Storage/Preferences/KeyValueStore.swift
+++ b/TablePro/Core/Storage/Preferences/KeyValueStore.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-protocol KeyValueStore: AnyObject {
+protocol KeyValueStore: AnyObject, Sendable {
     func dataValue(forKey key: String) -> Data?
     func setDataValue(_ data: Data?, forKey key: String)
 }

--- a/TablePro/Core/Storage/QueryHistoryManager.swift
+++ b/TablePro/Core/Storage/QueryHistoryManager.swift
@@ -1,7 +1,7 @@
 import Combine
 import Foundation
 
-final class QueryHistoryManager: QueryHistoryRecording, QueryHistoryReading {
+final class QueryHistoryManager: QueryHistoryRecording, QueryHistoryReading, Sendable {
     static let shared = QueryHistoryManager()
 
     private let storage: QueryHistoryStorage

--- a/TablePro/Core/Storage/QueryHistoryStorage.swift
+++ b/TablePro/Core/Storage/QueryHistoryStorage.swift
@@ -6,7 +6,21 @@ actor QueryHistoryStorage {
     private static let logger = Logger(subsystem: "com.TablePro", category: "QueryHistoryStorage")
     private static let cleanupInsertInterval = 100
 
-    private var db: OpaquePointer?
+    private struct DatabaseHandle: @unchecked Sendable {
+        var pointer: OpaquePointer?
+    }
+
+    private var dbHandle = DatabaseHandle()
+    private var isPrepared = false
+
+    private var db: OpaquePointer? {
+        if !isPrepared {
+            isPrepared = true
+            setupDatabase()
+        }
+        return dbHandle.pointer
+    }
+
     private var cachedMaxEntries: Int = 10_000
     private var cachedMaxDays: Int = 90
     private var cachedAutoCleanup: Bool = true
@@ -22,7 +36,6 @@ actor QueryHistoryStorage {
     ) {
         self.databaseURL = databaseURL
         self.removeDatabaseOnDeinit = removeDatabaseOnDeinit
-        setupDatabase()
     }
 
     static func defaultDatabaseURL() -> URL {
@@ -32,8 +45,8 @@ actor QueryHistoryStorage {
     }
 
     deinit {
-        if let db {
-            sqlite3_close_v2(db)
+        if let pointer = dbHandle.pointer {
+            sqlite3_close_v2(pointer)
         }
         if removeDatabaseOnDeinit {
             let path = databaseURL.path(percentEncoded: false)
@@ -53,12 +66,12 @@ actor QueryHistoryStorage {
         let dbPath = databaseURL.path(percentEncoded: false)
         protectDatabaseFiles(at: dbPath)
 
-        guard sqlite3_open(dbPath, &db) == SQLITE_OK else {
+        guard sqlite3_open(dbPath, &dbHandle.pointer) == SQLITE_OK else {
             Self.logger.error("Failed to open query history database at \(dbPath, privacy: .public)")
-            if let db {
-                sqlite3_close_v2(db)
+            if let pointer = dbHandle.pointer {
+                sqlite3_close_v2(pointer)
             }
-            db = nil
+            dbHandle.pointer = nil
             return
         }
 

--- a/TablePro/Core/Storage/RecentlyClosedTabStore.swift
+++ b/TablePro/Core/Storage/RecentlyClosedTabStore.swift
@@ -51,7 +51,7 @@ internal final class RecentlyClosedTabStore {
     internal static let maxEntries = 20
     internal static let maxAge: TimeInterval = 60 * 60 * 24 * 30
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "RecentlyClosedTabStore")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "RecentlyClosedTabStore")
 
     internal private(set) var entries: [RecentlyClosedTabEntry] = []
 

--- a/TablePro/Core/Storage/SQLFavoriteStorage.swift
+++ b/TablePro/Core/Storage/SQLFavoriteStorage.swift
@@ -10,7 +10,21 @@ import SQLite3
 internal actor SQLFavoriteStorage {
     private static let logger = Logger(subsystem: "com.TablePro", category: "SQLFavoriteStorage")
 
-    private var db: OpaquePointer?
+    private struct DatabaseHandle: @unchecked Sendable {
+        var pointer: OpaquePointer?
+    }
+
+    private var dbHandle = DatabaseHandle()
+    private var isPrepared = false
+
+    private var db: OpaquePointer? {
+        if !isPrepared {
+            isPrepared = true
+            setupDatabase()
+        }
+        return dbHandle.pointer
+    }
+
 
     private let databaseURL: URL
     private let removeDatabaseOnDeinit: Bool
@@ -21,7 +35,6 @@ internal actor SQLFavoriteStorage {
     ) {
         self.databaseURL = databaseURL
         self.removeDatabaseOnDeinit = removeDatabaseOnDeinit
-        setupDatabase()
     }
 
     static func defaultDatabaseURL() -> URL {
@@ -32,8 +45,8 @@ internal actor SQLFavoriteStorage {
     }
 
     deinit {
-        if let db = db {
-            sqlite3_close_v2(db)
+        if let pointer = dbHandle.pointer {
+            sqlite3_close_v2(pointer)
         }
         if removeDatabaseOnDeinit {
             let path = databaseURL.path(percentEncoded: false)
@@ -52,7 +65,7 @@ internal actor SQLFavoriteStorage {
 
         let dbPath = databaseURL.path(percentEncoded: false)
 
-        if sqlite3_open(dbPath, &db) != SQLITE_OK {
+        if sqlite3_open(dbPath, &dbHandle.pointer) != SQLITE_OK {
             Self.logger.error("Error opening database")
             return
         }

--- a/TablePro/Core/Storage/SSHProfileStorage.swift
+++ b/TablePro/Core/Storage/SSHProfileStorage.swift
@@ -7,9 +7,10 @@ import Foundation
 import os
 import TableProSyncTransport
 
+@MainActor
 final class SSHProfileStorage {
     static let shared = SSHProfileStorage()
-    private static let logger = Logger(subsystem: "com.TablePro", category: "SSHProfileStorage")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "SSHProfileStorage")
 
     private let profilesKey = "com.TablePro.sshProfiles"
     private let defaults = AppStorageEnvironment.shared.defaults

--- a/TablePro/Core/Storage/TabDiskActor.swift
+++ b/TablePro/Core/Storage/TabDiskActor.swift
@@ -67,14 +67,14 @@ private final class TabDiskConnectionWriteGate: @unchecked Sendable {
         token: UInt64,
         operation work: () throws -> T
     ) rethrows -> T? {
-        try operation.withLock { _ in
+        try operation.withLockUnchecked { _ in
             guard generation.withLock({ $0 == token }) else { return nil }
             return try work()
         }
     }
 
     func perform<T>(_ work: () throws -> T) rethrows -> T {
-        try operation.withLock { _ in
+        try operation.withLockUnchecked { _ in
             try work()
         }
     }

--- a/TablePro/Core/Storage/TagStorage.swift
+++ b/TablePro/Core/Storage/TagStorage.swift
@@ -13,7 +13,7 @@ import TableProSyncTransport
 @MainActor
 final class TagStorage {
     static let shared = TagStorage()
-    private static let logger = Logger(subsystem: "com.TablePro", category: "TagStorage")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "TagStorage")
 
     private let tagsKey = "com.TablePro.tags"
     private let defaults = AppStorageEnvironment.shared.defaults

--- a/TablePro/Core/Storage/TransferDialogStorage.swift
+++ b/TablePro/Core/Storage/TransferDialogStorage.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-final class TransferDialogStorage {
+final class TransferDialogStorage: Sendable {
     static let shared = TransferDialogStorage()
 
     private let defaults: UserDefaults

--- a/TablePro/Core/Sync/SyncChangeTracker.swift
+++ b/TablePro/Core/Sync/SyncChangeTracker.swift
@@ -11,7 +11,7 @@ import os
 import TableProSyncTransport
 
 /// Tracks dirty entities and deletions for sync
-final class SyncChangeTracker {
+final class SyncChangeTracker: Sendable {
     static let shared = SyncChangeTracker()
     private static let logger = Logger(subsystem: "com.TablePro", category: "SyncChangeTracker")
 

--- a/TablePro/Core/Sync/SyncCoordinator.swift
+++ b/TablePro/Core/Sync/SyncCoordinator.swift
@@ -16,7 +16,7 @@ import TableProSyncTransport
 @MainActor @Observable
 final class SyncCoordinator {
     static let shared = SyncCoordinator()
-    private static let logger = Logger(subsystem: "com.TablePro", category: "SyncCoordinator")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "SyncCoordinator")
 
     private(set) var syncStatus: SyncStatus = .disabled(.userDisabled)
     private(set) var lastSyncDate: Date?
@@ -27,7 +27,7 @@ final class SyncCoordinator {
     @ObservationIgnored private let changeTracker: SyncChangeTracker
     @ObservationIgnored private let metadataStorage: SyncMetadataStorage
     @ObservationIgnored private let recordCache = SyncRecordCache()
-    @ObservationIgnored private var accountObserver: NSObjectProtocol?
+    @ObservationIgnored private let accountObserver = OSAllocatedUnfairLock<(any NSObjectProtocol)?>(uncheckedState: nil)
     @ObservationIgnored private var changeCancellable: AnyCancellable?
     @ObservationIgnored private var licenseCancellable: AnyCancellable?
     @ObservationIgnored private var syncTask: Task<Void, Never>?
@@ -41,7 +41,7 @@ final class SyncCoordinator {
     }
 
     deinit {
-        if let accountObserver { NotificationCenter.default.removeObserver(accountObserver) }
+        if let observer = accountObserver.withLockUnchecked({ $0 }) { NotificationCenter.default.removeObserver(observer) }
         syncTask?.cancel()
     }
 
@@ -719,7 +719,7 @@ final class SyncCoordinator {
     // MARK: - Observers
 
     private func observeAccountChanges() {
-        accountObserver = NotificationCenter.default.addObserver(
+        let observer = NotificationCenter.default.addObserver(
             forName: .CKAccountChanged,
             object: nil,
             queue: .main
@@ -738,6 +738,7 @@ final class SyncCoordinator {
                 }
             }
         }
+        accountObserver.withLockUnchecked { $0 = observer }
     }
 
     private func observeLocalChanges() {

--- a/TablePro/Core/UsersRoles/PrivilegeNode.swift
+++ b/TablePro/Core/UsersRoles/PrivilegeNode.swift
@@ -88,6 +88,8 @@ final class PrivilegeNode: NSObject {
             } else {
                 .available
             }
+        @unknown default:
+            .none
         }
     }
 }

--- a/TablePro/Core/UsersRoles/PrivilegeScopeKey.swift
+++ b/TablePro/Core/UsersRoles/PrivilegeScopeKey.swift
@@ -21,6 +21,7 @@ extension PluginPrivilegeScope {
         case .schema: .schema
         case .table: .table
         case .column: .column
+        @unknown default: .server
         }
     }
 
@@ -38,6 +39,8 @@ extension PluginPrivilegeScope {
         case let .column(database, schema, table, column):
             schema.map { "db:\(database)/schema:\($0)/table:\(table)/column:\(column)" }
                 ?? "db:\(database)/table:\(table)/column:\(column)"
+        @unknown default:
+            "server"
         }
     }
 
@@ -54,6 +57,8 @@ extension PluginPrivilegeScope {
         case let .column(database, schema, table, column):
             schema.map { "\(database) › \($0) › \(table) › \(column)" }
                 ?? "\(database) › \(table) › \(column)"
+        @unknown default:
+            String(localized: "Server")
         }
     }
 
@@ -69,6 +74,8 @@ extension PluginPrivilegeScope {
             table
         case let .column(_, _, _, column):
             column
+        @unknown default:
+            String(localized: "Server")
         }
     }
 
@@ -79,6 +86,7 @@ extension PluginPrivilegeScope {
         case .schema: "folder"
         case .table: "tablecells"
         case .column: "rectangle.split.3x1"
+        @unknown default: "server.rack"
         }
     }
 }

--- a/TablePro/Core/Utilities/Connection/PasswordSourceResolver.swift
+++ b/TablePro/Core/Utilities/Connection/PasswordSourceResolver.swift
@@ -149,7 +149,7 @@ enum PasswordSourceResolver {
     }
 
     static func resolveCommand(shell: String, timeoutSeconds: UInt64) async throws -> String {
-        let output = try await Task.detached(priority: .userInitiated) { () throws -> String in
+        let output = try await Task.detached(priority: .userInitiated) { () async throws -> String in
             let process = Process()
             process.executableURL = URL(fileURLWithPath: "/bin/bash")
             process.arguments = ["-c", shell]
@@ -195,7 +195,9 @@ enum PasswordSourceResolver {
 
             process.waitUntilExit()
             timeoutTask.cancel()
-            drainGroup.wait()
+            await withCheckedContinuation { continuation in
+                drainGroup.notify(queue: drainQueue) { continuation.resume() }
+            }
 
             if stdoutCollector.overflowed {
                 throw ResolutionError.outputTooLarge

--- a/TablePro/Core/Utilities/MemoryPressureAdvisor.swift
+++ b/TablePro/Core/Utilities/MemoryPressureAdvisor.swift
@@ -10,7 +10,7 @@ import os
 /// Advises on tab eviction budget based on system memory and pressure state.
 @MainActor
 internal enum MemoryPressureAdvisor {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "MemoryPressureAdvisor")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "MemoryPressureAdvisor")
 
     /// Current memory pressure level from the OS dispatch source.
     private(set) static var isUnderPressure = false

--- a/TablePro/Core/Utilities/SQL/InClauseConverter.swift
+++ b/TablePro/Core/Utilities/SQL/InClauseConverter.swift
@@ -45,6 +45,8 @@ internal struct InClauseConverter {
                 return "TRUE"
             case .isFalse:
                 return "FALSE"
+            @unknown default:
+                return quoted(value)
             }
         }
         guard ColumnTypeSQLQuoting.isNumericLiteral(value, for: type) else { return quoted(value) }

--- a/TablePro/Core/Vim/VimCursorManager.swift
+++ b/TablePro/Core/Vim/VimCursorManager.swift
@@ -21,7 +21,7 @@ import os
 final class VimCursorManager {
     // MARK: - Properties
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "VimCursor")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "VimCursor")
 
     private weak var textView: TextView?
     private var blockCursorLayer: CALayer?

--- a/TablePro/Core/Vim/VimEngine.swift
+++ b/TablePro/Core/Vim/VimEngine.swift
@@ -44,7 +44,7 @@ enum VimScreenPosition { case top, middle, bottom }
 
 @MainActor
 final class VimEngine {
-    static let logger = Logger(subsystem: "com.TablePro", category: "VimEngine")
+    nonisolated static let logger = Logger(subsystem: "com.TablePro", category: "VimEngine")
 
     private(set) var mode: VimMode = .normal {
         didSet {

--- a/TablePro/Core/Vim/VimKeyInterceptor.swift
+++ b/TablePro/Core/Vim/VimKeyInterceptor.swift
@@ -40,17 +40,17 @@ enum VimKeyEventScopeResolver {
 final class VimKeyInterceptor {
     private let engine: VimEngine
     private weak var inlineSuggestionManager: InlineSuggestionManager?
-    private let _monitor = OSAllocatedUnfairLock<Any?>(initialState: nil)
+    private let _monitor = OSAllocatedUnfairLock<Any?>(uncheckedState: nil)
     private weak var controller: TextViewController?
-    private let _popupCloseObserver = OSAllocatedUnfairLock<Any?>(initialState: nil)
-    private let _keyWindowObservers = OSAllocatedUnfairLock<[Any]>(initialState: [])
+    private let _popupCloseObserver = OSAllocatedUnfairLock<Any?>(uncheckedState: nil)
+    private let _keyWindowObservers = OSAllocatedUnfairLock<[Any]>(uncheckedState: [])
     private var isEditorFirstResponder = false
     private(set) var isEditorFocused = false
 
     deinit {
-        if let monitor = _monitor.withLock({ $0 }) { NSEvent.removeMonitor(monitor) }
-        if let observer = _popupCloseObserver.withLock({ $0 }) { NotificationCenter.default.removeObserver(observer) }
-        for observer in _keyWindowObservers.withLock({ $0 }) { NotificationCenter.default.removeObserver(observer) }
+        if let monitor = _monitor.withLockUnchecked({ $0 }) { NSEvent.removeMonitor(monitor) }
+        if let observer = _popupCloseObserver.withLockUnchecked({ $0 }) { NotificationCenter.default.removeObserver(observer) }
+        for observer in _keyWindowObservers.withLockUnchecked({ $0 }) { NotificationCenter.default.removeObserver(observer) }
     }
 
     init(engine: VimEngine, inlineSuggestionManager: InlineSuggestionManager?) {
@@ -63,7 +63,7 @@ final class VimKeyInterceptor {
         self.controller = controller
         uninstall()
 
-        _popupCloseObserver.withLock { $0 = NotificationCenter.default.addObserver(
+        _popupCloseObserver.withLockUnchecked { $0 = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification,
             object: nil,
             queue: .main
@@ -122,11 +122,11 @@ final class VimKeyInterceptor {
         isEditorFirstResponder = false
         isEditorFocused = false
         removeMonitor()
-        _popupCloseObserver.withLock {
+        _popupCloseObserver.withLockUnchecked {
             if let observer = $0 { NotificationCenter.default.removeObserver(observer) }
             $0 = nil
         }
-        _keyWindowObservers.withLock {
+        _keyWindowObservers.withLockUnchecked {
             for observer in $0 { NotificationCenter.default.removeObserver(observer) }
             $0 = []
         }
@@ -143,7 +143,7 @@ final class VimKeyInterceptor {
                 }
             }
         }
-        _keyWindowObservers.withLock { $0 = observers }
+        _keyWindowObservers.withLockUnchecked { $0 = observers }
     }
 
     private func refreshFocusState() {
@@ -176,19 +176,19 @@ final class VimKeyInterceptor {
     }
 
     private func installMonitor() {
-        _monitor.withLock {
-            $0 = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] nsEvent in
-                nonisolated(unsafe) let event = nsEvent
-                return MainActor.assumeIsolated {
-                    guard let self, self.isEditorFocused else { return event }
-                    return self.handleKeyEvent(event)
-                }
+        let monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] nsEvent in
+            nonisolated(unsafe) let event = nsEvent
+            let consumed = MainActor.assumeIsolated { () -> Bool in
+                guard let self, self.isEditorFocused else { return false }
+                return self.handleKeyEvent(event) == nil
             }
+            return consumed ? nil : nsEvent
         }
+        _monitor.withLockUnchecked { $0 = monitor }
     }
 
     private func removeMonitor() {
-        _monitor.withLock {
+        _monitor.withLockUnchecked {
             if let monitor = $0 { NSEvent.removeMonitor(monitor) }
             $0 = nil
         }

--- a/TablePro/Extensions/Date+Extensions.swift
+++ b/TablePro/Extensions/Date+Extensions.swift
@@ -6,16 +6,17 @@
 //
 
 import Foundation
+import os
 
 extension Date {
-    private static let relativeFormatter: RelativeDateTimeFormatter = {
+    private static let relativeFormatter: OSAllocatedUnfairLock<RelativeDateTimeFormatter> = {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .full
-        return formatter
+        return OSAllocatedUnfairLock(uncheckedState: formatter)
     }()
 
     /// Returns a localized, human-readable relative time string (e.g., "2 hours ago", "3 days ago")
     func timeAgoDisplay() -> String {
-        Self.relativeFormatter.localizedString(for: self, relativeTo: Date())
+        Self.relativeFormatter.withLockUnchecked { $0.localizedString(for: self, relativeTo: Date()) }
     }
 }

--- a/TablePro/Models/Connection/DatabaseConnection+Display.swift
+++ b/TablePro/Models/Connection/DatabaseConnection+Display.swift
@@ -62,6 +62,8 @@ extension DatabaseConnection {
             return String(format: String(localized: "db %d"), index)
         case .filePath:
             return nil
+        @unknown default:
+            return nil
         }
     }
 

--- a/TablePro/Models/Query/QueryTabState.swift
+++ b/TablePro/Models/Query/QueryTabState.swift
@@ -612,17 +612,20 @@ struct TabDisplayState: Equatable {
         return resultSets.first { $0.id == id }
     }
 
+    @MainActor
     var hasPinnedResults: Bool {
-        resultSets.contains(where: \.isPinned)
+        resultSets.contains { $0.isPinned }
     }
 
+    @MainActor
     mutating func replaceUnpinnedResults(with newResults: [ResultSet]) {
-        resultSets = resultSets.filter(\.isPinned) + newResults
+        resultSets = resultSets.filter { $0.isPinned } + newResults
         activeResultSetId = newResults.last?.id ?? resultSets.last?.id
     }
 
+    @MainActor
     mutating func removeUnpinnedResults() {
-        resultSets = resultSets.filter(\.isPinned)
+        resultSets = resultSets.filter { $0.isPinned }
         activeResultSetId = resultSets.last?.id
     }
 

--- a/TablePro/Models/Settings/License.swift
+++ b/TablePro/Models/Settings/License.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import os
 
 // MARK: - License Status
 
@@ -267,12 +268,12 @@ struct License: Codable, Equatable {
     }
 
     var expiresAt: Date? {
-        payload.expiresAt.flatMap { Self.iso8601Formatter.date(from: $0) }
+        payload.expiresAt.flatMap { Self.date(fromInternetDateTime: $0) }
     }
 
     /// When the server signed this payload, which is when it last confirmed the license.
     var issuedAt: Date? {
-        Self.iso8601Formatter.date(from: payload.issuedAt)
+        Self.date(fromInternetDateTime: payload.issuedAt)
     }
 
     /// Whether the license has expired based on expiration date
@@ -294,11 +295,15 @@ struct License: Codable, Equatable {
         return max(0, Calendar.current.dateComponents([.day], from: issuedAt, to: Date()).day ?? 0)
     }
 
-    private static let iso8601Formatter: ISO8601DateFormatter = {
+    private static let iso8601Formatter: OSAllocatedUnfairLock<ISO8601DateFormatter> = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
-        return formatter
+        return OSAllocatedUnfairLock(uncheckedState: formatter)
     }()
+
+    private static func date(fromInternetDateTime value: String) -> Date? {
+        iso8601Formatter.withLockUnchecked { $0.date(from: value) }
+    }
 }
 
 // MARK: - License Error

--- a/TablePro/Theme/ThemeEngine.swift
+++ b/TablePro/Theme/ThemeEngine.swift
@@ -100,7 +100,7 @@ internal final class ThemeEngine {
 
     // MARK: - Private
 
-    @ObservationIgnored private static let logger = Logger(subsystem: "com.TablePro", category: "ThemeEngine")
+    @ObservationIgnored nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ThemeEngine")
     @ObservationIgnored private var accessibilityObserver: NSObjectProtocol?
     @ObservationIgnored private var lastAccessibilityScale: CGFloat = 1.0
 

--- a/TablePro/Theme/ThemeRegistryInstaller.swift
+++ b/TablePro/Theme/ThemeRegistryInstaller.swift
@@ -15,7 +15,7 @@ import os
 internal final class ThemeRegistryInstaller {
     static let shared = ThemeRegistryInstaller()
 
-    @ObservationIgnored private static let logger = Logger(subsystem: "com.TablePro", category: "ThemeRegistryInstaller")
+    @ObservationIgnored nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ThemeRegistryInstaller")
 
     private init() {}
 

--- a/TablePro/ViewModels/AIChatViewModel.swift
+++ b/TablePro/ViewModels/AIChatViewModel.swift
@@ -10,7 +10,7 @@ import TableProPluginKit
 
 @MainActor @Observable
 final class AIChatViewModel {
-    static let logger = Logger(subsystem: "com.TablePro", category: "AIChatViewModel")
+    nonisolated static let logger = Logger(subsystem: "com.TablePro", category: "AIChatViewModel")
 
     enum StreamingState {
         case idle

--- a/TablePro/ViewModels/DatabaseSwitcherViewModel.swift
+++ b/TablePro/ViewModels/DatabaseSwitcherViewModel.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 @MainActor @Observable
 final class DatabaseSwitcherViewModel {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "DatabaseSwitcherViewModel")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "DatabaseSwitcherViewModel")
 
     var databases: [DatabaseMetadata] = []
     var searchText = "" {

--- a/TablePro/ViewModels/ERDiagramViewModel.swift
+++ b/TablePro/ViewModels/ERDiagramViewModel.swift
@@ -8,7 +8,7 @@ import TableProPluginKit
 @MainActor
 @Observable
 final class ERDiagramViewModel {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "ERDiagram")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ERDiagram")
 
     // MARK: - Configuration
 
@@ -181,7 +181,7 @@ final class ERDiagramViewModel {
     private func waitForConnection() async {
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             let resumed = OSAllocatedUnfairLock(initialState: false)
-            let cancellableBox = OSAllocatedUnfairLock<AnyCancellable?>(initialState: nil)
+            let cancellableBox = OSAllocatedUnfairLock<AnyCancellable?>(uncheckedState: nil)
             let timeoutTaskBox = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
 
             @Sendable func resumeOnce() {
@@ -192,7 +192,7 @@ final class ERDiagramViewModel {
                 }
                 guard !alreadyResumed else { return }
                 timeoutTaskBox.withLock { $0?.cancel(); $0 = nil }
-                cancellableBox.withLock { $0 = nil }
+                cancellableBox.withLockUnchecked { $0 = nil }
                 continuation.resume()
             }
 
@@ -203,7 +203,7 @@ final class ERDiagramViewModel {
                     guard payload.connectionId == targetId else { return }
                     resumeOnce()
                 }
-            cancellableBox.withLock { $0 = cancellable }
+            cancellableBox.withLockUnchecked { $0 = cancellable }
 
             let timeoutTask = Task {
                 try? await Task.sleep(for: .seconds(10))

--- a/TablePro/ViewModels/QueryInsightsViewModel.swift
+++ b/TablePro/ViewModels/QueryInsightsViewModel.swift
@@ -6,7 +6,7 @@ import os
 @MainActor
 @Observable
 final class QueryInsightsViewModel {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "QueryInsights")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "QueryInsights")
 
     /// Recording a grid full of edits broadcasts once per statement, and every panel on this screen
     /// is a full aggregate. Collapsing the burst keeps one user action to one recomputation.

--- a/TablePro/ViewModels/QuickSwitcherViewModel.swift
+++ b/TablePro/ViewModels/QuickSwitcherViewModel.swift
@@ -47,7 +47,7 @@ internal final class QuickSwitcherViewModel {
         let items: [QuickSwitcherItem]
     }
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "QuickSwitcherViewModel")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "QuickSwitcherViewModel")
     private static let recentLimit = 10
     private static let filterDebounceNanoseconds: UInt64 = 40_000_000
 

--- a/TablePro/ViewModels/RedisKeyTreeViewModel.swift
+++ b/TablePro/ViewModels/RedisKeyTreeViewModel.swift
@@ -10,7 +10,7 @@ import TableProPluginKit
 
 @MainActor @Observable
 internal final class RedisKeyTreeViewModel {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "RedisKeyTree")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "RedisKeyTree")
     internal static let maxKeys = 50_000
 
     var rootNodes: [RedisKeyNode] = []

--- a/TablePro/ViewModels/ServerDashboardViewModel.swift
+++ b/TablePro/ViewModels/ServerDashboardViewModel.swift
@@ -4,7 +4,7 @@ import os
 @MainActor
 @Observable
 final class ServerDashboardViewModel {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "ServerDashboard")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ServerDashboard")
 
     // MARK: - Configuration
 

--- a/TablePro/ViewModels/UsersRolesViewModel.swift
+++ b/TablePro/ViewModels/UsersRolesViewModel.swift
@@ -62,7 +62,7 @@ final class UsersRolesViewModel {
         var restrictsBrowsing = false
     }
 
-    static let logger = Logger(subsystem: "com.TablePro", category: "UsersRolesViewModel")
+    nonisolated static let logger = Logger(subsystem: "com.TablePro", category: "UsersRolesViewModel")
     static let scopeSearchLimit = 200
 
     let connectionId: UUID

--- a/TablePro/ViewModels/WelcomeViewModel+Sample.swift
+++ b/TablePro/ViewModels/WelcomeViewModel+Sample.swift
@@ -11,7 +11,7 @@ import TableProPluginKit
 
 @MainActor
 internal enum SampleDatabaseLauncher {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "SampleDatabase")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "SampleDatabase")
 
     private static let sampleOpenedCountKey = "com.TablePro.sample.openedCount"
     private static let sampleAutoSelectTable = "Track"

--- a/TablePro/ViewModels/WelcomeViewModel.swift
+++ b/TablePro/ViewModels/WelcomeViewModel.swift
@@ -34,7 +34,7 @@ enum WelcomeActiveSheet: Identifiable {
 
 @MainActor @Observable
 final class WelcomeViewModel {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "WelcomeViewModel")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "WelcomeViewModel")
 
     @ObservationIgnored let services: AppServices
     private var storage: ConnectionStorage { services.connectionStorage }

--- a/TablePro/Views/AIChat/AIChatCodeBlockView.swift
+++ b/TablePro/Views/AIChat/AIChatCodeBlockView.swift
@@ -141,7 +141,7 @@ struct AIChatCodeBlockView: View, Equatable {
         return Self.detectLanguage(from: code)
     }
 
-    static func detectLanguage(from code: String) -> String? {
+    nonisolated static func detectLanguage(from code: String) -> String? {
         let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
         guard !trimmed.isEmpty else { return nil }
         let firstNonCommentLine = trimmed

--- a/TablePro/Views/AIChat/MarkdownView.swift
+++ b/TablePro/Views/AIChat/MarkdownView.swift
@@ -9,6 +9,7 @@
 //
 
 import AppKit
+import os
 import SwiftUI
 
 struct MarkdownView: View, Equatable {
@@ -244,11 +245,11 @@ private struct MarkdownTableView: View {
 // MARK: - Inline parsing
 
 enum MarkdownInline {
-    private static let cache: NSCache<NSString, NSAttributedString> = {
-        let c = NSCache<NSString, NSAttributedString>()
-        c.countLimit = 4_000
-        c.totalCostLimit = 8 * 1_024 * 1_024
-        return c
+    private static let cache: OSAllocatedUnfairLock<NSCache<NSString, NSAttributedString>> = {
+        let cache = NSCache<NSString, NSAttributedString>()
+        cache.countLimit = 4_000
+        cache.totalCostLimit = 8 * 1_024 * 1_024
+        return OSAllocatedUnfairLock(uncheckedState: cache)
     }()
 
     private static let options = AttributedString.MarkdownParsingOptions(
@@ -260,11 +261,11 @@ enum MarkdownInline {
             return attributedString(from: MarkdownInlineRepair.repairingDanglingSyntax(source))
         }
         let key = source as NSString
-        if let cached = cache.object(forKey: key) {
+        if let cached = cache.withLockUnchecked({ $0.object(forKey: key) }) {
             return AttributedString(cached)
         }
         let attributed = attributedString(from: source)
-        cache.setObject(NSAttributedString(attributed), forKey: key, cost: key.length)
+        cache.withLockUnchecked { $0.setObject(NSAttributedString(attributed), forKey: key, cost: key.length) }
         return attributed
     }
 

--- a/TablePro/Views/Components/VerticalCollapsibleSplitView.swift
+++ b/TablePro/Views/Components/VerticalCollapsibleSplitView.swift
@@ -88,6 +88,7 @@ struct VerticalCollapsibleSplitView<TopContent: View, BottomContent: View>: NSVi
     /// The divider is draggable and double-clickable, so AppKit owns this state as much as
     /// SwiftUI does. Observing it back keeps the persisted value honest instead of letting the
     /// two drift until the next programmatic toggle snaps the pane back.
+    @MainActor
     final class Coordinator {
         var topController: NSHostingController<TopContent>?
         var bottomController: NSHostingController<BottomContent>?
@@ -99,11 +100,12 @@ struct VerticalCollapsibleSplitView<TopContent: View, BottomContent: View>: NSVi
         private var isApplyingProgrammatically = false
 
         func observeCollapse(of item: NSSplitViewItem) {
-            collapseObservation = item.observe(\.isCollapsed, options: [.new]) { [weak self] item, _ in
+            collapseObservation = item.observe(\.isCollapsed, options: [.new]) { [weak self] observed, _ in
+                nonisolated(unsafe) let observedItem = observed
                 MainActor.assumeIsolated {
                     guard let self, !self.isApplyingProgrammatically else { return }
-                    self.lastCollapsedState = item.isCollapsed
-                    self.onUserCollapseChange?(item.isCollapsed)
+                    self.lastCollapsedState = observedItem.isCollapsed
+                    self.onUserCollapseChange?(observedItem.isCollapsed)
                 }
             }
         }

--- a/TablePro/Views/Connection/ImportFromApp/ImportFromAppSheet.swift
+++ b/TablePro/Views/Connection/ImportFromApp/ImportFromAppSheet.swift
@@ -102,7 +102,7 @@ struct ImportFromAppSheet: View {
 
     // MARK: - Actions
 
-    static func requiresKeychainConfirmation(includePasswords: Bool, importer: any ForeignAppImporter) -> Bool {
+    nonisolated static func requiresKeychainConfirmation(includePasswords: Bool, importer: any ForeignAppImporter) -> Bool {
         includePasswords && importer.readsPasswordsFromKeychain
     }
 

--- a/TablePro/Views/ConnectionForm/ConnectionFormCoordinator.swift
+++ b/TablePro/Views/ConnectionForm/ConnectionFormCoordinator.swift
@@ -22,7 +22,7 @@ final class WeakCoordinatorRef {
 @Observable
 @MainActor
 final class ConnectionFormCoordinator {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "ConnectionFormCoordinator")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ConnectionFormCoordinator")
 
     let connectionId: UUID?
     private(set) var originalConnection: DatabaseConnection?
@@ -477,7 +477,7 @@ final class ConnectionFormCoordinator {
             additionalFieldValues: additionalFieldValues
         )
 
-        testTask = Task { [weak self] in
+        testTask = Task { [weak self, services] in
             do {
                 let sshPasswordForTest = sshState.profileId == nil ? sshState.password : nil
                 let isApiOnly = services.pluginManager.connectionMode(for: connectionType) == .apiOnly
@@ -657,7 +657,7 @@ final class ConnectionFormCoordinator {
 
     func installPlugin(for databaseType: DatabaseType) {
         isInstallingPlugin = true
-        Task { [weak self] in
+        Task { [weak self, services] in
             do {
                 try await services.pluginManager.installMissingPlugin(for: databaseType) { _ in }
                 await MainActor.run {

--- a/TablePro/Views/ConnectionForm/ViewModels/CloudSQLProxyPaneViewModel.swift
+++ b/TablePro/Views/ConnectionForm/ViewModels/CloudSQLProxyPaneViewModel.swift
@@ -9,7 +9,7 @@ import os
 @Observable
 @MainActor
 final class CloudSQLProxyPaneViewModel {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "CloudSQLProxyPane")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "CloudSQLProxyPane")
 
     var state = CloudSQLProxyFormState()
 

--- a/TablePro/Views/ConnectionForm/ViewModels/CloudflareTunnelPaneViewModel.swift
+++ b/TablePro/Views/ConnectionForm/ViewModels/CloudflareTunnelPaneViewModel.swift
@@ -9,7 +9,7 @@ import os
 @Observable
 @MainActor
 final class CloudflareTunnelPaneViewModel {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "CloudflareTunnelPane")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "CloudflareTunnelPane")
 
     var state = CloudflareTunnelFormState()
 

--- a/TablePro/Views/Editor/QueryCompletionAdapter.swift
+++ b/TablePro/Views/Editor/QueryCompletionAdapter.swift
@@ -31,7 +31,7 @@ final class QueryCompletionAdapter: CodeSuggestionDelegate {
     private var lastRefilterPrefix: String?
     private var lastRefilterItems: [SQLCompletionItem]?
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "QueryCompletionAdapter")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "QueryCompletionAdapter")
 
     init(schemaProvider: SQLSchemaProvider?, databaseType: DatabaseType? = nil) {
         self.service = QueryCompletionServiceFactory.make(schemaProvider: schemaProvider, databaseType: databaseType)

--- a/TablePro/Views/Editor/QueryDiagnosticsController.swift
+++ b/TablePro/Views/Editor/QueryDiagnosticsController.swift
@@ -21,7 +21,7 @@ final class QueryDiagnosticsController {
 
     private let debounceNanoseconds: UInt64 = 500_000_000
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "QueryDiagnostics")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "QueryDiagnostics")
 
     init(databaseType: DatabaseType?) {
         self.producer = QueryDiagnosticsFactory.make(for: databaseType)

--- a/TablePro/Views/Editor/SQLEditorCoordinator.swift
+++ b/TablePro/Views/Editor/SQLEditorCoordinator.swift
@@ -20,7 +20,7 @@ import TableProPluginKit
 final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
     // MARK: - Properties
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "SQLEditorCoordinator")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "SQLEditorCoordinator")
 
     /// Above this document length inline AI features are suspended, at the same cutoff where syntax highlighting stops,
     /// so a large document does not copy its whole contents to the assistant on every keystroke.

--- a/TablePro/Views/Editor/StatementRunController.swift
+++ b/TablePro/Views/Editor/StatementRunController.swift
@@ -31,10 +31,10 @@ final class StatementRunController {
     ///
     /// The same threshold syntax highlighting and code folding stop at, so an editor that has given up on colouring a
     /// document does not still be walking it for statement boundaries.
-    static let defaultSizeLimit = 2_000_000
+    nonisolated static let defaultSizeLimit = 2_000_000
 
     /// How long typing has to pause before the run controls are recomputed.
-    static let refreshDelay: Duration = .milliseconds(150)
+    nonisolated static let refreshDelay: Duration = .milliseconds(150)
 
     /// Below this length the controls are recomputed on the keystroke rather than on the pause.
     ///

--- a/TablePro/Views/Filter/FilterValueTextField.swift
+++ b/TablePro/Views/Filter/FilterValueTextField.swift
@@ -5,6 +5,7 @@
 
 import AppKit
 import Combine
+import os
 import SwiftUI
 
 enum FilterCompletionSource {
@@ -40,7 +41,7 @@ struct FilterValueTextField: NSViewRepresentable {
     var onSubmit: () -> Void = {}
     var onCancel: () -> Void = {}
 
-    static func suggestions(for input: String, in completions: [String]) -> [String] {
+    nonisolated static func suggestions(for input: String, in completions: [String]) -> [String] {
         guard !input.isEmpty else { return [] }
         let needle = input.lowercased()
         let matches = completions.filter { $0.lowercased().hasPrefix(needle) }
@@ -50,7 +51,7 @@ struct FilterValueTextField: NSViewRepresentable {
         return matches
     }
 
-    static func shouldOfferTokenCompletion(fieldText: String, cursor: Int) -> Bool {
+    nonisolated static func shouldOfferTokenCompletion(fieldText: String, cursor: Int) -> Bool {
         let nsText = fieldText as NSString
         guard nsText.length > 0 else { return false }
         let clamped = min(max(cursor, 0), nsText.length)
@@ -59,7 +60,7 @@ struct FilterValueTextField: NSViewRepresentable {
         return !CharacterSet.whitespaces.contains(scalar)
     }
 
-    static func splice(into current: String, range: NSRange, insertText: String) -> (text: String, caret: Int)? {
+    nonisolated static func splice(into current: String, range: NSRange, insertText: String) -> (text: String, caret: Int)? {
         let ns = current as NSString
         guard range.location >= 0, range.location + range.length <= ns.length else { return nil }
         let caret = range.location + (insertText as NSString).length
@@ -72,7 +73,7 @@ struct FilterValueTextField: NSViewRepresentable {
         case passThrough
     }
 
-    static func suggestionCommandOutcome(
+    nonisolated static func suggestionCommandOutcome(
         for commandSelector: Selector,
         submitsOnAccept: Bool
     ) -> SuggestionCommandOutcome {
@@ -91,7 +92,7 @@ struct FilterValueTextField: NSViewRepresentable {
         case closeBar
     }
 
-    static func escapeOutcome(popupVisible: Bool, recentlyDismissedPopup: Bool) -> EscapeOutcome {
+    nonisolated static func escapeOutcome(popupVisible: Bool, recentlyDismissedPopup: Bool) -> EscapeOutcome {
         if popupVisible { return .dismissPopup }
         if recentlyDismissedPopup { return .consume }
         return .closeBar
@@ -172,7 +173,7 @@ struct FilterValueTextField: NSViewRepresentable {
         private let suggestionState = SuggestionState()
         private var suggestionPopover: NSPopover?
         private var focusState = FilterFocusState()
-        private var windowKeyObserver: NSObjectProtocol?
+        private let windowKeyObserver = OSAllocatedUnfairLock<(any NSObjectProtocol)?>(uncheckedState: nil)
         private var latestReplacementRange: NSRange?
         private var completionGeneration = 0
         private var escapeDismissedPopup = false
@@ -224,7 +225,7 @@ struct FilterValueTextField: NSViewRepresentable {
 
         func startObservingWindowKeyStatus(for window: NSWindow) {
             stopObservingWindowKeyStatus()
-            windowKeyObserver = NotificationCenter.default.addObserver(
+            let observer = NotificationCenter.default.addObserver(
                 forName: NSWindow.didResignKeyNotification,
                 object: window,
                 queue: .main
@@ -233,16 +234,17 @@ struct FilterValueTextField: NSViewRepresentable {
                     self?.handleResignedFirstResponder()
                 }
             }
+            windowKeyObserver.withLockUnchecked { $0 = observer }
         }
 
         func stopObservingWindowKeyStatus() {
-            guard let token = windowKeyObserver else { return }
+            guard let token = windowKeyObserver.withLockUnchecked({ $0 }) else { return }
             NotificationCenter.default.removeObserver(token)
-            windowKeyObserver = nil
+            windowKeyObserver.withLockUnchecked { $0 = nil }
         }
 
         deinit {
-            if let token = windowKeyObserver {
+            if let token = windowKeyObserver.withLockUnchecked({ $0 }) {
                 NotificationCenter.default.removeObserver(token)
             }
         }

--- a/TablePro/Views/Main/MainContentCommandActions+TextInputFocus.swift
+++ b/TablePro/Views/Main/MainContentCommandActions+TextInputFocus.swift
@@ -8,6 +8,7 @@
 
 import AppKit
 import Foundation
+import os
 
 extension MainContentCommandActions {
     /// AppKit matches a menu key equivalent before the first responder ever sees
@@ -21,13 +22,13 @@ extension MainContentCommandActions {
     }
 
     func updateTextInputFocusTracking() {
-        if let textInputFocusObserver {
-            NotificationCenter.default.removeObserver(textInputFocusObserver)
-            self.textInputFocusObserver = nil
+        if let observer = textInputFocusObserver.withLockUnchecked({ $0 }) {
+            NotificationCenter.default.removeObserver(observer)
+            textInputFocusObserver.withLockUnchecked { $0 = nil }
         }
         refreshFocusOwnsTextInput()
         guard let window else { return }
-        textInputFocusObserver = NotificationCenter.default.addObserver(
+        let observer = NotificationCenter.default.addObserver(
             forName: NSWindow.didUpdateNotification,
             object: window,
             queue: .main
@@ -37,6 +38,7 @@ extension MainContentCommandActions {
                 self.scheduleTextInputFocusCheck()
             }
         }
+        textInputFocusObserver.withLockUnchecked { $0 = observer }
     }
 
     /// `didUpdateNotification` fires once per event-loop pass, so the check is

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -56,7 +56,7 @@ final class MainContentCommandActions {
     /// crosses that boundary; `NSWindow.firstResponder` publishes no change.
     var focusOwnsTextInput = false
 
-    @ObservationIgnored var textInputFocusObserver: NSObjectProtocol?
+    @ObservationIgnored let textInputFocusObserver = OSAllocatedUnfairLock<(any NSObjectProtocol)?>(uncheckedState: nil)
 
     @ObservationIgnored var isTextInputFocusCheckScheduled = false
 
@@ -95,8 +95,8 @@ final class MainContentCommandActions {
         for task in notificationTasks {
             task.cancel()
         }
-        if let textInputFocusObserver {
-            NotificationCenter.default.removeObserver(textInputFocusObserver)
+        if let observer = textInputFocusObserver.withLockUnchecked({ $0 }) {
+            NotificationCenter.default.removeObserver(observer)
         }
     }
 

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -79,8 +79,8 @@ enum ActiveSheet: Identifiable {
 /// Coordinator managing MainContentView business logic
 @MainActor @Observable
 final class MainContentCoordinator {
-    static let logger = Logger(subsystem: "com.TablePro", category: "MainContentCoordinator")
-    static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
+    nonisolated static let logger = Logger(subsystem: "com.TablePro", category: "MainContentCoordinator")
+    nonisolated static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
 
     /// Monotonic counter for correlating rapid tab-switch/close log entries.
     static var switchSeq: Int = 0
@@ -914,9 +914,10 @@ final class MainContentCoordinator {
         }
 
         if !alreadyHandled {
+            let registry = services.schemaProviderRegistry
             Task { @MainActor in
-                services.schemaProviderRegistry.release(for: connectionId)
-                services.schemaProviderRegistry.purgeUnused()
+                registry.release(for: connectionId)
+                registry.purgeUnused()
             }
         }
     }

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -20,7 +20,7 @@ import TableProPluginKit
 
 /// Main content view - thin presentation layer
 struct MainContentView: View {
-    static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
+    nonisolated static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
 
     // MARK: - Properties
 

--- a/TablePro/Views/QuickSwitcher/QuickSwitcherSearchField.swift
+++ b/TablePro/Views/QuickSwitcher/QuickSwitcherSearchField.swift
@@ -4,6 +4,7 @@
 //
 
 import AppKit
+import os
 import SwiftUI
 
 internal struct QuickSwitcherSearchField: NSViewRepresentable {
@@ -81,7 +82,7 @@ internal struct QuickSwitcherSearchField: NSViewRepresentable {
 }
 
 internal final class QuickSwitcherTextField: NSTextField {
-    private var becomeKeyObserver: NSObjectProtocol?
+    private let becomeKeyObserver = OSAllocatedUnfairLock<(any NSObjectProtocol)?>(uncheckedState: nil)
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
@@ -90,7 +91,7 @@ internal final class QuickSwitcherTextField: NSTextField {
             window.makeFirstResponder(self)
             return
         }
-        becomeKeyObserver = NotificationCenter.default.addObserver(
+        let observer = NotificationCenter.default.addObserver(
             forName: NSWindow.didBecomeKeyNotification,
             object: window,
             queue: .main
@@ -98,17 +99,18 @@ internal final class QuickSwitcherTextField: NSTextField {
             MainActor.assumeIsolated {
                 guard let self else { return }
                 self.window?.makeFirstResponder(self)
-                if let observer = self.becomeKeyObserver {
-                    NotificationCenter.default.removeObserver(observer)
-                    self.becomeKeyObserver = nil
+                if let installed = self.becomeKeyObserver.withLockUnchecked({ $0 }) {
+                    NotificationCenter.default.removeObserver(installed)
+                    self.becomeKeyObserver.withLockUnchecked { $0 = nil }
                 }
             }
         }
+        becomeKeyObserver.withLockUnchecked { $0 = observer }
     }
 
     deinit {
-        if let becomeKeyObserver {
-            NotificationCenter.default.removeObserver(becomeKeyObserver)
+        if let observer = becomeKeyObserver.withLockUnchecked({ $0 }) {
+            NotificationCenter.default.removeObserver(observer)
         }
     }
 }

--- a/TablePro/Views/Results/SortableHeaderView.swift
+++ b/TablePro/Views/Results/SortableHeaderView.swift
@@ -4,6 +4,7 @@
 //
 
 import AppKit
+import os
 
 struct HeaderSortTransition: Equatable {
     let newState: SortState
@@ -100,7 +101,7 @@ final class SortableHeaderView: NSTableHeaderView {
         return commentsByColumn[column.identifier]
     }
 
-    private var emphasisObservers: [NSObjectProtocol] = []
+    private let emphasisObservers = OSAllocatedUnfairLock<[any NSObjectProtocol]>(uncheckedState: [])
     private var firstResponderObservation: NSKeyValueObservation?
 
     override init(frame frameRect: NSRect) {
@@ -109,7 +110,7 @@ final class SortableHeaderView: NSTableHeaderView {
     }
 
     deinit {
-        emphasisObservers.forEach(NotificationCenter.default.removeObserver)
+        emphasisObservers.withLockUnchecked { $0.forEach(NotificationCenter.default.removeObserver) }
     }
 
     required init?(coder: NSCoder) {
@@ -119,8 +120,10 @@ final class SortableHeaderView: NSTableHeaderView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        emphasisObservers.forEach(NotificationCenter.default.removeObserver)
-        emphasisObservers.removeAll()
+        emphasisObservers.withLockUnchecked {
+            $0.forEach(NotificationCenter.default.removeObserver)
+            $0.removeAll()
+        }
         firstResponderObservation = nil
         guard let window else {
             applyEmphasis(false)
@@ -134,7 +137,7 @@ final class SortableHeaderView: NSTableHeaderView {
             ) { [weak self] _ in
                 MainActor.assumeIsolated { self?.refreshEmphasis() }
             }
-            emphasisObservers.append(observer)
+            emphasisObservers.withLockUnchecked { $0.append(observer) }
         }
         /// The header and the row bodies are two halves of one selection, so they have to agree on
         /// what emphasis means. `NSTableRowView.isEmphasized` is key window *and* table focus, and

--- a/TablePro/Views/Settings/Plugins/InstalledPluginsView.swift
+++ b/TablePro/Views/Settings/Plugins/InstalledPluginsView.swift
@@ -55,7 +55,7 @@ struct InstalledPluginsView: View {
                       let url = URL(dataRepresentation: data, relativeTo: nil) else { return }
                 let ext = url.pathExtension.lowercased()
                 guard ext == "zip" || ext == "tableplugin" else { return }
-                Task {
+                Task { @MainActor in
                     installPlugin(from: url)
                 }
             }

--- a/TablePro/Views/Settings/ShortcutRecorderView.swift
+++ b/TablePro/Views/Settings/ShortcutRecorderView.swift
@@ -6,6 +6,7 @@
 //
 
 import AppKit
+import os
 import SwiftUI
 
 // MARK: - ShortcutRecorderNSView
@@ -40,7 +41,7 @@ final class ShortcutRecorderNSView: NSView {
     /// `keyDown` never sees Command W and the menu command fires instead of being recorded. A
     /// local monitor runs earlier than menu dispatch, which is the only place the key is still
     /// interceptable.
-    private var recordingMonitor: Any?
+    private let recordingMonitor = OSAllocatedUnfairLock<Any?>(uncheckedState: nil)
 
     /// Currently held modifier flags during recording (for live display)
     private var activeModifiers: NSEvent.ModifierFlags = []
@@ -112,17 +113,18 @@ final class ShortcutRecorderNSView: NSView {
     }
 
     private func startRecordingMonitor() {
-        guard recordingMonitor == nil else { return }
-        recordingMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { [weak self] event in
+        guard recordingMonitor.withLockUnchecked({ $0 }) == nil else { return }
+        let monitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { [weak self] event in
             guard let self else { return event }
             return self.handleRecordingEvent(event)
         }
+        recordingMonitor.withLockUnchecked { $0 = monitor }
     }
 
     private func stopRecordingMonitor() {
-        guard let monitor = recordingMonitor else { return }
+        guard let monitor = recordingMonitor.withLockUnchecked({ $0 }) else { return }
         NSEvent.removeMonitor(monitor)
-        recordingMonitor = nil
+        recordingMonitor.withLockUnchecked { $0 = nil }
     }
 
     /// A local monitor is app-wide, so anything arriving while this view's window is not key
@@ -168,7 +170,7 @@ final class ShortcutRecorderNSView: NSView {
     }
 
     deinit {
-        guard let monitor = recordingMonitor else { return }
+        guard let monitor = recordingMonitor.withLockUnchecked({ $0 }) else { return }
         NSEvent.removeMonitor(monitor)
     }
 

--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator.swift
@@ -5,6 +5,7 @@
 
 import AppKit
 import Observation
+import os
 import SwiftUI
 import TableProPluginKit
 
@@ -54,7 +55,7 @@ final class DatabaseTreeOutlineCoordinator: NSObject {
 
     internal let schemaService = SchemaService.shared
     private var favoriteTables: Set<FavoriteTablesStorage.FavoriteEntry> = []
-    private var favoritesObserver: (any NSObjectProtocol)?
+    private let favoritesObserver = OSAllocatedUnfairLock<(any NSObjectProtocol)?>(uncheckedState: nil)
 
     init(favoriteTablesStorage: FavoriteTablesStorage = .shared) {
         self.favoriteTablesStorage = favoriteTablesStorage
@@ -73,7 +74,7 @@ final class DatabaseTreeOutlineCoordinator: NSObject {
 
     func attach(outlineView: NSOutlineView) {
         self.outlineView = outlineView
-        favoritesObserver = NotificationCenter.default.addObserver(
+        let observer = NotificationCenter.default.addObserver(
             forName: .favoriteTablesDidChange, object: nil, queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
@@ -82,11 +83,12 @@ final class DatabaseTreeOutlineCoordinator: NSObject {
                 self.refreshVisibleRows()
             }
         }
+        favoritesObserver.withLockUnchecked { $0 = observer }
     }
 
     deinit {
-        if let favoritesObserver {
-            NotificationCenter.default.removeObserver(favoritesObserver)
+        if let observer = favoritesObserver.withLockUnchecked({ $0 }) {
+            NotificationCenter.default.removeObserver(observer)
         }
     }
 

--- a/TablePro/Views/Sidebar/NativeSearchField.swift
+++ b/TablePro/Views/Sidebar/NativeSearchField.swift
@@ -6,11 +6,12 @@
 //
 
 import AppKit
+import os
 import SwiftUI
 
 private final class IntrinsicHeightSearchField: NSSearchField {
     var focusOnAppear = false
-    private var windowKeyObserver: NSObjectProtocol?
+    private let windowKeyObserver = OSAllocatedUnfairLock<(any NSObjectProtocol)?>(uncheckedState: nil)
 
     override var intrinsicContentSize: NSSize {
         let cellHeight = cell?.cellSize.height ?? super.intrinsicContentSize.height
@@ -25,7 +26,7 @@ private final class IntrinsicHeightSearchField: NSSearchField {
             window.makeFirstResponder(self)
             return
         }
-        windowKeyObserver = NotificationCenter.default.addObserver(
+        let observer = NotificationCenter.default.addObserver(
             forName: NSWindow.didBecomeKeyNotification,
             object: window,
             queue: .main
@@ -36,16 +37,17 @@ private final class IntrinsicHeightSearchField: NSSearchField {
                 self.window?.makeFirstResponder(self)
             }
         }
+        windowKeyObserver.withLockUnchecked { $0 = observer }
     }
 
     private func removeWindowKeyObserver() {
-        guard let token = windowKeyObserver else { return }
+        guard let token = windowKeyObserver.withLockUnchecked({ $0 }) else { return }
         NotificationCenter.default.removeObserver(token)
-        windowKeyObserver = nil
+        windowKeyObserver.withLockUnchecked { $0 = nil }
     }
 
     deinit {
-        if let token = windowKeyObserver {
+        if let token = windowKeyObserver.withLockUnchecked({ $0 }) {
             NotificationCenter.default.removeObserver(token)
         }
     }

--- a/TablePro/Views/Structure/StructureColumnReorderHandler.swift
+++ b/TablePro/Views/Structure/StructureColumnReorderHandler.swift
@@ -12,7 +12,7 @@ import TableProPluginKit
 
 @MainActor
 enum StructureColumnReorderHandler {
-    private static let logger = Logger(subsystem: "com.TablePro", category: "StructureColumnReorderHandler")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "StructureColumnReorderHandler")
 
     enum ReorderError: LocalizedError {
         case noDriver

--- a/TableProMobile/TableProMobile/Drivers/DriverSSLConfiguration.swift
+++ b/TableProMobile/TableProMobile/Drivers/DriverSSLConfiguration.swift
@@ -2,7 +2,7 @@ import Foundation
 import TableProModels
 import TableProOracleCore
 
-struct DriverSSLConfiguration: Equatable, Sendable {
+nonisolated struct DriverSSLConfiguration: Equatable, Sendable {
     let mode: SSLConfiguration.SSLMode
     let caCertificatePath: String?
     let clientCertificatePath: String?

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Decode.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Decode.swift
@@ -163,7 +163,7 @@ extension DuckDBActor {
     }
 }
 
-enum HugeIntFormatter {
+nonisolated enum HugeIntFormatter {
     static func format(upper: Int64, lower: UInt64) -> String {
         if upper == 0 {
             return String(lower)

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Schema.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Schema.swift
@@ -2,7 +2,7 @@ import Foundation
 import TableProDatabase
 import TableProModels
 
-extension DuckDBDriver {
+nonisolated extension DuckDBDriver {
     func fetchTables(schema: String?) async throws -> [TableInfo] {
         let schemaName = resolveSchema(schema)
         let query = """

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Streaming.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver+Streaming.swift
@@ -3,14 +3,14 @@ import Foundation
 import TableProDatabase
 import TableProModels
 
-struct DuckDBStreamColumn: Sendable {
+nonisolated struct DuckDBStreamColumn: Sendable {
     let name: String
     let typeName: String
     let type: duckdb_type
     let castToText: Bool
 }
 
-extension DuckDBDriver {
+nonisolated extension DuckDBDriver {
     private static func yieldMaterialized(
         query: String,
         options: StreamOptions,

--- a/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/DuckDBDriver.swift
@@ -4,7 +4,7 @@ import Foundation
 import TableProDatabase
 import TableProModels
 
-final class DuckDBDriver: DatabaseDriver, @unchecked Sendable {
+nonisolated final class DuckDBDriver: DatabaseDriver, @unchecked Sendable {
     static let inMemoryPath = ":memory:"
 
     let actor = DuckDBActor()
@@ -38,7 +38,7 @@ final class DuckDBDriver: DatabaseDriver, @unchecked Sendable {
         try await actor.open(path: resolvedPath)
         try? await actor.query("SET autoinstall_known_extensions=false")
         try? await actor.query("SET autoload_known_extensions=false")
-        setInterruptHandle(await actor.connectionHandle)
+        setInterruptHandle(await actor.connectionHandle.connection)
     }
 
     func disconnect() async throws {
@@ -105,9 +105,7 @@ final class DuckDBDriver: DatabaseDriver, @unchecked Sendable {
     }
 
     func cancelCurrentQuery() async throws {
-        stateLock.lock()
-        let handle = interruptHandle
-        stateLock.unlock()
+        let handle = stateLock.withLock { interruptHandle }
         guard let handle else { return }
         duckdb_interrupt(handle)
     }
@@ -164,6 +162,11 @@ final class DuckDBDriver: DatabaseDriver, @unchecked Sendable {
 
 // MARK: - DuckDB Actor (thread-safe C API access)
 
+/// Hands the open connection pointer out of the actor so a cancel can interrupt the running query.
+nonisolated struct DuckDBInterruptHandle: @unchecked Sendable {
+    let connection: duckdb_connection?
+}
+
 actor DuckDBActor {
     static let maxRows = 100_000
 
@@ -177,7 +180,7 @@ actor DuckDBActor {
     var streamResult: duckdb_result?
     var streamColumns: [DuckDBStreamColumn] = []
 
-    var connectionHandle: duckdb_connection? { connection }
+    var connectionHandle: DuckDBInterruptHandle { DuckDBInterruptHandle(connection: connection) }
 
     func interrupt() {
         guard let connection else { return }
@@ -407,7 +410,7 @@ actor DuckDBActor {
     }
 }
 
-struct DuckDBRawResult: @unchecked Sendable {
+nonisolated struct DuckDBRawResult: @unchecked Sendable {
     let columnNames: [String]
     let columnTypeNames: [String]
     let rows: [[String?]]
@@ -418,7 +421,7 @@ struct DuckDBRawResult: @unchecked Sendable {
 
 // MARK: - Errors
 
-enum DuckDBDriverError: Error, LocalizedError {
+nonisolated enum DuckDBDriverError: Error, LocalizedError {
     case connectionFailed(String)
     case notConnected
     case queryFailed(String)

--- a/TableProMobile/TableProMobile/Drivers/MSSQLDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/MSSQLDriver.swift
@@ -4,7 +4,7 @@ import TableProModels
 import TableProMSSQLCore
 import TableProPluginKit
 
-private extension MSSQLRawResult {
+nonisolated private extension MSSQLRawResult {
     nonisolated func toQueryResult(executionTime: TimeInterval) -> QueryResult {
         let columnInfos = columns.enumerated().map { idx, col in
             ColumnInfo(name: col.name, typeName: col.type.canonicalName, ordinalPosition: idx)
@@ -19,7 +19,7 @@ private extension MSSQLRawResult {
     }
 }
 
-final class MSSQLDriver: DatabaseDriver, @unchecked Sendable {
+nonisolated final class MSSQLDriver: DatabaseDriver, @unchecked Sendable {
     nonisolated(unsafe) private var conn: FreeTDSConnection
     private let options: MSSQLConnectionOptions
     private let additionalFields: [String: String]
@@ -303,7 +303,7 @@ final class MSSQLDriver: DatabaseDriver, @unchecked Sendable {
     }
 }
 
-private extension Array {
+nonisolated private extension Array {
     subscript(safe index: Int) -> Element? {
         indices.contains(index) ? self[index] : nil
     }

--- a/TableProMobile/TableProMobile/Drivers/MySQLDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/MySQLDriver.swift
@@ -3,7 +3,7 @@ import Foundation
 import TableProDatabase
 import TableProModels
 
-final class MySQLDriver: DatabaseDriver, @unchecked Sendable {
+nonisolated final class MySQLDriver: DatabaseDriver, @unchecked Sendable {
     private let actor = MySQLActor()
     private let host: String
     private let port: Int
@@ -500,7 +500,7 @@ private actor MySQLActor {
     }
 }
 
-enum MySQLBeginStreamResult: Sendable {
+nonisolated enum MySQLBeginStreamResult: Sendable {
     case rowSet([ColumnInfo])
     case noResult(affectedRows: Int)
 }
@@ -538,7 +538,7 @@ nonisolated private func mysqlFieldTypeName(_ typeValue: UInt32) -> String {
     }
 }
 
-private struct RawMySQLResult: Sendable {
+nonisolated private struct RawMySQLResult: Sendable {
     let columns: [String]
     let columnTypes: [String]
     let rows: [[String?]]
@@ -549,7 +549,7 @@ private struct RawMySQLResult: Sendable {
 
 // MARK: - Errors
 
-enum MySQLError: Error, LocalizedError {
+nonisolated enum MySQLError: Error, LocalizedError {
     case connectionFailed(String)
     case notConnected
     case queryFailed(String)

--- a/TableProMobile/TableProMobile/Drivers/OracleDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/OracleDriver.swift
@@ -3,7 +3,7 @@ import TableProDatabase
 import TableProModels
 import TableProOracleCore
 
-private extension OracleRawResult {
+nonisolated private extension OracleRawResult {
     nonisolated func toQueryResult(executionTime: TimeInterval) -> QueryResult {
         QueryResult(
             columns: columns.enumerated().map { index, column in
@@ -17,7 +17,7 @@ private extension OracleRawResult {
     }
 }
 
-final class OracleDriver: DatabaseDriver, @unchecked Sendable {
+nonisolated final class OracleDriver: DatabaseDriver, @unchecked Sendable {
     private let core: OracleCoreConnection
     private let host: String
     private let fallbackSchema: String

--- a/TableProMobile/TableProMobile/Drivers/PostgreSQLConnectionString.swift
+++ b/TableProMobile/TableProMobile/Drivers/PostgreSQLConnectionString.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum PostgreSQLConnectionString {
+nonisolated enum PostgreSQLConnectionString {
     static let connectTimeoutSeconds = 10
 
     static func build(

--- a/TableProMobile/TableProMobile/Drivers/PostgreSQLDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/PostgreSQLDriver.swift
@@ -3,7 +3,7 @@ import Foundation
 import TableProDatabase
 import TableProModels
 
-final class PostgreSQLDriver: DatabaseDriver, @unchecked Sendable {
+nonisolated final class PostgreSQLDriver: DatabaseDriver, @unchecked Sendable {
     private let actor = PostgreSQLActor()
     private let host: String
     private let port: Int
@@ -606,7 +606,7 @@ private actor PostgreSQLActor {
     }
 }
 
-enum PGBeginStreamResult: Sendable {
+nonisolated enum PGBeginStreamResult: Sendable {
     case tuples([ColumnInfo])
     case commandOk(affectedRows: Int)
 }
@@ -645,7 +645,7 @@ nonisolated private func pgOidToTypeName(_ oid: UInt32) -> String {
     }
 }
 
-private struct RawPGResult: Sendable {
+nonisolated private struct RawPGResult: Sendable {
     let columns: [String]
     let columnTypes: [String]
     let rows: [[String?]]
@@ -656,7 +656,7 @@ private struct RawPGResult: Sendable {
 
 // MARK: - Errors
 
-enum PostgreSQLError: Error, LocalizedError {
+nonisolated enum PostgreSQLError: Error, LocalizedError {
     case connectionFailed(String)
     case notConnected
     case queryFailed(String)

--- a/TableProMobile/TableProMobile/Drivers/RedisDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/RedisDriver.swift
@@ -4,7 +4,7 @@ import os
 import TableProDatabase
 import TableProModels
 
-final class RedisDriver: DatabaseDriver, @unchecked Sendable {
+nonisolated final class RedisDriver: DatabaseDriver, @unchecked Sendable {
     private let actor = RedisActor()
     private let host: String
     private let port: Int
@@ -333,7 +333,7 @@ final class RedisDriver: DatabaseDriver, @unchecked Sendable {
 
 // MARK: - Redis Reply Value
 
-private enum RedisReplyValue: Sendable {
+nonisolated private enum RedisReplyValue: Sendable {
     case string(String)
     case integer(Int64)
     case array([RedisReplyValue])
@@ -353,7 +353,7 @@ private enum RedisReplyValue: Sendable {
     }
 }
 
-private func withOptionalCString<R>(_ string: String?, _ body: (UnsafePointer<CChar>?) throws -> R) rethrows -> R {
+nonisolated private func withOptionalCString<R>(_ string: String?, _ body: (UnsafePointer<CChar>?) throws -> R) rethrows -> R {
     guard let string else { return try body(nil) }
     return try string.withCString { try body($0) }
 }
@@ -578,7 +578,7 @@ private actor RedisActor {
 
 // MARK: - Errors
 
-enum RedisError: Error, LocalizedError {
+nonisolated enum RedisError: Error, LocalizedError {
     case connectionFailed(String)
     case authenticationFailed(serverMessage: String, failure: RedisAuthCommand.Failure)
     case notConnected

--- a/TableProMobile/TableProMobile/Drivers/SQLiteDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/SQLiteDriver.swift
@@ -3,7 +3,7 @@ import SQLite3
 import TableProDatabase
 import TableProModels
 
-final class SQLiteDriver: DatabaseDriver, @unchecked Sendable {
+nonisolated final class SQLiteDriver: DatabaseDriver, @unchecked Sendable {
     private let dbPath: String
     private let actor = SQLiteActor()
 
@@ -426,12 +426,12 @@ private actor SQLiteActor {
     }
 }
 
-enum SQLiteBeginStreamResult: Sendable {
+nonisolated enum SQLiteBeginStreamResult: Sendable {
     case rowSet([ColumnInfo])
     case commandOk(affectedRows: Int)
 }
 
-private struct RawResult: Sendable {
+nonisolated private struct RawResult: Sendable {
     let columns: [String]
     let columnTypes: [String]
     let rows: [[String?]]
@@ -442,7 +442,7 @@ private struct RawResult: Sendable {
 
 // MARK: - Errors
 
-enum SQLiteError: Error, LocalizedError {
+nonisolated enum SQLiteError: Error, LocalizedError {
     case connectionFailed(String)
     case notConnected
     case queryFailed(String)

--- a/TableProMobile/TableProMobile/Helpers/AppError.swift
+++ b/TableProMobile/TableProMobile/Helpers/AppError.swift
@@ -5,7 +5,7 @@ import TableProOracleCore
 
 // MARK: - Error Category
 
-enum AppErrorCategory: Sendable {
+nonisolated enum AppErrorCategory: Sendable {
     case network
     case auth
     case config
@@ -16,7 +16,7 @@ enum AppErrorCategory: Sendable {
 
 // MARK: - App Error
 
-struct AppError: LocalizedError, Sendable {
+nonisolated struct AppError: LocalizedError, Sendable {
     let category: AppErrorCategory
     let title: String
     let message: String
@@ -47,7 +47,7 @@ struct AppError: LocalizedError, Sendable {
 
 // MARK: - Error Context
 
-struct ErrorContext: Sendable {
+nonisolated struct ErrorContext: Sendable {
     let operation: String
     let databaseType: DatabaseType?
     let host: String?
@@ -63,7 +63,7 @@ struct ErrorContext: Sendable {
 
 // MARK: - Error Classifier
 
-enum ErrorClassifier {
+nonisolated enum ErrorClassifier {
     private static let logger = Logger(subsystem: "com.TablePro", category: "Error")
 
     /// ORA-12514 and ORA-12505 each name the identifier kind the listener was

--- a/TableProMobile/TableProMobile/Helpers/ClipboardExporter.swift
+++ b/TableProMobile/TableProMobile/Helpers/ClipboardExporter.swift
@@ -3,14 +3,14 @@ import TableProModels
 import UIKit
 import UniformTypeIdentifiers
 
-enum ExportFormat: String, CaseIterable, Identifiable {
+nonisolated enum ExportFormat: String, CaseIterable, Identifiable {
     case json = "JSON"
     case csv = "CSV"
     case sqlInsert = "SQL INSERT"
     var id: String { rawValue }
 }
 
-enum ClipboardExporter {
+nonisolated enum ClipboardExporter {
     static func exportRow(columns: [ColumnInfo], row: [String?], format: ExportFormat, tableName: String? = nil) -> String {
         switch format {
         case .json:

--- a/TableProMobile/TableProMobile/Helpers/QueryHistoryStorage.swift
+++ b/TableProMobile/TableProMobile/Helpers/QueryHistoryStorage.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct QueryHistoryItem: Identifiable, Codable, Hashable {
+nonisolated struct QueryHistoryItem: Identifiable, Codable, Hashable {
     let id: UUID
     let query: String
     let timestamp: Date
@@ -35,7 +35,7 @@ struct QueryHistoryItem: Identifiable, Codable, Hashable {
     }
 }
 
-struct QueryHistoryStorage {
+nonisolated struct QueryHistoryStorage {
     private static let maxEntries = 200
 
     private var fileURL: URL? {

--- a/TableProMobile/TableProMobile/Helpers/SQLBuilder.swift
+++ b/TableProMobile/TableProMobile/Helpers/SQLBuilder.swift
@@ -4,7 +4,7 @@ import TableProModels
 import TableProPluginKit
 import TableProQuery
 
-enum SQLBuilder {
+nonisolated enum SQLBuilder {
     static func quoteIdentifier(_ name: String, for type: DatabaseType) -> String {
         switch type {
         case .mysql, .mariadb:

--- a/TableProMobile/TableProMobile/Intents/AddRowIntents.swift
+++ b/TableProMobile/TableProMobile/Intents/AddRowIntents.swift
@@ -3,13 +3,13 @@ import Foundation
 import TableProModels
 import UniformTypeIdentifiers
 
-protocol RowInsertingIntent: AppIntent {
+nonisolated protocol RowInsertingIntent: AppIntent {
     var connection: ConnectionEntity { get }
     var database: DatabaseEntity? { get }
     var table: TableEntity { get }
 }
 
-extension RowInsertingIntent {
+nonisolated extension RowInsertingIntent {
     func insert(rows: [PayloadRow]) async throws -> Int {
         guard let savedConnection = IntentConnectionLoader.connection(id: connection.id) else {
             throw IntentDataError.connectionNotFound
@@ -45,14 +45,14 @@ extension RowInsertingIntent {
 }
 
 struct AddRowToTableIntent: RowInsertingIntent {
-    static var title: LocalizedStringResource = "Add Row to Table"
-    static var description = IntentDescription(
+    static let title: LocalizedStringResource = "Add Row to Table"
+    static let description = IntentDescription(
         "Add one row to a table on a saved connection. Provide the row as a JSON object or a CSV row.",
         categoryName: "Database",
         searchKeywords: ["TablePro", "database", "SQL", "insert", "row", "table"]
     )
-    static var openAppWhenRun = false
-    static var authenticationPolicy: IntentAuthenticationPolicy = .requiresAuthentication
+    static let openAppWhenRun = false
+    static let authenticationPolicy: IntentAuthenticationPolicy = .requiresAuthentication
 
     @Parameter(title: "Connection")
     var connection: ConnectionEntity
@@ -82,14 +82,14 @@ struct AddRowToTableIntent: RowInsertingIntent {
 }
 
 struct AddRowsToTableIntent: RowInsertingIntent {
-    static var title: LocalizedStringResource = "Add Rows to Table"
-    static var description = IntentDescription(
+    static let title: LocalizedStringResource = "Add Rows to Table"
+    static let description = IntentDescription(
         "Add multiple rows to a table on a saved connection. Provide the rows as a JSON array, CSV text, or a file.",
         categoryName: "Database",
         searchKeywords: ["TablePro", "database", "SQL", "insert", "rows", "table", "import"]
     )
-    static var openAppWhenRun = false
-    static var authenticationPolicy: IntentAuthenticationPolicy = .requiresAuthentication
+    static let openAppWhenRun = false
+    static let authenticationPolicy: IntentAuthenticationPolicy = .requiresAuthentication
 
     @Parameter(title: "Connection")
     var connection: ConnectionEntity

--- a/TableProMobile/TableProMobile/Intents/ConnectionEntity.swift
+++ b/TableProMobile/TableProMobile/Intents/ConnectionEntity.swift
@@ -3,8 +3,8 @@ import Foundation
 import TableProModels
 
 struct ConnectionEntity: AppEntity {
-    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Connection")
-    static var defaultQuery = ConnectionEntityQuery()
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Connection")
+    static let defaultQuery = ConnectionEntityQuery()
 
     var id: UUID
     var name: String

--- a/TableProMobile/TableProMobile/Intents/DatabaseEntity.swift
+++ b/TableProMobile/TableProMobile/Intents/DatabaseEntity.swift
@@ -2,8 +2,8 @@ import AppIntents
 import Foundation
 
 struct DatabaseEntity: AppEntity {
-    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Database or Schema")
-    static var defaultQuery = DatabaseEntityQuery()
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Database or Schema")
+    static let defaultQuery = DatabaseEntityQuery()
 
     var id: String
     var name: String

--- a/TableProMobile/TableProMobile/Intents/IntentConnectionLoader.swift
+++ b/TableProMobile/TableProMobile/Intents/IntentConnectionLoader.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TableProModels
 
-enum IntentConnectionLoader {
+nonisolated enum IntentConnectionLoader {
     static func load() -> [DatabaseConnection] {
         guard let fileURL else { return [] }
         guard let data = try? Data(contentsOf: fileURL) else { return [] }

--- a/TableProMobile/TableProMobile/Intents/IntentDataError.swift
+++ b/TableProMobile/TableProMobile/Intents/IntentDataError.swift
@@ -1,7 +1,7 @@
 import AppIntents
 import Foundation
 
-enum IntentDataError: Error, CustomLocalizedStringResourceConvertible, Equatable {
+nonisolated enum IntentDataError: Error, CustomLocalizedStringResourceConvertible, Equatable {
     case connectionNotFound
     case unsupportedDatabaseType(String)
     case connectionFailed(String)

--- a/TableProMobile/TableProMobile/Intents/OpenConnectionIntent.swift
+++ b/TableProMobile/TableProMobile/Intents/OpenConnectionIntent.swift
@@ -3,13 +3,13 @@ import Foundation
 import UIKit
 
 struct OpenConnectionIntent: AppIntent {
-    static var title: LocalizedStringResource = "Open Connection"
-    static var description = IntentDescription(
+    static let title: LocalizedStringResource = "Open Connection"
+    static let description = IntentDescription(
         "Opens a database connection in TablePro",
         categoryName: "Database",
         searchKeywords: ["TablePro", "database", "connection", "SQL", "open"]
     )
-    static var openAppWhenRun = true
+    static let openAppWhenRun = true
 
     @Parameter(title: "Connection")
     var connection: ConnectionEntity

--- a/TableProMobile/TableProMobile/Intents/PayloadRow.swift
+++ b/TableProMobile/TableProMobile/Intents/PayloadRow.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum PayloadValue: Equatable {
+nonisolated enum PayloadValue: Equatable {
     case null
     case text(String)
 
@@ -23,7 +23,7 @@ enum PayloadValue: Equatable {
     }
 }
 
-struct PayloadRow: Equatable {
+nonisolated struct PayloadRow: Equatable {
     let values: [String: PayloadValue]
 
     var keys: [String] {

--- a/TableProMobile/TableProMobile/Intents/RowInserter.swift
+++ b/TableProMobile/TableProMobile/Intents/RowInserter.swift
@@ -2,7 +2,7 @@ import Foundation
 import TableProDatabase
 import TableProModels
 
-enum RowInsertPlanner {
+nonisolated enum RowInsertPlanner {
     static func statements(
         table: String,
         schema: String?,
@@ -40,7 +40,7 @@ enum RowInsertPlanner {
     }
 }
 
-enum RowInserter {
+nonisolated enum RowInserter {
     static func insert(
         driver: any DatabaseDriver,
         table: String,

--- a/TableProMobile/TableProMobile/Intents/RowPayload.swift
+++ b/TableProMobile/TableProMobile/Intents/RowPayload.swift
@@ -2,7 +2,7 @@ import AppIntents
 import Foundation
 import UniformTypeIdentifiers
 
-enum RowPayload {
+nonisolated enum RowPayload {
     static let maxRows = 10_000
 
     static func parse(data: String?, file: IntentFile?) async throws -> [PayloadRow] {
@@ -112,7 +112,7 @@ enum RowPayload {
     }
 }
 
-enum CSVRecordParser {
+nonisolated enum CSVRecordParser {
     static func parse(_ text: String) -> [[String]] {
         var records: [[String]] = []
         var record: [String] = []

--- a/TableProMobile/TableProMobile/Intents/TableEntity.swift
+++ b/TableProMobile/TableProMobile/Intents/TableEntity.swift
@@ -2,8 +2,8 @@ import AppIntents
 import Foundation
 
 struct TableEntity: AppEntity {
-    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Table")
-    static var defaultQuery = TableEntityQuery()
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Table")
+    static let defaultQuery = TableEntityQuery()
 
     var id: String
     var name: String

--- a/TableProMobile/TableProMobile/Platform/AppPreferences.swift
+++ b/TableProMobile/TableProMobile/Platform/AppPreferences.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TableProModels
 
-enum AppPreferences {
+nonisolated enum AppPreferences {
     static let cloudSyncEnabledKey = "com.TablePro.settings.cloudSyncEnabled"
     static let syncPasswordsKey = "com.TablePro.settings.syncPasswords"
     static let defaultPageSizeKey = "com.TablePro.settings.defaultPageSize"

--- a/TableProMobile/TableProMobile/Platform/FileBookmarkStore.swift
+++ b/TableProMobile/TableProMobile/Platform/FileBookmarkStore.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct FileBookmarkStore: Sendable {
+nonisolated struct FileBookmarkStore: Sendable {
     private let suiteName: String?
     private static let keyPrefix = "com.TablePro.fileBookmark."
 

--- a/TableProMobile/TableProMobile/Platform/IOSDriverFactory.swift
+++ b/TableProMobile/TableProMobile/Platform/IOSDriverFactory.swift
@@ -2,7 +2,7 @@ import Foundation
 import TableProDatabase
 import TableProModels
 
-final class IOSDriverFactory: DriverFactory {
+nonisolated final class IOSDriverFactory: DriverFactory {
     private let bookmarkStore: FileBookmarkStore
     private let materializer: CertificateMaterializer
 

--- a/TableProMobile/TableProMobile/Platform/KeychainSecureStore.swift
+++ b/TableProMobile/TableProMobile/Platform/KeychainSecureStore.swift
@@ -3,16 +3,16 @@ import os
 import Security
 import TableProDatabase
 
-final class KeychainSecureStore: SecureStore {
+nonisolated final class KeychainSecureStore: SecureStore {
     private static let logger = Logger(subsystem: "com.TablePro", category: "KeychainSecureStore")
 
     private let serviceName = "com.TablePro"
     private let accessGroup: String?
 
-    private static var cachedAccessGroup: String?
+    private static let cachedAccessGroup = OSAllocatedUnfairLock<String?>(initialState: nil)
 
     private static func resolveAccessGroup() -> String? {
-        if let cached = cachedAccessGroup { return cached }
+        if let cached = cachedAccessGroup.withLock({ $0 }) { return cached }
 
         guard let prefix = Bundle.main.infoDictionary?["AppIdentifierPrefix"] as? String,
               !prefix.isEmpty,
@@ -22,7 +22,7 @@ final class KeychainSecureStore: SecureStore {
         }
 
         let group = "\(prefix)com.TablePro.shared"
-        cachedAccessGroup = group
+        cachedAccessGroup.withLock { $0 = group }
         return group
     }
 
@@ -140,7 +140,7 @@ final class KeychainSecureStore: SecureStore {
     }
 }
 
-enum KeychainError: Error, LocalizedError {
+nonisolated enum KeychainError: Error, LocalizedError {
     case storeFailed(OSStatus)
     case retrieveFailed(OSStatus)
     case deleteFailed(OSStatus)

--- a/TableProMobile/TableProMobile/SSH/HostKeyStore.swift
+++ b/TableProMobile/TableProMobile/SSH/HostKeyStore.swift
@@ -10,7 +10,7 @@ import CryptoKit
 import Foundation
 import os
 
-final class HostKeyStore: @unchecked Sendable {
+nonisolated final class HostKeyStore: @unchecked Sendable {
     static let shared = HostKeyStore()
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "HostKeyStore")

--- a/TableProMobile/TableProMobile/SSH/SSHTunnel.swift
+++ b/TableProMobile/TableProMobile/SSH/SSHTunnel.swift
@@ -4,7 +4,7 @@ import os
 
 final class AliveFlag: Sendable {
     private let _lock = NSLock()
-    private nonisolated(unsafe) var _value = true
+    nonisolated(unsafe) private var _value = true
 
     nonisolated init() {}
 
@@ -12,6 +12,11 @@ final class AliveFlag: Sendable {
         get { _lock.lock(); defer { _lock.unlock() }; return _value }
         set { _lock.lock(); _value = newValue; _lock.unlock() }
     }
+}
+
+/// Hands a libssh2 channel out of the tunnel actor to the relay task that takes it over.
+nonisolated struct ChannelHandle: @unchecked Sendable {
+    let channel: OpaquePointer?
 }
 
 actor SSHTunnel {
@@ -256,12 +261,12 @@ actor SSHTunnel {
                 let clientFD = await self.acceptClient()
                 guard clientFD >= 0 else { continue }
 
-                let channel = await self.openDirectTcpipChannel(
+                let opened = await self.openDirectTcpipChannel(
                     remoteHost: remoteHost,
                     remotePort: remotePort
                 )
 
-                guard let channel else {
+                guard let channel = opened.channel else {
                     Self.logger.error("Failed to open direct-tcpip channel")
                     Darwin.close(clientFD)
                     continue
@@ -418,9 +423,9 @@ actor SSHTunnel {
         }
     }
 
-    private func openDirectTcpipChannel(remoteHost: String, remotePort: Int) -> OpaquePointer? {
+    private func openDirectTcpipChannel(remoteHost: String, remotePort: Int) -> ChannelHandle {
         for _ in 0..<30 {
-            guard isAlive, let session else { return nil }
+            guard isAlive, let session else { return ChannelHandle(channel: nil) }
 
             sessionLock.lock()
             let channel = libssh2_channel_direct_tcpip_ex(
@@ -433,19 +438,19 @@ actor SSHTunnel {
             let errNo = libssh2_session_last_errno(session)
             sessionLock.unlock()
 
-            if let channel {
-                return channel
+            if channel != nil {
+                return ChannelHandle(channel: channel)
             }
 
             guard errNo == LIBSSH2_ERROR_EAGAIN else {
-                return nil
+                return ChannelHandle(channel: nil)
             }
 
             if !waitForSocket(timeoutMs: 5_000) {
-                return nil
+                return ChannelHandle(channel: nil)
             }
         }
-        return nil
+        return ChannelHandle(channel: nil)
     }
 
     // Relay runs outside the actor on a detached thread.

--- a/TableProMobile/TableProMobile/Security/CertificateMaterialStore.swift
+++ b/TableProMobile/TableProMobile/Security/CertificateMaterialStore.swift
@@ -2,7 +2,7 @@ import Foundation
 import os
 import Security
 
-enum CertificateRole: String, CaseIterable, Identifiable, Sendable {
+nonisolated enum CertificateRole: String, CaseIterable, Identifiable, Sendable {
     case certificateAuthority
     case clientCertificate
     case clientKey
@@ -10,7 +10,7 @@ enum CertificateRole: String, CaseIterable, Identifiable, Sendable {
     var id: String { rawValue }
 }
 
-enum CertificateStoreError: Error, LocalizedError {
+nonisolated enum CertificateStoreError: Error, LocalizedError {
     case writeFailed(OSStatus)
 
     var errorDescription: String? {
@@ -18,14 +18,14 @@ enum CertificateStoreError: Error, LocalizedError {
     }
 }
 
-protocol CertificateMaterialStoring: Sendable {
+nonisolated protocol CertificateMaterialStoring: Sendable {
     func store(_ pem: String, role: CertificateRole, for connectionId: UUID) throws
     func pem(role: CertificateRole, for connectionId: UUID) -> String?
     func delete(role: CertificateRole, for connectionId: UUID)
     func deleteAll(for connectionId: UUID)
 }
 
-final class CertificateMaterialStore: CertificateMaterialStoring {
+nonisolated final class CertificateMaterialStore: CertificateMaterialStoring {
     private static let logger = Logger(subsystem: "com.TablePro", category: "CertificateMaterialStore")
     private let serviceName = "com.TablePro.clientCertificates"
 

--- a/TableProMobile/TableProMobile/Security/CertificateMaterializer.swift
+++ b/TableProMobile/TableProMobile/Security/CertificateMaterializer.swift
@@ -1,7 +1,7 @@
 import Foundation
 import os
 
-struct MaterializedCertificates: Equatable, Sendable {
+nonisolated struct MaterializedCertificates: Equatable, Sendable {
     let caCertificatePath: String?
     let clientCertificatePath: String?
     let clientKeyPath: String?
@@ -11,7 +11,7 @@ struct MaterializedCertificates: Equatable, Sendable {
     }
 }
 
-final class CertificateMaterializer {
+nonisolated final class CertificateMaterializer: @unchecked Sendable {
     private static let logger = Logger(subsystem: "com.TablePro", category: "CertificateMaterializer")
     private static let directoryName = "ClientCertificates"
 

--- a/TableProMobile/TableProMobile/Security/CertificatePreflight.swift
+++ b/TableProMobile/TableProMobile/Security/CertificatePreflight.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-enum CertificateRequirement: String, Equatable, Sendable {
+nonisolated enum CertificateRequirement: String, Equatable, Sendable {
     case certificateAuthority
     case clientCertificate
     case clientKey
 }
 
-enum CertificatePreflightError: Error, LocalizedError, Equatable {
+nonisolated enum CertificatePreflightError: Error, LocalizedError, Equatable {
     case fileMissing(CertificateRequirement)
     case clientCertificateWithoutKey
     case clientKeyWithoutCertificate
@@ -27,7 +27,7 @@ enum CertificatePreflightError: Error, LocalizedError, Equatable {
     }
 }
 
-enum CertificatePreflight {
+nonisolated enum CertificatePreflight {
     static func validate(_ ssl: DriverSSLConfiguration) throws {
         guard ssl.isEnabled else { return }
 

--- a/TableProMobile/TableProMobile/Security/CertificateSummary.swift
+++ b/TableProMobile/TableProMobile/Security/CertificateSummary.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Security
 
-enum CertificateSummary {
+nonisolated enum CertificateSummary {
     static func subject(ofFirstCertificateIn pem: String) -> String? {
         guard let block = PEMDocument.inspect(pem).certificates.first,
               let der = der(from: block.text),

--- a/TableProMobile/TableProMobile/Security/PEMDocument.swift
+++ b/TableProMobile/TableProMobile/Security/PEMDocument.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum PEMLabel: String, CaseIterable, Sendable {
+nonisolated enum PEMLabel: String, CaseIterable, Sendable {
     case certificate = "CERTIFICATE"
     case pkcs8PrivateKey = "PRIVATE KEY"
     case rsaPrivateKey = "RSA PRIVATE KEY"
@@ -10,12 +10,12 @@ enum PEMLabel: String, CaseIterable, Sendable {
     var isPrivateKey: Bool { self != .certificate }
 }
 
-struct PEMBlock: Equatable, Sendable {
+nonisolated struct PEMBlock: Equatable, Sendable {
     let label: PEMLabel
     let text: String
 }
 
-struct PEMInspection: Equatable, Sendable {
+nonisolated struct PEMInspection: Equatable, Sendable {
     let certificates: [PEMBlock]
     let privateKeys: [PEMBlock]
     let usesPassphrase: Bool
@@ -23,7 +23,7 @@ struct PEMInspection: Equatable, Sendable {
     var isEmpty: Bool { certificates.isEmpty && privateKeys.isEmpty }
 }
 
-enum PEMDocument {
+nonisolated enum PEMDocument {
     static let lineLength = 64
 
     static func inspect(_ text: String) -> PEMInspection {

--- a/TableProMobile/TableProMobile/Security/PKCS12Importer.swift
+++ b/TableProMobile/TableProMobile/Security/PKCS12Importer.swift
@@ -2,13 +2,13 @@ import CryptoKit
 import Foundation
 import Security
 
-struct ClientCertificateMaterial: Equatable, Sendable {
+nonisolated struct ClientCertificateMaterial: Equatable, Sendable {
     let certificateChainPEM: String
     let privateKeyPEM: String
     let commonName: String?
 }
 
-enum PKCS12ImportError: Error, LocalizedError, Equatable {
+nonisolated enum PKCS12ImportError: Error, LocalizedError, Equatable {
     case passwordRequired
     case importFailed(OSStatus)
     case noIdentityInFile
@@ -28,7 +28,7 @@ enum PKCS12ImportError: Error, LocalizedError, Equatable {
     }
 }
 
-enum PKCS12Importer {
+nonisolated enum PKCS12Importer {
     static func material(from data: Data, password: String) throws -> ClientCertificateMaterial {
         guard !password.isEmpty else { throw PKCS12ImportError.passwordRequired }
 

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -494,8 +494,9 @@ struct QueryEditorView: View {
         activity: Activity<QueryActivityAttributes>?,
         startedAt: Date
     ) -> Task<Void, Never> {
-        Task { [weak viewModel] in
+        return Task { [weak viewModel] in
             guard let activity else { return }
+            nonisolated(unsafe) let liveActivity = activity
             var lastReportedCount = 0
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(1))
@@ -508,7 +509,7 @@ struct QueryEditorView: View {
                     endedAt: nil,
                     rowsStreamed: count
                 )
-                await activity.update(.init(
+                await liveActivity.update(.init(
                     state: state,
                     staleDate: startedAt.addingTimeInterval(5 * 60)
                 ))
@@ -523,8 +524,9 @@ struct QueryEditorView: View {
             endedAt: Date(),
             rowsStreamed: viewModel.legacyRows.count
         )
+        nonisolated(unsafe) let liveActivity = activity
         Task {
-            await activity.end(.init(state: final, staleDate: nil), dismissalPolicy: .immediate)
+            await liveActivity.end(.init(state: final, staleDate: nil), dismissalPolicy: .immediate)
         }
     }
 }

--- a/TableProMobile/TableProWidget/Shared/QueryActivityAttributes.swift
+++ b/TableProMobile/TableProWidget/Shared/QueryActivityAttributes.swift
@@ -1,7 +1,7 @@
 import ActivityKit
 import Foundation
 
-struct QueryActivityAttributes: ActivityAttributes {
+nonisolated struct QueryActivityAttributes: ActivityAttributes {
     public struct ContentState: Codable, Hashable {
         var startedAt: Date
         var endedAt: Date?

--- a/TableProMobile/TableProWidget/Shared/WidgetConnectionItem.swift
+++ b/TableProMobile/TableProWidget/Shared/WidgetConnectionItem.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct WidgetConnectionItem: Codable, Identifiable, Hashable {
+nonisolated struct WidgetConnectionItem: Codable, Identifiable, Hashable {
     let id: UUID
     let name: String
     let type: String

--- a/TableProTests/Core/AI/ChatTurnObservationTests.swift
+++ b/TableProTests/Core/AI/ChatTurnObservationTests.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import Observation
+import os
 @testable import TablePro
 import Testing
 
@@ -22,16 +23,16 @@ struct ChatTurnObservationTests {
         let (turn, _) = makeStreamingTurn()
         viewModel.messages.append(turn)
 
-        var messagesInvalidated = false
+        let messagesInvalidated = OSAllocatedUnfairLock(initialState: false)
         withObservationTracking {
             _ = viewModel.messages.count
         } onChange: {
-            messagesInvalidated = true
+            messagesInvalidated.withLock { $0 = true }
         }
 
         turn.appendStreamingToken("hello")
 
-        #expect(messagesInvalidated == false)
+        #expect(messagesInvalidated.withLock { $0 } == false)
         #expect(turn.plainText == "hello")
     }
 
@@ -39,32 +40,32 @@ struct ChatTurnObservationTests {
     func tokenAppendDoesNotInvalidateBlockList() {
         let (turn, _) = makeStreamingTurn()
 
-        var blockListInvalidated = false
+        let blockListInvalidated = OSAllocatedUnfairLock(initialState: false)
         withObservationTracking {
             _ = turn.blocks.count
         } onChange: {
-            blockListInvalidated = true
+            blockListInvalidated.withLock { $0 = true }
         }
 
         turn.appendStreamingToken("hello")
 
-        #expect(blockListInvalidated == false)
+        #expect(blockListInvalidated.withLock { $0 } == false)
     }
 
     @Test("Appending a streaming token invalidates only the block that grew")
     func tokenAppendInvalidatesGrowingBlock() {
         let (turn, block) = makeStreamingTurn()
 
-        var blockInvalidated = false
+        let blockInvalidated = OSAllocatedUnfairLock(initialState: false)
         withObservationTracking {
             _ = block.kind
         } onChange: {
-            blockInvalidated = true
+            blockInvalidated.withLock { $0 = true }
         }
 
         turn.appendStreamingToken("hello")
 
-        #expect(blockInvalidated)
+        #expect(blockInvalidated.withLock { $0 })
     }
 
     @Test("The message list's own reads survive a streaming token without invalidation")
@@ -74,7 +75,7 @@ struct ChatTurnObservationTests {
         viewModel.messages.append(turn)
         viewModel.streamingState = .streaming(assistantID: turn.id)
 
-        var panelInvalidated = false
+        let panelInvalidated = OSAllocatedUnfairLock(initialState: false)
         withObservationTracking {
             for message in viewModel.messages {
                 _ = message.id
@@ -84,12 +85,12 @@ struct ChatTurnObservationTests {
                 }
             }
         } onChange: {
-            panelInvalidated = true
+            panelInvalidated.withLock { $0 = true }
         }
 
         turn.appendStreamingToken("hello")
 
-        #expect(panelInvalidated == false)
+        #expect(panelInvalidated.withLock { $0 } == false)
     }
 
     @Test("Starting a new block invalidates the owning turn but not the messages array")
@@ -98,24 +99,24 @@ struct ChatTurnObservationTests {
         let (turn, _) = makeStreamingTurn()
         viewModel.messages.append(turn)
 
-        var messagesInvalidated = false
+        let messagesInvalidated = OSAllocatedUnfairLock(initialState: false)
         withObservationTracking {
             _ = viewModel.messages.count
         } onChange: {
-            messagesInvalidated = true
+            messagesInvalidated.withLock { $0 = true }
         }
 
-        var blockListInvalidated = false
+        let blockListInvalidated = OSAllocatedUnfairLock(initialState: false)
         withObservationTracking {
             _ = turn.blocks.count
         } onChange: {
-            blockListInvalidated = true
+            blockListInvalidated.withLock { $0 = true }
         }
 
         turn.appendBlock(.toolUse(ToolUseBlock(id: "t1", name: "noop", input: .object([:]))))
 
-        #expect(messagesInvalidated == false)
-        #expect(blockListInvalidated)
+        #expect(messagesInvalidated.withLock { $0 } == false)
+        #expect(blockListInvalidated.withLock { $0 })
     }
 
     @Test("Setting usage on one turn does not invalidate a sibling turn")
@@ -123,15 +124,15 @@ struct ChatTurnObservationTests {
         let first = ChatTurn(role: .assistant, blocks: [ChatContentBlock.text("done")])
         let (second, _) = makeStreamingTurn()
 
-        var siblingInvalidated = false
+        let siblingInvalidated = OSAllocatedUnfairLock(initialState: false)
         withObservationTracking {
             _ = first.usage
         } onChange: {
-            siblingInvalidated = true
+            siblingInvalidated.withLock { $0 = true }
         }
 
         second.usage = AITokenUsage(inputTokens: 10, outputTokens: 20)
 
-        #expect(siblingInvalidated == false)
+        #expect(siblingInvalidated.withLock { $0 } == false)
     }
 }

--- a/TableProTests/Core/AI/ExecuteToolUsesTests.swift
+++ b/TableProTests/Core/AI/ExecuteToolUsesTests.swift
@@ -13,7 +13,7 @@ import Testing
 struct ExecuteToolUsesTests {
     /// Stub tool that returns a fixed response when invoked. Tracks invocation
     /// count and the input it received so tests can assert dispatch behaviour.
-    private final class StubTool: ChatTool {
+    private final class StubTool: ChatTool, @unchecked Sendable {
         let name: String
         let description: String
         let inputSchema: JsonValue

--- a/TableProTests/Core/Database/DatabaseManagerSchemaChangeRoutingTests.swift
+++ b/TableProTests/Core/Database/DatabaseManagerSchemaChangeRoutingTests.swift
@@ -39,7 +39,7 @@ private class SchemaRoutingBaseDriver {
     }
 }
 
-private final class SchemaRoutingDriver: SchemaRoutingBaseDriver, PluginDatabaseDriver {
+private final class SchemaRoutingDriver: SchemaRoutingBaseDriver, PluginDatabaseDriver, @unchecked Sendable {
     private(set) var executedQueries: [String] = []
     private(set) var switchedDatabases: [String] = []
     var switchDatabaseError: Error?

--- a/TableProTests/Core/Database/DatabaseManagerTests.swift
+++ b/TableProTests/Core/Database/DatabaseManagerTests.swift
@@ -120,7 +120,7 @@ private class DatabaseSwitchBaseDriver {
     }
 }
 
-private final class DatabaseSwitchingDriver: DatabaseSwitchBaseDriver, PluginDatabaseDriver {
+private final class DatabaseSwitchingDriver: DatabaseSwitchBaseDriver, PluginDatabaseDriver, @unchecked Sendable {
     private(set) var switchedDatabases: [String] = []
     private var schema: String?
 

--- a/TableProTests/Core/Database/ScopedDriverPinningTests.swift
+++ b/TableProTests/Core/Database/ScopedDriverPinningTests.swift
@@ -129,9 +129,7 @@ private final class CallRecordingPluginDriver: PluginDatabaseDriver, @unchecked 
     }
 
     func switchDatabase(to database: String) async throws {
-        lock.lock()
-        self.database = database
-        lock.unlock()
+        lock.withLock { self.database = database }
         record("switch:\(database)")
     }
 

--- a/TableProTests/Core/Database/TableOperationSQLBuilderTests.swift
+++ b/TableProTests/Core/Database/TableOperationSQLBuilderTests.swift
@@ -8,7 +8,7 @@ import Foundation
 import TableProPluginKit
 import Testing
 
-private final class StubDropDriver: PluginDatabaseDriver {
+private final class StubDropDriver: PluginDatabaseDriver, @unchecked Sendable {
     var supportsSchemas: Bool { false }
     var supportsTransactions: Bool { false }
     var currentSchema: String? { nil }

--- a/TableProTests/Core/Database/TriggerInfoMappingTests.swift
+++ b/TableProTests/Core/Database/TriggerInfoMappingTests.swift
@@ -10,7 +10,7 @@ import Foundation
 import TableProPluginKit
 import Testing
 
-private final class StubTriggerDriver: PluginDatabaseDriver {
+private final class StubTriggerDriver: PluginDatabaseDriver, @unchecked Sendable {
     var supportsSchemas: Bool { false }
     var supportsTransactions: Bool { false }
     var currentSchema: String? { nil }

--- a/TableProTests/Core/MCP/Transport/MCPStreamableHttpClientTransportTests.swift
+++ b/TableProTests/Core/MCP/Transport/MCPStreamableHttpClientTransportTests.swift
@@ -655,12 +655,12 @@ final class MockHttpServer: @unchecked Sendable {
     }
 
     func stop() async {
-        lock.lock()
-        let listener = self.listener
-        let connections = self.connections
-        self.listener = nil
-        self.connections = []
-        lock.unlock()
+        let (listener, connections) = lock.withLock { () -> (NWListener?, [NWConnection]) in
+            let taken = (self.listener, self.connections)
+            self.listener = nil
+            self.connections = []
+            return taken
+        }
         listener?.cancel()
         for connection in connections {
             connection.cancel()

--- a/TableProTests/Core/Plugins/ExplainQueryPluginTests.swift
+++ b/TableProTests/Core/Plugins/ExplainQueryPluginTests.swift
@@ -9,15 +9,15 @@ import Testing
 
 /// Minimal stub implementing PluginDatabaseDriver for testing buildExplainQuery.
 /// Returns a fixed explain string or nil depending on configuration.
-private final class StubExplainDriver: PluginDatabaseDriver {
+private final class StubExplainDriver: PluginDatabaseDriver, @unchecked Sendable {
     var supportsSchemas: Bool { false }
     var supportsTransactions: Bool { false }
     var currentSchema: String? { nil }
     var serverVersion: String? { nil }
 
-    private let explainResult: ((String) -> String?)?
+    private let explainResult: (@Sendable (String) -> String?)?
 
-    init(explainResult: ((String) -> String?)? = nil) {
+    init(explainResult: (@Sendable (String) -> String?)? = nil) {
         self.explainResult = explainResult
     }
 

--- a/TableProTests/Core/Plugins/PluginDriverAdapterPartitionDefaultTests.swift
+++ b/TableProTests/Core/Plugins/PluginDriverAdapterPartitionDefaultTests.swift
@@ -8,7 +8,7 @@ import Foundation
 import TableProPluginKit
 import Testing
 
-private final class PartitionUnawareDriver: PluginDatabaseDriver {
+private final class PartitionUnawareDriver: PluginDatabaseDriver, @unchecked Sendable {
     var supportsSchemas: Bool { false }
     var supportsTransactions: Bool { false }
     var currentSchema: String? { nil }

--- a/TableProTests/Core/Plugins/PluginDriverAdapterPingTests.swift
+++ b/TableProTests/Core/Plugins/PluginDriverAdapterPingTests.swift
@@ -8,7 +8,7 @@ import Foundation
 import TableProPluginKit
 import Testing
 
-private class BasePingDriver {
+private class BasePingDriver: @unchecked Sendable {
     var supportsSchemas: Bool { false }
     var supportsTransactions: Bool { false }
     var currentSchema: String? { nil }
@@ -42,7 +42,7 @@ private class BasePingDriver {
 
 private final class DefaultPingDriver: BasePingDriver, PluginDatabaseDriver {}
 
-private final class PingOverrideDriver: BasePingDriver, PluginDatabaseDriver {
+private final class PingOverrideDriver: BasePingDriver, PluginDatabaseDriver, @unchecked Sendable {
     private(set) var pingCallCount = 0
 
     func ping() async throws {

--- a/TableProTests/Core/Plugins/PluginDriverAdapterTableOpsTests.swift
+++ b/TableProTests/Core/Plugins/PluginDriverAdapterTableOpsTests.swift
@@ -8,7 +8,7 @@ import Foundation
 import TableProPluginKit
 import Testing
 
-private final class StubTableOpsDriver: PluginDatabaseDriver {
+private final class StubTableOpsDriver: PluginDatabaseDriver, @unchecked Sendable {
     var supportsSchemas: Bool { false }
     var supportsTransactions: Bool { false }
     var currentSchema: String? { nil }

--- a/TableProTests/Core/Plugins/PluginDriverAdapterTableTypeMappingTests.swift
+++ b/TableProTests/Core/Plugins/PluginDriverAdapterTableTypeMappingTests.swift
@@ -8,7 +8,7 @@ import Foundation
 import TableProPluginKit
 import Testing
 
-private final class StubTableTypeDriver: PluginDatabaseDriver {
+private final class StubTableTypeDriver: PluginDatabaseDriver, @unchecked Sendable {
     var stubbedSupportsSchemas = false
     var stubbedCurrentSchema: String?
 

--- a/TableProTests/Core/Plugins/PluginParameterEscapingTests.swift
+++ b/TableProTests/Core/Plugins/PluginParameterEscapingTests.swift
@@ -7,7 +7,7 @@ import Foundation
 import TableProPluginKit
 import Testing
 
-private final class StubDriver: PluginDatabaseDriver {
+private final class StubDriver: PluginDatabaseDriver, @unchecked Sendable {
     var supportsSchemas: Bool { false }
     var supportsTransactions: Bool { false }
     var currentSchema: String? { nil }
@@ -35,7 +35,7 @@ private final class StubDriver: PluginDatabaseDriver {
     }
 }
 
-private final class SqlStandardStubDriver: PluginDatabaseDriver {
+private final class SqlStandardStubDriver: PluginDatabaseDriver, @unchecked Sendable {
     var supportsSchemas: Bool { false }
     var supportsTransactions: Bool { false }
     var currentSchema: String? { nil }

--- a/TableProTests/Core/Plugins/PluginValidationTests.swift
+++ b/TableProTests/Core/Plugins/PluginValidationTests.swift
@@ -11,16 +11,16 @@ import Testing
 // MARK: - Mock DriverPlugin for Testing
 
 private final class MockDriverPlugin: NSObject, TableProPlugin, DriverPlugin {
-    static var pluginName = "MockDriver"
-    static var pluginVersion = "1.0.0"
-    static var pluginDescription = "Test plugin"
-    static var capabilities: [PluginCapability] = [.databaseDriver]
-    static var dependencies: [String] = []
+    static let pluginName = "MockDriver"
+    static let pluginVersion = "1.0.0"
+    static let pluginDescription = "Test plugin"
+    static let capabilities: [PluginCapability] = [.databaseDriver]
+    static let dependencies: [String] = []
 
-    static var databaseTypeId = "mock-db"
-    static var databaseDisplayName = "Mock Database"
-    static var iconName = "cylinder.fill"
-    static var defaultPort = 9999
+    nonisolated(unsafe) static var databaseTypeId = "mock-db"
+    nonisolated(unsafe) static var databaseDisplayName = "Mock Database"
+    static let iconName = "cylinder.fill"
+    static let defaultPort = 9999
 
     func createDriver(config: DriverConnectionConfig) -> any PluginDatabaseDriver {
         fatalError("Not used in tests")
@@ -40,7 +40,7 @@ private final class MockDriverPlugin: NSObject, TableProPlugin, DriverPlugin {
         additionalDatabaseTypeIds = additionalIds
     }
 
-    static var additionalDatabaseTypeIds: [String] = []
+    nonisolated(unsafe) static var additionalDatabaseTypeIds: [String] = []
 }
 
 // MARK: - validateDriverDescriptor Tests

--- a/TableProTests/Core/SSH/SSHForwardChannelOpenPumpTests.swift
+++ b/TableProTests/Core/SSH/SSHForwardChannelOpenPumpTests.swift
@@ -132,7 +132,7 @@ struct SSHForwardChannelOpenPumpTests {
         )
     }
 
-    private static let fakeChannel = OpaquePointer(bitPattern: 0xDEAD_BEEF)!
+    private static var fakeChannel: OpaquePointer { OpaquePointer(bitPattern: 0xDEAD_BEEF)! }
 }
 
 @Suite("handleChannelOpenOutcome")

--- a/TableProTests/Core/Services/Execution/ExecutionGateTests.swift
+++ b/TableProTests/Core/Services/Execution/ExecutionGateTests.swift
@@ -8,7 +8,7 @@ import Foundation
 import Testing
 
 @MainActor
-final class StubConfirming: OperationConfirming {
+final class StubConfirming: OperationConfirming, @unchecked Sendable {
     private(set) var callCount = 0
     private(set) var lastDestructive = false
     private let answer: Bool

--- a/TableProTests/Core/Services/ForeignApp/TablePlusImporterTests.swift
+++ b/TableProTests/Core/Services/ForeignApp/TablePlusImporterTests.swift
@@ -631,12 +631,26 @@ struct TablePlusImporterTests {
     }
 }
 
-private final class KeychainSpy {
-    var calls: [(service: String, account: String)] = []
-    var responses: [String: KeychainReadResult] = [:]
+private final class KeychainSpy: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedCalls: [(service: String, account: String)] = []
+    private var storedResponses: [String: KeychainReadResult] = [:]
 
-    func read(_ service: String, _ account: String) -> KeychainReadResult {
-        calls.append((service: service, account: account))
-        return responses[account] ?? .notFound
+    var calls: [(service: String, account: String)] {
+        lock.withLock { recordedCalls }
+    }
+
+    var responses: [String: KeychainReadResult] {
+        get { lock.withLock { storedResponses } }
+        set { lock.withLock { storedResponses = newValue } }
+    }
+
+    var read: ForeignKeychainRead {
+        { [self] service, account in
+            lock.withLock {
+                recordedCalls.append((service: service, account: account))
+                return storedResponses[account] ?? .notFound
+            }
+        }
     }
 }

--- a/TableProTests/Core/Services/Infrastructure/WindowOpenerTests.swift
+++ b/TableProTests/Core/Services/Infrastructure/WindowOpenerTests.swift
@@ -11,8 +11,8 @@ final class WindowOpenerTests: XCTestCase {
     private var openedRequests: [ConnectionFormRequest] = []
     private var openedSettingsPanes: [SettingsPane?] = []
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         _ = WelcomeRouter.shared.consumePendingRequest()
         openedRequests = []
         openedSettingsPanes = []
@@ -26,9 +26,9 @@ final class WindowOpenerTests: XCTestCase {
         }
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         _ = WelcomeRouter.shared.consumePendingRequest()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func testNewConnectionRoutesTheChooserInsteadOfOpeningAWindow() {

--- a/TableProTests/Core/Storage/GroupStorageTests.swift
+++ b/TableProTests/Core/Storage/GroupStorageTests.swift
@@ -19,8 +19,8 @@ final class GroupStorageTests: XCTestCase {
     private var connectionStorage: ConnectionStorage!
     private var connectionFileURL: URL!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         let unique = UUID().uuidString
         suiteName = "com.TablePro.tests.GroupStorage.\(unique)"
         defaults = UserDefaults(suiteName: suiteName)!

--- a/TableProTests/Editor/PasteHighlightCancelTests.swift
+++ b/TableProTests/Editor/PasteHighlightCancelTests.swift
@@ -14,7 +14,7 @@
 
 import AppKit
 import CodeEditLanguages
-@testable import CodeEditSourceEditor
+@preconcurrency @testable import CodeEditSourceEditor
 import CodeEditTextView
 import Foundation
 import Rearrange

--- a/TableProTests/Helpers/FakeMSSQLPlugin.swift
+++ b/TableProTests/Helpers/FakeMSSQLPlugin.swift
@@ -8,6 +8,7 @@
 //
 
 import Foundation
+import os
 import TableProPluginKit
 @testable import TablePro
 
@@ -171,21 +172,17 @@ final class FakeMSSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 }
 
 enum FakeMSSQLPluginRegistration {
-    private static var didRegister = false
-    private static let lock = NSLock()
+    private static let didRegister = OSAllocatedUnfairLock(initialState: false)
 
     @MainActor
     static func registerIfNeeded() {
-        lock.lock()
-        defer { lock.unlock() }
-        guard !didRegister else { return }
-        let manager = PluginManager.shared
-        if manager.driverPlugins[FakeMSSQLPlugin.databaseTypeId] != nil {
-            didRegister = true
-            return
+        let alreadyRegistered = didRegister.withLock { registered -> Bool in
+            defer { registered = true }
+            return registered
         }
-        let instance = FakeMSSQLPlugin()
-        manager.driverPlugins[FakeMSSQLPlugin.databaseTypeId] = instance
-        didRegister = true
+        guard !alreadyRegistered else { return }
+        let manager = PluginManager.shared
+        guard manager.driverPlugins[FakeMSSQLPlugin.databaseTypeId] == nil else { return }
+        manager.driverPlugins[FakeMSSQLPlugin.databaseTypeId] = FakeMSSQLPlugin()
     }
 }

--- a/TableProTests/Plugins/MySQLGrantEscapingTests.swift
+++ b/TableProTests/Plugins/MySQLGrantEscapingTests.swift
@@ -137,6 +137,8 @@ struct PluginGrantSQLBuilderTests {
             return "\(database(db)).*"
         case let .table(db, _, table), let .column(db, _, table, _):
             return "\(database(db)).\(mysqlQuote(table))"
+        @unknown default:
+            return nil
         }
     }
 

--- a/TableProTests/SOCKS/SOCKSProxyManagerTests.swift
+++ b/TableProTests/SOCKS/SOCKSProxyManagerTests.swift
@@ -302,7 +302,7 @@ private struct TestTCPClient {
         let connection = NWConnection(host: "127.0.0.1", port: nwPort, using: .tcp)
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             let resumed = OSAllocatedUnfairLock(initialState: false)
-            let finish: (Result<Void, Error>) -> Void = { result in
+            let finish: @Sendable (Result<Void, Error>) -> Void = { result in
                 let shouldResume = resumed.withLock { done -> Bool in
                     guard !done else { return false }
                     done = true

--- a/TableProTests/ViewModels/WelcomeViewModelTests.swift
+++ b/TableProTests/ViewModels/WelcomeViewModelTests.swift
@@ -20,8 +20,8 @@ final class WelcomeViewModelTests: XCTestCase {
     private var welcomeRouter: WelcomeRouter!
     private var viewModel: WelcomeViewModel!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         let unique = UUID().uuidString
         suiteName = "com.TablePro.tests.WelcomeViewModel.\(unique)"
         syncSuiteName = "com.TablePro.tests.WelcomeViewModel.sync.\(unique)"

--- a/TableProTests/Views/AIChat/CodeBlockHeightEstimatorTests.swift
+++ b/TableProTests/Views/AIChat/CodeBlockHeightEstimatorTests.swift
@@ -9,7 +9,7 @@ import Testing
 
 @Suite("Code block height estimation")
 struct CodeBlockHeightEstimatorTests {
-    private static let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+    private static var font: NSFont { NSFont.monospacedSystemFont(ofSize: 12, weight: .regular) }
 
     private func height(_ code: String, width: CGFloat = 480) -> CGFloat {
         CodeBlockHeightEstimator.height(for: code, font: Self.font, availableWidth: width)

--- a/TableProTests/Views/Editor/QueryEditorLargePasteTests.swift
+++ b/TableProTests/Views/Editor/QueryEditorLargePasteTests.swift
@@ -13,7 +13,7 @@
 //
 
 import CodeEditLanguages
-@testable import CodeEditSourceEditor
+@preconcurrency @testable import CodeEditSourceEditor
 import CodeEditTextView
 import Foundation
 import Testing

--- a/TableProTests/Views/Editor/SQLCompletionProviderConcurrencyTests.swift
+++ b/TableProTests/Views/Editor/SQLCompletionProviderConcurrencyTests.swift
@@ -62,6 +62,12 @@ struct SQLCompletionProviderConcurrencyTests {
         #expect(rankedLabels.isSubset(of: filteredLabels))
     }
 
+    /// The point of the test is that `filterAndRank` reads no mutable state, which is what the
+    /// compiler cannot see from the provider's type alone.
+    private struct ConcurrentProvider: @unchecked Sendable {
+        let provider: SQLCompletionProvider
+    }
+
     @Test("filterAndRank is safe under concurrent invocations from a detached task")
     func filterAndRankConcurrent() async {
         let provider = makeProvider()
@@ -70,10 +76,11 @@ struct SQLCompletionProviderConcurrencyTests {
 
         let baseline = provider.filterAndRank(items, prefix: "sc", context: context)
 
+        let shared = ConcurrentProvider(provider: provider)
         await withTaskGroup(of: [SQLCompletionItem].self) { group in
             for _ in 0..<8 {
                 group.addTask {
-                    provider.filterAndRank(items, prefix: "sc", context: context)
+                    shared.provider.filterAndRank(items, prefix: "sc", context: context)
                 }
             }
             for await result in group {

--- a/TableProTests/Views/Sidebar/SidebarOutlineScaffoldTests.swift
+++ b/TableProTests/Views/Sidebar/SidebarOutlineScaffoldTests.swift
@@ -4,6 +4,7 @@
 //
 
 import AppKit
+import os
 import SwiftUI
 import TableProPluginKit
 import TableProSyncTransport
@@ -550,11 +551,16 @@ struct DatabaseTreeObjectGroupHierarchyTests {
     }
 }
 
-private final class WriteCountingDefaults: UserDefaults, @unchecked Sendable {
-    var writeCount = 0
+private final class WriteCountingDefaults: UserDefaults {
+    private let writes = OSAllocatedUnfairLock(initialState: 0)
+
+    var writeCount: Int {
+        get { writes.withLock { $0 } }
+        set { writes.withLock { $0 = newValue } }
+    }
 
     override func set(_ value: Any?, forKey defaultName: String) {
-        writeCount += 1
+        writes.withLock { $0 += 1 }
         super.set(value, forKey: defaultName)
     }
 }

--- a/TableProTests/Views/Structure/StructureEditingSessionTests.swift
+++ b/TableProTests/Views/Structure/StructureEditingSessionTests.swift
@@ -37,7 +37,7 @@ private class StructureSessionBaseDriver {
     }
 }
 
-private final class StructureSessionDriver: StructureSessionBaseDriver, PluginDatabaseDriver {
+private final class StructureSessionDriver: StructureSessionBaseDriver, PluginDatabaseDriver, @unchecked Sendable {
     private(set) var executedQueries: [String] = []
 
     func execute(query: String) async throws -> PluginQueryResult {

--- a/TableProTests/Views/Structure/StructureEditingSupportBooleanParsingTests.swift
+++ b/TableProTests/Views/Structure/StructureEditingSupportBooleanParsingTests.swift
@@ -23,8 +23,8 @@ struct StructureEditingSupportBooleanParsingTests {
         .name, .type, .nullable, .defaultValue, .onUpdate, .primaryKey, .autoIncrement, .comment
     ]
 
-    private static let trueTokens = ["YES", "yes", "Yes", "TRUE", "true", "True", "1"]
-    private static let falseTokens = ["NO", "no", "FALSE", "false", "0", "", "maybe"]
+    nonisolated private static let trueTokens = ["YES", "yes", "Yes", "TRUE", "true", "True", "1"]
+    nonisolated private static let falseTokens = ["NO", "no", "FALSE", "false", "0", "", "maybe"]
 
     private func makeColumn() -> EditableColumnDefinition {
         EditableColumnDefinition(

--- a/docs/development/setup.mdx
+++ b/docs/development/setup.mdx
@@ -8,7 +8,7 @@ description: Clone, configure signing, and build TablePro in Xcode
 | Software | Version | Notes |
 |----------|---------|-------|
 | Xcode | 26.0+ | Ships the macOS 26 SDK the app builds against. Every CI job pins 26.4.1. |
-| Swift | 5 language mode | Comes with Xcode, set by `SWIFT_VERSION` in `Configs/Base.xcconfig` |
+| Swift | 6 language mode | Comes with Xcode, set by `SWIFT_VERSION` in `Configs/Base.xcconfig`. The two local packages under `Packages/` declare it through `swift-tools-version: 6.0` instead. |
 | XcodeGen | 2.46.0 | Generates `TablePro.xcodeproj` from `project.yml`. `brew install xcodegen` |
 
 The app references macOS 26 SDK symbols (`NSGlassEffectView` in the quick switcher), so an older Xcode cannot compile it. The deployment target stays at macOS 14.0 Sonoma, which is what the built app runs on, not what you build on.


### PR DESCRIPTION
Moves the whole project to the Swift 6 language mode, which is the newest the toolchain accepts (`-swift-version 6.1`, `6.2` and `7` are all rejected; Swift 6.4 is the compiler, 6 is the language mode).

| | Before | After |
|---|---|---|
| `Configs/Base.xcconfig` | `SWIFT_VERSION = 5.0` | `6.0` |
| `Packages/TableProCore`, `Packages/TableProOracle` | `swift-tools-version: 5.9` | `6.0` |
| `.swiftformat` | `--swiftversion 5.9` | `6.0` |

`LocalPackages/` (the vendored CodeEdit forks) stays on 5.9 so it can still take upstream changes. An xcconfig does not reach SwiftPM targets, which is why the two first-party packages need their own manifest bump; that trap is now written down in `CLAUDE.md` along with the reason never to test a language-mode change by passing `SWIFT_VERSION=` on the `xcodebuild` command line.

## What the compiler actually made us fix

- **Non-Sendable Foundation statics.** `ISO8601DateFormatter`, `ByteCountFormatter` and `RelativeDateTimeFormatter` are not `Sendable`, so shared statics now sit behind `OSAllocatedUnfairLock`. `DateFormatter`, `NumberFormatter` and `DateComponentsFormatter` already carry `NS_SWIFT_SENDABLE` in the macOS 26 SDK and were left alone.
- **`NSLock.lock()`/`unlock()` inside `async` bodies** is a hard error in Swift 6. Converted to scoped `withLock` across 12 plugins and app areas. Every critical section keeps the exact statements it had, including the multi-exit shapes where `unlock()` sat before an early `return`.
- **AppKit observer tokens read from `deinit`.** `NSEvent`/`NotificationCenter` tokens typed `Any?` or `NSObjectProtocol?` cannot be touched from a nonisolated `deinit`, so they moved behind a lock.
- **Cross-module enum switches** over `PluginPrivilegeScope`, `PluginImportFieldType`, `PluginBooleanSynonym`, `PathFieldRole`, `AutoLimitStyle` and `SQLDialectDescriptor.BooleanLiteralStyle` gained `@unknown default`, which is what `CLAUDE.md` already asks for on an open domain.
- **`Sendable` conformances** added to protocols and value types that were already thread-safe: `SupervisedProcessRunner`, `KeyValueStore`, `ForeignAppImporter`, `KeyCode`, the `Exportable*` and `ConnectionImport*` transfer types, and several storage singletons.
- **`nonisolated`** on loggers inside `@MainActor` types, on pure statics, and across the iOS driver, platform, security and intent layers, which run under `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` and are background code by nature.
- **Three SQLite actors** (`MCPAuditLogStorage`, `SQLFavoriteStorage`, `QueryHistoryStorage`, plus `LinkedSQLIndex`) moved from an `init`-time bootstrap, which Swift 6 rejects, to a handle that prepares itself on first use. `static let shared` was already lazy, so first touch is still first use.
- **C pointers crossing a task boundary** (libssh2 channels, libduckdb connections, libmongoc documents, BSON handles) travel in small named transfer types instead of implicitly.

## A regression this caught in the migration itself

The first attempt replaced `CSVTypeInferrer`'s `ISO8601DateFormatter` with `Date.ISO8601FormatStyle`. A 329-input probe showed `"  2026-08-20"`, `"2026/08/20"` and `"-0001-01-01"` would have stopped being inferred as dates, so a CSV column of slash-separated dates would have imported as text. Reverted to the original formatters behind a lock. The new `CSVTypeInferrerTests` pins those three cases plus the lenient forms the formatter accepts, and runs in CI through the `TableProCore` package job.

A second, subtler one: a pure `static func` on a SwiftUI `View` becomes main-actor isolated in Swift 6, and calling it from a nonisolated test traps at runtime rather than failing to compile. That crash took down 2,410 tests in one run. Fixed by marking those helpers `nonisolated`; a scan found and fixed all three occurrences.

## Verification

- macOS app, all 31 plugin bundles, both test bundles, the iOS app and widget, and both SPM packages build.
- **macOS suite: 12,812 passed, 27 failed**, all 27 pre-existing and outside this diff (see below).
- **iOS suite: 221 passed, 0 failed.**
- **TableProCore package: all pass**, including 13 new `CSVTypeInferrerTests`.
- `swiftlint lint --strict` clean over the app, `Plugins/`, `Packages/`, `TableProMobile/` and the test targets.

The 27 macOS failures: six suites are the known local environment failures (network, pasteboard, timers), four are timing-flaky and pass in isolation, and the rest fail on code this branch never touches. `PreferenceKeysGuardTests` trips on `removeValue(forKey: "extensions")` in `CLI/BridgeProxy.swift`; `URLClassifierTests` on the new DuckDB file classification; `ThirdPartyLicenseInventoryTests` on `DUCKDB_VERSION` missing from a build script; `TabExecutionSettleGuardTests` on `MCPProtocolDispatcher+Requests.swift`; `StringCatalogIntegrityTests` and `KoreanLocalizationSourceTests` on `.xcstrings` content. The two `.xcstrings` files were already uncommitted before this work started and are deliberately left out of this branch.

## Reviewer notes

- **PluginKit surface.** `SettablePluginDiscoverable.settingsView()` gained `@MainActor` and `ExportFormatPlugin`/`ImportFormatPlugin` gained `Sendable`. Isolation and marker-protocol conformances do not change mangled symbols or witness-table layout, so already-shipped plugins keep loading and no `currentPluginKitVersion` bump is needed. It is a source-level change for a third-party plugin author, whose `settingsView()` now has to be `@MainActor`. Please run `scripts/check-pluginkit-abi.sh <merge-base>` before merging; nothing in CI does it and I did not run it.
- **Two pre-existing thread-safety gaps are now written down rather than fixed.** `CopilotChatProvider` and the eight export/import plugins carry `@unchecked Sendable` over genuinely unsynchronised mutable state. Swift 5 was not checking them; making them safe is a redesign of how plugin settings are read during an export, not part of a language-mode bump.
- **`XLSXWriter.write(to:)` is now `async`** and does the zip build and file write inside its detached task, taking only `[ZipFileEntry]` across the boundary. Same work, same thread, nothing non-Sendable crossing.
