### PR TITLE
ci: load every plugin before shipping it, and report where the test time goes

### DIFF
--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -1,0 +1,26 @@
+name: Select Xcode
+description: Selects the Xcode version every TablePro build and test job uses.
+
+# The version lives here and nowhere else. It used to be written out in four workflows, eight
+# times counting the pinned action SHA beside it, so bumping Xcode meant finding every copy and
+# a missed one silently built against a different toolchain.
+
+inputs:
+  xcode-version:
+    description: Override the pinned version. Leave unset; it exists for trying a toolchain on one job.
+    required: false
+    default: "26.4.1"
+
+runs:
+  using: composite
+  steps:
+    - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+      with:
+        xcode-version: ${{ inputs.xcode-version }}
+
+    # Proves the pin was actually applied before a twenty minute build starts. build.yml carried
+    # this as a separate step in both of its jobs.
+    - shell: bash
+      run: |
+        echo "Active Xcode: $(xcode-select -p)"
+        xcodebuild -version

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -121,9 +121,7 @@ jobs:
         run: git lfs pull
 
       - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
-        with:
-          xcode-version: "26.4.1"
+        uses: ./.github/actions/setup-xcode
 
       - name: Setup XcodeGen
         uses: ./.github/actions/setup-xcodegen

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -172,6 +172,24 @@ jobs:
       # Assert the result rather than trusting the flag. The previous notarization step was
       # gated on an environment variable nothing defined, so it never ran and nothing noticed
       # for every plugin release the registry has ever published.
+      # Before anything is published. The registry serves these to users directly, so a bundle
+      # that will not load is a plugin nobody can install.
+      - name: Verify the built bundles load
+        env:
+          BUNDLE_NAME: ${{ steps.plugin.outputs.bundleName }}
+        run: |
+          set -euo pipefail
+          for ARCH in arm64 x86_64; do
+            WORK="$(mktemp -d)"
+            unzip -oq "build/Plugins/${BUNDLE_NAME}-${ARCH}.zip" -d "$WORK"
+            # Only the native slice can be dlopened on this runner; the other is checked by
+            # `lipo -info` having produced it and by Gatekeeper below.
+            if [ "$ARCH" = "arm64" ]; then
+              scripts/ci/verify-plugin-loads.sh "$WORK"
+            fi
+            rm -rf "$WORK"
+          done
+
       - name: Verify the built bundles are notarized
         run: |
           BUNDLE_NAME="${{ steps.plugin.outputs.bundleName }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,9 +67,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
-        with:
-          xcode-version: '26.4.1'
+        uses: ./.github/actions/setup-xcode
 
       - name: Download static libraries
         env:
@@ -103,14 +101,6 @@ jobs:
 
       - name: Prepare libraries
         run: scripts/ci/prepare-libs.sh ${{ matrix.arch }}
-
-      # The only thing that proves the pinned toolchain was actually selected before a twenty
-      # minute build starts.
-      - name: Verify Xcode
-        run: |
-          echo "Active Xcode:"
-          xcode-select -p
-          xcodebuild -version
 
       - name: Create Secrets.xcconfig
         env:
@@ -188,9 +178,7 @@ jobs:
           fetch-depth: 0
 
       - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
-        with:
-          xcode-version: '26.4.1'
+        uses: ./.github/actions/setup-xcode
 
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -47,24 +47,15 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        # Shared with macos-tests.yml; see scripts/ci/detect-changed-paths.sh.
         run: |
           set -euo pipefail
