### PR TITLE
docs: add the missing troubleshooting, FAQ, privacy and iOS pages, and restructure the nav

### DIFF
--- a/docs/databases/overview.mdx
+++ b/docs/databases/overview.mdx
@@ -3,7 +3,7 @@ title: Managing Connections
 description: Create, organize, and switch database connections, with health monitoring and startup commands
 ---
 
-TablePro connects to 26 databases through its plugin system. This page covers creating and organizing connections. Driver-specific fields and quirks live on each database's own page.
+TablePro connects to 27 databases through its plugin system. This page covers creating and organizing connections. Driver-specific fields and quirks live on each database's own page.
 
 ## Supported databases
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -71,17 +71,19 @@
         "tab": "Documentation",
         "groups": [
           {
-            "group": "Getting Started",
+            "group": "Start here",
             "pages": [
               "index",
-              "quickstart",
               "installation",
+              "quickstart",
               "switching",
+              "faq",
+              "troubleshooting",
               "changelog"
             ]
           },
           {
-            "group": "Database Connections",
+            "group": "Connections",
             "pages": [
               "databases/overview",
               "databases/connection-urls",
@@ -89,58 +91,39 @@
               "databases/cloudflare-tunnel",
               "databases/cloud-sql-proxy",
               "databases/socks-proxy",
-              "databases/aws-iam",
-              {
-                "group": "SQL",
-                "pages": [
-                  "databases/mysql",
-                  "databases/mariadb",
-                  "databases/postgresql",
-                  "databases/redshift",
-                  "databases/cockroachdb",
-                  "databases/pglite",
-                  "databases/mssql",
-                  "databases/oracle",
-                  "databases/dameng"
-                ]
-              },
-              {
-                "group": "NoSQL & Key-Value",
-                "pages": [
-                  "databases/mongodb",
-                  "databases/redis",
-                  "databases/cassandra",
-                  "databases/etcd",
-                  "databases/elasticsearch",
-                  "databases/surrealdb"
-                ]
-              },
-              {
-                "group": "File-Based & Embedded",
-                "pages": [
-                  "databases/sqlite",
-                  "databases/duckdb",
-                  "databases/beancount",
-                  "databases/libsql"
-                ]
-              },
-              {
-                "group": "Cloud & API",
-                "pages": [
-                  "databases/dynamodb",
-                  "databases/bigquery",
-                  "databases/snowflake",
-                  "databases/cloudflare-d1"
-                ]
-              },
-              {
-                "group": "Analytics",
-                "pages": [
-                  "databases/clickhouse",
-                  "databases/teradata",
-                  "databases/trino"
-                ]
-              }
+              "databases/aws-iam"
+            ]
+          },
+          {
+            "group": "Databases",
+            "icon": "database",
+            "pages": [
+              "databases/beancount",
+              "databases/bigquery",
+              "databases/cassandra",
+              "databases/clickhouse",
+              "databases/cloudflare-d1",
+              "databases/cockroachdb",
+              "databases/dameng",
+              "databases/duckdb",
+              "databases/dynamodb",
+              "databases/elasticsearch",
+              "databases/etcd",
+              "databases/libsql",
+              "databases/mariadb",
+              "databases/mongodb",
+              "databases/mssql",
+              "databases/mysql",
+              "databases/oracle",
+              "databases/pglite",
+              "databases/postgresql",
+              "databases/redis",
+              "databases/redshift",
+              "databases/snowflake",
+              "databases/sqlite",
+              "databases/surrealdb",
+              "databases/teradata",
+              "databases/trino"
             ]
           },
           {
@@ -200,11 +183,9 @@
                 ]
               },
               {
-                "group": "Security & Sharing",
+                "group": "Sharing",
                 "pages": [
-                  "features/safe-mode",
                   "features/ssh-profiles",
-                  "features/ssl",
                   "features/connection-sharing"
                 ]
               },
