### PR TITLE
fix(plugin-sqlite): let Stop end a wait on a locked database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A search highlight or diagnostic underline whose text you delete now disappears, instead of staying put or jumping to the end of the editor. (#2341)
 - Fixed crashes when the editor's layout, syntax highlighting or accessibility read text that a newer edit had already removed. (#2340)
 - A SQLite query that stops early, because the database is locked or the volume returns an error, now says so instead of showing an empty table.
+- Stop now ends a SQLite query that is waiting on a database another program has locked, instead of leaving it to wait out the query timeout.
 - The XLSX, MQL and SQL Import plugins linked to a documentation page that did not exist. They now point at Import & Export.
 
 ## [0.67.0] - 2026-08-21

--- a/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
+++ b/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
@@ -99,12 +99,75 @@ final class SQLitePlugin: NSObject, TableProPlugin, DriverPlugin {
     }
 }
 
+// MARK: - Busy Wait
+
+/// Ends a wait on a locked database when the user presses Stop, and after the configured timeout.
+///
+/// `sqlite3_busy_timeout` cannot do the first of those: it sleeps inside SQLite with nothing to
+/// interrupt it, and `sqlite3_interrupt` does not reach a connection that is waiting for a lock
+/// rather than running a statement. Measured against SQLite 3.54.0 with a second connection
+/// holding `BEGIN EXCLUSIVE`: the interrupt was ignored and the waiter ran the full 60 seconds
+/// before returning `SQLITE_BUSY`. A busy handler is the documented way to keep that decision,
+/// because it is called back on every retry and stops the wait by returning zero.
+///
+/// Read and written from whichever thread is stepping a statement and from the caller of Stop, so
+/// every access takes the lock.
+private final class SQLiteBusyState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var isCancelled = false
+    private var timeoutMilliseconds: Int32 = 0
+
+    /// How long one retry waits. Also the granularity at which Stop is noticed.
+    static let retryIntervalMilliseconds: Int32 = 10
+
+    func setTimeout(milliseconds: Int32) {
+        lock.lock()
+        defer { lock.unlock() }
+        timeoutMilliseconds = milliseconds
+    }
+
+    func beginOperation() {
+        lock.lock()
+        defer { lock.unlock() }
+        isCancelled = false
+    }
+
+    func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
+        isCancelled = true
+    }
+
+    /// - Parameter retryCount: How many times SQLite has already called back for this lock.
+    /// - Returns: `true` to wait and retry, `false` to give up and let the step return `SQLITE_BUSY`.
+    func shouldRetry(afterRetryCount retryCount: Int32) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isCancelled else { return false }
+        guard timeoutMilliseconds > 0 else { return true }
+        return retryCount * Self.retryIntervalMilliseconds < timeoutMilliseconds
+    }
+}
+
+private let sqliteBusyHandler: @convention(c) (UnsafeMutableRawPointer?, Int32) -> Int32 = { context, retryCount in
+    guard let context else { return 0 }
+    let state = Unmanaged<SQLiteBusyState>.fromOpaque(context).takeUnretainedValue()
+    guard state.shouldRetry(afterRetryCount: retryCount) else { return 0 }
+    usleep(UInt32(SQLiteBusyState.retryIntervalMilliseconds) * 1_000)
+    return 1
+}
+
 // MARK: - SQLite Connection Actor
 
 private actor SQLiteConnectionActor {
     private static let logger = Logger(subsystem: "com.TablePro", category: "SQLiteConnectionActor")
 
     private var db: OpaquePointer?
+    private let busyState: SQLiteBusyState
+
+    init(busyState: SQLiteBusyState) {
+        self.busyState = busyState
+    }
 
     var isConnected: Bool { db != nil }
 
@@ -116,6 +179,7 @@ private actor SQLiteConnectionActor {
                 ?? "Unknown SQLite error"
             throw SQLitePluginError.connectionFailed(errorMessage)
         }
+        installBusyHandler()
     }
 
     func close() {
@@ -126,8 +190,16 @@ private actor SQLiteConnectionActor {
     }
 
     func applyBusyTimeout(_ milliseconds: Int32) {
+        busyState.setTimeout(milliseconds: milliseconds)
+    }
+
+    func beginBusyOperation() {
+        busyState.beginOperation()
+    }
+
+    private func installBusyHandler() {
         guard let db else { return }
-        sqlite3_busy_timeout(db, milliseconds)
+        sqlite3_busy_handler(db, sqliteBusyHandler, Unmanaged.passUnretained(busyState).toOpaque())
     }
 
     var dbHandleForInterrupt: Int { db.map { Int(bitPattern: $0) } ?? 0 }
@@ -136,6 +208,7 @@ private actor SQLiteConnectionActor {
         guard let db else {
             throw SQLitePluginError.notConnected
         }
+        busyState.beginOperation()
 
         let startTime = Date()
         var statement: OpaquePointer?
@@ -225,6 +298,7 @@ private actor SQLiteConnectionActor {
     }
 
     func streamQuery(_ query: String, continuation: AsyncThrowingStream<PluginStreamElement, Error>.Continuation) throws {
+        busyState.beginOperation()
         guard let db else {
             throw SQLitePluginError.notConnected
         }
@@ -326,6 +400,7 @@ private actor SQLiteConnectionActor {
         guard let db else {
             throw SQLitePluginError.notConnected
         }
+        busyState.beginOperation()
 
         let startTime = Date()
         var statement: OpaquePointer?
@@ -454,7 +529,8 @@ private struct SQLiteRawResult: Sendable {
 
 final class SQLitePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     private let config: DriverConnectionConfig
-    private let connectionActor = SQLiteConnectionActor()
+    private let busyState = SQLiteBusyState()
+    private let connectionActor: SQLiteConnectionActor
     private let interruptLock = NSLock()
     nonisolated(unsafe) private var _dbHandleForInterrupt: OpaquePointer?
 
@@ -484,6 +560,7 @@ final class SQLitePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     init(config: DriverConnectionConfig) {
         self.config = config
+        self.connectionActor = SQLiteConnectionActor(busyState: busyState)
     }
 
     // MARK: - Connection
@@ -514,8 +591,7 @@ final class SQLitePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func applyQueryTimeout(_ seconds: Int) async throws {
-        guard seconds > 0 else { return }
-        await connectionActor.applyBusyTimeout(Int32(seconds * 1_000))
+        await connectionActor.applyBusyTimeout(Int32(max(0, seconds) * 1_000))
     }
 
     // MARK: - Query Execution
@@ -544,7 +620,10 @@ final class SQLitePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         )
     }
 
+    /// `sqlite3_interrupt` ends a statement that is running. A connection waiting for a lock is
+    /// not running one, and measurably ignores it, so the busy handler is what ends that wait.
     func cancelQuery() throws {
+        busyState.cancel()
         interruptLock.lock()
         defer { interruptLock.unlock() }
         guard let db = _dbHandleForInterrupt else { return }


### PR DESCRIPTION
Found while investigating #2342, and the last thing I can evidence on that path. It does not close the issue: the reported hang still does not reproduce here. What it does fix is that the app offers a Stop control which, for one whole class of wait, provably cannot stop anything.

## The defect

A SQLite connection waiting for a lock is not running a statement, and `sqlite3_interrupt` only reaches a statement. TablePro's Stop is `sqlite3_interrupt`, so pressing it while a query waits on a database another program has locked does nothing at all: the wait runs to the end of the query timeout, 60 seconds by default.

Measured twice, independently, against SQLite 3.54.0, with a second connection holding `BEGIN EXCLUSIVE` and Stop pressed 0.7s in:

```
PROBE mode=timeout stoppedAfter=60.46s rc=5 (database is locked)
```

Worse, `applyQueryTimeout` opened with `guard seconds > 0 else { return }`, so a user who sets the query timeout to "no timeout" got no busy timeout either. That is not an unbounded query, which is what the setting means: it is an unbounded, uninterruptible wait for a lock, with the app's own Stop button unable to end it.

## The fix

`sqlite3_busy_handler` replaces `sqlite3_busy_timeout`. It is the documented way to keep the retry decision in the app's hands: SQLite calls it back on every retry, and returning zero ends the wait. The handler checks a cancel flag that Stop sets, then the configured timeout, and otherwise sleeps 10ms and retries. Same probe, same lock, same 0.7s Stop:

```
PROBE mode=handler stoppedAfter=0.74s rc=5 (database is locked)
```

The timeout still applies exactly as before when nobody presses Stop, and `0` now means "no deadline" rather than "no way out": the wait is still stoppable. Combined with the terminating-code fix in #2355, a locked database now ends in a clear error at the moment the user asks for it, instead of an empty grid after a minute.

Implementation notes: the busy state is a small locked box shared by the driver and its connection actor, because the handler runs on whichever thread is stepping while Stop is pressed from the main thread. Both hold a strong reference, so the unretained pointer SQLite holds can never outlive it. The handler is installed once with the connection rather than per statement, which is what SQLite expects. The cancel flag resets at the start of each statement, so a Stop cannot leak into the next query.

## Verification

- `xcodebuild -scheme TablePro build`: passes.
- The before and after probe above, which is the whole claim.
- SwiftLint on the changed file: clean.

No unit test, for the same reason as #2355: the SQLite driver has no test target and its sources are not in `TableProTests`. Reproducing this needs two processes and a real lock, which the probe does and a unit test could not without the same setup.

Note for release: SQLite is bundled but also has a registry arm, so users on an already-shipped app only get this once the plugin is published.
