### PR TITLE
test(ui): resolve menu items without opening their parent menu first

### DIFF
--- a/TableProUITests/OpenQuicklyCommandUITests.swift
+++ b/TableProUITests/OpenQuicklyCommandUITests.swift
@@ -183,20 +183,17 @@ final class OpenQuicklyCommandUITests: UITestCase {
         )
         app.activate()
 
-        let fileMenu = app.menuBars.menuBarItems["File"]
-        XCTAssertTrue(fileMenu.waitToExist(timeout: 10))
-        fileMenu.click()
-
+        /// Resolved and clicked without opening File first; see the note in
+        /// QueryStatementNavigationUITests for why the parent click only costs a traversal.
         let openQuickly = app.menuBars.menuItems["Open Quickly…"]
         XCTAssertTrue(openQuickly.waitToExist(timeout: 5))
-        XCTAssertTrue(waitUntilHittable(openQuickly, timeout: 5))
         openQuickly.click()
 
         let searchField = switcherPanel(in: app).textFields["quick-switcher-search-field"]
         XCTAssertTrue(searchField.waitToExist(timeout: 15))
 
         XCTAssertFalse(
-            app.menuBars.menuItems["Quick Switcher..."].exists,
+            app.menuBars.menuBarItems["Database"].menuItems["Quick Switcher..."].exists,
             "The old Database menu item must not survive the move"
         )
     }

--- a/TableProUITests/QueryInsightsTabUITests.swift
+++ b/TableProUITests/QueryInsightsTabUITests.swift
@@ -159,14 +159,14 @@ final class QueryInsightsTabUITests: UITestCase {
 
     /// Walks the Database menu rather than typing a shortcut, because the tab has no key
     /// equivalent and the menu item is the only way in.
+    /// Resolved and clicked in one step, with no click on the parent menu first. macOS exposes an
+    /// unopened menu's items in the accessibility tree, so opening the parent buys nothing and
+    /// costs XCUITest a second traversal of the menu bar, which measures at 4 to 6 seconds on the
+    /// CI runner once a connection window is loaded. `launchWithSampleDatabase` has always relied
+    /// on this.
     private func openInsights(in app: XCUIApplication) {
-        let databaseMenu = app.menuBars.menuBarItems["Database"]
-        XCTAssertTrue(databaseMenu.waitToExist(timeout: 10), "The Database menu must exist")
-        databaseMenu.click()
-
         let item = app.menuBars.menuItems["Query Insights"]
         XCTAssertTrue(item.waitToExist(timeout: 10), "Database > Query Insights must exist")
-        XCTAssertTrue(waitUntilHittable(item, timeout: 10), "The menu item must be clickable")
         item.click()
     }
 

--- a/TableProUITests/QueryStatementNavigationUITests.swift
+++ b/TableProUITests/QueryStatementNavigationUITests.swift
@@ -62,14 +62,14 @@ final class QueryStatementNavigationUITests: UITestCase {
 
     // MARK: - Helpers
 
+    /// Resolved and clicked in one step, with no click on the parent menu first. macOS exposes an
+    /// unopened menu's items in the accessibility tree, so opening the parent buys nothing and
+    /// costs XCUITest a second traversal of the menu bar, which measures at 4 to 6 seconds on the
+    /// CI runner once a connection window is loaded. `launchWithSampleDatabase` has always relied
+    /// on this.
     private func clickQueryMenuItem(_ title: String, in app: XCUIApplication) {
-        let queryMenu = app.menuBars.menuBarItems["Query"]
-        XCTAssertTrue(queryMenu.waitToExist(timeout: 10), "The Query menu must exist")
-        queryMenu.click()
-
         let item = app.menuBars.menuItems[title]
         XCTAssertTrue(item.waitToExist(timeout: 10), "Query > \(title) must exist")
-        XCTAssertTrue(waitUntilHittable(item, timeout: 10), "Query > \(title) must be clickable")
         item.click()
     }
 

--- a/TableProUITests/ResultStatementLinkUITests.swift
+++ b/TableProUITests/ResultStatementLinkUITests.swift
@@ -51,7 +51,7 @@ final class ResultStatementLinkUITests: UITestCase {
         XCTAssertFalse(before.isEmpty, "The editor must hold the script that was run")
 
         let tabs = app.buttons.matching(identifier: "result-tab")
-        waitUntilHittable(tabs.element(boundBy: 2))
+        XCTAssertTrue(waitUntilHittable(tabs.element(boundBy: 2), timeout: 10))
         tabs.element(boundBy: 2).click()
         tabs.element(boundBy: 0).click()
         tabs.element(boundBy: 0).click()
@@ -79,13 +79,5 @@ final class ResultStatementLinkUITests: UITestCase {
             "The script must produce a result per statement"
         )
         return app
-    }
-
-    /// A control in a pane that is still settling exists but hit-tests to nothing, so existence is not enough to
-    /// click on.
-    private func waitUntilHittable(_ element: XCUIElement) {
-        let hittable = NSPredicate(format: "isHittable == true")
-        let expectation = XCTNSPredicateExpectation(predicate: hittable, object: element)
-        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 10), .completed)
     }
 }


### PR DESCRIPTION
Follow-up to #2325, which fixed this for `launchWithSampleDatabase` only. The same shape survives at three more menu call sites.

`UITestCase` documents the rule already: never click the parent menu first, because `click()` on a menu item runs its own traversal and opens the parent as part of it, so an already-open menu makes that traversal fail. These three helpers do exactly what the rule forbids, then paper over it with a `waitUntilHittable` that the deleted version of this code did not have.

macOS exposes an unopened menu's items in the accessibility tree, which is what `launchWithSampleDatabase` has always relied on. Opening the parent buys nothing and costs a second traversal of the menu bar, which measures at 4 to 6 seconds on the CI runner once a connection window is loaded.

Measured in the activity trace of the `macos-ui-test-results` bundle from run 32473179239:

| Menu item | Stalls | Total |
| --- | --- | --- |
| `showQueryInsights:` | 3 | 15.4s |
| `Open Quickly…` | 3 | 12.5s |
| `shortcut.quickSwitcher` | 2 | 11.0s |
| `Query Insights` | 2 | 9.9s |
| `Quick Switcher...` | 1 | 6.8s |
| `Database` MenuBarItem | 1 | 6.1s |
| `File` MenuBarItem | 1 | 4.2s |

Three helpers go from six element resolutions to two: `clickQueryMenuItem` in `QueryStatementNavigationUITests`, `openInsights` in `QueryInsightsTabUITests`, and the File menu walk in `OpenQuicklyCommandUITests`.

`NavigationHistoryUITests` is deliberately left alone. It reads `item.isEnabled`, and AppKit only validates a menu item when its menu opens, so the parent click is load-bearing there rather than redundant.

Two smaller things in the same files:

- The negative assertion in `OpenQuicklyCommandUITests` searched the whole menu bar for `Quick Switcher...`, which is a full resolution to prove an absence. It now asks the Database menu it is actually about. The assertion is kept: it is what proves the old item did not survive the move.
- `ResultStatementLinkUITests` carried a private `waitUntilHittable` that restated the base class's helper and its doc comment. It uses the base class one now.

## Verification

`xcodebuild build-for-testing` succeeds and `swiftlint lint --strict` is clean on the target. As with #2325 the UI suite cannot run on this machine, whose XCUITest runner is killed on launch, so CI is where the timings land.

https://claude.ai/code/session_013MEaba8K1HQcyDNeq5wEFk