-
-          if [ "$EVENT_NAME" != "pull_request" ]; then
-              echo "run=true" >> "$GITHUB_OUTPUT"
-              exit 0
-          fi
-
-          # Raw NUL-separated records, read from a file. See the note in macos-tests.yml for what
-          # core.quotePath and a pipeline each break here.
-          git -c core.quotePath=false diff --no-renames --name-only -z \
-              "$BASE_SHA" HEAD > "$RUNNER_TEMP/changed-files"
-
-          if LC_ALL=C grep -zqE '^(TableProMobile/|Configs/|Packages/TableProCore/|Libs/|\.github/workflows/ios-tests\.yml$)' "$RUNNER_TEMP/changed-files"; then
-              echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-              echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
+          RUN=$(scripts/ci/detect-changed-paths.sh \
+            --event "$EVENT_NAME" \
+            --base "$BASE_SHA" \
+            'TableProMobile/' 'Configs/' 'Packages/TableProCore/' 'Libs/' 'scripts/' \
+            '\.github/actions/' '\.github/workflows/ios-tests\.yml$')
+          echo "run=$RUN" >> "$GITHUB_OUTPUT"
 
   test:
     name: Run iOS Tests

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -73,60 +73,24 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           REF: ${{ github.ref }}
+        # The reasoning lives in scripts/ci/detect-changed-paths.sh. It was inline here and in
+        # ios-tests.yml, with a comment asking a human to keep the two copies in step and nothing
+        # enforcing it.
         run: |
           set -euo pipefail
+          RUN=$(scripts/ci/detect-changed-paths.sh \
+            --event "$EVENT_NAME" \
+            --base "$BASE_SHA" \
+            --ref "$REF" \
+            --skip-release-commit \
+            'TablePro/' 'Plugins/' 'Packages/' 'LocalPackages/' \
+            'TableProTests/' 'TableProUITests/' 'Native/' 'Configs/' 'Libs/' 'scripts/' \
+            '\.github/actions/' '\.github/macos-(ui-)?test-quarantine\.txt$' \
+            'TablePro\.xcodeproj/project\.xcworkspace/xcshareddata/swiftpm/Package\.resolved$' \
+            'TableProMobile/project\.yml$' 'project\.yml$' \
+            '\.github/workflows/macos-tests\.yml$')
+          echo "run=$RUN" >> "$GITHUB_OUTPUT"
 
-          # A release pushes the version commit to main and then tags that same commit, so the
-          # push and the tag both reach this workflow: once directly, once through build.yml's
-          # workflow_call. That tests one SHA twice on two macos-26 runners, and because the
-          # account runs five macOS jobs at a time, the duplicate is what leaves the release's
-          # own suite queued behind it. The tag run is the one that gates the release, so the
-          # push to main stands down. github.ref belongs to the caller, so build.yml's
-          # workflow_call reads refs/tags/v* here and can never match this guard, which is what
-          # keeps "a release that skipped its tests" impossible.
-          #
-          # The subject goes into a variable instead of a pipe into grep. grep -q exits on the
-          # first match, and the SIGPIPE that then kills git log would surface through pipefail
-          # as a skipped guard (the same trap scripts/check-freetds-fedauth.sh:69 documents).
-          SUBJECT="$(git log -1 --format=%s HEAD)"
-          if [ "$EVENT_NAME" = "push" ] && [ "$REF" = "refs/heads/main" ] &&
-             [[ "$SUBJECT" =~ ^release:\ v[0-9] ]]; then
-              echo "run=false" >> "$GITHUB_OUTPUT"
-              exit 0
-          fi
-
-          # Anything that is not a pull request runs the full suite: a release calls this
-          # workflow with workflow_call, and a release that skipped its tests is the failure
-          # this guard exists to prevent.
-          if [ "$EVENT_NAME" != "pull_request" ]; then
-              echo "run=true" >> "$GITHUB_OUTPUT"
-              exit 0
-          fi
-
-          # core.quotePath defaults to true, which wraps any path holding a non-ASCII byte or a
-          # control character in double quotes and C-escapes it, so `TablePro/Café.swift` arrives
-          # as `"TablePro/Caf\303\251.swift"` and the leading quote defeats the `^` anchor. This
-          # detector fails open, so a misread means every suite skips behind a green gate. Reading
-          # raw NUL-separated records removes both that and any embedded-newline trick.
-          #
-          # A file, not a variable: bash drops NUL bytes from "$(...)", which would run every path
-          # together into one record. It also keeps grep out of a pipeline, so the SIGPIPE that
-          # scripts/check-freetds-fedauth.sh:69 warns about cannot come back.
-          git -c core.quotePath=false diff --no-renames --name-only -z \
-              "$BASE_SHA" HEAD > "$RUNNER_TEMP/changed-files"
-
-          # Keep in step with the `push: paths:` list above. scripts/ and .github/actions/ are on
-          # both because the jobs below execute them: a change to the shard tooling or to the
-          # quarantine files used to merge behind a green gate having run nothing.
-          if LC_ALL=C grep -zqE '^(TablePro/|Plugins/|Packages/|LocalPackages/|TableProTests/|TableProUITests/|Native/|Configs/|Libs/|scripts/|\.github/actions/|\.github/macos-(ui-)?test-quarantine\.txt$|TablePro\.xcodeproj/project\.xcworkspace/xcshareddata/swiftpm/Package\.resolved$|TableProMobile/project\.yml$|project\.yml$|\.github/workflows/macos-tests\.yml$)' "$RUNNER_TEMP/changed-files"; then
-              echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-              echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  # One job for both packages rather than two. They cost 1.3 and 2.1 minutes, and a macOS
-  # concurrency slot is the scarce resource here: the account runs five at a time, and the build
-  # plus three UI shards plus the unit job already want four of them.
   packages:
     name: Package Tests
     needs: changes

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -215,6 +215,12 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             | xcbeautify --renderer github-actions
 
