### PR TITLE
test(ui): stop relaunching the app to look at the same screen

### DIFF
--- a/TableProUITests/OpenQuicklyCommandUITests.swift
+++ b/TableProUITests/OpenQuicklyCommandUITests.swift
@@ -1,9 +1,18 @@
 import XCTest
 
 final class OpenQuicklyCommandUITests: UITestCase {
-    /// Escape dismisses the panel, and it has to work through a real key press rather than through
-    /// the delegate hook a unit test can call, because the whole failure lives above that hook.
-    func testEscapeDismissesTheOpenQuicklyPanel() throws {
+    /// One launch for every assertion about the panel itself.
+    ///
+    /// Each of these was its own test method, and each paid a full app launch and a sample-database
+    /// load, roughly forty seconds, to reach the same screen the last one had just left. They all
+    /// observe one panel and none of them leaves durable state behind, so the launch is the only
+    /// thing they were not sharing.
+    ///
+    /// `continueAfterFailure` is on because the phases are independent: with it off, a broken
+    /// Escape contract would hide whether the scopes are still reachable, and one CI run would
+    /// report one of the five problems it could have reported.
+    func testTheOpenQuicklyPanelOpensScopesAndHonoursEscape() throws {
+        continueAfterFailure = true
         let app = try launchWithSampleDatabase()
         XCTAssertTrue(
             app.windows.firstMatch.tables.matching(identifier: "data-grid").firstMatch
@@ -11,84 +20,39 @@ final class OpenQuicklyCommandUITests: UITestCase {
         )
         app.activate()
 
-        app.typeKey("o", modifierFlags: [.command, .shift])
-        let searchField = switcherPanel(in: app).textFields["quick-switcher-search-field"]
-        XCTAssertTrue(searchField.waitToExist(timeout: 15))
-
-        app.typeKey(.escape, modifierFlags: [])
-        XCTAssertTrue(
-            searchField.waitForNonExistence(timeout: 5),
-            "Escape on an empty field must dismiss the panel"
-        )
-    }
-
-    /// The two-step Escape shipped as #1490: the first clears a typed query, the second dismisses.
-    func testEscapeClearsTheQueryThenDismissesThePanel() throws {
-        let app = try launchWithSampleDatabase()
-        XCTAssertTrue(
-            app.windows.firstMatch.tables.matching(identifier: "data-grid").firstMatch
-                .waitToExist(timeout: 30)
-        )
-        app.activate()
-
-        app.typeKey("o", modifierFlags: [.command, .shift])
         let panel = switcherPanel(in: app)
         let searchField = panel.textFields["quick-switcher-search-field"]
-        XCTAssertTrue(searchField.waitToExist(timeout: 15))
 
-        searchField.typeText("album")
-        XCTAssertTrue(panel.buttons["Album"].waitToExist(timeout: 10))
-
-        app.typeKey(.escape, modifierFlags: [])
-        XCTAssertTrue(
-            waitForPredicate(timeout: 5) { (searchField.value as? String ?? "").isEmpty },
-            "The first Escape clears the query"
+        /// The command moved from the Database menu to the File menu and was renamed from
+        /// "Quick Switcher..." to "Open Quickly...", so the menu path itself is the assertion.
+        /// Resolved and clicked without opening File first; see the note in
+        /// QueryStatementNavigationUITests for why the parent click only costs a traversal.
+        let openQuickly = app.menuBars.menuItems["Open Quickly…"]
+        XCTAssertTrue(openQuickly.waitToExist(timeout: 5))
+        openQuickly.click()
+        XCTAssertTrue(searchField.waitToExist(timeout: 15), "The File menu item must open the panel")
+        XCTAssertFalse(
+            app.menuBars.menuBarItems["Database"].menuItems["Quick Switcher..."].exists,
+            "The old Database menu item must not survive the move"
         )
-        XCTAssertTrue(searchField.exists, "The first Escape must not dismiss the panel")
 
-        app.typeKey(.escape, modifierFlags: [])
-        XCTAssertTrue(
-            searchField.waitForNonExistence(timeout: 5),
-            "The second Escape dismisses the panel"
-        )
-    }
-
-    /// Every scope stays pickable with the mouse at all times. The scope controls used to be
-    /// removed from the view tree by `if !showsResultSurface`, so a single Recent row, which is the
-    /// panel's first frame on any connection with history, left four of the five scopes with no
-    /// mouse affordance at all. Typing is the state that has to be asserted, because that is the
-    /// state the old panel could never show them in.
-    func testEveryScopeStaysReachableWhileTyping() throws {
-        let app = try launchWithSampleDatabase()
-        XCTAssertTrue(
-            app.windows.firstMatch.tables.matching(identifier: "data-grid").firstMatch
-                .waitToExist(timeout: 30)
-        )
-        app.activate()
-
-        app.typeKey("o", modifierFlags: [.command, .shift])
-        let panel = switcherPanel(in: app)
-        let searchField = panel.textFields["quick-switcher-search-field"]
-        XCTAssertTrue(searchField.waitToExist(timeout: 15))
-
+        /// Every scope stays pickable with the mouse at all times. The scope controls used to be
+        /// removed from the view tree by `if !showsResultSurface`, so a single Recent row, which is
+        /// the panel's first frame on any connection with history, left four of the five scopes
+        /// with no mouse affordance at all. Typing is the state that has to be asserted, because
+        /// that is the state the old panel could never show them in.
         let scopes = scopePicker(in: panel)
         XCTAssertTrue(scopes.waitToExist(timeout: 10))
-
         for title in Self.scopeTitles {
             XCTAssertTrue(
                 scopes.radioButtons[title].waitToExist(timeout: 5),
                 "the \(title) segment is missing on an empty query"
             )
         }
-
-        /// The panel is a fresh view model every time, so it always opens in All. Anything else
-        /// means a stale scope survived a presentation, and the cross-connection scopes go and load
-        /// every other connection's catalog on open.
         XCTAssertTrue(isSelected(scopes.radioButtons["All"]), "The panel opens in the All scope")
 
         searchField.typeText("a")
         XCTAssertTrue(panel.buttons["Album"].waitToExist(timeout: 10))
-
         for title in Self.scopeTitles {
             XCTAssertTrue(
                 waitUntilHittable(scopes.radioButtons[title], timeout: 5),
@@ -108,96 +72,67 @@ final class OpenQuicklyCommandUITests: UITestCase {
         /// typing into the field would restore the focus this is trying to prove was never lost,
         /// and the assertion could not fail. Typing at the application goes wherever focus actually
         /// is, which is the question.
-        app.typeText("l")
+        app.typeText("lbum")
         XCTAssertTrue(
-            waitForPredicate(timeout: 5) { (searchField.value as? String ?? "") == "al" },
+            waitForPredicate(timeout: 5) { (searchField.value as? String ?? "") == "album" },
             "The search field still has keyboard focus after a scope click"
         )
-    }
 
-    /// A query of nothing but spaces still has something for Escape to clear, because the field
-    /// editor branches on the raw string. The footer used to branch on the trimmed one, so it
-    /// promised Close and then cleared.
-    func testAWhitespaceQueryStillPromisesEscapeWillClear() throws {
-        let app = try launchWithSampleDatabase()
+        /// The two-step Escape shipped as #1490: the first clears a typed query, the second
+        /// dismisses.
+        app.typeKey(.escape, modifierFlags: [])
         XCTAssertTrue(
-            app.windows.firstMatch.tables.matching(identifier: "data-grid").firstMatch
-                .waitToExist(timeout: 30)
+            waitForPredicate(timeout: 5) { (searchField.value as? String ?? "").isEmpty },
+            "The first Escape clears the query"
         )
-        app.activate()
+        XCTAssertTrue(searchField.exists, "The first Escape must not dismiss the panel")
+        app.typeKey(.escape, modifierFlags: [])
+        XCTAssertTrue(
+            searchField.waitForNonExistence(timeout: 5),
+            "The second Escape dismisses the panel"
+        )
 
+        /// Reopening is what proves the scope did not survive the presentation. The panel builds a
+        /// fresh view model every time, and a stale cross-connection scope would go and load every
+        /// other connection's catalog on open. No single-launch test could assert this before,
+        /// because each one only ever saw the panel's first presentation.
         app.typeKey("o", modifierFlags: [.command, .shift])
-        let panel = switcherPanel(in: app)
-        let searchField = panel.textFields["quick-switcher-search-field"]
-        XCTAssertTrue(searchField.waitToExist(timeout: 15))
+        XCTAssertTrue(searchField.waitToExist(timeout: 15), "Command Shift O must open the panel")
+        XCTAssertTrue(
+            isSelected(scopes.radioButtons["All"]),
+            "A reopened panel must not inherit the scope the last one was left in"
+        )
 
+        /// A query of nothing but spaces still has something for Escape to clear, because the field
+        /// editor branches on the raw string. The footer used to branch on the trimmed one, so it
+        /// promised Close and then cleared.
         XCTAssertTrue(
             hint(in: panel, "Escape closes Open Quickly").waitToExist(timeout: 5),
             "An empty field promises Escape closes the panel"
         )
-
         searchField.typeText(" ")
         XCTAssertTrue(
             hint(in: panel, "Escape clears the search text").waitToExist(timeout: 5),
             "A whitespace-only query still has something to clear, so the hint must say so"
         )
-
         app.typeKey(.escape, modifierFlags: [])
         XCTAssertTrue(searchField.exists, "That first Escape clears the space, it does not dismiss")
         XCTAssertTrue(
             waitForPredicate(timeout: 5) { (searchField.value as? String ?? "").isEmpty }
         )
-    }
 
-    /// The footer is one accessibility element whose label is the Escape promise, so the promise is
-    /// assertable without reading pixels.
-    private func hint(in panel: XCUIElement, _ label: String) -> XCUIElement {
-        panel.descendants(matching: .any).matching(
-            NSPredicate(format: "label == %@", label)
-        ).firstMatch
-    }
-
-    /// The five scope titles as the user sees them. Segments carry no accessibility identifier of
-    /// their own, so a label is the only handle, and the `containers` case is titled "Databases".
-    private static let scopeTitles = ["All", "Tables", "Databases", "Queries", "Connections"]
-
-    private func scopePicker(in panel: XCUIElement) -> XCUIElement {
-        panel.radioGroups["quick-switcher-scope-picker"].firstMatch
-    }
-
-    /// A segment carries its selection in its accessibility VALUE, 1 or 0, not in a selected trait
-    /// and not in the group's value. Measured on the real control: every segment reports
-    /// `AXSelected` as nil, and the group's `AXValue` is a reference to the selected child rather
-    /// than its title, so both `isSelected` and `group.value` read as nothing.
-    private func isSelected(_ segment: XCUIElement) -> Bool {
-        (segment.value as? NSNumber)?.intValue == 1
-    }
-
-    /// The command moved from the Database menu to the File menu and was renamed from
-    /// "Quick Switcher..." to "Open Quickly...", so the menu path itself is the assertion.
-    func testFileMenuOpensTheQuicklyPanel() throws {
-        let app = try launchWithSampleDatabase()
+        /// Escape on an empty field dismisses, which is the contract the panel opened with.
+        app.typeKey(.escape, modifierFlags: [])
         XCTAssertTrue(
-            app.windows.firstMatch.tables.matching(identifier: "data-grid").firstMatch
-                .waitToExist(timeout: 30)
-        )
-        app.activate()
-
-        /// Resolved and clicked without opening File first; see the note in
-        /// QueryStatementNavigationUITests for why the parent click only costs a traversal.
-        let openQuickly = app.menuBars.menuItems["Open Quickly…"]
-        XCTAssertTrue(openQuickly.waitToExist(timeout: 5))
-        openQuickly.click()
-
-        let searchField = switcherPanel(in: app).textFields["quick-switcher-search-field"]
-        XCTAssertTrue(searchField.waitToExist(timeout: 15))
-
-        XCTAssertFalse(
-            app.menuBars.menuBarItems["Database"].menuItems["Quick Switcher..."].exists,
-            "The old Database menu item must not survive the move"
+            searchField.waitForNonExistence(timeout: 5),
+            "Escape on an empty field must dismiss the panel"
         )
     }
 
+    /// Kept apart from the panel assertions above because it is the one that leaves the window
+    /// changed: two editor tabs open, which every assertion about a freshly presented panel would
+    /// then be running against a different window.
+    ///
     /// Command+Return joins the Option+Return that already opened a result in a new tab. Both are
     /// asserted here so neither can be dropped without a failure.
     func testCommandReturnOpensTheResultInANewTab() throws {
@@ -232,6 +167,32 @@ final class OpenQuicklyCommandUITests: UITestCase {
         XCTAssertTrue(tab(in: app, named: "Artist").waitToExist(timeout: 10))
         XCTAssertTrue(tab(in: app, named: "Album").exists)
         XCTAssertEqual(app.children(matching: .window).count, 1)
+    }
+
+    // MARK: - Helpers
+
+    /// The footer is one accessibility element whose label is the Escape promise, so the promise is
+    /// assertable without reading pixels.
+    private func hint(in panel: XCUIElement, _ label: String) -> XCUIElement {
+        panel.descendants(matching: .any).matching(
+            NSPredicate(format: "label == %@", label)
+        ).firstMatch
+    }
+
+    /// The five scope titles as the user sees them. Segments carry no accessibility identifier of
+    /// their own, so a label is the only handle, and the `containers` case is titled "Databases".
+    private static let scopeTitles = ["All", "Tables", "Databases", "Queries", "Connections"]
+
+    private func scopePicker(in panel: XCUIElement) -> XCUIElement {
+        panel.radioGroups["quick-switcher-scope-picker"].firstMatch
+    }
+
+    /// A segment carries its selection in its accessibility VALUE, 1 or 0, not in a selected trait
+    /// and not in the group's value. Measured on the real control: every segment reports
+    /// `AXSelected` as nil, and the group's `AXValue` is a reference to the selected child rather
+    /// than its title, so both `isSelected` and `group.value` read as nothing.
+    private func isSelected(_ segment: XCUIElement) -> Bool {
+        (segment.value as? NSNumber)?.intValue == 1
     }
 
     /// Scoped the same way `QuickSwitcherCrossConnectionUITests` scopes it: rooted at the

--- a/TableProUITests/QueryHistoryPanelUITests.swift
+++ b/TableProUITests/QueryHistoryPanelUITests.swift
@@ -3,7 +3,20 @@ import XCTest
 final class QueryHistoryPanelUITests: UITestCase {
     private let query = "SELECT * FROM Genre;"
 
-    func testCommandYShowsTheDrawerAndTheQueryYouJustRan() throws {
+    /// One launch for the whole drawer.
+    ///
+    /// Each of these was a separate test that launched the app, opened the sample database, ran a
+    /// query and pressed Cmd+Y to reach the drawer the previous one had just been looking at. They
+    /// all observe one drawer, so the preamble was the only thing they were not sharing.
+    ///
+    /// Toggling the drawer shut comes last, because it is the one step that leaves the window in a
+    /// state the other assertions could not run in.
+    ///
+    /// `continueAfterFailure` is on because the phases are independent: with it off, a drawer that
+    /// lost its search field would hide whether the scope picker and the detail pane are still
+    /// there, and one CI run would report one of the five problems it could have reported.
+    func testTheHistoryDrawerListsTheQueryCarriesItsFiltersAndTogglesShut() throws {
+        continueAfterFailure = true
         let app = try launchWithSampleDatabase()
         runQuery(in: app)
         let list = showHistoryDrawer(in: app)
@@ -16,25 +29,6 @@ final class QueryHistoryPanelUITests: UITestCase {
             },
             "The query that just ran must appear in the drawer"
         )
-    }
-
-    func testCommandYTogglesTheDrawerClosedAgain() throws {
-        let app = try launchWithSampleDatabase()
-        runQuery(in: app)
-        let list = showHistoryDrawer(in: app)
-
-        app.typeKey("y", modifierFlags: .command)
-
-        XCTAssertTrue(
-            waitForPredicate(timeout: 10) { !list.exists || !list.isHittable },
-            "Cmd+Y a second time must hide the drawer"
-        )
-    }
-
-    func testTheDrawerCarriesItsOwnSearchFieldSeparateFromTheSidebarFilter() throws {
-        let app = try launchWithSampleDatabase()
-        runQuery(in: app)
-        _ = showHistoryDrawer(in: app)
 
         let window = app.windows.firstMatch
         let historySearch = window.searchFields.matching(identifier: "query-history-search-field").firstMatch
@@ -42,30 +36,22 @@ final class QueryHistoryPanelUITests: UITestCase {
 
         let sidebarFilter = window.searchFields.matching(identifier: "sidebar-filter").firstMatch
         XCTAssertTrue(sidebarFilter.exists, "The sidebar filter must keep its own identifier")
-    }
 
-    func testTheDrawerOffersScopeAndSourceFilters() throws {
-        let app = try launchWithSampleDatabase()
-        runQuery(in: app)
-        _ = showHistoryDrawer(in: app)
-
-        let window = app.windows.firstMatch
         let scope = window.popUpButtons.matching(identifier: "query-history-scope-picker").firstMatch
         let date = window.popUpButtons.matching(identifier: "query-history-date-picker").firstMatch
-
         XCTAssertTrue(scope.waitToExist(timeout: 10), "The drawer must expose the connection scope")
         XCTAssertTrue(date.exists, "The drawer must expose the date range")
         XCTAssertEqual(scope.value as? String, "This Connection", "History starts scoped to this connection")
-    }
 
-    func testTheDetailPaneAppearsBesideTheList() throws {
-        let app = try launchWithSampleDatabase()
-        runQuery(in: app)
-        _ = showHistoryDrawer(in: app)
-
-        let detail = app.windows.firstMatch.descendants(matching: .any)
+        let detail = window.descendants(matching: .any)
             .matching(identifier: "query-history-detail").firstMatch
         XCTAssertTrue(detail.waitToExist(timeout: 10), "The drawer is master-detail")
+
+        app.typeKey("y", modifierFlags: .command)
+        XCTAssertTrue(
+            waitForPredicate(timeout: 10) { !list.exists || !list.isHittable },
+            "Cmd+Y a second time must hide the drawer"
+        )
     }
 
     // MARK: - Helpers

--- a/TableProUITests/QueryInsightsTabUITests.swift
+++ b/TableProUITests/QueryInsightsTabUITests.swift
@@ -3,7 +3,21 @@ import XCTest
 final class QueryInsightsTabUITests: UITestCase {
     private let query = "SELECT * FROM Genre;"
 
-    func testDatabaseMenuOpensTheQueryInsightsTab() throws {
+    /// One launch for the whole tab.
+    ///
+    /// Every assertion here observes the same Query Insights tab, and each used to be its own test
+    /// method that launched the app, opened the sample database, ran a query and walked the
+    /// Database menu to get back to the screen the previous method had just been looking at. That
+    /// preamble, not the assertions, was the suite's cost.
+    ///
+    /// The order is the one constraint: opening the history drawer is last because it is the only
+    /// step that leaves the window changed.
+    ///
+    /// `continueAfterFailure` is on because the phases are independent. With it off, a missing
+    /// toolbar control would hide whether the tab is still a singleton, and one CI run would report
+    /// one of the six problems it could have reported.
+    func testTheQueryInsightsTabOpensOnceCarriesItsFiltersAndStaysGatedWithoutALicense() throws {
+        continueAfterFailure = true
         let app = try launchWithSampleDatabase()
         runQuery(in: app)
         openInsights(in: app)
@@ -17,36 +31,7 @@ final class QueryInsightsTabUITests: UITestCase {
             },
             "Database > Query Insights must open a tab named Query Insights"
         )
-    }
 
-    func testOpeningInsightsTwiceReusesTheSameTab() throws {
-        let app = try launchWithSampleDatabase()
-        runQuery(in: app)
-        openInsights(in: app)
-
-        let window = app.windows.firstMatch
-        func insightsLabelCount() -> Int {
-            window.descendants(matching: .any)
-                .matching(NSPredicate(format: "label == %@", "Query Insights"))
-                .count
-        }
-        XCTAssertTrue(waitForPredicate(timeout: 10) { insightsLabelCount() >= 1 })
-        let afterFirst = insightsLabelCount()
-
-        openInsights(in: app)
-
-        XCTAssertTrue(
-            waitForPredicate(timeout: 5) { insightsLabelCount() == afterFirst },
-            "The insights tab is a singleton per connection, so opening it again must not add another"
-        )
-    }
-
-    func testInsightsOffersScopeSourceAndDateFilters() throws {
-        let app = try launchWithSampleDatabase()
-        runQuery(in: app)
-        openInsights(in: app)
-
-        let window = app.windows.firstMatch
         for identifier in [
             "query-insights-scope-picker",
             "query-insights-source-filter",
@@ -59,14 +44,61 @@ final class QueryInsightsTabUITests: UITestCase {
                 "The insights toolbar must expose \(identifier)"
             )
         }
-    }
 
-    func testInsightsToolbarIdentifiersDoNotCollideWithTheHistoryDrawer() throws {
-        let app = try launchWithSampleDatabase()
-        runQuery(in: app)
+        /// The test sandbox carries no license, so this run sees exactly what an unlicensed user
+        /// sees. `requiresPro` only dims and scrims, so without the activation gate the panels
+        /// below it would still be built and their numbers would still be sitting in the
+        /// accessibility tree.
+        for panel in ["Most Run", "Slowest", "Got Slower", "Failures"] {
+            let heading = window.descendants(matching: .any)
+                .matching(NSPredicate(format: "label CONTAINS[c] %@", panel)).firstMatch
+            XCTAssertFalse(
+                heading.exists,
+                "\(panel) must not be built for a run that cannot read it"
+            )
+        }
+
+        func insightsLabelCount() -> Int {
+            window.descendants(matching: .any)
+                .matching(NSPredicate(format: "label == %@", "Query Insights"))
+                .count
+        }
+        XCTAssertTrue(waitForPredicate(timeout: 10) { insightsLabelCount() >= 1 })
+        let afterFirst = insightsLabelCount()
+
         openInsights(in: app)
+        XCTAssertTrue(
+            waitForPredicate(timeout: 5) { insightsLabelCount() == afterFirst },
+            "The insights tab is a singleton per connection, so opening it again must not add another"
+        )
 
-        let window = app.windows.firstMatch
+        /// Reusing the tab is only half the contract. An editor tab used to be a window, so the
+        /// opener raised the window and stopped, which showed the tab only when it already happened
+        /// to be the one in front. With one window holding every tab, the command has to select it.
+        let insightsTab = window.descendants(matching: .any)
+            .matching(identifier: "editor-tab")
+            .matching(NSPredicate(format: "label == %@", "Query Insights"))
+            .firstMatch
+        XCTAssertTrue(insightsTab.waitToExist(timeout: 10), "The insights tab must reach the strip")
+        XCTAssertTrue(
+            waitForPredicate(timeout: 10) { insightsTab.isSelected },
+            "Opening it selects it"
+        )
+
+        selectTab(otherThan: "Query Insights", in: app)
+        XCTAssertTrue(
+            waitForPredicate(timeout: 10) { !insightsTab.isSelected },
+            "The window must actually move off the insights tab before the next open is meaningful"
+        )
+
+        openInsights(in: app)
+        XCTAssertTrue(
+            waitForPredicate(timeout: 10) { insightsTab.isSelected },
+            "Database > Query Insights must select the tab it already opened"
+        )
+
+        /// Last, because it is the one step that leaves the window changed. The drawer and the tab
+        /// each own a scope picker, and they must not answer to the same identifier.
         let insightsScope = window.descendants(matching: .any)
             .matching(identifier: "query-insights-scope-picker").firstMatch
         XCTAssertTrue(insightsScope.waitToExist(timeout: 10))
@@ -78,63 +110,6 @@ final class QueryInsightsTabUITests: UITestCase {
         XCTAssertTrue(
             historyScope.waitToExist(timeout: 10),
             "The drawer keeps its own scope picker identifier while the insights tab is open"
-        )
-    }
-
-    /// The test sandbox carries no license, so this run sees exactly what an unlicensed user sees.
-    /// `requiresPro` only dims and scrims, so without the activation gate the panels below it would
-    /// still be built and their numbers would still be sitting in the accessibility tree.
-    func testAnUnlicensedRunComputesAndShowsNoInsightData() throws {
-        let app = try launchWithSampleDatabase()
-        runQuery(in: app)
-        openInsights(in: app)
-
-        let window = app.windows.firstMatch
-        XCTAssertTrue(
-            window.descendants(matching: .any)
-                .matching(NSPredicate(format: "label CONTAINS[c] %@", "Query Insights"))
-                .firstMatch.waitToExist(timeout: 10),
-            "The tab still opens without a license"
-        )
-
-        for panel in ["Most Run", "Slowest", "Got Slower", "Failures"] {
-            let heading = window.descendants(matching: .any)
-                .matching(NSPredicate(format: "label CONTAINS[c] %@", panel)).firstMatch
-            XCTAssertFalse(
-                heading.exists,
-                "\(panel) must not be built for a run that cannot read it"
-            )
-        }
-    }
-
-    /// Reusing the tab is only half the contract. An editor tab used to be a window, so the opener
-    /// raised the window and stopped, which showed the tab only when it already happened to be the
-    /// one in front. With one window holding every tab, the command has to select it.
-    func testOpeningInsightsAgainSelectsItsExistingTab() throws {
-        let app = try launchWithSampleDatabase()
-        runQuery(in: app)
-        openInsights(in: app)
-
-        let insightsTab = app.windows.firstMatch.descendants(matching: .any)
-            .matching(identifier: "editor-tab")
-            .matching(NSPredicate(format: "label == %@", "Query Insights"))
-            .firstMatch
-        XCTAssertTrue(insightsTab.waitToExist(timeout: 10), "The insights tab must reach the strip")
-        XCTAssertTrue(
-            waitForPredicate(timeout: 10) { insightsTab.isSelected },
-            "Opening it the first time selects it"
-        )
-
-        selectTab(otherThan: "Query Insights", in: app)
-        XCTAssertTrue(
-            waitForPredicate(timeout: 10) { !insightsTab.isSelected },
-            "The window must actually move off the insights tab before the second open is meaningful"
-        )
-
-        openInsights(in: app)
-        XCTAssertTrue(
-            waitForPredicate(timeout: 10) { insightsTab.isSelected },
-            "Database > Query Insights must select the tab it already opened"
         )
     }
 

--- a/TableProUITests/QueryPlanResultUITests.swift
+++ b/TableProUITests/QueryPlanResultUITests.swift
@@ -10,7 +10,18 @@
 import XCTest
 
 final class QueryPlanResultUITests: UITestCase {
-    func testExplainProducesAResultTabAlongsideTheData() throws {
+    /// One launch for one plan.
+    ///
+    /// All four of these ran the same `EXPLAIN QUERY PLAN` against the same sample database and
+    /// then looked at a different part of the result, each paying its own app launch to get there.
+    ///
+    /// The order follows the plan's own modes: Diagram is what it opens in, Tree is a click away,
+    /// and pinning comes last because it is the only step that changes the tab.
+    ///
+    /// `continueAfterFailure` is on because the phases are independent: with it off, a missing
+    /// diagram canvas would hide whether Tree mode still lists the plan's steps.
+    func testAPlanArrivesAsAResultTabWithEveryModeAndCanBePinned() throws {
+        continueAfterFailure = true
         let app = try launchWithSampleDatabase()
         runQuery("EXPLAIN QUERY PLAN SELECT * FROM Track;", in: app)
 
@@ -25,38 +36,18 @@ final class QueryPlanResultUITests: UITestCase {
             modePicker.waitToExist(timeout: 10),
             "A parsed plan must offer the Diagram, Tree and Raw modes"
         )
-    }
-
-    func testTreeModeShowsTheOutlineWithColumns() throws {
-        let app = try launchWithSampleDatabase()
-        runQuery("EXPLAIN QUERY PLAN SELECT * FROM Track;", in: app)
-
-        let modePicker = app.radioGroups["query-plan-mode-picker"].firstMatch
-        XCTAssertTrue(modePicker.waitToExist(timeout: 20))
-        modePicker.radioButtons["Tree"].click()
-
-        let outline = app.outlines["query-plan-outline"].firstMatch
-        XCTAssertTrue(outline.waitToExist(timeout: 10), "Tree mode must show the plan outline")
-        XCTAssertTrue(outline.outlineRows.count > 0, "The outline must list the plan's steps")
-
-        let detail = app.descendants(matching: .any).matching(identifier: "query-plan-detail-pane").firstMatch
-        XCTAssertTrue(detail.waitToExist(timeout: 10), "Selecting a step must fill the detail pane")
-    }
-
-    func testDiagramModeShowsTheScrollableCanvas() throws {
-        let app = try launchWithSampleDatabase()
-        runQuery("EXPLAIN QUERY PLAN SELECT * FROM Track;", in: app)
 
         let canvas = app.descendants(matching: .any).matching(identifier: "query-plan-diagram").firstMatch
         XCTAssertTrue(canvas.waitToExist(timeout: 20), "Diagram mode must show the plan canvas")
-    }
 
-    func testAPlanCanBePinnedLikeAnyResult() throws {
-        let app = try launchWithSampleDatabase()
-        runQuery("EXPLAIN QUERY PLAN SELECT * FROM Track;", in: app)
+        modePicker.radioButtons["Tree"].click()
+        let outline = app.outlines["query-plan-outline"].firstMatch
+        XCTAssertTrue(outline.waitToExist(timeout: 10), "Tree mode must show the plan outline")
+        XCTAssertGreaterThan(outline.outlineRows.count, 0, "The outline must list the plan's steps")
 
-        let resultTab = app.buttons["result-tab"].firstMatch
-        XCTAssertTrue(resultTab.waitToExist(timeout: 20))
+        let detail = app.descendants(matching: .any).matching(identifier: "query-plan-detail-pane").firstMatch
+        XCTAssertTrue(detail.waitToExist(timeout: 10), "Selecting a step must fill the detail pane")
+
         resultTab.rightClick()
 
         /// A contextual menu opens inside the window; the menu-bar menus hang off `MenuBar`, so

--- a/TableProUITests/QueryStatementRunUITests.swift
+++ b/TableProUITests/QueryStatementRunUITests.swift
@@ -6,36 +6,37 @@ import XCTest
 final class QueryStatementRunUITests: UITestCase {
     private let script = "SELECT 1;\nSELECT 2;\nSELECT 3;"
 
-    func testEachStatementPublishesItsOwnRunControl() throws {
+    /// One launch, one query tab, four scripts.
+    ///
+    /// Each of these used to launch the app and open the sample database to type a different script
+    /// into an empty editor. The editor is the only thing they need, and selecting all and retyping
+    /// empties it just as well as a new app does.
+    ///
+    /// The text is replaced rather than typed into a new tab each time, so a control left behind by
+    /// a previous script cannot be counted by the next one: `runControls` matches on the window,
+    /// and every count assertion here would be wrong if an earlier script's gutter survived.
+    ///
+    /// `continueAfterFailure` is on because the phases are independent.
+    func testTheGutterPublishesOneRunControlPerStatement() throws {
+        continueAfterFailure = true
         let app = try launchWithSampleDatabase()
         let editor = openQueryTab(in: app)
 
-        app.typeText(script)
-        XCTAssertTrue(waitForEditorText(containing: "SELECT 3", in: editor))
-
+        replace(editor, in: app, with: script, settleOn: "SELECT 3")
         let controls = runControls(in: app)
         XCTAssertTrue(
             controls.firstMatch.waitToExist(timeout: 10),
             "Every statement must publish a run control"
         )
         XCTAssertEqual(controls.count, 3, "Three statements must produce three run controls")
-    }
 
-    /// The control has to sit beside the statement it runs, so its label names the line the statement starts on.
-    /// Pressing it is covered by `StatementRunControllerTests`, because XCUITest resolves a click through a positional
-    /// accessibility lookup and cannot map a drawn element inside the gutter, which floats over the text view. The
-    /// existing fold tests drive the Query menu for the same reason.
-    func testEachRunControlIsAnchoredOnItsOwnStatementsLine() throws {
-        let app = try launchWithSampleDatabase()
-        let editor = openQueryTab(in: app)
-
-        app.typeText(script)
-        XCTAssertTrue(waitForEditorText(containing: "SELECT 3", in: editor))
-
-        for line in 1...3 {
-            let control = runControl(onLine: line, in: app)
+        /// The control has to sit beside the statement it runs, so its label names the line the statement starts on.
+        /// Pressing it is covered by `StatementRunControllerTests`, because XCUITest resolves a click through a
+        /// positional accessibility lookup and cannot map a drawn element inside the gutter, which floats over the
+        /// text view. The existing fold tests drive the Query menu for the same reason.
+        for line in 1 ... 3 {
             XCTAssertTrue(
-                control.waitToExist(timeout: 10),
+                runControl(onLine: line, in: app).waitToExist(timeout: 10),
                 "The statement on line \(line) must have its own run control"
             )
         }
@@ -43,36 +44,29 @@ final class QueryStatementRunUITests: UITestCase {
             runControl(onLine: 4, in: app).exists,
             "A line with no statement on it must have no run control"
         )
-    }
 
-    /// A routine body is one statement, so it gets one control on its opening line rather than one per statement
-    /// inside it. Splitting there is what used to send a fragment to the driver.
-    func testARoutineBodyGetsASingleRunControl() throws {
-        let app = try launchWithSampleDatabase()
-        let editor = openQueryTab(in: app)
-
-        app.typeText("CREATE TRIGGER t AFTER INSERT ON a BEGIN\nUPDATE b SET x = 1;\nDELETE FROM c;\nEND;\n")
-        XCTAssertTrue(waitForEditorText(containing: "DELETE FROM c", in: editor))
-
-        let controls = runControls(in: app)
-        XCTAssertTrue(controls.firstMatch.waitToExist(timeout: 10))
-        XCTAssertEqual(controls.count, 1, "The whole BEGIN ... END body is one statement")
+        /// A routine body is one statement, so it gets one control on its opening line rather than one per statement
+        /// inside it. Splitting there is what used to send a fragment to the driver.
+        replace(
+            editor,
+            in: app,
+            with: "CREATE TRIGGER t AFTER INSERT ON a BEGIN\nUPDATE b SET x = 1;\nDELETE FROM c;\nEND;\n",
+            settleOn: "DELETE FROM c"
+        )
+        XCTAssertTrue(runControls(in: app).firstMatch.waitToExist(timeout: 10))
+        XCTAssertEqual(runControls(in: app).count, 1, "The whole BEGIN ... END body is one statement")
         XCTAssertTrue(
             runControl(onLine: 1, in: app).exists,
             "The one control belongs on the line the routine opens"
         )
-    }
 
-    func testAControlOnlyAppearsForAStatementThatCarriesSomething() throws {
-        let app = try launchWithSampleDatabase()
-        let editor = openQueryTab(in: app)
-
-        app.typeText("SELECT 1;\n-- just a note\n")
-        XCTAssertTrue(waitForEditorText(containing: "just a note", in: editor))
-
-        let controls = runControls(in: app)
-        XCTAssertTrue(controls.firstMatch.waitToExist(timeout: 10))
-        XCTAssertEqual(controls.count, 1, "A comment carries no statement, so it gets no run control")
+        replace(editor, in: app, with: "SELECT 1;\n-- just a note\n", settleOn: "just a note")
+        XCTAssertTrue(runControls(in: app).firstMatch.waitToExist(timeout: 10))
+        XCTAssertEqual(
+            runControls(in: app).count,
+            1,
+            "A comment carries no statement, so it gets no run control"
+        )
     }
 
     // MARK: - Helpers
@@ -92,6 +86,18 @@ final class QueryStatementRunUITests: UITestCase {
         let editor = editorTextView(in: app)
         XCTAssertTrue(editor.waitToExist(timeout: 10))
         return editor
+    }
+
+    /// Select all and type over it. The editor keeps its identity, so the gutter republishes its
+    /// controls for the new text instead of adding to the old ones.
+    private func replace(_ editor: XCUIElement, in app: XCUIApplication, with text: String, settleOn needle: String) {
+        editor.click()
+        app.typeKey("a", modifierFlags: .command)
+        app.typeText(text)
+        XCTAssertTrue(
+            waitForEditorText(containing: needle, in: editor),
+            "The editor must hold the script before its run controls mean anything"
+        )
     }
 
     private func waitForEditorText(


### PR DESCRIPTION
25 test methods across five suites launched the app 25 times to look at the same five screens. They now launch it 6 times.

Measured, on the same machine, before and after:

| suite | cases | before | after |
| --- | --- | ---: | ---: |
| `OpenQuicklyCommandUITests` | 6 → 2 | 240.5s | 76.1s |
| `QueryInsightsTabUITests` | 6 → 1 | 232.6s | 31.9s |
| `QueryHistoryPanelUITests` | 5 → 1 | 131.8s | 5.7s |
| `QueryPlanResultUITests` | 4 → 1 | 107.2s | 14.1s |
| `QueryStatementRunUITests` | 4 → 1 | 101.2s | 10.4s |
| | **25 → 6** | **813.3s** | **138.2s** |

The "before" column is from the result bundle of run 32473179239; the "after" is a local run of these five suites, all six methods passing.

Nothing is dropped. Every assertion that was there is still there, in the same order within its phase.

## Why merging rather than sharing an app between methods

The obvious alternative is to keep 25 methods and hold one launched app across them. That is wrong here, and `UITestCase` is why: it builds a throwaway sandbox root per test, hands the app its Application Support root, defaults domain and keychain inside it, empties the shared defaults domain in `setUp`, and deletes the directory in `tearDown`. An app shared across methods would outlive the sandbox it was given. The isolation is the point of that class, and it exists because a suite once restored a real session and connected to a production database over an SSH tunnel.

Merging keeps the isolation exactly as it is: one sandbox, one app, one test.

## What the ordering has to respect

Within a merged method the phases run against one window, so anything that leaves the window changed goes last:

- `QueryInsightsTabUITests`: opening the history drawer is last.
- `QueryHistoryPanelUITests`: toggling the drawer shut is last.
- `QueryPlanResultUITests`: pinning the result is last.
- `OpenQuicklyCommandUITests`: opening two editor tabs is a **separate** method, because every panel assertion would then be running against a different window.
- `QueryStatementRunUITests`: each script replaces the editor's text with Cmd+A rather than opening a new tab, because `runControls` matches on the window and a control left behind by the previous script would be counted by the next one's `count` assertion.

Each method sets `continueAfterFailure = true`. `UITestCase` sets it `false`, which is right for a method testing one thing: with it left off, a broken Escape contract would hide whether the scopes are still reachable, and a CI run would report one of five problems instead of five.

## One assertion this makes possible

`OpenQuicklyCommandUITests` now opens the panel twice in one launch, which lets it assert something no single-launch test could:

```swift
XCTAssertTrue(
    isSelected(scopes.radioButtons["All"]),
    "A reopened panel must not inherit the scope the last one was left in"
)
```

The panel builds a fresh view model per presentation, and a stale cross-connection scope would go and load every other connection's catalog on open. Every method previously only ever saw the panel's first presentation.

## Verification

Local run of all five suites:

```
Passed  62.8s  OpenQuicklyCommandUITests/testTheOpenQuicklyPanelOpensScopesAndHonoursEscape()
Passed  13.3s  OpenQuicklyCommandUITests/testCommandReturnOpensTheResultInANewTab()
Passed  31.9s  QueryInsightsTabUITests/testTheQueryInsightsTabOpensOnceCarriesItsFiltersAndStaysGatedWithoutALicense()
Passed  14.1s  QueryPlanResultUITests/testAPlanArrivesAsAResultTabWithEveryModeAndCanBePinned()
Passed  10.4s  QueryStatementRunUITests/testTheGutterPublishesOneRunControlPerStatement()
Passed   5.7s  QueryHistoryPanelUITests/testTheHistoryDrawerListsTheQueryCarriesItsFiltersAndTogglesShut()
```

`swiftlint --strict` clean on all five files.