### PR TITLE
fix(build): code-sign the OpenSSL dylibs the app embeds

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -110,22 +110,6 @@ targets:
       - path: TablePro/Resources/ThirdPartyLicenses
         type: folder
         buildPhase: resources
-      # Copied into the bundle rather than reached through an absolute rpath into the source
-      # tree. TablePro.debug.dylib and the MySQL, PostgreSQL and Redis plugins all link
-      # @rpath/libssl.3.dylib and @rpath/libcrypto.3.dylib, and both dylibs already carry an
-      # @rpath install name, so @executable_path/../Frameworks resolves them once they are here.
-      #
-      # Without this the app only launched from a checkout that had Libs/dylibs on disk, which is
-      # what made the sharded test jobs abort with SIGABRT before XCTest could connect (#2334).
-      # A release build was already self-contained, because build-release.sh copies them in.
-      - path: Libs/dylibs/libssl.3.dylib
-        buildPhase:
-          copyFiles:
-            destination: frameworks
-      - path: Libs/dylibs/libcrypto.3.dylib
-        buildPhase:
-          copyFiles:
-            destination: frameworks
     configFiles:
       Debug: Configs/Version.xcconfig
       Release: Configs/Version.xcconfig
@@ -134,6 +118,31 @@ targets:
         embed: true
         codeSign: true
         removeHeaders: true
+      # Embedded rather than reached through an absolute rpath into the source tree.
+      # TablePro.debug.dylib and the MySQL, PostgreSQL and Redis plugins all link
+      # @rpath/libssl.3.dylib and @rpath/libcrypto.3.dylib, and both dylibs already carry an
+      # @rpath install name, so @executable_path/../Frameworks resolves them once they are here.
+      # Without this the app only launched from a checkout that had Libs/dylibs on disk, which is
+      # what made the sharded test jobs abort with SIGABRT before XCTest could connect (#2334).
+      # A release build was already self-contained: build-release.sh copies them in.
+      #
+      # codeSign matters as much as embed. create-openssl-dylibs.sh leaves them ad-hoc signed, and
+      # codesign refuses a bundle whose nested code carries a different identity from the app:
+      # "code object is not signed at all, in subcomponent libcrypto.3.dylib". A plain copy-files
+      # phase does not re-sign, so this built only until download-libs.sh next regenerated the
+      # dylibs. CI never saw it, because every CI build passes CODE_SIGNING_ALLOWED=NO.
+      #
+      # link: false keeps this to embedding and signing. A framework dependency links by default,
+      # which would put both into Link Binary With Libraries and change what the app links against;
+      # the app reaches them through @rpath from TablePro.debug.dylib and the plugins, as before.
+      - framework: Libs/dylibs/libssl.3.dylib
+        embed: true
+        codeSign: true
+        link: false
+      - framework: Libs/dylibs/libcrypto.3.dylib
+        embed: true
+        codeSign: true
+        link: false
       - target: mcp-server
         embed: true
         codeSign: true


### PR DESCRIPTION
A Debug build fails on any machine with a signing identity configured. Second piece of #2358 fallout, after #2367.

```
TablePro.app: code object is not signed at all
In subcomponent: .../TablePro.app/Contents/Frameworks/libcrypto.3.dylib
Command CodeSign failed with a nonzero exit code
```

#2358 put `libssl.3.dylib` and `libcrypto.3.dylib` into `Contents/Frameworks` through a plain copy-files phase. A copy-files phase does not re-sign what it copies, and `create-openssl-dylibs.sh` leaves them **ad-hoc** signed:

```
Libs/dylibs/libssl.3.dylib       Signature=adhoc
Libs/dylibs/libcrypto.3.dylib    Signature=adhoc
```

`codesign` refuses a bundle whose nested code carries a different identity from the app, so the app never gets signed and the build stops.

## Why nobody has hit it yet

Two reasons, and they are the interesting part.

**CI cannot see it.** Every macOS CI build passes `CODE_SIGNING_ALLOWED=NO`, so the signing step that fails never runs there.

**It is latent until the dylibs are regenerated.** Whatever was in `Libs/dylibs` before #2358 happened to carry a real signature, so the copy produced a valid bundle. `scripts/download-libs.sh` ends by running `create-openssl-dylibs.sh`, which rewrites them ad-hoc. I hit this by running `download-libs.sh --force` for unrelated reasons, and every Debug build afterwards failed. Anyone doing a fresh setup in the documented order gets the ad-hoc pair from the start, which is to say every new checkout is already broken.

CLAUDE.md tells developers to put `TABLEPRO_DEVELOPMENT_TEAM` in `Configs/Secrets.xcconfig`, so the affected configuration is the documented one.

## Fix

The two dylibs become embedded framework dependencies, which is what `Sparkle`, `TableProPluginKit` and `mcp-server` in the same file already do:

```yaml
- framework: Libs/dylibs/libssl.3.dylib
  embed: true
  codeSign: true
  link: false
```

`codeSign: true` re-signs on copy with the app's own identity. `link: false` is deliberate: a framework dependency links by default, which would add both to Link Binary With Libraries and change what the app links against. Verified in the generated project, before and after:

```
without link: false   libssl.3.dylib -> ['Embed Frameworks', 'Frameworks']
with    link: false   libssl.3.dylib -> ['Embed Frameworks']
```

The app reaches them through `@rpath` from `TablePro.debug.dylib` and the plugins, exactly as before.

## Verification

With a real Apple Development identity:

```
build exit=0
deep verify: OK                       (codesign --verify --deep --strict)
libssl.3.dylib     Authority=Apple Development: Dat Ngo Quoc (YWHY3DYQ53)
libcrypto.3.dylib  Authority=Apple Development: Dat Ngo Quoc (YWHY3DYQ53)
app binary ssl/crypto link entries = 0
```

The app still launches, which is the bug #2358 existed to fix: `QueryExecutorTests` runs through the app host and passes. All 14 bundled plugins still `dlopen` (`scripts/ci/verify-plugin-loads.sh`). The only rpaths in the built binary are `@executable_path`, `@loader_path`, the DerivedData `PackageFrameworks` path Xcode adds, and `@executable_path/../Frameworks`: no absolute path into the source tree.

The release path is unaffected. `build-release.sh:332` copies both dylibs into the embed directory itself with `cp -f` and then re-signs the whole bundle with Developer ID, so Xcode placing them there first is overwritten and re-signed either way.