+      # Builds and signs used to be the whole check: nothing ever tried to load one. "Bundle
+      # failed to load executable" has shipped twice, and dlopen is exactly the dyld path that
+      # fails in that case.
+      - name: Verify every plugin loads
+        run: scripts/ci/verify-plugin-loads.sh "$DERIVED_DATA/Build/Products/Debug"
+
       - name: Build the app and both test bundles
         run: |
           set -o pipefail
@@ -308,6 +314,11 @@ jobs:
             -parallel-testing-enabled NO \
             | xcbeautify --renderer github-actions
 
+      # Always, including on failure: a red run is when the durations matter most.
+      - name: Summarise test durations
+        if: ${{ !cancelled() }}
+        run: scripts/ci/summarize-xcresult.sh TestResults.xcresult "Unit tests"
+
       - name: Upload test results
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -379,6 +390,10 @@ jobs:
             -retry-tests-on-failure \
             -resultBundlePath UITestResults.xcresult \
             | xcbeautify --renderer github-actions
+
+      - name: Summarise UI test durations
+        if: ${{ !cancelled() }}
+        run: scripts/ci/summarize-xcresult.sh UITestResults.xcresult "UI tests ${{ matrix.shard }}/${{ matrix.of }}"
 
       - name: Upload UI test results
         if: ${{ !cancelled() }}

