### PR TITLE
ci(security): validate plugin tags, pin every action, and scope the tokens

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -290,7 +290,8 @@ when its final job succeeds.
 ```bash
 gh run list --workflow build.yml --limit 1
 gh release view v<version> --json tagName,assets -q '"\(.tagName) assets=\(.assets|length)"'
-curl -s https://tablepro.app/appcast.xml | grep -o 'sparkle:shortVersionString="[^"]*"' | head -2
+curl -s https://raw.githubusercontent.com/TableProApp/TablePro/main/appcast.xml \
+  | grep -o '<sparkle:shortVersionString>[^<]*' | head -2
 ```
 
 Report blockers separately from any draft, as a list of things that must be true

--- a/.claude/skills/release/references/fact-checks.md
+++ b/.claude/skills/release/references/fact-checks.md
@@ -123,12 +123,19 @@ appear when its final job succeeds.
 gh release view v<version> --json tagName,assets -q '"\(.tagName) assets=\(.assets|length)"'
 gh run list --limit 5 --json workflowName,headBranch,status,conclusion \
   -q '.[] | "\(.headBranch) \(.workflowName) \(.status)/\(.conclusion // "-")"'
-curl -s https://tablepro.app/appcast.xml | grep -o 'sparkle:shortVersionString="[^"]*"' | head -2
+curl -s https://raw.githubusercontent.com/TableProApp/TablePro/main/appcast.xml \
+  | grep -o '<sparkle:shortVersionString>[^<]*' | head -2
 ```
 
 "release not found" with the tag pushed means the build is still running or it failed. Sending
 then puts people on a Download button that hands them the previous version, and Check for
 Updates tells them they are up to date. Wait for the release object and the appcast entry.
+
+The feed is the `SUFeedURL` in `TablePro/Info.plist`, which is the raw GitHub URL above.
+`https://tablepro.app/appcast.xml` is a 404 and always has been, and
+`shortVersionString` is an XML element, not an attribute, so a grep written for
+`sparkle:shortVersionString="..."` silently matches nothing and reads as "not
+published yet".
 
 At 0.66 the tag was pushed, all seven plugin builds had finished, and Build TablePro was still
 in progress, which is exactly the window in which the email looks ready and is not.

--- a/.github/actions/unpack-test-products/action.yml
+++ b/.github/actions/unpack-test-products/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Download the built products
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: test-products
 

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -13,8 +13,17 @@ on:
         required: true
         type: string
 
+# Declared per job rather than here. resolve-tags reads two integers out of a Swift file and needs
+# nothing, and a workflow-level grant hands it a write token it has no use for.
 permissions:
-  contents: write
+  contents: read
+
+# Without this, two runs for the same tag race each other through a delete-and-recreate of the same
+# GitHub Release. Never cancel one in flight: it holds a notarization submission open with Apple and
+# publishes release assets.
+concurrency:
+  group: build-plugin-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   resolve-tags:
@@ -58,12 +67,29 @@ jobs:
           JSON='{"include":['
           FIRST=true
           for ITEM in "${RAW_TAGS[@]}"; do
