### PR TITLE
fix(scripts): stop three scripts from silently doing less than they claim

### DIFF
--- a/scripts/check-redis-command-routing.sh
+++ b/scripts/check-redis-command-routing.sh
@@ -77,6 +77,18 @@ def policies(text):
 
 curated = {}
 
+# This parses Swift with regular expressions, which works until somebody reformats the table.
+# The dangerous shape is a partial parse: 115 of the 151 entries live inside `for name in [...]`
+# blocks, so a change to how those are written drops three quarters of the table and the check
+# still reports that the curated list matches the server. Both counts are therefore asserted
+# against the source before anything is compared.
+# Every add(spec(...)) call in the source must be accounted for by exactly one parsed construct,
+# either a direct entry or a `for name in [...]` block. Counting the blocks alone is not enough:
+# renaming the loop variable makes both the expectation and the match zero, and the check would
+# sail past having lost three quarters of the table.
+expected_calls = len(re.findall(r'add\(spec\(', table))
+expected_direct = len(re.findall(r'add\(spec\(\s*"', table))
+
 # add(spec("name", first, last, step, ...))
 for match in re.finditer(r'spec\(\s*"([^"]+)",\s*(-?\d+),\s*(-?\d+),\s*(-?\d+)([^)]*)\)', table):
     name, first, last, step, rest = match.groups()
@@ -87,8 +99,22 @@ for match in re.finditer(r'spec\(\s*"([^"]+)",\s*(-?\d+),\s*(-?\d+),\s*(-?\d+)([
         "request": request, "response": response,
     }
 
+if len(curated) != expected_direct:
+    sys.exit(
+        f"parsed {len(curated)} direct spec() entries but the source has {expected_direct}; "
+        "the parser and RedisCommandRouting.swift have diverged"
+    )
+
 # for name in [...] { add(spec(name, first, last, step, ...)) }
-for block, values in re.findall(r'for name in \[(.*?)\]\s*\{\s*add\(spec\(name,\s*(.*?)\)\)', table, re.S):
+blocks = re.findall(r'for name in \[(.*?)\]\s*\{\s*add\(spec\(name,\s*(.*?)\)\)', table, re.S)
+if len(curated) + len(blocks) != expected_calls:
+    sys.exit(
+        f"accounted for {len(curated)} direct entries and {len(blocks)} loop blocks, "
+        f"but the source makes {expected_calls} add(spec(...)) calls; "
+        "the parser and RedisCommandRouting.swift have diverged"
+    )
+
+for block, values in blocks:
     parts = values.split(",")
     positions = [int(p.strip()) for p in parts[:3]]
     rest = ",".join(parts[3:])

--- a/scripts/install-plugin-dev.sh
+++ b/scripts/install-plugin-dev.sh
@@ -24,8 +24,17 @@ TARGET="${1:-ElasticsearchDriverPlugin}"
 BUNDLE="${TARGET}.tableplugin"
 DEST_DIR="${HOME}/Library/Application Support/TablePro/Plugins"
 
-SRC="$(find "${HOME}/Library/Developer/Xcode/DerivedData/TablePro-"*/Build/Products/Debug \
-  -maxdepth 1 -name "${BUNDLE}" -print 2>/dev/null | head -n 1)"
+# The newest build, not whichever one the filesystem happened to list first. This repo carries
+# several worktrees and each gets its own DerivedData, so `head -n 1` routinely installed a stale
+# bundle from somebody else's checkout and the mismatch only showed up as a load failure later.
+CANDIDATES="$(find "${HOME}/Library/Developer/Xcode/DerivedData/TablePro-"*/Build/Products/Debug \
+  -maxdepth 1 -name "${BUNDLE}" -print0 2>/dev/null | xargs -0 stat -f '%m %N' 2>/dev/null | sort -rn)"
+SRC="$(printf '%s' "${CANDIDATES}" | head -n 1 | cut -d' ' -f2-)"
+
+if [[ "$(printf '%s' "${CANDIDATES}" | grep -c .)" -gt 1 ]]; then
+    echo "note: several builds of ${BUNDLE} exist; using the most recent:"
+    echo "      ${SRC}"
+fi
 
 if [[ -z "${SRC}" ]]; then
     echo "error: ${BUNDLE} not found in DerivedData. Build the app (or the ${TARGET} target) first." >&2

