### PR TITLE
ci: one place for the Xcode version and one for the changed-path detector

### DIFF
--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -1,0 +1,26 @@
+name: Select Xcode
+description: Selects the Xcode version every TablePro build and test job uses.
+
+# The version lives here and nowhere else. It used to be written out in four workflows, eight
+# times counting the pinned action SHA beside it, so bumping Xcode meant finding every copy and
+# a missed one silently built against a different toolchain.
+
+inputs:
+  xcode-version:
+    description: Override the pinned version. Leave unset; it exists for trying a toolchain on one job.
+    required: false
+    default: "26.4.1"
+
+runs:
+  using: composite
+  steps:
+    - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+      with:
+        xcode-version: ${{ inputs.xcode-version }}
+
+    # Proves the pin was actually applied before a twenty minute build starts. build.yml carried
+    # this as a separate step in both of its jobs.
+    - shell: bash
+      run: |
+        echo "Active Xcode: $(xcode-select -p)"
+        xcodebuild -version

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -121,9 +121,7 @@ jobs:
         run: git lfs pull
 
       - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
-        with:
-          xcode-version: "26.4.1"
+        uses: ./.github/actions/setup-xcode
 
       - name: Setup XcodeGen
         uses: ./.github/actions/setup-xcodegen

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,9 +67,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
-        with:
-          xcode-version: '26.4.1'
+        uses: ./.github/actions/setup-xcode
 
       - name: Download static libraries
         env:
@@ -103,14 +101,6 @@ jobs:
 
       - name: Prepare libraries
         run: scripts/ci/prepare-libs.sh ${{ matrix.arch }}
-
-      # The only thing that proves the pinned toolchain was actually selected before a twenty
-      # minute build starts.
-      - name: Verify Xcode
-        run: |
-          echo "Active Xcode:"
-          xcode-select -p
-          xcodebuild -version
 
       - name: Create Secrets.xcconfig
         env:
@@ -188,9 +178,7 @@ jobs:
           fetch-depth: 0
 
       - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
-        with:
-          xcode-version: '26.4.1'
+        uses: ./.github/actions/setup-xcode
 
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -47,24 +47,15 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        # Shared with macos-tests.yml; see scripts/ci/detect-changed-paths.sh.
         run: |
           set -euo pipefail
-
-          if [ "$EVENT_NAME" != "pull_request" ]; then
-              echo "run=true" >> "$GITHUB_OUTPUT"
-              exit 0
-          fi
-
-          # Raw NUL-separated records, read from a file. See the note in macos-tests.yml for what
-          # core.quotePath and a pipeline each break here.
-          git -c core.quotePath=false diff --no-renames --name-only -z \
-              "$BASE_SHA" HEAD > "$RUNNER_TEMP/changed-files"
-
-          if LC_ALL=C grep -zqE '^(TableProMobile/|Configs/|Packages/TableProCore/|Libs/|\.github/workflows/ios-tests\.yml$)' "$RUNNER_TEMP/changed-files"; then
-              echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-              echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
+          RUN=$(scripts/ci/detect-changed-paths.sh \
+            --event "$EVENT_NAME" \
+            --base "$BASE_SHA" \
+            'TableProMobile/' 'Configs/' 'Packages/TableProCore/' 'Libs/' 'scripts/' \
+            '\.github/actions/' '\.github/workflows/ios-tests\.yml$')
+          echo "run=$RUN" >> "$GITHUB_OUTPUT"
 
   test:
     name: Run iOS Tests

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -73,60 +73,24 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           REF: ${{ github.ref }}
+        # The reasoning lives in scripts/ci/detect-changed-paths.sh. It was inline here and in
+        # ios-tests.yml, with a comment asking a human to keep the two copies in step and nothing
+        # enforcing it.
         run: |
           set -euo pipefail
+          RUN=$(scripts/ci/detect-changed-paths.sh \
+            --event "$EVENT_NAME" \
+            --base "$BASE_SHA" \
+            --ref "$REF" \
+            --skip-release-commit \
+            'TablePro/' 'Plugins/' 'Packages/' 'LocalPackages/' \
+            'TableProTests/' 'TableProUITests/' 'Native/' 'Configs/' 'Libs/' 'scripts/' \
+            '\.github/actions/' '\.github/macos-(ui-)?test-quarantine\.txt$' \
+            'TablePro\.xcodeproj/project\.xcworkspace/xcshareddata/swiftpm/Package\.resolved$' \
+            'TableProMobile/project\.yml$' 'project\.yml$' \
+            '\.github/workflows/macos-tests\.yml$')
+          echo "run=$RUN" >> "$GITHUB_OUTPUT"
 
