### PR TITLE
fix(editor): resolve the ranges input services send against the document before using them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a crash on macOS 26 and later when the editor redrew a diagnostic underline or search highlight whose text had been edited away.
+- Fixed a crash when an input method, dictation or Look Up asked the editor about text that had already been edited away. (#2339)
 - The XLSX, MQL and SQL Import plugins linked to a documentation page that did not exist. They now point at Import & Export.
 
 ## [0.67.0] - 2026-08-21

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+clamped.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/Extensions/NSRange+/NSRange+clamped.swift
@@ -16,4 +16,22 @@ extension NSRange {
         let end = Swift.min(Swift.max(self.max, 0), length)
         return NSRange(location: start, length: Swift.max(0, end - start))
     }
+
+    /// Returns the range resolved against a document of `length`, or `nil` when it names no
+    /// position in that document.
+    ///
+    /// Use this for a range that came from outside the text view: an input service, an
+    /// accessibility client, or state stored before an edit. Those may send `NSNotFound`, a
+    /// negative value, or a length that overflows when added to the location, none of which
+    /// ``clamped(toLength:)`` can move inside the document, and the second of which traps when
+    /// `max` is computed.
+    func resolved(inDocumentOfLength length: Int) -> NSRange? {
+        guard location != NSNotFound,
+              location >= 0,
+              self.length >= 0,
+              location <= Int.max - self.length else {
+            return nil
+        }
+        return clamped(toLength: length)
+    }
 }

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/MarkedTextManager/MarkedTextManager.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/MarkedTextManager/MarkedTextManager.swift
@@ -27,6 +27,25 @@ class MarkedTextManager {
         markedRanges.removeAll()
     }
 
+    /// Resolves the stored ranges against a document of `length`, dropping any that name no
+    /// position in it and collapsing any that resolve to the same one.
+    ///
+    /// An input session spans many callbacks and this object has no hook for edits made through
+    /// any other path, so an edit that shrinks the document leaves its ranges behind. Resolving
+    /// before they are used keeps the next keystroke of a composition computed against text that
+    /// still exists, rather than replacing at a position the document no longer has.
+    func resolveRanges(inDocumentOfLength length: Int) {
+        var resolved: [NSRange] = []
+        for range in markedRanges {
+            guard let clamped = range.resolved(inDocumentOfLength: length),
+                  !resolved.contains(clamped) else {
+                continue
+            }
+            resolved.append(clamped)
+        }
+        markedRanges = resolved
+    }
+
     /// Updates the stored marked ranges.
     ///
     /// Two cases here:

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+NSTextInput.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+NSTextInput.swift
@@ -51,7 +51,7 @@ extension TextView: NSTextInputClient {
             insertString = LineEnding.carriageReturnLineFeed.rawValue
         }
 
-        replaceCharacters(in: replacementRanges, with: insertString)
+        replaceCharacters(in: resolvedReplacementRanges(replacementRanges), with: insertString)
 
         selectionManager.textSelections.forEach { $0.suggestedXPos = nil }
     }
