### PR TITLE
ci(macos-tests): build once and run the suites on four runners

### DIFF
--- a/.github/actions/unpack-test-products/action.yml
+++ b/.github/actions/unpack-test-products/action.yml
@@ -1,0 +1,41 @@
+name: Unpack test products
+description: Downloads the products the build job produced and points XCTESTRUN at them.
+
+runs:
+  using: composite
+  steps:
+    - name: Download the built products
+      uses: actions/download-artifact@v8
+      with:
+        name: test-products
+
+    - name: Unpack and locate the test plans
+      shell: bash
+      # Every path inside a generated .xctestrun is written relative to __TESTROOT__, which
+      # resolves to the directory holding the file, so the products run from wherever they land.
+      # The file name carries the SDK version (TablePro_macosx26.4-arm64.xctestrun), which is why
+      # it is found rather than spelled out: an Xcode bump would otherwise break this silently.
+      run: |
+        set -euo pipefail
+        mkdir -p DerivedData/Build
+        tar -xzf products.tar.gz -C DerivedData/Build
+        rm -f products.tar.gz
+
+        products="$PWD/DerivedData/Build/Products"
+        [ -d "$products" ] || { echo "::error::the artifact did not contain Build/Products"; exit 1; }
+
+        locate() {
+            local scheme="$1" found
+            found="$(find "$products" -maxdepth 1 -name "${scheme}_*.xctestrun" -print -quit)"
+            if [ -z "$found" ]; then
+                echo "::error::no .xctestrun for scheme ${scheme} in $products"
+                ls -1 "$products" >&2
+                exit 1
+            fi
+            printf '%s' "$found"
+        }
+
+        {
+            echo "XCTESTRUN=$(locate TablePro)"
+            echo "DAMENG_XCTESTRUN=$(locate DamengDriverTests)"
+        } >> "$GITHUB_ENV"

--- a/.github/macos-test-quarantine.txt
+++ b/.github/macos-test-quarantine.txt
@@ -24,7 +24,6 @@ QueryExecutorTests
 ClickHouseDialectTests
 ValidateDriverDescriptorTests
 PluginCapabilityTests
-FreeTDSClassifierTests
 DatabaseTypeCassandraTests
 RowOperationsManagerTests
 StructureGridDelegateAddRowTests

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -17,8 +17,14 @@ on:
       - "TableProUITests/**"
       - "Native/**"
       - "project.yml"
+      - "TableProMobile/project.yml"
       - "Configs/**"
       - "Libs/**"
