### PR TITLE
ci(release): collapse the two build jobs into a matrix and stop the appcast rewinding

### DIFF
--- a/.github/actions/apple-signing/action.yml
+++ b/.github/actions/apple-signing/action.yml
@@ -1,0 +1,70 @@
+name: Apple signing
+description: Imports the Developer ID certificate, stores notary credentials, and installs the provisioning profile.
+
+inputs:
+  certificate-p12:
+    description: Base64 of the .p12 holding the Developer ID Application certificate.
+    required: true
+  certificate-password:
+    description: Password for that .p12.
+    required: true
+  apple-id:
+    description: Apple ID the notary submissions are made under.
+    required: true
+  team-id:
+    description: Apple Developer team identifier.
+    required: true
+  notary-password:
+    description: App-specific password for notarytool.
+    required: true
+  provisioning-profile:
+    description: Base64 of the provisioning profile. Omit to skip installing one.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Import signing certificate
+      shell: bash
+      env:
+        CERTIFICATES_P12: ${{ inputs.certificate-p12 }}
+        CERTIFICATES_PASSWORD: ${{ inputs.certificate-password }}
+      # A keychain of its own, unlocked with an empty password and given a six hour lock timeout,
+      # so a long notarization wait cannot relock it mid-run. The runner is thrown away afterwards.
+      run: |
+        set -euo pipefail
+        KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+        security create-keychain -p "" "$KEYCHAIN_PATH"
+        security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+        security unlock-keychain -p "" "$KEYCHAIN_PATH"
+        echo "$CERTIFICATES_P12" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+        security import "$RUNNER_TEMP/certificate.p12" -P "$CERTIFICATES_PASSWORD" \
+          -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+        rm -f "$RUNNER_TEMP/certificate.p12"
+        security set-key-partition-list -S apple-tool:,apple: -k "" "$KEYCHAIN_PATH"
+        security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain
+
+    - name: Configure notarization
+      shell: bash
+      env:
+        APPLE_ID: ${{ inputs.apple-id }}
+        APPLE_TEAM_ID: ${{ inputs.team-id }}
+        NOTARY_PASSWORD: ${{ inputs.notary-password }}
+      run: |
+        set -euo pipefail
+        xcrun notarytool store-credentials "TablePro" \
+          --apple-id "$APPLE_ID" \
+          --team-id "$APPLE_TEAM_ID" \
+          --password "$NOTARY_PASSWORD"
+
+    - name: Install provisioning profile
+      if: inputs.provisioning-profile != ''
+      shell: bash
+      env:
+        PROVISIONING_PROFILE: ${{ inputs.provisioning-profile }}
+      run: |
+        set -euo pipefail
+        profiles="$HOME/Library/MobileDevice/Provisioning Profiles"
+        mkdir -p "$profiles"
+        echo "$PROVISIONING_PROFILE" | base64 --decode > "$profiles/tablepro.provisionprofile"

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -130,31 +130,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: scripts/download-libs.sh
 
-      - name: Import signing certificate
-        env:
-          CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}
-          CERTIFICATES_PASSWORD: ${{ secrets.CERTIFICATES_PASSWORD }}
-        run: |
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-          security create-keychain -p "" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "" "$KEYCHAIN_PATH"
-          echo "$CERTIFICATES_P12" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
-          security import "$RUNNER_TEMP/certificate.p12" -P "$CERTIFICATES_PASSWORD" \
-            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple: -k "" "$KEYCHAIN_PATH"
-          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain
-
-      - name: Configure notarization
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          NOTARY_PASSWORD: ${{ secrets.NOTARY_PASSWORD }}
-        run: |
-          xcrun notarytool store-credentials "TablePro" \
-            --apple-id "$APPLE_ID" \
-            --team-id "$APPLE_TEAM_ID" \
-            --password "$NOTARY_PASSWORD"
+      # No provisioning profile: a .tableplugin is signed with Developer ID and notarized, and
+      # never carries an embedded profile the way the app does.
+      - name: Set up Apple signing
+        uses: ./.github/actions/apple-signing
+        with:
+          certificate-p12: ${{ secrets.CERTIFICATES_P12 }}
+          certificate-password: ${{ secrets.CERTIFICATES_PASSWORD }}
+          apple-id: ${{ secrets.APPLE_ID }}
+          team-id: ${{ secrets.APPLE_TEAM_ID }}
+          notary-password: ${{ secrets.NOTARY_PASSWORD }}
 
       - name: Resolve plugin info
         id: plugin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,10 +43,24 @@ jobs:
     name: macOS Tests
     uses: ./.github/workflows/macos-tests.yml
 