@@ -85,6 +85,7 @@ extension TextView: NSTextInputClient {
     @objc public func insertText(_ string: Any, replacementRange: NSRange) {
         guard isEditable, let insertString = anyToString(string) else { return }
 
+        layoutManager.markedTextManager.resolveRanges(inDocumentOfLength: textStorage.length)
         let markedRanges = layoutManager.markedTextManager.markedRanges
         let hadMarkedText = !markedRanges.isEmpty
 
@@ -126,6 +127,7 @@ extension TextView: NSTextInputClient {
         guard isEditable, let insertString = anyToString(string) else { return }
         // Needs to insert text, but not notify the undo manager.
         _undoManager?.disable()
+        layoutManager.markedTextManager.resolveRanges(inDocumentOfLength: textStorage.length)
         let shouldInsert = layoutManager.markedTextManager.markedRanges.isEmpty
 
         // Copy the text selections *before* we modify them.
@@ -172,6 +174,7 @@ extension TextView: NSTextInputClient {
     @objc public func unmarkText() {
         if layoutManager.markedTextManager.hasMarkedText {
             _undoManager?.disable()
+            layoutManager.markedTextManager.resolveRanges(inDocumentOfLength: textStorage.length)
             replaceCharacters(in: layoutManager.markedTextManager.markedRanges, with: "")
             _undoManager?.enable()
             layoutManager.markedTextManager.removeAll()
@@ -238,9 +241,47 @@ extension TextView: NSTextInputClient {
         forProposedRange range: NSRange,
         actualRange: NSRangePointer?
     ) -> NSAttributedString? {
-        let realRange = (textStorage.string as NSString).rangeOfComposedCharacterSequences(for: range)
+        actualRange?.pointee = .notFound
+        guard let realRange = composedRange(forProposedRange: range) else { return nil }
         actualRange?.pointee = realRange
         return textStorage.attributedSubstring(from: realRange)
+    }
+
+    /// Resolves a range handed to us by an input service against the document.
+    ///
+    /// Returns `nil` when the range starts outside the document, which is the case
+    /// `NSTextInputClient` documents as having no answer. A range that starts inside it keeps its
+    /// position and gives up only the part that no longer exists, so a caret question still has
+    /// an answer and an empty result means "no characters there" rather than "no such place".
+    private func composedRange(forProposedRange range: NSRange) -> NSRange? {
+        let documentLength = textStorage.length
+        guard let clamped = range.resolved(inDocumentOfLength: documentLength),
+              clamped.location == range.location else {
+            return nil
+        }
+        guard !clamped.isEmpty else { return clamped }
+        return (textStorage.string as NSString).rangeOfComposedCharacterSequences(for: clamped)
+    }
+
+    /// Resolves the ranges an input service asked us to replace against the current document.
+    ///
+    /// The ranges an input session works with are computed against the document as it was, and any
+    /// edit made through another path can leave them behind: marked-text bookkeeping keeps its own
+    /// ranges and has no hook for those edits. `replaceCharacters` registers undo before it
+    /// mutates, and building the inverse slices the storage, so a range that outruns the document
+    /// traps there rather than raising something catchable. Two ranges that resolve to the same
+    /// position would replace the same text twice, so they collapse to one.
+    internal func resolvedReplacementRanges(_ ranges: [NSRange]) -> [NSRange] {
+        let documentLength = textStorage.length
+        var resolved: [NSRange] = []
+        for range in ranges {
+            guard let clamped = range.resolved(inDocumentOfLength: documentLength),
+                  !resolved.contains(clamped) else {
+                continue
+            }
+            resolved.append(clamped)
+        }
+        return resolved
     }
 
     /// Returns an attributed string representing the receiver's text storage.
@@ -259,14 +300,21 @@ extension TextView: NSTextInputClient {
     /// - Returns: The boundary rectangle for the given range of characters, in *screen* coordinates.
     ///            The rectangle’s size value can be negative if the text flows to the left.
     @objc public func firstRect(forCharacterRange range: NSRange, actualRange: NSRangePointer?) -> NSRect {
-        if actualRange != nil {
-            let realRange = (textStorage.string as NSString).rangeOfComposedCharacterSequences(for: range)
-            if realRange != range {
-                actualRange?.pointee = realRange
-            }
+        actualRange?.pointee = .notFound
+
+        // A range we cannot resolve still has to produce a usable rect: an input service places
+        // its candidate window, accent popover or dictation indicator here, and a zero rect puts
+        // all of them in the corner of the display. The end of the document is where the old code
+        // landed for those, because `rectForOffset` answers any offset past the end that way.
+        let offset: Int
+        if let realRange = composedRange(forProposedRange: range) {
+            actualRange?.pointee = realRange
+            offset = realRange.location
+        } else {
+            offset = textStorage.length
         }
 
-        let localRect = (layoutManager.rectForOffset(range.location) ?? .zero)
+        let localRect = (layoutManager.rectForOffset(offset) ?? .zero)
         let windowRect = convert(localRect, to: nil)
         return window?.convertToScreen(windowRect) ?? .zero
     }

--- a/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/NSTextInputRangeGuardTests.swift
+++ b/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/NSTextInputRangeGuardTests.swift
@@ -1,0 +1,242 @@
+import AppKit
+import Testing
+@testable import CodeEditTextView
+
+/// Input services, accessibility clients and the view's own marked-text bookkeeping all hand the
+/// text view ranges computed against a document that may since have changed. `NSString` and
+/// `NSTextStorage` raise for those, and the undo manager's inverse-mutation slice traps outright,
+/// so every one of these used to end the process rather than return an answer.
+@Suite()
+struct NSTextInputRangeGuardTests {
+    @Test()
+    func resolvingKeepsWhatStillFitsInTheDocument() {
+        #expect(NSRange(location: 2, length: 99).resolved(inDocumentOfLength: 5) == NSRange(location: 2, length: 3))
+        #expect(NSRange(location: 9, length: 3).resolved(inDocumentOfLength: 5) == NSRange(location: 5, length: 0))
+        #expect(NSRange(location: 0, length: 5).resolved(inDocumentOfLength: 5) == NSRange(location: 0, length: 5))
+        #expect(NSRange(location: 0, length: 1).resolved(inDocumentOfLength: 0) == NSRange(location: 0, length: 0))
+        #expect(
+            NSRange(location: 3, length: 1_000_000).resolved(inDocumentOfLength: 5)
+                == NSRange(location: 3, length: 2)
+        )
+    }
+
+    @Test()
+    func resolvingRejectsRangesWithNoPosition() {
+        #expect(NSRange(location: NSNotFound, length: 0).resolved(inDocumentOfLength: 5) == nil)
+        #expect(NSRange(location: -1, length: 2).resolved(inDocumentOfLength: 5) == nil)
+        #expect(NSRange(location: 2, length: -1).resolved(inDocumentOfLength: 5) == nil)
+        #expect(NSRange(location: Int.max, length: 3).resolved(inDocumentOfLength: 5) == nil)
+        #expect(NSRange(location: 3, length: Int.max).resolved(inDocumentOfLength: 5) == nil)
+    }
+
+    /// `NSTextInputClient` reserves nil for a range whose location is outside the document. A
+    /// location inside it has an answer even when no characters fall in the range, and a client
+    /// reading the caret's context tells those two apart.
+    @Test()
+    @MainActor
+    func attributedSubstringReturnsNilOnlyWhenTheLocationIsOutsideTheDocument() {
+        let textView = makeTextView(string: "Hello")
+
+        for proposed in [
+            NSRange(location: 10, length: 3),
+            NSRange(location: NSNotFound, length: 0),
+            NSRange(location: Int.max, length: 1)
+        ] {
+            var actual = NSRange(location: 0, length: 0)
+            #expect(textView.attributedSubstring(forProposedRange: proposed, actualRange: &actual) == nil)
+            #expect(actual == .notFound)
+        }
+    }
+
+    @Test()
+    @MainActor
+    func attributedSubstringAnswersACaretPositionWithAnEmptyString() throws {
+        let textView = makeTextView(string: "Hello")
+
+        var endOfDocument = NSRange(location: 0, length: 0)
+        let atEnd = try #require(
+            textView.attributedSubstring(forProposedRange: NSRange(location: 5, length: 1), actualRange: &endOfDocument)
+        )
+        #expect(atEnd.string.isEmpty)
+        #expect(endOfDocument == NSRange(location: 5, length: 0))
+
+        var start = NSRange(location: 0, length: 0)
+        let atStart = try #require(
+            textView.attributedSubstring(forProposedRange: NSRange(location: 0, length: 0), actualRange: &start)
+        )
+        #expect(atStart.string.isEmpty)
+        #expect(start == NSRange(location: 0, length: 0))
+    }
+
+    @Test()
+    @MainActor
+    func attributedSubstringClampsARangeThatOverrunsTheEnd() throws {
+        let textView = makeTextView(string: "Hello")
+
+        var actual = NSRange(location: 0, length: 0)
+        let substring = textView.attributedSubstring(
+            forProposedRange: NSRange(location: 3, length: 99),
+            actualRange: &actual
+        )
+
+        let resolved = try #require(substring)
+        #expect(resolved.string == "lo")
+        #expect(actual == NSRange(location: 3, length: 2))
+    }
+
+    @Test()
+    @MainActor
+    func attributedSubstringAnswersAnEmptyDocumentWithAnEmptyString() throws {
+        let textView = makeTextView(string: "")
+
+        var actual = NSRange(location: 0, length: 0)
+        let substring = try #require(
+            textView.attributedSubstring(forProposedRange: NSRange(location: 0, length: 4), actualRange: &actual)
+        )
+        #expect(substring.string.isEmpty)
+        #expect(actual == NSRange(location: 0, length: 0))
+    }
+
+    @Test()
+    @MainActor
+    func attributedSubstringRoundsToTheComposedSequence() throws {
+        let textView = makeTextView(string: "a👨‍👩‍👧b")
+
+        var actual = NSRange(location: 0, length: 0)
+        let substring = textView.attributedSubstring(
+            forProposedRange: NSRange(location: 1, length: 2),
+            actualRange: &actual
+        )
+
+        let resolved = try #require(substring)
+        #expect(resolved.string == "👨‍👩‍👧")
+        #expect(actual.upperBound <= (textView.string as NSString).length)
+    }
+
+    /// An input method asks for the rect of a zero-length range to place its candidate window, so
+    /// resolving must keep that question answerable. `actualRange` is the observable part here:
+    /// the rect itself converts through the window, and a detached text view has none.
+    @Test()
+    @MainActor
+    func firstRectResolvesTheCaretAndRejectsARangeWithNoPosition() {
+        let textView = makeTextView(string: "Hello")
+
+        var caret = NSRange(location: 0, length: 0)
+        _ = textView.firstRect(forCharacterRange: NSRange(location: 5, length: 0), actualRange: &caret)
+        #expect(caret == NSRange(location: 5, length: 0))
+
+        var beyond = NSRange(location: 0, length: 0)
+        _ = textView.firstRect(forCharacterRange: NSRange(location: 40, length: 2), actualRange: &beyond)
+        #expect(beyond == .notFound)
+
+        var missing = NSRange(location: 0, length: 0)
+        let rect = textView.firstRect(forCharacterRange: .notFound, actualRange: &missing)
+        #expect(missing == .notFound)
+        #expect(rect == .zero)
+    }
+
+    /// The guard has to hold with a NULL `actualRange` too: the raising call used to sit inside a
+    /// branch that only ran when the caller wanted the adjusted range back.
+    @Test()
+    @MainActor
+    func firstRectSurvivesAnOutOfBoundsRangeWithNoActualRange() {
+        let textView = makeTextView(string: "Hello")
+
+        #expect(textView.firstRect(forCharacterRange: NSRange(location: 99, length: 4), actualRange: nil) == .zero)
+    }
+
+    @Test()
+    @MainActor
+    func insertTextClampsAReplacementRangeThatOutrunsTheDocument() {
+        let textView = makeTextView(string: "Hello")
+
+        textView.insertText("X", replacementRange: NSRange(location: 4, length: 99))
+
+        #expect(textView.string == "HellX")
+    }
+
+    @Test()
+    @MainActor
+    func insertTextAppendsWhenTheReplacementRangeStartsPastTheEnd() {
+        let textView = makeTextView(string: "Hello")
+
+        textView.insertText("X", replacementRange: NSRange(location: 12, length: 3))
+
+        #expect(textView.string == "HelloX")
+    }
+
+    @Test()
+    @MainActor
+    func setMarkedTextSurvivesAReplacementRangeThatOutrunsTheDocument() {
+        let textView = makeTextView(string: "Hello")
+
+        textView.setMarkedText(
+            "ni",
+            selectedRange: NSRange(location: 2, length: 0),
+            replacementRange: NSRange(location: 12, length: 3)
+        )
+
+        #expect(textView.string == "Helloni")
+    }
+
+    /// Multi-cursor input marks one range per cursor. Once the document shrinks under them they can
+    /// all resolve to the same position, and replacing that position once per cursor would insert
+    /// the text as many times as there were cursors.
+    @Test()
+    @MainActor
+    func replacementRangesThatResolveToTheSamePositionCollapse() {
+        let textView = makeTextView(string: "Hello")
+
+        let resolved = textView.resolvedReplacementRanges([
+            NSRange(location: 9, length: 2),
+            NSRange(location: 12, length: 4),
+            NSRange(location: NSNotFound, length: 0),
+            NSRange(location: 1, length: 1)
+        ])
+
+        #expect(resolved == [NSRange(location: 5, length: 0), NSRange(location: 1, length: 1)])
+    }
+
+    /// A composition spans many callbacks, and an edit made through any other path in between
+    /// leaves the marked ranges pointing at text that has moved. Resolving only what gets replaced
+    /// stops the crash but leaves the bookkeeping stale, so the next keystroke appends instead of
+    /// replacing what the one before it inserted.
+    @Test()
+    @MainActor
+    func aCompositionSurvivesAnEditMadeOutsideIt() {
+        let textView = makeTextView(string: "Hello")
+        textView.selectionManager.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.setMarkedText(
+            "n",
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        #expect(textView.string == "Hellon")
+
+        textView.replaceCharacters(in: NSRange(location: 0, length: 6), with: "Hi")
+
+        textView.setMarkedText(
+            "ni",
+            selectedRange: NSRange(location: 2, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        #expect(textView.string == "Hini")
+
+        textView.setMarkedText(
+            "nih",
+            selectedRange: NSRange(location: 3, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        #expect(textView.string == "Hinih")
+    }
+
+    @MainActor
+    private func makeTextView(string: String) -> TextView {
+        let textView = TextView(string: string)
+        textView.isEditable = true
+        textView.frame = NSRect(x: 0, y: 0, width: 1_000, height: 100)
+        textView.layoutManager.layoutLines(in: CGRect(origin: .zero, size: CGSize(width: 1_000, height: 100)))
+        return textView
+    }
+}


### PR DESCRIPTION
Fixes #2339.

## The problem

`TextView`'s `NSTextInputClient` conformance treated a caller-supplied `NSRange` as trusted. The callers are macOS system services, and they are documented to send ranges that fall outside the document: the doc comment sitting directly above the method that crashes is Apple's own text, and it says an implementation "should be prepared for aRange to be out of bounds", should return the intersection, and should return nil when the location is completely outside. Ghostty ships a comment on the same method saying "a lot of macOS system behaviors request bogus ranges", naming Look Up and QuickLook, so an IME is not even needed to reach this.

The write half is worse than the read half, and it is not an Objective-C exception at all:

- **Read half.** `attributedSubstring(forProposedRange:actualRange:)` and `firstRect(forCharacterRange:actualRange:)` passed the raw range to `rangeOfComposedCharacterSequences(for:)` and `attributedSubstring(from:)`. Measured on macOS 27: `NSInvalidArgumentException` ("The index N is invalid") and `NSRangeException`. Whether that kills the app depends on which dispatch path the callback arrived on. Measured: an exception under `sendEvent`, a `Timer`, or a `CFRunLoopSource0` callout is swallowed; one inside a main-queue block is fatal; and `NSApplicationCrashOnExceptions=YES`, which any crash-reporting SDK sets, makes it always fatal. Even swallowed it unwinds AppKit's input-manager frames mid-operation and skips Swift deinits, so the input session is left inconsistent.
- **Write half.** `insertText(_:replacementRange:)` and `setMarkedText(_:selectedRange:replacementRange:)` forwarded the range into `replaceCharacters(in:with:)`, which registers undo before it validates anything. Building the inverse mutation slices the storage, and TextStory answers an out-of-range slice with `fatalError("Range invalid for string")`. Measured: `insertText("X", replacementRange: NSRange(location: 4, length: 99))` on a five-character document exits with signal 5. No exception handler can reach that one and no dispatch path swallows it.

`unmarkText()` and the marked-text branch of `insertText` feed stored ranges back in, and `MarkedTextManager` has no hook for edits made through any other path, so its ranges outlive the text they were computed against.

## The fix

The clamp sits at the `NSTextInputClient` boundary, which is where the untrusted values enter, and `replaceCharacters` stays strict for first-party callers such as Vim and the inline suggestions. Every peer engine that implements this protocol without `NSTextView` does the same: STTextView, Chromium, WebKit, Zed and Ghostty all resolve the range against the document before touching storage.

- `NSRange.resolved(inDocumentOfLength:)` composes the package's existing `clamped(toLength:)` and returns nil for the cases a clamp cannot express: `NSNotFound`, a negative location or length, and a location plus length that overflows. That last one also protects `clamped(toLength:)` itself, whose `max` traps on those inputs.
- `attributedSubstring(forProposedRange:actualRange:)` presets `actualRange` to `{NSNotFound, 0}`, returns nil when the range names nothing in the document, and otherwise writes the resolved range and returns that substring.
- `firstRect(forCharacterRange:actualRange:)` resolves outside the `actualRange != nil` branch. The raising call used to sit inside it, so the old code only crashed when the caller wanted the adjusted range back. A zero-length range still resolves, because that is how an input method asks where to put its candidate window.
- The three sites that replace text on an input service's behalf resolve their ranges first, and two ranges that resolve to the same position collapse to one, so a multi-cursor composition cannot insert the same text once per cursor.
- `MarkedTextManager` resolves its own stored ranges before they are used. Resolving only what gets replaced would stop the crash and leave the bookkeeping stale, which corrupts the composition instead: measured, marking "n" into "Hello", replacing the document with "Hi" from elsewhere, then typing the composition gave "Hini" and then "Hininih" rather than "Hinih".
- `firstRect` falls back to the end-of-document rect, converted through the window, for a range it cannot resolve. Returning a bare `NSZeroRect` would have put the candidate window, the press-and-hold accent popover and the dictation indicator in the corner of the display, because that value is read as screen coordinates.
- `attributedSubstring` returns nil only when the location itself is outside the document, which is the case the protocol documents. A caret position inside it answers with an empty string, so a client reading the caret's context can still tell "no characters selected" from "no text here".

## Verification

- `swift test --package-path LocalPackages/CodeEditTextView`: 165 tests in 16 suites pass. Against the unfixed code the new suite dies with `NSInvalidArgumentException: The index 3 is invalid`, which is the reported failure.
- 14 new cases cover resolution itself, both read methods (past the end, entirely past the end, `NSNotFound`, `Int.max` length, empty document, grapheme rounding, caret positions), the caret rect, the NULL `actualRange` path, both write methods, the multi-cursor collapse, and a composition that survives an edit made outside it.
- `xcodebuild -scheme TablePro build`: passes.
- SwiftLint on the changed files adds no violations; the four it reports in `TextView+NSTextInput.swift` are present at HEAD as well.

No UI automation: reaching this needs a real input service to send a stale range, which no deterministic XCUITest can arrange.

## Found while investigating, not fixed here

All four were reproduced with compiled probes. None is required for this fix to be correct.

1. `unmarkText()` deletes the composition instead of accepting it, contradicting the docstring three lines above it. Measured side by side against `NSTextView`: on "alpha " with "ceshi" marked, AppKit keeps "alpha ceshi" and drops only the marking, while this view leaves "alpha ". Shift-click mid-composition, at `TextView+Mouse.swift:52`, throws away what the user typed.
2. `MarkedTextManager.updateForNewSelections` returns the inverse of what its own comment says, so collapsing to one cursor mid-composition leaves both marked ranges live and the commit writes two edits.
3. `CEUndoManager.registerMutation` never consults `isDisabled`, so every IME keystroke becomes its own undo step and Cmd+Z walks back through romaji that was never committed.
4. `MarkedTextManager` still has no edit-tracking hook of the kind `selectionManager.didReplaceCharacters` gives selections. This change resolves its ranges every time they are used, which is enough for the composition to stay correct, but the ranges still go stale in between.
