### PR TITLE
fix(security): pin Sparkle and the DuckDB extension, and publish only what is verified

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -12,7 +12,6 @@ BUILD_DIR="build/Release"
 SIGN_IDENTITY="${SIGN_IDENTITY:-Developer ID Application: Dat Ngo Quoc (D7HJ5TFYCU)}"
 TEAM_ID="D7HJ5TFYCU"
 NOTARIZE="${NOTARIZE:-false}"
-APPLE_ID="${APPLE_ID:-datngoquoc@icloud.com}"
 
 echo "🏗️  Building TablePro for: $ARCH"
 
@@ -360,7 +359,6 @@ build_for_arch() {
         CLANG_COVERAGE_MAPPING=NO \
         ENABLE_CODE_COVERAGE=NO \
         ${PROFILE_ARGS[@]+"${PROFILE_ARGS[@]}"} \
-        ${ANALYTICS_HMAC_SECRET:+ANALYTICS_HMAC_SECRET="$ANALYTICS_HMAC_SECRET"} \
         -skipPackagePluginValidation \
         -clonedSourcePackagesDirPath "$SPM_CACHE_DIR" \
         -derivedDataPath build/DerivedData \

--- a/scripts/check-redis-command-routing.sh
+++ b/scripts/check-redis-command-routing.sh
@@ -45,12 +45,17 @@ esac
 
 echo "Checking the curated table against Redis $VERSION at $HOST:$PORT"
 
-redis-cli --json -h "$HOST" -p "$PORT" command > /tmp/redis-command-table.json || {
+# A private directory, matching every sibling check script. /tmp is world-writable, so a fixed
+# name is something another local user can pre-create and control.
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+redis-cli --json -h "$HOST" -p "$PORT" command > "$WORK/command-table.json" || {
     echo "COMMAND was refused; the user's ACL has to allow it for this check" >&2
     exit 3
 }
 
-python3 - "$SOURCE" /tmp/redis-command-table.json <<'PY'
+python3 - "$SOURCE" "$WORK/command-table.json" <<'PY'
 import json
 import re
 import sys
@@ -180,5 +185,4 @@ if mismatches:
 print("the curated table matches the server")
 PY
 status=$?
-rm -f /tmp/redis-command-table.json
 exit $status

--- a/scripts/ci/sign-and-appcast.sh
+++ b/scripts/ci/sign-and-appcast.sh
@@ -22,8 +22,18 @@ fi
 # ---------------------------------------------------------------------------
 # 1. Locate Sparkle tools
 # ---------------------------------------------------------------------------
-brew list --cask sparkle &>/dev/null || brew install --cask sparkle
-SPARKLE_BIN="$(brew --caskroom)/sparkle/$(ls "$(brew --caskroom)/sparkle" | head -1)/bin"
+# Pinned and checksum-verified rather than installed from a cask that tracks latest. This step
+# holds the EdDSA private key that signs every update every user receives, so it should not run a
+# binary whose contents can change between releases. The version matches the Sparkle framework
+# pinned in Package.resolved, so both move together.
+SPARKLE_VERSION="2.9.5"
+SPARKLE_SHA256="015336b601493e05c237964954bff6191370003d94edefe663724c88840d73cc"
+SPARKLE_DIR="$(mktemp -d)"
+curl -sSLo "$SPARKLE_DIR/sparkle.tar.xz" \
+    "https://github.com/sparkle-project/Sparkle/releases/download/$SPARKLE_VERSION/Sparkle-$SPARKLE_VERSION.tar.xz"
+echo "$SPARKLE_SHA256  $SPARKLE_DIR/sparkle.tar.xz" | shasum -a 256 -c -
+tar xf "$SPARKLE_DIR/sparkle.tar.xz" -C "$SPARKLE_DIR"
+SPARKLE_BIN="$SPARKLE_DIR/bin"
 
 # ---------------------------------------------------------------------------
 # 2. Extract release notes from CHANGELOG.md → HTML

--- a/scripts/duckdb-ios-extensions.cmake
+++ b/scripts/duckdb-ios-extensions.cmake
@@ -9,9 +9,15 @@
 # (httpfs, quack) are fetched from their own repos. quack is what powers remote
 # DuckDB connections; it requires httpfs (TLS over OpenSSL) at runtime.
 #
-# Pin httpfs and quack to commits whose duckdb submodule matches DUCKDB_VERSION
-# in build-duckdb-ios.sh. quack tracks duckdb main, so when you bump DuckDB,
-# update QUACK_GIT_TAG to a commit built against the same tag.
+# Both are pinned to a commit, never a branch: these are compiled into a binary that ships on
+# the App Store, and a moving ref means nobody can say what was in a given release.
+#
+# The rule when bumping DuckDB is to move each pin to a commit whose own duckdb submodule matches
+# DUCKDB_VERSION in build-duckdb-ios.sh. That is not satisfied today: the quack pin below is the
+# head of its v1.5-variegata line and carries duckdb v1.5.4, while the build uses v1.5.2. No
+# commit on that branch carries v1.5.2, so closing the gap means either moving DUCKDB_VERSION to
+# v1.5.4, which also has to move the bundled macOS libduckdb.a, or backporting quack. Pinned
+# anyway, because a fixed commit on the right release line is strictly better than tracking main.
 
 duckdb_extension_load(core_functions)
 duckdb_extension_load(json)
@@ -26,4 +32,4 @@ duckdb_extension_load(httpfs
 
 duckdb_extension_load(quack
     GIT_URL https://github.com/duckdb/duckdb-quack
-    GIT_TAG main)
+    GIT_TAG 7e80f7ffcc98d0b3e81d0e1df8cc1c2da240a64b)

--- a/scripts/publish-libs.sh
+++ b/scripts/publish-libs.sh
@@ -128,12 +128,27 @@ echo "✅ All unchanged libraries match HEAD"
 echo "📝 Regenerating $CHECKSUMS_FILE..."
 shasum -a 256 Libs/*.a > "$CHECKSUMS_FILE"
 
+# An allowlist of exactly what the checksum guard above covers, not `-C Libs .`. The dot swept in
+# Libs/ios and Libs/dylibs, so every download of the macOS archive also carried about 78 MB of iOS
+# xcframeworks that nothing here verified, and the marker files with them.
 echo "📦 Creating $LIBS_ARCHIVE..."
-tar czf "/tmp/$LIBS_ARCHIVE" -C Libs .
+archive_members=()
+for lib in Libs/*.a; do
+    archive_members+=("$(basename "$lib")")
+done
+if [ "${#archive_members[@]}" -eq 0 ]; then
+    echo "❌ No Libs/*.a to publish."
+    exit 1
+fi
+
+# A private directory rather than a predictable /tmp name: this archive is uploaded publicly, and
+# /tmp is world-writable, so a fixed path is something another local user can replace first.
+staging="$(mktemp -d)"
+trap 'rm -rf "$staging"' EXIT
+tar czf "$staging/$LIBS_ARCHIVE" -C Libs "${archive_members[@]}" "$(basename "$CHECKSUMS_FILE")"
 
 echo "☁️  Uploading to $REPO@$LIBS_TAG..."
-gh release upload "$LIBS_TAG" "/tmp/$LIBS_ARCHIVE" --clobber --repo "$REPO"
-rm -f "/tmp/$LIBS_ARCHIVE"
+gh release upload "$LIBS_TAG" "$staging/$LIBS_ARCHIVE" --clobber --repo "$REPO"
 
 echo ""
 echo "🎉 Published. Now commit the checksum update:"


### PR DESCRIPTION
Five supply-chain items from the CI audit. Every pin here was verified by fetching the artifact and hashing it, not copied from a report.

## The signing path installed an unpinned Sparkle

`sign-and-appcast.sh` ran `brew install --cask sparkle` and then picked a directory with `ls | head -1`. That step holds `SPARKLE_PRIVATE_KEY`, the EdDSA key that signs every update every user receives, so it should not be running a binary whose contents can change between releases.

It now downloads a pinned release tarball and verifies it. Checked by downloading it here:

```
actual   015336b601493e05c237964954bff6191370003d94edefe663724c88840d73cc
declared 015336b601493e05c237964954bff6191370003d94edefe663724c88840d73cc
```

The archive has `./bin/` at its root and carries `generate_appcast`, which is the only binary this script invokes; extracted and run it to be sure. Version 2.9.5 matches the Sparkle framework pinned in `Package.resolved`, so the tool and the framework move together.

## The iOS DuckDB build compiled a moving ref into a shipped binary

```cmake
duckdb_extension_load(quack
    GIT_URL https://github.com/duckdb/duckdb-quack
    GIT_TAG main)
```

This ends up in a binary that ships on the App Store, and with a branch ref nobody can say what was in a given release. Pinned to `7e80f7ff`, the head of quack's `v1.5-variegata` line.

**One thing this does not fix, recorded in the file rather than hidden.** The file's own rule is that each pin should carry a duckdb submodule matching `DUCKDB_VERSION`, which is `v1.5.2`. That commit carries `v1.5.4`, and no commit in the recent history of `v1.5-variegata` carries `v1.5.2`, so an exact match is not available on that line. Closing the gap means either moving `DUCKDB_VERSION` to `v1.5.4`, which also has to move the bundled macOS `libduckdb.a`, or backporting quack. Pinned anyway, because a fixed commit on the right release line is strictly better than tracking `main`, which today is further from `v1.5.2` than `v1.5.4` is.

The comment also referenced a `QUACK_GIT_TAG` variable that has never existed. Rewritten to describe what the file actually does.

## The published archive carried 80 MB nothing verified

`publish-libs.sh` built the macOS archive with `tar czf ... -C Libs .`. The dot swept in `Libs/ios`, `Libs/dylibs` and the `.downloaded` markers, so every download of the macOS libraries also carried the iOS xcframeworks, which that script's checksum guard does not cover at all.

It now publishes an allowlist: exactly the `.a` files the guard walks, plus `checksums.sha256`. Measured against the current tree:

| | size | members |
| --- | --- | --- |
| before | 177 MB | 541 |
| after | 97 MB | 61 |

61 is the 60 entries in `Libs/checksums.sha256` plus the checksum file itself. Verified that the baseline is fully covered and there are no extras.

## A personal Apple ID in a tracked file

`build-release.sh` carried `APPLE_ID="${APPLE_ID:-datngoquoc@icloud.com}"` in a public repository. It is also dead: notarization goes through `--keychain-profile "TablePro"` at all three call sites and never reads it.

## A secret on the process argument list

The same script passed `ANALYTICS_HMAC_SECRET=...` to `xcodebuild` on the command line, where any local process can read it. It is redundant: `build.yml` writes the value into `Configs/Secrets.xcconfig` before the build step, and that is how the project reads it. The argv pass is removed.

## Predictable temp paths

`publish-libs.sh` staged a public upload at a fixed `/tmp` name and `check-redis-command-routing.sh` used one too, unlike every sibling check script. `/tmp` is world-writable, so a fixed name is something another local user can create first. Both use `mktemp -d` with a cleanup trap now.

## Verification

`shellcheck -x --severity=warning` is clean on all four scripts. The Sparkle pin and the archive contents were verified by actually fetching and building them. The iOS DuckDB change cannot be verified here without an iOS DuckDB build, which is why the remaining submodule mismatch is written into the file rather than left implicit.

https://claude.ai/code/session_013MEaba8K1HQcyDNeq5wEFk
