### PR TITLE
build(scripts): fix the deployment-target check, the libpq header path, and gate the scripts in CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,8 +35,10 @@ indent_size = 2
 indent_size = 4
 
 # Shell scripts
+# CLAUDE.md sets 4 spaces for the codebase, and 34 of the 43 shell scripts already use it.
+# This file said 2, so it disagreed with both.
 [*.sh]
-indent_size = 2
+indent_size = 4
 
 # Makefile
 [Makefile]

--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -1,0 +1,70 @@
+name: Repo Hygiene
+
+# Lints the parts of the repo the macOS suite cannot reach. 7,500 lines of shell build, sign,
+# notarize and publish this app, and nothing checked any of it: the six findings actionlint reported
+# the first time it ran here were all inside `run:` blocks in the release and plugin workflows.
+#
+# Runs on ubuntu, where minutes are free on a public repo, and finishes in well under a minute.
+
+on:
+  pull_request:
+    paths:
+      - "scripts/**"
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/scripts/**"
+      - ".github/plugin-registry.json"
+      - "Plugins/**/*.swift"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/**"
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/scripts/**"
+      - ".github/plugin-registry.json"
+      - "Plugins/**/*.swift"
+  workflow_dispatch:
+
+concurrency:
+  group: repo-hygiene-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint workflows and scripts
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install shellcheck and actionlint
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq shellcheck
+          bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
+          ./actionlint --version
+
+      # actionlint shells out to shellcheck for every inline `run:` block, which is the only way
+      # those get checked at all: they are not files, so a plain shellcheck run never sees them.
+      - name: Lint workflows
+        run: ./actionlint -color
+
+      # --severity=warning is the floor the repo currently holds at zero. The remaining
+      # informational findings are almost all SC2012 (`ls` where `find` would be sturdier) in
+      # message strings, and gating on them today would only add noise.
+      - name: Lint scripts
+        run: |
+          set -euo pipefail
+          mapfile -t SCRIPTS < <(find scripts .claude/skills -name '*.sh' | sort)
+          echo "checking ${#SCRIPTS[@]} scripts"
+          shellcheck --severity=warning "${SCRIPTS[@]}"
+
+      - name: Check the plugin manifest against the plugin classes
+        run: python3 scripts/ci/check-plugin-manifest.py
+
+      - name: Validate the registry update script
+        run: python3 .github/scripts/test_update_registry.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,6 +345,8 @@ If anything matches, rewrite before committing.
 
 GitHub Actions (`.github/workflows/build.yml`) triggered by `v*` tags. The `release` job needs all four of `lint`, `test`, `build` (a matrix over arm64 and x86_64) and `registry-readiness`, so a red test suite or a registry missing a compatible plugin binary blocks the tag. It produces the DMG and ZIP plus Sparkle signatures, and release notes are auto-extracted from `CHANGELOG.md`.
 
+**Repo hygiene** (`.github/workflows/repo-hygiene.yml`): runs `actionlint` over every workflow (which shells out to `shellcheck` for each inline `run:` block, the only way those get checked), `shellcheck --severity=warning` over every script, and the plugin manifest check. Ubuntu, under a minute, free on a public repo. The scripts hold at zero warning-level findings; the remaining informational ones are almost all `SC2012`.
+
 **Plugin CI** (`.github/workflows/build-plugin.yml`): triggered by `plugin-*-v*` tags or `workflow_dispatch`. The dispatch input accepts comma-separated `tag:pluginKitVersion` pairs; if `:pluginKitVersion` is omitted, the workflow reads `currentPluginKitVersion` from `PluginManager.swift`. Registry update logic lives in `.github/scripts/update-registry.py` (atomic write, per-binary `pluginKitVersion`, prune-old policy). Use `scripts/release-all-plugins.sh <version>` for bulk re-release after an ABI bump.
 
 **Plugin tag naming**: The slug in a tag must be a key in `.github/plugin-registry.json`, which maps it to the target and the release metadata. Notable non-obvious mappings: `CloudflareD1DriverPlugin` → `plugin-cloudflare-d1-v*`, `EtcdDriverPlugin` → `plugin-etcd-v*`. Check existing tags with `git tag -l "plugin-*"` before creating new ones.