-          # A release pushes the version commit to main and then tags that same commit, so the
-          # push and the tag both reach this workflow: once directly, once through build.yml's
-          # workflow_call. That tests one SHA twice on two macos-26 runners, and because the
-          # account runs five macOS jobs at a time, the duplicate is what leaves the release's
-          # own suite queued behind it. The tag run is the one that gates the release, so the
-          # push to main stands down. github.ref belongs to the caller, so build.yml's
-          # workflow_call reads refs/tags/v* here and can never match this guard, which is what
-          # keeps "a release that skipped its tests" impossible.
-          #
-          # The subject goes into a variable instead of a pipe into grep. grep -q exits on the
-          # first match, and the SIGPIPE that then kills git log would surface through pipefail
-          # as a skipped guard (the same trap scripts/check-freetds-fedauth.sh:69 documents).
-          SUBJECT="$(git log -1 --format=%s HEAD)"
-          if [ "$EVENT_NAME" = "push" ] && [ "$REF" = "refs/heads/main" ] &&
-             [[ "$SUBJECT" =~ ^release:\ v[0-9] ]]; then
-              echo "run=false" >> "$GITHUB_OUTPUT"
-              exit 0
-          fi
-
-          # Anything that is not a pull request runs the full suite: a release calls this
-          # workflow with workflow_call, and a release that skipped its tests is the failure
-          # this guard exists to prevent.
-          if [ "$EVENT_NAME" != "pull_request" ]; then
-              echo "run=true" >> "$GITHUB_OUTPUT"
-              exit 0
-          fi
-
-          # core.quotePath defaults to true, which wraps any path holding a non-ASCII byte or a
-          # control character in double quotes and C-escapes it, so `TablePro/Café.swift` arrives
-          # as `"TablePro/Caf\303\251.swift"` and the leading quote defeats the `^` anchor. This
-          # detector fails open, so a misread means every suite skips behind a green gate. Reading
-          # raw NUL-separated records removes both that and any embedded-newline trick.
-          #
-          # A file, not a variable: bash drops NUL bytes from "$(...)", which would run every path
-          # together into one record. It also keeps grep out of a pipeline, so the SIGPIPE that
-          # scripts/check-freetds-fedauth.sh:69 warns about cannot come back.
-          git -c core.quotePath=false diff --no-renames --name-only -z \
-              "$BASE_SHA" HEAD > "$RUNNER_TEMP/changed-files"
-
-          # Keep in step with the `push: paths:` list above. scripts/ and .github/actions/ are on
-          # both because the jobs below execute them: a change to the shard tooling or to the
-          # quarantine files used to merge behind a green gate having run nothing.
-          if LC_ALL=C grep -zqE '^(TablePro/|Plugins/|Packages/|LocalPackages/|TableProTests/|TableProUITests/|Native/|Configs/|Libs/|scripts/|\.github/actions/|\.github/macos-(ui-)?test-quarantine\.txt$|TablePro\.xcodeproj/project\.xcworkspace/xcshareddata/swiftpm/Package\.resolved$|TableProMobile/project\.yml$|project\.yml$|\.github/workflows/macos-tests\.yml$)' "$RUNNER_TEMP/changed-files"; then
-              echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-              echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  # One job for both packages rather than two. They cost 1.3 and 2.1 minutes, and a macOS
-  # concurrency slot is the scarce resource here: the account runs five at a time, and the build
-  # plus three UI shards plus the unit job already want four of them.
   packages:
     name: Package Tests
     needs: changes

