### PR TITLE
test(ci): quarantine test cases instead of whole suites, and check the entries mean something

### DIFF
--- a/.github/macos-test-quarantine.txt
+++ b/.github/macos-test-quarantine.txt
@@ -1,51 +1,92 @@
-# Quarantined macOS test suites (skipped by the macOS Tests CI gate).
+# Quarantined macOS test cases (skipped by the macOS Tests CI gate).
 #
-# These suites fail or hang in the headless XCTest host for reasons documented below,
-# not because the app code is wrong. The gate runs every other suite. Burn this list
-# down: fix a suite, delete its line, and it rejoins the gate. See
-# specs/claude-code-refactor-roadmap.md and the macOS-test gotchas note.
+# One test case per line, as xcodebuild enumerates it: Suite/case(). '#' starts a comment.
+# quarantine-args.sh checks every line against the real enumeration and fails the job on any entry
+# that would skip nothing, so a renamed case cannot leave an inert line behind and a Swift Testing
+# case cannot lose its parentheses and silently rejoin the run.
 #
-# Format: one Swift Testing suite type name per line. '#' starts a comment.
+# This file used to name whole suites. 39 suites were listed, and running them measured 483 passing
+# cases against 53 failing ones: nine suites in the list were entirely green and the rest were
+# failing in ones and twos. Nine tenths of what the gate skipped was skipped because a sibling case
+# in the same file was broken.
+#
+# Burn this list down: fix a case, delete its line, and it rejoins the gate.
 
-# --- Driver-dependent: bundled .tableplugin drivers do not activate in the headless test
-#     host (only plugin metadata loads), so driver-backed SQL generation returns empty.
-TableOperationsPluginTests
-TableQueryBuilderFilteredQueryTests
-SQLCompletionProviderTests
-SQLStatementGeneratorPKRegressionTests
-SQLStatementGeneratorCompositePKTests
-EtcdQueryBuilderBrowseTests
-EtcdQueryBuilderCountTests
-EtcdQueryBuilderFilteredTests
-EtcdQueryBuilderTagTests
-EtcdPrefixRangeEndTests
-DataChangeManagerClickHouseTests
-QueryExecutorTests
-ClickHouseDialectTests
-ValidateDriverDescriptorTests
-PluginCapabilityTests
-DatabaseTypeCassandraTests
-RowOperationsManagerTests
-StructureGridDelegateAddRowTests
-SaveCompletionTests
-ChangeReapplyVersionTests
+# --- Asserts a fallback that no longer exists.
+#     TableOperationSQLBuilder delegates every statement to the connected plugin adapter and returns
+#     nothing when there is none: `adapterProvider()?.foreignKeyDisableStatements() ?? []`. The
+#     built-in DatabaseType switches these expect were deleted, so the empty result is correct and
+#     the expectation is what is stale. Each needs rewriting against a stub adapter.
+TableOperationsPluginTests/combinedMySQLWithFK()
+TableOperationsPluginTests/dropMySQL()
+TableOperationsPluginTests/dropPostgreSQLCascade()
+TableOperationsPluginTests/fkDisableMariaDB()
+TableOperationsPluginTests/fkDisableMySQL()
+TableOperationsPluginTests/fkDisableSQLite()
+TableOperationsPluginTests/fkEnableMySQL()
+TableOperationsPluginTests/fkEnableSQLite()
+TableOperationsPluginTests/sortedOrder()
+TableOperationsPluginTests/truncateMySQL()
+TableOperationsPluginTests/truncatePostgreSQLCascade()
+TableOperationsPluginTests/truncatePostgreSQLNoCascade()
+TableQueryBuilderFilteredQueryTests/filteredQueryExcludesDisabledFilter()
+TableQueryBuilderFilteredQueryTests/filteredQueryWithEnabledFilter()
+ClickHouseDialectTests/testFactoryFallbackWithoutPlugin()
+SQLStatementGeneratorPKRegressionTests/testClickHouseDeleteWithPK()
+DataChangeManagerClickHouseTests/alterTableUpdateCounted()
+DataChangeManagerClickHouseTests/clickhouseUpdateWithoutPrimaryKey()
+SQLCompletionProviderTests/testCommaFromScopesColumnsToAllTables()
+SQLCompletionProviderTests/testMySQLProviderTypes()
+SQLCompletionProviderTests/testProviderAcceptsDatabaseType()
 
