### PR TITLE
fix(ci): stop the iOS job generating a macOS project it cannot generate and never builds

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -98,8 +98,11 @@ jobs:
       - name: Setup XcodeGen
         uses: ./.github/actions/setup-xcodegen
 
+      # The iOS project only. The macOS spec names Libs/dylibs/*.dylib by path and XcodeGen
+      # validates that at generation time, so generating it here failed before the static
+      # libraries were even downloaded, and nothing in this job builds it.
       - name: Generate Xcode project
-        run: scripts/generate-project.sh
+        run: scripts/generate-project.sh ios
 
       - name: Cache static libraries
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ TablePro is a native macOS database client (SwiftUI + AppKit), a fast, lightweig
 ```bash
 # First-time setup (and after any project.yml / Configs change, or adding a source file)
 scripts/download-libs.sh          # static libraries, not in git
-scripts/generate-project.sh       # generates both .xcodeproj bundles from project.yml
+scripts/generate-project.sh       # generates both .xcodeproj bundles from project.yml (or pass macos|ios)
 
 # Build (development), -skipPackagePluginValidation required for SwiftLint plugin in CodeEditSourceEditor
 xcodebuild -project TablePro.xcodeproj -scheme TablePro -configuration Debug build -skipPackagePluginValidation

--- a/docs/development/building.mdx
+++ b/docs/development/building.mdx
@@ -63,6 +63,7 @@ Static `.a` files (libmariadb, libpq, libsybdb, and others) are hosted on the `l
 scripts/download-libs.sh          # Download (skips if already present)
 scripts/download-libs.sh --force  # Re-download and overwrite
 scripts/generate-project.sh       # Regenerate both .xcodeproj bundles from project.yml
+scripts/generate-project.sh ios   # Just the iOS one (macos and both are the other options)
 ```
 
 ### Publishing libraries (maintainers)

--- a/scripts/generate-project.sh
+++ b/scripts/generate-project.sh
@@ -5,9 +5,19 @@ set -euo pipefail
 # project.yml specs. Both projects are build artifacts and are not in git; run this
 # after cloning, after editing a project.yml or Configs/*.xcconfig, and after adding,
 # moving, or deleting a source file.
+#
+# Usage: generate-project.sh [both|macos|ios]
+#
+# The macOS spec names two files by path, Libs/dylibs/libssl.3.dylib and libcrypto.3.dylib, which
+# it copies into the app bundle. XcodeGen validates a named path at generation time, so the macOS
+# project cannot be generated before scripts/download-libs.sh has produced them. The iOS job does
+# not build the macOS project and has no reason to pay for that, which is why the platform is
+# selectable: it generated both, ahead of downloading anything, and every iOS run failed with
+# "Target TablePro has a missing source directory".
 
 REQUIRED_XCODEGEN_VERSION="2.46.0"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLATFORM="${1:-both}"
 
 if ! command -v xcodegen > /dev/null; then
     echo "ERROR: xcodegen is not installed." >&2
@@ -22,7 +32,26 @@ if [ "$installed_version" != "$REQUIRED_XCODEGEN_VERSION" ]; then
 fi
 
 cd "$REPO_ROOT"
-xcodegen generate --quiet --spec project.yml
-xcodegen generate --quiet --spec TableProMobile/project.yml --project TableProMobile
 
-echo "Generated TablePro.xcodeproj and TableProMobile/TableProMobile.xcodeproj"
+generate_macos() {
+    for dylib in libssl.3.dylib libcrypto.3.dylib; do
+        [ -f "Libs/dylibs/$dylib" ] && continue
+        echo "ERROR: Libs/dylibs/$dylib is missing, and the macOS project copies it into the app bundle." >&2
+        echo "       Run scripts/download-libs.sh first; it builds the dylibs from the static libraries." >&2
+        exit 1
+    done
+    xcodegen generate --quiet --spec project.yml
+    echo "Generated TablePro.xcodeproj"
+}
+
+generate_ios() {
+    xcodegen generate --quiet --spec TableProMobile/project.yml --project TableProMobile
+    echo "Generated TableProMobile/TableProMobile.xcodeproj"
+}
+
+case "$PLATFORM" in
+    both) generate_macos; generate_ios ;;
+    macos) generate_macos ;;
+    ios) generate_ios ;;
+    *) echo "ERROR: unknown platform '$PLATFORM'. Use both, macos or ios." >&2; exit 1 ;;
+esac


### PR DESCRIPTION
**main's iOS Tests is red.** I broke it in #2358 and did not notice.

```
2 Spec validations errors:
  - Target "TablePro" has a missing source directory ".../Libs/dylibs/libssl.3.dylib"
  - Target "TablePro" has a missing source directory ".../Libs/dylibs/libcrypto.3.dylib"
```

#2358 made the macOS spec name those two dylibs by path so they get copied into the app bundle, which is what stopped the Debug app depending on an absolute rpath into the source tree. XcodeGen validates a named path at generation time, so from that commit on, `TablePro.xcodeproj` cannot be generated until `download-libs.sh` has produced them.

The iOS job ran `scripts/generate-project.sh`, which generates **both** projects, at a step that comes *before* the static libraries are fetched. It also has no use for the macOS project: nothing in that job references `TablePro.xcodeproj`.

## Fix

`generate-project.sh` takes an optional platform, defaulting to `both`, so every existing caller is unchanged:

```bash
scripts/generate-project.sh          # both, as before
scripts/generate-project.sh ios      # the iOS job
scripts/generate-project.sh macos
```

The iOS workflow passes `ios`. That removes the dependency rather than working around it, and drops one XcodeGen run from every iOS build.

Generating the macOS project now also checks for the two dylibs first and says what to do, instead of leaving XcodeGen to report a "missing source directory" for a file:

```
ERROR: Libs/dylibs/libssl.3.dylib is missing, and the macOS project copies it into the app bundle.
       Run scripts/download-libs.sh first; it builds the dylibs from the static libraries.
```

This is a real precondition, not just a nicer message: the documented setup order in CLAUDE.md has always been `download-libs.sh` then `generate-project.sh`, and until #2358 nothing enforced it.

## Verification

Reproduced the CI failure locally by moving `Libs/dylibs` aside, then checked all four paths:

```
ios, no dylibs present   exit=0  Generated TableProMobile/TableProMobile.xcodeproj
both, no dylibs present  exit=1  ERROR: Libs/dylibs/libssl.3.dylib is missing...
both, dylibs restored    exit=0  Generated TablePro.xcodeproj + TableProMobile.xcodeproj
bad argument             exit=1  ERROR: unknown platform 'sideways'. Use both, macos or ios.
```

`shellcheck --severity=warning` and `actionlint` clean.