--- a/scripts/ci/detect-changed-paths.sh
+++ b/scripts/ci/detect-changed-paths.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Decides whether a workflow's suites need to run for this event. Prints "true" or "false".
+#
+# Usage:
+#   detect-changed-paths.sh --event <name> [--base <sha>] [--ref <ref>] [--skip-release-commit] \
+#                           <path-regex> [<path-regex>...]
+#
+# The path arguments are alternatives in one anchored regex, so pass prefixes like "TablePro/" or
+# anchored files like 'project\.yml$'.
+#
+# This lived twice, inline in macos-tests.yml and ios-tests.yml, with a comment asking a human to
+# keep the two copies in step and nothing enforcing it. The reasoning below is the part worth not
+# duplicating.
+
+EVENT=""
+BASE=""
+REF=""
+SKIP_RELEASE_COMMIT=0
+PATTERNS=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --event) EVENT="${2:?--event needs a value}"; shift 2 ;;
+        --base) BASE="${2:-}"; shift 2 ;;
+        --ref) REF="${2:-}"; shift 2 ;;
+        --skip-release-commit) SKIP_RELEASE_COMMIT=1; shift ;;
+        --) shift; PATTERNS+=("$@"); break ;;
+        -*) echo "detect-changed-paths.sh: unknown flag $1" >&2; exit 2 ;;
+        *) PATTERNS+=("$1"); shift ;;
+    esac
+done
+
+[ -n "$EVENT" ] || { echo "detect-changed-paths.sh: --event is required" >&2; exit 2; }
+[ "${#PATTERNS[@]}" -gt 0 ] || { echo "detect-changed-paths.sh: at least one path pattern is required" >&2; exit 2; }
+
+# A release pushes the version commit to main and then tags that same commit, so the push and the
+# tag both reach the workflow: once directly, once through build.yml's workflow_call. That tests one
+# SHA twice, and because the account runs five macOS jobs at a time, the duplicate is what leaves
+# the release's own suite queued behind it. The tag run is the one that gates the release, so the
+# push to main stands down. github.ref belongs to the caller, so a workflow_call reads refs/tags/v*
+# here and can never match this guard, which is what keeps "a release that skipped its tests"
+# impossible.
+#
+# The subject goes into a variable instead of a pipe into grep. grep -q exits on the first match,
+# and the SIGPIPE that then kills git log would surface through pipefail as a skipped guard (the
+# same trap scripts/check-freetds-fedauth.sh documents).
+if [ "$SKIP_RELEASE_COMMIT" -eq 1 ] && [ "$EVENT" = "push" ] && [ "$REF" = "refs/heads/main" ]; then
+    SUBJECT="$(git log -1 --format=%s HEAD)"
+    if [[ "$SUBJECT" =~ ^release:\ v[0-9] ]]; then
+        echo "false"
+        exit 0
+    fi
+fi
+
+# Anything that is not a pull request runs everything: a release calls the suite with
+# workflow_call, and a release that skipped its tests is the failure this exists to prevent.
+if [ "$EVENT" != "pull_request" ]; then
+    echo "true"
+    exit 0
+fi
+
+[ -n "$BASE" ] || { echo "detect-changed-paths.sh: --base is required for a pull request" >&2; exit 2; }
+
+# core.quotePath defaults to true, which wraps any path holding a non-ASCII byte or a control
+# character in double quotes and C-escapes it, so `TablePro/Café.swift` arrives as
+# `"TablePro/Caf\303\251.swift"` and the leading quote defeats the `^` anchor. This detector fails
+# open, so a misread means every suite skips behind a green gate. Reading raw NUL-separated records
+# removes both that and any embedded-newline trick.
+#
+# A file, not a variable: bash drops NUL bytes from "$(...)", which would run every path together
+# into one record. It also keeps grep out of a pipeline, so the SIGPIPE noted above cannot come back.
+CHANGED="$(mktemp)"
+trap 'rm -f "$CHANGED"' EXIT
+git -c core.quotePath=false diff --no-renames --name-only -z "$BASE" HEAD > "$CHANGED"
+
+JOINED="$(IFS='|'; echo "${PATTERNS[*]}")"
+if LC_ALL=C grep -zqE "^($JOINED)" "$CHANGED"; then
+    echo "true"
+else
+    echo "false"
+fi


### PR DESCRIPTION
Two pieces of CI that existed in several copies with a comment asking a human to keep them in step.

## The Xcode version

`26.4.1` was written out in four workflows, and the pinned `setup-xcode` SHA beside it eight times. Bumping Xcode meant finding every copy, and a missed one silently built against a different toolchain.

`.github/actions/setup-xcode` owns both now. Every workflow says `uses: ./.github/actions/setup-xcode` with no version. There are no `maxim-lobanov/setup-xcode` references and no `26.4.1` literals left in `.github/workflows`.

The composite also absorbs `build.yml`'s separate `Verify Xcode` step, which printed `xcode-select -p` and `xcodebuild -version` to prove the pin took effect. That belongs next to the selection, and now every job gets it rather than one.

## The changed-path detector

`macos-tests.yml` and `ios-tests.yml` each carried their own copy of the detector, including the whole comment explaining why it reads NUL-separated records with `core.quotePath=false` and why `grep` must stay out of a pipeline. The macOS copy carried the release-commit guard on top. A comment asked whoever edits one to keep the other in step; nothing enforced it.

It is `scripts/ci/detect-changed-paths.sh` now, taking the path patterns as arguments and the release guard as `--skip-release-commit`. `macos-tests.yml` goes from 463 lines to 414, `ios-tests.yml` from 200 to 180.

## Verified against real history

The detector was run against real commits in this repository:

| commit | first changed paths | run |
| --- | --- | --- |
| `b8a059a7b` | `TableProTests/…`, `scripts/…` | true |
| `889811082` | `docs/docs.json`, `docs/logo/dark.png` | false |
| `e0f1f399e` | `.github/workflows/macos-tests.yml` | true |

and the release guard was exercised in a worktree checked out at `5b2cc7a9a release: v0.67.0`, which is the exact case it exists for:

```
push to main, release commit, guard ON:   false
push to main, release commit, guard OFF:  true
workflow_call from the tag, guard ON:     true
```

`workflow_call` and tag pushes return true regardless, which is what keeps "a release that skipped its tests" impossible.

`actionlint` is clean across all six workflows and `shellcheck -x --severity=warning` clean on the new script. Both workflows still parse, and the `changes` job in each has exactly its checkout and its decide step.