### PR TITLE
fix(ci): give the test jobs the OpenSSL dylibs the app links through an absolute rpath

### DIFF
--- a/.github/actions/unpack-test-products/action.yml
+++ b/.github/actions/unpack-test-products/action.yml
@@ -4,6 +4,24 @@ description: Downloads the products the build job produced and points XCTESTRUN 
 runs:
   using: composite
   steps:
+    # The app cannot launch without these, so a test job needs them even though it does not build.
+    # project.yml puts $(SRCROOT)/Libs/dylibs on LD_RUNPATH_SEARCH_PATHS, which bakes an absolute
+    # path into the binary, and TablePro.debug.dylib (the app's own code, loaded at launch) links
+    # @rpath/libssl.3.dylib and @rpath/libcrypto.3.dylib. Those are not copied into the bundle in a
+    # Debug build, so with Libs/dylibs absent dyld cannot load the app and the test host aborts with
+    # SIGABRT before XCTest ever connects, reporting zero tests rather than a missing file.
+    - name: Cache static libraries
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: Libs
+        key: ${{ runner.os }}-libs-${{ hashFiles('Libs/checksums.sha256', 'Plugins/MSSQLDriverPlugin/CFreeTDS/include/sybdb.h') }}
+
+    - name: Download static libraries
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: scripts/download-libs.sh
+
     - name: Download the built products
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
@@ -39,3 +57,13 @@ runs:
             echo "XCTESTRUN=$(locate TablePro)"
             echo "DAMENG_XCTESTRUN=$(locate DamengDriverTests)"
         } >> "$GITHUB_ENV"
+
+        # Checked here rather than discovered at test time. A missing one of these surfaces as
+        # "crashed with signal abrt before establishing connection" with zero executed tests, which
+        # names neither the library nor the reason.
+        for lib in libssl.3.dylib libcrypto.3.dylib; do
+            if [ ! -f "Libs/dylibs/$lib" ]; then
+                echo "::error::Libs/dylibs/$lib is missing; the app links it through an absolute rpath and will abort on launch"
+                exit 1
+            fi
+        done


### PR DESCRIPTION
**main is red.** #2328 split the macOS suite into a build job and test jobs, and dropped the `Libs` download from the test jobs on the grounds that they do not build anything. They do not, but the app still has to launch.

## What happens

`Unit tests` fails with zero tests executed:

```
TablePro (8776) encountered an error
Early unexpected exit, operation never finished bootstrapping
(Underlying Error: Test crashed with signal abrt before establishing connection.)
```

No dyld message, no failing test, nothing naming a file.

## Why

`project.yml` puts `$(SRCROOT)/Libs/dylibs` on `LD_RUNPATH_SEARCH_PATHS`, which bakes an absolute path into the binary:

```
$ otool -l TablePro.app/Contents/MacOS/TablePro | grep -A2 LC_RPATH
    path @executable_path
    path @loader_path
    path .../DerivedData/Build/Products/Debug/PackageFrameworks
    path @executable_path/../Frameworks
    path /Users/runner/work/TablePro/TablePro/Libs/dylibs
```

`TablePro.debug.dylib` is the app's own code, and the app binary loads it at launch:

```
$ otool -L TablePro.app/Contents/MacOS/TablePro.debug.dylib
    @rpath/libssl.3.dylib
    @rpath/libcrypto.3.dylib
    ...
```

Those two are not copied into `Contents/Frameworks` in a Debug build, so that last rpath is the only thing that resolves them. With `Libs/dylibs` absent, dyld cannot load the app's own code, and the host aborts before XCTest can connect. Every test is reported as not run rather than as failed, which is why the failure names nothing.

It passed on my machine for the least useful reason: the rpath is absolute, and that directory exists locally.

## The fix

The unpack action restores `Libs` before the products, exactly as the build job does and as the old single job did. `download-libs.sh` runs `create-openssl-dylibs.sh`, which is what produces `Libs/dylibs`. The cache key is the same, so on a hit this costs seconds.

It then asserts both dylibs are present and fails naming the file if not. A missing runtime dependency should not cost 20 minutes and produce a message that mentions neither the library nor the reason.

## What this does not fix

The real oddity is that a Debug app depends on a path inside the source tree at runtime. Copying the two dylibs into `Contents/Frameworks` like Sparkle and TableProPluginKit already are would make the bundle self-contained and remove the absolute rpath entirely. That is a `project.yml` change that touches how the app is packaged, and it is not what belongs in a fix for a red main.

https://claude.ai/code/session_013MEaba8K1HQcyDNeq5wEFk
