### PR TITLE
ci(plugins): move the plugin release metadata out of a shell case block into a manifest

### DIFF
--- a/.github/plugin-registry.json
+++ b/.github/plugin-registry.json
@@ -1,0 +1,339 @@
+{
+  "$comment": [
+    "The release metadata for every plugin published to the registry, keyed by the slug in its",
+    "git tag (plugin-<slug>-v<version>). This is data the repo owns nowhere else: the summary,",
+    "the category and the homepage exist only here, and the slug-to-target mapping has no",
+    "derivation rule (mssql -> MSSQLDriver, cloudflare-d1 -> CloudflareD1DriverPlugin).",
+    "",
+    "'icon' and 'databaseTypeIds' do exist elsewhere, in the plugin's own DriverPlugin class,",
+    "and scripts/ci/check-plugin-manifest.py fails if the two disagree. Seven icons here were",
+    "already wrong when that check was first run.",
+    "",
+    "The 8 plugins absent from this file are the ones bundled inside the app and never published",
+    "",
+    "'bundled' marks a plugin that also ships inside the app. Those six can still be published",
+    "individually when users on an already-shipped app need a fix sooner, but a bulk ABI re-release",
+    "skips them, because their binaries ride with the next app release.",
+    "to the registry: MySQL, PostgreSQL, CSV/JSON/SQL export, CSV/JSON import, CSV inspector."
+  ],
+  "plugins": {
+    "beancount": {
+      "target": "BeancountDriver",
+      "bundleName": "BeancountDriver",
+      "bundleId": "com.TablePro.BeancountDriver",
+      "bundled": false,
+      "displayName": "Beancount Driver",
+      "summary": "Read-only Beancount ledger driver using user-provided rledger or Python Beancount",
+      "databaseTypeIds": [
+        "Beancount"
+      ],
+      "icon": "beancount-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/beancount"
+    },
+    "bigquery": {
+      "target": "BigQueryDriverPlugin",
+      "bundleName": "BigQueryDriverPlugin",
+      "bundleId": "com.TablePro.BigQueryDriverPlugin",
+      "bundled": false,
+      "displayName": "BigQuery Driver",
+      "summary": "Google BigQuery analytics database driver via REST API",
+      "databaseTypeIds": [
+        "BigQuery"
+      ],
+      "icon": "bigquery-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/bigquery"
+    },
+    "cassandra": {
+      "target": "CassandraDriver",
+      "bundleName": "CassandraDriver",
+      "bundleId": "com.TablePro.CassandraDriver",
+      "bundled": false,
+      "displayName": "Cassandra Driver",
+      "summary": "Apache Cassandra and ScyllaDB driver via DataStax C driver",
+      "databaseTypeIds": [
+        "Cassandra",
+        "ScyllaDB"
+      ],
+      "icon": "cassandra-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/cassandra"
+    },
+    "clickhouse": {
+      "target": "ClickHouseDriver",
+      "bundleName": "ClickHouseDriver",
+      "bundleId": "com.TablePro.ClickHouseDriver",
+      "bundled": true,
+      "displayName": "ClickHouse Driver",
+      "summary": "ClickHouse OLAP database driver via HTTP interface",
+      "databaseTypeIds": [
+        "ClickHouse"
+      ],
+      "icon": "clickhouse-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/clickhouse"
+    },
+    "cloudflare-d1": {
+      "target": "CloudflareD1DriverPlugin",
+      "bundleName": "CloudflareD1DriverPlugin",
+      "bundleId": "com.TablePro.CloudflareD1DriverPlugin",
+      "bundled": false,
+      "displayName": "Cloudflare D1 Driver",
+      "summary": "Cloudflare D1 serverless SQLite-compatible database driver via REST API",
+      "databaseTypeIds": [
+        "Cloudflare D1"
+      ],
+      "icon": "cloudflare-d1-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/cloudflare-d1"
+    },
+    "dameng": {
+      "target": "DamengDriver",
+      "bundleName": "DamengDriver",
+      "bundleId": "com.TablePro.DamengDriver",
+      "bundled": false,
+      "displayName": "Dameng Driver",
+      "summary": "Dameng DM8 database driver via a native wire client",
+      "databaseTypeIds": [
+        "Dameng"
+      ],
+      "icon": "cylinder",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/dameng"
+    },
+    "duckdb": {
+      "target": "DuckDBDriver",
+      "bundleName": "DuckDBDriver",
+      "bundleId": "com.TablePro.DuckDBDriver",
+      "bundled": false,
+      "displayName": "DuckDB Driver",
+      "summary": "DuckDB analytical database driver",
+      "databaseTypeIds": [
+        "DuckDB"
+      ],
+      "icon": "duckdb-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/duckdb"
+    },
+    "dynamodb": {
+      "target": "DynamoDBDriverPlugin",
+      "bundleName": "DynamoDBDriverPlugin",
+      "bundleId": "com.TablePro.DynamoDBDriverPlugin",
+      "bundled": false,
+      "displayName": "DynamoDB Driver",
+      "summary": "Amazon DynamoDB driver with PartiQL queries and AWS IAM/Profile/SSO authentication",
+      "databaseTypeIds": [
+        "DynamoDB"
+      ],
+      "icon": "dynamodb-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/dynamodb"
+    },
+    "elasticsearch": {
+      "target": "ElasticsearchDriverPlugin",
+      "bundleName": "ElasticsearchDriverPlugin",
+      "bundleId": "com.TablePro.ElasticsearchDriverPlugin",
+      "bundled": false,
+      "displayName": "Elasticsearch Driver",
+      "summary": "Elasticsearch driver via the REST API with a Query DSL console",
+      "databaseTypeIds": [
+        "Elasticsearch"
+      ],
+      "icon": "elasticsearch-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/elasticsearch"
+    },
+    "etcd": {
+      "target": "EtcdDriverPlugin",
+      "bundleName": "EtcdDriverPlugin",
+      "bundleId": "com.TablePro.EtcdDriverPlugin",
+      "bundled": false,
+      "displayName": "etcd Driver",
+      "summary": "etcd v3 key-value store driver with prefix-tree browsing and lease management",
+      "databaseTypeIds": [
+        "etcd"
+      ],
+      "icon": "etcd-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/etcd"
+    },
+    "libsql": {
+      "target": "LibSQLDriverPlugin",
+      "bundleName": "LibSQLDriverPlugin",
+      "bundleId": "com.TablePro.LibSQLDriverPlugin",
+      "bundled": false,
+      "displayName": "libSQL / Turso Driver",
+      "summary": "libSQL and Turso database support via Hrana HTTP protocol",
+      "databaseTypeIds": [
+        "libSQL",
+        "Turso"
+      ],
+      "icon": "libsql-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/libsql"
+    },
+    "mongodb": {
+      "target": "MongoDBDriver",
+      "bundleName": "MongoDBDriver",
+      "bundleId": "com.TablePro.MongoDBDriver",
+      "bundled": false,
+      "displayName": "MongoDB Driver",
+      "summary": "MongoDB document database driver via libmongoc",
+      "databaseTypeIds": [
+        "MongoDB"
+      ],
+      "icon": "mongodb-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/mongodb"
+    },
+    "mql": {
+      "target": "MQLExport",
+      "bundleName": "MQLExport",
+      "bundleId": "com.TablePro.MQLExportPlugin",
+      "bundled": true,
+      "displayName": "MQL Export",
+      "summary": "Export MongoDB data as MQL statements",
+      "databaseTypeIds": null,
+      "icon": "leaf",
+      "category": "export-format",
+      "homepage": "https://docs.tablepro.app/features/import-export"
+    },
+    "mssql": {
+      "target": "MSSQLDriver",
+      "bundleName": "MSSQLDriver",
+      "bundleId": "com.TablePro.MSSQLDriver",
+      "bundled": false,
+      "displayName": "MSSQL Driver",
+      "summary": "Microsoft SQL Server driver via FreeTDS",
+      "databaseTypeIds": [
+        "SQL Server"
+      ],
+      "icon": "mssql-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/mssql"
+    },
+    "oracle": {
+      "target": "OracleDriver",
+      "bundleName": "OracleDriver",
+      "bundleId": "com.TablePro.OracleDriver",
+      "bundled": false,
+      "displayName": "Oracle Driver",
+      "summary": "Oracle Database 12c+ driver via OracleNIO",
+      "databaseTypeIds": [
+        "Oracle"
+      ],
+      "icon": "oracle-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/oracle"
+    },
+    "redis": {
+      "target": "RedisDriver",
+      "bundleName": "RedisDriver",
+      "bundleId": "com.TablePro.RedisDriver",
+      "bundled": true,
+      "displayName": "Redis Driver",
+      "summary": "Redis in-memory data store driver via hiredis",
+      "databaseTypeIds": [
+        "Redis"
+      ],
+      "icon": "redis-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/redis"
+    },
+    "snowflake": {
+      "target": "SnowflakeDriverPlugin",
+      "bundleName": "SnowflakeDriverPlugin",
+      "bundleId": "com.TablePro.SnowflakeDriverPlugin",
+      "bundled": false,
+      "displayName": "Snowflake Driver",
+      "summary": "Snowflake cloud data warehouse driver via the connector REST protocol",
+      "databaseTypeIds": [
+        "Snowflake"
+      ],
+      "icon": "snowflake-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/snowflake"
+    },
+    "sqlimport": {
+      "target": "SQLImport",
+      "bundleName": "SQLImport",
+      "bundleId": "com.TablePro.SQLImportPlugin",
+      "bundled": true,
+      "displayName": "SQL Import",
+      "summary": "Import data from SQL dump files",
+      "databaseTypeIds": null,
+      "icon": "doc.text",
+      "category": "import-format",
+      "homepage": "https://docs.tablepro.app/features/import-export"
+    },
+    "sqlite": {
+      "target": "SQLiteDriver",
+      "bundleName": "SQLiteDriver",
+      "bundleId": "com.TablePro.SQLiteDriver",
+      "bundled": true,
+      "displayName": "SQLite Driver",
+      "summary": "SQLite embedded database driver",
+      "databaseTypeIds": [
+        "SQLite"
+      ],
+      "icon": "sqlite-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/sqlite"
+    },
+    "surrealdb": {
+      "target": "SurrealDBDriverPlugin",
+      "bundleName": "SurrealDBDriverPlugin",
+      "bundleId": "com.TablePro.SurrealDBDriverPlugin",
+      "bundled": false,
+      "displayName": "SurrealDB Driver",
+      "summary": "SurrealDB driver over the HTTP RPC protocol with SurrealQL",
+      "databaseTypeIds": [
+        "SurrealDB"
+      ],
+      "icon": "surrealdb-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/surrealdb"
+    },
+    "teradata": {
+      "target": "TeradataDriver",
+      "bundleName": "TeradataDriver",
+      "bundleId": "com.TablePro.TeradataDriver",
+      "bundled": false,
+      "displayName": "Teradata Driver",
+      "summary": "Teradata Vantage driver via a native Swift TD2 client",
+      "databaseTypeIds": [
+        "Teradata"
+      ],
+      "icon": "teradata-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/teradata"
+    },
+    "trino": {
+      "target": "TrinoDriverPlugin",
+      "bundleName": "TrinoDriverPlugin",
+      "bundleId": "com.TablePro.TrinoDriverPlugin",
+      "bundled": false,
+      "displayName": "Trino Driver",
+      "summary": "Trino distributed SQL engine driver via the REST client protocol",
+      "databaseTypeIds": [
+        "Trino"
+      ],
+      "icon": "trino-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/trino"
+    },
+    "xlsx": {
+      "target": "XLSXExport",
+      "bundleName": "XLSXExport",
+      "bundleId": "com.TablePro.XLSXExportPlugin",
+      "bundled": true,
+      "displayName": "XLSX Export",
+      "summary": "Export data to Microsoft Excel XLSX format",
+      "databaseTypeIds": null,
+      "icon": "tablecells",
+      "category": "export-format",
+      "homepage": "https://docs.tablepro.app/features/import-export"
+    }
+  }
+}