-            ITEM=$(echo "$ITEM" | xargs)
+            ITEM="${ITEM#"${ITEM%%[![:space:]]*}"}"
+            ITEM="${ITEM%"${ITEM##*[![:space:]]}"}"
             TAG=$(echo "$ITEM" | cut -d: -f1)
             PKV=$(echo "$ITEM" | cut -d: -f2 -s)
             if [ -z "$PKV" ]; then
               PKV="$DEFAULT_PKV"
             fi
+
+            # Both values are checked here, on ubuntu, before any macOS job exists to import a
+            # signing certificate. TAG reaches a shell and PKV is spliced unquoted into the JSON
+            # below, and neither had ever been validated: nothing downstream checks the version
+            # format either, and update-registry.py takes --version as an arbitrary string, so a
+            # malformed tag publishes a garbage version into the plugins.json every app reads.
+            # Checked against all 366 existing plugin-* tags: every one matches.
+            if [[ ! "$TAG" =~ ^plugin-[a-z0-9-]+-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Malformed plugin tag: $TAG"
+              exit 1
+            fi
+            if [[ ! "$PKV" =~ ^[0-9]+$ ]]; then
+              echo "::error::Non-numeric pluginKitVersion for $TAG: $PKV"
+              exit 1
+            fi
+
             if [ "$FIRST" = true ]; then FIRST=false; else JSON+=','; fi
             JSON+="{\"tag\":\"$TAG\",\"pluginKitVersion\":$PKV}"
           done
@@ -74,6 +100,8 @@ jobs:
   build-plugin:
     name: "Build ${{ matrix.tag }} (PluginKit ${{ matrix.pluginKitVersion }})"
     needs: resolve-tags
+    permissions:
+      contents: write
     runs-on: macos-26
     timeout-minutes: 30
     strategy:
@@ -111,8 +139,8 @@ jobs:
           security create-keychain -p "" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "" "$KEYCHAIN_PATH"
-          echo "$CERTIFICATES_P12" | base64 --decode > $RUNNER_TEMP/certificate.p12
-          security import $RUNNER_TEMP/certificate.p12 -P "$CERTIFICATES_PASSWORD" \
+          echo "$CERTIFICATES_P12" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+          security import "$RUNNER_TEMP/certificate.p12" -P "$CERTIFICATES_PASSWORD" \
             -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple: -k "" "$KEYCHAIN_PATH"
           security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain
@@ -296,9 +324,11 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           NOTARY_PROFILE: TablePro
           NOTARIZE: "true"
+          TARGET: ${{ steps.plugin.outputs.target }}
+          VERSION: ${{ steps.plugin.outputs.version }}
         run: |
-          ./scripts/build-plugin.sh "${{ steps.plugin.outputs.target }}" arm64 "${{ steps.plugin.outputs.version }}"
-          ./scripts/build-plugin.sh "${{ steps.plugin.outputs.target }}" x86_64 "${{ steps.plugin.outputs.version }}"
+          ./scripts/build-plugin.sh "$TARGET" arm64 "$VERSION"
+          ./scripts/build-plugin.sh "$TARGET" x86_64 "$VERSION"
 
       # Assert the result rather than trusting the flag. The previous notarization step was
       # gated on an environment variable nothing defined, so it never ran and nothing noticed
@@ -360,10 +390,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           MATRIX_TAG: ${{ matrix.tag }}
           MATRIX_PKV: ${{ matrix.pluginKitVersion }}
+          PLUGIN_VERSION: ${{ steps.plugin.outputs.version }}
         run: |
           TAG="$MATRIX_TAG"
           DISPLAY_NAME="${{ steps.plugin.outputs.displayName }}"
-          VERSION="${{ steps.plugin.outputs.version }}"
+          VERSION="$PLUGIN_VERSION"
           BUNDLE_NAME="${{ steps.plugin.outputs.bundleName }}"
           ARM64_SHA="${{ steps.sha.outputs.arm64 }}"
           X86_SHA="${{ steps.sha.outputs.x86_64 }}"
@@ -435,18 +466,18 @@ jobs:
           done
 
       - name: Update plugin registry
-        if: ${{ env.REGISTRY_DEPLOY_KEY != '' }}
         env:
           REGISTRY_DEPLOY_KEY: ${{ secrets.REGISTRY_DEPLOY_KEY }}
           GH_TOKEN: ${{ github.token }}
           MATRIX_TAG: ${{ matrix.tag }}
           MATRIX_PKV: ${{ matrix.pluginKitVersion }}
+          PLUGIN_VERSION: ${{ steps.plugin.outputs.version }}
         run: |
           TAG="$MATRIX_TAG"
           BUNDLE_NAME="${{ steps.plugin.outputs.bundleName }}"
           BUNDLE_ID="${{ steps.plugin.outputs.bundleId }}"
           DISPLAY_NAME="${{ steps.plugin.outputs.displayName }}"
-          VERSION="${{ steps.plugin.outputs.version }}"
+          VERSION="$PLUGIN_VERSION"
           SUMMARY="${{ steps.plugin.outputs.summary }}"
           DB_TYPE_IDS='${{ steps.plugin.outputs.dbTypeIds }}'
           MIN_APP_VERSION="${{ steps.plugin.outputs.minAppVersion }}"

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -24,7 +24,7 @@ jobs:
       matrix: ${{ steps.tags.outputs.matrix }}
       currentPluginKitVersion: ${{ steps.pkv.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate registry update script
         run: python3 .github/scripts/test_update_registry.py
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           lfs: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,11 @@ concurrency:
   group: build-tablepro-${{ github.ref }}
   cancel-in-progress: false
 
+# The release job raises this to write for itself. Everything else here builds and notarizes and
+# needs nothing beyond the checkout.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: SwiftLint
@@ -31,10 +36,12 @@ jobs:
       - name: Run SwiftLint
         run: swiftlint lint --strict
 
+  # No `secrets: inherit`. That handed the suite CERTIFICATES_P12, CERTIFICATES_PASSWORD,
+  # NOTARY_PASSWORD, PROVISIONING_PROFILE, SPARKLE_PRIVATE_KEY, TELEGRAM_BOT_TOKEN and
+  # REGISTRY_DEPLOY_KEY, none of which it reads.
   test:
     name: macOS Tests
     uses: ./.github/workflows/macos-tests.yml
-    secrets: inherit
 
   build-arm64:
     name: Build ARM64
@@ -100,8 +107,8 @@ jobs:
           security create-keychain -p "" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "" "$KEYCHAIN_PATH"
-          echo "$CERTIFICATES_P12" | base64 --decode > $RUNNER_TEMP/certificate.p12
-          security import $RUNNER_TEMP/certificate.p12 -P "$CERTIFICATES_PASSWORD" \
+          echo "$CERTIFICATES_P12" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+          security import "$RUNNER_TEMP/certificate.p12" -P "$CERTIFICATES_PASSWORD" \
             -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple: -k "" "$KEYCHAIN_PATH"
           security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain
@@ -206,8 +213,8 @@ jobs:
           security create-keychain -p "" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "" "$KEYCHAIN_PATH"
-          echo "$CERTIFICATES_P12" | base64 --decode > $RUNNER_TEMP/certificate.p12
-          security import $RUNNER_TEMP/certificate.p12 -P "$CERTIFICATES_PASSWORD" \
+          echo "$CERTIFICATES_P12" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+          security import "$RUNNER_TEMP/certificate.p12" -P "$CERTIFICATES_PASSWORD" \
             -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple: -k "" "$KEYCHAIN_PATH"
           security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install SwiftLint
         run: brew list swiftlint &>/dev/null || brew install swiftlint
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -59,7 +59,7 @@ jobs:
       # so this restores the checkouts instead of re-cloning 30 repositories on every release.
       # Package.resolved pins every revision and is tracked, which is why it can key the cache.
       - name: Cache Swift package checkouts
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.spm-cache
           key: ${{ runner.os }}-spm-${{ hashFiles('TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
@@ -139,7 +139,7 @@ jobs:
         run: scripts/ci/package-artifacts.sh arm64
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifacts-arm64
           path: |
@@ -153,7 +153,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -166,7 +166,7 @@ jobs:
         run: scripts/download-libs.sh --force
 
       - name: Cache Swift package checkouts
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.spm-cache
           key: ${{ runner.os }}-spm-${{ hashFiles('TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
@@ -245,7 +245,7 @@ jobs:
         run: scripts/ci/package-artifacts.sh x86_64
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifacts-x86_64
           path: |
@@ -262,7 +262,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Verify registry has compatible plugin binaries
         run: |
@@ -283,7 +283,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -293,7 +293,7 @@ jobs:
           xcode-version: '26.4.1'
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts-raw/
           merge-multiple: true
@@ -345,7 +345,7 @@ jobs:
         run: scripts/ci/sign-and-appcast.sh "${GITHUB_REF#refs/tags/v}"
 
       - name: Upload appcast artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: appcast-${{ github.sha }}
           path: appcast/appcast.xml
@@ -355,7 +355,7 @@ jobs:
         run: scripts/ci/extract-release-notes.sh "${GITHUB_REF#refs/tags/v}"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: |
             artifacts/*.dmg

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,9 @@ concurrency:
   group: docs-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   docs:
     name: Validate docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,9 +24,9 @@ jobs:
     name: Validate docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
 

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -19,14 +19,18 @@ concurrency:
   group: ios-tests-${{ github.ref }}
   cancel-in-progress: true
 
+# A downgrade or an exact match is always allowed for a called workflow; only asking for more than
+# the caller holds fails at run creation. Declaring read cannot break a caller, and it stops every
+# job here from inheriting a write token if the repository default is ever flipped.
+permissions:
+  contents: read
+
 env:
   XCODE_PROJECT: TableProMobile/TableProMobile.xcodeproj
   XCODE_SCHEME: TableProMobile
   TEST_DESTINATION: "platform=iOS Simulator,name=iPhone 17 Pro,OS=latest"
 
 jobs:
-  # No `permissions:` block here either. See the note in macos-tests.yml: this workflow has no
-  # workflow_call caller today, but the same shape must not be copied back into one.
   changes:
     name: Detect relevant changes
     runs-on: ubuntu-latest

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -34,7 +34,7 @@ jobs:
     outputs:
       run: ${{ steps.decide.outputs.run }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 25
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -107,7 +107,7 @@ jobs:
         run: scripts/generate-project.sh
 
       - name: Cache static libraries
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: Libs
           # Include C bridge stub headers in the cache key so the iOS xcframework set
@@ -141,7 +141,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ios-test-results
           path: TestResults.xcresult

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -63,7 +63,7 @@ jobs:
     outputs:
       run: ${{ steps.decide.outputs.run }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -134,7 +134,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -165,7 +165,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -176,7 +176,7 @@ jobs:
         run: brew list xcbeautify &>/dev/null || brew install xcbeautify
 
       - name: Cache static libraries
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: Libs
           key: ${{ runner.os }}-libs-${{ hashFiles('Libs/checksums.sha256', 'Plugins/MSSQLDriverPlugin/CFreeTDS/include/sybdb.h') }}
@@ -215,7 +215,7 @@ jobs:
       # build.yml has cached these checkouts for a while; this workflow paid 1.5 minutes a run
       # re-resolving them.
       - name: Cache Swift package checkouts
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.spm-cache
           key: ${{ runner.os }}-spm-${{ hashFiles('TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
@@ -281,7 +281,7 @@ jobs:
         run: tar -czf products.tar.gz -C "$DERIVED_DATA/Build" Products
 
       - name: Upload the built products
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-products
           path: products.tar.gz
@@ -295,7 +295,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -340,7 +340,7 @@ jobs:
 
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: macos-test-results
           path: TestResults.xcresult
@@ -366,7 +366,7 @@ jobs:
         shard: [0, 1, 2]
         of: [3]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -412,7 +412,7 @@ jobs:
 
       - name: Upload UI test results
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: macos-ui-test-results-${{ matrix.shard }}
           path: UITestResults.xcresult

--- a/scripts/build-mariadb.sh
+++ b/scripts/build-mariadb.sh
@@ -18,6 +18,12 @@ set -eo pipefail
 # Usage: ./scripts/build-mariadb.sh
 
 MARIADB_VERSION="3.4.4"
+# MariaDB publishes a digest for this tarball independently of the tarball itself, at
+# https://archive.mariadb.org/connector-c-$MARIADB_VERSION/sha256sums.txt, which is why the source
+# moved here from the GitHub tag archive: GitHub publishes no digest, so pinning one would only
+# record whatever was served the first time anybody looked. Note the upstream tarball unpacks to a
+# "-src" directory, unlike the GitHub one.
+MARIADB_SHA256="58876fad1c2d33979d78bbfa61d7a3476e8faa2cd0af0f7f8bfeb06deaa1034e"
 MIN_MACOS="14.0"
 OPENSSL_ROOT="${OPENSSL_ROOT:-$(brew --prefix openssl@3 2>/dev/null || true)}"
 
@@ -47,10 +53,11 @@ trap cleanup EXIT
 echo "Building MariaDB Connector/C $MARIADB_VERSION for macOS (OpenSSL: $OPENSSL_ROOT)"
 
 echo "=> Downloading source..."
-curl -fSL "https://github.com/mariadb-corporation/mariadb-connector-c/archive/refs/tags/v$MARIADB_VERSION.tar.gz" \
+curl -fSL "https://archive.mariadb.org/connector-c-$MARIADB_VERSION/mariadb-connector-c-$MARIADB_VERSION-src.tar.gz" \
     -o "$BUILD_DIR/mariadb.tar.gz"
+echo "$MARIADB_SHA256  $BUILD_DIR/mariadb.tar.gz" | shasum -a 256 -c -
 tar xzf "$BUILD_DIR/mariadb.tar.gz" -C "$BUILD_DIR"
-MARIADB_SRC="$BUILD_DIR/mariadb-connector-c-$MARIADB_VERSION"
+MARIADB_SRC="$BUILD_DIR/mariadb-connector-c-$MARIADB_VERSION-src"
 
 build_slice() {
     local ARCH=$1
@@ -100,17 +107,18 @@ lipo -create "$BUILD_DIR/libmariadb_arm64.a" "$BUILD_DIR/libmariadb_x86_64.a" \
     -output "$LIBS_DIR/libmariadb_universal.a"
 cp "$LIBS_DIR/libmariadb_universal.a" "$LIBS_DIR/libmariadb.a"
 
+# The cleartext plugin is the whole reason this script exists, so a build without it is a failed
+# build, not a warning somebody might read in a 200 line log.
 echo "=> Verifying mysql_clear_password is now built in:"
-if [ "$(nm "$LIBS_DIR/libmariadb_arm64.a" 2>/dev/null | grep -c "clear_password_client_plugin")" -gt 0 ]; then
-    echo "   OK: mysql_clear_password_client_plugin present"
-else
-    echo "   WARNING: clear_password plugin symbol not found; check the build" >&2
+if [ "$(nm "$LIBS_DIR/libmariadb_arm64.a" 2>/dev/null | grep -c "clear_password_client_plugin")" -eq 0 ]; then
+    echo "ERROR: mysql_clear_password_client_plugin is missing from the build" >&2
+    exit 1
 fi
+echo "   OK: mysql_clear_password_client_plugin present"
 lipo -info "$LIBS_DIR/libmariadb_universal.a"
 
 echo ""
 echo "Done. Libs/libmariadb*.a rebuilt with the cleartext plugin."
 echo "Next: rebuild the app and test MySQL IAM. When confirmed working, publish the libs:"
-echo "  shasum -a 256 Libs/*.a > Libs/checksums.sha256"
-echo "  tar czf /tmp/tablepro-libs-v1.tar.gz -C Libs . && gh release upload libs-v1 /tmp/tablepro-libs-v1.tar.gz --clobber --repo TableProApp/TablePro"
-echo "  git add Libs/checksums.sha256 && git commit -m 'build: rebuild libmariadb with cleartext auth plugin'"
+echo "  scripts/publish-libs.sh libmariadb_arm64.a libmariadb_x86_64.a libmariadb_universal.a libmariadb.a"
+echo "  git add Libs/checksums.sha256 && git commit -m 'build: update static library checksums'"

--- a/scripts/ios/build-mariadb-ios.sh
+++ b/scripts/ios/build-mariadb-ios.sh
@@ -11,6 +11,12 @@ set -eo pipefail
 #   ./scripts/ios/build-mariadb-ios.sh
 
 MARIADB_VERSION="3.4.4"
+# MariaDB publishes a digest for this tarball independently of the tarball itself, at
+# https://archive.mariadb.org/connector-c-$MARIADB_VERSION/sha256sums.txt, which is why the source
+# moved here from the GitHub tag archive: GitHub publishes no digest, so pinning one would only
+# record whatever was served the first time anybody looked. Note the upstream tarball unpacks to a
+# "-src" directory, unlike the GitHub one.
+MARIADB_SHA256="58876fad1c2d33979d78bbfa61d7a3476e8faa2cd0af0f7f8bfeb06deaa1034e"
 IOS_DEPLOY_TARGET="17.0"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -66,11 +72,12 @@ setup_openssl_prefix() {
 # --- Download MariaDB Connector/C ---
 
 echo "=> Downloading MariaDB Connector/C $MARIADB_VERSION..."
-curl -fSL "https://github.com/mariadb-corporation/mariadb-connector-c/archive/refs/tags/v$MARIADB_VERSION.tar.gz" \
+curl -fSL "https://archive.mariadb.org/connector-c-$MARIADB_VERSION/mariadb-connector-c-$MARIADB_VERSION-src.tar.gz" \
     -o "$BUILD_DIR/mariadb.tar.gz"
+echo "$MARIADB_SHA256  $BUILD_DIR/mariadb.tar.gz" | shasum -a 256 -c -
 
 tar xzf "$BUILD_DIR/mariadb.tar.gz" -C "$BUILD_DIR"
-MARIADB_SRC="$BUILD_DIR/mariadb-connector-c-$MARIADB_VERSION"
+MARIADB_SRC="$BUILD_DIR/mariadb-connector-c-$MARIADB_VERSION-src"
 
 # --- Build function ---
 

--- a/scripts/release-all-plugins.sh
+++ b/scripts/release-all-plugins.sh
@@ -43,6 +43,7 @@ PLUGINS=(
     surrealdb
     teradata
     trino
+    dameng
 )
 
 BUNDLED_PLUGINS=(


### PR DESCRIPTION
Nine findings from the CI audit, all in the supply chain and permission surface. Nothing here changes what any workflow does on the happy path.

## A plugin tag reached a shell unvalidated

`build-plugin.yml` derived the plugin name and version from the tag with `sed`, then interpolated the version into four `run:` blocks with `${{ }}`. GitHub substitutes those as text before bash parses the line, on the runner that holds `CERTIFICATES_P12`, `NOTARY_PASSWORD` and `REGISTRY_DEPLOY_KEY`. `pluginKitVersion` had it worse: it was spliced unquoted into the matrix JSON straight from the `workflow_dispatch` input.

The correctness case is the stronger one. Nothing downstream checked the version format either, and `update-registry.py` takes `--version` as an arbitrary string, so a malformed tag publishes a garbage version into the `plugins.json` that every user's app reads for update checks.

Both are now validated in `resolve-tags`, which runs on ubuntu and holds no secrets, so a bad tag fails before a macOS job exists to import a certificate. Checked against all 366 existing `plugin-*` tags: every one matches `^plugin-[a-z0-9-]+-v[0-9]+\.[0-9]+\.[0-9]+$`.

The tag-derived version then moves out of the three `run:` bodies into `env:`, where a value sitting in a shell variable is never re-evaluated. The other `steps.plugin.outputs.*` reads are literal constants from the `case` arm and are deliberately left alone, so this stays reviewable.

The trim in the same loop was `echo "$ITEM" | xargs`, which is not a trim: `xargs` applies shell quote and backslash processing.

## Every action is pinned to a commit SHA

24 references were on mutable tags. A tag can be moved; a SHA cannot.

One of them was a real deadline. `softprops/action-gh-release` was pinned to `de2c0eb8`, a revision from 2022 whose `action.yml` declares `using: node16`. node16 actions run today only because the runner force-upgrades them, and that ends **2026-09-16**, which is 26 days out. The failure would land at the publish step of a release, after both notarized builds had already run. It moves to v3.0.2, which is node24. Verified against the action's own `action.yml` at that SHA: `files`, `body_path`, `draft` and `prerelease` are all still declared inputs and `GITHUB_TOKEN` is still read from env, so this usage needs no changes.

`build-plugin.yml` was also three majors behind on `actions/checkout` (v4, node20) while the other workflows were on v7.

## Token scope

- Every workflow now declares `permissions: contents: read`. The old comment in `macos-tests.yml` said never to add one because a called workflow may not request more than its caller. That premise is right but the conclusion did not follow: a downgrade or an exact match always succeeds. Without the declaration, every job inherits whatever the repository default happens to be, which is a setting no reviewer can see from a checkout.
- `build-plugin.yml` granted `contents: write` at workflow level, so `resolve-tags`, which reads two integers out of a Swift file, got a write token. It moves to the one job that publishes.
- `build.yml` called the test workflow with `secrets: inherit`, handing it `CERTIFICATES_P12`, `CERTIFICATES_PASSWORD`, `NOTARY_PASSWORD`, `PROVISIONING_PROFILE`, `SPARKLE_PRIVATE_KEY`, `TELEGRAM_BOT_TOKEN` and `REGISTRY_DEPLOY_KEY`. It reads none of them, so the line is gone.

## A missing secret was a silent skip

`Update plugin registry` was gated on `if: env.REGISTRY_DEPLOY_KEY != ''`. If that key were missing or rotated, the GitHub Release would exist, the registry would never learn about it, no user would ever see the plugin, and the job would go green. The condition is removed, so the step fails instead.

`build-plugin.yml` also had no `concurrency` group while deleting and recreating GitHub Releases. Two runs for the same tag raced each other. It gets one, with `cancel-in-progress: false`, because a run in flight holds a notarization submission open.

## MariaDB was the last unverified download

Every other fetched tarball in the repo is checksum-verified. Both MariaDB scripts fetched the GitHub tag archive with no check at all.

They now fetch MariaDB's own release tarball, whose digest upstream publishes independently at `archive.mariadb.org/connector-c-3.4.4/sha256sums.txt`. That matters more than pinning the GitHub archive's hash would: GitHub publishes no digest, so a pin there only records whatever was served the first time somebody looked.

Verified by downloading both: the published digest `58876fad…` matches the upstream tarball byte for byte. The upstream archive unpacks to `mariadb-connector-c-3.4.4-src/` rather than `mariadb-connector-c-3.4.4/`, which both scripts hardcoded, so both are updated together.

Then actually built it: `scripts/build-mariadb.sh` runs clean from the new source and produces arm64, x86_64 and universal slices carrying `mysql_clear_password_client_plugin`, which is the plugin the script exists to add. `Libs/` was restored from the published archive afterwards and verifies against the committed baseline.

While in that file: the "plugin symbol not found" case was a warning inside a 200 line log, and a build without that plugin is a failed build, so it exits now. And its closing instructions told the operator to run `shasum -a 256 Libs/*.a > Libs/checksums.sha256`, the exact command CLAUDE.md says never to run by hand because it silently reverts other libraries. It points at `publish-libs.sh` instead.

## Not in here

The iOS xcframeworks are still downloaded and linked with no integrity check, including in CI. Fixing it properly needs a committed baseline, a publisher that regenerates it, and the CLAUDE.md snippet that currently documents a manual upload bypassing all of it. That lands with the `publish-libs.sh` work rather than being half-done here.

## Verification

`actionlint`, with its shellcheck integration over every inline `run:` block, is now **completely clean across all five workflows**. It reported six findings before this change. `shellcheck` shows no new findings on either MariaDB script.

https://claude.ai/code/session_013MEaba8K1HQcyDNeq5wEFk