--- a/scripts/ci/detect-changed-paths.sh
+++ b/scripts/ci/detect-changed-paths.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Decides whether a workflow's suites need to run for this event. Prints "true" or "false".
+#
+# Usage:
+#   detect-changed-paths.sh --event <name> [--base <sha>] [--ref <ref>] [--skip-release-commit] \
+#                           <path-regex> [<path-regex>...]
+#
+# The path arguments are alternatives in one anchored regex, so pass prefixes like "TablePro/" or
+# anchored files like 'project\.yml$'.
+#
+# This lived twice, inline in macos-tests.yml and ios-tests.yml, with a comment asking a human to
+# keep the two copies in step and nothing enforcing it. The reasoning below is the part worth not
+# duplicating.
+
+EVENT=""
+BASE=""
+REF=""
+SKIP_RELEASE_COMMIT=0
+PATTERNS=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --event) EVENT="${2:?--event needs a value}"; shift 2 ;;
+        --base) BASE="${2:-}"; shift 2 ;;
+        --ref) REF="${2:-}"; shift 2 ;;
+        --skip-release-commit) SKIP_RELEASE_COMMIT=1; shift ;;
+        --) shift; PATTERNS+=("$@"); break ;;
+        -*) echo "detect-changed-paths.sh: unknown flag $1" >&2; exit 2 ;;
+        *) PATTERNS+=("$1"); shift ;;
+    esac
+done
+
+[ -n "$EVENT" ] || { echo "detect-changed-paths.sh: --event is required" >&2; exit 2; }
+[ "${#PATTERNS[@]}" -gt 0 ] || { echo "detect-changed-paths.sh: at least one path pattern is required" >&2; exit 2; }
+
+# A release pushes the version commit to main and then tags that same commit, so the push and the
+# tag both reach the workflow: once directly, once through build.yml's workflow_call. That tests one
+# SHA twice, and because the account runs five macOS jobs at a time, the duplicate is what leaves
+# the release's own suite queued behind it. The tag run is the one that gates the release, so the
+# push to main stands down. github.ref belongs to the caller, so a workflow_call reads refs/tags/v*
+# here and can never match this guard, which is what keeps "a release that skipped its tests"
+# impossible.
+#
+# The subject goes into a variable instead of a pipe into grep. grep -q exits on the first match,
+# and the SIGPIPE that then kills git log would surface through pipefail as a skipped guard (the
+# same trap scripts/check-freetds-fedauth.sh documents).
+if [ "$SKIP_RELEASE_COMMIT" -eq 1 ] && [ "$EVENT" = "push" ] && [ "$REF" = "refs/heads/main" ]; then
+    SUBJECT="$(git log -1 --format=%s HEAD)"
+    if [[ "$SUBJECT" =~ ^release:\ v[0-9] ]]; then
+        echo "false"
+        exit 0
+    fi
+fi
+
+# Anything that is not a pull request runs everything: a release calls the suite with
+# workflow_call, and a release that skipped its tests is the failure this exists to prevent.
+if [ "$EVENT" != "pull_request" ]; then
+    echo "true"
+    exit 0
+fi
+
+[ -n "$BASE" ] || { echo "detect-changed-paths.sh: --base is required for a pull request" >&2; exit 2; }
+
+# core.quotePath defaults to true, which wraps any path holding a non-ASCII byte or a control
+# character in double quotes and C-escapes it, so `TablePro/Café.swift` arrives as
+# `"TablePro/Caf\303\251.swift"` and the leading quote defeats the `^` anchor. This detector fails
+# open, so a misread means every suite skips behind a green gate. Reading raw NUL-separated records
+# removes both that and any embedded-newline trick.
+#
+# A file, not a variable: bash drops NUL bytes from "$(...)", which would run every path together
+# into one record. It also keeps grep out of a pipeline, so the SIGPIPE noted above cannot come back.
+CHANGED="$(mktemp)"
+trap 'rm -f "$CHANGED"' EXIT
+git -c core.quotePath=false diff --no-renames --name-only -z "$BASE" HEAD > "$CHANGED"
+
+JOINED="$(IFS='|'; echo "${PATTERNS[*]}")"
+if LC_ALL=C grep -zqE "^($JOINED)" "$CHANGED"; then
+    echo "true"
+else
+    echo "false"
+fi

--- a/scripts/ci/summarize-xcresult.sh
+++ b/scripts/ci/summarize-xcresult.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Writes a test-duration summary from an .xcresult to $GITHUB_STEP_SUMMARY, or to stdout locally.
+#
+# Usage: summarize-xcresult.sh <path.xcresult> [title]
+#
+# Nothing in this repo measured how long tests take. The two result bundles were uploaded as
+# artifacts and never read, so finding out which of 85 UI tests took ninety seconds meant
+# downloading one and opening Xcode. That is why a ten second XCUITest retry sat in every
+# sample-database test, 30% of the UI job, until somebody went looking.
+#
+# Never fails the job: a summary that can break a green run is worse than no summary.
+
+RESULT="${1:?Usage: summarize-xcresult.sh <path.xcresult> [title]}"
+TITLE="${2:-Test durations}"
+OUT="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+if [ ! -d "$RESULT" ]; then
+    echo "summarize-xcresult.sh: no result bundle at $RESULT" >&2
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+if ! xcrun xcresulttool get test-results tests --path "$RESULT" --format json > "$WORK/tests.json" 2> "$WORK/err"; then
+    echo "summarize-xcresult.sh: could not read $RESULT" >&2
+    head -3 "$WORK/err" >&2
+    exit 0
+fi
+
+TITLE="$TITLE" python3 - "$WORK/tests.json" >> "$OUT" <<'PY'
+import json
+import os
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+cases = []
+
+
+def walk(node, suite):
+    kind = node.get("nodeType")
+    name = node.get("name", "")
+    if kind == "Test Case":
+        cases.append((suite, name, node.get("durationInSeconds") or 0.0, node.get("result")))
+        return
+    for child in node.get("children") or []:
+        walk(child, name if kind == "Test Suite" else suite)
+
+
+for root in payload.get("testNodes") or []:
+    walk(root, "")
+
+title = os.environ.get("TITLE", "Test durations")
+if not cases:
+    print(f"### {title}\n\nNo test cases in the result bundle.")
+    raise SystemExit
+
+total = sum(case[2] for case in cases)
+failed = [case for case in cases if case[3] not in (None, "Passed", "Skipped")]
+
+print(f"### {title}\n")
+print(f"{len(cases)} cases in {total / 60:.1f} min"
+      + (f", {len(failed)} not passing" if failed else ""))
+
+by_suite = {}
+for suite, _, duration, _ in cases:
+    entry = by_suite.setdefault(suite or "(none)", [0, 0.0])
+    entry[0] += 1
+    entry[1] += duration
+
+print("\n<details><summary>Slowest 20 suites</summary>\n")
+print("| suite | cases | seconds |")
+print("| --- | ---: | ---: |")
+for suite, (count, seconds) in sorted(by_suite.items(), key=lambda item: -item[1][1])[:20]:
+    print(f"| {suite} | {count} | {seconds:.1f} |")
+print("\n</details>\n")
+
+print("<details><summary>Slowest 20 cases</summary>\n")
+print("| case | suite | seconds |")
+print("| --- | --- | ---: |")
+for suite, name, duration, _ in sorted(cases, key=lambda case: -case[2])[:20]:
+    print(f"| {name} | {suite} | {duration:.1f} |")
+print("\n</details>")
+PY

