### PR TITLE
refactor(scripts): give the native library builds one shared set of helpers

### DIFF
--- a/scripts/build-hiredis.sh
+++ b/scripts/build-hiredis.sh
@@ -1,18 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# Run a command silently, showing output only on failure.
-run_quiet() {
-    local logfile
-    logfile=$(mktemp)
-    if ! "$@" > "$logfile" 2>&1; then
-        tail -30 "$logfile"
-        rm -f "$logfile"
-        return 1
-    fi
-    rm -f "$logfile"
-}
-
 # Build static hiredis (with SSL support) for TablePro
 #
 # Produces architecture-specific and universal static libraries in Libs/:
@@ -33,19 +21,17 @@ run_quiet() {
 #   - CMake (brew install cmake)
 #   - curl (for downloading source tarballs)
 
-DEPLOY_TARGET="14.0"
+# shellcheck source=lib/macos.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/macos.sh"
+
 HIREDIS_VERSION="1.2.0"
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/openssl-version.sh"
 HIREDIS_SHA256="82ad632d31ee05da13b537c124f819eb88e18851d9cb0c30ae0552084811588c"
 
 ARCH="${1:-both}"
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-LIBS_DIR="$PROJECT_DIR/Libs"
 # The headers the Redis plugin compiles against. The old path under TablePro/Core/Database was
 # deleted when the driver moved into a plugin bundle, so this script was installing them where
 # nothing read them and leaving the real ones untouched.
-HEADER_DIR="$PROJECT_DIR/Plugins/RedisDriverPlugin/CRedis/include/hiredis"
+HEADER_DIR="$REPO_ROOT/Plugins/RedisDriverPlugin/CRedis/include/hiredis"
 BUILD_DIR="$(mktemp -d)"
 NCPU=$(sysctl -n hw.ncpu)
 
@@ -64,11 +50,7 @@ trap cleanup EXIT
 download_sources() {
     echo "📥 Downloading source tarballs..."
 
-    if [ ! -f "$BUILD_DIR/openssl-$OPENSSL_VERSION.tar.gz" ]; then
-        curl -fSL "https://github.com/openssl/openssl/releases/download/openssl-$OPENSSL_VERSION/openssl-$OPENSSL_VERSION.tar.gz" \
-            -o "$BUILD_DIR/openssl-$OPENSSL_VERSION.tar.gz"
-    fi
-    echo "$OPENSSL_SHA256  $BUILD_DIR/openssl-$OPENSSL_VERSION.tar.gz" | shasum -a 256 -c -
+    fetch_openssl
 
     if [ ! -f "$BUILD_DIR/hiredis-$HIREDIS_VERSION.tar.gz" ]; then
         curl -fSL "https://github.com/redis/hiredis/archive/refs/tags/v$HIREDIS_VERSION.tar.gz" \
@@ -77,43 +59,6 @@ download_sources() {
     echo "$HIREDIS_SHA256  $BUILD_DIR/hiredis-$HIREDIS_VERSION.tar.gz" | shasum -a 256 -c -
 
     echo "✅ Sources downloaded"
-}
-
-build_openssl() {
-    local arch=$1
-    local prefix="$BUILD_DIR/install-openssl-$arch"
-
-    echo ""
-    echo "🔨 Building OpenSSL $OPENSSL_VERSION for $arch..."
-
-    # Extract fresh copy for this arch
-    rm -rf "$BUILD_DIR/openssl-$OPENSSL_VERSION-$arch"
-    mkdir -p "$BUILD_DIR/openssl-$OPENSSL_VERSION-$arch"
-    tar xzf "$BUILD_DIR/openssl-$OPENSSL_VERSION.tar.gz" -C "$BUILD_DIR/openssl-$OPENSSL_VERSION-$arch" --strip-components=1
-
-    cd "$BUILD_DIR/openssl-$OPENSSL_VERSION-$arch"
-
-    local target
-    if [ "$arch" = "arm64" ]; then
-        target="darwin64-arm64-cc"
-    else
-        target="darwin64-x86_64-cc"
-    fi
-
-    MACOSX_DEPLOYMENT_TARGET=$DEPLOY_TARGET \
-    ./Configure \
-        "$target" \
-        no-shared \
-        no-tests \
-        no-apps \
-        no-docs \
-        --prefix="$prefix" \
-        -mmacosx-version-min=$DEPLOY_TARGET > /dev/null 2>&1
-
-    run_quiet make -j"$NCPU"
-    run_quiet make install_sw
-
-    echo "✅ OpenSSL $arch: $(ls -lh "$prefix/lib/libssl.a" | awk '{print $5}') (libssl) $(ls -lh "$prefix/lib/libcrypto.a" | awk '{print $5}') (libcrypto)"
 }
 
 build_hiredis() {
@@ -191,23 +136,6 @@ install_headers() {
     echo "✅ Headers installed to $dest"
 }
 
-create_universal() {
-    echo ""
-    echo "🔗 Creating universal (fat) libraries..."
-    for lib in libhiredis libhiredis_ssl; do
-        if [ -f "$LIBS_DIR/${lib}_arm64.a" ] && [ -f "$LIBS_DIR/${lib}_x86_64.a" ]; then
-            lipo -create \
-                "$LIBS_DIR/${lib}_arm64.a" \
-                "$LIBS_DIR/${lib}_x86_64.a" \
-                -output "$LIBS_DIR/${lib}_universal.a"
-            if ! [ "$LIBS_DIR/${lib}_universal.a" -ef "$LIBS_DIR/${lib}.a" ]; then
-                cp "$LIBS_DIR/${lib}_universal.a" "$LIBS_DIR/${lib}.a"
-            fi
-            echo "   ${lib}_universal.a ($(ls -lh "$LIBS_DIR/${lib}_universal.a" | awk '{print $5}'))"
-        fi
-    done
-}
-
 build_for_arch() {
     local arch=$1
     build_openssl "$arch"
@@ -216,36 +144,6 @@ build_for_arch() {
     # Install headers once (they're arch-independent)
     if [ ! -f "$HEADER_DIR/hiredis.h" ]; then
         install_headers "$arch"
-    fi
-}
-
-verify_deployment_target() {
-    echo ""
-    echo "🔍 Verifying deployment targets..."
-    local failed=0
-    for lib in "$LIBS_DIR"/lib{hiredis,hiredis_ssl}_*.a; do
-        [ -f "$lib" ] || continue
-        local name min_ver
-        name=$(basename "$lib")
-        min_ver=$(otool -l "$lib" 2>/dev/null | awk '/LC_BUILD_VERSION/{found=1} found && /minos/{print $2; found=0}' | sort -V | tail -1)
-        if [ -z "$min_ver" ]; then
-            min_ver=$(otool -l "$lib" 2>/dev/null | awk '/LC_VERSION_MIN_MACOSX/{found=1} found && /version/{print $2; found=0}' | sort -V | tail -1)
-        fi
-        if [ -n "$min_ver" ]; then
-            # max(target, minos) must be the target: a library built for a NEWER macOS than the
-            # app cannot run on the app's floor, while one built for an older macOS is fine. The
-            # head form asked the opposite question, so it passed exactly the libraries that break.
-            if [ "$(printf '%s\n' "$DEPLOY_TARGET" "$min_ver" | sort -V | tail -1)" != "$DEPLOY_TARGET" ]; then
-                echo "   ❌ $name targets macOS $min_ver (expected $DEPLOY_TARGET)"
-                failed=1
-            else
-                echo "   ✅ $name targets macOS $min_ver"
-            fi
-        fi
-    done
-    if [ "$failed" -eq 1 ]; then
-        echo "❌ FATAL: Some libraries have incorrect deployment targets"
-        exit 1
     fi
 }
 
@@ -263,7 +161,7 @@ case "$ARCH" in
     both)
         build_for_arch arm64
         build_for_arch x86_64
-        create_universal
+        make_universal libhiredis libhiredis_ssl
         ;;
     *)
         echo "Usage: $0 [arm64|x86_64|both]"
@@ -271,7 +169,7 @@ case "$ARCH" in
         ;;
 esac
 
-verify_deployment_target
+verify_deployment_target "$LIBS_DIR"/libhiredis_*.a "$LIBS_DIR"/libhiredis_ssl_*.a
 
 echo ""
 echo "🎉 Build complete! Libraries in Libs/:"

--- a/scripts/build-libmongoc.sh
+++ b/scripts/build-libmongoc.sh
@@ -1,17 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-run_quiet() {
-    local logfile
-    logfile=$(mktemp)
-    if ! "$@" > "$logfile" 2>&1; then
-        tail -30 "$logfile"
-        rm -f "$logfile"
-        return 1
-    fi
-    rm -f "$logfile"
-}
-
 # Build static libmongoc + libbson for TablePro
 #
 # Produces architecture-specific and universal static libraries in Libs/:
@@ -37,15 +26,12 @@ run_quiet() {
 #   - CMake 3.15+ (brew install cmake)
 #   - curl
 
-DEPLOY_TARGET="14.0"
 MONGOC_VERSION="1.28.1"
 MONGOC_SHA256="a93259840f461b28e198311e32144f5f8dc9fbd74348029f2793774d781bb7da"
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/openssl-version.sh"
+# shellcheck source=lib/macos.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/macos.sh"
 
 ARCH="${1:-both}"
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-LIBS_DIR="$PROJECT_DIR/Libs"
 BUILD_DIR="$(mktemp -d)"
 NCPU=$(sysctl -n hw.ncpu)
 
@@ -64,11 +50,7 @@ trap cleanup EXIT
 download_sources() {
     echo "📥 Downloading source tarballs..."
 
-    if [ ! -f "$BUILD_DIR/openssl-$OPENSSL_VERSION.tar.gz" ]; then
-        curl -fSL "https://github.com/openssl/openssl/releases/download/openssl-$OPENSSL_VERSION/openssl-$OPENSSL_VERSION.tar.gz" \
-            -o "$BUILD_DIR/openssl-$OPENSSL_VERSION.tar.gz"
-    fi
-    echo "$OPENSSL_SHA256  $BUILD_DIR/openssl-$OPENSSL_VERSION.tar.gz" | shasum -a 256 -c -
+    fetch_openssl
 
     if [ ! -f "$BUILD_DIR/mongo-c-driver-$MONGOC_VERSION.tar.gz" ]; then
         curl -fSL "https://github.com/mongodb/mongo-c-driver/releases/download/$MONGOC_VERSION/mongo-c-driver-$MONGOC_VERSION.tar.gz" \
@@ -77,42 +59,6 @@ download_sources() {
     echo "$MONGOC_SHA256  $BUILD_DIR/mongo-c-driver-$MONGOC_VERSION.tar.gz" | shasum -a 256 -c -
 
     echo "✅ Sources downloaded"
-}
-
-build_openssl() {
-    local arch=$1
-    local prefix="$BUILD_DIR/install-openssl-$arch"
-
-    echo ""
-    echo "🔨 Building OpenSSL $OPENSSL_VERSION for $arch..."
-
-    rm -rf "$BUILD_DIR/openssl-$OPENSSL_VERSION-$arch"
-    mkdir -p "$BUILD_DIR/openssl-$OPENSSL_VERSION-$arch"
-    tar xzf "$BUILD_DIR/openssl-$OPENSSL_VERSION.tar.gz" -C "$BUILD_DIR/openssl-$OPENSSL_VERSION-$arch" --strip-components=1
-
-    cd "$BUILD_DIR/openssl-$OPENSSL_VERSION-$arch"
-
-    local target
-    if [ "$arch" = "arm64" ]; then
-        target="darwin64-arm64-cc"
-    else
-        target="darwin64-x86_64-cc"
-    fi
-
-    MACOSX_DEPLOYMENT_TARGET=$DEPLOY_TARGET \
-    run_quiet ./Configure \
-        "$target" \
-        no-shared \
-        no-tests \
-        no-apps \
-        no-docs \
-        --prefix="$prefix" \
-        -mmacosx-version-min=$DEPLOY_TARGET
-
-    run_quiet make -j"$NCPU"
-    run_quiet make install_sw
-
-    echo "✅ OpenSSL $arch: $(ls -lh "$prefix/lib/libssl.a" | awk '{print $5}') (libssl) $(ls -lh "$prefix/lib/libcrypto.a" | awk '{print $5}') (libcrypto)"
 }
 
 build_mongoc() {
@@ -191,7 +137,7 @@ install_libs() {
 install_headers() {
     local arch=$1
     local prefix="$BUILD_DIR/install-mongoc-$arch"
-    local dest="$PROJECT_DIR/Plugins/MongoDBDriverPlugin/CLibMongoc/include"
+    local dest="$REPO_ROOT/Plugins/MongoDBDriverPlugin/CLibMongoc/include"
 
     echo "📦 Installing libmongoc headers..."
 
@@ -204,23 +150,6 @@ install_headers() {
     cp "$inc_dir/libbson-1.0/bson/"*.h "$dest/bson/"
 
     echo "✅ Headers installed to $dest"
-}
-
-create_universal() {
-    echo ""
-    echo "🔗 Creating universal (fat) libraries..."
-    for lib in libmongoc libbson; do
-        if [ -f "$LIBS_DIR/${lib}_arm64.a" ] && [ -f "$LIBS_DIR/${lib}_x86_64.a" ]; then
-            lipo -create \
-                "$LIBS_DIR/${lib}_arm64.a" \
-                "$LIBS_DIR/${lib}_x86_64.a" \
-                -output "$LIBS_DIR/${lib}_universal.a"
-            if ! [ "$LIBS_DIR/${lib}_universal.a" -ef "$LIBS_DIR/${lib}.a" ]; then
-                cp "$LIBS_DIR/${lib}_universal.a" "$LIBS_DIR/${lib}.a"
-            fi
-            echo "   ${lib}_universal.a ($(ls -lh "$LIBS_DIR/${lib}_universal.a" | awk '{print $5}'))"
-        fi
-    done
 }
 
 build_for_arch() {
@@ -253,36 +182,6 @@ verify_tls_backend() {
     echo "   ✅ libmongoc has no Secure Transport references"
 }
 
-verify_deployment_target() {
-    echo ""
-    echo "🔍 Verifying deployment targets..."
-    local failed=0
-    for lib in "$LIBS_DIR"/lib{mongoc,bson}_*.a; do
-        [ -f "$lib" ] || continue
-        local name min_ver
-        name=$(basename "$lib")
-        min_ver=$(otool -l "$lib" 2>/dev/null | awk '/LC_BUILD_VERSION/{found=1} found && /minos/{print $2; found=0}' | sort -V | tail -1)
-        if [ -z "$min_ver" ]; then
-            min_ver=$(otool -l "$lib" 2>/dev/null | awk '/LC_VERSION_MIN_MACOSX/{found=1} found && /version/{print $2; found=0}' | sort -V | tail -1)
-        fi
-        if [ -n "$min_ver" ]; then
-            # max(target, minos) must be the target: a library built for a NEWER macOS than the
-            # app cannot run on the app's floor, while one built for an older macOS is fine. The
-            # head form asked the opposite question, so it passed exactly the libraries that break.
-            if [ "$(printf '%s\n' "$DEPLOY_TARGET" "$min_ver" | sort -V | tail -1)" != "$DEPLOY_TARGET" ]; then
-                echo "   ❌ $name targets macOS $min_ver (expected $DEPLOY_TARGET)"
-                failed=1
-            else
-                echo "   ✅ $name targets macOS $min_ver"
-            fi
-        fi
-    done
-    if [ "$failed" -eq 1 ]; then
-        echo "❌ FATAL: Some libraries have incorrect deployment targets"
-        exit 1
-    fi
-}
-
 mkdir -p "$LIBS_DIR"
 download_sources
 
@@ -296,7 +195,7 @@ case "$ARCH" in
     both)
         build_for_arch arm64
         build_for_arch x86_64
-        create_universal
+        make_universal libmongoc libbson
         ;;
     *)
         echo "Usage: $0 [arm64|x86_64|both]"
@@ -305,8 +204,7 @@ case "$ARCH" in
 esac
 
 verify_tls_backend
-verify_deployment_target
-
+verify_deployment_target "$LIBS_DIR"/libmongoc_*.a "$LIBS_DIR"/libbson_*.a
 echo ""
 echo "🎉 Build complete! Libraries in Libs/:"
 ls -lh "$LIBS_DIR"/lib{mongoc,bson}*.a 2>/dev/null

--- a/scripts/build-libpq.sh
+++ b/scripts/build-libpq.sh
@@ -1,17 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# Run a command silently, showing output only on failure.
-run_quiet() {
-    local logfile
-    logfile=$(mktemp)
-    if ! "$@" > "$logfile" 2>&1; then
-        tail -20 "$logfile"
-        rm -f "$logfile"
-        return 1
-    fi
-    rm -f "$logfile"
-}
 
 # Build static libpq and OpenSSL for TablePro
 #
@@ -34,19 +23,16 @@ run_quiet() {
 #   - Xcode Command Line Tools
 #   - curl (for downloading source tarballs)
 
-DEPLOY_TARGET="14.0"
 PG_VERSION="17.4"
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/openssl-version.sh"
+# shellcheck source=lib/macos.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/macos.sh"
 PG_SHA256="c4605b73fea11963406699f949b966e5d173a7ee0ccaef8938dec0ca8a995fe7"
 
 ARCH="${1:-both}"
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-LIBS_DIR="$PROJECT_DIR/Libs"
 # The PostgreSQL driver became a plugin, and its headers moved with it. This pointed at
 # TablePro/Core/Database/CLibPQ/include, which no longer exists, so every rebuild recreated a dead
 # directory and never updated the headers the plugin actually compiles against.
-HEADER_DIR="$PROJECT_DIR/Plugins/PostgreSQLDriverPlugin/CLibPQ/include"
+HEADER_DIR="$REPO_ROOT/Plugins/PostgreSQLDriverPlugin/CLibPQ/include"
 BUILD_DIR="$(mktemp -d)"
 NCPU=$(sysctl -n hw.ncpu)
 
@@ -65,11 +51,7 @@ trap cleanup EXIT
 download_sources() {
     echo "📥 Downloading source tarballs..."
 
-    if [ ! -f "$BUILD_DIR/openssl-$OPENSSL_VERSION.tar.gz" ]; then
-        curl -fSL "https://github.com/openssl/openssl/releases/download/openssl-$OPENSSL_VERSION/openssl-$OPENSSL_VERSION.tar.gz" \
-            -o "$BUILD_DIR/openssl-$OPENSSL_VERSION.tar.gz"
-    fi
-    echo "$OPENSSL_SHA256  $BUILD_DIR/openssl-$OPENSSL_VERSION.tar.gz" | shasum -a 256 -c -
+    fetch_openssl
 
     if [ ! -f "$BUILD_DIR/postgresql-$PG_VERSION.tar.bz2" ]; then
         curl -fSL "https://ftp.postgresql.org/pub/source/v$PG_VERSION/postgresql-$PG_VERSION.tar.bz2" \
@@ -78,43 +60,6 @@ download_sources() {
     echo "$PG_SHA256  $BUILD_DIR/postgresql-$PG_VERSION.tar.bz2" | shasum -a 256 -c -
 
     echo "✅ Sources downloaded"
-}
-
-build_openssl() {
-    local arch=$1
-    local prefix="$BUILD_DIR/install-openssl-$arch"
-
-    echo ""
-    echo "🔨 Building OpenSSL $OPENSSL_VERSION for $arch..."
-
-    # Extract fresh copy for this arch
-    rm -rf "$BUILD_DIR/openssl-$OPENSSL_VERSION-$arch"
-    mkdir -p "$BUILD_DIR/openssl-$OPENSSL_VERSION-$arch"
-    tar xzf "$BUILD_DIR/openssl-$OPENSSL_VERSION.tar.gz" -C "$BUILD_DIR/openssl-$OPENSSL_VERSION-$arch" --strip-components=1
-
-    cd "$BUILD_DIR/openssl-$OPENSSL_VERSION-$arch"
-
-    local target
-    if [ "$arch" = "arm64" ]; then
-        target="darwin64-arm64-cc"
-    else
-        target="darwin64-x86_64-cc"
-    fi
-
-    MACOSX_DEPLOYMENT_TARGET=$DEPLOY_TARGET \
-    ./Configure \
-        "$target" \
-        no-shared \
-        no-tests \
-        no-apps \
-        no-docs \
-        --prefix="$prefix" \
-        -mmacosx-version-min=$DEPLOY_TARGET > /dev/null 2>&1
-
-    run_quiet make -j"$NCPU"
-    run_quiet make install_sw
-
-    echo "✅ OpenSSL $arch: $(ls -lh "$prefix/lib/libssl.a" | awk '{print $5}') (libssl) $(ls -lh "$prefix/lib/libcrypto.a" | awk '{print $5}') (libcrypto)"
 }
 
 build_libpq() {
@@ -215,23 +160,6 @@ install_headers() {
     echo "✅ Headers installed to $dest"
 }
 
-create_universal() {
-    echo ""
-    echo "🔗 Creating universal (fat) libraries..."
-    for lib in libpq libpgcommon libpgport libssl libcrypto; do
-        if [ -f "$LIBS_DIR/${lib}_arm64.a" ] && [ -f "$LIBS_DIR/${lib}_x86_64.a" ]; then
-            lipo -create \
-                "$LIBS_DIR/${lib}_arm64.a" \
-                "$LIBS_DIR/${lib}_x86_64.a" \
-                -output "$LIBS_DIR/${lib}_universal.a"
-            if ! [ "$LIBS_DIR/${lib}_universal.a" -ef "$LIBS_DIR/${lib}.a" ]; then
-                cp "$LIBS_DIR/${lib}_universal.a" "$LIBS_DIR/${lib}.a"
-            fi
-            echo "   ${lib}_universal.a ($(ls -lh "$LIBS_DIR/${lib}_universal.a" | awk '{print $5}'))"
-        fi
-    done
-}
-
 build_for_arch() {
     local arch=$1
     build_openssl "$arch"
@@ -240,36 +168,6 @@ build_for_arch() {
     # Unconditional. Skipping when a header already exists meant a version bump shipped new
     # binaries against the previous release's headers.
     install_headers "$arch"
-}
-
-verify_deployment_target() {
-    echo ""
-    echo "🔍 Verifying deployment targets..."
-    local failed=0
-    for lib in "$LIBS_DIR"/lib{pq,pgcommon,pgport,ssl,crypto}_*.a; do
-        [ -f "$lib" ] || continue
-        local name min_ver
-        name=$(basename "$lib")
-        min_ver=$(otool -l "$lib" 2>/dev/null | awk '/LC_BUILD_VERSION/{found=1} found && /minos/{print $2; found=0}' | sort -V | tail -1)
-        if [ -z "$min_ver" ]; then
-            min_ver=$(otool -l "$lib" 2>/dev/null | awk '/LC_VERSION_MIN_MACOSX/{found=1} found && /version/{print $2; found=0}' | sort -V | tail -1)
-        fi
-        if [ -n "$min_ver" ]; then
-            # max(target, minos) must be the target: a library built for a NEWER macOS than the
-            # app cannot run on the app's floor, while one built for an older macOS is fine. The
-            # head form asked the opposite question, so it passed exactly the libraries that break.
-            if [ "$(printf '%s\n' "$DEPLOY_TARGET" "$min_ver" | sort -V | tail -1)" != "$DEPLOY_TARGET" ]; then
-                echo "   ❌ $name targets macOS $min_ver (expected $DEPLOY_TARGET)"
-                failed=1
-            else
-                echo "   ✅ $name targets macOS $min_ver"
-            fi
-        fi
-    done
-    if [ "$failed" -eq 1 ]; then
-        echo "❌ FATAL: Some libraries have incorrect deployment targets"
-        exit 1
-    fi
 }
 
 # Main
@@ -286,7 +184,7 @@ case "$ARCH" in
     both)
         build_for_arch arm64
         build_for_arch x86_64
-        create_universal
+        make_universal libpq libpgcommon libpgport libssl libcrypto
         ;;
     *)
         echo "Usage: $0 [arm64|x86_64|both]"
@@ -294,8 +192,7 @@ case "$ARCH" in
         ;;
 esac
 
-verify_deployment_target
-
+verify_deployment_target "$LIBS_DIR"/libpq_*.a "$LIBS_DIR"/libpgcommon_*.a "$LIBS_DIR"/libpgport_*.a "$LIBS_DIR"/libssl_*.a "$LIBS_DIR"/libcrypto_*.a
 echo ""
 echo "🎉 Build complete! Libraries in Libs/:"
 ls -lh "$LIBS_DIR"/lib{pq,pgcommon,pgport,ssl,crypto}*.a 2>/dev/null

--- a/scripts/build-libssh2.sh
+++ b/scripts/build-libssh2.sh
@@ -1,17 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# Run a command silently, showing output only on failure.
-run_quiet() {
-    local logfile
-    logfile=$(mktemp)
-    if ! "$@" > "$logfile" 2>&1; then
-        tail -30 "$logfile"
-        rm -f "$logfile"
-        return 1
-    fi
-    rm -f "$logfile"
-}
 
 # Build static libssh2 (with OpenSSL backend) for TablePro
 #
@@ -32,15 +21,12 @@ run_quiet() {
 #   - CMake (brew install cmake)
 #   - curl (for downloading source tarballs)
 
-DEPLOY_TARGET="14.0"
 LIBSSH2_VERSION="1.11.1"
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/openssl-version.sh"
+# shellcheck source=lib/macos.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/macos.sh"
 LIBSSH2_SHA256="d9ec76cbe34db98eec3539fe2c899d26b0c837cb3eb466a56b0f109cabf658f7"
 
 ARCH="${1:-both}"
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-LIBS_DIR="$PROJECT_DIR/Libs"
 BUILD_DIR="$(mktemp -d)"
 NCPU=$(sysctl -n hw.ncpu)
 
@@ -59,11 +45,7 @@ trap cleanup EXIT
 download_sources() {
     echo "📥 Downloading source tarballs..."
 
-    if [ ! -f "$BUILD_DIR/openssl-$OPENSSL_VERSION.tar.gz" ]; then
-        curl -fSL "https://github.com/openssl/openssl/releases/download/openssl-$OPENSSL_VERSION/openssl-$OPENSSL_VERSION.tar.gz" \
-            -o "$BUILD_DIR/openssl-$OPENSSL_VERSION.tar.gz"
-    fi
-    echo "$OPENSSL_SHA256  $BUILD_DIR/openssl-$OPENSSL_VERSION.tar.gz" | shasum -a 256 -c -
+    fetch_openssl
 
     if [ ! -f "$BUILD_DIR/libssh2-$LIBSSH2_VERSION.tar.gz" ]; then
         curl -fSL "https://github.com/libssh2/libssh2/releases/download/libssh2-$LIBSSH2_VERSION/libssh2-$LIBSSH2_VERSION.tar.gz" \
@@ -72,43 +54,6 @@ download_sources() {
     echo "$LIBSSH2_SHA256  $BUILD_DIR/libssh2-$LIBSSH2_VERSION.tar.gz" | shasum -a 256 -c -
 
     echo "✅ Sources downloaded"
-}
-
-build_openssl() {
-    local arch=$1
-    local prefix="$BUILD_DIR/install-openssl-$arch"
-
-    echo ""
-    echo "🔨 Building OpenSSL $OPENSSL_VERSION for $arch..."
-
-    # Extract fresh copy for this arch
-    rm -rf "$BUILD_DIR/openssl-$OPENSSL_VERSION-$arch"
-    mkdir -p "$BUILD_DIR/openssl-$OPENSSL_VERSION-$arch"
-    tar xzf "$BUILD_DIR/openssl-$OPENSSL_VERSION.tar.gz" -C "$BUILD_DIR/openssl-$OPENSSL_VERSION-$arch" --strip-components=1
-
-    cd "$BUILD_DIR/openssl-$OPENSSL_VERSION-$arch"
-
-    local target
-    if [ "$arch" = "arm64" ]; then
-        target="darwin64-arm64-cc"
-    else
-        target="darwin64-x86_64-cc"
-    fi
-
-    MACOSX_DEPLOYMENT_TARGET=$DEPLOY_TARGET \
-    ./Configure \
-        "$target" \
-        no-shared \
-        no-tests \
-        no-apps \
-        no-docs \
-        --prefix="$prefix" \
-        -mmacosx-version-min=$DEPLOY_TARGET > /dev/null 2>&1
-
-    run_quiet make -j"$NCPU"
-    run_quiet make install_sw
-
-    echo "✅ OpenSSL $arch: $(ls -lh "$prefix/lib/libssl.a" | awk '{print $5}') (libssl) $(ls -lh "$prefix/lib/libcrypto.a" | awk '{print $5}') (libcrypto)"
 }
 
 # libssh2 1.11.1 is the newest release and is still vulnerable to CVE-2026-55200 (CVSS 9.2):
@@ -201,7 +146,7 @@ install_libs() {
 install_headers() {
     local arch=$1
     local prefix="$BUILD_DIR/install-libssh2-$arch"
-    local dest="$PROJECT_DIR/TablePro/Core/SSH/CLibSSH2/include"
+    local dest="$REPO_ROOT/TablePro/Core/SSH/CLibSSH2/include"
 
     echo "📦 Installing libssh2 headers..."
 
@@ -213,54 +158,12 @@ install_headers() {
     echo "✅ Headers installed to $dest"
 }
 
-create_universal() {
-    echo ""
-    echo "🔗 Creating universal (fat) library..."
-    if [ -f "$LIBS_DIR/libssh2_arm64.a" ] && [ -f "$LIBS_DIR/libssh2_x86_64.a" ]; then
-        lipo -create \
-            "$LIBS_DIR/libssh2_arm64.a" \
-            "$LIBS_DIR/libssh2_x86_64.a" \
-            -output "$LIBS_DIR/libssh2_universal.a"
-        if ! [ "$LIBS_DIR/libssh2_universal.a" -ef "$LIBS_DIR/libssh2.a" ]; then
-            cp "$LIBS_DIR/libssh2_universal.a" "$LIBS_DIR/libssh2.a"
-        fi
-        echo "   libssh2_universal.a ($(ls -lh "$LIBS_DIR/libssh2_universal.a" | awk '{print $5}'))"
-    fi
-}
-
 build_for_arch() {
     local arch=$1
     build_openssl "$arch"
     build_libssh2 "$arch"
     install_libs "$arch"
     install_headers "$arch"
-}
-
-verify_deployment_target() {
-    echo ""
-    echo "🔍 Verifying deployment targets..."
-    local failed=0
-    for lib in "$LIBS_DIR"/libssh2_*.a; do
-        [ -f "$lib" ] || continue
-        local name min_ver
-        name=$(basename "$lib")
-        min_ver=$(otool -l "$lib" 2>/dev/null | awk '/LC_BUILD_VERSION/{found=1} found && /minos/{print $2; found=0}' | sort -V | tail -1)
-        if [ -z "$min_ver" ]; then
-            min_ver=$(otool -l "$lib" 2>/dev/null | awk '/LC_VERSION_MIN_MACOSX/{found=1} found && /version/{print $2; found=0}' | sort -V | tail -1)
-        fi
-        if [ -n "$min_ver" ]; then
-            if [ "$(printf '%s\n' "$DEPLOY_TARGET" "$min_ver" | sort -V | tail -1)" != "$DEPLOY_TARGET" ]; then
-                echo "   ❌ $name targets macOS $min_ver (expected $DEPLOY_TARGET)"
-                failed=1
-            else
-                echo "   ✅ $name targets macOS $min_ver"
-            fi
-        fi
-    done
-    if [ "$failed" -eq 1 ]; then
-        echo "❌ FATAL: Some libraries have incorrect deployment targets"
-        exit 1
-    fi
 }
 
 # Main
@@ -277,7 +180,7 @@ case "$ARCH" in
     both)
         build_for_arch arm64
         build_for_arch x86_64
-        create_universal
+        make_universal libssh2
         ;;
     *)
         echo "Usage: $0 [arm64|x86_64|both]"
@@ -285,8 +188,7 @@ case "$ARCH" in
         ;;
 esac
 
-verify_deployment_target
-
+verify_deployment_target "$LIBS_DIR"/libssh2_*.a
 echo ""
 echo "🎉 Build complete! Libraries in Libs/:"
 ls -lh "$LIBS_DIR"/libssh2*.a 2>/dev/null

--- a/scripts/build-mariadb.sh
+++ b/scripts/build-mariadb.sh
@@ -24,8 +24,10 @@ MARIADB_VERSION="3.4.4"
 # record whatever was served the first time anybody looked. Note the upstream tarball unpacks to a
 # "-src" directory, unlike the GitHub one.
 MARIADB_SHA256="58876fad1c2d33979d78bbfa61d7a3476e8faa2cd0af0f7f8bfeb06deaa1034e"
-MIN_MACOS="14.0"
 OPENSSL_ROOT="${OPENSSL_ROOT:-$(brew --prefix openssl@3 2>/dev/null || true)}"
+
+# shellcheck source=lib/macos.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/macos.sh"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -37,15 +39,6 @@ if [ -z "$OPENSSL_ROOT" ] || [ ! -d "$OPENSSL_ROOT" ]; then
     echo "ERROR: OpenSSL 3 not found. Install with 'brew install openssl@3' or set OPENSSL_ROOT." >&2
     exit 1
 fi
-
-run_quiet() {
-    local logfile
-    logfile=$(mktemp)
-    if ! "$@" > "$logfile" 2>&1; then
-        echo "FAILED: $*"; tail -50 "$logfile"; rm -f "$logfile"; return 1
-    fi
-    rm -f "$logfile"
-}
 
 cleanup() { rm -rf "$BUILD_DIR"; }
 trap cleanup EXIT
@@ -69,7 +62,7 @@ build_slice() {
     echo "=> Building $ARCH..."
     run_quiet cmake .. \
         -DCMAKE_OSX_ARCHITECTURES="$ARCH" \
-        -DCMAKE_OSX_DEPLOYMENT_TARGET="$MIN_MACOS" \
+        -DCMAKE_OSX_DEPLOYMENT_TARGET="$DEPLOY_TARGET" \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
         -DCMAKE_C_FLAGS="-w -Wno-error -Wno-inline-asm -Wno-deprecated-non-prototype -Wno-macro-redefined" \

--- a/scripts/ios/build-hiredis-ios.sh
+++ b/scripts/ios/build-hiredis-ios.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+# shellcheck source=../lib/common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/common.sh"
+
 # Build static hiredis (with SSL) for iOS → xcframework
 #
 # Requires: OpenSSL xcframework already built (run build-openssl-ios.sh first)
@@ -19,18 +22,6 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LIBS_DIR="$PROJECT_DIR/Libs/ios"
 BUILD_DIR="$(mktemp -d)"
 NCPU=$(sysctl -n hw.ncpu)
-
-run_quiet() {
-    local logfile
-    logfile=$(mktemp)
-    if ! "$@" > "$logfile" 2>&1; then
-        echo "FAILED: $*"
-        tail -50 "$logfile"
-        rm -f "$logfile"
-        return 1
-    fi
-    rm -f "$logfile"
-}
 
 cleanup() {
     echo "   Cleaning up build directory..."

--- a/scripts/ios/build-libssh2-ios.sh
+++ b/scripts/ios/build-libssh2-ios.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+# shellcheck source=../lib/common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/common.sh"
+
 # Build static libssh2 for iOS → xcframework
 #
 # Requires: OpenSSL xcframework already built (run build-openssl-ios.sh first)
@@ -15,18 +18,6 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LIBS_DIR="$PROJECT_DIR/Libs/ios"
 BUILD_DIR="$(mktemp -d)"
 NCPU=$(sysctl -n hw.ncpu)
-
-run_quiet() {
-    local logfile
-    logfile=$(mktemp)
-    if ! "$@" > "$logfile" 2>&1; then
-        echo "FAILED: $*"
-        tail -50 "$logfile"
-        rm -f "$logfile"
-        return 1
-    fi
-    rm -f "$logfile"
-}
 
 cleanup() {
     echo "   Cleaning up build directory..."

--- a/scripts/ios/build-mariadb-ios.sh
+++ b/scripts/ios/build-mariadb-ios.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+# shellcheck source=../lib/common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/common.sh"
+
 # Build static MariaDB Connector/C for iOS → xcframework
 #
 # Requires: OpenSSL xcframework already built
@@ -24,18 +27,6 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LIBS_DIR="$PROJECT_DIR/Libs/ios"
 BUILD_DIR="$(mktemp -d)"
 NCPU=$(sysctl -n hw.ncpu)
-
-run_quiet() {
-    local logfile
-    logfile=$(mktemp)
-    if ! "$@" > "$logfile" 2>&1; then
-        echo "FAILED: $*"
-        tail -50 "$logfile"
-        rm -f "$logfile"
-        return 1
-    fi
-    rm -f "$logfile"
-}
 
 cleanup() {
     echo "   Cleaning up build directory..."

--- a/scripts/ios/build-openssl-ios.sh
+++ b/scripts/ios/build-openssl-ios.sh
@@ -14,7 +14,8 @@ set -eo pipefail
 #   - Xcode Command Line Tools
 #   - curl
 
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../openssl-version.sh"
+# shellcheck source=../lib/common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/common.sh"
 IOS_DEPLOY_TARGET="17.0"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -22,18 +23,6 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LIBS_DIR="$PROJECT_DIR/Libs/ios"
 BUILD_DIR="$(mktemp -d)"
 NCPU=$(sysctl -n hw.ncpu)
-
-run_quiet() {
-    local logfile
-    logfile=$(mktemp)
-    if ! "$@" > "$logfile" 2>&1; then
-        echo "FAILED: $*"
-        tail -50 "$logfile"
-        rm -f "$logfile"
-        return 1
-    fi
-    rm -f "$logfile"
-}
 
 cleanup() {
     echo "   Cleaning up build directory..."

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,0 +1,69 @@
+# Shared helpers for the native library build scripts.
+#
+# Sourced, never executed. A script picks this up with:
+#
+#     source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/macos.sh"    # macOS builds
+#     source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/common.sh" # iOS builds
+#
+# Holds only what both the macOS and the iOS builds use. The macOS-only helpers live in macos.sh,
+# which sources this. Every function here was copied between scripts before, and the copies had
+# drifted: `run_quiet` existed in four variants across nine files, three of them hiding which
+# command had failed.
+#
+# shellcheck shell=bash
+# shellcheck source-path=SCRIPTDIR
+# shellcheck disable=SC2034  # the constants below are read by the scripts that source this
+
+[ -n "${TABLEPRO_LIB_COMMON_SOURCED:-}" ] && return 0
+TABLEPRO_LIB_COMMON_SOURCED=1
+
+TABLEPRO_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TABLEPRO_LIB_DIR/../.." && pwd)"
+LIBS_DIR="$REPO_ROOT/Libs"
+
+# OpenSSL is built from source on both platforms so it carries the right deployment target; a
+# Homebrew build targets whatever macOS that machine runs, which is what produced the
+# "Symbol not found" crashes these scripts exist to avoid. Digests from https://openssl.org/source/.
+OPENSSL_VERSION="3.4.3"
+OPENSSL_SHA256="fa727ed1399a64e754030a033435003991aee36bda9a5b080995cb2ac5cf7f37"
+
+# Runs a command silently and shows its output only when it fails.
+#
+# Names the command as well as showing the tail: the variants that printed only a tail left you
+# guessing which of a dozen configure and make invocations had produced it.
+run_quiet() {
+    local logfile
+    logfile=$(mktemp)
+    if ! "$@" > "$logfile" 2>&1; then
+        echo "FAILED: $*" >&2
+        tail -50 "$logfile" >&2
+        rm -f "$logfile"
+        return 1
+    fi
+    rm -f "$logfile"
+}
+
+# Fails with one message listing everything missing, rather than dying on the first absence
+# partway through a twenty minute build.
+require_tools() {
+    local tool missing=()
+    for tool in "$@"; do
+        command -v "$tool" > /dev/null 2>&1 || missing+=("$tool")
+    done
+    if [ "${#missing[@]}" -gt 0 ]; then
+        echo "ERROR: missing required tool(s): ${missing[*]}" >&2
+        echo "       install them and run this again" >&2
+        return 1
+    fi
+}
+
+# Verifies a downloaded file against a checksum the caller pins.
+verify_sha256() {
+    local file="$1" expected="$2"
+    echo "$expected  $file" | shasum -a 256 -c - > /dev/null || {
+        echo "ERROR: checksum mismatch for $file" >&2
+        echo "       expected $expected" >&2
+        echo "       actual   $(shasum -a 256 "$file" | cut -d' ' -f1)" >&2
+        return 1
+    }
+}

--- a/scripts/lib/macos.sh
+++ b/scripts/lib/macos.sh
@@ -1,0 +1,129 @@
+# macOS-only helpers for the native library build scripts.
+#
+# Sourced, never executed. A macOS build script picks this up with:
+#
+#     source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/macos.sh"
+#
+# and gets everything in common.sh with it. The iOS scripts source common.sh directly, because a
+# darwin64 OpenSSL target and a macOS deployment floor mean nothing to them.
+#
+# shellcheck shell=bash
+# shellcheck source-path=SCRIPTDIR
+# shellcheck disable=SC2034  # DEPLOY_TARGET is read by the scripts that source this
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+# The app's floor, and the only place it is written down for these scripts. Configs/Base.xcconfig
+# holds the same number for the Xcode build.
+DEPLOY_TARGET="14.0"
+
+make_universal() {
+    local lib
+    for lib in "$@"; do
+        if [ ! -f "$LIBS_DIR/${lib}_arm64.a" ] || [ ! -f "$LIBS_DIR/${lib}_x86_64.a" ]; then
+            continue
+        fi
+        lipo -create \
+            "$LIBS_DIR/${lib}_arm64.a" \
+            "$LIBS_DIR/${lib}_x86_64.a" \
+            -output "$LIBS_DIR/${lib}_universal.a"
+        if ! [ "$LIBS_DIR/${lib}_universal.a" -ef "$LIBS_DIR/${lib}.a" ]; then
+            cp "$LIBS_DIR/${lib}_universal.a" "$LIBS_DIR/${lib}.a"
+        fi
+        echo "   ${lib}_universal.a ($(du -h "$LIBS_DIR/${lib}_universal.a" | cut -f1))"
+    done
+}
+
+# Reads the macOS version a Mach-O was built for. Prefers LC_BUILD_VERSION and falls back to the
+# older LC_VERSION_MIN_MACOSX. `tail -1` takes the highest across the archive's members, which is
+# the one that decides whether the whole library can run on the app's floor.
+macho_min_version() {
+    local lib="$1" version
+    version=$(otool -l "$lib" 2>/dev/null |
+        awk '/LC_BUILD_VERSION/{found=1} found && /minos/{print $2; found=0}' | sort -V | tail -1)
+    if [ -z "$version" ]; then
+        version=$(otool -l "$lib" 2>/dev/null |
+            awk '/LC_VERSION_MIN_MACOSX/{found=1} found && /version/{print $2; found=0}' | sort -V | tail -1)
+    fi
+    printf '%s' "$version"
+}
+
+# Fails if any given library was built for a NEWER macOS than the app supports.
+#
+# The direction matters and three copies had it backwards. A library built for an older macOS is
+# fine, it simply supports more systems; one built for a newer macOS cannot run on the app's floor.
+# `max(target, minos) == target` is the question. The inverted form passed exactly the libraries
+# that break.
+verify_deployment_target() {
+    local lib name version failed=0
+    echo ""
+    echo "🔍 Verifying deployment targets..."
+    for lib in "$@"; do
+        [ -f "$lib" ] || continue
+        name=$(basename "$lib")
+        version=$(macho_min_version "$lib")
+        [ -n "$version" ] || continue
+        if [ "$(printf '%s\n' "$DEPLOY_TARGET" "$version" | sort -V | tail -1)" != "$DEPLOY_TARGET" ]; then
+            echo "   ❌ $name targets macOS $version (expected $DEPLOY_TARGET)"
+            failed=1
+        else
+            echo "   ✅ $name targets macOS $version"
+        fi
+    done
+    if [ "$failed" -eq 1 ]; then
+        echo "❌ FATAL: some libraries have incorrect deployment targets" >&2
+        return 1
+    fi
+}
+
+OPENSSL_VERSION="3.4.3"
+OPENSSL_SHA256="fa727ed1399a64e754030a033435003991aee36bda9a5b080995cb2ac5cf7f37"
+
+# Downloads the OpenSSL tarball into BUILD_DIR once, verified against the pin above.
+fetch_openssl() {
+    local tarball="$BUILD_DIR/openssl-$OPENSSL_VERSION.tar.gz"
+    if [ ! -f "$tarball" ]; then
+        echo "⬇️  Downloading OpenSSL $OPENSSL_VERSION..."
+        curl -fSL "https://github.com/openssl/openssl/releases/download/openssl-$OPENSSL_VERSION/openssl-$OPENSSL_VERSION.tar.gz" \
+            -o "$tarball"
+    fi
+    # Verified on every call, not only after a download, so a cached tarball is checked too.
+    verify_sha256 "$tarball" "$OPENSSL_SHA256"
+}
+
+# Builds static OpenSSL for one architecture into $BUILD_DIR/install-openssl-<arch>.
+#
+# Expects BUILD_DIR, NCPU and the tarball fetched by fetch_openssl. Configure runs through
+# run_quiet rather than being redirected to /dev/null: three copies discarded its output entirely,
+# so a configure failure produced a bare non-zero exit with nothing to read.
+build_openssl() {
+    local arch="$1"
+    local prefix="$BUILD_DIR/install-openssl-$arch"
+    local source_dir="$BUILD_DIR/openssl-$OPENSSL_VERSION-$arch"
+
+    echo ""
+    echo "🔨 Building OpenSSL $OPENSSL_VERSION for $arch..."
+
+    rm -rf "$source_dir"
+    mkdir -p "$source_dir"
+    tar xzf "$BUILD_DIR/openssl-$OPENSSL_VERSION.tar.gz" -C "$source_dir" --strip-components=1
+    cd "$source_dir" || return 1
+
+    local target="darwin64-x86_64-cc"
+    [ "$arch" = "arm64" ] && target="darwin64-arm64-cc"
+
+    MACOSX_DEPLOYMENT_TARGET=$DEPLOY_TARGET \
+        run_quiet ./Configure \
+        "$target" \
+        no-shared \
+        no-tests \
+        no-apps \
+        no-docs \
+        --prefix="$prefix" \
+        "-mmacosx-version-min=$DEPLOY_TARGET"
+
+    run_quiet make -j"$NCPU"
+    run_quiet make install_sw
+
+    echo "✅ OpenSSL $arch: $(du -h "$prefix/lib/libssl.a" | cut -f1) (libssl) $(du -h "$prefix/lib/libcrypto.a" | cut -f1) (libcrypto)"
+}

--- a/scripts/openssl-version.sh
+++ b/scripts/openssl-version.sh
@@ -1,6 +1,0 @@
-# Shared OpenSSL version, sourced by all build scripts.
-# Update this single file when bumping OpenSSL.
-# shellcheck shell=bash
-# shellcheck disable=SC2034  # both are read by the scripts that source this file
-OPENSSL_VERSION="3.4.3"
-OPENSSL_SHA256="fa727ed1399a64e754030a033435003991aee36bda9a5b080995cb2ac5cf7f37"


### PR DESCRIPTION
The cleanup #2333 deliberately left out. `scripts/lib/` now holds the helpers that were copied between the native library build scripts, and the copies had drifted in ways that mattered.

## What was duplicated, and how the copies disagreed

| | before | after |
| --- | --- | --- |
| `run_quiet` | 9 copies, 4 variants | 1 |
| `build_openssl` | 4 copies | 1 |
| `create_universal` | 4 copies | 1 (`make_universal`) |
| `verify_deployment_target` | 4 copies | 1 |
| `DEPLOY_TARGET` | 9 declarations | 1 |

The variants were not cosmetic:

- **`run_quiet`** differed in tail depth (20, 30, 50) and in whether it printed the failing command. Five scripts showed a bare tail with no indication of which of a dozen configure and make invocations had produced it. The shared one names the command and shows 50 lines, so those five get better failure output.
- **`build_openssl`** ran `./Configure ... > /dev/null 2>&1` in three copies, discarding its output entirely: a configure failure produced a bare non-zero exit with nothing to read. libmongoc's copy already ran it through `run_quiet`. That is the one that survived.
- **`create_universal`** wrote only `*_universal.a` in three copies. `project.yml` links `Libs/libpq.a`, `Libs/libssh2.a` and `Libs/libhiredis.a` by name, so a rebuild changed nothing the app could see. #2333 fixed the three; the shared `make_universal` means there is no fourth to forget.
- The `-ef` guard in `make_universal` is load-bearing, not defensive: `Libs/libssh2.a` and `Libs/libduckdb.a` are symlinks to their `_universal` counterparts, and `cp` onto a symlink pointing at the source truncates it.

## Layering

Two files, because the iOS scripts should not inherit a `darwin64` OpenSSL target or a macOS deployment floor:

- `lib/common.sh` holds what both platforms use: `run_quiet`, `require_tools`, `verify_sha256`, `REPO_ROOT`, `LIBS_DIR`, and the OpenSSL version pin.
- `lib/macos.sh` sources it and adds `DEPLOY_TARGET`, `make_universal`, `macho_min_version`, `verify_deployment_target`, `fetch_openssl` and `build_openssl`.

`scripts/openssl-version.sh` is gone; its two constants live in `lib/common.sh`, which is where its five sourcers now look.

Net: 496 lines deleted, 238 added, and the shared code is 198 of those.

## Verified by building, not by reading

I said in #2333 that this needed each migrated script actually run, because these run by hand and nothing in CI would catch a regression. So:

**`build-hiredis.sh both` and `build-libssh2.sh both` were run end to end against the final library**, and their output compared against the libraries currently published in `libs-v1`:

```
libhiredis_arm64.a       arch=arm64         minos=14.0  symbols=122
libhiredis_x86_64.a      arch=x86_64        minos=14.0  symbols=122
libhiredis_universal.a   arch=x86_64 arm64  minos=14.0  symbols=122
libhiredis.a             arch=x86_64 arm64  minos=14.0  symbols=122
libhiredis_ssl_*.a       ...                minos=14.0  symbols=7
libssh2_*.a              ...                minos=14.0  ...
```

Identical architectures, identical deployment targets, identical symbol counts, for every slice of both libraries. Every shared function was exercised on the way: `fetch_openssl`, `build_openssl` for both architectures, `make_universal` including the symlink guard, and `verify_deployment_target`.

`Libs/` was then restored from the published archive and re-verified against the checksum baseline committed in git, so nothing locally built is left in the working tree.

`build-mariadb.sh` was run end to end earlier in this series, on the same shared `run_quiet` and `DEPLOY_TARGET`.

## Still not done, and why

- **`build-libpq.sh` and `build-libmongoc.sh` are migrated but not run here.** They are the same four helpers exercised by the two that were run, and both parse and lint clean, but neither has been built end to end. Worth one run each before the next library bump.
- **The iOS scripts take `run_quiet` and the OpenSSL pin only.** Nothing else of theirs is shared, and I cannot build an iOS slice to verify more than that they source and parse.
- **`cleanup` stays as it is in ten scripts.** Each is one to three lines, and two of them (`build-cassandra.sh`, `build-freetds.sh`) use a fixed `/tmp` path that a shared helper would have to change. FreeTDS caches its downloaded tarball at that path, so switching it to `mktemp -d` loses the cache. That trade needs its own decision and a real FreeTDS build, and it is not worth touching eight more scripts I cannot run to save ten lines.

## Verification

All 42 scripts parse. `shellcheck -x --severity=warning` is clean across every script including the new library. Every `source` path resolves. `run_quiet` is defined in exactly one file.

https://claude.ai/code/session_013MEaba8K1HQcyDNeq5wEFk