-  build-arm64:
-    name: Build ARM64
+  build:
+    name: Build ${{ matrix.arch }}
     runs-on: macos-26
-    timeout-minutes: 30
+    timeout-minutes: ${{ matrix.timeout }}
+    strategy:
+      # No fail-fast. A failing arch would otherwise cancel its sibling mid-notarization, which is
+      # the same thing the concurrency block above exists to prevent.
+      fail-fast: false
+      matrix:
+        include:
+          # Separate timeouts because the two arms genuinely differ: measured over v0.62 to v0.67,
+          # x86_64 was never the faster of the two and once ran 22 minutes longer than an ARM64
+          # sibling that started in the same second, so this is the architecture rather than the
+          # notary queue.
+          - arch: arm64
+            timeout: 30
+          - arch: x86_64
+            timeout: 45
 
     steps:
       - name: Checkout code
@@ -72,18 +86,26 @@ jobs:
           key: ${{ runner.os }}-spm-${{ hashFiles('TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: ${{ runner.os }}-spm-
 
-      # create-dmg is the only Homebrew formula either build job needs. The MySQL plugin
-      # links Libs/libmariadb.a, which download-libs.sh vendors and prepare-libs.sh selects
-      # per architecture, and its headers live in Plugins/MySQLDriverPlugin/CMariaDB/include.
+      # create-dmg is the only Homebrew formula either arm needs. The MySQL plugin links
+      # Libs/libmariadb.a, which download-libs.sh vendors and prepare-libs.sh selects per
+      # architecture, and its headers live in Plugins/MySQLDriverPlugin/CMariaDB/include.
       # LIBRARY_SEARCH_PATHS names $(SRCROOT)/Libs and no Homebrew prefix, so nothing in the
-      # build ever read mariadb-connector-c. macos-tests.yml proves it: the app-tests job
-      # links all 31 plugin bundles with no Homebrew mariadb installed at all.
+      # build ever read mariadb-connector-c. macos-tests.yml proves it: its build job links all
+      # 31 plugin bundles with no Homebrew mariadb installed at all.
+      #
+      # The x86_64 arm is a cross-compile on an arm64 runner: every tool that runs during the
+      # build is native and the x86_64 slices of the static libraries are vendored in Libs.
+      # Bootstrapping a second Homebrew prefix cost five minutes a release to install a
+      # mariadb-connector-c the build never opened. create-dmg is a shell script, so the native
+      # prefix serves both arms.
       - name: Install create-dmg
         run: brew list create-dmg &>/dev/null || brew install create-dmg
 
       - name: Prepare libraries
-        run: scripts/ci/prepare-libs.sh arm64
+        run: scripts/ci/prepare-libs.sh ${{ matrix.arch }}
 
+      # The only thing that proves the pinned toolchain was actually selected before a twenty
+      # minute build starts.
       - name: Verify Xcode
         run: |
           echo "Active Xcode:"
@@ -98,163 +120,34 @@ jobs:
       - name: Setup XcodeGen
         uses: ./.github/actions/setup-xcodegen
 
-      - name: Import signing certificate
-        env:
-          CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}
-          CERTIFICATES_PASSWORD: ${{ secrets.CERTIFICATES_PASSWORD }}
-        run: |
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-          security create-keychain -p "" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "" "$KEYCHAIN_PATH"
-          echo "$CERTIFICATES_P12" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
-          security import "$RUNNER_TEMP/certificate.p12" -P "$CERTIFICATES_PASSWORD" \
-            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple: -k "" "$KEYCHAIN_PATH"
-          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain
+      - name: Set up Apple signing
+        uses: ./.github/actions/apple-signing
+        with:
+          certificate-p12: ${{ secrets.CERTIFICATES_P12 }}
+          certificate-password: ${{ secrets.CERTIFICATES_PASSWORD }}
+          apple-id: ${{ secrets.APPLE_ID }}
+          team-id: ${{ secrets.APPLE_TEAM_ID }}
+          notary-password: ${{ secrets.NOTARY_PASSWORD }}
+          provisioning-profile: ${{ secrets.PROVISIONING_PROFILE }}
 
-      - name: Configure notarization
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          NOTARY_PASSWORD: ${{ secrets.NOTARY_PASSWORD }}
-        run: |
-          xcrun notarytool store-credentials "TablePro" \
-            --apple-id "$APPLE_ID" \
-            --team-id "$APPLE_TEAM_ID" \
-            --password "$NOTARY_PASSWORD"
-
-      - name: Install provisioning profile
-        env:
-          PROVISIONING_PROFILE: ${{ secrets.PROVISIONING_PROFILE }}
-        run: |
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          echo "$PROVISIONING_PROFILE" | base64 --decode > ~/Library/MobileDevice/Provisioning\ Profiles/tablepro.provisionprofile
-
-      - name: Build ARM64
+      - name: Build ${{ matrix.arch }}
         env:
           ANALYTICS_HMAC_SECRET: ${{ secrets.ANALYTICS_HMAC_SECRET }}
           NOTARIZE: "true"
-        run: scripts/build-release.sh arm64
+        run: scripts/build-release.sh ${{ matrix.arch }}
 
       - name: Verify build
-        run: scripts/ci/verify-build.sh arm64
+        run: scripts/ci/verify-build.sh ${{ matrix.arch }}
 
       - name: Package artifacts
         env:
           NOTARIZE: "true"
-        run: scripts/ci/package-artifacts.sh arm64
+        run: scripts/ci/package-artifacts.sh ${{ matrix.arch }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: artifacts-arm64
-          path: |
-            build/Release/TablePro-*.dmg
-            build/Release/TablePro-*.zip
-
-  build-x86_64:
-    name: Build x86_64
-    runs-on: macos-26
-    timeout-minutes: 45
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
-        with:
-          xcode-version: '26.4.1'
-
-      - name: Download static libraries
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: scripts/download-libs.sh --force
-
-      - name: Cache Swift package checkouts
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.spm-cache
-          key: ${{ runner.os }}-spm-${{ hashFiles('TablePro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
-          restore-keys: ${{ runner.os }}-spm-
-
-      # No Rosetta and no x86_64 Homebrew here. This is a cross-compile on an arm64 runner:
-      # every tool that runs during the build is native, and the x86_64 slices of the static
-      # libraries are vendored in Libs. Bootstrapping a second Homebrew prefix cost five
-      # minutes a release to install a mariadb-connector-c the build never opened. create-dmg
-      # is a shell script, so the native prefix serves both jobs.
-      - name: Install create-dmg
-        run: brew list create-dmg &>/dev/null || brew install create-dmg
-
-      - name: Prepare libraries
-        run: scripts/ci/prepare-libs.sh x86_64
-
-      - name: Verify Xcode
-        run: |
-          echo "Active Xcode:"
-          xcode-select -p
-          xcodebuild -version
-
-      - name: Create Secrets.xcconfig
-        env:
-          ANALYTICS_HMAC_SECRET: ${{ secrets.ANALYTICS_HMAC_SECRET }}
-        run: echo "ANALYTICS_HMAC_SECRET = ${ANALYTICS_HMAC_SECRET}" > Configs/Secrets.xcconfig
-
-      - name: Setup XcodeGen
-        uses: ./.github/actions/setup-xcodegen
-
-      - name: Import signing certificate
-        env:
-          CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}
-          CERTIFICATES_PASSWORD: ${{ secrets.CERTIFICATES_PASSWORD }}
-        run: |
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-          security create-keychain -p "" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "" "$KEYCHAIN_PATH"
-          echo "$CERTIFICATES_P12" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
-          security import "$RUNNER_TEMP/certificate.p12" -P "$CERTIFICATES_PASSWORD" \
-            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple: -k "" "$KEYCHAIN_PATH"
-          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain
-
-      - name: Configure notarization
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          NOTARY_PASSWORD: ${{ secrets.NOTARY_PASSWORD }}
-        run: |
-          xcrun notarytool store-credentials "TablePro" \
-            --apple-id "$APPLE_ID" \
-            --team-id "$APPLE_TEAM_ID" \
-            --password "$NOTARY_PASSWORD"
-
-      - name: Install provisioning profile
-        env:
-          PROVISIONING_PROFILE: ${{ secrets.PROVISIONING_PROFILE }}
-        run: |
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          echo "$PROVISIONING_PROFILE" | base64 --decode > ~/Library/MobileDevice/Provisioning\ Profiles/tablepro.provisionprofile
-
-      - name: Build x86_64
-        env:
-          ANALYTICS_HMAC_SECRET: ${{ secrets.ANALYTICS_HMAC_SECRET }}
-          NOTARIZE: "true"
-        run: scripts/build-release.sh x86_64
-
-      - name: Verify build
-        run: scripts/ci/verify-build.sh x86_64
-
-      - name: Package artifacts
-        env:
-          NOTARIZE: "true"
-        run: scripts/ci/package-artifacts.sh x86_64
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: artifacts-x86_64
+          name: artifacts-${{ matrix.arch }}
           path: |
             build/Release/TablePro-*.dmg
             build/Release/TablePro-*.zip
@@ -282,7 +175,7 @@ jobs:
   release:
     name: Create GitHub Release
     runs-on: macos-26
-    needs: [lint, test, build-arm64, build-x86_64, registry-readiness]
+    needs: [lint, test, build, registry-readiness]
     if: startsWith(github.ref, 'refs/tags/v')
     timeout-minutes: 10
     permissions:
@@ -312,6 +205,16 @@ jobs:
           rm -rf artifacts-raw/
           echo "Artifacts:"
           ls -lh artifacts/
+
+      - name: Verify the tag matches the declared version
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          XCCONFIG_VERSION=$(sed -n 's/^MARKETING_VERSION[[:space:]]*=[[:space:]]*//p' Configs/Version.xcconfig | tr -d ' ')
+          if [ "$TAG_VERSION" != "$XCCONFIG_VERSION" ]; then
+            echo "::error::tag v$TAG_VERSION does not match MARKETING_VERSION $XCCONFIG_VERSION"
+            exit 1
+          fi
+          echo "tag and MARKETING_VERSION agree on $TAG_VERSION"
 
       - name: Verify and organize artifacts for release
         run: |
@@ -346,9 +249,19 @@ jobs:
       # so the key is always meant to be present, and gating on it meant a missing or rotated
       # secret published a release that no existing install could ever see. A signing key that
       # is not there is now a red job, not a silent skip.
+      # The tag's own appcast.xml is the feed as of that commit. Seeding from it drops every
+      # version published since, and generate_appcast keeps only what it is handed, so the
+      # committed feed would silently rewind and those releases would stop being offered.
+      - name: Seed the appcast from the published feed
+        run: |
+          git fetch origin main
+          mkdir -p appcast
+          git show origin/main:appcast.xml > appcast/seed.xml
+
       - name: Sign update archives with Sparkle
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+          SEED_APPCAST: appcast/seed.xml
         run: scripts/ci/sign-and-appcast.sh "${GITHUB_REF#refs/tags/v}"
 
       - name: Upload appcast artifact
@@ -391,6 +304,17 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin main
           git checkout main
+
+          # Refuse to publish a feed that drops a version main already advertises. Sparkle serves
+          # this file to every install, so a rewind stops offering updates that were shipped.
+          missing=$(comm -23 \
+            <(git show origin/main:appcast.xml | grep -o '<sparkle:shortVersionString>[^<]*' | sed 's/.*>//' | sort -u) \
+            <(grep -o '<sparkle:shortVersionString>[^<]*' appcast/appcast.xml | sed 's/.*>//' | sort -u))
+          if [ -n "$missing" ]; then
+            echo "❌ ERROR: the generated feed drops versions already published on main: $missing" >&2
+            exit 1
+          fi
+
           cp appcast/appcast.xml appcast.xml
           git add appcast.xml
 
@@ -406,7 +330,9 @@ jobs:
               exit 0
             fi
             echo "Push rejected, rebasing onto origin/main (attempt ${attempt})"
-            git pull --rebase origin main
+            # A conflicting rebase leaves the repo mid-rebase with main still at the pre-rebase
+            # commit, so the next attempt pushed a stale ref and failed differently every time.
+            git pull --rebase origin main || git rebase --abort || true
           done
 
           echo "❌ ERROR: could not push appcast.xml after 3 attempts" >&2

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -390,8 +390,10 @@ build_for_arch() {
         exit 1
     }
 
-    # Copy and rename app
+    # Copy and rename app. Removed first: cp -R onto an existing bundle merges into it, so a
+    # rebuild carried the previous build's files into the one being signed and shipped.
     OUTPUT_NAME="TablePro-${arch}.app"
+    rm -rf "$BUILD_DIR/$OUTPUT_NAME"
     echo "Copying app bundle to release directory..."
     if ! cp -R "$APP_PATH" "$BUILD_DIR/$OUTPUT_NAME"; then
         echo "❌ FATAL: Failed to copy app bundle"
@@ -405,11 +407,6 @@ build_for_arch() {
         echo "❌ FATAL: App bundle was not copied successfully"
         exit 1
     fi
-
-    # Remove any stale nested .app bundles in the bundle root (breaks codesign)
-    for nested in "$BUILD_DIR/$OUTPUT_NAME"/*.app; do
-        [ -d "$nested" ] && rm -rf "$nested"
-    done
 
     # Strip plugin binaries — removes debug symbols, code coverage (__LLVM_COV),
     # and dead LINKEDIT metadata that bloat the bundle (e.g., OracleDriver 43MB → ~15MB)
@@ -671,8 +668,11 @@ if [ "$NOTARIZE" = "true" ]; then
         ditto -c -k --keepParent "$app" "$zip_path"
 
         echo "   Submitting $name for notarization..."
-        submit_output=$(xcrun notarytool submit "$zip_path" --keychain-profile "TablePro" --wait 2>&1)
-        submit_status=$?
+        # Assigned before the substitution, then overwritten on failure. Written the other way
+        # round, `submit_status=$?` reads the exit status of the assignment, which is always 0,
+        # so every failure took the success branch and the log fetch below was unreachable.
+        submit_status=0
+        submit_output=$(xcrun notarytool submit "$zip_path" --keychain-profile "TablePro" --wait 2>&1) || submit_status=$?
         echo "$submit_output"
 
         submission_id=$(echo "$submit_output" | grep "id:" | head -1 | awk '{print $2}')

--- a/scripts/ci/package-artifacts.sh
+++ b/scripts/ci/package-artifacts.sh
@@ -9,7 +9,12 @@ if [[ "$ARCH" != "arm64" && "$ARCH" != "x86_64" ]]; then
   exit 1
 fi
 
-VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//') || VERSION="dev"
+# Read from the bundle being packaged rather than inferred from git. `git describe --tags` picks
+# up whatever tag is nearest, which on a release commit that also carries a plugin tag is the
+# wrong one, and its "dev" fallback shipped that name to a public release rather than failing.
+# Taken from the artifact, the DMG name cannot disagree with the app inside it.
+APP_BUNDLE="build/Release/TablePro-${ARCH}.app"
+VERSION=$(plutil -extract CFBundleShortVersionString raw -o - "$APP_BUNDLE/Contents/Info.plist")
 
 # --- Create DMG ---
 echo "Creating DMG installer..."
@@ -23,25 +28,17 @@ fi
 chmod +x scripts/create-dmg.sh
 
 echo "📌 Using version: $VERSION"
-NOTARIZE="${NOTARIZE:-false}" scripts/create-dmg.sh "$VERSION" "$ARCH" "build/Release/TablePro-${ARCH}.app"
+NOTARIZE="${NOTARIZE:-false}" scripts/create-dmg.sh "$VERSION" "$ARCH" "$APP_BUNDLE"
 
-# Verify DMG was created
+# Verify DMG was created. A DMG under any other name is not the one the release will upload, so
+# accepting it here only moved the failure to somewhere it was harder to read.
 DMG_FILE="build/Release/TablePro-${VERSION}-${ARCH}.dmg"
-if [ -f "$DMG_FILE" ]; then
-  echo "✅ DMG installer created successfully: $DMG_FILE"
-else
-  echo "⚠️  Expected DMG not found at: $DMG_FILE"
-  echo "📂 Checking for any DMG files in build/Release/:"
-  ls -la build/Release/*.dmg 2>/dev/null || echo "   No DMG files found"
-
-  if ls build/Release/*-${ARCH}.dmg 1>/dev/null 2>&1; then
-    echo "✅ Found ${ARCH} DMG file(s):"
-    ls -lh build/Release/*-${ARCH}.dmg
-  else
-    echo "❌ ERROR: No ${ARCH} DMG file was created"
-    exit 1
-  fi
+if [ ! -f "$DMG_FILE" ]; then
+  echo "❌ ERROR: expected DMG not found at: $DMG_FILE" >&2
+  ls -la build/Release/*.dmg 2>/dev/null || true
+  exit 1
 fi
+echo "✅ DMG installer created successfully: $DMG_FILE"
 
 ls -lh build/Release/*.dmg
 

--- a/scripts/ci/sign-and-appcast.sh
+++ b/scripts/ci/sign-and-appcast.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 # Usage: sign-and-appcast.sh <version>
 # Requires: SPARKLE_PRIVATE_KEY env var, artifacts/ directory with ZIPs.
 
+SEED_APPCAST="${SEED_APPCAST:-appcast.xml}"
 VERSION="${1:?Usage: sign-and-appcast.sh <version>}"
 
 if [ -z "${SPARKLE_PRIVATE_KEY:-}" ]; then
@@ -84,9 +85,11 @@ for arch in "${ARCHS[@]}"; do
   basename="${STAGING}/TablePro-${VERSION}-${arch}"
   echo "$RELEASE_HTML" > "${basename}.html"
 
-  # Copy existing appcast for history preservation (only for first arch)
-  if [ "${#APPCAST_XMLS[@]}" -eq 0 ] && [ -f appcast.xml ]; then
-    cp appcast.xml "$STAGING/"
+  # Seed the generator with the feed that is actually published, so every version already in it
+  # survives. The default is the checkout's own appcast.xml, which is the file as of the tag
+  # rather than the state of main, and generate_appcast only keeps what it is given.
+  if [ "${#APPCAST_XMLS[@]}" -eq 0 ] && [ -f "$SEED_APPCAST" ]; then
+    cp "$SEED_APPCAST" "$STAGING/appcast.xml"
   fi
 
   "$SPARKLE_BIN/generate_appcast" \

--- a/scripts/ci/verify-build.sh
+++ b/scripts/ci/verify-build.sh
@@ -140,12 +140,24 @@ else
   exit 1
 fi
 
-# Verify notarization staple (if notarized)
-if xcrun stapler validate "$APP_BUNDLE" 2>&1 | grep -q "The validate action worked"; then
-  echo "✅ Notarization ticket stapled"
-else
-  echo "⚠️  No notarization ticket stapled (may not have been notarized yet)"
+# The release path always notarizes, so there is no legitimate "not yet" case: a warning here
+# meant an unnotarized build passed verification and shipped. Checked by exit code rather than by
+# grepping for a message, matching scripts/build-plugin.sh.
+if ! xcrun stapler validate "$APP_BUNDLE"; then
+  echo "❌ ERROR: No notarization ticket stapled to $APP_BUNDLE"
+  exit 1
 fi
+echo "✅ Notarization ticket stapled"
+
+# spctl is what a user's Mac runs. It accepts an unstapled but notarized bundle over the network,
+# so it proves the app will launch but never that it will launch offline. The staple check above
+# is what covers that, and both have to pass.
+if ! spctl -a -vvv -t exec "$APP_BUNDLE" 2>&1 | grep -q "accepted"; then
+  echo "❌ ERROR: Gatekeeper rejects $APP_BUNDLE"
+  spctl -a -vvv -t exec "$APP_BUNDLE" 2>&1 || true
+  exit 1
+fi
+echo "✅ Accepted by Gatekeeper"
 
 # Display info
 echo "✅ Build verified successfully"

--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -6,7 +6,20 @@ set -e
 
 # Configuration
 APP_NAME="TablePro"
-VERSION="${1:-0.1.13}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+    # Configs/Version.xcconfig is the single declaration of the app version. The literal that
+    # used to sit here as a default was 0.1.13, 66 releases behind, so a run without an explicit
+    # version produced a correctly built DMG under a badly wrong name.
+    VERSION=$(sed -n 's/^MARKETING_VERSION[[:space:]]*=[[:space:]]*//p' \
+        "$REPO_ROOT/Configs/Version.xcconfig" | tr -d ' ')
+fi
+if [ -z "$VERSION" ]; then
+    # sed exits 0 when it matches nothing, so set -e does not cover this.
+    echo "❌ ERROR: MARKETING_VERSION missing from Configs/Version.xcconfig" >&2
+    exit 1
+fi
 ARCH="${2:-universal}"
 SOURCE_APP="${3:-build/Release/${APP_NAME}.app}"
 DMG_NAME="${APP_NAME}-${VERSION}-${ARCH}.dmg"
@@ -234,6 +247,9 @@ if [ "$NOTARIZE" = "true" ]; then
     echo "📮 Notarizing DMG..."
     if xcrun notarytool submit "$FINAL_DMG" --keychain-profile "TablePro" --wait; then
         xcrun stapler staple "$FINAL_DMG"
+        # Stapling can report success and still leave no usable ticket, which is why
+        # build-plugin.sh validates after stapling. The DMG had no such check.
+        xcrun stapler validate "$FINAL_DMG"
         echo "✅ DMG notarized and stapled"
     else
         echo "❌ DMG notarization failed"


### PR DESCRIPTION
Duplication and a set of release-path guards that could not fail. `build.yml` drops from 414 lines to 314.

## build-arm64 and build-x86_64 were 75 of 84 identical lines

They are one matrix job now. The two arms had already drifted on `timeout-minutes` (30 vs 45) with nothing recording why, so that difference is kept as a matrix value rather than flattened: measured over v0.62 to v0.67, x86_64 was never the faster arm and once ran 22 minutes longer than an ARM64 sibling that started in the same second, so it is the architecture rather than the notary queue.

`fail-fast: false` is mandatory here. The default would cancel the sibling mid-notarization, which is exactly what the `cancel-in-progress: false` above it exists to prevent.

## The keychain, notary and provisioning steps existed in three byte-identical copies

They are now `.github/actions/apple-signing`, used by both release arms and by `build-plugin.yml`. `security create-keychain` appears in exactly one place in the repo again.

Two things picked up on the way: the decoded `.p12` is removed once imported rather than left in `RUNNER_TEMP`, and the provisioning profile is optional, because a `.tableplugin` is signed and notarized but never carries one.

## The appcast could rewind and delete published versions

`generate_appcast` keeps only the versions it is handed, and it was seeded from the `appcast.xml` in the tag's own checkout, which is the feed as of that commit rather than the feed on `main`. Anything published in between was dropped, and the result was committed over `main`'s copy. Sparkle serves that file to every install, so a dropped version stops being offered.

Three changes:

- The seed comes from `git show origin/main:appcast.xml` through an untracked path, so the tracked file is never written before the check below.
- Before the overwrite, the generated feed is compared against what `main` advertises, and the job fails if anything is missing. Verified against the real feed: 68 versions are advertised today, an identical feed produces no false positive, and a feed with one version removed is correctly reported as dropping `0.26.0`.
- The push retry loop never ran `git rebase --abort`, so a conflicting `git pull --rebase` left the repo mid-rebase with `main` still at the pre-rebase commit and attempts 2 and 3 pushed a stale ref. It aborts now.

## Guards that could not fail

- **`verify-build.sh` treated a missing notarization ticket as a warning.** The release path always notarizes, so there was no legitimate "not yet" case: an unnotarized build passed verification. It is fatal now, checked by exit code rather than by grepping for a message, and Gatekeeper is asked as well. Both are needed: `spctl` accepts an unstapled but notarized bundle over the network, so it proves the app launches but never that it launches offline.
- **`build-release.sh` swallowed notarization failures.** `submit_output=$(...)` followed by `submit_status=$?` reads the exit status of the assignment, which is always 0. Every failure took the success branch, and the log-fetch block below it was unreachable. Assigned before the substitution now.
- **`cp -R` onto an existing app bundle merges into it**, so a rebuild carried the previous build's files into the bundle being signed and shipped. The destination is removed first, which also makes the stale-nested-`.app` loop underneath it dead code.
- **`create-dmg.sh` defaulted to version `0.1.13`**, 66 releases behind. It reads `Configs/Version.xcconfig` now, using the same `sed` form `build-plugin.yml` already uses for that file, with an explicit empty check because `sed` exits 0 when it matches nothing. It also validates the DMG after stapling, which `build-plugin.sh` already did and this did not.
- **`package-artifacts.sh` derived the version with `git describe --tags`**, which picks the nearest tag, and on a release commit that also carries a plugin tag that is the wrong one. Its `|| VERSION="dev"` fallback would have shipped that name to a public release. It reads `CFBundleShortVersionString` out of the bundle being packaged, so the DMG name cannot disagree with the app inside it, and a DMG under an unexpected name is now a hard failure instead of a warning followed by a glob.
- **Nothing checked that the tag matched `MARKETING_VERSION`.** A forgotten version bump shipped under the tag's name with the app declaring something else. The release job asserts it before touching any artifact.

## Not in here

`build-release.sh` still carries four near-identical `prepare_*` functions that do the same job as `scripts/ci/prepare-libs.sh`, and the two disagree about whether to copy the per-arch slice or thin the universal one. That is 163 lines that should be about 35, and it belongs with the `scripts/lib/` work rather than here, where it would make an already broad diff unreviewable.

## Verification

`actionlint` stays clean across all five workflows. `shellcheck` reports nothing new on any of the four scripts. The appcast drop-detection was exercised against the live feed; the rest of the release path needs signing credentials, so it is reviewed rather than run, and the first tag after this merges is where it lands.

https://claude.ai/code/session_013MEaba8K1HQcyDNeq5wEFk