--- a/scripts/ci/verify-plugin-loads.sh
+++ b/scripts/ci/verify-plugin-loads.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Loads every built .tableplugin with dlopen and fails naming any that will not load.
+#
+# Usage: verify-plugin-loads.sh <directory-with-tableplugins> [more-directories...]
+#
+# "Bundle failed to load executable" is the failure this repo has shipped twice, both times because
+# a plugin's witness table hard-referenced a PluginKit symbol that had been removed. CI built and
+# signed the bundles and never once tried to load one, so the first thing to find out was a user's
+# install. dlopen is exactly the dyld path that fails in that case, and it takes milliseconds.
+#
+# This proves the binary and its dependencies resolve. It does not instantiate the principal class
+# or call into PluginKit; the app's own version gate does that at runtime.
+
+[ $# -gt 0 ] || { echo "Usage: $0 <directory-with-tableplugins>..." >&2; exit 2; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/probe.c" <<'PROBE'
+#include <dlfcn.h>
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+    if (argc < 2) { return 2; }
+    void *handle = dlopen(argv[1], RTLD_NOW | RTLD_LOCAL);
+    if (handle == NULL) {
+        fprintf(stderr, "%s\n", dlerror());
+        return 1;
+    }
+    return 0;
+}
+PROBE
+clang -o "$WORK/probe" "$WORK/probe.c"
+
+# The plugins link the app's frameworks, which sit beside them in the products directory. Without
+# these dyld cannot resolve TableProPluginKit and every plugin would "fail" for the wrong reason.
+search_paths=""
+for dir in "$@"; do
+    [ -d "$dir" ] || { echo "verify-plugin-loads.sh: no such directory: $dir" >&2; exit 1; }
+    search_paths="${search_paths:+$search_paths:}$dir:$dir/PackageFrameworks"
+done
+export DYLD_FRAMEWORK_PATH="$search_paths"
+export DYLD_LIBRARY_PATH="$search_paths"
+
+checked=0
+failed=()
+
+while IFS= read -r bundle; do
+    name="$(basename "$bundle" .tableplugin)"
+    binary="$bundle/Contents/MacOS/$name"
+    if [ ! -f "$binary" ]; then
+        echo "  ✗ $name has no executable at Contents/MacOS/$name" >&2
+        failed+=("$name")
+        continue
+    fi
+    if output="$("$WORK/probe" "$binary" 2>&1)"; then
+        echo "  ✓ $name"
+    else
+        # dlerror lists every path it tried, which is a screenful. The reason is the part before
+        # that list, and the distinct "(...)" causes after it.
+        reason="${output%% tried:*}"
+        causes="$(printf '%s' "$output" | grep -oE "\\(([a-z][^)]*)\\)" | sort -u | tr '\n' ' ')"
+        echo "  ✗ $name: $reason${causes:+ [$causes]}" >&2
+        failed+=("$name")
+    fi
+    checked=$((checked + 1))
+done < <(for dir in "$@"; do find "$dir" -maxdepth 1 -name '*.tableplugin'; done | sort)
+
+if [ "$checked" -eq 0 ]; then
+    echo "verify-plugin-loads.sh: found no .tableplugin bundles in $*" >&2
+    exit 1
+fi
+
+if [ "${#failed[@]}" -gt 0 ]; then
+    echo "" >&2
+    echo "${#failed[@]} of $checked plugins will not load: ${failed[*]}" >&2
+    echo "This is the 'Bundle failed to load executable' a user would hit. A removed PluginKit" >&2
+    echo "requirement is the usual cause; see the ABI rules in CLAUDE.md." >&2
+    exit 1
+fi
+
+echo "All $checked plugins load."


