### PR TITLE
fix(build): make the app bundle self-contained instead of reaching into the source tree

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -110,6 +110,22 @@ targets:
       - path: TablePro/Resources/ThirdPartyLicenses
         type: folder
         buildPhase: resources
+      # Copied into the bundle rather than reached through an absolute rpath into the source
+      # tree. TablePro.debug.dylib and the MySQL, PostgreSQL and Redis plugins all link
+      # @rpath/libssl.3.dylib and @rpath/libcrypto.3.dylib, and both dylibs already carry an
+      # @rpath install name, so @executable_path/../Frameworks resolves them once they are here.
+      #
+      # Without this the app only launched from a checkout that had Libs/dylibs on disk, which is
+      # what made the sharded test jobs abort with SIGABRT before XCTest could connect (#2334).
+      # A release build was already self-contained, because build-release.sh copies them in.
+      - path: Libs/dylibs/libssl.3.dylib
+        buildPhase:
+          copyFiles:
+            destination: frameworks
+      - path: Libs/dylibs/libcrypto.3.dylib
+        buildPhase:
+          copyFiles:
+            destination: frameworks
     configFiles:
       Debug: Configs/Version.xcconfig
       Release: Configs/Version.xcconfig
@@ -198,7 +214,9 @@ targets:
         LD_RUNPATH_SEARCH_PATHS:
           - $(inherited)
           - "@executable_path/../Frameworks"
-          - $(SRCROOT)/Libs/dylibs
+          # No $(SRCROOT)/Libs/dylibs here. The two dylibs are copied into Contents/Frameworks
+          # above, so @executable_path/../Frameworks resolves them and the built app no
+          # longer depends on the checkout it was built from.
         LIBRARY_SEARCH_PATHS:
           - $(inherited)
           - $(SRCROOT)/Libs/dylibs


### PR DESCRIPTION
The root cause behind #2334. That PR restored `Libs/` in the test jobs and asserted the two dylibs exist, which stops the symptom; this stops the app needing them from a source tree at all.

## What was wrong

`project.yml` put `$(SRCROOT)/Libs/dylibs` on `LD_RUNPATH_SEARCH_PATHS`, which bakes an absolute path into the binary. `TablePro.debug.dylib` is the app's own code, loaded at launch, and it links `@rpath/libssl.3.dylib` and `@rpath/libcrypto.3.dylib`. Those are not copied into the bundle in a Debug build, so that absolute rpath was the only thing resolving them.

A Debug app therefore only ran from a checkout that happened to have `Libs/dylibs` on disk. When the sharded test jobs stopped downloading `Libs`, the host aborted with SIGABRT before XCTest could connect, reporting zero tests and naming neither the library nor the reason.

A release build was already self-contained: `build-release.sh`'s `bundle_dylibs()` copies them in and rewrites the install names.

## The fix

Both dylibs already carry an `@rpath/` install name, set by `create-openssl-dylibs.sh`, so copying them into `Contents/Frameworks` is enough and no `install_name_tool` is needed. A copy-files phase does that, and `@executable_path/../Frameworks` was already first on the rpath list.

`$(SRCROOT)/Libs/dylibs` then comes off the app target's `LD_RUNPATH_SEARCH_PATHS`. `LIBRARY_SEARCH_PATHS` keeps it, because that is link time and legitimate.

## Verified by building

```
Contents/Frameworks/   libcrypto.3.dylib  libssl.3.dylib

app rpaths:  @executable_path
             @loader_path
             <DerivedData>/Build/Products/Debug/PackageFrameworks
             @executable_path/../Frameworks

source-tree rpaths: 0
```

Then the scenario that failed in #2334: products tarred, unpacked into a different directory, and the full unit suite run against them.

```
Test run with 11666 tests in 1387 suites passed after 132 seconds
```

The host launches, no SIGABRT. The remaining absolute path is the DerivedData `PackageFrameworks` entry, which is normal for a Debug build and travels inside the products tarball.

## Scope

The six plugin targets keep their `$(SRCROOT)/Libs/dylibs` rpath entry. A plugin loaded into the app resolves through the app's `Contents/Frameworks` anyway, so the entry is inert there, and I cannot verify a registry plugin installed outside the bundle from here. Removing those is cosmetic and belongs with someone who can test that path.