### PR TITLE
ci(docs): run the docs gate on every pull request so it can be required

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,18 +1,12 @@
 name: Docs
 
+# No paths filter. As a required status check, a filtered workflow never starts on a PR
+# that misses the filter, so the check sits pending and blocks the merge forever. It runs
+# in about a minute, which is cheaper than the exception handling.
 on:
   pull_request:
-    paths:
-      - 'docs/**'
-      - '.github/workflows/docs.yml'
-      - 'TablePro/Core/Menu/**'
-      - 'TablePro/Core/Plugins/PluginManager.swift'
-      - 'TablePro/Models/UI/KeyboardShortcutModels.swift'
   push:
     branches: [main]
-    paths:
-      - 'docs/**'
-      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
`Validate docs` is now a required status check on `main`. A workflow with a `paths:` filter never starts on a PR that misses the filter, so the required check would sit pending and block the merge with nothing to click.

Dropping the filter is the simpler of the two fixes. The job takes about a minute, which is cheaper than maintaining an exception list or explaining to everyone why an unrelated PR is stuck.

https://claude.ai/code/session_01TvGVLvwiH8ahw2wghtVs8s