@@ -236,22 +217,59 @@
             ]
           },
           {
-            "group": "External API",
+            "group": "iPhone and iPad",
+            "icon": "mobile",
+            "pages": [
+              "ios/index"
+            ]
+          },
+          {
+            "group": "Security and privacy",
+            "icon": "shield",
+            "pages": [
+              "security/privacy",
+              "features/safe-mode",
+              "features/ssl"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "External API",
+        "icon": "code",
+        "groups": [
+          {
+            "group": "Overview",
             "pages": [
               "external-api/index",
+              "external-api/versioning"
+            ]
+          },
+          {
+            "group": "Drive the app",
+            "pages": [
               "external-api/url-scheme",
               "external-api/terminal",
-              "external-api/ios-shortcuts",
               "external-api/raycast",
+              "external-api/ios-shortcuts"
+            ]
+          },
+          {
+            "group": "MCP",
+            "pages": [
               "external-api/mcp-clients",
-              "external-api/pairing",
-              "external-api/tokens",
               "external-api/mcp-protocol",
               "external-api/mcp-tools",
               "external-api/mcp-resources",
               "external-api/mcp-prompts",
-              "external-api/mcp-subscriptions",
-              "external-api/versioning"
+              "external-api/mcp-subscriptions"
+            ]
+          },
+          {
+            "group": "Auth",
+            "pages": [
+              "external-api/pairing",
+              "external-api/tokens"
             ]
           }
         ]

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -1,0 +1,100 @@
+---
+title: FAQ
+description: Short answers on licensing, privacy, offline use, database coverage, syncing, and moving from another client
+---
+
+Each answer is the short version, with a link to the page that goes deeper. Anything not covered is worth an issue on [GitHub](https://github.com/TableProApp/TablePro/issues), where driver requests and support questions are tracked in the open.
+
+## Cost and licensing
+
+<AccordionGroup>
+
+<Accordion title="Is TablePro free?">
+Yes. It runs without a license and has no trial countdown, so every driver, the SQL editor, import and export, and the AI assistant work unlicensed. A license adds the features in the tier table and nothing else changes. See [Licensing](/features/licensing).
+</Accordion>
+
+<Accordion title="What does a license add?">
+Two tiers. Starter covers iCloud Sync, encrypted connection export, environment variables in connection fields, Linked Folders, Query Insights, and result charts. Team adds the Team Catalog and the Team Library on top of Starter. Until you activate, those screens show an overlay with **Activate License…** and a purchase link. See [Licensing](/features/licensing).
+</Accordion>
+
+<Accordion title="Can I use it at work?">
+Yes. The app is free to run and nothing counts seats. To share connections and saved queries with teammates, the Team tier hands out seats from your account on tablepro.app, and each teammate activates with an invite code instead of a key. See [Team Plan](/features/team).
+</Accordion>
+
+<Accordion title="What license is the source code under?">
+The GNU Affero General Public License v3.0. The full source, plugins included, is on [GitHub](https://github.com/TableProApp/TablePro). That is a separate thing from a TablePro license key, which activates the paid features rather than the app itself.
+</Accordion>
+
+</AccordionGroup>
+
+## Privacy and security
+
+<AccordionGroup>
+
+<Accordion title="Is my data sent anywhere?">
+Your queries, results, and schemas stay on your Mac. The one thing TablePro sends on its own is an anonymous heartbeat every 24 hours: a hashed machine ID, platform, app and OS version, architecture, language, which database types are open, how many connections are open, and whether a license is present. Turn it off with **Share anonymous usage data** in **Settings > General**. AI is the exception, since the context you allow reaches the provider you configured. See [Settings](/customization/settings) and [AI Assistant](/features/ai-assistant).
+</Accordion>
+
+<Accordion title="Is my password safe?">
+Passwords go into the macOS Keychain, not the connections file, and an ordinary export leaves them out. Publishing to the Team Library sends the connection definition and query text only, and MCP clients query through your saved connections without seeing a password. Two exceptions: **Copy Connection String** puts the password on the clipboard in plain text, and an encrypted export (Starter) carries credentials behind a passphrase. See [Connection Sharing](/features/connection-sharing).
+</Accordion>
+
+</AccordionGroup>
+
+## Databases and drivers
+
+<AccordionGroup>
+
+<Accordion title="Which databases are supported?">
+27, from MySQL, PostgreSQL, and SQLite through MongoDB, Redis, ClickHouse, BigQuery, and DuckDB. The table on the [home page](/) lists each one, and [Managing Connections](/databases/overview) adds the transport each supports and whether it can go through an SSH tunnel, SSL, Cloudflare Tunnel, Cloud SQL Proxy, or a SOCKS proxy.
+</Accordion>
+
+<Accordion title="Why is my database not in the list?">
+Its driver is probably not installed yet. The database type chooser badges registry drivers **Not Installed**; pick one anyway and the download runs before the connection opens, with no restart. **Settings > Plugins > Browse** holds the full catalog. If the database is genuinely missing, open a request on [GitHub](https://github.com/TableProApp/TablePro/issues). See [Plugins & Themes](/features/plugins).
+</Accordion>
+
+<Accordion title="Why does a driver need downloading?">
+Five drivers ship inside the app and cover 9 databases. Another 17 drivers come from the registry and install on the first connection that needs them, which keeps the app download at about 20 MB. Each one must match the SHA-256 checksum in the registry manifest and carry a valid code signature before it loads.
+</Accordion>
+
+<Accordion title="Why does a plugin need updating after I update the app?">
+An app update can raise the plugin interface version, and a plugin built against the old one is rejected at load instead of crashing. TablePro repairs it on its own: at launch it fetches the registry and reinstalls a compatible build, retrying when the registry is unreachable. Until then the plugin sits in a banner in **Settings > Plugins > Installed** with the reason and an action.
+</Accordion>
+
+</AccordionGroup>
+
+## Platforms and sync
+
+<AccordionGroup>
+
+<Accordion title="Does it work offline?">
+Connecting, browsing, and querying need nothing but the database. The license is re-verified offline on every launch from the signed copy on disk, and when the license server cannot be reached it keeps working for 30 days after the last successful validation. What does need the network: installing or updating a plugin, and any AI provider that is not local. See [Licensing](/features/licensing).
+</Accordion>
+
+<Accordion title="Does it sync between Macs?">
+Through iCloud, with a Starter or Team license. Sync is off by default and each category has its own toggle: connections, groups and tags, SSH profiles, saved queries, table favorites, and settings. Passwords are a separate opt-in that rides iCloud Keychain, and a connection can be marked **Local only** to stay off iCloud. See [iCloud Sync](/features/icloud-sync).
+</Accordion>
+
+<Accordion title="Is there an iPhone app?">
+Yes, for iPhone and iPad on iOS 18 or later. It reads the same CloudKit data as the Mac app but carries connections, groups, and tags only, and it updates on its own schedule rather than with a Mac release. See [iCloud Sync](/features/icloud-sync) and [iOS Shortcuts](/external-api/ios-shortcuts).
+</Accordion>
+
+<Accordion title="Is there a Windows or Linux version?">
+No. macOS 14 or later, plus iPhone and iPad on iOS 18 or later. A Linux port is a prototype with nothing to install yet, and there is no Windows build at all. Progress is tracked on [GitHub](https://github.com/TableProApp/TablePro).
+</Accordion>
+
+</AccordionGroup>
+
+## Moving from another client
+
+<AccordionGroup>
+
+<Accordion title="How do I move from TablePlus?">
+**File > Import from Other App…** reads the connections TablePlus already has, groups included, and TablePlus does not need to be running. TablePlus keeps each password as its own Keychain item, so macOS asks per item; choose **Always Allow** and the run finishes without asking again. Saved queries, query history, and column widths do not come across. The same dialog handles Sequel Ace, DBeaver, DataGrip, Beekeeper Studio, and Navicat. See [Switching to TablePro](/switching).
+</Accordion>
+
+<Accordion title="What if my client is not in the importer?">
+Two other routes. **Add from Existing > Import from URL** takes a `postgres://` or `mysql://` URL and fills in the form. [Open Project Folder](/features/project-folder-import) reads database settings out of a repository's `.env`, `docker-compose.yml`, or framework config, so a project becomes a connection without typing a host.
+</Accordion>
+
+</AccordionGroup>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,14 +1,26 @@
 ---
 title: Introduction
-description: Native macOS database client for MySQL, PostgreSQL, SQLite, MongoDB, Redis, and 20 more
+description: Native macOS database client for MySQL, PostgreSQL, SQLite, MongoDB, Redis, and 22 more
 ---
 
-Native macOS client for 26 databases. Built with SwiftUI and AppKit, no Electron. The download is about 20 MB.
+Native macOS client for 27 databases. Built with SwiftUI and AppKit, no Electron. The download is about 20 MB.
 
 <Frame caption="TablePro - Native macOS Database Client">
   <img className="block dark:hidden" src="/images/app.png" alt="TablePro main interface" />
   <img className="hidden dark:block" src="/images/app-dark.png" alt="TablePro main interface" />
 </Frame>
+
+<CardGroup cols={3}>
+  <Card title="Install it" icon="download" href="/installation">
+    Homebrew or the DMG, on macOS 14 and later.
+  </Card>
+  <Card title="Connect to something" icon="plug" href="/quickstart">
+    A first connection and a first query, or the bundled sample database if you have no server.
+  </Card>
+  <Card title="Coming from another client" icon="right-left" href="/switching">
+    Import connections from TablePlus, Sequel Ace, DBeaver, DataGrip and others.
+  </Card>
+</CardGroup>
 
 ## Features
 
@@ -29,32 +41,33 @@ Native macOS client for 26 databases. Built with SwiftUI and AppKit, no Electron
 
 | Database | Default Port | Distribution |
 |----------|--------------|--------------|
-| MySQL | 3306 | Built-in |
-| MariaDB | 3306 | Built-in |
-| PostgreSQL | 5432 | Built-in |
-| SQLite | N/A (file-based) | Built-in |
-| Amazon Redshift | 5439 | Built-in |
-| CockroachDB | 26257 | Built-in |
-| PGlite | 5432 | Built-in |
-| Microsoft SQL Server | 1433 | Plugin |
-| ClickHouse | 8123 | Built-in |
-| Redis | 6379 | Built-in |
-| MongoDB | 27017 | Plugin |
-| Oracle Database | 1521 | Plugin |
-| Dameng DM8 | 5236 | Plugin |
-| DuckDB | File, or 9494 remote | Plugin |
-| Beancount | N/A (file-based) | Plugin |
-| Cassandra / ScyllaDB | 9042 | Plugin |
-| etcd | 2379 | Plugin |
-| Cloudflare D1 | N/A (API-based) | Plugin |
-| DynamoDB | N/A (API-based) | Plugin |
-| BigQuery | N/A (API-based) | Plugin |
-| Snowflake | 443 | Plugin |
-| Teradata | 1025 | Plugin |
-| libSQL / Turso | N/A (API-based) | Plugin |
-| Elasticsearch | 9200 | Plugin |
-| SurrealDB | 8000 | Plugin |
-| Trino | 8080 | Plugin |
+| [MySQL](/databases/mysql) | 3306 | Built-in |
+| [MariaDB](/databases/mariadb) | 3306 | Built-in |
+| [PostgreSQL](/databases/postgresql) | 5432 | Built-in |
+| [SQLite](/databases/sqlite) | N/A (file-based) | Built-in |
+| [Amazon Redshift](/databases/redshift) | 5439 | Built-in |
+| [CockroachDB](/databases/cockroachdb) | 26257 | Built-in |
+| [PGlite](/databases/pglite) | 5432 | Built-in |
+| [Microsoft SQL Server](/databases/mssql) | 1433 | Plugin |
+| [ClickHouse](/databases/clickhouse) | 8123 | Built-in |
+| [Redis](/databases/redis) | 6379 | Built-in |
+| [MongoDB](/databases/mongodb) | 27017 | Plugin |
+| [Oracle Database](/databases/oracle) | 1521 | Plugin |
+| [Dameng DM8](/databases/dameng) | 5236 | Plugin |
+| [DuckDB](/databases/duckdb) | File, or 9494 remote | Plugin |
+| [Beancount](/databases/beancount) | N/A (file-based) | Plugin |
+| [Cassandra](/databases/cassandra) | 9042 | Plugin |
+| [ScyllaDB](/databases/cassandra) | 9042 | Plugin |
+| [etcd](/databases/etcd) | 2379 | Plugin |
+| [Cloudflare D1](/databases/cloudflare-d1) | N/A (API-based) | Plugin |
+| [DynamoDB](/databases/dynamodb) | N/A (API-based) | Plugin |
+| [BigQuery](/databases/bigquery) | N/A (API-based) | Plugin |
+| [Snowflake](/databases/snowflake) | 443 | Plugin |
+| [Teradata](/databases/teradata) | 1025 | Plugin |
+| [libSQL / Turso](/databases/libsql) | N/A (API-based) | Plugin |
+| [Elasticsearch](/databases/elasticsearch) | 9200 | Plugin |
+| [SurrealDB](/databases/surrealdb) | 8000 | Plugin |
+| [Trino](/databases/trino) | 8080 | Plugin |
 
 ## System requirements
 

--- a/docs/ios/index.mdx
+++ b/docs/ios/index.mdx
@@ -1,0 +1,80 @@
+---
+title: iPhone and iPad
+description: Browse tables, run queries, and edit rows on eight database engines from a synced connection list
+---
+
+The mobile app has its own version number, its own release schedule, and a smaller feature set than the Mac. It requires iOS 18. Connections saved on a Mac arrive over iCloud; the rest of your Mac setup stays on the Mac.
+
+## Supported databases
+
+There is no plugin system on iOS. Every driver is compiled into the app, so nothing is installed. The connection type picker offers eight:
+
+| Type | Notes |
+| --- | --- |
+| **MySQL** / **MariaDB** | Port 3306 by default |
+| **PostgreSQL** | Port 5432 by default |
+| **SQL Server** | TDS, including Microsoft Entra ID sign-in on a connection synced from the Mac |
+| **Oracle** | Service name or SID |
+| **Redis** | Port 6379 by default |
+| **SQLite** | Copies the file you pick into the app |
+| **DuckDB** | A file on the device, or in-memory |
+
+<Info>
+Redshift is not in the picker, but the driver is present: a Redshift connection created on the Mac connects once it syncs over.
+</Info>
+
+Every other engine the Mac supports, MongoDB, ClickHouse, Cassandra, BigQuery, Snowflake and the rest, has no iOS driver. Those connections still sync and still appear in the list, but opening one fails.
+
+## What syncs over
+
+The app reads the same CloudKit container as the Mac, and iCloud Sync is on by default here (it is off by default on the Mac). It carries three record types and ignores the rest of the zone:
+
+- Connections, including host, port, SSH tunnel and SSL settings, color, and safe mode level
+- Groups, with their nesting
+- Tags
+
+Nothing else crosses. SSH profiles, table favorites, saved queries, and app settings are skipped. Query history on the phone is only the queries you ran on the phone.
+
+<Warning>
+Three things a connection depends on are per device and never sync. Certificates live in the local keychain, so a connection using a CA or client certificate reports it missing until you import it again in the connection's SSL settings. An SSH private key syncs as a path, not as a file, and that path points at the Mac, so a key-authenticated tunnel does not open here. And SQLite and DuckDB paths point at the Mac's disk, so those connections need the file picked again.
+</Warning>
+
+Passwords are a separate opt-in, off by default, under **Settings > Sync > Sync Passwords**. It routes them through iCloud Keychain and only affects new saves, so re-save a password on the Mac to push it across. **Sync Now** is in that same **Sync** section, **Refresh from iCloud** is in the one below it, and a background refresh runs about every 30 minutes.
+
+<Warning>
+Picking a SQLite file copies it into the app. Edits go to that copy, so the file you picked is untouched and the two drift apart. DuckDB keeps a reference to the original instead and writes back to it.
+</Warning>
+
+## What you can do
+
+Opening a connection gives four tabs: **Tables**, **Query**, **History**, and **Info**. `Cmd+1` through `Cmd+4` switch between them on a keyboard. A toolbar menu switches database and schema when the engine has more than one.
+
+**Browsing.** Page through a table at 50, 100, 200, or 500 rows, jump to a page number, sort by a column, search text columns, and stack filters with AND or OR. A foreign key value previews the row it points at. **Table Structure** lists columns, indexes, and foreign keys, read only.
+
+**Editing.** Tap a row to open it full screen, page between rows, edit values, toggle one to `NULL`, and save. You can insert a row, delete a row, and truncate or drop a table. Editing needs a primary key.
+
+**Querying.** The editor highlights SQL, runs a statement, and stops one mid-flight. Results copy or export as JSON, CSV, or SQL `INSERT`. A running query shows in a Live Activity on the lock screen and Dynamic Island; **Settings > Privacy** hides the SQL text there.
+
+## What is missing
+
+- **Schema changes.** Drop and truncate a table is the whole list. Creating or altering tables, columns, indexes, triggers, and views is Mac only.
+- **AI.** No AI chat, no inline suggestions, no MCP server. None of it is in the iOS app.
+- **Plugins.** The eight built-in drivers are all there is; no registry plugin installs on iOS.
+
+## Security
+
+Turn on Face ID, Touch ID, or Optic ID under **Settings > Security**. A cold launch always asks; after that the app relocks immediately or after 1, 5, 15, or 60 minutes idle.
+
+Each connection carries its own safe mode level, synced from the Mac and settable here: **Off**, **Confirm Writes**, or **Read-Only**. Read-only refuses writes outright; confirm mode prompts before a row edit, an insert, or a write query. **Settings > New Connections** sets the starting level.
+
+SSH tunnels work with a password, a private key, or no authentication, and an unknown host key prompts with its fingerprint first.
+
+## Shortcuts and widgets
+
+Three App Intents put the app in Shortcuts, the Share Sheet, and Siri: **Open Connection**, **Add Row to Table**, and **Add Rows to Table**. See [iOS Shortcuts](/external-api/ios-shortcuts) for pickers, data formats, and limits.
+
+A **Quick Connect** home screen widget opens a saved connection directly. `tablepro://connect/<uuid>` deep links work as on the Mac, Handoff carries an open connection between devices, and a `.tablepro` file from Files or AirDrop imports connections.
+
+## Updates
+
+Builds ship separately from the Mac app, so a Mac release note does not mean your phone has the feature yet. Check the version and build under **Settings > About**.

--- a/docs/security/privacy.mdx
+++ b/docs/security/privacy.mdx
@@ -1,0 +1,182 @@
+---
+title: Privacy
+description: "Every outbound request the app can make, what each one carries, and where its off switch is"
+---
+
+Three requests leave a stock install without you asking: one anonymous heartbeat a day, an update check, and a fetch of the plugin catalog. None of the three carries a query, a row, a hostname, or a password. Every other channel below is one you switch on yourself.
+
+| Channel | Goes to | On by default | Off switch |
+| --- | --- | --- | --- |
+| [Usage heartbeat](#usage-heartbeat) | `api.tablepro.app` | Yes | **Settings > General**, under Privacy |
+| [Update check](#update-checks) | `raw.githubusercontent.com` | Yes | **Settings > General**, under Software Update |
+| [Plugin catalog](#the-plugin-catalog) | `raw.githubusercontent.com` | Yes | None |
+| [AI provider](#ai-providers) | whichever provider you add | No provider is configured on a fresh install | Delete the provider, or turn off **Enable AI Features** |
+| [iCloud sync](#icloud-sync) | your own iCloud account | No | **Settings > Account** |
+| [MCP clients](#the-mcp-server) | nowhere: it listens on `127.0.0.1` | Off, but starts on demand | **Settings > Integrations** |
+| [License and team library](#license-checks-and-the-team-library) | `api.tablepro.app` | Only after you activate a license | Do not activate one |
+| [Your databases](#your-database-connections) | the hosts you type into the connection form | Only what you connect to | Do not connect |
+| Crash reports | Nowhere. The app has no crash reporter. | - | - |
+
+## Usage heartbeat
+
+One `POST` to `https://api.tablepro.app/v1/analytics`, ten seconds after the app first becomes active and every 24 hours it keeps running. A 20-hour cooldown is stamped in preferences, so quitting and reopening does not send a second one.
+
+The JSON body holds these fields and no others:
+
+| Field | What it is |
+| --- | --- |
+| `machine_id` | SHA-256 of the Mac's hardware UUID, read from IOKit |
+| `platform` | always `macos` |
+| `app_version`, `os_version`, `architecture` | for example `0.67.0`, `macOS 15.1.0`, `arm64` |
+| `locale` | the language setting: `system`, `en`, `vi`, `zh-Hans`, `zh-Hant`, `ko`, or `tr` |
+| `database_types` | the types of the connections open at that moment, such as `MySQL` |
+| `connection_count` | how many connections are open |
+| `has_license` | whether a license key is stored |
+| `connection_attempted_at`, `connection_succeeded_at` | when you first tried to connect on this Mac, and when a connection first succeeded |
+
+No query text. No hostnames, ports, database names, or usernames. No email address, no file paths, no connection names.
+
+The body is signed with HMAC-SHA256 using a secret compiled into the build (`ANALYTICS_HMAC_SECRET`) and sent as an `X-Signature` header. It is an integrity check over the body, not encryption, and it carries nothing about you. A build without the secret configured sends the payload with no signature at all.
+
+`machine_id` is a hash of a hardware identifier, never of anything you typed, so two heartbeats from the same Mac count as one Mac. Where that identifier cannot be read, a random one is generated and stored instead, and it does not survive a reset.
+
+**Share anonymous usage data** in **Settings > General** is on by default. With it off, the send returns before the payload is built, and nothing queues for later.
+
+## AI providers
+
+Nothing reaches a model until you add a provider. A fresh install has none, and with none configured every AI path returns before it builds a request. **Enable AI Features** in **Settings > AI** is on out of the box, but it gates an empty tab.
+
+One provider is marked active, and it answers inline suggestions and the editor actions. The chat panel has its own model picker, so a chat turn can go to any provider you have configured, not only the active one. Requests go to that provider's endpoint, `api.anthropic.com`, `api.openai.com`, `generativelanguage.googleapis.com`, `api.x.ai`, `openrouter.ai`, `api.cursor.com` and `opencode.ai` all ship as presets, and a custom provider goes wherever you point it. Ollama, llama.cpp, and MLX default to `http://localhost:11434` and `http://localhost:8080`, so their traffic stays on the machine, but the endpoint field is editable and points wherever you set it.
+
+A chat turn carries:
+
+- The database type and the name of the database you are connected to.
+- The schema, while **Include database schema** is on (the default): table names, estimated row counts, column names and types, primary key and NOT NULL flags, DEFAULT values, and foreign keys, for up to **Max schema tables** tables (20 by default).
+- The query in the current tab, while **Include current query** is on (the default), truncated at 2,000 characters.
+- Result rows, only if you turn on **Include query results**, which is off by default. It attaches the first 10 rows of the current result, each value cut at 200 characters.
+- The connection's [AI Rules](/features/ai-assistant#per-connection-ai-rules) text, if you wrote any.
+- Any images you paste into the composer, and the conversation so far.
+
+In Edit and Agent modes the model calls `execute_query` itself, and the rows it gets back become part of the conversation, so they go to the provider on the next turn. Those results are capped by the row limits in **Settings > Integrations**: 500 rows by default, 10,000 at most.
+
+Per connection, the **AI Policy** picker in the connection form's Advanced pane takes **Use Default**, **Always Allow**, **Ask Each Time**, or **Never**. The app-wide default is **Ask Each Time**, which asks once per connection per chat session before the first send. **Never** blocks the chat panel and external AI tool calls against that connection.
+
+<Warning>
+**Ask Each Time** gates the chat panel only. Inline suggestions check the policy for **Never** and nothing else, so with **Enable inline suggestions while typing** on, the text before your cursor, the whole query, and the schema go to the provider after every typing pause with no prompt. That toggle is off by default.
+</Warning>
+
+Provider API keys live in the keychain under the `com.TablePro` service, never in `connections.json` and never in a CloudKit record. The provider list itself (type, name, endpoint, model) rides along with the Settings category of iCloud sync when sync is on.
+
+Signing in to ChatGPT opens a second local listener on port 1455 for the OAuth redirect. It runs only during that sign-in and closes after it.
+
+Two provider paths run a program rather than call an endpoint. **Claude Agent** runs the `claude` command line tool, which talks to Anthropic under your own subscription. **GitHub Copilot** downloads its language server from `registry.npmjs.org` on first use, and its provider sheet has **Send telemetry to GitHub**, which is on when you add the provider. Turning it off sets the language server's telemetry level to `off`.
+
+## iCloud sync
+
+Off by default, and it needs a Starter or Team license. When it is on, records go to the CloudKit container `iCloud.com.TablePro`, into the private database of your own iCloud account, in the Production environment.
+
+Eight record types sync: `Connection`, `ConnectionGroup`, `ConnectionTag`, `AppSettings`, `SQLFavorite`, `SQLFavoriteFolder`, `FavoriteTable`, and `SSHProfile`. A connection record carries host, port, username, database, and SSH and SSL settings. Sync runs on launch, when you switch back to the app, and about two seconds after you change something synced.
+
+Passwords are not one of those record types. The **Passwords** toggle nested under Connections instead marks keychain items as synchronizable, so Apple's iCloud Keychain carries them end to end encrypted. It is off by default, and it applies to items written after you turn it on.
+
+<Warning>
+That flag is set on every keychain item the app writes, not only connection passwords: AI provider keys and the license key go through the same helper. MCP tokens do not; their store always writes device-only items.
+</Warning>
+
+With password sync off, secrets are written `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`, which keeps them on that one Mac. Query history, the activity log, the execution log, tab state, MCP settings, and the sync settings themselves are never synced. Individual connections can be marked **Local only**. Full detail in [iCloud Sync](/features/icloud-sync).
+
+## The MCP server
+
+The server listens on `127.0.0.1` and nothing else. Its listener sets `requiredLocalEndpoint` to the IPv4 loopback address, so there is no remote mode and no setting that opens it to your network. Default port 23508.
+
+It is off by default, but it starts on demand: the bundled bridge and the pairing flow both start it. What a paired client can reach is real data, so four gates stack:
+
+1. **Require authentication**, on by default. With it on, a request that arrives without an `Authorization` header is refused. Turn it off and a loopback caller with no header is allowed instead, capped at `tools:read` and `resources:read` however much it asks for.
+2. The token's scope and its connection allowlist.
+3. The connection's **External Clients** level: **Blocked**, **Read Only** (the default for a new connection), or **Read & Write**. The effective permission is the lower of that and the token's scope.
+4. The connection's **AI Policy** and its [Safe Mode](/features/safe-mode) level, which still apply to statements a client sends.
+
+Loopback-only describes where the server binds, not everything that can reach it. The server returns CORS headers for two remote origins, `claude.ai` and `app.cursor.com`, so a page you have open there can call your local server from your own browser. The four gates above are what stands between such a call and your data, which is the reason to leave **Require authentication** on.
+
+Every call is written to the local activity log with the token behind it, statements as SHA-256 digests. See [Tokens](/external-api/tokens) for the whole model.
+
+## Update checks
+
+Sparkle fetches `https://raw.githubusercontent.com/TableProApp/TablePro/main/appcast.xml`, one day apart by default. The request is a plain `GET` with no query parameters: the app sets no system profiling key, so no profile is attached. The user agent names the app and its version, and GitHub sees your IP address as it would for any web request.
+
+Updates download from the GitHub release named in the feed. Each build carries an EdDSA signature that Sparkle checks against the public key in the app's `Info.plist` before installing anything.
+
+**Automatically check for updates** in **Settings > General** is on by default. With it off, **Check for Updates…** in the same section is the only thing that reaches the feed.
+
+## The plugin catalog
+
+At launch the app fetches `https://raw.githubusercontent.com/TableProApp/plugins/main/plugins.json` when its cached copy is more than five minutes old, and again when it reconciles a plugin that a newer app version rejected. The request adds no header of its own; GitHub sees the IP address and the user agent URLSession sends. The response is cached on disk.
+
+Installing a plugin or a theme downloads its ZIP over HTTPS from the URL in that catalog and checks it against the SHA-256 the catalog declares. The plugin browser also calls `https://api.github.com/repos/TableProApp/TablePro/releases?per_page=100` for download counts, at most once every five minutes, and only while that pane is open.
+
+There is no setting that turns the catalog fetch off.
+
+## License checks and the team library
+
+With no license activated, the app never calls the license API. Activation sends the license key or invite code, the hashed machine ID, the Mac's name, the app version, and the OS version to `https://api.tablepro.app/v1/license`. The same fields go out on re-validation, which runs every 7 days, and on deactivation.
+
+<Info>
+The Mac's name is the only field in any request that tends to hold a person's name, because macOS builds it from the account name. It goes to the license API, never to the analytics endpoint.
+</Info>
+
+Team Library is a Team-tier feature and it publishes only when you ask. **Share > Publish to Team Library…** uploads the connection definitions and the saved query text to `https://api.tablepro.app/v1/license/library`; the publish path builds the export envelope without credentials, so passwords, key passphrases, and TOTP secrets are not in it. A member's app pulls the library on its own weekly timer, and again straight after anyone publishes.
+
+## Crash reports
+
+There are none. The app links no crash reporting SDK: its only remote packages are Sparkle, swift-certificates, and Yams. Nothing uploads a crash log, a stack trace, or a diagnostic file.
+
+Logging goes through OSLog, which stays in the system log store on your Mac.
+
+## Your database connections
+
+The largest thing leaving your Mac is the traffic you asked for: the connection to your own server, plus whatever hops you configured, such as an SSH tunnel, a Cloudflare tunnel, a SOCKS proxy, or Cloud SQL Proxy. Cloud drivers reach their vendor's endpoint by design, so BigQuery talks to `bigquery.googleapis.com`, DynamoDB to AWS, and Microsoft Entra authentication to `login.microsoftonline.com`.
+
+Two helpers download on first use, and each is verified before it runs: the Cloud SQL Proxy binary from `storage.googleapis.com` against a pinned SHA-256, and the Copilot language server tarball against the integrity hash npm publishes with it.
+
+## What stays local
+
+The execution log added in 0.67.0 records every authorization decision the app makes, from the UI, an MCP client, the AI assistant, the import pipeline, or background maintenance. Each record holds a sequence number, a timestamp, the connection ID, the operation kind, which of those five callers asked, allowed or denied, whether it counted as a write, a SHA-256 digest of the statement, and the previous record's hash.
+
+The statement text is never stored, and a caller-supplied label such as an MCP client name or an AI session ID is not stored either, only the channel. The hash chain is tamper evident, not tamper proof: anyone who can write the file can also recompute every hash after the record they changed.
+
+It is a JSON file in Application Support. No sync record type covers it, and no code path uploads it. It does not leave the Mac.
+
+### Where it lives on disk
+
+Everything below is under `~/Library/Application Support/TablePro/` unless the path says otherwise.
+
+| Path | What it holds |
+| --- | --- |
+| `connections.json` | Connection definitions: host, port, username, database, SSH and SSL settings. No passwords. |
+| `connections.json.hmac` | The integrity tag for the file above. |
+| `known_hosts` | SSH host keys you accepted. |
+| `query_history.db` | The statements you ran, as text, with a full-text index. Parameter values are never recorded. |
+| `sql_favorites.db` | Saved queries and their folders. |
+| `ai_chats/` | One JSON file per AI conversation, including the context attached to each turn. |
+| `AIChatImages/` | Images pasted into chat. |
+| `ExecutionAudit.json` | The execution log described above. |
+| `mcp-audit.db` | The MCP activity log, 90 days, statements as digests. Mode `0600` inside a `0700` directory. |
+| `mcp-handshake.json` | The bound port and the bridge token, mode `0600`. |
+| `TabState/`, `RecentlyClosedTabs/` | Open and recently closed tabs, including their query text. |
+| `FilterState/`, `ColumnLayout/` | Per-table filters and column widths. |
+| `LastOpenConnections.json` | What to reopen for **Reopen Last Session**. |
+| `Plugins/` | Plugins you installed yourself. |
+| `Registry/registry-manifest.json`, `Registry/URLCache/` | The cached plugin catalog. |
+| `team_library.json` | The cached team library. |
+| `linked_sql_index.db` | File metadata for linked SQL folders. |
+| `~/Library/Preferences/com.TablePro.plist` | Settings, and the signed license blob, which carries the email on the license. |
+
+## Passwords and secrets
+
+Secrets live in the keychain under the `com.TablePro` service, in the `D7HJ5TFYCU.com.TablePro.shared` access group, and the app asks for the data protection keychain: connection passwords, SSH passwords, key passphrases, SSL client key passphrases, TOTP secrets, plugin secure fields, AI provider keys, and the license key. MCP tokens are stored as a salted SHA-256 hash; the plaintext is shown once at creation and never written down.
+
+A connection can name a [password source](/features/connection-sharing#password-sources) instead of using the keychain: a file, an environment variable, a shell command, 1Password, HashiCorp Vault, or AWS Secrets Manager. Those resolve at connect time, on your machine, and are never synced, since a path or a command belongs to one Mac.
+
+<Warning>
+The `command`, `onePassword`, `vault`, and `awsSecretsManager` kinds run a program on your Mac. The app keeps a signature over `connections.json` for that reason: if the file changed outside the app, password sources do not run and the connection reports why. Open the connection and save it from TablePro to accept the change.
+</Warning>

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -1,0 +1,108 @@
+---
+title: Troubleshooting
+description: Symptom-first checks for launch, connection, plugin, tunnel and save failures
+---
+
+Everything on this page applies to every connection. A failure that only happens on one engine is on that engine's page, and each of those ends with its own Troubleshooting section.
+
+## The app will not open
+
+- **Wrong architecture**: release assets are per-architecture, `TablePro-<version>-arm64.dmg` and the `x86_64` one. Check yours under **Apple menu > About This Mac**.
+- **Too old a macOS**: 14.0 (Sonoma) is the minimum.
+- **macOS refuses to open it**: the DMG and the app inside it are both signed, notarized and stapled, so a Gatekeeper block means the copy was damaged or stripped of its signature. Check with `spctl -a -vvv /Applications/TablePro.app`, then re-download or run `brew install --cask tablepro`.
+- **Opens then quits**: look for the crash report in Console.app and attach it to an issue.
+
+## A connection fails
+
+A failed connect paints the window with **Could not connect to `<name>`** and the driver's own message below it, alongside **Try Again**, **Manage Connections…**, and **Copy Details**.
+
+- **Refused** means something answered and said no: the server is not listening on that port, or it is bound to `127.0.0.1` only. **Timed out** means nothing answered, which points at a firewall, a security group or a VPN. Tell them apart with `nc -zv host port`.
+- On macOS 15 and later, a database at a local network address (`192.168.x.x`, `.local`) needs the Local Network permission. Check TablePro under **System Settings > Privacy & Security > Local Network**. Loopback and internet hosts are not affected.
+- Authentication failures are engine-specific. See [PostgreSQL](/databases/postgresql), [MySQL](/databases/mysql) or [SQL Server](/databases/mssql).
+
+## TLS and certificates
+
+A handshake failure is reported with the cause named and a specific SSL Mode to switch to, with the driver's original error underneath. The ladder is Disabled, Preferred, Required, Verify CA, Verify Identity. Every handshake error string and the mode that fixes it is on [SSL/TLS](/features/ssl).
+
+## A plugin will not install or load
+
+Every plugin is checked before it loads: a registry download must match the SHA-256 in the manifest, and the bundle must carry a valid Developer ID signature. A plugin that fails appears as a banner in **Settings > Plugins > Installed** with the reason.
+
+### "Plugin code signature verification failed: …"
+
+The bundle is unsigned, ad-hoc signed, or was altered after signing. Unsigned and ad-hoc bundles are refused outright and there is no override. Download it again from the registry or from its developer.
+
+### "Plugin checksum does not match expected value"
+
+The downloaded file does not match the SHA-256 the registry manifest lists. Retry the install. If it repeats, the registry entry and the file disagree, so file an issue.
+
+### "Plugin was built for PluginKit version …; this release of TablePro needs version …"
+
+An app update raised the driver interface version and this plugin predates it. TablePro fetches a compatible build on its own, retrying after 30 seconds, then 5 and 10 minutes, up to five attempts. Click **Update Now** in the banner, or **Update TablePro** when the plugin needs a newer app.
+
+### "Couldn't reach the plugin registry"
+
+A network problem, not a bad plugin. Retry once you are online.
+
+### "The … plugin is not installed"
+
+A saved connection's driver is missing. The failure screen offers **Install Plugin…**.
+
+User-installed plugins live in `~/Library/Application Support/TablePro/Plugins`. macOS cannot fully unload plugin code, so after removing one a banner offers **Quit & Reopen**. See [Plugins & Themes](/features/plugins).
+
+## SSH tunnel failures
+
+### "SSH host key verification failed"
+
+The server presented a key that does not match the stored one, or you declined the prompt. Trusted keys live in `~/Library/Application Support/TablePro/known_hosts`. Accept a changed key only when you know why it changed, such as a rebuild or a key rotation.
+
+### "No available local port for SSH tunnel"
+
+The tunnel binds a local port between 60000 and 65000 and found none free. List what is holding them with `lsof -nP -iTCP -sTCP:LISTEN`. Quit those processes and reconnect.
+
+Failures on the far side start with "The SSH server could not reach …". Those and the authentication rejections are in [SSH Tunneling](/databases/ssh-tunneling).
+
+## A query is slow, or the results stop short
+
+- A `SELECT` with no `LIMIT` of its own stops at 10,000 rows and shows a **Fetch All** button. **Execute Without Limit** skips the cap for one run. The SQL sent to the server is always what you typed; only the rows read back are capped. Change it in **Settings > Data**.
+- Browsing a table pages 1,000 rows at a time, which is a separate setting on the same pane.
+- A query is cancelled after 60 seconds by default. Cancel one yourself with `Cmd+.`. The limit is under **Settings > General**.
+
+<Note>
+The query timeout applies to new connections. Change it and reconnect, or the old value stays in force with nothing to say so.
+</Note>
+
+## Edits will not save
+
+- The connection is at the **Read-Only** [safe mode](/features/safe-mode) level, which disables cell editing, row changes and import.
+- Query results are editable only when they come from one table. Joins, comma joins, subqueries in `FROM`, CTEs, `UNION`, `EXCEPT` and `INTERSECT` are read-only.
+- A column renamed with `AS` cannot be written back. A query that renames or omits the primary key blocks the whole save, because there is nothing to match the row on.
+- Generated columns are left out of every `INSERT` and `UPDATE`, so a value typed into one never reaches the server.
+- A table with no primary key is matched on every original column value. The save fails when that still identifies no row, which usually means someone else changed it first.
+
+See [Change Tracking](/features/change-tracking) for what the save actually runs.
+
+## Logs and diagnostics
+
+Logging goes to OSLog under the subsystem `com.TablePro`. Some drivers use their own: `com.TablePro.PostgreSQLDriver`, `com.TablePro.RedisDriver`, `com.TablePro.CassandraDriver`, `com.TablePro.OracleDriver`. Filter on the subsystem in Console.app, or read the last half hour in Terminal:
+
+```bash
+log show --predicate 'subsystem BEGINSWITH "com.TablePro"' --last 30m
+```
+
+Oracle connections get a diagnostic sheet on a recognized driver error, with **Copy Diagnostic Info** and **Open Issue Tracker**. The copied block names the target, the user and the error. No other driver builds one.
+
+Application data is in `~/Library/Application Support/TablePro`, preferences in `~/Library/Preferences/com.TablePro.plist`. **Settings > General** has **Reset All Settings to Defaults**.
+
+<Note>
+Neither button copies a password; those stay in the macOS Keychain. **Copy Details** carries the host, the database name, and the SSH host if there is one, plus the port when it is not the driver's default. **Copy Diagnostic Info** carries the user name as well.
+</Note>
+
+## Filing a bug report
+
+**Help > Report an Issue** opens the [issue tracker](https://github.com/TableProApp/TablePro/issues). A report that gets fixed quickly has:
+
+1. The TablePro version from **TablePro > About TablePro**, your macOS version, and whether the Mac is Apple Silicon or Intel.
+2. The database engine and server version, plus the plugin version from **Settings > Plugins > Installed**.
+3. The error text pasted from **Copy Details** or **Copy Diagnostic Info**, not retyped.
+4. What you ran, what happened, and what you expected instead. Add the matching log lines when the failure left no dialog.


### PR DESCRIPTION
Four pages the docs never had, the navigation changes that do not need traffic data to justify, and the database count.

## Four new pages

- `troubleshooting.mdx` — 34 pages carried their own Troubleshooting section and nothing aggregated them. This is not a copy of those: it covers what is not engine-specific and links out for what is. Error strings are H3 headings, verbatim, so `Cmd+F` on a string from an error dialog lands on the answer.
- `faq.mdx` — questions taken from the CHANGELOG's recurring fixes and from what the docs already state defensively, not invented.
- `security/privacy.mdx` — what leaves your Mac. Three scattered "## Privacy" sections existed and none was the answer.
- `ios/index.mdx` — the iPhone and iPad app was mentioned 56 times across 12 pages and documented nowhere.

Every claim was written against the source and then attacked by a separate reviewer who checked each one independently. **That pass earned its keep on the privacy page.**

### The one that mattered

The privacy page shipped a security claim exactly backwards:

> **Require authentication**, on by default. Without a token, a loopback caller gets `tools:read` and `resources:read`…

```swift
// MCPCompositeAuthenticator.swift:24
guard !requireAuthentication, clientAddress.isLoopback, !presentedCredential else {
    return await bearer.authenticate(...)
}
return .allow(.anonymousLoopback)
```

The anonymous grant is reachable only when the toggle is **off**, and `MCPSettings.swift:19` ships it `true`. As written, the page told a reader that on stock defaults any local process could read their schema and run `SELECT`s. On the page whose entire job is to be trusted.

Also fixed there:

- "One provider is active at a time and answers every AI request" is false for chat. `AIProviderFactory.swift:70` prefers the chat panel's own `overrideProviderId`, so a chat turn reaches any configured provider. Only inline suggestions use the active one.
- **Two outbound channels the page missed.** `MCPCorsHeaders.swift:4` allowlists `claude.ai` and `app.cursor.com`, so loopback-only describes the bind and not the reach. `ChatGPTCodexCallbackServer.swift` opens a second local listener on port 1455 during ChatGPT sign-in.
- Two absolutes the source cannot support: "Nobody but you and Apple is in that path" is a claim about Apple's infrastructure, and the HMAC's meaning was overstated. `MacAnalyticsProvider.swift:71` returns nil for an unexpanded secret and the heartbeat then sends with no signature at all.
- `machine_id` "stable across reinstalls" holds only for the IOKit path; `LicenseStorage.swift:112` falls back to a random UUID.
- `registry-manifest.json` is under `Registry/`. `connections.json.hmac` and `known_hosts` were missing from the disk inventory.
- The password-sync callout was `<Info>`; its consequence is that AI provider keys and the license key become synchronizable, which is `<Warning>`.

Other pages: **Copy Details** does not copy a username and omits a default port (`DatabaseConnection+Display.swift:10`); the diagnostic sheet is Oracle-only (`PluginDiagnostic(` is constructed in exactly one file); the FAQ's 27 collided with the 26-row table it linked to, and its 9 + 17 did not reach 27; the iOS page said "Two things never sync" when the SSH private key is a third (`SSHConfiguration.privateKeyData` is not a synced field, so a key-authenticated tunnel does not open on the phone); and TestFlight was asserted from nothing but another docs page citing it.

One thing the reviewer found that the source made worth saying out loud: picking a SQLite file on iOS **copies it into the app** (`ConnectionFormViewModel.swift:209`) while DuckDB keeps a bookmark to the original (`:222`). Edits go to the copy. That is data-loss-shaped and the page now warns about it.

## Navigation

- **Databases flattened** to one alphabetical group of 26. The five category groups were cut on two incompatible axes: "SQL" is a query language while "File-Based" and "Cloud & API" are deployment models, which is how Redshift, BigQuery, ClickHouse and Trino ended up in four different buckets. Readers arrive knowing their engine's name.
- **External API promoted to its own tab.** 14 pages, a different audience, and 9,221 words of MCP reference sitting flat beside a 657-word Raycast how-to. It also scopes search.
- **Security and privacy** is now a group, with Safe Mode and SSL moved into it from "Security & Sharing".
- No page URL moved, so no redirects are needed.

## Counts and links

The type chooser offers **27** entries: ScyllaDB has its own tile and its own subtitle (`PluginMetadataRegistry.swift:1219`) even though it shares the Cassandra driver and page. The docs said 26 because the two were one table row.

`/quickstart` and `/switching` had **zero** inbound links from anywhere on the site, and `/installation` had one. `index.mdx` linked to 14 feature pages and to none of the pages a new reader needs next. It now opens with three cards for install, first connection, and migrating from another client.

All 27 database rows on the landing page are links. None was clickable before.

## Deliberately not done

Moving 11 pages into `connections/` and re-cutting the eight Features sub-groups. Both change URLs that already rank, and `docs.json` has carried GA4 `G-GQYNPKSK83` for months. That decision should be made against the traffic, not against taste.

All 13 gates green. 106 pages.

https://claude.ai/code/session_01TvGVLvwiH8ahw2wghtVs8s