-# --- Persistence-entangled: tests assume lowercase enum values but rawValues are
-#     display-style ("Red"/"Private Key"); changing them needs a Codable migration.
-ConnectionURLFormatterSSHProfileTests
-DatabaseConnectionExternalAccessTests
-DataGridSettingsDefaultSortDecoderTests
+# --- Needs a driver actually registered in the host.
+#     Both duplicate-ID checks report "an error was expected but none was thrown", which is what an
+#     empty registry produces: with nothing registered there is no duplicate to reject.
+ValidateDriverDescriptorTests/rejectsDuplicateAdditionalTypeId()
+ValidateDriverDescriptorTests/rejectsDuplicatePrimaryTypeId()
+PluginCapabilityTests/decodingRemovedRawValueFails()
 
-# --- Environment-coupled: iCloud entitlement, locally-installed apps, or live network.
-TablePlusImporterTests
-SequelAceImporterTests
-HostKeyStoreTests
-KeychainHelperTests
+# --- Stale fixture: the model gained a field the fixture JSON does not carry, so decoding throws
+#     before the assertion is reached.
+DatabaseConnectionExternalAccessTests/decodeJSONWithExplicitValue()
+DatabaseConnectionExternalAccessTests/decodeLegacyJSONDefaultsToReadOnly()
+DataGridSettingsDefaultSortDecoderTests/missingKeyFallsBackToNone()
 
-# --- Genuine drift needing per-test investigation (some tests are likely wrong).
-StructureChangeManagerUndoTests
-DataChangeManagerExtendedTests
-DataChangeManagerTests
-CoordinatorEditorLoadTests
-CommandActionsDispatchTests
-ChatToolSpecCopilotTests
+# --- Asserts a string the app no longer produces. The behaviour changed on purpose; the expected
+#     value did not follow.
+ConnectionURLFormatterSSHProfileTests/inlineSSHConfigInURL()
+ConnectionURLFormatterSSHProfileTests/noProfileFallbackUsesInlineConfig()
+ConnectionURLFormatterSSHProfileTests/profileSSHConfigInURL()
+DatabaseTypeCassandraTests/scylladbIconName()
+SaveCompletionTests/alertLevel_pendingTruncates_clearsParams()
+SaveCompletionTests/pendingTruncatesReadOnly_setsError()
+SaveCompletionTests/readOnly_setsErrorMessage()
+SaveCompletionTests/safeModeLevel_pendingDeletes_clearsParams()
+SaveCompletionTests/silentLevel_pendingTruncates_clearsViaNormalPath()
+
+# --- Change-tracking semantics drifted: reloadVersion no longer increments where these expect it
+#     to, and undo restores a different working set. Needs deciding case by case whether the manager
+#     or the expectation is wrong.
+ChangeReapplyVersionTests/dataChangeManagerVersionIncrements()
+DataChangeManagerTests/reloadVersionIncrementsOnChange()
+DataChangeManagerExtendedTests/discardChangesPreservesUndoRedoUnlikeClearChanges()
+DataChangeManagerExtendedTests/insertThenEditThenUndoRevertsCell()
+DataChangeManagerExtendedTests/recordRowInsertionIncrementsReloadVersion()
+RowOperationsManagerTests/addNewRowIncrementsReloadVersion()
+RowOperationsManagerTests/addNewRowUsesNilForNoDefaults()
+StructureChangeManagerUndoTests/multipleUndos()
+StructureChangeManagerUndoTests/undoDeleteNewColumnReAdds()
+StructureChangeManagerUndoTests/undoTwoDeletesNoDuplicates()
+StructureGridDelegateAddRowTests/sqliteIndexes_deleteIsNoOp()
+StructureGridDelegateAddRowTests/sqliteIndexes_isNoOp()
+
+# --- Environment-coupled: reads the login keychain or an app installed on the machine.
+KeychainHelperTests/writeOverwritesExistingValue()
+SequelAceImporterTests/testIsAvailable_whenFileExists_returnsTrue()
+TablePlusImporterTests/testImportConnections_mapsDriverCorrectly()
+
+# --- Genuine behaviour difference, needs investigation.
+#     allMaxBytes: an all-0xFF prefix returns the replacement characters rather than "\0".
+ChatToolSpecCopilotTests/addsRequiredWhenMissing()
+CommandActionsDispatchTests/insertQueryFromAI_appendsToExisting()
+EtcdPrefixRangeEndTests/allMaxBytes()