--- a/scripts/ios/build-libpq-ios.sh
+++ b/scripts/ios/build-libpq-ios.sh
@@ -259,7 +259,6 @@ build_slice() {
         src/common/psprintf.c
         src/common/logging.c
         src/common/percentrepl.c
-        src/common/md5_common.c
         src/common/sha1.c
         src/common/sha1_int.c
         src/common/sha2.c
@@ -280,7 +279,6 @@ build_slice() {
         src/port/strerror.c
         src/port/thread.c
         src/port/path.c
-        src/port/pg_strong_random.c
         src/port/pgstrcasecmp.c
         src/port/explicit_bzero.c
         src/port/user.c
@@ -292,19 +290,34 @@ build_slice() {
     # Compile all source files
     local ALL_OBJS=()
     local FAILED_SRCS=()
+    local MISSING_SRCS=()
     for src in "${LIBPQ_SRCS[@]}" "${COMMON_SRCS[@]}" "${PORT_SRCS[@]}"; do
         local obj_name
         obj_name=$(basename "${src%.c}.o")
-        if [ -f "$src" ]; then
-            if "$CC" "${CFLAGS[@]}" "${PG_INCLUDES[@]}" -DFRONTEND -c "$src" -o "$OBJ_DIR/$obj_name" 2>"$OBJ_DIR/${obj_name}.err"; then
-                ALL_OBJS+=("$OBJ_DIR/$obj_name")
-            else
-                FAILED_SRCS+=("$src")
-                echo "   FAILED: $src"
-                cat "$OBJ_DIR/${obj_name}.err"
-            fi
+        # A source that is not there used to be skipped in silence, so a PostgreSQL bump that
+        # renamed or moved a file produced a libpq.a quietly missing that object. Only a
+        # compile failure was ever reported.
+        if [ ! -f "$src" ]; then
+            MISSING_SRCS+=("$src")
+            continue
+        fi
+        if "$CC" "${CFLAGS[@]}" "${PG_INCLUDES[@]}" -DFRONTEND -c "$src" -o "$OBJ_DIR/$obj_name" 2>"$OBJ_DIR/${obj_name}.err"; then
+            ALL_OBJS+=("$OBJ_DIR/$obj_name")
+        else
+            FAILED_SRCS+=("$src")
+            echo "   FAILED: $src"
+            cat "$OBJ_DIR/${obj_name}.err"
         fi
     done
+
+    if [ ${#MISSING_SRCS[@]} -gt 0 ]; then
+        echo ""
+        echo "ERROR: ${#MISSING_SRCS[@]} source file(s) listed here are not in PostgreSQL $PG_VERSION:"
+        printf '   %s\n' "${MISSING_SRCS[@]}"
+        echo ""
+        echo "Update the source lists in this script to match the version being built."
+        exit 1
+    fi
 
     if [ ${#FAILED_SRCS[@]} -gt 0 ]; then
         echo ""


### PR DESCRIPTION
Three more from the CI audit, all the same shape as #2343: the script reports success while quietly doing less than it says.

## `build-libpq-ios.sh` could ship a libpq missing objects

The compile loop was:

```sh
for src in "${LIBPQ_SRCS[@]}" "${COMMON_SRCS[@]}" "${PORT_SRCS[@]}"; do
    if [ -f "$src" ]; then
        ... compile, collect, report failures ...
    fi
done
```

No `else`. A source file that is not there is skipped in silence, the archive is built without it, and only a *compile* failure is ever reported. A PostgreSQL bump that renames or moves a file would produce a quietly incomplete `libpq.a` for iOS, and the first sign would be a link error in an app build much later.

A missing source is now collected and fails the build naming every file, the same way compile failures already do.

The lists also carried two duplicates: `src/common/md5_common.c` and `src/port/pg_strong_random.c` were each listed twice, so each was compiled twice to the same object path. Removed.

## `install-plugin-dev.sh` installed whichever build the filesystem listed first

```sh
SRC="$(find ".../DerivedData/TablePro-"*/Build/Products/Debug -name "${BUNDLE}" -print | head -n 1)"
```

`find` returns filesystem order, not newest. This repo carries several worktrees and each gets its own DerivedData, so `head -n 1` routinely picked a stale bundle from a different checkout, and the mismatch only surfaced later as a load failure.

It now takes the most recently modified match, and says so when there is more than one candidate.

## `check-redis-command-routing.sh` could compare a quarter of its table and call it a match

The script parses `RedisCommandRouting.swift` with regular expressions, which works until somebody reformats it. The dangerous shape is a *partial* parse: 115 of the table's 151 entries live inside `for name in [...]` blocks, so a change to how those are written drops three quarters of the table and the script still prints that the curated list matches the server. Only a parse yielding literally zero entries was caught.

Every `add(spec(...))` call in the source must now be accounted for by exactly one parsed construct, direct entry or loop block, and the script exits if the numbers disagree.

Counting the loop blocks alone would not have been enough. Verified against three plausible reformats:

| | direct + blocks | `add(spec(` calls | |
| --- | --- | --- | --- |
| current source | 36 + 11 | 47 | passes |
| a comment between `{` and the call | 36 + 0 | 47 | fires |
| the loop variable renamed | 36 + 0 | 47 | fires |
| the array wrapped in `Set(...)` | 36 + 0 | 47 | fires |

The rename case is the one that motivated the stronger form: it makes both the block expectation and the block match zero, so a guard comparing only those two would have passed while losing 115 entries.

## Verification

All three parse and are clean under `shellcheck -x --severity=warning`. The Redis guard was exercised against the real `RedisCommandRouting.swift` and against each reformat above. Neither `build-libpq-ios.sh` nor `check-redis-command-routing.sh` is run end to end here: the first needs an iOS toolchain pass and the second needs a live Redis 7 to talk to.

https://claude.ai/code/session_013MEaba8K1HQcyDNeq5wEFk
