### PR TITLE
fix(tests): find version pins in scripts/lib, and drop the duplicated OpenSSL constants

### DIFF
--- a/TableProTests/Core/ThirdPartyLicenseInventoryTests.swift
+++ b/TableProTests/Core/ThirdPartyLicenseInventoryTests.swift
@@ -38,13 +38,20 @@ struct ThirdPartyLicenseInventoryTests {
     /// static libraries are actually built from.
     private static func shellVersionPins() throws -> [String: String] {
         let scripts = repositoryRoot.appendingPathComponent("scripts")
-        let names = try FileManager.default.contentsOfDirectory(atPath: scripts.path)
-            .filter { $0.hasPrefix("build-") && $0.hasSuffix(".sh") } + ["openssl-version.sh"]
+        /// `scripts/lib` as well as the build scripts. A pin shared by several builds lives in the
+        /// library rather than in any one script, and naming a single file here meant the test
+        /// stopped seeing `OPENSSL_VERSION` the moment it moved there.
+        let buildScripts = try FileManager.default.contentsOfDirectory(atPath: scripts.path)
+            .filter { $0.hasPrefix("build-") && $0.hasSuffix(".sh") }
+            .map { scripts.appendingPathComponent($0) }
+        let libraryDirectory = scripts.appendingPathComponent("lib")
+        let libraryScripts = ((try? FileManager.default.contentsOfDirectory(atPath: libraryDirectory.path)) ?? [])
+            .filter { $0.hasSuffix(".sh") }
+            .map { libraryDirectory.appendingPathComponent($0) }
 
         let pattern = try NSRegularExpression(pattern: #"^([A-Z0-9_]+_VERSION)="(v?[0-9][^"$]*)""#, options: [.anchorsMatchLines])
         var pins: [String: String] = [:]
-        for name in names {
-            let path = scripts.appendingPathComponent(name)
+        for path in buildScripts + libraryScripts {
             guard let source = try? String(contentsOf: path, encoding: .utf8) else { continue }
             let range = NSRange(source.startIndex ..< source.endIndex, in: source)
             for match in pattern.matches(in: source, range: range) {

--- a/scripts/lib/macos.sh
+++ b/scripts/lib/macos.sh
@@ -76,8 +76,8 @@ verify_deployment_target() {
     fi
 }
 
-OPENSSL_VERSION="3.4.3"
-OPENSSL_SHA256="fa727ed1399a64e754030a033435003991aee36bda9a5b080995cb2ac5cf7f37"
+# OPENSSL_VERSION and OPENSSL_SHA256 come from common.sh, sourced above. They were duplicated
+# here by the split, which is the thing this library exists to stop.
 
 # Downloads the OpenSSL tarball into BUILD_DIR once, verified against the pin above.
 fetch_openssl() {


### PR DESCRIPTION
**main is red on this**, and #2336 is what broke it. I did not run the full unit suite after that change, and this is what it would have caught.

```
Test "A component's recorded version matches the version its build script pins"
  recorded an issue at ThirdPartyLicenseInventoryTests.swift:143:13
  Expectation failed: pinned != nil
```

`shellVersionPins()` scanned `scripts/build-*.sh` plus a hardcoded `"openssl-version.sh"`. #2336 deleted that file and moved `OPENSSL_VERSION` into `scripts/lib/common.sh`, so the test stopped finding the pin the OpenSSL license entry points at, and every run since has failed.

It now scans `scripts/lib/*.sh` as well, by directory rather than by naming a file. A pin shared by several build scripts belongs in the library, which is exactly why hardcoding one filename was fragile.

## A second thing, from the same change

`OPENSSL_VERSION` and `OPENSSL_SHA256` ended up defined in **both** `scripts/lib/common.sh` and `scripts/lib/macos.sh`. `macos.sh` sources `common.sh`, so the second copy shadowed the first. Both said `3.4.3`, so nothing misbehaved, but a duplicated constant in the library whose whole purpose is removing duplicated constants is the bug that library exists to prevent. The copy in `macos.sh` is gone; sourcing it still exposes the value.

## Verification

The full unit suite, run from a relocated build:

```
Test run with 11666 tests in 1387 suites passed after 131.649 seconds
issues: 0
```

`ThirdPartyLicenseInventoryTests` passes all 9 of its cases. `shellcheck -x` is clean on the library, and sourcing `macos.sh` still yields `OPENSSL_VERSION=3.4.3`.