--- a/.github/scripts/update-registry.py
+++ b/.github/scripts/update-registry.py
@@ -122,6 +122,15 @@ def update_plugin_entry(manifest, args):
 
     merged_binaries = prune_old_kit_versions(merged_binaries, args.keep_kit_versions)
 
+    # The prune keeps the newest N PluginKit versions, so publishing for an older one drops the
+    # binary that was just built while still advertising its version number. The entry would then
+    # point every app at a download that does not exist for it.
+    if not any(kit_version(b) == pkv for b in merged_binaries):
+        raise SystemExit(
+            f"PluginKit {pkv} is older than the {args.keep_kit_versions} retained versions; "
+            f"publishing would advertise {args.version} with no binary for it"
+        )
+
     updated_entry = {
         "id": bundle_id,
         "name": args.name,

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Validate registry update script
         run: python3 .github/scripts/test_update_registry.py
 
+      - name: Check the plugin manifest against the plugin classes
+        run: python3 scripts/ci/check-plugin-manifest.py
+
       - name: Read currentPluginKitVersion
         id: pkv
         run: |
@@ -145,153 +148,10 @@ jobs:
         id: plugin
         env:
           MATRIX_TAG: ${{ matrix.tag }}
-        run: |
-          TAG="$MATRIX_TAG"
-          PLUGIN_NAME=$(echo "$TAG" | sed -E 's/^plugin-([a-z0-9-]+)-v([0-9].*)$/\1/')
-          VERSION=$(echo "$TAG" | sed -E 's/^plugin-([a-z0-9-]+)-v([0-9].*)$/\2/')
-
-          case "$PLUGIN_NAME" in
-            oracle)
-              TARGET="OracleDriver"; BUNDLE_ID="com.TablePro.OracleDriver"
-              DISPLAY_NAME="Oracle Driver"; SUMMARY="Oracle Database 12c+ driver via OracleNIO"
-              DB_TYPE_IDS='["Oracle"]'; ICON="server.rack"; BUNDLE_NAME="OracleDriver"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/oracle" ;;
-            clickhouse)
-              TARGET="ClickHouseDriver"; BUNDLE_ID="com.TablePro.ClickHouseDriver"
-              DISPLAY_NAME="ClickHouse Driver"; SUMMARY="ClickHouse OLAP database driver via HTTP interface"
-              DB_TYPE_IDS='["ClickHouse"]'; ICON="chart.bar.xaxis"; BUNDLE_NAME="ClickHouseDriver"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/clickhouse" ;;
-            dameng)
-              TARGET="DamengDriver"; BUNDLE_ID="com.TablePro.DamengDriver"
-              DISPLAY_NAME="Dameng Driver"; SUMMARY="Dameng DM8 database driver via a native wire client"
-              DB_TYPE_IDS='["Dameng"]'; ICON="cylinder"; BUNDLE_NAME="DamengDriver"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/dameng" ;;
-            sqlite)
-              TARGET="SQLiteDriver"; BUNDLE_ID="com.TablePro.SQLiteDriver"
-              DISPLAY_NAME="SQLite Driver"; SUMMARY="SQLite embedded database driver"
-              DB_TYPE_IDS='["SQLite"]'; ICON="internaldrive"; BUNDLE_NAME="SQLiteDriver"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/sqlite" ;;
-            duckdb)
-              TARGET="DuckDBDriver"; BUNDLE_ID="com.TablePro.DuckDBDriver"
-              DISPLAY_NAME="DuckDB Driver"; SUMMARY="DuckDB analytical database driver"
-              DB_TYPE_IDS='["DuckDB"]'; ICON="bird"; BUNDLE_NAME="DuckDBDriver"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/duckdb" ;;
-            beancount)
-              TARGET="BeancountDriver"; BUNDLE_ID="com.TablePro.BeancountDriver"
-              DISPLAY_NAME="Beancount Driver"; SUMMARY="Read-only Beancount ledger driver using user-provided rledger or Python Beancount"
-              DB_TYPE_IDS='["Beancount"]'; ICON="beancount-icon"; BUNDLE_NAME="BeancountDriver"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/beancount" ;;
-            cassandra)
-              TARGET="CassandraDriver"; BUNDLE_ID="com.TablePro.CassandraDriver"
-              DISPLAY_NAME="Cassandra Driver"; SUMMARY="Apache Cassandra and ScyllaDB driver via DataStax C driver"
-              DB_TYPE_IDS='["Cassandra","ScyllaDB"]'; ICON="cassandra-icon"; BUNDLE_NAME="CassandraDriver"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/cassandra" ;;
-            etcd)
-              TARGET="EtcdDriverPlugin"; BUNDLE_ID="com.TablePro.EtcdDriverPlugin"
-              DISPLAY_NAME="etcd Driver"; SUMMARY="etcd v3 key-value store driver with prefix-tree browsing and lease management"
-              DB_TYPE_IDS='["etcd"]'; ICON="etcd-icon"; BUNDLE_NAME="EtcdDriverPlugin"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/etcd" ;;
-            mssql)
-              TARGET="MSSQLDriver"; BUNDLE_ID="com.TablePro.MSSQLDriver"
-              DISPLAY_NAME="MSSQL Driver"; SUMMARY="Microsoft SQL Server driver via FreeTDS"
-              DB_TYPE_IDS='["SQL Server"]'; ICON="mssql-icon"; BUNDLE_NAME="MSSQLDriver"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/mssql" ;;
-            teradata)
-              TARGET="TeradataDriver"; BUNDLE_ID="com.TablePro.TeradataDriver"
-              DISPLAY_NAME="Teradata Driver"; SUMMARY="Teradata Vantage driver via a native Swift TD2 client"
-              DB_TYPE_IDS='["Teradata"]'; ICON="teradata-icon"; BUNDLE_NAME="TeradataDriver"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/teradata" ;;
-            trino)
-              TARGET="TrinoDriverPlugin"; BUNDLE_ID="com.TablePro.TrinoDriverPlugin"
-              DISPLAY_NAME="Trino Driver"; SUMMARY="Trino distributed SQL engine driver via the REST client protocol"
-              DB_TYPE_IDS='["Trino"]'; ICON="trino-icon"; BUNDLE_NAME="TrinoDriverPlugin"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/trino" ;;
-            mongodb)
-              TARGET="MongoDBDriver"; BUNDLE_ID="com.TablePro.MongoDBDriver"
-              DISPLAY_NAME="MongoDB Driver"; SUMMARY="MongoDB document database driver via libmongoc"
-              DB_TYPE_IDS='["MongoDB"]'; ICON="mongodb-icon"; BUNDLE_NAME="MongoDBDriver"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/mongodb" ;;
-            redis)
-              TARGET="RedisDriver"; BUNDLE_ID="com.TablePro.RedisDriver"
-              DISPLAY_NAME="Redis Driver"; SUMMARY="Redis in-memory data store driver via hiredis"
-              DB_TYPE_IDS='["Redis"]'; ICON="redis-icon"; BUNDLE_NAME="RedisDriver"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/redis" ;;
-            cloudflare-d1)
-              TARGET="CloudflareD1DriverPlugin"; BUNDLE_ID="com.TablePro.CloudflareD1DriverPlugin"
-              DISPLAY_NAME="Cloudflare D1 Driver"; SUMMARY="Cloudflare D1 serverless SQLite-compatible database driver via REST API"
-              DB_TYPE_IDS='["Cloudflare D1"]'; ICON="cloudflare-d1-icon"; BUNDLE_NAME="CloudflareD1DriverPlugin"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/cloudflare-d1" ;;
-            libsql)
-              TARGET="LibSQLDriverPlugin"; BUNDLE_ID="com.TablePro.LibSQLDriverPlugin"
-              DISPLAY_NAME="libSQL / Turso Driver"; SUMMARY="libSQL and Turso database support via Hrana HTTP protocol"
-              DB_TYPE_IDS='["libSQL","Turso"]'; ICON="libsql-icon"; BUNDLE_NAME="LibSQLDriverPlugin"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/libsql" ;;
-            dynamodb)
-              TARGET="DynamoDBDriverPlugin"; BUNDLE_ID="com.TablePro.DynamoDBDriverPlugin"
-              DISPLAY_NAME="DynamoDB Driver"; SUMMARY="Amazon DynamoDB driver with PartiQL queries and AWS IAM/Profile/SSO authentication"
-              DB_TYPE_IDS='["DynamoDB"]'; ICON="dynamodb-icon"; BUNDLE_NAME="DynamoDBDriverPlugin"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/dynamodb" ;;
-            elasticsearch)
-              TARGET="ElasticsearchDriverPlugin"; BUNDLE_ID="com.TablePro.ElasticsearchDriverPlugin"
-              DISPLAY_NAME="Elasticsearch Driver"; SUMMARY="Elasticsearch driver via the REST API with a Query DSL console"
-              DB_TYPE_IDS='["Elasticsearch"]'; ICON="elasticsearch-icon"; BUNDLE_NAME="ElasticsearchDriverPlugin"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/elasticsearch" ;;
-            surrealdb)
-              TARGET="SurrealDBDriverPlugin"; BUNDLE_ID="com.TablePro.SurrealDBDriverPlugin"
-              DISPLAY_NAME="SurrealDB Driver"; SUMMARY="SurrealDB driver over the HTTP RPC protocol with SurrealQL"
-              DB_TYPE_IDS='["SurrealDB"]'; ICON="surrealdb-icon"; BUNDLE_NAME="SurrealDBDriverPlugin"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/surrealdb" ;;
-            bigquery)
-              TARGET="BigQueryDriverPlugin"; BUNDLE_ID="com.TablePro.BigQueryDriverPlugin"
-              DISPLAY_NAME="BigQuery Driver"; SUMMARY="Google BigQuery analytics database driver via REST API"
-              DB_TYPE_IDS='["BigQuery"]'; ICON="bigquery-icon"; BUNDLE_NAME="BigQueryDriverPlugin"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/bigquery" ;;
-            snowflake)
-              TARGET="SnowflakeDriverPlugin"; BUNDLE_ID="com.TablePro.SnowflakeDriverPlugin"
-              DISPLAY_NAME="Snowflake Driver"; SUMMARY="Snowflake cloud data warehouse driver via the connector REST protocol"
-              DB_TYPE_IDS='["Snowflake"]'; ICON="snowflake-icon"; BUNDLE_NAME="SnowflakeDriverPlugin"
-              CATEGORY="database-driver"; HOMEPAGE="https://docs.tablepro.app/databases/snowflake" ;;
-            xlsx)
-              TARGET="XLSXExport"; BUNDLE_ID="com.TablePro.XLSXExportPlugin"
-              DISPLAY_NAME="XLSX Export"; SUMMARY="Export data to Microsoft Excel XLSX format"
-              DB_TYPE_IDS='null'; ICON="doc.richtext"; BUNDLE_NAME="XLSXExport"
-              CATEGORY="export-format"; HOMEPAGE="https://docs.tablepro.app/features/import-export" ;;
-            mql)
-              TARGET="MQLExport"; BUNDLE_ID="com.TablePro.MQLExportPlugin"
-              DISPLAY_NAME="MQL Export"; SUMMARY="Export MongoDB data as MQL statements"
-              DB_TYPE_IDS='null'; ICON="doc.text"; BUNDLE_NAME="MQLExport"
-              CATEGORY="export-format"; HOMEPAGE="https://docs.tablepro.app/features/import-export" ;;
-            sqlimport)
-              TARGET="SQLImport"; BUNDLE_ID="com.TablePro.SQLImportPlugin"
-              DISPLAY_NAME="SQL Import"; SUMMARY="Import data from SQL dump files"
-              DB_TYPE_IDS='null'; ICON="square.and.arrow.down"; BUNDLE_NAME="SQLImport"
-              CATEGORY="import-format"; HOMEPAGE="https://docs.tablepro.app/features/import-export" ;;
-            *)
-              echo "::error::Unknown plugin name: $PLUGIN_NAME"
-              exit 1 ;;
-          esac
-
-          # Configs/Version.xcconfig is the single declaration of the app version.
-          MIN_APP_VERSION=$(sed -n 's/^MARKETING_VERSION[[:space:]]*=[[:space:]]*//p' \
-            Configs/Version.xcconfig | tr -d ' ')
-          if [ -z "$MIN_APP_VERSION" ]; then
-            echo "::error::MARKETING_VERSION missing from Configs/Version.xcconfig"
-            exit 1
-          fi
-
-          {
-            echo "target=$TARGET"
-            echo "bundleId=$BUNDLE_ID"
-            echo "displayName=$DISPLAY_NAME"
-            echo "summary=$SUMMARY"
-            echo "dbTypeIds=$DB_TYPE_IDS"
-            echo "icon=$ICON"
-            echo "bundleName=$BUNDLE_NAME"
-            echo "category=$CATEGORY"
-            echo "homepage=$HOMEPAGE"
-            echo "version=$VERSION"
-            echo "minAppVersion=$MIN_APP_VERSION"
-          } >> "$GITHUB_OUTPUT"
+        # The metadata lives in .github/plugin-registry.json. It used to be a 120-line `case` block
+        # here, which is shell holding data, and seven of its icon values had drifted away from the
+        # plugin classes they describe with nothing to notice.
+        run: python3 scripts/ci/plugin-info.py "$MATRIX_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Build Cassandra dependencies
         if: ${{ contains(matrix.tag, 'plugin-cassandra-') }}
