### PR TITLE
fix(editor): hide an emphasis whose text has been deleted instead of drawing it somewhere else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a crash on macOS 26 and later when the editor redrew a diagnostic underline or search highlight whose text had been edited away.
 - Fixed a crash when an input method, dictation or Look Up asked the editor about text that had already been edited away. (#2339)
+- A search highlight or diagnostic underline whose text you delete now disappears, instead of staying put or jumping to the end of the editor. (#2341)
 - The XLSX, MQL and SQL Import plugins linked to a documentation page that did not exist. They now point at Import & Export.
 
 ## [0.67.0] - 2026-08-21

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/EmphasisManager/EmphasisManager.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/EmphasisManager/EmphasisManager.swift
@@ -150,8 +150,16 @@ public final class EmphasisManager {
                 forStyle: emphasis.emphasis.style,
                 range: emphasis.emphasis.range
             ) else {
+                // An emphasis marks specific text. Once that text is gone there is no shape to
+                // draw, and the layer would otherwise keep painting the last one it had, over
+                // whatever now occupies that place. Hiding rather than clearing is what lets the
+                // shape come back when the range lays out again.
+                emphasis.layer.isHidden = true
+                emphasis.textLayer?.isHidden = true
                 continue
             }
+            emphasis.layer.isHidden = false
+            emphasis.textLayer?.isHidden = false
             if #available(macOS 14.0, *) {
                 emphasis.layer.path = shapePath.cgPath
             } else {
@@ -194,6 +202,15 @@ public final class EmphasisManager {
     }
 
     private func makeShapePath(forStyle emphasisStyle: EmphasisStyle, range: NSRange) -> NSBezierPath? {
+        // A range that no longer fits the document names text an edit has removed. Drawing it
+        // anyway puts the emphasis somewhere it does not belong: `roundedPathForRange` answers a
+        // range past the end with the caret rect at the end of the document, so a stale search
+        // highlight would reappear there rather than disappear.
+        guard let documentLength = textView?.textStorage.length,
+              range.resolved(inDocumentOfLength: documentLength) == range else {
+            return nil
+        }
+
         switch emphasisStyle {
         case .standard, .outline:
             return textView?.layoutManager.roundedPathForRange(range, cornerRadius: emphasisStyle.shapeRadius)

--- a/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/EmphasisManagerTests.swift
+++ b/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/EmphasisManagerTests.swift
@@ -81,6 +81,43 @@ struct EmphasisManagerTests {
         #expect(textView.layer?.sublayers?.count == 2)
     }
 
+    /// The layer keeps the last path it was given, so an emphasis whose text has been deleted would
+    /// otherwise go on painting over whatever now occupies that place. A search highlight was the
+    /// worst case: a range past the end resolves to the caret rect, so it reappeared at the end of
+    /// the document instead of disappearing.
+    @Test()
+    @MainActor
+    func anEmphasisWhoseTextIsGoneStopsBeingDrawn() throws {
+        let textView = makeLaidOutTextView()
+
+        textView.emphasisManager?.addEmphasis(
+            Emphasis(range: NSRange(location: 6, length: 5), style: .standard),
+            for: "e"
+        )
+        let layer = try #require(textView.layer?.sublayers?.first)
+        #expect(layer.isHidden == false)
+
+        textView.textStorage.replaceCharacters(in: NSRange(location: 5, length: 6), with: "")
+        textView.layoutManager.layoutLines(in: CGRect(origin: .zero, size: CGSize(width: 1_000, height: 100)))
+        textView.emphasisManager?.updateLayerBackgrounds()
+
+        #expect(textView.layer?.sublayers?.allSatisfy(\.isHidden) == true)
+    }
+
+    @Test()
+    @MainActor
+    func anEmphasisWhoseTextIsStillThereKeepsBeingDrawn() {
+        let textView = makeLaidOutTextView()
+
+        textView.emphasisManager?.addEmphasis(
+            Emphasis(range: NSRange(location: 0, length: 5), style: .standard),
+            for: "e"
+        )
+        textView.emphasisManager?.updateLayerBackgrounds()
+
+        #expect(textView.layer?.sublayers?.contains(where: \.isHidden) == false)
+    }
+
     @MainActor
     private func makeLaidOutTextView() -> TextView {
         let textView = TextView(string: "Lorem Ipsum")


### PR DESCRIPTION
Fixes #2341.

## The problem

`EmphasisManager.updateLayerBackgrounds()` runs on every draw and skips any emphasis whose shape it cannot build. Skipping leaves that emphasis's `CAShapeLayer` holding the last path it was given, so once the text under it is edited away the highlight goes on painting at its old position, over whatever now occupies that place.

Search highlights had a worse version of it. `roundedPathForRange` answers a range whose length no longer fits with `rectForEndOffset()`, the caret rect at the end of the document, so a stale `.standard` emphasis did not keep its old position: it jumped to the end of the editor and drew a highlight over nothing.

This was split out of #2338, which fixed the crash on the same code path and deliberately left the behaviour alone, and the risk it names is why: an attribute-only edit invalidates lines, so clearing too eagerly could make a find highlight blink off and on during ordinary syntax highlighting traffic.

## The fix

Two parts, and the second is what makes the first safe.

- `makeShapePath` returns nil when the emphasis range no longer fits the document, so a range that outran the text stops resolving to the caret rect at the end. An emphasis marks specific text; once that text is gone there is no shape to draw.
- The skip path hides the emphasis and text layers instead of leaving them visible with a stale path, and the draw path unhides them.

Hiding rather than clearing the path is what answers the flicker risk. A line that is invalidated and re-typeset inside the same layout pass has its rects back before the draw, so nothing changes for it. A line invalidated outside the layout window has no rects and is not on screen either, so hiding it is not observable. When the range lays out again the layer is unhidden with its shape intact, rather than having to be rebuilt.

## Verification

- `swift test --package-path LocalPackages/CodeEditTextView`: 167 tests in 16 suites pass, including 2 new ones. Against the unfixed code `anEmphasisWhoseTextIsGoneStopsBeingDrawn` fails: the layer is still visible after its text is deleted.
- The control case, `anEmphasisWhoseTextIsStillThereKeepsBeingDrawn`, fails any fix that hides too much.
- `xcodebuild -scheme TablePro build`: passes.

No UI automation: the assertion is about which layers are hidden inside the editor's own layer tree, which XCUITest cannot see.