--- a/scripts/build-cassandra.sh
+++ b/scripts/build-cassandra.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Build DataStax C/C++ driver (cassandra-cpp-driver) static library for TablePro

--- a/scripts/build-freetds.sh
+++ b/scripts/build-freetds.sh
@@ -239,7 +239,7 @@ rm -f \
 echo ""
 echo "FreeTDS.xcframework built at: $XCFRAMEWORK_OUT"
 echo "Slices:"
-ls -1 "$XCFRAMEWORK_OUT" | grep -v Info.plist | sed 's/^/  - /'
+find "$XCFRAMEWORK_OUT" -mindepth 1 -maxdepth 1 ! -name Info.plist -exec basename {} \; | sed 's/^/  - /'
 echo ""
 echo "NEXT STEPS:"
 echo "  1. Inspect: xcodebuild -checkFirstLaunchStatus; file ${XCFRAMEWORK_OUT}/*/libsybdb.a"

--- a/scripts/build-hiredis.sh
+++ b/scripts/build-hiredis.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 # Run a command silently, showing output only on failure.
@@ -200,6 +200,9 @@ create_universal() {
                 "$LIBS_DIR/${lib}_arm64.a" \
                 "$LIBS_DIR/${lib}_x86_64.a" \
                 -output "$LIBS_DIR/${lib}_universal.a"
+            if ! [ "$LIBS_DIR/${lib}_universal.a" -ef "$LIBS_DIR/${lib}.a" ]; then
+                cp "$LIBS_DIR/${lib}_universal.a" "$LIBS_DIR/${lib}.a"
+            fi
             echo "   ${lib}_universal.a ($(ls -lh "$LIBS_DIR/${lib}_universal.a" | awk '{print $5}'))"
         fi
     done
@@ -229,7 +232,10 @@ verify_deployment_target() {
             min_ver=$(otool -l "$lib" 2>/dev/null | awk '/LC_VERSION_MIN_MACOSX/{found=1} found && /version/{print $2; found=0}' | sort -V | tail -1)
         fi
         if [ -n "$min_ver" ]; then
-            if [ "$(printf '%s\n' "$DEPLOY_TARGET" "$min_ver" | sort -V | head -1)" != "$DEPLOY_TARGET" ]; then
+            # max(target, minos) must be the target: a library built for a NEWER macOS than the
+            # app cannot run on the app's floor, while one built for an older macOS is fine. The
+            # head form asked the opposite question, so it passed exactly the libraries that break.
+            if [ "$(printf '%s\n' "$DEPLOY_TARGET" "$min_ver" | sort -V | tail -1)" != "$DEPLOY_TARGET" ]; then
                 echo "   ❌ $name targets macOS $min_ver (expected $DEPLOY_TARGET)"
                 failed=1
             else

--- a/scripts/build-libmongoc.sh
+++ b/scripts/build-libmongoc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 run_quiet() {
@@ -266,7 +266,10 @@ verify_deployment_target() {
             min_ver=$(otool -l "$lib" 2>/dev/null | awk '/LC_VERSION_MIN_MACOSX/{found=1} found && /version/{print $2; found=0}' | sort -V | tail -1)
         fi
         if [ -n "$min_ver" ]; then
-            if [ "$(printf '%s\n' "$DEPLOY_TARGET" "$min_ver" | sort -V | head -1)" != "$DEPLOY_TARGET" ]; then
+            # max(target, minos) must be the target: a library built for a NEWER macOS than the
+            # app cannot run on the app's floor, while one built for an older macOS is fine. The
+            # head form asked the opposite question, so it passed exactly the libraries that break.
+            if [ "$(printf '%s\n' "$DEPLOY_TARGET" "$min_ver" | sort -V | tail -1)" != "$DEPLOY_TARGET" ]; then
                 echo "   ❌ $name targets macOS $min_ver (expected $DEPLOY_TARGET)"
                 failed=1
             else

--- a/scripts/build-libpq.sh
+++ b/scripts/build-libpq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 # Run a command silently, showing output only on failure.
@@ -43,6 +43,10 @@ ARCH="${1:-both}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 LIBS_DIR="$PROJECT_DIR/Libs"
+# The PostgreSQL driver became a plugin, and its headers moved with it. This pointed at
+# TablePro/Core/Database/CLibPQ/include, which no longer exists, so every rebuild recreated a dead
+# directory and never updated the headers the plugin actually compiles against.
+HEADER_DIR="$PROJECT_DIR/Plugins/PostgreSQLDriverPlugin/CLibPQ/include"
 BUILD_DIR="$(mktemp -d)"
 NCPU=$(sysctl -n hw.ncpu)
 
@@ -200,7 +204,7 @@ install_libs() {
 install_headers() {
     local arch=$1
     local pg_src="$BUILD_DIR/postgresql-$PG_VERSION-$arch"
-    local dest="$PROJECT_DIR/TablePro/Core/Database/CLibPQ/include"
+    local dest="$HEADER_DIR"
 
     echo "📦 Installing libpq headers..."
     mkdir -p "$dest"
@@ -220,6 +224,9 @@ create_universal() {
                 "$LIBS_DIR/${lib}_arm64.a" \
                 "$LIBS_DIR/${lib}_x86_64.a" \
                 -output "$LIBS_DIR/${lib}_universal.a"
+            if ! [ "$LIBS_DIR/${lib}_universal.a" -ef "$LIBS_DIR/${lib}.a" ]; then
+                cp "$LIBS_DIR/${lib}_universal.a" "$LIBS_DIR/${lib}.a"
+            fi
             echo "   ${lib}_universal.a ($(ls -lh "$LIBS_DIR/${lib}_universal.a" | awk '{print $5}'))"
         fi
     done
@@ -230,10 +237,9 @@ build_for_arch() {
     build_openssl "$arch"
     build_libpq "$arch"
     install_libs "$arch"
-    # Install headers once (they're arch-independent)
-    if [ ! -f "$PROJECT_DIR/TablePro/Core/Database/CLibPQ/include/libpq-fe.h" ]; then
-        install_headers "$arch"
-    fi
+    # Unconditional. Skipping when a header already exists meant a version bump shipped new
+    # binaries against the previous release's headers.
+    install_headers "$arch"
 }
 
 verify_deployment_target() {
@@ -249,7 +255,10 @@ verify_deployment_target() {
             min_ver=$(otool -l "$lib" 2>/dev/null | awk '/LC_VERSION_MIN_MACOSX/{found=1} found && /version/{print $2; found=0}' | sort -V | tail -1)
         fi
         if [ -n "$min_ver" ]; then
-            if [ "$(printf '%s\n' "$DEPLOY_TARGET" "$min_ver" | sort -V | head -1)" != "$DEPLOY_TARGET" ]; then
+            # max(target, minos) must be the target: a library built for a NEWER macOS than the
+            # app cannot run on the app's floor, while one built for an older macOS is fine. The
+            # head form asked the opposite question, so it passed exactly the libraries that break.
+            if [ "$(printf '%s\n' "$DEPLOY_TARGET" "$min_ver" | sort -V | tail -1)" != "$DEPLOY_TARGET" ]; then
                 echo "   ❌ $name targets macOS $min_ver (expected $DEPLOY_TARGET)"
                 failed=1
             else

--- a/scripts/build-libssh2.sh
+++ b/scripts/build-libssh2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 # Run a command silently, showing output only on failure.
@@ -221,6 +221,9 @@ create_universal() {
             "$LIBS_DIR/libssh2_arm64.a" \
             "$LIBS_DIR/libssh2_x86_64.a" \
             -output "$LIBS_DIR/libssh2_universal.a"
+        if ! [ "$LIBS_DIR/libssh2_universal.a" -ef "$LIBS_DIR/libssh2.a" ]; then
+            cp "$LIBS_DIR/libssh2_universal.a" "$LIBS_DIR/libssh2.a"
+        fi
         echo "   libssh2_universal.a ($(ls -lh "$LIBS_DIR/libssh2_universal.a" | awk '{print $5}'))"
     fi
 }

--- a/scripts/build-plugin.sh
+++ b/scripts/build-plugin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Build script for creating standalone plugin bundles

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Build script for creating architecture-specific releases
@@ -393,7 +393,7 @@ build_for_arch() {
     # Copy and rename app. Removed first: cp -R onto an existing bundle merges into it, so a
     # rebuild carried the previous build's files into the one being signed and shipped.
     OUTPUT_NAME="TablePro-${arch}.app"
-    rm -rf "$BUILD_DIR/$OUTPUT_NAME"
+    rm -rf "${BUILD_DIR:?}/$OUTPUT_NAME"
     echo "Copying app bundle to release directory..."
     if ! cp -R "$APP_PATH" "$BUILD_DIR/$OUTPUT_NAME"; then
         echo "❌ FATAL: Failed to copy app bundle"

--- a/scripts/check-doc-symbols.sh
+++ b/scripts/check-doc-symbols.sh
@@ -106,7 +106,7 @@ prose() {
 # ------------------------------------------------------------------ checks
 
 check_doc() {
-    local doc="$1" dir line body token target
+    local doc="$1" dir line token
     dir="$(dirname "$doc")"
     prose "$doc" > "$WORK/prose"
 

--- a/scripts/check-freetds-fedauth.sh
+++ b/scripts/check-freetds-fedauth.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Proves scripts/patches/freetds/freetds-fedauth.patch still produces the LOGIN7 bytes
 # Microsoft Entra ID authentication needs, and that it leaves password logins alone.
 #
@@ -84,8 +84,8 @@ run_case() {
     python3 "$CHECK_DIR/fake-tds-server.py" "$mode" "$expect" "$BUILD_DIR/results-$mode.json" \
         > "$BUILD_DIR/server-$mode.log" 2>&1 &
     local srv=$!
-    local port="" i
-    for i in $(seq 1 100); do
+    local port=""
+    for _ in $(seq 1 100); do
         port=$(head -1 "$BUILD_DIR/server-$mode.log" 2>/dev/null)
         [ -n "$port" ] && break
     done

--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Create a DMG installer with drag-and-drop installation window
 # Uses create-dmg tool for reliable CI builds
 

--- a/scripts/generate-project.sh
+++ b/scripts/generate-project.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Generates TablePro.xcodeproj and TableProMobile/TableProMobile.xcodeproj from their

--- a/scripts/ios/build-hiredis-ios.sh
+++ b/scripts/ios/build-hiredis-ios.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 # Build static hiredis (with SSL) for iOS → xcframework
@@ -54,9 +54,12 @@ resolve_openssl() {
     fi
 
     # Find the correct slice directory
-    local SSL_LIB=$(find "$XCFW_SSL" -path "*$PLATFORM*/libssl.a" | head -1)
-    local CRYPTO_LIB=$(find "$XCFW_CRYPTO" -path "*$PLATFORM*/libcrypto.a" | head -1)
-    local HEADERS=$(find "$XCFW_SSL" -path "*$PLATFORM*/Headers" -type d | head -1)
+    local SSL_LIB
+    SSL_LIB=$(find "$XCFW_SSL" -path "*$PLATFORM*/libssl.a" | head -1)
+    local CRYPTO_LIB
+    CRYPTO_LIB=$(find "$XCFW_CRYPTO" -path "*$PLATFORM*/libcrypto.a" | head -1)
+    local HEADERS
+    HEADERS=$(find "$XCFW_SSL" -path "*$PLATFORM*/Headers" -type d | head -1)
 
     if [ -z "$SSL_LIB" ] || [ -z "$CRYPTO_LIB" ]; then
         echo "ERROR: Could not find OpenSSL libs for platform $PLATFORM"
@@ -66,7 +69,6 @@ resolve_openssl() {
     OPENSSL_SSL_LIB="$SSL_LIB"
     OPENSSL_CRYPTO_LIB="$CRYPTO_LIB"
     OPENSSL_INCLUDE="$HEADERS"
-    OPENSSL_LIB_DIR="$(dirname "$SSL_LIB")"
 }
 
 # --- Download hiredis ---

--- a/scripts/ios/build-libpq-ios.sh
+++ b/scripts/ios/build-libpq-ios.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 # Build static libpq for iOS using xcodebuild/xcrun clang directly.
@@ -15,7 +15,6 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LIBS_DIR="$PROJECT_DIR/Libs/ios"
 BUILD_DIR="$(mktemp -d)"
-NCPU=$(sysctl -n hw.ncpu)
 
 cleanup() {
     echo "   Cleaning up build directory..."
@@ -165,9 +164,12 @@ setup_openssl() {
     local PLATFORM_KEY=$1
     local PREFIX="$BUILD_DIR/openssl-$PLATFORM_KEY"
 
-    local SSL_LIB=$(find "$LIBS_DIR/OpenSSL-SSL.xcframework" -path "*$PLATFORM_KEY*/libssl.a" | head -1)
-    local CRYPTO_LIB=$(find "$LIBS_DIR/OpenSSL-Crypto.xcframework" -path "*$PLATFORM_KEY*/libcrypto.a" | head -1)
-    local HEADERS=$(find "$LIBS_DIR/OpenSSL-SSL.xcframework" -path "*$PLATFORM_KEY*/Headers" -type d | head -1)
+    local SSL_LIB
+    SSL_LIB=$(find "$LIBS_DIR/OpenSSL-SSL.xcframework" -path "*$PLATFORM_KEY*/libssl.a" | head -1)
+    local CRYPTO_LIB
+    CRYPTO_LIB=$(find "$LIBS_DIR/OpenSSL-Crypto.xcframework" -path "*$PLATFORM_KEY*/libcrypto.a" | head -1)
+    local HEADERS
+    HEADERS=$(find "$LIBS_DIR/OpenSSL-SSL.xcframework" -path "*$PLATFORM_KEY*/Headers" -type d | head -1)
 
     if [ -z "$SSL_LIB" ] || [ -z "$CRYPTO_LIB" ]; then
         echo "ERROR: OpenSSL not found for $PLATFORM_KEY"
@@ -194,10 +196,14 @@ build_slice() {
 
     setup_openssl "$PLATFORM_KEY"
 
-    local SDK=$(xcrun --sdk "$SDK_NAME" --show-sdk-path)
-    local CC=$(xcrun --sdk "$SDK_NAME" -f cc)
-    local AR=$(xcrun --sdk "$SDK_NAME" -f ar)
-    local RANLIB=$(xcrun --sdk "$SDK_NAME" -f ranlib)
+    local SDK
+    SDK=$(xcrun --sdk "$SDK_NAME" --show-sdk-path)
+    local CC
+    CC=$(xcrun --sdk "$SDK_NAME" -f cc)
+    local AR
+    AR=$(xcrun --sdk "$SDK_NAME" -f ar)
+    local RANLIB
+    RANLIB=$(xcrun --sdk "$SDK_NAME" -f ranlib)
 
     local TARGET_FLAG
     if [ "$SDK_NAME" = "iphonesimulator" ]; then
@@ -206,7 +212,7 @@ build_slice() {
         TARGET_FLAG="-target arm64-apple-ios${IOS_DEPLOY_TARGET}"
     fi
 
-    local -a CFLAGS=(-arch "$ARCH" -isysroot "$SDK" $TARGET_FLAG -mios-version-min="$IOS_DEPLOY_TARGET" -O2 -DHAVE_STRCHRNUL=1 -Wno-int-conversion -Wno-ignored-attributes -Wno-implicit-function-declaration -Wno-error -w)
+    local -a CFLAGS=(-arch "$ARCH" -isysroot "$SDK" "$TARGET_FLAG" -mios-version-min="$IOS_DEPLOY_TARGET" -O2 -DHAVE_STRCHRNUL=1 -Wno-int-conversion -Wno-ignored-attributes -Wno-implicit-function-declaration -Wno-error -w)
     local -a PG_INCLUDES=(-I"$NATIVE_DIR/src/include" -I"$NATIVE_DIR/src/include/port/darwin" -I"$NATIVE_DIR/src/interfaces/libpq" -I"$NATIVE_DIR/src/port" -I"$OPENSSL_PREFIX/include" -I"$NATIVE_DIR/src/common")
 
     local OBJ_DIR="$BUILD_DIR/obj-$SDK_NAME-$ARCH"
@@ -287,7 +293,8 @@ build_slice() {
     local ALL_OBJS=()
     local FAILED_SRCS=()
     for src in "${LIBPQ_SRCS[@]}" "${COMMON_SRCS[@]}" "${PORT_SRCS[@]}"; do
-        local obj_name=$(basename "${src%.c}.o")
+        local obj_name
+        obj_name=$(basename "${src%.c}.o")
         if [ -f "$src" ]; then
             if "$CC" "${CFLAGS[@]}" "${PG_INCLUDES[@]}" -DFRONTEND -c "$src" -o "$OBJ_DIR/$obj_name" 2>"$OBJ_DIR/${obj_name}.err"; then
                 ALL_OBJS+=("$OBJ_DIR/$obj_name")

--- a/scripts/ios/build-libssh2-ios.sh
+++ b/scripts/ios/build-libssh2-ios.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 # Build static libssh2 for iOS → xcframework
@@ -43,9 +43,12 @@ resolve_openssl() {
     local PLATFORM_KEY=$1
     local PREFIX="$BUILD_DIR/openssl-$PLATFORM_KEY"
 
-    local SSL_LIB=$(find "$LIBS_DIR/OpenSSL-SSL.xcframework" -path "*$PLATFORM_KEY*/libssl.a" | head -1)
-    local CRYPTO_LIB=$(find "$LIBS_DIR/OpenSSL-Crypto.xcframework" -path "*$PLATFORM_KEY*/libcrypto.a" | head -1)
-    local HEADERS=$(find "$LIBS_DIR/OpenSSL-SSL.xcframework" -path "*$PLATFORM_KEY*/Headers" -type d | head -1)
+    local SSL_LIB
+    SSL_LIB=$(find "$LIBS_DIR/OpenSSL-SSL.xcframework" -path "*$PLATFORM_KEY*/libssl.a" | head -1)
+    local CRYPTO_LIB
+    CRYPTO_LIB=$(find "$LIBS_DIR/OpenSSL-Crypto.xcframework" -path "*$PLATFORM_KEY*/libcrypto.a" | head -1)
+    local HEADERS
+    HEADERS=$(find "$LIBS_DIR/OpenSSL-SSL.xcframework" -path "*$PLATFORM_KEY*/Headers" -type d | head -1)
 
     if [ -z "$SSL_LIB" ] || [ -z "$CRYPTO_LIB" ]; then
         echo "ERROR: OpenSSL not found for $PLATFORM_KEY. Run build-openssl-ios.sh first."

--- a/scripts/ios/build-mariadb-ios.sh
+++ b/scripts/ios/build-mariadb-ios.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 # Build static MariaDB Connector/C for iOS → xcframework
@@ -52,9 +52,12 @@ setup_openssl_prefix() {
     local PLATFORM_KEY=$1
     local PREFIX_DIR="$BUILD_DIR/openssl-$PLATFORM_KEY"
 
-    local SSL_LIB=$(find "$LIBS_DIR/OpenSSL-SSL.xcframework" -path "*$PLATFORM_KEY*/libssl.a" | head -1)
-    local CRYPTO_LIB=$(find "$LIBS_DIR/OpenSSL-Crypto.xcframework" -path "*$PLATFORM_KEY*/libcrypto.a" | head -1)
-    local HEADERS=$(find "$LIBS_DIR/OpenSSL-SSL.xcframework" -path "*$PLATFORM_KEY*/Headers" -type d | head -1)
+    local SSL_LIB
+    SSL_LIB=$(find "$LIBS_DIR/OpenSSL-SSL.xcframework" -path "*$PLATFORM_KEY*/libssl.a" | head -1)
+    local CRYPTO_LIB
+    CRYPTO_LIB=$(find "$LIBS_DIR/OpenSSL-Crypto.xcframework" -path "*$PLATFORM_KEY*/libcrypto.a" | head -1)
+    local HEADERS
+    HEADERS=$(find "$LIBS_DIR/OpenSSL-SSL.xcframework" -path "*$PLATFORM_KEY*/Headers" -type d | head -1)
 
     if [ -z "$SSL_LIB" ] || [ -z "$CRYPTO_LIB" ]; then
         echo "ERROR: OpenSSL not found for $PLATFORM_KEY. Run build-openssl-ios.sh first."

--- a/scripts/ios/build-openssl-ios.sh
+++ b/scripts/ios/build-openssl-ios.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 # Build static OpenSSL for iOS (device + simulator) → xcframework
@@ -74,9 +74,6 @@ build_openssl_slice() {
     cp -R "$OPENSSL_SRC" "$SRC_COPY"
     cd "$SRC_COPY"
 
-    local SDK_PATH
-    SDK_PATH=$(xcrun --sdk "$PLATFORM" --show-sdk-path)
-
     export IPHONEOS_DEPLOYMENT_TARGET="$IOS_DEPLOY_TARGET"
 
     run_quiet ./Configure "$TARGET" \
@@ -103,7 +100,6 @@ SIMULATOR_SRC="$BUILD_DIR/openssl-iphonesimulator-arm64"
 cp -R "$OPENSSL_SRC" "$SIMULATOR_SRC"
 cd "$SIMULATOR_SRC"
 
-SIMULATOR_SDK=$(xcrun --sdk iphonesimulator --show-sdk-path)
 SIMULATOR_INSTALL="$BUILD_DIR/install-iphonesimulator-arm64"
 
 export IPHONEOS_DEPLOYMENT_TARGET="$IOS_DEPLOY_TARGET"

--- a/scripts/openssl-version.sh
+++ b/scripts/openssl-version.sh
@@ -1,5 +1,6 @@
-#!/usr/bin/env bash
-# Shared OpenSSL version — sourced by all build scripts.
+# Shared OpenSSL version, sourced by all build scripts.
 # Update this single file when bumping OpenSSL.
+# shellcheck shell=bash
+# shellcheck disable=SC2034  # both are read by the scripts that source this file
 OPENSSL_VERSION="3.4.3"
 OPENSSL_SHA256="fa727ed1399a64e754030a033435003991aee36bda9a5b080995cb2ac5cf7f37"

--- a/scripts/release-all-plugins.sh
+++ b/scripts/release-all-plugins.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Trigger a bulk re-release of all registry plugins for a given PluginKit version.
 #
 # Usage: ./scripts/release-all-plugins.sh <pluginKitVersion>


### PR DESCRIPTION
Stacked on #2331; it retargets to main once that merges.

7,500 lines of shell build, sign, notarize and publish this app, and until now nothing linted any of it. This fixes the defects that were hiding in there and adds the gate that keeps them out.

## The deployment-target check passed exactly the libraries that break

Four scripts verify that a built static library's `minos` matches the app's floor. Three asked the wrong question:

```sh
if [ "$(printf '%s\n' "$DEPLOY_TARGET" "$min_ver" | sort -V | head -1)" != "$DEPLOY_TARGET" ]
```

`head` is the minimum, so this fires when the library targets an **older** macOS than the app, which is harmless. The case that breaks, a library built for a **newer** macOS than the app can run on, took the success branch. `build-libssh2.sh` had it right with `tail`.

Measured against `DEPLOY_TARGET=14.0`:

| library minos | `head` form | `tail` form |
| --- | --- | --- |
| 13.0 | rejects (wrong) | accepts |
| 14.0 | accepts | accepts |
| 15.0 | **accepts (the bug)** | rejects |

Fixed in `build-libpq.sh`, `build-hiredis.sh` and `build-libmongoc.sh`.

## libpq headers went to a directory that no longer exists

`install_headers` copied into `TablePro/Core/Database/CLibPQ/include`. That directory was deleted when PostgreSQL became a plugin; the headers the plugin compiles against live in `Plugins/PostgreSQLDriverPlugin/CLibPQ/include`. Every rebuild recreated a dead directory and left the real headers untouched.

The copy was also guarded on `[ ! -f .../libpq-fe.h ]`, so even pointed at the right place a version bump would have shipped new binaries against the previous release's headers. It runs unconditionally now.

## Three scripts never wrote the library the app links

`project.yml` links `Libs/libpq.a`, `Libs/libssh2.a`, `Libs/libhiredis.a`. Those three `create_universal` functions wrote only `*_universal.a`, so a rebuild changed nothing the app could see and the next release quietly shipped the previous binary. `build-libmongoc.sh` already did it right, including the `-ef` guard for when the two paths are the same file; that shape is now in all four.

## 17 assignments where `set -e` was blind

`local NAME=$(cmd)` makes the assignment's exit status the value, which is always 0, so a failing command left the variable silently empty and the script carried on. Split into a declaration and an assignment across the four iOS build scripts.

## The gate

`.github/workflows/repo-hygiene.yml` runs on ubuntu, in under a minute, on free minutes:

- `actionlint`, which shells out to `shellcheck` for every inline `run:` block. That is the only way those get checked at all, since they are not files. It caught six real findings the first time it was run here.
- `shellcheck --severity=warning` over all 43 scripts.
- the plugin manifest check and the registry-script tests, which previously only ran during a release.

**The scripts are now at zero warning-level findings**, down from 12, so the gate needs no baseline file and no exclusions. Cleared on the way:

- `rm -rf "$BUILD_DIR/$OUTPUT_NAME"` in `build-release.sh` becomes `"${BUILD_DIR:?}"`, so it can never expand to a rooted path.
- Four genuinely dead assignments, including `NCPU=$(sysctl -n hw.ncpu)` in `build-libpq-ios.sh`, which was computed and never passed to `make`: that build has always been serial and now says so rather than looking like it does something.
- An unquoted expansion inside an array literal, an `ls | grep` over a directory, and two unused loop and function locals.
- `openssl-version.sh` is sourced rather than executed, so it loses its shebang and its executable bit and declares `# shellcheck shell=bash`. Its two constants are read by the five scripts that source it, verified.

The remaining 48 findings are informational, almost all `SC2012` (`ls` where `find` is sturdier) inside message strings. Gating on those today would be noise.

## Consistency

- One shebang: 16 scripts used `#!/bin/bash` and 25 the `env` form. All 42 executable scripts use `#!/usr/bin/env bash` now.
- `.editorconfig` declared `indent_size = 2` for `*.sh`, contradicting both CLAUDE.md and the code: 34 of 43 scripts are 4-space. The config said 2. It says 4 now. The 8 two-space files are left alone; reformatting them is a mechanical diff that belongs on its own.

## Deliberately not in here

- **The `scripts/lib/` extraction.** About 1,200 of the 7,500 lines are duplicated idioms: `run_quiet` defined 9 times with four different tail depths, `cleanup` 10 times, `build_openssl` byte-identical in 4 scripts, `lipo` hand-rolled in 12. It is the largest remaining cleanup and it is worth doing, but it touches every build script and those run by hand, not in CI, so nothing here would catch a regression. It needs each migrated script actually run, one at a time. I would rather land it that way than sweep it in behind a green lint job.
- **`set -u` on the 10 scripts that only have `set -eo pipefail`.** Same reason: each needs `${VAR:-}` on its genuinely optional variables and one real run to prove it.
- **The iOS xcframework checksums.** Still unverified on download. Doing it properly needs a committed baseline, a publisher that regenerates it under the stale-checkout guard, and the CLAUDE.md snippet that currently documents a manual upload bypassing all of it.

## Verification

Every script still parses under `bash -n`. `check-doc-symbols.sh` runs clean (263 references check out). `openssl-version.sh` sources correctly. `build-mariadb.sh` was run end to end earlier in this series and produced working slices. `actionlint` is clean across all six workflows, `shellcheck --severity=warning` is clean across all 43 scripts.

https://claude.ai/code/session_013MEaba8K1HQcyDNeq5wEFk