@@ -403,13 +263,41 @@ jobs:
             exit 1
           fi
 
-          gh release delete "$TAG" --yes 2>/dev/null || true
-          gh release create "$TAG" \
-            --title "$DISPLAY_NAME v$VERSION" \
-            --notes "$RELEASE_BODY" \
-            --latest=false \
-            build/Plugins/${BUNDLE_NAME}-arm64.zip \
-            build/Plugins/${BUNDLE_NAME}-x86_64.zip
+          # Three outcomes, decided before anything is destroyed. The old form deleted the
+          # release and recreated it, so a re-run of an already-published tag briefly left
+          # plugins.json pointing at URLs that 404, and permanently replaced assets that a
+          # published registry entry may point at. release-all-plugins.sh already states the
+          # policy: an existing tag's assets are not to be replaced.
+          if ! gh release view "$TAG" > /dev/null 2>&1; then
+            gh release create "$TAG" \
+              --title "$DISPLAY_NAME v$VERSION" \
+              --notes "$RELEASE_BODY" \
+              --latest=false \
+              "build/Plugins/${BUNDLE_NAME}-arm64.zip" \
+              "build/Plugins/${BUNDLE_NAME}-x86_64.zip"
+          else
+            # A release already here is either this same build resumed, or a different binary.
+            # Only the first is safe to continue from.
+            IDENTICAL=true
+            for ARCH in arm64 x86_64; do
+              EXPECTED=$(cut -d' ' -f1 < "build/Plugins/${BUNDLE_NAME}-${ARCH}.zip.sha256")
+              WORK=$(mktemp -d)
+              if gh release download "$TAG" --pattern "${BUNDLE_NAME}-${ARCH}.zip" --dir "$WORK" 2>/dev/null; then
+                PUBLISHED=$(shasum -a 256 "$WORK/${BUNDLE_NAME}-${ARCH}.zip" | cut -d' ' -f1)
+                [ "$PUBLISHED" = "$EXPECTED" ] || IDENTICAL=false
+              else
+                IDENTICAL=false
+              fi
+              rm -rf "$WORK"
+            done
+
+            if [ "$IDENTICAL" = true ]; then
+              echo "Release $TAG already carries these exact binaries; continuing to the registry step."
+            else
+              echo "::error::Release $TAG already exists with different binaries. Refusing to replace assets a published registry entry may point at; bump the patch version and release a new tag."
+              exit 1
+            fi
+          fi
 
       - name: Verify published assets match the PluginKit label
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ All database drivers are `.tableplugin` bundles loaded at runtime by `PluginMana
 - **DatabaseManager** (`Core/Database/DatabaseManager.swift`), connection pool, lifecycle, primary interface for views/coordinators
 - **ConnectionHealthMonitor**: 30s ping, auto-reconnect with exponential backoff
 
-When adding a new driver: create a new plugin bundle under `Plugins/`, implement `DriverPlugin` + `PluginDatabaseDriver`, add the target to `project.yml`, add `DatabaseType` static constant, add a `case` arm to the `case "$PLUGIN_NAME"` block in the `Resolve plugin info` step of `.github/workflows/build-plugin.yml`, add row to `docs/index.mdx` supported databases table, and add CHANGELOG entry. See `docs/development/plugin-development.mdx` and `docs/development/plugin-registry.mdx` for details.
+When adding a new driver: create a new plugin bundle under `Plugins/`, implement `DriverPlugin` + `PluginDatabaseDriver`, add the target to `project.yml`, add `DatabaseType` static constant, add an entry to `.github/plugin-registry.json`, add row to `docs/index.mdx` supported databases table, and add CHANGELOG entry. See `docs/development/plugin-development.mdx` and `docs/development/plugin-registry.mdx` for details.
 
 When adding a new method to the driver protocol: add to `PluginDatabaseDriver` (with default implementation), then update `PluginDriverAdapter` to bridge it to `DatabaseDriver`. This is an additive, ABI-safe change (see below) and needs no version bump.
 
@@ -343,8 +343,8 @@ If anything matches, rewrite before committing.
 
 ## CI/CD
 
-GitHub Actions (`.github/workflows/build.yml`) triggered by `v*` tags. The `release` job needs all five of `lint`, `test`, `build-arm64`, `build-x86_64` and `registry-readiness`, so a red test suite or a registry missing a compatible plugin binary blocks the tag. It produces the DMG and ZIP plus Sparkle signatures, and release notes are auto-extracted from `CHANGELOG.md`.
+GitHub Actions (`.github/workflows/build.yml`) triggered by `v*` tags. The `release` job needs all four of `lint`, `test`, `build` (a matrix over arm64 and x86_64) and `registry-readiness`, so a red test suite or a registry missing a compatible plugin binary blocks the tag. It produces the DMG and ZIP plus Sparkle signatures, and release notes are auto-extracted from `CHANGELOG.md`.
 
 **Plugin CI** (`.github/workflows/build-plugin.yml`): triggered by `plugin-*-v*` tags or `workflow_dispatch`. The dispatch input accepts comma-separated `tag:pluginKitVersion` pairs; if `:pluginKitVersion` is omitted, the workflow reads `currentPluginKitVersion` from `PluginManager.swift`. Registry update logic lives in `.github/scripts/update-registry.py` (atomic write, per-binary `pluginKitVersion`, prune-old policy). Use `scripts/release-all-plugins.sh <version>` for bulk re-release after an ABI bump.
 
-**Plugin tag naming**: Tag names must match the `case "$PLUGIN_NAME"` mapping in the CI workflow's `Resolve plugin info` step. Notable non-obvious mappings: `CloudflareD1DriverPlugin` → `plugin-cloudflare-d1-v*`, `EtcdDriverPlugin` → `plugin-etcd-v*`. Check existing tags with `git tag -l "plugin-*"` before creating new ones.
+**Plugin tag naming**: The slug in a tag must be a key in `.github/plugin-registry.json`, which maps it to the target and the release metadata. Notable non-obvious mappings: `CloudflareD1DriverPlugin` → `plugin-cloudflare-d1-v*`, `EtcdDriverPlugin` → `plugin-etcd-v*`. Check existing tags with `git tag -l "plugin-*"` before creating new ones.

--- a/docs/development/plugin-development.mdx
+++ b/docs/development/plugin-development.mdx
@@ -115,7 +115,7 @@ Link the XCFramework as **Do Not Embed**. The app supplies TableProPluginKit at 
 
 Publishing to TablePro's registry takes two steps in this repo:
 
-1. Add a case for your plugin to the `case "$PLUGIN_NAME"` block in the `Resolve plugin info` step of `.github/workflows/build-plugin.yml`: target name, bundle ID, display name, summary, database type IDs, icon, category, homepage. Without it the workflow exits with `Unknown plugin name`.
+1. Add an entry for your plugin to `.github/plugin-registry.json`, keyed by the slug its tag will use: target, bundle name, bundle ID, whether it is also bundled in the app, display name, summary, database type IDs, icon, category, homepage. Without one the release workflow stops with `Unknown plugin`. `icon` and `databaseTypeIds` must match what your `DriverPlugin` class declares; `scripts/ci/check-plugin-manifest.py` fails the release if they drift.
 2. Push the tag `plugin-<name>-v<version>`. CI builds both architectures, signs, notarizes, and updates `plugins.json`.
 
 CI signs with TablePro's own certificate, so a third-party plugin ships through a pull request, not a tag of your own. See [Plugin Registry](/development/plugin-registry) for the manifest format, the self-describing `metadata` block, and the publishing flow.

--- a/docs/development/plugin-registry.mdx
+++ b/docs/development/plugin-registry.mdx
@@ -100,7 +100,7 @@ The full field list is `RegistryPluginMetadata` in `TablePro/Core/Plugins/Regist
 
 ## Registry Plugins and databaseTypeIds
 
