### PR TITLE
fix(plugin-sqlite): report a query that stops early instead of returning the rows it got

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a crash on macOS 26 and later when the editor redrew a diagnostic underline or search highlight whose text had been edited away.
 - Fixed a crash when an input method, dictation or Look Up asked the editor about text that had already been edited away. (#2339)
 - Fixed crashes when the editor's layout, syntax highlighting or accessibility read text that a newer edit had already removed. (#2340)
+- A SQLite query that stops early, because the database is locked or the volume returns an error, now says so instead of showing an empty table.
 - The XLSX, MQL and SQL Import plugins linked to a documentation page that did not exist. They now point at Import & Export.
 
 ## [0.67.0] - 2026-08-21

--- a/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
+++ b/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
@@ -173,7 +173,8 @@ private actor SQLiteConnectionActor {
         var rowsAffected = 0
         var truncated = false
 
-        while sqlite3_step(statement) == SQLITE_ROW {
+        var stepResult = sqlite3_step(statement)
+        while stepResult == SQLITE_ROW {
             if rows.count >= PluginRowLimits.emergencyMax {
                 truncated = true
                 break
@@ -200,6 +201,11 @@ private actor SQLiteConnectionActor {
             }
 
             rows.append(row)
+            stepResult = sqlite3_step(statement)
+        }
+
+        if !truncated, stepResult != SQLITE_DONE {
+            throw SQLitePluginError.queryFailed(String(cString: sqlite3_errmsg(db)))
         }
 
         if columns.isEmpty {
@@ -259,7 +265,8 @@ private actor SQLiteConnectionActor {
         var batch: [PluginRow] = []
         batch.reserveCapacity(batchSize)
 
-        while sqlite3_step(statement) == SQLITE_ROW {
+        var stepResult = sqlite3_step(statement)
+        while stepResult == SQLITE_ROW {
             if Task.isCancelled {
                 if !batch.isEmpty {
                     continuation.yield(.rows(batch))
@@ -294,10 +301,21 @@ private actor SQLiteConnectionActor {
                 continuation.yield(.rows(batch))
                 batch.removeAll(keepingCapacity: true)
             }
+            stepResult = sqlite3_step(statement)
         }
 
         if !batch.isEmpty {
             continuation.yield(.rows(batch))
+        }
+
+        // A step that ends on anything but `SQLITE_DONE` stopped early: a locked database, an I/O
+        // error on the volume, a corrupt page. Finishing the stream normally would report the rows
+        // read so far as the whole table, which is indistinguishable from an empty one.
+        guard stepResult == SQLITE_DONE else {
+            let message = String(cString: sqlite3_errmsg(db))
+            sqlite3_finalize(statement)
+            continuation.finish(throwing: SQLitePluginError.queryFailed(message))
+            return
         }
 
         sqlite3_finalize(statement)
@@ -371,7 +389,8 @@ private actor SQLiteConnectionActor {
         var rowsAffected = 0
         var truncated = false
 
-        while sqlite3_step(statement) == SQLITE_ROW {
+        var stepResult = sqlite3_step(statement)
+        while stepResult == SQLITE_ROW {
             if rows.count >= PluginRowLimits.emergencyMax {
                 truncated = true
                 break
@@ -398,6 +417,11 @@ private actor SQLiteConnectionActor {
             }
 
             rows.append(row)
+            stepResult = sqlite3_step(statement)
+        }
+
+        if !truncated, stepResult != SQLITE_DONE {
+            throw SQLitePluginError.queryFailed(String(cString: sqlite3_errmsg(db)))
         }
 
         if columns.isEmpty {

--- a/TableProUITests/SQLiteFirstTableLoadUITests.swift
+++ b/TableProUITests/SQLiteFirstTableLoadUITests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+/// Issue #2342. The first table clicked after opening a SQLite database showed "Executing…"
+/// forever. Cancelling it and clicking any table afterwards, including the same one, loaded
+/// immediately, and an empty table stalled exactly like a large one, so the stall was never the
+/// query itself.
+final class SQLiteFirstTableLoadUITests: UITestCase {
+    func testTheFirstTableClickAfterOpeningADatabaseLoadsItsRows() throws {
+        let app = try launchWithSampleDatabase()
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitToExist(timeout: 30))
+        XCTAssertTrue(
+            waitForPredicate(timeout: 30) { window.outlines.firstMatch.outlineRows.count > 1 },
+            "The object browser must list the sample database's tables"
+        )
+
+        clickAtCenter(try tableRow(named: "Album", in: window))
+
+        let grid = window.tables.matching(identifier: "data-grid").firstMatch
+        XCTAssertTrue(grid.waitToExist(timeout: 30), "The first table click must open the data grid")
+        XCTAssertTrue(
+            waitForPredicate(timeout: 30) { !grid.tableRows.allElementsBoundByIndex.isEmpty },
+            "The first table click must load its rows rather than stall"
+        )
+        XCTAssertTrue(
+            waitForPredicate(timeout: 15) { !window.staticTexts["Executing…"].exists },
+            "The executing indicator must clear once the rows are in"
+        )
+    }
+
+    private func tableRow(named name: String, in window: XCUIElement) throws -> XCUIElement {
+        let match = window.outlines.firstMatch.staticTexts
+            .matching(NSPredicate(format: "value == %@", "Table: \(name)"))
+            .firstMatch
+        XCTAssertTrue(match.waitToExist(timeout: 20), "The object browser must list \(name)")
+        return match
+    }
+}


### PR DESCRIPTION
Found while investigating #2342. This does **not** close that issue: the reported hang did not reproduce here, and what it fixes is a different, measured defect on the same path. See the note at the end for where #2342 stands.

## The defect

All three `sqlite3_step` loops in the SQLite driver were written as `while sqlite3_step(stmt) == SQLITE_ROW`, so the code that ends the loop was never looked at. `SQLITE_ROW` is one of six things a step can return, and every other one exits the loop the same way a clean finish does.

The result is that a query that failed halfway, or never started, is reported as a successful result containing whatever rows were read before it stopped:

- A database locked by another process returns zero rows and no error, so the grid renders an empty table.
- An I/O error partway through a scan on a network volume returns the rows read so far as the complete table.
- A corrupt page does the same.

Measured against the system SQLite (3.54.0, which is what `project.yml:526` links), with a second handle holding `BEGIN EXCLUSIVE` while a prepared statement steps:

```
PROBE rows=0 terminatingCode=5 isDone=false
PROBE oldBehaviour: returns a successful result with 0 rows and no error
PROBE newBehaviour: throws 'database is locked'
```

The `prepare` call was already checked, which is why this only shows up when the lock is taken after the statement is prepared, or when the failure happens mid-scan.

## The fix

Each of the three loops keeps its terminating code and reports anything that is not `SQLITE_DONE` as the error SQLite gives for it. The buffered paths throw; the streaming path finishes its continuation with the error rather than completing normally, after yielding what it had. Hitting the row cap is still a clean truncation, not an error.

## Verification

- `xcodebuild -scheme TablePro build`: passes. The SQLite driver is a bundled plugin, so this compiles it.
- The probe above, before and after.
- New UI test `SQLiteFirstTableLoadUITests`: opens the sample SQLite database, clicks a table, and asserts the rows arrive and the "Executing…" indicator clears. It passes on `main`, which is part of why #2342 is still open; it is here so the flow the issue describes has a test at all.

No unit test: the SQLite driver has no test target, its sources are not in `TableProTests`, and the actor that owns these loops is private to the plugin. Making it testable means putting the plugin's sources in the test target, which is a change worth making on its own rather than inside this one.

## Where #2342 stands

Not reproduced, so not fixed. What was ruled out, all by measurement:

- **The driver's connect path.** `sqlite3_open` is lazy and took 0.1ms; the file is untouched until the first statement.
- **A second connection blocking the first.** TablePro opens a pooled metadata connection alongside the browse query, so this was the leading theory. An uncommitted writer does not block a second handle's reads in rollback-journal mode, and WAL never blocks them.
- **Row count.** Nothing in the driver treats an empty table differently, which matches the reporter saying an empty table hangs the same way.

What is still open, and what would settle it: whether the stall is in the app's execution-ownership state (`retireQueryTask` clears the toolbar only for the claim that installed it) or in a wait that never returns. Both would need the reporter's own database, or the `TableLoadTracer` output from a session where it happens.

Two things worth fixing separately, both confirmed while investigating:

1. `sqlite3_interrupt` does not break a busy wait, measured. Stop therefore cannot end a lock wait, only the app's own state, so the driver keeps waiting out the busy timeout with nothing to stop it. A `sqlite3_busy_handler` that checks a cancel flag would make Stop reach it.
2. Every non-parameterized DML statement reports "0 rows affected": `executeUserQuery` returns a hardcoded `rowsAffected: 0` for the streaming path, and `sqlite3_changes` is only called on the two buffered ones. MySQL and PostgreSQL report the true count, so SQLite is the only driver that tells a user their `DELETE` did nothing.