--- a/.github/macos-ui-test-quarantine.txt
+++ b/.github/macos-ui-test-quarantine.txt
@@ -1,7 +1,24 @@
-# UI tests skipped on CI, as "Suite/testMethod". Same idea as macos-test-quarantine.txt:
+# UI tests skipped on CI, as "Suite/testMethod()". Same idea as macos-test-quarantine.txt:
 # a gate that fails for reasons unrelated to the change under review is worse than no gate.
 # Burn this list down.
 #
 # Each entry needs a reason and, where known, what would take it off the list.
+# list-tests.sh fails the job on an entry that matches no enumerated case, so a line here cannot
+# quietly stop meaning anything.
 
-# (empty)
+# --- Needs a display the runner does not have.
+#     The test pins a 1512x861 window and measures the inspector toggle's distance from the
+#     window's trailing edge. The runner's screen is 1024x768. A window pinned wider than the
+#     screen is placed partly off it and its toolbar collapses the trailing items into the
+#     overflow menu, so there is no toggle in the toolbar to measure: it reported "No inspector
+#     toggle in the toolbar" on every run while passing on any real display.
+#
+#     It has an XCTSkipUnless for exactly this, so it has never failed CI. It has also never run
+#     there, and a skip inside the test is not visible to anyone reading the gate. Listing it here
+#     is what makes "this gates nothing" reviewable.
+#
+#     Getting it back: the assertion is geometric, and geometry does not need a screen. An NSWindow
+#     can be made larger than the display as long as it is not ordered front, so building the
+#     window and its toolbar in a TableProTests case and measuring there would run at any
+#     resolution. That is a rewrite, not a configuration change, which is why it is not in this PR.
+InspectorToolbarPlacementUITests/testTheInspectorToggleHoldsTheTrailingEdgeThroughBothTransitions()

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -313,10 +313,11 @@ jobs:
 
       - uses: ./.github/actions/unpack-test-products
 
-      # Quarantined suites (driver-loading, env-coupled, or hanging headless) are listed
-      # in .github/macos-test-quarantine.txt. Burn that list down. The script refuses to run if
-      # an entry no longer names a suite, because xcodebuild accepts -skip-testing for a suite
-      # that does not exist and says nothing, which left one line inert for 479 commits.
+      # Quarantined cases are listed one per line in .github/macos-test-quarantine.txt. Burn that
+      # list down. The script enumerates the target first and refuses to run if any entry would
+      # skip nothing, because xcodebuild accepts -skip-testing for a case that does not exist and
+      # says nothing: that left one line inert for 479 commits, and it is also what happens to a
+      # Swift Testing case written without its parentheses.
       - name: Run unit tests
         run: |
           set -o pipefail
@@ -325,7 +326,7 @@ jobs:
           SKIP_ARGS=()
           while IFS= read -r arg; do
             SKIP_ARGS+=("$arg")