-`databaseTypeIds` tells the app which plugin to install when a user picks a database type with no loaded driver. Tag names must match the `case "$PLUGIN_NAME"` block in the `Resolve plugin info` step of `.github/workflows/build-plugin.yml`. Note the non-obvious tags for Cloudflare D1 and etcd.
+`databaseTypeIds` tells the app which plugin to install when a user picks a database type with no loaded driver. The slug in a tag must be a key in `.github/plugin-registry.json`. Note the non-obvious tags for Cloudflare D1 and etcd.
 
 | Tag prefix | databaseTypeIds |
 |-----------|-----------------|
@@ -126,7 +126,7 @@ Bundled plugins (MySQL, PostgreSQL, SQLite, ClickHouse, Redis, and the import/ex
 
 ## Publishing a Plugin
 
-A new plugin needs a case in the `Resolve plugin info` step of `.github/workflows/build-plugin.yml` before its first tag. Without one the workflow exits with `Unknown plugin name`.
+A new plugin needs an entry in `.github/plugin-registry.json` before its first tag. Without one the workflow exits with `Unknown plugin`.
 
 Tag the commit and push that one tag:
 

--- a/scripts/ci/check-plugin-manifest.py
+++ b/scripts/ci/check-plugin-manifest.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Fails when .github/plugin-registry.json disagrees with the plugin classes it describes.
+
+Two of the manifest's fields also exist in Swift: `icon` is `DriverPlugin.iconName`, and
+`databaseTypeIds` is `databaseTypeId` plus `additionalDatabaseTypeIds`. Nothing checked that the
+two agreed, and by the time this was written seven icons had drifted: the registry advertised
+`chart.bar.xaxis` for ClickHouse while the plugin declared `clickhouse-icon`, and so on. Users see
+the manifest's value in the plugin browser and the plugin's value once it is installed.
+
+Every plugin must resolve. A plugin whose declarations cannot be parsed is a failure, not a skip:
+a check that silently passes when it cannot read its input is worse than no check.
+"""
+
+import json
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+MANIFEST = REPO_ROOT / ".github" / "plugin-registry.json"
+PLUGINS_DIR = REPO_ROOT / "Plugins"
+
+ICON = re.compile(r"^\s*(?:public |internal |private )?static (?:let|var) iconName(?:\s*:\s*String)?\s*=\s*\"([^\"]+)\"", re.M)
+PRIMARY_ID = re.compile(r"^\s*(?:public |internal |private )?static (?:let|var) databaseTypeId(?:\s*:\s*String)?\s*=\s*\"([^\"]+)\"", re.M)
+EXTRA_IDS = re.compile(r"^\s*(?:public |internal |private )?static (?:let|var) additionalDatabaseTypeIds\s*(?::\s*\[String\]\s*)?=\s*\[([^\]]*)\]", re.M)
+
+
+def plugin_directory(target):
+    """Plugin folders and targets are named alike once the Driver/Plugin suffixes are dropped."""
+    def normalise(name):
+        return name.lower().replace("driverplugin", "").replace("driver", "").replace("plugin", "")
+
+    wanted = normalise(target)
+    for path in sorted(PLUGINS_DIR.iterdir()):
+        if path.is_dir() and normalise(path.name) == wanted:
+            return path
+    return None
+
+
+def declared(directory):
+    """The values the plugin's own class declares, read across its Swift sources."""
+    icon = ids = None
+    extra = []
+    for source in sorted(directory.rglob("*.swift")):
+        text = source.read_text(encoding="utf-8")
+        if icon is None:
+            found = ICON.search(text)
+            icon = found.group(1) if found else None
+        if ids is None:
+            found = PRIMARY_ID.search(text)
+            ids = found.group(1) if found else None
+        found = EXTRA_IDS.search(text)
+        if found and not extra:
+            extra = [part.strip().strip('"') for part in found.group(1).split(",") if part.strip()]
+    return icon, ids, extra
+
+
+def main():
+    with open(MANIFEST, encoding="utf-8") as handle:
+        plugins = json.load(handle)["plugins"]
+
+    problems = []
+    for slug, entry in sorted(plugins.items()):
+        directory = plugin_directory(entry["target"])
+        if directory is None:
+            problems.append(f"{slug}: no plugin directory matches target {entry['target']}")
+            continue
+
+        icon, primary, extra = declared(directory)
+        if icon is None:
+            problems.append(f"{slug}: could not read iconName from {directory.name}")
+        elif icon != entry["icon"]:
+            problems.append(f"{slug}: manifest icon {entry['icon']!r} but the plugin declares {icon!r}")
+
+        # An export or import plugin drives no database type and declares none.
+        if entry["databaseTypeIds"] is None:
+            if primary is not None:
+                problems.append(f"{slug}: manifest says no database types but the plugin declares {primary!r}")
+            continue
+
+        if primary is None:
+            problems.append(f"{slug}: could not read databaseTypeId from {directory.name}")
+            continue
+        if [primary, *extra] != entry["databaseTypeIds"]:
+            problems.append(
+                f"{slug}: manifest databaseTypeIds {entry['databaseTypeIds']} "
+                f"but the plugin declares {[primary, *extra]}"
+            )
+
+    if problems:
+        for problem in problems:
+            print(f"::error::{problem}", file=sys.stderr)
+        sys.exit(f"\n{len(problems)} plugin(s) disagree with {MANIFEST.name}")
+
+    print(f"{len(plugins)} plugins agree with {MANIFEST.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/plugin-info.py
+++ b/scripts/ci/plugin-info.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Resolves a plugin tag to the release metadata the workflow needs.
+
+Replaces a 120-line `case` block in build-plugin.yml. That block was shell holding data, which is
+how seven of its icon values drifted away from the plugin classes they describe without anything
+noticing.
+
+Usage: plugin-info.py <tag>            prints KEY=VALUE lines for $GITHUB_OUTPUT
+       plugin-info.py --list-slugs     prints every publishable slug, one per line
+"""
+
+import json
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+MANIFEST = REPO_ROOT / ".github" / "plugin-registry.json"
+VERSION_XCCONFIG = REPO_ROOT / "Configs" / "Version.xcconfig"
+TAG_PATTERN = re.compile(r"^plugin-([a-z0-9-]+)-v([0-9]+\.[0-9]+\.[0-9]+)$")
+
+
+def load_plugins():
+    with open(MANIFEST, encoding="utf-8") as handle:
+        return json.load(handle)["plugins"]
+
+
+def marketing_version():
+    """Configs/Version.xcconfig is the single declaration of the app version."""
+    for line in VERSION_XCCONFIG.read_text(encoding="utf-8").splitlines():
+        if line.startswith("MARKETING_VERSION"):
+            return line.split("=", 1)[1].strip()
+    sys.exit(f"MARKETING_VERSION missing from {VERSION_XCCONFIG}")
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit(__doc__)
+
+    plugins = load_plugins()
+
+    if sys.argv[1] == "--list-slugs":
+        print("\n".join(sorted(plugins)))
+        return
+
+    match = TAG_PATTERN.match(sys.argv[1])
+    if not match:
+        sys.exit(f"::error::Malformed plugin tag: {sys.argv[1]}")
+    slug, version = match.groups()
+
+    plugin = plugins.get(slug)
+    if plugin is None:
+        known = ", ".join(sorted(plugins))
+        sys.exit(f"::error::Unknown plugin '{slug}'. {MANIFEST.name} knows: {known}")
+
+    ids = plugin["databaseTypeIds"]
+    fields = {
+        "target": plugin["target"],
+        "bundleId": plugin["bundleId"],
+        "displayName": plugin["displayName"],
+        "summary": plugin["summary"],
+        "dbTypeIds": "null" if ids is None else json.dumps(ids, separators=(",", ":")),
+        "icon": plugin["icon"],
+        "bundleName": plugin["bundleName"],
+        "category": plugin["category"],
+        "homepage": plugin["homepage"],
+        "version": version,
+        "minAppVersion": marketing_version(),
+    }
+    for key, value in fields.items():
+        if "\n" in value:
+            sys.exit(f"::error::{slug}.{key} contains a newline, which $GITHUB_OUTPUT cannot carry")
+        print(f"{key}={value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release-all-plugins.sh
+++ b/scripts/release-all-plugins.sh
@@ -23,52 +23,28 @@ fi
 
 PKV="$1"
 
-# Registry-only plugins. Bundled plugins (Redis, ClickHouse, SQLite, MySQL,
-# PostgreSQL, CSV/JSON/SQL/XLSX/MQL export, SQL import) ship inside the app
-# bundle and must NEVER be published to the registry.
-PLUGINS=(
-    mongodb
-    oracle
-    duckdb
-    beancount
-    mssql
-    cassandra
-    etcd
-    cloudflare-d1
-    dynamodb
-    bigquery
-    snowflake
-    libsql
-    elasticsearch
-    surrealdb
-    teradata
-    trino
-    dameng
-)
+# Derived from .github/plugin-registry.json rather than restated here. This used to be two
+# hand-maintained arrays that had to agree with the workflow, the registry and each other, which is
+# three copies of one list and no way to tell when they drift apart.
+#
+# A bulk ABI re-release covers the registry-only plugins. The six marked `bundled` ship inside the
+# app and their binaries ride with the next app release, so re-publishing them here would put a
+# second copy in the registry for no one.
+PLUGINS=()
+while IFS= read -r PLUGIN; do
+    PLUGINS+=("$PLUGIN")
+done < <(python3 -c '
+import json, pathlib
+manifest = pathlib.Path(".github/plugin-registry.json")
+for slug, entry in sorted(json.loads(manifest.read_text())["plugins"].items()):
+    if not entry["bundled"]:
+        print(slug)
+')
 
-BUNDLED_PLUGINS=(
-    redis
-    clickhouse
-    sqlite
-    mysql
-    postgresql
-    csv
-    json
-    sql
-    xlsx
-    mql
-    sqlimport
-)
-
-for PLUGIN in "${PLUGINS[@]}"; do
-    for BUNDLED in "${BUNDLED_PLUGINS[@]}"; do
-        if [ "$PLUGIN" = "$BUNDLED" ]; then
-            echo "ERROR: '$PLUGIN' is a bundled plugin and must not be published to the registry." >&2
-            echo "Remove it from PLUGINS in $0." >&2
-            exit 1
-        fi
-    done
-done
+if [ "${#PLUGINS[@]}" -eq 0 ]; then
+    echo "ERROR: no registry-only plugins found in .github/plugin-registry.json" >&2
+    exit 1
+fi
 
 TAG_LIST=""
 FIRST=true
@@ -80,7 +56,7 @@ for PLUGIN in "${PLUGINS[@]}"; do
         echo "  WARNING: No remote tag found for plugin-${PLUGIN}-v*. Skipping."
         continue
     fi
-    LATEST_VER="${LATEST_TAG#plugin-${PLUGIN}-v}"
+    LATEST_VER="${LATEST_TAG#plugin-"${PLUGIN}"-v}"
     NEW_TAG="plugin-${PLUGIN}-v${LATEST_VER%.*}.$(( ${LATEST_VER##*.} + 1 ))"
     PAIR="${NEW_TAG}:${PKV}"
     if [ "$FIRST" = true ]; then


### PR DESCRIPTION
`build-plugin.yml` carried a 152-line `case "$PLUGIN_NAME"` block: shell holding data for 23 plugins. It moves to `.github/plugin-registry.json`. The workflow drops from 520 lines to 396.

## The drift the block was hiding

Two of its fields also exist in the plugin's own `DriverPlugin` class. Nothing checked that they agreed, and **seven of the 23 icons had drifted**:

| Plugin | Workflow said | The plugin declares |
| --- | --- | --- |
| clickhouse | `chart.bar.xaxis` | `clickhouse-icon` |
| duckdb | `bird` | `duckdb-icon` |
| mql | `doc.text` | `leaf` |
| oracle | `server.rack` | `oracle-icon` |
| sqlimport | `square.and.arrow.down` | `doc.text` |
| sqlite | `internaldrive` | `sqlite-icon` |
| xlsx | `doc.richtext` | `tablecells` |

Users see the registry's value in the plugin browser and the plugin's own value once it is installed, so those seven showed one icon before installing and a different one after. All seven are corrected to what the plugin declares.

`scripts/ci/check-plugin-manifest.py` now compares both fields against the Swift declarations and runs in `resolve-tags`, before any macOS job starts. It fails when a plugin's declarations cannot be parsed rather than skipping it, because a check that silently passes when it cannot read its input is worse than no check. Verified in both directions: it reports 23 agreeing today, and reverting one icon by hand makes it fail naming that plugin.

## What is data and what is derived

The manifest holds what the repo owns nowhere else: the summary, the category, the homepage, the bundle name and id, and the slug-to-target mapping, which has no derivation rule (`mssql` to `MSSQLDriver`, `cloudflare-d1` to `CloudflareD1DriverPlugin`). That mapping having no rule is why CLAUDE.md had to warn readers about it.

The 8 plugins with no entry are not an omission: they are exactly the ones bundled in the app and never published to the registry (MySQL, PostgreSQL, CSV/JSON/SQL export, CSV/JSON import, CSV inspector). 23 + 8 = 31.

## A fourth copy of the plugin list

`release-all-plugins.sh` hardcoded a 17-entry `PLUGINS` array and an 11-entry `BUNDLED_PLUGINS` array, with a loop that only caught a plugin appearing in *both*. A plugin in neither fell through silently.

Both are gone. The manifest carries a `bundled` flag, and the script selects the ones without it. Cross-checked against the old arrays: the 6 the manifest marks bundled are exactly `sqlite`, `clickhouse`, `redis`, `xlsx`, `mql`, `sqlimport`, which is exactly the set CLAUDE.md documents as bundled-but-publishable, and the derived list is the same 17 the array held.

## Delete-and-recreate could destroy published assets

The release step ran `gh release delete "$TAG" --yes` and then recreated it. For the window in between, a `plugins.json` entry pointing at that tag served URLs that 404. Worse, a re-run permanently replaced assets a published registry entry may point at, which is the thing `release-all-plugins.sh`'s own comment says must never happen.

There is no delete now. Three outcomes, decided before anything is destroyed:

1. No release at the tag: create it, exactly as before.
2. A release exists and both assets hash to the SHA-256s this build just produced: a resumed run, so log it and continue to the registry step. That keeps working the case a strict refusal would break, which is a publish that succeeded before the registry step lost its rebase race.
3. A release exists with different binaries: fail, and say to bump the patch version.

## The prune could drop the binary it was publishing

`update-registry.py` keeps the newest two PluginKit versions. Publishing for an older one pruned away the binary just built while still writing the new version number into the entry, so every app would be pointed at a download that did not exist for it. It now refuses instead.

## Verification

`actionlint` stays clean. `shellcheck` is clean on `release-all-plugins.sh`, including an `SC2295` it had. `test_update_registry.py` passes. The manifest check, the tag resolver, the derived plugin list and the drift detection were each exercised locally, in both the passing and the failing direction.

CLAUDE.md and both plugin docs pages described adding a `case` arm; they describe the manifest now. CLAUDE.md's CI section also still named `build-arm64` and `build-x86_64`, which #2330 replaced with one matrix job.

https://claude.ai/code/session_013MEaba8K1HQcyDNeq5wEFk
