### PR TITLE
fix(editor): stop the editor crashing when it redraws an emphasis whose text is gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a crash on macOS 26 and later when the editor redrew a diagnostic underline or search highlight whose text had been edited away.
 - The XLSX, MQL and SQL Import plugins linked to a documentation page that did not exist. They now point at Import & Export.
 
 ## [0.67.0] - 2026-08-21

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/EmphasisManager/EmphasisManager.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/EmphasisManager/EmphasisManager.swift
@@ -166,8 +166,7 @@ public final class EmphasisManager {
             }
 
             // Update text layer if it exists
-            if let textLayer = emphasis.textLayer {
-                var bounds = shapePath.bounds
+            if let textLayer = emphasis.textLayer, var bounds = shapePath.drawableBounds {
                 bounds.origin.y += 1 // Move down by 1 pixel
                 textLayer.frame = bounds
             }
@@ -209,7 +208,7 @@ public final class EmphasisManager {
                 path.move(to: NSPoint(x: rect.minX, y: rect.maxY - lineBottomPadding))
                 path.line(to: NSPoint(x: rect.maxX, y: rect.maxY - lineBottomPadding))
             }
-            return path
+            return path.isEmpty ? nil : path
         }
     }
 
@@ -261,12 +260,15 @@ public final class EmphasisManager {
     private func createTextLayer(for emphasis: Emphasis) -> CATextLayer? {
         guard let textView = textView,
               let layoutManager = textView.layoutManager,
+              let textStorage = textView.textStorage,
+              emphasis.range.length > 0,
+              emphasis.range.upperBound <= textStorage.length,
               let shapePath = layoutManager.roundedPathForRange(emphasis.range),
-              let originalString = textView.textStorage?.attributedSubstring(from: emphasis.range) else {
+              var bounds = shapePath.drawableBounds else {
             return nil
         }
 
-        var bounds = shapePath.bounds
+        let originalString = textStorage.attributedSubstring(from: emphasis.range)
         bounds.origin.y += 1 // Move down by 1 pixel
 
         // Create text layer

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/Extensions/NSBezierPath+DrawableBounds.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/Extensions/NSBezierPath+DrawableBounds.swift
@@ -1,0 +1,16 @@
+//
+//  NSBezierPath+DrawableBounds.swift
+//  CodeEditTextView
+//
+
+import AppKit
+
+extension NSBezierPath {
+    /// The bounding box of the path, or `nil` when the path has no elements.
+    ///
+    /// `bounds` raises `NSGenericException` for a path with no elements, and AppKit terminates the process when an
+    /// exception escapes `draw(_:)`, so drawing code must never read `bounds` without knowing the path has elements.
+    var drawableBounds: CGRect? {
+        isEmpty ? nil : bounds
+    }
+}

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/Extensions/NSBezierPath+SmoothPath.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/Extensions/NSBezierPath+SmoothPath.swift
@@ -26,17 +26,20 @@ extension NSBezierPath {
     }
 
     // swiftlint:disable:next function_body_length
-    static func smoothPath(_ points: [NSPoint], radius cornerRadius: CGFloat) -> NSBezierPath {
+    static func smoothPath(_ points: [NSPoint], radius cornerRadius: CGFloat) -> NSBezierPath? {
         // Normalizing radius to compensate for the quadraticCurve
         let radius = cornerRadius * 1.15
 
-        let path = NSBezierPath()
-
-        guard points.count > 1 else { return path }
+        guard points.count > 1 else { return nil }
 
         // Calculate the initial corner start based on the first two points
         let initialVector = NSPoint(x: points[1].x - points[0].x, y: points[1].y - points[0].y)
         let initialDistance = sqrt(initialVector.x * initialVector.x + initialVector.y * initialVector.y)
+
+        // Dividing by 0 would make every point that follows `NaN`, which raises when the path is drawn or measured.
+        guard !initialDistance.isZero else { return nil }
+
+        let path = NSBezierPath()
 
         let initialUnitVector = NSPoint(x: initialVector.x / initialDistance, y: initialVector.y / initialDistance)
         let initialCornerStart = NSPoint(

--- a/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/EmphasisManagerTests.swift
+++ b/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/EmphasisManagerTests.swift
@@ -8,9 +8,7 @@ struct EmphasisManagerTests {
     @MainActor
     func testFlashEmphasisLayersNotLeaked() {
         // Ensure layers are not leaked when switching from flash emphasis to any other emphasis type.
-        let textView = TextView(string: "Lorem Ipsum")
-        textView.frame = NSRect(x: 0, y: 0, width: 1000, height: 100)
-        textView.layoutManager.layoutLines(in: CGRect(origin: .zero, size: CGSize(width: 1000, height: 100)))
+        let textView = makeLaidOutTextView()
         textView.emphasisManager?.addEmphasis(
             Emphasis(range: NSRange(location: 0, length: 5), style: .standard, flash: true),
             for: "e"
@@ -33,5 +31,61 @@ struct EmphasisManagerTests {
         // No emphasis layers remain
         #expect(textView.layer?.sublayers?.count == nil)
         #expect(textView.emphasisManager?.getEmphases(for: "e").count == 0)
+    }
+
+    @Test()
+    @MainActor
+    func testUnderlineEmphasisWithoutRectsDrawsNothing() {
+        // A range that produces no rects used to yield an element-less path, whose bounds raise while drawing.
+        let textView = makeLaidOutTextView()
+
+        textView.emphasisManager?.addEmphasis(
+            Emphasis(range: NSRange(location: 3, length: 0), style: .underline(color: .red)),
+            for: "e"
+        )
+        textView.emphasisManager?.updateLayerBackgrounds()
+
+        #expect(textView.layer?.sublayers?.count == nil)
+    }
+
+    @Test()
+    @MainActor
+    func testUnderlineEmphasisWithRectsKeepsDrawing() {
+        let textView = makeLaidOutTextView()
+
+        textView.emphasisManager?.addEmphasis(
+            Emphasis(range: NSRange(location: 0, length: 5), style: .underline(color: .red)),
+            for: "e"
+        )
+        textView.emphasisManager?.updateLayerBackgrounds()
+
+        // Emphasis layer and text layer
+        #expect(textView.layer?.sublayers?.count == 2)
+    }
+
+    @Test()
+    @MainActor
+    func testEmphasisOutlivingTheTextItMarksSurvivesRedraw() {
+        // Redrawing an emphasis whose text has been deleted used to raise from `NSBezierPath.bounds`.
+        let textView = makeLaidOutTextView()
+
+        textView.emphasisManager?.addEmphasis(
+            Emphasis(range: NSRange(location: 6, length: 5), style: .underline(color: .red)),
+            for: "e"
+        )
+        textView.textStorage.replaceCharacters(in: NSRange(location: 5, length: 6), with: "")
+        textView.layoutManager.layoutLines(in: CGRect(origin: .zero, size: CGSize(width: 1_000, height: 100)))
+        textView.emphasisManager?.updateLayerBackgrounds()
+
+        #expect(textView.emphasisManager?.getEmphases(for: "e").count == 1)
+        #expect(textView.layer?.sublayers?.count == 2)
+    }
+
+    @MainActor
+    private func makeLaidOutTextView() -> TextView {
+        let textView = TextView(string: "Lorem Ipsum")
+        textView.frame = NSRect(x: 0, y: 0, width: 1_000, height: 100)
+        textView.layoutManager.layoutLines(in: CGRect(origin: .zero, size: CGSize(width: 1_000, height: 100)))
+        return textView
     }
 }

--- a/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/NSBezierPathSmoothPathTests.swift
+++ b/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/NSBezierPathSmoothPathTests.swift
@@ -1,0 +1,34 @@
+import AppKit
+import Testing
+@testable import CodeEditTextView
+
+@Suite()
+struct NSBezierPathSmoothPathTests {
+    @Test()
+    func returnsNilForFewerThanTwoPoints() {
+        #expect(NSBezierPath.smoothPath([], radius: 4) == nil)
+        #expect(NSBezierPath.smoothPath([NSPoint(x: 1, y: 1)], radius: 4) == nil)
+    }
+
+    @Test()
+    func returnsNilWhenTheFirstTwoPointsAreIdentical() {
+        let points = [NSPoint(x: 5, y: 5), NSPoint(x: 5, y: 5), NSPoint(x: 20, y: 5)]
+        #expect(NSBezierPath.smoothPath(points + [points[0]], radius: 4) == nil)
+    }
+
+    @Test()
+    func returnsAMeasurablePathForARectangle() throws {
+        let corners = [
+            NSPoint(x: 0, y: 0),
+            NSPoint(x: 0, y: 10),
+            NSPoint(x: 10, y: 10),
+            NSPoint(x: 10, y: 0)
+        ]
+        let path = try #require(NSBezierPath.smoothPath(corners + [corners[0]], radius: 4))
+
+        #expect(path.isEmpty == false)
+        let bounds = try #require(path.drawableBounds)
+        #expect(bounds.width > 0)
+        #expect(bounds.height > 0)
+    }
+}


### PR DESCRIPTION
A crash report from 0.67.0 (build 120) on macOS 27.0: `EXC_BREAKPOINT` through `+[NSApplication _crashOnException:]`, with an uncaught `NSGenericException` raised by `-[NSBezierPath controlPointBounds]` inside a view's `drawRect`.

## What happened

`TextView.draw(_:)` calls `emphasisManager?.updateLayerBackgrounds()` on every draw, with no dirty-rect or validity filter. For a `.underline` emphasis, `makeShapePath` built its path from `layoutManager.rectsFor(range:)` and returned that path even when the array was empty, so the caller got a path with zero elements. `updateLayerBackgrounds` then read `shapePath.bounds` to position the emphasis's text layer, and `bounds` raises `NSGenericException` ("No current point for control point bounds") on a path with no elements.

`rectsFor(range:)` returns an empty array whenever the emphasis range outruns the string or its line has no laid-out fragments, which is routine after an edit. TablePro reaches it far more often than upstream does: `QueryDiagnosticsController` keeps `.underline` emphases on the document across a 500 ms debounce, so their ranges are regularly stale relative to what is laid out. The guard added in #1835 (`range.upperBound <= textStorage.length`) is what turns a stale range into an empty rect list, so that fix moved the failure one frame later instead of removing it.

Two things made this fatal rather than cosmetic:

- On macOS 26 and later, AppKit no longer lets an exception escape `drawRect` as a logged non-fatal. It catches it inside `_NSViewDrawRect` and calls `+[NSApplication _crashOnException:]`. Measured here: `NSApplicationCrashOnExceptions NO` does not help, and neither does linking against an older SDK (checked at deployment targets 13.0, 15.0 and 26.0).
- The bug is live on upstream CodeEditTextView `main`, so it will need re-applying if the vendored fork is rebased.

## The fix

- `makeShapePath` returns `nil` when there is nothing to draw, instead of a path with no elements. `updateLayerBackgrounds` already skips a `nil` shape.
- New `NSBezierPath.drawableBounds` returns `nil` for an empty path. Both reads of `bounds` in `EmphasisManager` go through it, so drawing code can no longer reach the accessor that raises.
- `smoothPath` returns an optional and answers `nil` for fewer than two points, so `roundedPathForRange` propagates `nil` rather than an empty path. It also guards the one division the function did not already guard: identical first two points produced `NaN` coordinates, and a `NaN` point raises on `move(to:)`, on `.bounds` and on `.cgPath`.
- `createTextLayer` checks the emphasis range against the text storage before slicing it. Two more exception routes sat on this same path, both from the same stale range: `attributedSubstring(from:)` raises `NSRangeException` for a range past the end, and `attribute(.font, at: 0)` raises for a zero-length range. The second one fired first in the reproduction run, so it ships here.

## Verification

- New test `testEmphasisOutlivingTheTextItMarksSurvivesRedraw` adds an underline emphasis, deletes the text under it, relays out and redraws. Against the unfixed code it dies with `NSGenericException: No current point for control point bounds` at `-[NSBezierPath controlPointBounds] + 60` and `-[NSBezierPath bounds] + 68`, the same two frames and offsets as the crash report.
- `testUnderlineEmphasisWithoutRectsDrawsNothing` fails cleanly against the unfixed code (it leaves two layers where there should be none).
- `testUnderlineEmphasisWithRectsKeepsDrawing` is the control: an emphasis with real rects still draws both layers.
- `NSBezierPathSmoothPathTests` covers the `nil` returns and checks a normal rectangle still yields a measurable path.
- `swift test --package-path LocalPackages/CodeEditTextView`: 151 tests in 15 suites pass. `xcodebuild -scheme TablePro build` passes.

## Left for follow-ups

Found while verifying, all reported as issues rather than fixed here:

- `TextView+NSTextInput.swift:241/243/263`. The method's own doc comment says the range will be out of bounds, and both calls raise instead of clamping. Reachable by any IME, dictation or character viewer user.
- `TextLine.prepareForDisplay` slices the text storage with a line range that transiently outruns it, the layout-pass twin of the `rectForOffset` crash fixed in #1835. Plus `Highlighter.setAttributes`, the missing lower bound in `TextView+Accessibility`, and the minimap's unguarded attribute reads.
- Behaviour, not a crash: an emphasis whose range stops laying out keeps painting its last path. That is pre-existing for `.standard` and this change extends it to `.underline`. Clearing the layer instead would flicker on every attribute edit, so it wants its own change.