### PR DESCRIPTION
Two things CI never did: try to load a plugin it built, and say how long anything took.

## Nothing ever loaded a plugin

CI built and signed 31 plugin bundles and never once tried to load one. "Bundle failed to load executable" is the failure this repo has shipped **twice**, both times because a witness table hard-referenced a PluginKit symbol that had been removed, and both times the first thing to find out was a user's install.

`scripts/ci/verify-plugin-loads.sh` `dlopen`s each bundle's executable, which is exactly the dyld path that fails in that case. It takes milliseconds.

It runs in two places: the `build` job of `macos-tests.yml` right after `AllPlugins` compiles all 31, so every pull request checks them, and in `build-plugin.yml` before a bundle is published, because the registry serves those to users directly.

Verified against a real build. All 14 bundled plugins load:

```
✓ ClickHouseDriver  ✓ CSVExport  ✓ CSVImport  ✓ CSVInspectorPlugin  ✓ JSONExport
✓ JSONImport  ✓ MQLExport  ✓ MySQLDriver  ✓ PostgreSQLDriver  ✓ RedisDriver
✓ SQLExport  ✓ SQLImport  ✓ SQLiteDriver  ✓ XLSXExport
All 14 plugins load.
```

And it fails when one cannot. Corrupting a single executable:

```
✗ CSVExport: dlopen(.../CSVExport, 0x0006): [(no such file) (slice is not valid mach-o file)]
1 of 16 plugins will not load: CSVExport
```

`dlerror` prints every path it tried, which is a screenful, so the message keeps the reason and the distinct causes and drops the list. An empty directory is a failure too, not a silent pass, because "found nothing, therefore fine" is how a check like this stops working.

The plugins need `DYLD_FRAMEWORK_PATH` pointing at the products directory to resolve `TableProPluginKit`; without it every plugin would fail for the wrong reason.

## Nothing measured how long tests take

`grep -rn GITHUB_STEP_SUMMARY` found nothing in the repo. Both `.xcresult` bundles were uploaded as artifacts and never read, so finding out which of 85 UI tests took ninety seconds meant downloading one and opening Xcode.

That is why a ten second XCUITest retry sat in every sample-database test, 30% of the UI job, until somebody went looking for it.

`scripts/ci/summarize-xcresult.sh` writes a duration table to `$GITHUB_STEP_SUMMARY` from the unit job and each UI shard. Run against the real bundle from run 32473179239, it surfaces exactly the hotspots that took manual digging to find:

```
85 cases in 36.5 min

| suite                     | cases | seconds |
| OpenQuicklyCommandUITests |     6 |   240.5 |
| QueryInsightsTabUITests   |     6 |   232.6 |
| QueryHistoryPanelUITests  |     5 |   131.8 |
| ResultTabPinUITests       |     1 |   103.0 |
```

It runs on failure as well, because a red run is when the durations matter most, and it never fails the job: a summary that can break a green run is worse than no summary. A missing or unreadable bundle exits 0 with a note.

## Verification

`actionlint` clean across all six workflows, `shellcheck -x --severity=warning` clean on both new scripts. Both were exercised against real artifacts, in the passing and the failing direction.