+      - "scripts/**"
+      - "TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+      - ".github/actions/**"
+      - ".github/macos-test-quarantine.txt"
+      - ".github/macos-ui-test-quarantine.txt"
       - ".github/workflows/macos-tests.yml"
   workflow_dispatch:
   workflow_call:
@@ -28,21 +34,28 @@ concurrency:
   group: macos-tests-${{ github.ref }}
   cancel-in-progress: true
 
+# A downgrade or an exact match is always allowed for a called workflow; only asking for more than
+# the caller holds fails at run creation. Declaring read here therefore cannot break build.yml's
+# workflow_call, and it stops every job in this file from inheriting a write token if the repository
+# default is ever flipped.
+permissions:
+  contents: read
+
 env:
+  XCODE_VERSION: "26.4.1"
   XCODE_PROJECT: TablePro.xcodeproj
   XCODE_SCHEME: TablePro
   TEST_DESTINATION: "platform=macOS"
+  # Inside the workspace rather than the default location, because the build job tars it and the
+  # test jobs unpack it. Every path inside the generated .xctestrun is written relative to
+  # __TESTROOT__, so the products relocate to any directory.
+  DERIVED_DATA: DerivedData
 
 jobs:
   # Reproduces the paths filter this workflow used to carry on `on: pull_request`. Keep this
   # list and the `push:` paths above identical, so a pull request and a push to main run the
   # same suites. `Native/` is on both because the Dameng steps below build and test the Rust
   # bridge that lives there, and a bridge-only change would otherwise compile nowhere.
-  # Never give this job a `permissions:` block. build.yml calls this workflow with
-  # workflow_call, and a called job may not request more than the caller holds. The repository
-  # default is read, which carries no pull-requests scope, so asking for one fails the whole
-  # release at run creation, before a single job starts. Reading the diff from git keeps this
-  # job inside contents:read, which every caller already grants.
   changes:
     name: Detect relevant changes
     runs-on: ubuntu-latest
@@ -102,14 +115,20 @@ jobs:
           git -c core.quotePath=false diff --no-renames --name-only -z \
               "$BASE_SHA" HEAD > "$RUNNER_TEMP/changed-files"
 
-          if LC_ALL=C grep -zqE '^(TablePro/|Plugins/|Packages/|LocalPackages/|TableProTests/|TableProUITests/|Native/|Configs/|Libs/|project\.yml$|\.github/workflows/macos-tests\.yml$)' "$RUNNER_TEMP/changed-files"; then
+          # Keep in step with the `push: paths:` list above. scripts/ and .github/actions/ are on
+          # both because the jobs below execute them: a change to the shard tooling or to the
+          # quarantine files used to merge behind a green gate having run nothing.
+          if LC_ALL=C grep -zqE '^(TablePro/|Plugins/|Packages/|LocalPackages/|TableProTests/|TableProUITests/|Native/|Configs/|Libs/|scripts/|\.github/actions/|\.github/macos-(ui-)?test-quarantine\.txt$|TablePro\.xcodeproj/project\.xcworkspace/xcshareddata/swiftpm/Package\.resolved$|TableProMobile/project\.yml$|project\.yml$|\.github/workflows/macos-tests\.yml$)' "$RUNNER_TEMP/changed-files"; then
               echo "run=true" >> "$GITHUB_OUTPUT"
           else
               echo "run=false" >> "$GITHUB_OUTPUT"
           fi
 
-  package-tests:
-    name: TableProCore Package Tests
+  # One job for both packages rather than two. They cost 1.3 and 2.1 minutes, and a macOS
+  # concurrency slot is the scarce resource here: the account runs five at a time, and the build
+  # plus three UI shards plus the unit job already want four of them.
+  packages:
+    name: Package Tests
     needs: changes
     if: needs.changes.outputs.run == 'true'
     runs-on: macos-26
@@ -120,24 +139,10 @@ jobs:
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
-          xcode-version: '26.4.1'
+          xcode-version: ${{ env.XCODE_VERSION }}
 
-      - name: Run package tests
+      - name: Run TableProCore package tests
         run: swift test --package-path Packages/TableProCore
-
-  editor-tests:
-    name: CodeEditTextView Package Tests
-    needs: changes
-    if: needs.changes.outputs.run == 'true'
-    runs-on: macos-26
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
-        with:
-          xcode-version: '26.4.1'
 
       # CodeEditSourceEditor is deliberately not run here. `swift test` cannot build it on this
       # runner: its CodeEditSymbols dependency fails with "type 'Bundle' has no member 'module'",
@@ -145,28 +150,27 @@ jobs:
       # Xcode project, so the app target still compiles it; only the standalone package test run
       # is broken. Its own suites also fail on main (HighlighterTests, TagEditingTests, plus one
       # that aborts the runner), so this needs fixing at the package level before it can gate.
-      - name: Run editor package tests
+      - name: Run CodeEditTextView package tests
         run: swift test --package-path LocalPackages/CodeEditTextView
 
-  # Budget on a macos-26 runner, measured on run 32391276238: ~3 min of setup and package
-  # resolution, ~5 min to compile every plugin, ~21 min for the unit step (17 of them building the
-  # app and both test bundles, 4.5 running 11,500 tests), and ~43 min for the UI suite, which
-  # launches the app once per test at roughly 30 seconds each. That is ~72 min, so 60 killed the
-  # job with ten UI suites still to run. A slow runner stretches all of it and one UI retry costs
-  # another minute or two, so keep real headroom here rather than trimming to the last measurement.
-  app-tests:
-    name: macOS App Tests
+  # Compiles the app, both test bundles and all 31 plugins once, then hands the products to the
+  # test jobs. That build used to happen inside the same job that ran the tests, which meant the
+  # unit step spent 12 of its 15.3 minutes compiling and the UI step could not start until the
+  # unit step had finished. All 12,662 unit cases execute in 206 seconds, so the build was almost
+  # all of the cost and none of it was parallel.
+  build:
+    name: Build for testing
     needs: changes
     if: needs.changes.outputs.run == 'true'
     runs-on: macos-26
-    timeout-minutes: 90
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
-          xcode-version: '26.4.1'
+          xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Install xcbeautify
         run: brew list xcbeautify &>/dev/null || brew install xcbeautify
@@ -196,12 +200,10 @@ jobs:
         working-directory: Native/DamengBridge
         run: cargo test --locked
 
-      # Secrets.xcconfig is gitignored. Tests do not need analytics keys, so an empty
-      # value is enough for the project to resolve $(ANALYTICS_HMAC_SECRET).
+      # Secrets.xcconfig is gitignored. Tests do not need analytics keys, and the project only
+      # needs the variable to resolve, so an empty value is enough and no secret is read here.
       - name: Create Secrets.xcconfig
-        env:
-          ANALYTICS_HMAC_SECRET: ${{ secrets.ANALYTICS_HMAC_SECRET }}
-        run: echo "ANALYTICS_HMAC_SECRET = ${ANALYTICS_HMAC_SECRET}" > Configs/Secrets.xcconfig
+        run: echo "ANALYTICS_HMAC_SECRET = " > Configs/Secrets.xcconfig
 
       - name: Setup XcodeGen
         uses: ./.github/actions/setup-xcodegen
@@ -209,15 +211,26 @@ jobs:
       - name: Generate Xcode project
         run: scripts/generate-project.sh
 
+      # Package.resolved pins every revision and is tracked, which is why it can key the cache.
+      # build.yml has cached these checkouts for a while; this workflow paid 1.5 minutes a run
+      # re-resolving them.
+      - name: Cache Swift package checkouts
+        uses: actions/cache@v6
+        with:
+          path: ~/.spm-cache
+          key: ${{ runner.os }}-spm-${{ hashFiles('TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: ${{ runner.os }}-spm-
+
       - name: Resolve Swift package dependencies
         run: |
           xcodebuild -resolvePackageDependencies \
             -project "$XCODE_PROJECT" \
             -scheme "$XCODE_SCHEME" \
+            -clonedSourcePackagesDirPath ~/.spm-cache \
             -skipPackagePluginValidation
 
       # The TablePro scheme only builds the 14 bundled plugins, so a change confined to one
-      # of the 16 registry-only plugins compiles nowhere else in CI. AllPlugins is the only
+      # of the 17 registry-only plugins compiles nowhere else in CI. AllPlugins is the only
       # target that covers them, and build-plugin.yml does not run until a release tag.
       - name: Compile every plugin
         run: |
@@ -226,6 +239,21 @@ jobs:
             -project "$XCODE_PROJECT" \
             -scheme AllPlugins \
             -destination "$TEST_DESTINATION" \
+            -derivedDataPath "$DERIVED_DATA" \
+            -clonedSourcePackagesDirPath ~/.spm-cache \
+            -skipPackagePluginValidation \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcbeautify --renderer github-actions
+
+      - name: Build the app and both test bundles
+        run: |
+          set -o pipefail
+          xcodebuild build-for-testing \
+            -project "$XCODE_PROJECT" \
+            -scheme "$XCODE_SCHEME" \
+            -destination "$TEST_DESTINATION" \
+            -derivedDataPath "$DERIVED_DATA" \
+            -clonedSourcePackagesDirPath ~/.spm-cache \
             -skipPackagePluginValidation \
             CODE_SIGNING_ALLOWED=NO \
             | xcbeautify --renderer github-actions
@@ -233,87 +261,161 @@ jobs:
       # DamengDriverTests is the one plugin-owned unit bundle: its suites import CDameng, so
       # they cannot move into TableProTests the way pure-logic plugin tests do. Without this
       # step nothing runs them and they rot silently.
-      - name: Run Dameng driver tests
+      - name: Build the Dameng driver tests
         run: |
           set -o pipefail
-          xcodebuild test \
+          xcodebuild build-for-testing \
             -project "$XCODE_PROJECT" \
             -scheme DamengDriverTests \
             -destination "$TEST_DESTINATION" \
-            -parallel-testing-enabled NO \
+            -derivedDataPath "$DERIVED_DATA" \
+            -clonedSourcePackagesDirPath ~/.spm-cache \
             -skipPackagePluginValidation \
             CODE_SIGNING_ALLOWED=NO \
             | xcbeautify --renderer github-actions
 
+      # Tarred rather than uploaded as a directory. actions/upload-artifact does not preserve
+      # the executable bit or symlinks, and both matter to an .app bundle: the app would arrive
+      # unable to run. The archive measures 144 MB against 559 MB on disk.
+      - name: Pack the built products
+        run: tar -czf products.tar.gz -C "$DERIVED_DATA/Build" Products
+
+      - name: Upload the built products
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-products
+          path: products.tar.gz
+          retention-days: 1
+          compression-level: 0
+
+  unit:
+    name: Unit tests
+    needs: [changes, build]
+    if: needs.changes.outputs.run == 'true'
+    runs-on: macos-26
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Install xcbeautify
+        run: brew list xcbeautify &>/dev/null || brew install xcbeautify
+
+      - uses: ./.github/actions/unpack-test-products
+
       # Quarantined suites (driver-loading, env-coupled, or hanging headless) are listed
-      # in .github/macos-test-quarantine.txt. Burn that list down over time.
+      # in .github/macos-test-quarantine.txt. Burn that list down. The script refuses to run if
+      # an entry no longer names a suite, because xcodebuild accepts -skip-testing for a suite
+      # that does not exist and says nothing, which left one line inert for 479 commits.
       - name: Run unit tests
         run: |
           set -o pipefail
+          # A read loop, not mapfile: the macOS runner's /bin/bash is 3.2, which has neither
+          # mapfile nor readarray, and a `run:` block gets that bash.
           SKIP_ARGS=()
-          while IFS= read -r line; do
-            suite="${line%%#*}"
-            suite="$(echo "$suite" | xargs)"
-            [ -z "$suite" ] && continue
-            SKIP_ARGS+=("-skip-testing:TableProTests/$suite")
-          done < .github/macos-test-quarantine.txt
-          xcodebuild test \
-            -project "$XCODE_PROJECT" \
-            -scheme "$XCODE_SCHEME" \
+          while IFS= read -r arg; do
+            SKIP_ARGS+=("$arg")
+          done < <(scripts/ci/quarantine-args.sh .github/macos-test-quarantine.txt TableProTests TableProTests)
+          xcodebuild test-without-building \
+            -xctestrun "$XCTESTRUN" \
             -destination "$TEST_DESTINATION" \
             -only-testing:TableProTests \
             "${SKIP_ARGS[@]}" \
             -parallel-testing-enabled NO \
-            -skipPackagePluginValidation \
             -resultBundlePath TestResults.xcresult \
-            CODE_SIGNING_ALLOWED=NO \
             | xcbeautify --renderer github-actions
 
-      # UI tests drive the real app, so they need the runner's GUI session and cannot run beside
-      # the unit run. Every case launches the app against a throwaway storage sandbox that
-      # UITestCase hands it, so nothing here touches a real store.
-      #
-      # One retry is allowed. A full local suite flaked once in three runs on a single
-      # waitForExistence, which without a retry would fail roughly a third of runs and train
-      # people to re-run until green. A case that fails twice is a real failure.
-      - name: Run UI tests
+      - name: Run Dameng driver tests
         run: |
           set -o pipefail
-          SKIP_ARGS=()
-          while IFS= read -r line; do
-            entry="${line%%#*}"
-            entry="$(echo "$entry" | xargs)"
-            [ -z "$entry" ] && continue
-            SKIP_ARGS+=("-skip-testing:TableProUITests/$entry")
-          done < .github/macos-ui-test-quarantine.txt
-          xcodebuild test \
-            -project "$XCODE_PROJECT" \
-            -scheme "$XCODE_SCHEME" \
+          xcodebuild test-without-building \
+            -xctestrun "$DAMENG_XCTESTRUN" \
             -destination "$TEST_DESTINATION" \
-            -only-testing:TableProUITests \
-            "${SKIP_ARGS[@]}" \
             -parallel-testing-enabled NO \
-            -test-iterations 2 \
-            -retry-tests-on-failure \
-            -skipPackagePluginValidation \
-            -resultBundlePath UITestResults.xcresult \
-            CODE_SIGNING_ALLOWED=NO \
             | xcbeautify --renderer github-actions
 
-      - name: Upload UI test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: macos-ui-test-results
-          path: UITestResults.xcresult
-          retention-days: 7
-
       - name: Upload test results
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
           name: macos-test-results
           path: TestResults.xcresult
+          retention-days: 7
+
+  # UI tests drive the real app, so they need the runner's GUI session and cannot run beside
+  # the unit run. Every case launches the app against a throwaway storage sandbox that
+  # UITestCase hands it, so nothing here touches a real store.
+  #
+  # Sharded across runners rather than parallelised on one. Three things in the suite are shared
+  # per machine and cannot be made per-worker: the single `com.TablePro.uitest` defaults domain,
+  # the preferences sweep in UITestCase's class setUp, and the menu bar itself, which belongs to
+  # whichever app is frontmost. A separate runner per shard has its own of all three.
+  ui:
+    name: UI tests ${{ matrix.shard }}/${{ matrix.of }}
+    needs: [changes, build]
+    if: needs.changes.outputs.run == 'true'
+    runs-on: macos-26
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2]
+        of: [3]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Install xcbeautify
+        run: brew list xcbeautify &>/dev/null || brew install xcbeautify
+
+      - uses: ./.github/actions/unpack-test-products
+
+      # One retry is allowed. A full local suite flaked once in three runs on a single
+      # waitForExistence, which without a retry would fail roughly a third of runs and train
+      # people to re-run until green. A case that fails twice is a real failure.
+      - name: Run UI tests
+        env:
+          SHARD: ${{ matrix.shard }}
+          SHARD_COUNT: ${{ matrix.of }}
+        run: |
+          set -o pipefail
+          # A read loop, not mapfile: the macOS runner's /bin/bash is 3.2, which has neither.
+          ONLY_ARGS=()
+          while IFS= read -r arg; do
+            ONLY_ARGS+=("$arg")
+          done < <(
+            scripts/ci/list-tests.sh \
+              --xctestrun "$XCTESTRUN" \
+              --target TableProUITests \
+              --quarantine .github/macos-ui-test-quarantine.txt \
+              --shard "$SHARD/$SHARD_COUNT"
+          )
+          [ "${#ONLY_ARGS[@]}" -gt 0 ] || { echo "::error::shard $SHARD selected no cases"; exit 1; }
+          echo "shard $SHARD of $SHARD_COUNT runs ${#ONLY_ARGS[@]} cases"
+          xcodebuild test-without-building \
+            -xctestrun "$XCTESTRUN" \
+            -destination "$TEST_DESTINATION" \
+            "${ONLY_ARGS[@]}" \
+            -parallel-testing-enabled NO \
+            -test-iterations 2 \
+            -retry-tests-on-failure \
+            -resultBundlePath UITestResults.xcresult \
+            | xcbeautify --renderer github-actions
+
+      - name: Upload UI test results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-ui-test-results-${{ matrix.shard }}
+          path: UITestResults.xcresult
           retention-days: 7
 
   # The one check to mark required on main. It reports on every pull request, so a docs-only
@@ -321,7 +423,7 @@ jobs:
   gate:
     name: macOS Tests Gate
     if: always()
-    needs: [changes, package-tests, editor-tests, app-tests]
+    needs: [changes, packages, build, unit, ui]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/scripts/ci/list-tests.sh
+++ b/scripts/ci/list-tests.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prints the -only-testing arguments for one shard of a test target, one per line.
+#
+# The list comes from xcodebuild itself rather than from a file somebody maintains, so a test added
+# tomorrow lands in a shard with nothing to update. A hand-written shard list is the failure mode
+# worth avoiding here: a suite that falls out of every shard still reports green.
+#
+# Usage: list-tests.sh --xctestrun PATH --target NAME [--quarantine FILE] [--shard I/N]
+#
+#   --quarantine  one suite name per line, '#' starts a comment. Matched against the suite and
+#                 against the full Target/Suite/case() identifier.
+#   --shard I/N   round-robin over the sorted identifiers: shard I of N, zero-based. Round-robin
+#                 rather than contiguous blocks because it spreads a slow suite's cases across
+#                 shards instead of landing them all in one.
+
+usage() {
+    sed -n '3,17p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' >&2
+    exit "${1:-1}"
+}
+
+XCTESTRUN=""
+TARGET=""
+QUARANTINE=""
+SHARD=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --xctestrun) XCTESTRUN="${2:?--xctestrun needs a path}"; shift 2 ;;
+        --target) TARGET="${2:?--target needs a name}"; shift 2 ;;
+        --quarantine) QUARANTINE="${2:?--quarantine needs a path}"; shift 2 ;;
+        --shard) SHARD="${2:?--shard needs I/N}"; shift 2 ;;
+        -h | --help) usage 0 ;;
+        *) echo "list-tests.sh: unknown argument '$1'" >&2; usage ;;
+    esac
+done
+
+[ -n "$XCTESTRUN" ] || { echo "list-tests.sh: --xctestrun is required" >&2; usage; }
+[ -n "$TARGET" ] || { echo "list-tests.sh: --target is required" >&2; usage; }
+[ -f "$XCTESTRUN" ] || { echo "list-tests.sh: no such xctestrun: $XCTESTRUN" >&2; exit 1; }
+
+# A directory, not mktemp: xcodebuild refuses to write its enumeration to a path that already
+# exists, and mktemp creates the file it names.
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+xcodebuild test-without-building \
+    -xctestrun "$XCTESTRUN" \
+    -destination "platform=macOS" \
+    -only-testing:"$TARGET" \
+    -enumerate-tests \
+    -test-enumeration-style flat \
+    -test-enumeration-format json \
+    -test-enumeration-output-path "$workdir/tests.json" > "$workdir/enumerate.log" 2>&1 || {
+    echo "list-tests.sh: test enumeration failed for $TARGET" >&2
+    tail -40 "$workdir/enumerate.log" >&2
+    exit 1
+}
+
+TARGET="$TARGET" QUARANTINE="$QUARANTINE" SHARD="$SHARD" \
+    python3 "$(dirname "${BASH_SOURCE[0]}")/list_tests.py" "$workdir/tests.json"

--- a/scripts/ci/list_tests.py
+++ b/scripts/ci/list_tests.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Turns xcodebuild's test enumeration into the -only-testing arguments for one shard.
+
+Driven by list-tests.sh, which owns the xcodebuild call. This half exists in Python because the
+enumeration is JSON and the quarantine file needs comment stripping, and neither is work bash does
+without producing the kind of quoting bug the quarantine parser used to have.
+
+Reads TARGET, QUARANTINE and SHARD from the environment; takes the enumeration JSON as argv[1].
+"""
+
+import json
+import os
+import sys
+
+
+def quarantined_names(path):
+    """Suite names to skip. '#' starts a comment, blank lines are ignored."""
+    if not path:
+        return set()
+    names = set()
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            entry = line.split("#", 1)[0].strip()
+            if entry:
+                names.add(entry)
+    return names
+
+
+def enumerated_identifiers(path):
+    with open(path, encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    errors = payload.get("errors") or []
+    if errors:
+        sys.exit("test enumeration reported: " + "; ".join(errors))
+
+    identifiers = {
+        test["identifier"]
+        for value in payload.get("values", [])
+        for test in value.get("enabledTests", [])
+    }
+    return sorted(identifiers)
+
+
+def parse_shard(raw, total):
+    """'I/N' -> (index, count). Absent means one shard holding everything."""
+    if not raw:
+        return 0, 1
+    try:
+        index, count = (int(part) for part in raw.split("/", 1))
+    except ValueError:
+        sys.exit(f"--shard expects I/N, got {raw!r}")
+    if count < 1 or not 0 <= index < count:
+        sys.exit(f"--shard {raw} is out of range")
+    if count > total:
+        sys.exit(f"--shard {raw} asks for more shards than there are tests ({total})")
+    return index, count
+
+
+def main():
+    target = os.environ["TARGET"]
+    identifiers = enumerated_identifiers(sys.argv[1])
+    if not identifiers:
+        sys.exit(f"test enumeration returned no cases for {target}")
+
+    skipped = quarantined_names(os.environ.get("QUARANTINE"))
+
+    def is_quarantined(identifier):
+        parts = identifier.split("/")
+        suite = parts[1] if len(parts) > 1 else identifier
+        return suite in skipped or identifier in skipped
+
+    runnable = [identifier for identifier in identifiers if not is_quarantined(identifier)]
+    if not runnable:
+        sys.exit(f"every enumerated case in {target} is quarantined")
+
+    index, count = parse_shard(os.environ.get("SHARD"), len(runnable))
+    selected = runnable[index::count]
+    if not selected:
+        sys.exit(f"shard {index}/{count} of {target} selected no cases")
+
+    print("\n".join(f"-only-testing:{identifier}" for identifier in selected))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/quarantine-args.sh
+++ b/scripts/ci/quarantine-args.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prints the -skip-testing arguments for a quarantine file, one per line, after checking that every
+# entry still names something.
+#
+# Usage: quarantine-args.sh <quarantine-file> <target> <sources-dir>
+#
+# The check is the point. xcodebuild accepts -skip-testing for a suite that does not exist and says
+# nothing, so a renamed or deleted suite leaves an inert line behind: FreeTDSClassifierTests sat in
+# the list for 479 commits after the suite was deleted. The same silence is what makes a rename
+# dangerous, because the suite quietly rejoins the run and goes red on somebody else's pull request.
+#
+# Entries are trimmed in bash rather than through `echo ... | xargs`, which is not a trim: xargs
+# applies shell quote and backslash processing, so an entry containing a quote aborted the step with
+# `xargs: unterminated quote` and an entry containing a backslash was silently mangled into an
+# inert skip.
+
+QUARANTINE="${1:?Usage: quarantine-args.sh <quarantine-file> <target> <sources-dir>}"
+TARGET="${2:?Usage: quarantine-args.sh <quarantine-file> <target> <sources-dir>}"
+SOURCES="${3:?Usage: quarantine-args.sh <quarantine-file> <target> <sources-dir>}"
+
+[ -f "$QUARANTINE" ] || { echo "quarantine-args.sh: no such file: $QUARANTINE" >&2; exit 1; }
+[ -d "$SOURCES" ] || { echo "quarantine-args.sh: no such directory: $SOURCES" >&2; exit 1; }
+
+status=0
+line_number=0
+
+while IFS= read -r line || [ -n "$line" ]; do
+    line_number=$((line_number + 1))
+    entry="${line%%#*}"
+    entry="${entry#"${entry%%[![:space:]]*}"}"
+    entry="${entry%"${entry##*[![:space:]]}"}"
+    [ -n "$entry" ] || continue
+
+    if ! [[ "$entry" =~ ^[A-Za-z_][A-Za-z0-9_]*(/[A-Za-z_][A-Za-z0-9_]*)?$ ]]; then
+        echo "$QUARANTINE:$line_number: '$entry' is not a suite or Suite/testMethod name" >&2
+        status=1
+        continue
+    fi
+
+    suite="${entry%%/*}"
+    if ! grep -rqE "(struct|final class|class|enum|actor)[[:space:]]+${suite}\b" "$SOURCES"; then
+        echo "$QUARANTINE:$line_number: '$suite' does not exist in $SOURCES; delete the line" >&2
+        status=1
+        continue
+    fi
+
+    printf -- '-skip-testing:%s/%s\n' "$TARGET" "$entry"
+done < "$QUARANTINE"
+
+exit "$status"


### PR DESCRIPTION
The `app-tests` job was the whole wall clock of this workflow: 61.1 minutes of a 61.1 minute run, with every step inside it serial. This splits it into a build plus four test jobs.

## Why the build was most of it

Measured from run 32473179239 and the two `.xcresult` bundles it uploaded:

| Step | Time |
| --- | --- |
| compile every plugin | 3.5 min |
| unit tests (build + run) | 15.3 min |
| UI tests | 38.8 min |
| everything else | 3.5 min |

All 12,662 unit cases execute in **206 seconds**. So roughly 12 of the unit step's 15.3 minutes was compiling the app and both test bundles, that build was thrown away when the job ended, and the UI step could not start until it had finished. Sharding unit tests would buy nothing; building once and reusing the products is the whole win.

## Shape

```
changes ─┬─ packages
         └─ build ─┬─ unit
                   ├─ ui 0/3
                   ├─ ui 1/3
                   └─ ui 2/3
                                → gate
```

`build` runs `xcodebuild build-for-testing`, tars `Build/Products` and uploads it. The test jobs run `test-without-building -xctestrun`, so they never open the project, never resolve packages and never download `Libs/`.

At most four macOS jobs are live at once, which matters: the account's cap is **five concurrent macOS jobs** on every plan below Enterprise, shared across all workflows, so a release running beside this must still find a slot. That is also why the two package-test jobs, which cost 1.3 and 2.1 minutes, are now one job.

## Verified locally, not assumed

- `Build/Products` is 559 MB on disk and 144 MB tarred; 10s to pack, 1s to unpack.
- The generated `.xctestrun` writes every path relative to `__TESTROOT__` (58 of them), so the products run from wherever they land. Unpacked into a different directory, the exact unit-job command ran **11,666 tests in 131.8 seconds, all passing**, with no rebuild.
- `DamengDriverTests` produces its own `.xctestrun` and its suite passes from the relocated copy too.
- Tarred rather than uploaded as a directory because `actions/upload-artifact` preserves neither the executable bit nor symlinks, and an `.app` needs both.

## Shards are derived, never listed

`scripts/ci/list-tests.sh` asks xcodebuild for the test list (`-enumerate-tests -test-enumeration-format json`) and round-robins the sorted identifiers into shards. Nothing is hardcoded, so a test added tomorrow lands in a shard with no file to update. A hand-written shard list is the failure worth avoiding here: a suite that falls out of every shard still reports green.

Cross-checked against the real run: enumeration lists 13,199 cases, the quarantine leaves 12,662, which is exactly what CI executed. Three shards come out 4221 / 4221 / 4220.

Round-robin rather than contiguous blocks, so a slow suite's cases spread across shards instead of landing in one.

## One quarantine parser, and it now validates

The two `-skip-testing` loops were copy-pasted between the unit and UI steps. They are now `scripts/ci/quarantine-args.sh`, called once.

It also checks that every entry still names a suite. `xcodebuild` accepts `-skip-testing` for a suite that does not exist and says nothing, so a deleted or renamed suite leaves an inert line behind. Running the new script against the existing file found exactly that: `FreeTDSClassifierTests` was deleted by a6feadf2f in June and had been sitting there for 479 commits. That line is removed here, and the check means the next one fails the job instead of hiding.

The old trim was `echo "$suite" | xargs`, which is not a trim. `xargs` applies shell quote and backslash processing: an entry containing a quote aborted the step with `xargs: unterminated quote`, and one containing a backslash was silently mangled into an inert skip. It trims in bash now.

## Also

- The changes detector ignored `scripts/`, `.github/actions/`, both quarantine files, the tracked `Package.resolved` and `TableProMobile/project.yml`, all of which this job executes or consumes. A change to the shard tooling or to the quarantine list merged behind a green gate having run nothing. Added to both the `push: paths:` list and the regex.
- The workflow declares `permissions: contents: read`. The old comment said never to add one, but the rule is that a called workflow may not request *more* than its caller; a downgrade or an exact match always succeeds. Without it, every job here inherits whatever the repository default happens to be.
- The `Create Secrets.xcconfig` step no longer reads `ANALYTICS_HMAC_SECRET`. Its own comment already said tests do not need the key and an empty value is enough, but it was passing the secret anyway.
- `if: always()` on the result uploads becomes `if: !cancelled()`, so a cancelled run stops instead of spending a minute uploading a partial bundle.
- SPM checkouts are cached, as `build.yml` already does. That was 1.5 minutes a run.
- `mapfile` is deliberately not used anywhere: the macOS runner's `/bin/bash` is 3.2, which does not have it. Verified both scripts and both call sites under 3.2.

## Expected effect

Build about 20 minutes, then the longest test job. With #2325 and #2326 already in, the UI suite should be near 24 minutes total, so roughly 8 per shard. That puts the run around 28 minutes against 61, and the build becomes the floor worth attacking next.

These are projections from measured parts. The first run on this PR is the real number.

## Verification

`actionlint` (with its shellcheck integration) is clean on the new workflow and the new composite action. `shellcheck` is clean on both new shell scripts. The sharding, the quarantine validation, the artifact round-trip and the full unit run were each exercised locally against a real build of this repo.

https://claude.ai/code/session_013MEaba8K1HQcyDNeq5wEFk