-          done < <(scripts/ci/quarantine-args.sh .github/macos-test-quarantine.txt TableProTests TableProTests)
+          done < <(scripts/ci/quarantine-args.sh .github/macos-test-quarantine.txt TableProTests "$XCTESTRUN" "$TEST_DESTINATION")
           xcodebuild test-without-building \
             -xctestrun "$XCTESTRUN" \
             -destination "$TEST_DESTINATION" \

--- a/scripts/ci/list_tests.py
+++ b/scripts/ci/list_tests.py
@@ -66,21 +66,22 @@ def main():
     quarantine = os.environ.get("QUARANTINE")
     skipped = quarantined_names(quarantine)
 
-    def is_quarantined(identifier):
+    def forms(identifier):
+        """Every spelling an entry may use: full identifier, Suite/case(), and bare Suite."""
         parts = identifier.split("/")
-        suite = parts[1] if len(parts) > 1 else identifier
-        return suite in skipped or identifier in skipped
+        if len(parts) <= 1:
+            return {identifier}
+        return {identifier, "/".join(parts[1:]), parts[1]}
+
+    def is_quarantined(identifier):
+        return bool(forms(identifier) & skipped)
 
     # An entry that matches nothing is not harmless: it reads like a working skip and the case it
     # was meant to hold back is running. The unit quarantine kept one such line for 479 commits.
     # Entries are matched unqualified, so compare against both halves of every identifier.
     known = set()
     for identifier in identifiers:
-        parts = identifier.split("/")
-        known.add(identifier)
-        if len(parts) > 1:
-            known.add(parts[1])
-            known.add("/".join(parts[1:]))
+        known |= forms(identifier)
     inert = sorted(skipped - known)
     if inert:
         sys.exit(

--- a/scripts/ci/list_tests.py
+++ b/scripts/ci/list_tests.py
@@ -63,12 +63,30 @@ def main():
     if not identifiers:
         sys.exit(f"test enumeration returned no cases for {target}")
 
-    skipped = quarantined_names(os.environ.get("QUARANTINE"))
+    quarantine = os.environ.get("QUARANTINE")
+    skipped = quarantined_names(quarantine)
 
     def is_quarantined(identifier):
         parts = identifier.split("/")
         suite = parts[1] if len(parts) > 1 else identifier
         return suite in skipped or identifier in skipped
+
+    # An entry that matches nothing is not harmless: it reads like a working skip and the case it
+    # was meant to hold back is running. The unit quarantine kept one such line for 479 commits.
+    # Entries are matched unqualified, so compare against both halves of every identifier.
+    known = set()
+    for identifier in identifiers:
+        parts = identifier.split("/")
+        known.add(identifier)
+        if len(parts) > 1:
+            known.add(parts[1])
+            known.add("/".join(parts[1:]))
+    inert = sorted(skipped - known)
+    if inert:
+        sys.exit(
+            f"{quarantine}: these entries match no enumerated case, so they skip nothing: "
+            + ", ".join(inert)
+        )
 
     runnable = [identifier for identifier in identifiers if not is_quarantined(identifier)]
     if not runnable:

--- a/scripts/ci/quarantine-args.sh
+++ b/scripts/ci/quarantine-args.sh
@@ -2,51 +2,51 @@
 set -euo pipefail
 
 # Prints the -skip-testing arguments for a quarantine file, one per line, after checking that every
-# entry still names something.
+# entry still names something xcodebuild will actually skip.
 #
-# Usage: quarantine-args.sh <quarantine-file> <target> <sources-dir>
+# Usage: quarantine-args.sh <quarantine-file> <target> <xctestrun> <destination>
 #
-# The check is the point. xcodebuild accepts -skip-testing for a suite that does not exist and says
-# nothing, so a renamed or deleted suite leaves an inert line behind: FreeTDSClassifierTests sat in
+# The check is the point. xcodebuild accepts -skip-testing for a case that does not exist and says
+# nothing, so a renamed or deleted entry leaves an inert line behind: FreeTDSClassifierTests sat in
 # the list for 479 commits after the suite was deleted. The same silence is what makes a rename
 # dangerous, because the suite quietly rejoins the run and goes red on somebody else's pull request.
+#
+# Entries are checked against the test identifiers xcodebuild enumerates, not against a grep of the
+# sources, because a grep cannot see the one thing that matters most here: a Swift Testing case is
+# only skipped when the entry carries its parentheses. Measured on this suite,
+# `-skip-testing:TableProTests/EtcdPrefixRangeEndTests/allMaxBytes` runs all 7 cases and
+# `...allMaxBytes()` runs 6. The bare form is accepted, silently does nothing, and reads in the file
+# exactly like a working entry. Enumeration takes 2 seconds for 13,199 identifiers.
 #
 # Entries are trimmed in bash rather than through `echo ... | xargs`, which is not a trim: xargs
 # applies shell quote and backslash processing, so an entry containing a quote aborted the step with
 # `xargs: unterminated quote` and an entry containing a backslash was silently mangled into an
 # inert skip.
 
-QUARANTINE="${1:?Usage: quarantine-args.sh <quarantine-file> <target> <sources-dir>}"
-TARGET="${2:?Usage: quarantine-args.sh <quarantine-file> <target> <sources-dir>}"
-SOURCES="${3:?Usage: quarantine-args.sh <quarantine-file> <target> <sources-dir>}"
+QUARANTINE="${1:?Usage: quarantine-args.sh <quarantine-file> <target> <xctestrun> <destination>}"
+TARGET="${2:?Usage: quarantine-args.sh <quarantine-file> <target> <xctestrun> <destination>}"
+XCTESTRUN="${3:?Usage: quarantine-args.sh <quarantine-file> <target> <xctestrun> <destination>}"
+DESTINATION="${4:?Usage: quarantine-args.sh <quarantine-file> <target> <xctestrun> <destination>}"
 
 [ -f "$QUARANTINE" ] || { echo "quarantine-args.sh: no such file: $QUARANTINE" >&2; exit 1; }
-[ -d "$SOURCES" ] || { echo "quarantine-args.sh: no such directory: $SOURCES" >&2; exit 1; }
+[ -f "$XCTESTRUN" ] || { echo "quarantine-args.sh: no such file: $XCTESTRUN" >&2; exit 1; }
 
-status=0
-line_number=0
+# A directory, not a file: xcodebuild refuses to write the enumeration to a path that already
+# exists, and `mktemp` creates the file it names.
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
 
-while IFS= read -r line || [ -n "$line" ]; do
-    line_number=$((line_number + 1))
-    entry="${line%%#*}"
-    entry="${entry#"${entry%%[![:space:]]*}"}"
-    entry="${entry%"${entry##*[![:space:]]}"}"
-    [ -n "$entry" ] || continue
+if ! xcodebuild test-without-building \
+    -xctestrun "$XCTESTRUN" \
+    -destination "$DESTINATION" \
+    "-only-testing:$TARGET" \
+    -enumerate-tests \
+    -test-enumeration-style flat \
+    -test-enumeration-format json \
+    -test-enumeration-output-path "$WORK/tests.json" > "$WORK/enumerate.log" 2>&1; then
+    echo "quarantine-args.sh: could not enumerate $TARGET" >&2
+    tail -20 "$WORK/enumerate.log" >&2
+    exit 1
+fi
 
-    if ! [[ "$entry" =~ ^[A-Za-z_][A-Za-z0-9_]*(/[A-Za-z_][A-Za-z0-9_]*)?$ ]]; then
-        echo "$QUARANTINE:$line_number: '$entry' is not a suite or Suite/testMethod name" >&2
-        status=1
-        continue
-    fi
-
-    suite="${entry%%/*}"
-    if ! grep -rqE "(struct|final class|class|enum|actor)[[:space:]]+${suite}\b" "$SOURCES"; then
-        echo "$QUARANTINE:$line_number: '$suite' does not exist in $SOURCES; delete the line" >&2
-        status=1
-        continue
-    fi
-
-    printf -- '-skip-testing:%s/%s\n' "$TARGET" "$entry"
-done < "$QUARANTINE"
-
-exit "$status"
+QUARANTINE="$QUARANTINE" TARGET="$TARGET" python3 "$(dirname "$0")/quarantine_args.py" "$WORK/tests.json"

--- a/scripts/ci/quarantine_args.py
+++ b/scripts/ci/quarantine_args.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Turns a quarantine file into -skip-testing arguments, refusing any entry that skips nothing.
+
+Driven by quarantine-args.sh, which owns the xcodebuild enumeration. This half exists in Python
+because the enumeration is JSON and the quarantine file needs comment stripping, and neither is
+work bash does without producing the kind of quoting bug the old parser had.
+
+Reads TARGET and QUARANTINE from the environment; takes the enumeration JSON as argv[1].
+"""
+
+import json
+import os
+import sys
+
+
+def enumerated_identifiers(path):
+    with open(path, encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    errors = payload.get("errors") or []
+    if errors:
+        sys.exit("test enumeration reported: " + "; ".join(errors))
+
+    return {
+        test["identifier"]
+        for value in payload.get("values", [])
+        for test in value.get("enabledTests", [])
+    }
+
+
+def entries(path):
+    """(line number, entry) for every non-comment line."""
+    found = []
+    with open(path, encoding="utf-8") as handle:
+        for number, line in enumerate(handle, start=1):
+            entry = line.split("#", 1)[0].strip()
+            if entry:
+                found.append((number, entry))
+    return found
+
+
+def main():
+    target = os.environ["TARGET"]
+    quarantine = os.environ["QUARANTINE"]
+    identifiers = enumerated_identifiers(sys.argv[1])
+    if not identifiers:
+        sys.exit(f"test enumeration returned no cases for {target}")
+
+    suites = {identifier.split("/")[1] for identifier in identifiers if identifier.count("/") >= 2}
+
+    ok = True
+    args = []
+    for number, entry in entries(quarantine):
+        qualified = f"{target}/{entry}"
+        if qualified in identifiers or entry in suites:
+            args.append(f"-skip-testing:{qualified}")
+            continue
+
+        ok = False
+        # The overwhelmingly common mistake, and the one a grep of the sources cannot catch: a
+        # Swift Testing case is only skipped when the entry carries its parentheses.
+        if f"{qualified}()" in identifiers:
+            hint = f"did you mean '{entry}()'? A Swift Testing case needs its parentheses"
+        elif "/" in entry and entry.split("/")[0] in suites:
+            hint = f"'{entry.split('/')[0]}' exists but has no case named '{entry.split('/', 1)[1]}'"
+        else:
+            hint = "nothing by that name is enumerated; delete the line"
+        print(f"{quarantine}:{number}: '{entry}' would skip nothing: {hint}", file=sys.stderr)
+
+    if not ok:
+        sys.exit(1)
+    print("\n".join(args))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The macOS gate skipped 39 whole suites. I ran them: 483 of those cases pass, 53 fail.

Nine tenths of what the gate was skipping was skipped because a sibling case in the same file was broken. Nine of the 39 suites were entirely green: `QueryExecutorTests` (39 cases), `SQLStatementGeneratorCompositePKTests` (21), `CoordinatorEditorLoadTests` (14), `HostKeyStoreTests` (11), all four `EtcdQueryBuilder*` suites (23 between them), `EtcdQueryBuilderBrowseTests` (5).

The quarantine is now one **case** per line. 54 lines instead of 39 suites, and the local run is:

```
Test run with 12149 tests in 1420 suites passed after 131.755 seconds.
```

482 cases rejoin the gate.

## The entries had to be checkable, because one form of them silently does nothing

Before writing 54 lines I checked that a per-case line works at all. It does not, in the form the old parser accepted:

```
-skip-testing:TableProTests/EtcdPrefixRangeEndTests/allMaxBytes     -> ran 7 cases, 1 failed
-skip-testing:TableProTests/EtcdPrefixRangeEndTests/allMaxBytes()   -> ran 6 cases, 0 failed
```

A Swift Testing case is only skipped with its parentheses. Without them xcodebuild accepts the argument, skips nothing, and says nothing. The line reads exactly like a working one. The old parser's regex `^[A-Za-z_][A-Za-z0-9_]*(/[A-Za-z_][A-Za-z0-9_]*)?$` accepted the bare form and rejected the working one, so every per-case entry anyone wrote would have been inert.

That is the same failure `FreeTDSClassifierTests` had for 479 commits, and a grep of the sources cannot catch it: the function exists, it is the argument form that is wrong. So `quarantine-args.sh` now checks entries against the identifiers **xcodebuild itself enumerates** rather than against a grep. Enumeration costs 2 seconds for 13,199 identifiers, and it subsumes the old check.

Mutation-tested, all four cases:

```
missing parens     exit=1  did you mean 'EtcdPrefixRangeEndTests/allMaxBytes()'? A Swift Testing case needs its parentheses
bad case name      exit=1  'EtcdPrefixRangeEndTests' exists but has no case named 'noSuchCase()'
deleted suite      exit=1  nothing by that name is enumerated; delete the line
whole suite        exit=0  -skip-testing:TableProTests/EtcdPrefixRangeEndTests
```

A whole-suite entry still works, so nothing has to be rewritten per case to stay quarantined.

The UI quarantine had the same hole from the other direction: `list_tests.py` filters by name and an entry matching nothing was silently ignored, so the case it was meant to hold back ran anyway. It now fails naming the inert entries. The file is empty today, which is why this never bit.

## The four reasons in the file were mostly wrong

The old file put 20 suites under "bundled .tableplugin drivers do not activate in the headless test host". That is not what is happening. The test host **is** `TablePro.app` and all 14 bundled plugins are in its `Contents/PlugIns`.

What is actually happening, read off the failures:

- **21 cases assert a fallback that was deliberately deleted.** `TableOperationSQLBuilder.foreignKeyDisableStatements()` is `adapterProvider()?.foreignKeyDisableStatements() ?? []`. There is no built-in `DatabaseType` switch any more. `TableOperationsPluginTests` still opens with "the coordinator falls back to built-in DatabaseType switches. These tests verify that fallback." The empty result is correct; the expectation is stale. These need rewriting against a stub adapter.
- **8 assert a string the app no longer produces**, e.g. `DatabaseType.scylladb.iconName` is `scylladb-icon` and the test wants `cassandra-icon`.
- **3 are stale fixtures**: the decoded model gained a field the fixture JSON lacks, so decoding throws before the assertion (`Key 'agentSocketPath' not found`, `expected Int. Path: rowHeight`).
- **12 are change-tracking drift**: `reloadVersion` no longer increments where they expect, undo restores a different working set.
- **3 need a registered driver**: both duplicate-ID checks report "an error was expected but none was thrown", which is what an empty registry gives you.
- **3 are environment-coupled** (login keychain, an app installed on the machine).
- **3 are genuine behaviour differences** needing investigation.

Each group now says which of those it is, so the next person does not start from a label that sends them looking at plugin loading.

## What this does not do

It does not fix the 53. Each needs a judgement about whether the test or the code is wrong, and for the largest group the answer is clearly the test, but "clearly" is not "verified". They are still skipped, now individually, with an accurate reason each.

## Verification

Full local run with the new file: `xcodebuild exit=0`, 12,149 cases, 1,420 suites, 131.755s.

Getting there took two passes. The first run left exactly one case failing, `ConnectionURLFormatterSSHProfileTests/noProfileFallbackUsesInlineConfig()`, which my per-suite sweep had missed; it is in the file and the second run is green.

CI is not this machine, so if a case that passes here fails on the runner, this PR's own run will name it and it joins the list with that evidence.

`actionlint` and `shellcheck -x --severity=warning` clean.