### PR TITLE
fix(datagrid): scroll long text values in the row inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Open in Window on a row inspector text field, for reading or editing a long value on a bigger surface.
+
 ### Fixed
 
 - Switch Connection and Open Database now open on a narrow window, and after you remove their toolbar button, instead of doing nothing at all.
+- A large text value in the row inspector now scrolls in a resizable text view instead of being clipped, and stays selectable and copyable when the row is read-only.
+- The inspector picks its multi-line editor from the value, so a large value in `VARCHAR(MAX)`, `NCLOB` or ClickHouse's `Nullable(String)` is no longer stuck on one line.
+- Right-clicking a read-only inspector field now offers Copy Value instead of an empty menu.
 
 ## [0.67.1] - 2026-08-22
 

--- a/TablePro/Core/Storage/AppSettingsStorage.swift
+++ b/TablePro/Core/Storage/AppSettingsStorage.swift
@@ -229,6 +229,7 @@ final class AppSettingsStorage: Sendable {
         saveMCP(.default)
         defaults.removeObject(forKey: PreferenceKeys.selectedSettingsPane.name)
         defaults.removeObject(forKey: PreferenceKeys.rowInspectorJsonFieldHeight.name)
+        defaults.removeObject(forKey: PreferenceKeys.rowInspectorTextFieldHeight.name)
         defaults.removeObject(forKey: SidebarPersistenceKey.defaultLayout)
     }
 

--- a/TablePro/Core/Storage/Preferences/PreferenceKeys.swift
+++ b/TablePro/Core/Storage/Preferences/PreferenceKeys.swift
@@ -10,6 +10,7 @@ enum PreferenceKeys {
     static let linkedSQLFolders = DefaultsKey<[LinkedSQLFolder]>("com.TablePro.linkedSQLFolders")
     static let selectedSettingsPane = DefaultsKey<String>("com.TablePro.settings.selectedPane")
     static let rowInspectorJsonFieldHeight = DefaultsKey<Double>("com.TablePro.rightSidebar.jsonFieldHeight")
+    static let rowInspectorTextFieldHeight = DefaultsKey<Double>("com.TablePro.rightSidebar.textFieldHeight")
     static let workspaceRailOrder = DefaultsKey<[WorkspaceID]>("com.TablePro.workspaceRail.order")
     static let queryPlanRawFontSize = DefaultsKey<Double>("com.TablePro.queryPlan.rawFontSize")
 
@@ -18,6 +19,7 @@ enum PreferenceKeys {
         linkedSQLFolders.name,
         selectedSettingsPane.name,
         rowInspectorJsonFieldHeight.name,
+        rowInspectorTextFieldHeight.name,
         workspaceRailOrder.name,
         queryPlanRawFontSize.name,
     ]

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -115311,6 +115311,74 @@
         }
       }
     },
+    "Text Viewer" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트 뷰어"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metin Görüntüleyici"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trình xem văn bản"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文本查看器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字檢視器"
+          }
+        }
+      }
+    },
+    "Text: %@" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트: %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metin: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Văn bản: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文本：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字：%@"
+          }
+        }
+      }
+    },
     "That doesn't look like a valid license key. Check for typos and try again." : {
       "localizations" : {
         "ko" : {

--- a/TablePro/Views/Connection/ConnectionAdvancedView.swift
+++ b/TablePro/Views/Connection/ConnectionAdvancedView.swift
@@ -5,6 +5,7 @@
 //  Created by Ngo Quoc Dat on 31/3/26.
 //
 
+import AppKit
 import SwiftUI
 import TableProPluginKit
 
@@ -121,50 +122,14 @@ struct ConnectionAdvancedView: View {
 
 // MARK: - Startup Commands Editor
 
-struct StartupCommandsEditor: NSViewRepresentable {
+struct StartupCommandsEditor: View {
     @Binding var text: String
 
-    func makeNSView(context: Context) -> NSScrollView {
-        let scrollView = NSTextView.scrollableTextView()
-        guard let textView = scrollView.documentView as? NSTextView else { return scrollView }
-
-        textView.font = .monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
-        textView.isAutomaticQuoteSubstitutionEnabled = false
-        textView.isAutomaticDashSubstitutionEnabled = false
-        textView.isAutomaticTextReplacementEnabled = false
-        textView.isAutomaticSpellingCorrectionEnabled = false
-        textView.isRichText = false
-        textView.string = text
-        textView.textContainerInset = NSSize(width: 4, height: 6)
-        textView.delegate = context.coordinator
-
-        scrollView.borderType = .bezelBorder
-        scrollView.hasVerticalScroller = true
-
-        return scrollView
-    }
-
-    func updateNSView(_ scrollView: NSScrollView, context: Context) {
-        guard let textView = scrollView.documentView as? NSTextView else { return }
-        if textView.string != text {
-            textView.string = text
-        }
-    }
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text)
-    }
-
-    final class Coordinator: NSObject, NSTextViewDelegate {
-        private var text: Binding<String>
-
-        init(text: Binding<String>) {
-            self.text = text
-        }
-
-        func textDidChange(_ notification: Notification) {
-            guard let textView = notification.object as? NSTextView else { return }
-            text.wrappedValue = textView.string
-        }
+    var body: some View {
+        TextValueEditor(
+            text: $text,
+            font: .monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular),
+            borderType: .bezelBorder
+        )
     }
 }

--- a/TablePro/Views/ConnectionForm/Panes/AIRulesPaneView.swift
+++ b/TablePro/Views/ConnectionForm/Panes/AIRulesPaneView.swift
@@ -42,62 +42,15 @@ struct AIRulesPaneView: View {
     }
 }
 
-private struct AIRulesEditor: NSViewRepresentable {
+private struct AIRulesEditor: View {
     @Binding var text: String
 
-    func makeNSView(context: Context) -> NSScrollView {
-        let scrollView = NSTextView.scrollableTextView()
-        guard let textView = scrollView.documentView as? NSTextView else { return scrollView }
-
-        textView.font = .monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
-        textView.isAutomaticQuoteSubstitutionEnabled = false
-        textView.isAutomaticDashSubstitutionEnabled = false
-        textView.isAutomaticTextReplacementEnabled = false
-        textView.isAutomaticSpellingCorrectionEnabled = false
-        textView.isRichText = false
-        textView.string = text
-        textView.textContainerInset = NSSize(width: 4, height: 6)
-        textView.delegate = context.coordinator
-
-        scrollView.borderType = .bezelBorder
-        scrollView.hasVerticalScroller = true
-
-        return scrollView
-    }
-
-    func updateNSView(_ scrollView: NSScrollView, context: Context) {
-        guard let textView = scrollView.documentView as? NSTextView else { return }
-        if textView.string != text {
-            textView.string = text
-        }
-    }
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text)
-    }
-
-    final class Coordinator: NSObject, NSTextViewDelegate {
-        private var text: Binding<String>
-
-        init(text: Binding<String>) {
-            self.text = text
-        }
-
-        func textDidChange(_ notification: Notification) {
-            guard let textView = notification.object as? NSTextView else { return }
-            text.wrappedValue = textView.string
-        }
-
-        func textView(_ textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
-            if commandSelector == #selector(NSResponder.insertTab(_:)) {
-                textView.window?.selectNextKeyView(nil)
-                return true
-            }
-            if commandSelector == #selector(NSResponder.insertBacktab(_:)) {
-                textView.window?.selectPreviousKeyView(nil)
-                return true
-            }
-            return false
-        }
+    var body: some View {
+        TextValueEditor(
+            text: $text,
+            font: .monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular),
+            borderType: .bezelBorder,
+            movesFocusOnTab: true
+        )
     }
 }

--- a/TablePro/Views/Results/PhpViewerWindowController.swift
+++ b/TablePro/Views/Results/PhpViewerWindowController.swift
@@ -7,78 +7,22 @@ import AppKit
 import SwiftUI
 
 @MainActor
-final class PhpViewerWindowController {
-    private static var activeWindows: [ObjectIdentifier: PhpViewerWindowController] = [:]
-    private static let defaultSize = NSSize(width: 640, height: 500)
-    private static let minSize = NSSize(width: 400, height: 300)
-    private static let autosaveName: NSWindow.FrameAutosaveName = "PhpViewerWindow"
-
-    private var window: NSWindow?
-    private var closeObserver: NSObjectProtocol?
-
+internal final class PhpViewerWindowController: ValueViewerWindowController {
     static func open(text: String?, columnName: String?) {
-        let controller = PhpViewerWindowController()
-        controller.showWindow(text: text, columnName: columnName)
-    }
-
-    private func showWindow(text: String?, columnName: String?) {
-        let window = NSWindow(
-            contentRect: NSRect(origin: .zero, size: Self.defaultSize),
-            styleMask: [.titled, .closable, .resizable, .miniaturizable],
-            backing: .buffered,
-            defer: false
-        )
-        window.identifier = NSUserInterfaceItemIdentifier("php-viewer")
+        let title: String
         if let columnName {
-            window.title = String(format: String(localized: "PHP: %@"), columnName)
+            title = String(format: String(localized: "PHP: %@"), columnName)
         } else {
-            window.title = String(localized: "PHP Viewer")
-        }
-        window.isReleasedWhenClosed = false
-        window.minSize = Self.minSize
-        window.collectionBehavior = [.fullScreenPrimary]
-
-        let closeWindow: () -> Void = { [weak window] in window?.close() }
-        let contentView = PhpViewerWindowContent(
-            initialValue: text,
-            onDismiss: closeWindow
-        )
-        window.contentView = NSHostingView(rootView: contentView)
-
-        self.window = window
-
-        let key = ObjectIdentifier(self)
-        Self.activeWindows[key] = self
-
-        closeObserver = NotificationCenter.default.addObserver(
-            forName: NSWindow.willCloseNotification,
-            object: window,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in
-                Self.activeWindows.removeValue(forKey: key)
-                self?.closeObserver.map { NotificationCenter.default.removeObserver($0) }
-                self?.closeObserver = nil
-                self?.window = nil
-            }
+            title = String(localized: "PHP Viewer")
         }
 
-        window.applyAutosaveName(Self.autosaveName)
-        window.makeKeyAndOrderFront(nil)
-    }
-}
-
-// MARK: - Window Content
-
-private struct PhpViewerWindowContent: View {
-    let initialValue: String?
-    let onDismiss: (() -> Void)?
-
-    var body: some View {
-        PhpViewerView(
-            rawValue: initialValue ?? "",
-            onDismiss: onDismiss,
-            onPopOut: nil
-        )
+        let controller = PhpViewerWindowController()
+        controller.present(
+            identifier: "php-viewer",
+            title: title,
+            autosaveName: "PhpViewerWindow"
+        ) { dismiss in
+            PhpViewerView(rawValue: text ?? "", onDismiss: dismiss, onPopOut: nil)
+        }
     }
 }

--- a/TablePro/Views/Results/TextViewerWindowController.swift
+++ b/TablePro/Views/Results/TextViewerWindowController.swift
@@ -1,5 +1,5 @@
 //
-//  JSONViewerWindowController.swift
+//  TextViewerWindowController.swift
 //  TablePro
 //
 
@@ -7,42 +7,39 @@ import AppKit
 import SwiftUI
 
 @MainActor
-internal final class JSONViewerWindowController: ValueViewerWindowController {
-    @discardableResult
+internal final class TextViewerWindowController: ValueViewerWindowController {
     static func open(
         text: String?,
         columnName: String?,
         isEditable: Bool,
         onCommit: ((String) -> Void)?
-    ) -> JSONViewerWindowController {
+    ) {
         let title: String
         if let columnName {
-            title = String(format: String(localized: "JSON: %@"), columnName)
+            title = String(format: String(localized: "Text: %@"), columnName)
         } else {
-            title = String(localized: "JSON Viewer")
+            title = String(localized: "Text Viewer")
         }
 
-        let controller = JSONViewerWindowController()
+        let controller = TextViewerWindowController()
         controller.present(
-            identifier: "json-viewer",
+            identifier: "text-viewer",
             title: title,
-            autosaveName: "JSONViewerWindow"
+            autosaveName: "TextViewerWindow"
         ) { dismiss in
-            JSONViewerWindowContent(
+            TextViewerWindowContent(
                 initialValue: text,
                 isEditable: isEditable,
                 onCommit: onCommit,
                 onDismiss: dismiss
             )
         }
-        return controller
     }
 }
 
 // MARK: - Window Content
 
-private struct JSONViewerWindowContent: View {
-    let initialValue: String?
+private struct TextViewerWindowContent: View {
     let isEditable: Bool
     let onCommit: ((String) -> Void)?
     let onDismiss: (() -> Void)?
@@ -55,7 +52,6 @@ private struct JSONViewerWindowContent: View {
         onCommit: ((String) -> Void)?,
         onDismiss: (() -> Void)?
     ) {
-        self.initialValue = initialValue
         self.isEditable = isEditable
         self.onCommit = onCommit
         self.onDismiss = onDismiss
@@ -63,16 +59,16 @@ private struct JSONViewerWindowContent: View {
     }
 
     var body: some View {
-        JSONViewerView(
+        TextValueEditor(
             text: $text,
             isEditable: isEditable,
-            onDismiss: onDismiss,
-            onCommit: isEditable ? { newValue in
-                if newValue.isEmpty && initialValue == nil { return }
-                if newValue != JsonReindenter.normalize(initialValue ?? "") {
-                    onCommit?(newValue)
-                }
-            } : nil
+            font: .preferredFont(forTextStyle: .body),
+            textContainerInset: NSSize(width: 8, height: 10)
         )
+        .onChange(of: text) {
+            guard isEditable else { return }
+            onCommit?(text)
+        }
+        .onExitCommand { onDismiss?() }
     }
 }

--- a/TablePro/Views/Results/ValueViewerWindowController.swift
+++ b/TablePro/Views/Results/ValueViewerWindowController.swift
@@ -1,0 +1,66 @@
+//
+//  ValueViewerWindowController.swift
+//  TablePro
+//
+
+import AppKit
+import SwiftUI
+
+/// The detached window a popped-out cell value opens in. Subclasses supply the content and the
+/// window's identity; the bookkeeping that keeps a detached window alive lives here once.
+@MainActor
+internal class ValueViewerWindowController {
+    private static var activeWindows: [ObjectIdentifier: ValueViewerWindowController] = [:]
+    private static let defaultSize = NSSize(width: 640, height: 500)
+    private static let minSize = NSSize(width: 400, height: 300)
+
+    private var window: NSWindow?
+    private var closeObserver: NSObjectProtocol?
+
+    /// A popped-out editor commits through the display row it was opened from, so whoever opened
+    /// it has to be able to close it once those rows are gone.
+    func close() {
+        window?.close()
+    }
+
+    func present<Content: View>(
+        identifier: String,
+        title: String,
+        autosaveName: NSWindow.FrameAutosaveName,
+        @ViewBuilder content: (@escaping () -> Void) -> Content
+    ) {
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: ValueViewerWindowController.defaultSize),
+            styleMask: [.titled, .closable, .resizable, .miniaturizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.identifier = NSUserInterfaceItemIdentifier(identifier)
+        window.title = title
+        window.isReleasedWhenClosed = false
+        window.minSize = ValueViewerWindowController.minSize
+        window.collectionBehavior = [.fullScreenPrimary]
+        window.contentView = NSHostingView(rootView: content { [weak window] in window?.close() })
+
+        self.window = window
+
+        let key = ObjectIdentifier(self)
+        ValueViewerWindowController.activeWindows[key] = self
+
+        closeObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                ValueViewerWindowController.activeWindows.removeValue(forKey: key)
+                self?.closeObserver.map { NotificationCenter.default.removeObserver($0) }
+                self?.closeObserver = nil
+                self?.window = nil
+            }
+        }
+
+        window.applyAutosaveName(autosaveName)
+        window.makeKeyAndOrderFront(nil)
+    }
+}

--- a/TablePro/Views/RightSidebar/EditableFieldView.swift
+++ b/TablePro/Views/RightSidebar/EditableFieldView.swift
@@ -25,20 +25,15 @@ internal struct FieldDetailView: View {
 
     @State private var isHovered = false
 
-    private var offersNullAndDefault: Bool {
-        !context.isReadOnly && context.allowsNullAndDefault
-    }
-
     var body: some View {
         let kind = FieldEditorResolver.resolve(context: context)
 
         let isPickerField: Bool = {
             switch kind {
-            case .boolean, .enumPicker, .setPicker: return true
+            case .boolean, .enumPicker, .setPicker, .typePicker: return true
             default: return false
             }
         }()
-        let showsFieldMenu = offersNullAndDefault
 
         VStack(alignment: .leading, spacing: 4) {
             fieldHeader
@@ -54,11 +49,12 @@ internal struct FieldDetailView: View {
                     resolvedEditor(for: kind)
                 }
                 .overlay(alignment: .topTrailing) {
-                    if showsFieldMenu && isHovered {
+                    if isHovered {
                         FieldMenuView(
                             value: context.value.wrappedValue,
                             columnType: context.columnType,
                             sqlFunctions: SQLFunctionProvider.functions(for: databaseType),
+                            canMutate: context.canMutate,
                             isPendingNull: isPendingNull,
                             isPendingDefault: isPendingDefault,
                             onSetNull: onSetNull,
@@ -75,20 +71,19 @@ internal struct FieldDetailView: View {
         .labelsHidden()
         .onHover { isHovered = $0 }
         .contextMenu {
-            if showsFieldMenu {
-                FieldMenuContent(
-                    value: context.value.wrappedValue,
-                    columnType: context.columnType,
-                    sqlFunctions: SQLFunctionProvider.functions(for: databaseType),
-                    isPendingNull: isPendingNull,
-                    isPendingDefault: isPendingDefault,
-                    onSetNull: onSetNull,
-                    onSetDefault: onSetDefault,
-                    onSetEmpty: onSetEmpty,
-                    onSetFunction: onSetFunction,
-                    onClear: { context.value.wrappedValue = context.originalValue ?? "" }
-                )
-            }
+            FieldMenuContent(
+                value: context.value.wrappedValue,
+                columnType: context.columnType,
+                sqlFunctions: SQLFunctionProvider.functions(for: databaseType),
+                canMutate: context.canMutate,
+                isPendingNull: isPendingNull,
+                isPendingDefault: isPendingDefault,
+                onSetNull: onSetNull,
+                onSetDefault: onSetDefault,
+                onSetEmpty: onSetEmpty,
+                onSetFunction: onSetFunction,
+                onClear: { context.value.wrappedValue = context.originalValue ?? "" }
+            )
         }
     }
 
@@ -133,6 +128,8 @@ internal struct FieldDetailView: View {
             return 80
         case .blobHex:
             return 60
+        case .multiLine:
+            return ResizableFieldMetrics.defaultTextHeight
         default:
             return nil
         }
@@ -160,8 +157,8 @@ internal struct FieldDetailView: View {
                 context: context,
                 isPendingNull: isPendingNull,
                 isPendingDefault: isPendingDefault,
-                onSetNull: offersNullAndDefault ? onSetNull : nil,
-                onSetDefault: offersNullAndDefault ? onSetDefault : nil
+                onSetNull: context.canMutate ? onSetNull : nil,
+                onSetDefault: context.canMutate ? onSetDefault : nil
             )
         case .enumPicker(let values):
             EnumPickerView(
@@ -169,8 +166,8 @@ internal struct FieldDetailView: View {
                 values: values,
                 isPendingNull: isPendingNull,
                 isPendingDefault: isPendingDefault,
-                onSetNull: offersNullAndDefault ? onSetNull : nil,
-                onSetDefault: offersNullAndDefault ? onSetDefault : nil
+                onSetNull: context.canMutate ? onSetNull : nil,
+                onSetDefault: context.canMutate ? onSetDefault : nil
             )
         case .setPicker(let values):
             SetPickerView(
@@ -178,15 +175,15 @@ internal struct FieldDetailView: View {
                 values: values,
                 isPendingNull: isPendingNull,
                 isPendingDefault: isPendingDefault,
-                onSetNull: offersNullAndDefault ? onSetNull : nil,
-                onSetDefault: offersNullAndDefault ? onSetDefault : nil
+                onSetNull: context.canMutate ? onSetNull : nil,
+                onSetDefault: context.canMutate ? onSetDefault : nil
             )
         case .typePicker:
             TypePickerFieldView(context: context, databaseType: databaseType)
         case .schemaText:
             SchemaTextFieldView(context: context)
         case .multiLine:
-            MultiLineEditorView(context: context)
+            MultiLineEditorView(context: context, onPopOut: onPopOut)
         case .singleLine:
             SingleLineEditorView(context: context)
         }

--- a/TablePro/Views/RightSidebar/FieldEditors/FieldEditorContext.swift
+++ b/TablePro/Views/RightSidebar/FieldEditors/FieldEditorContext.swift
@@ -56,4 +56,19 @@ internal struct FieldEditorContext {
             return "NULL"
         }
     }
+
+    /// Set NULL, Set DEFAULT and the SQL functions only make sense where an edit can be recorded.
+    /// The copy actions in the same menu are always available, which is why this is its own flag.
+    var canMutate: Bool {
+        !isReadOnly && allowsNullAndDefault
+    }
+
+    /// A text view has no placeholder of its own, and echoing a long stored value behind an
+    /// emptied editor would draw the whole value twice. Only the state placeholders belong there,
+    /// and nil where the stored value really is the empty string: a database client must not
+    /// report `''` as NULL.
+    var emptyStatePlaceholder: String? {
+        if hasMultipleValues { return String(localized: "Multiple values") }
+        return originalValue == nil ? "NULL" : nil
+    }
 }

--- a/TablePro/Views/RightSidebar/FieldEditors/FieldMenuView.swift
+++ b/TablePro/Views/RightSidebar/FieldEditors/FieldMenuView.swift
@@ -7,10 +7,14 @@ import SwiftUI
 
 /// The field actions (Set NULL/DEFAULT/EMPTY, copy, SQL functions). Shared by the
 /// hover menu button and the field's context menu so both stay in sync.
+///
+/// A read-only field keeps the copy actions and loses the mutating ones. Hiding the whole menu
+/// left a value that is neither selectable nor copyable.
 internal struct FieldMenuContent: View {
     let value: String
     let columnType: ColumnType
     let sqlFunctions: [SQLFunctionProvider.SQLFunction]
+    let canMutate: Bool
     let isPendingNull: Bool
     let isPendingDefault: Bool
     let onSetNull: () -> Void
@@ -20,11 +24,13 @@ internal struct FieldMenuContent: View {
     let onClear: () -> Void
 
     var body: some View {
-        Button("Set NULL") { onSetNull() }
-        Button("Set DEFAULT") { onSetDefault() }
-        Button("Set EMPTY") { onSetEmpty() }
+        if canMutate {
+            Button("Set NULL") { onSetNull() }
+            Button("Set DEFAULT") { onSetDefault() }
+            Button("Set EMPTY") { onSetEmpty() }
 
-        Divider()
+            Divider()
+        }
 
         if columnType.isJsonType {
             Button("Pretty Print") {
@@ -46,17 +52,19 @@ internal struct FieldMenuContent: View {
             ClipboardService.shared.writeText(value)
         }
 
-        Divider()
-
-        Menu("SQL Functions") {
-            ForEach(sqlFunctions, id: \.expression) { function in
-                Button(function.label) { onSetFunction(function.expression) }
-            }
-        }
-
-        if isPendingNull || isPendingDefault {
+        if canMutate {
             Divider()
-            Button("Clear") { onClear() }
+
+            Menu("SQL Functions") {
+                ForEach(sqlFunctions, id: \.expression) { function in
+                    Button(function.label) { onSetFunction(function.expression) }
+                }
+            }
+
+            if isPendingNull || isPendingDefault {
+                Divider()
+                Button("Clear") { onClear() }
+            }
         }
     }
 }
@@ -65,6 +73,7 @@ internal struct FieldMenuView: View {
     let value: String
     let columnType: ColumnType
     let sqlFunctions: [SQLFunctionProvider.SQLFunction]
+    let canMutate: Bool
     let isPendingNull: Bool
     let isPendingDefault: Bool
     let onSetNull: () -> Void
@@ -79,6 +88,7 @@ internal struct FieldMenuView: View {
                 value: value,
                 columnType: columnType,
                 sqlFunctions: sqlFunctions,
+                canMutate: canMutate,
                 isPendingNull: isPendingNull,
                 isPendingDefault: isPendingDefault,
                 onSetNull: onSetNull,

--- a/TablePro/Views/RightSidebar/FieldEditors/MultiLineEditorView.swift
+++ b/TablePro/Views/RightSidebar/FieldEditors/MultiLineEditorView.swift
@@ -7,16 +7,50 @@ import SwiftUI
 
 internal struct MultiLineEditorView: View {
     let context: FieldEditorContext
+    var onPopOut: ((String) -> Void)?
 
-    @FocusState private var isFocused: Bool
+    @AppStorage(PreferenceKeys.rowInspectorTextFieldHeight.name, store: AppStorageEnvironment.shared.defaults)
+    private var fieldHeight = ResizableFieldMetrics.defaultTextHeight
 
     var body: some View {
-        TextField(context.placeholderText, text: context.value, axis: .vertical)
-            .textFieldStyle(.roundedBorder)
-            .font(.subheadline)
-            .lineLimit(3...6)
-            .autocorrectionDisabled(true)
-            .focused($isFocused)
-            .disabled(context.isReadOnly)
+        ResizableEditorContainer(height: $fieldHeight, range: ResizableFieldMetrics.textHeightRange) {
+            TextValueEditor(
+                text: context.value,
+                isEditable: !context.isReadOnly,
+                font: .preferredFont(forTextStyle: .subheadline),
+                movesFocusOnTab: true
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 5))
+            .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Color(nsColor: .separatorColor)))
+            .overlay(alignment: .topLeading) { placeholder }
+            .overlay(alignment: .bottomTrailing) { popOutButton }
+        }
+    }
+
+    @ViewBuilder
+    private var placeholder: some View {
+        if context.value.wrappedValue.isEmpty, let text = context.emptyStatePlaceholder {
+            Text(text)
+                .font(.subheadline)
+                .foregroundStyle(.tertiary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+                .allowsHitTesting(false)
+        }
+    }
+
+    @ViewBuilder
+    private var popOutButton: some View {
+        if let onPopOut {
+            Button { onPopOut(context.value.wrappedValue) } label: {
+                Image(systemName: "arrow.up.forward.app")
+                    .font(.caption2)
+                    .padding(4)
+                    .themeMaterial(.inlineControl, .ultraThinMaterial, in: RoundedRectangle(cornerRadius: 4))
+            }
+            .buttonStyle(.borderless)
+            .help(String(localized: "Open in Window"))
+            .padding(4)
+        }
     }
 }

--- a/TablePro/Views/RightSidebar/FieldEditors/ResizableFieldMetrics.swift
+++ b/TablePro/Views/RightSidebar/FieldEditors/ResizableFieldMetrics.swift
@@ -9,6 +9,9 @@ internal enum ResizableFieldMetrics {
     static let jsonHeightRange: ClosedRange<Double> = 80...600
     static let defaultJsonHeight: Double = 120
 
+    static let textHeightRange: ClosedRange<Double> = 60...600
+    static let defaultTextHeight: Double = 110
+
     static func resolve(base: Double, delta: Double, range: ClosedRange<Double>) -> Double {
         min(max(base + delta, range.lowerBound), range.upperBound)
     }

--- a/TablePro/Views/RightSidebar/FieldEditors/SingleLineEditorView.swift
+++ b/TablePro/Views/RightSidebar/FieldEditors/SingleLineEditorView.swift
@@ -11,11 +11,30 @@ internal struct SingleLineEditorView: View {
     @FocusState private var isFocused: Bool
 
     var body: some View {
-        TextField(context.placeholderText, text: context.value)
-            .textFieldStyle(.roundedBorder)
+        if context.isReadOnly {
+            readOnlyValue
+        } else {
+            TextField(context.placeholderText, text: context.value)
+                .textFieldStyle(.roundedBorder)
+                .font(.subheadline)
+                .autocorrectionDisabled(true)
+                .focused($isFocused)
+        }
+    }
+
+    /// A disabled text field takes no first responder, so a read-only value could be neither
+    /// selected nor copied out of the field. Selectable text is the read-only presentation.
+    private var readOnlyValue: some View {
+        let value = context.value.wrappedValue
+        let placeholder = value.isEmpty ? context.emptyStatePlaceholder : nil
+        return Text(placeholder ?? value)
             .font(.subheadline)
-            .autocorrectionDisabled(true)
-            .focused($isFocused)
-            .disabled(context.isReadOnly)
+            .foregroundStyle(placeholder == nil ? .primary : .tertiary)
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, minHeight: 16, alignment: .leading)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 4)
+            .background(Color(nsColor: .textBackgroundColor), in: RoundedRectangle(cornerRadius: 5))
+            .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Color(nsColor: .separatorColor)))
     }
 }

--- a/TablePro/Views/RightSidebar/RightSidebarView.swift
+++ b/TablePro/Views/RightSidebar/RightSidebarView.swift
@@ -266,6 +266,20 @@ struct RightSidebarView: View {
         PhpViewerWindowController.open(text: text, columnName: field.columnName)
     }
 
+    private func popOutTextField(text: String? = nil, field: FieldEditState, isEditable: Bool) {
+        let text = text ?? field.pendingValue ?? field.originalValue
+        let fieldId = field.id
+        TextViewerWindowController.open(
+            text: text,
+            columnName: field.columnName,
+            isEditable: isEditable,
+            onCommit: isEditable ? { [editState] newValue in
+                guard let current = editState.fields.first(where: { $0.id == fieldId }) else { return }
+                editState.updateField(at: current.columnIndex, value: newValue)
+            } : nil
+        )
+    }
+
     // MARK: - Field List
 
     private func fieldListForm(
@@ -320,6 +334,7 @@ struct RightSidebarView: View {
         let isJsonField = kind == .json
         let isPhpField = kind == .phpSerialized
         let isStructuredField = isJsonField || isPhpField
+        let isTextField = kind == .multiLine
 
         FieldDetailView(
             context: FieldEditorContext(
@@ -355,11 +370,13 @@ struct RightSidebarView: View {
                     expandedPhpColumnIndex = field.columnIndex
                 }
             } : nil,
-            onPopOut: isStructuredField ? { currentText in
+            onPopOut: isStructuredField || isTextField ? { currentText in
                 if isJsonField {
                     popOutJsonField(text: currentText, field: field, isEditable: isEditable)
-                } else {
+                } else if isPhpField {
                     popOutPhpField(text: currentText, field: field)
+                } else {
+                    popOutTextField(text: currentText, field: field, isEditable: isEditable)
                 }
             } : nil
         )

--- a/TablePro/Views/Shared/FieldEditors/FieldEditorResolver.swift
+++ b/TablePro/Views/Shared/FieldEditors/FieldEditorResolver.swift
@@ -66,9 +66,24 @@ internal enum FieldEditorResolver {
         if BlobFormattingService.shared.requiresFormatting(columnType: type) {
             return .blobHex
         }
-        if isLongText {
+        if isLongText || needsMultiLineEditor(originalValue) {
             return .multiLine
         }
         return .singleLine
     }
+
+    /// `isLongText` only matches six exact type names, so a large value in `VARCHAR(MAX)`,
+    /// `NCLOB` or ClickHouse's `Nullable(String)` never reached the multi-line editor. Whether a
+    /// value belongs on one line is a property of the value, so ask the value as well.
+    static func needsMultiLineEditor(_ value: String?) -> Bool {
+        guard let value, !value.isEmpty else { return false }
+        let text = value as NSString
+        if text.length > multiLineValueThreshold { return true }
+        return text.rangeOfCharacter(from: .newlines).location != NSNotFound
+    }
+
+    /// Two lines' worth. Between 32 and 46 subheadline characters fit one line at the inspector's
+    /// minimum width, so a value past this needs a third line and a short scalar keeps the text
+    /// field AppKit intends for it.
+    static let multiLineValueThreshold = 80
 }

--- a/TablePro/Views/Shared/FieldEditors/TextValueEditor.swift
+++ b/TablePro/Views/Shared/FieldEditors/TextValueEditor.swift
@@ -1,0 +1,122 @@
+//
+//  TextValueEditor.swift
+//  TablePro
+//
+
+import AppKit
+import SwiftUI
+
+/// A scrolling plain-text view for a stored value.
+///
+/// `TextField` is an `NSTextField` at every `axis` setting, so it clips instead of scrolling, and
+/// `TextEditor` leaves AppKit's quote, dash and text substitutions on with no API to reach them,
+/// which would rewrite a value on its way to the database.
+internal struct TextValueEditor: NSViewRepresentable {
+    @Binding var text: String
+    var isEditable: Bool = true
+    var font: NSFont = .systemFont(ofSize: NSFont.systemFontSize)
+    var borderType: NSBorderType = .noBorder
+    var movesFocusOnTab: Bool = false
+    var textContainerInset = NSSize(width: 4, height: 6)
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSTextView.scrollableTextView()
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+
+        guard let textView = scrollView.documentView as? NSTextView else { return scrollView }
+        TextValueEditor.applyPlainTextDefaults(to: textView)
+        textView.delegate = context.coordinator
+        applyConfiguration(to: scrollView, textView: textView, coordinator: context.coordinator)
+
+        textView.string = text
+        context.coordinator.lastAppliedText = text
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        guard let textView = scrollView.documentView as? NSTextView else { return }
+        applyConfiguration(to: scrollView, textView: textView, coordinator: context.coordinator)
+
+        guard context.coordinator.lastAppliedText != text else { return }
+        context.coordinator.lastAppliedText = text
+
+        let caret = textView.selectedRange().location
+        textView.string = text
+        let clamped = min(caret, (text as NSString).length)
+        textView.setSelectedRange(NSRange(location: clamped, length: 0))
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text, movesFocusOnTab: movesFocusOnTab)
+    }
+
+    /// AppKit substitutes typed quotes, dashes and text by default. A stored value has to reach
+    /// the database as the user typed it, so every substitution is off.
+    static func applyPlainTextDefaults(to textView: NSTextView) {
+        textView.isRichText = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.isAutomaticLinkDetectionEnabled = false
+        textView.isAutomaticDataDetectionEnabled = false
+        textView.usesFindBar = true
+        textView.isIncrementalSearchingEnabled = true
+        textView.allowsUndo = true
+    }
+
+    private func applyConfiguration(to scrollView: NSScrollView, textView: NSTextView, coordinator: Coordinator) {
+        coordinator.text = $text
+        coordinator.movesFocusOnTab = movesFocusOnTab
+        if scrollView.borderType != borderType {
+            scrollView.borderType = borderType
+        }
+        if textView.font != font {
+            textView.font = font
+        }
+        if textView.textContainerInset != textContainerInset {
+            textView.textContainerInset = textContainerInset
+        }
+        if textView.isEditable != isEditable {
+            textView.isEditable = isEditable
+        }
+        if !textView.isSelectable {
+            textView.isSelectable = true
+        }
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var text: Binding<String>
+        var movesFocusOnTab: Bool
+        /// What the text view was last given. Comparing against it answers "has the binding
+        /// moved" without bridging the whole NSString back, which costs 45ms on a 1 MB value and
+        /// would run on every SwiftUI update pass.
+        var lastAppliedText: String = ""
+
+        init(text: Binding<String>, movesFocusOnTab: Bool) {
+            self.text = text
+            self.movesFocusOnTab = movesFocusOnTab
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            let value = textView.string
+            lastAppliedText = value
+            text.wrappedValue = value
+        }
+
+        func textView(_ textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+            guard movesFocusOnTab else { return false }
+            if commandSelector == #selector(NSResponder.insertTab(_:)) {
+                textView.window?.selectNextKeyView(nil)
+                return true
+            }
+            if commandSelector == #selector(NSResponder.insertBacktab(_:)) {
+                textView.window?.selectPreviousKeyView(nil)
+                return true
+            }
+            return false
+        }
+    }
+}

--- a/TableProTests/Views/RightSidebar/FieldEditorContextPolicyTests.swift
+++ b/TableProTests/Views/RightSidebar/FieldEditorContextPolicyTests.swift
@@ -1,0 +1,68 @@
+//
+//  FieldEditorContextPolicyTests.swift
+//  TableProTests
+//
+
+import SwiftUI
+@testable import TablePro
+import Testing
+
+@MainActor
+@Suite("FieldEditorContext policy")
+struct FieldEditorContextPolicyTests {
+    private func makeContext(
+        isReadOnly: Bool,
+        allowsNullAndDefault: Bool = true,
+        originalValue: String? = "value",
+        hasMultipleValues: Bool = false
+    ) -> FieldEditorContext {
+        FieldEditorContext(
+            columnName: "body",
+            columnType: .text(rawType: "TEXT"),
+            isLongText: true,
+            value: .constant(originalValue ?? ""),
+            originalValue: originalValue,
+            hasMultipleValues: hasMultipleValues,
+            isReadOnly: isReadOnly,
+            allowsNullAndDefault: allowsNullAndDefault
+        )
+    }
+
+    @Test("a read-only field cannot mutate, so the menu keeps only its copy actions")
+    func readOnlyFieldCannotMutate() {
+        #expect(!makeContext(isReadOnly: true).canMutate)
+    }
+
+    @Test("an editable field can mutate")
+    func editableFieldCanMutate() {
+        #expect(makeContext(isReadOnly: false).canMutate)
+    }
+
+    @Test("a schema field has no NULL or DEFAULT state, so it cannot mutate either")
+    func schemaFieldCannotMutate() {
+        #expect(!makeContext(isReadOnly: false, allowsNullAndDefault: false).canMutate)
+    }
+
+    @Test("the empty-state placeholder never echoes the stored value")
+    func emptyStatePlaceholderIsAStateNotAValue() {
+        let long = String(repeating: "a", count: 5_000)
+        #expect(makeContext(isReadOnly: false, originalValue: long).emptyStatePlaceholder == nil)
+        #expect(makeContext(isReadOnly: false, originalValue: long).placeholderText == long)
+    }
+
+    @Test("a stored empty string is not reported as NULL")
+    func storedEmptyStringIsNotNull() {
+        #expect(makeContext(isReadOnly: true, originalValue: "").emptyStatePlaceholder == nil)
+    }
+
+    @Test("a stored NULL says NULL")
+    func storedNullSaysNull() {
+        #expect(makeContext(isReadOnly: true, originalValue: nil).emptyStatePlaceholder == "NULL")
+    }
+
+    @Test("a multi-row selection says so instead of showing NULL")
+    func emptyStatePlaceholderReportsMultipleValues() {
+        let context = makeContext(isReadOnly: false, originalValue: nil, hasMultipleValues: true)
+        #expect(context.emptyStatePlaceholder == String(localized: "Multiple values"))
+    }
+}

--- a/TableProTests/Views/RightSidebar/ResizableFieldMetricsTests.swift
+++ b/TableProTests/Views/RightSidebar/ResizableFieldMetricsTests.swift
@@ -34,4 +34,14 @@ final class ResizableFieldMetricsTests: XCTestCase {
     func testDefaultJsonHeightIsWithinJsonRange() {
         XCTAssertTrue(ResizableFieldMetrics.jsonHeightRange.contains(ResizableFieldMetrics.defaultJsonHeight))
     }
+
+    func testDefaultTextHeightIsWithinTextRange() {
+        XCTAssertTrue(ResizableFieldMetrics.textHeightRange.contains(ResizableFieldMetrics.defaultTextHeight))
+    }
+
+    func testTextHeightResolvesWithinItsOwnRange() {
+        let textRange = ResizableFieldMetrics.textHeightRange
+        XCTAssertEqual(ResizableFieldMetrics.resolve(base: 110, delta: -500, range: textRange), textRange.lowerBound)
+        XCTAssertEqual(ResizableFieldMetrics.resolve(base: 110, delta: 5_000, range: textRange), textRange.upperBound)
+    }
 }

--- a/TableProTests/Views/Shared/FieldEditorResolverTests.swift
+++ b/TableProTests/Views/Shared/FieldEditorResolverTests.swift
@@ -51,6 +51,98 @@ struct FieldEditorResolverTests {
         #expect(kind == .phpSerialized)
     }
 
+    @Test("a stored value with a newline needs the multi-line editor whatever the column type says")
+    func newlineInVarcharReturnsMultiLine() {
+        let kind = FieldEditorResolver.resolve(
+            for: .text(rawType: "VARCHAR(255)"),
+            isLongText: false,
+            originalValue: "first line\nsecond line"
+        )
+        #expect(kind == .multiLine)
+    }
+
+    @Test("a long single-line value needs the multi-line editor")
+    func longVarcharValueReturnsMultiLine() {
+        let kind = FieldEditorResolver.resolve(
+            for: .text(rawType: "VARCHAR(10000)"),
+            isLongText: false,
+            originalValue: String(repeating: "a", count: 5_000)
+        )
+        #expect(kind == .multiLine)
+    }
+
+    @Test("NCLOB and VARCHAR(MAX) route on the value, which the exact-match type list never covered")
+    func longValueRoutesForTypesIsLongTextMisses() {
+        let long = String(repeating: "a", count: 20_000)
+        #expect(ColumnType.text(rawType: "NCLOB").isLongText == false)
+        #expect(ColumnType.text(rawType: "nvarchar(max)").isLongText == false)
+        #expect(ColumnType.text(rawType: "Nullable(String)").isLongText == false)
+        for raw in ["NCLOB", "nvarchar(max)", "Nullable(String)"] {
+            let type = ColumnType.text(rawType: raw)
+            #expect(FieldEditorResolver.resolve(for: type, isLongText: type.isLongText, originalValue: long) == .multiLine)
+        }
+    }
+
+    @Test("a short scalar keeps the single-line field AppKit intends for it")
+    func shortVarcharStaysSingleLine() {
+        let kind = FieldEditorResolver.resolve(
+            for: .text(rawType: "VARCHAR(255)"),
+            isLongText: false,
+            originalValue: "hello"
+        )
+        #expect(kind == .singleLine)
+    }
+
+    @Test("an empty long-text column still opens the multi-line editor")
+    func emptyLongTextColumnStaysMultiLine() {
+        let kind = FieldEditorResolver.resolve(
+            for: .text(rawType: "TEXT"),
+            isLongText: true,
+            originalValue: ""
+        )
+        #expect(kind == .multiLine)
+    }
+
+    @Test("a NULL value in a short column stays single-line")
+    func nullShortValueStaysSingleLine() {
+        let kind = FieldEditorResolver.resolve(
+            for: .text(rawType: "VARCHAR(255)"),
+            isLongText: false,
+            originalValue: nil
+        )
+        #expect(kind == .singleLine)
+    }
+
+    @Test("a value right at the threshold stays single-line and one past it does not")
+    func thresholdBoundary() {
+        let type = ColumnType.text(rawType: "VARCHAR(255)")
+        let atLimit = String(repeating: "a", count: FieldEditorResolver.multiLineValueThreshold)
+        let overLimit = String(repeating: "a", count: FieldEditorResolver.multiLineValueThreshold + 1)
+        #expect(FieldEditorResolver.resolve(for: type, isLongText: false, originalValue: atLimit) == .singleLine)
+        #expect(FieldEditorResolver.resolve(for: type, isLongText: false, originalValue: overLimit) == .multiLine)
+    }
+
+    @Test("a long JSON value still opens the JSON editor rather than the plain text one")
+    func longJsonValueStillResolvesJson() {
+        let json = "{\"k\":\"" + String(repeating: "a", count: 5_000) + "\"}"
+        let kind = FieldEditorResolver.resolve(
+            for: .text(rawType: "TEXT"),
+            isLongText: true,
+            originalValue: json
+        )
+        #expect(kind == .json)
+    }
+
+    @Test("a long value in a boolean column still opens the picker")
+    func longValueInBooleanColumnStillResolvesPicker() {
+        let kind = FieldEditorResolver.resolve(
+            for: .boolean(rawType: "TINYINT(1)"),
+            isLongText: false,
+            originalValue: String(repeating: "1", count: 5_000)
+        )
+        #expect(kind == .boolean)
+    }
+
     @Test("override .json forces .json on non-JSON text")
     func overrideJsonWins() {
         let kind = FieldEditorResolver.resolve(

--- a/TableProTests/Views/Shared/TextValueEditorDefaultsTests.swift
+++ b/TableProTests/Views/Shared/TextValueEditorDefaultsTests.swift
@@ -1,0 +1,45 @@
+//
+//  TextValueEditorDefaultsTests.swift
+//  TableProTests
+//
+
+import AppKit
+@testable import TablePro
+import Testing
+
+@MainActor
+@Suite("TextValueEditor defaults")
+struct TextValueEditorDefaultsTests {
+    @Test("every automatic substitution is off, so a typed value reaches the database unchanged")
+    func substitutionsAreDisabled() {
+        let textView = NSTextView(frame: .zero)
+        textView.isAutomaticQuoteSubstitutionEnabled = true
+        textView.isAutomaticDashSubstitutionEnabled = true
+        textView.isAutomaticTextReplacementEnabled = true
+        textView.isAutomaticSpellingCorrectionEnabled = true
+        textView.isAutomaticLinkDetectionEnabled = true
+        textView.isAutomaticDataDetectionEnabled = true
+        textView.isRichText = true
+
+        TextValueEditor.applyPlainTextDefaults(to: textView)
+
+        #expect(!textView.isAutomaticQuoteSubstitutionEnabled)
+        #expect(!textView.isAutomaticDashSubstitutionEnabled)
+        #expect(!textView.isAutomaticTextReplacementEnabled)
+        #expect(!textView.isAutomaticSpellingCorrectionEnabled)
+        #expect(!textView.isAutomaticLinkDetectionEnabled)
+        #expect(!textView.isAutomaticDataDetectionEnabled)
+        #expect(!textView.isRichText)
+    }
+
+    /// `undoManager` itself comes from the window through the responder chain, so a detached text
+    /// view has none. What this function owns, and what a field editor needs, is `allowsUndo`:
+    /// without it Command Z walks past the field and reaches the app's row-edit undo instead.
+    @Test("undo is local, so Command Z in a field does not reach the app's row-edit undo")
+    func undoIsLocalToTheTextView() {
+        let textView = NSTextView(frame: .zero)
+        textView.allowsUndo = false
+        TextValueEditor.applyPlainTextDefaults(to: textView)
+        #expect(textView.allowsUndo)
+    }
+}

--- a/TableProUITests/InspectorLongTextFieldUITests.swift
+++ b/TableProUITests/InspectorLongTextFieldUITests.swift
@@ -1,0 +1,105 @@
+//
+//  InspectorLongTextFieldUITests.swift
+//  TableProUITests
+//
+//  The row inspector rendered a plain string in an NSTextField, which carries no scroll view at
+//  any axis setting, so a value past the line limit was clipped with no way to reach the rest.
+//  The element type is what separates the fix from the bug: a text view scrolls, a text field
+//  cannot, and both report the same accessibility value.
+//
+
+import XCTest
+
+final class InspectorLongTextFieldUITests: UITestCase {
+    /// 1,998 characters on one line, produced by the sample database itself so the test needs no
+    /// fixture. XCUITest synthesizes typing at roughly 113ms per character, so the query is short
+    /// even though its result is not.
+    private let query = "SELECT hex(zeroblob(999));"
+    private let shortestAcceptedValue = 1_500
+
+    func testALongValueOpensInAScrollingTextViewInTheInspector() throws {
+        let app = try launchWithSampleDatabase()
+        let editor = try runQuery(in: app)
+
+        let window = app.windows.firstMatch
+        let grid = window.tables.matching(identifier: "data-grid").firstMatch
+        XCTAssertTrue(grid.waitToExist(timeout: 30), "The query must produce a result grid")
+        XCTAssertTrue(
+            waitForPredicate(timeout: 30) { !grid.tableRows.allElementsBoundByIndex.isEmpty },
+            "The query must return a row; the editor holds '\(editor.value as? String ?? "nil")'"
+        )
+
+        showInspector(in: app)
+        clickAtCenter(grid.tableRows.firstMatch)
+
+        XCTAssertTrue(
+            waitForPredicate(timeout: 20) { self.longValueTextView(in: window) != nil },
+            "A \(shortestAcceptedValue)+ character value must render in a text view, which "
+                + "scrolls, rather than in a text field, which clips. Text view lengths present: "
+                + "\(textViewLengths(in: window))"
+        )
+    }
+
+    /// The editor has live autocompletion, and it costs this flow twice. Typing into a tab that is
+    /// not ready yet loses and reorders characters, and a suggestion list still open when Command
+    /// Return arrives takes the Return as an acceptance, so the run executed
+    /// `SELECT hex(zeroblob(999));Total`. Waiting for the empty editor, then for the exact query,
+    /// then dismissing the list, is what makes it deterministic; without it the failure surfaces
+    /// much later as a query that returned no rows.
+    private func runQuery(in app: XCUIApplication) throws -> XCUIElement {
+        app.typeKey("t", modifierFlags: .command)
+
+        let editor = editorTextView(in: app)
+        XCTAssertTrue(editor.waitToExist(timeout: 15))
+        XCTAssertTrue(
+            waitForValue("", in: editor, timeout: 15),
+            "A new tab starts with an empty editor; got '\(editor.value as? String ?? "nil")'"
+        )
+
+        app.typeText(query)
+        XCTAssertTrue(
+            waitForValue(query, in: editor, timeout: 15),
+            "Every typed character must land in the editor; got '\(editor.value as? String ?? "nil")'"
+        )
+
+        app.typeKey(.escape, modifierFlags: [])
+        XCTAssertTrue(
+            waitForValue(query, in: editor, timeout: 5),
+            "Dismissing the suggestion list must leave the query alone; got "
+                + "'\(editor.value as? String ?? "nil")'"
+        )
+
+        app.typeKey(.return, modifierFlags: .command)
+        return editor
+    }
+
+    /// The inspector remembers whether it was open, so the starting state is whatever the previous
+    /// launch left. The View menu item reads Hide Inspector once it is showing, which is the only
+    /// handle on that state.
+    private func showInspector(in app: XCUIApplication) {
+        let menuBar = app.menuBars.firstMatch
+        XCTAssertTrue(menuBar.waitToExist(timeout: 10))
+        menuBar.menuBarItems["View"].click()
+
+        let show = menuBar.menuItems["Show Inspector"]
+        if show.waitToExist(timeout: 5) {
+            show.click()
+            return
+        }
+        app.typeKey(.escape, modifierFlags: [])
+    }
+
+    private func waitForValue(_ expected: String, in element: XCUIElement, timeout: TimeInterval) -> Bool {
+        waitForPredicate(timeout: timeout) { (element.value as? String) == expected }
+    }
+
+    private func longValueTextView(in window: XCUIElement) -> XCUIElement? {
+        window.textViews.allElementsBoundByIndex.first { element in
+            (element.value as? String)?.count ?? 0 >= shortestAcceptedValue
+        }
+    }
+
+    private func textViewLengths(in window: XCUIElement) -> [Int] {
+        window.textViews.allElementsBoundByIndex.map { ($0.value as? String)?.count ?? -1 }
+    }
+}

--- a/docs/features/json-viewer.mdx
+++ b/docs/features/json-viewer.mdx
@@ -72,13 +72,30 @@ A value that refuses to open in one mode still opens in another.
 
 ## Row details inspector
 
-**View > Show Inspector** (`Cmd+Option+I`) opens the right sidebar. Select a row and every field appears with an editor matched to its content, with no **Display As** step: JSON columns and text values that parse as JSON get the JSON editor, PHP serialized values the read-only tree, blob columns the hex editor, and enum, set, and boolean columns get pickers.
+**View > Show Inspector** (`Cmd+Option+I`), or the toolbar button at the trailing end, opens it. A field's editor follows its content, with no **Display As** step, and the first match wins.
+
+| Content | Editor |
+| --- | --- |
+| A JSON column, or text that parses as JSON | JSON editor |
+| A PHP serialized value | Read-only [PHP viewer](#php-serialized-viewer) |
+| An enum, set, or boolean column | Picker |
+| A blob column | Hex editor |
+| A `TEXT` variant, `CLOB` or `NTEXT` column, or any value with a line break or over 80 characters | Scrolling text box |
+| Anything else | One-line field |
 
 <Frame caption="Row details inspector with per-field editors">
   <img className="block dark:hidden" src="/images/row-details-inspector.png" alt="Row details inspector" />
   <img className="hidden dark:block" src="/images/row-details-inspector-dark.png" alt="Row details inspector" />
 </Frame>
 
-JSON and PHP fields carry buttons to expand inside the sidebar or pop out to a window. Hover an editable field for a menu that sets NULL, the column default, an empty value, or a SQL function. With no row selected, the inspector lists table statistics instead: data, index and total size, row count, average row size, engine, collation, and creation and update dates, as far as the database reports them. On a Structure tab it follows the structure grid instead of the rows.
+The length test reads the stored value, so a long value pasted into a one-line field stays on one line until you save and reselect the row.
+
+The text box and the JSON editor each carry a drag handle under them, with separate remembered heights that survive a relaunch.
+
+**Open in Window** detaches a JSON, PHP or text value into its own resizable window; on an editable row, edits there join the same pending changes as the field. **Expand in Sidebar**, on JSON and PHP only, fills the inspector with that one field, and **Fields** goes back.
+
+Right-click a field for its menu; an editable field also shows it on a hover button. **Set NULL**, **Set DEFAULT**, **Set EMPTY** and **SQL Functions** need an editable field. **Copy Value** is always there, and a read-only field keeps its text selectable.
+
+With no row selected, the inspector describes the table: data, index and total size, row count, average row size, engine, collation, and creation and update dates, as far as the database reports them. On a Structure tab it follows the structure grid.
 
 For whole-row JSON, switch the result to JSON mode with the switcher at the leading edge of the status bar, or from **View > Result View**. It shows what the [grid](/features/data-grid) shows, in the same order, minus hidden columns and rows marked for deletion, which the count line reports separately. Select rows in Data mode first to narrow it, then click **Copy JSON**.


### PR DESCRIPTION
Reported in chat: "string field in inspector detail pane cannot scrollable when have large string in that field".

## What was wrong

Three mechanisms, all in the row-details inspector (right panel, Details tab).

**1. The control has no scroll view.** SwiftUI's `TextField` is an `NSTextField` on macOS at every `axis` setting. Dumping the `NSView` tree under `NSHostingView` for `TextField(text:, axis: .vertical).lineLimit(3...6)` holding a 400-line value gives:

```
AppKitPlatformViewHost<PlatformViewRepresentableAdaptor<PlatformTextFieldAdaptor>>
  AppKitTextField frame={{0, 0}, {268, 109.5}} [editable=true selectable=true enabled=true]
    NSSimpleLabel frame={{4, 2}, {260, 105.5}}
```

There is no `NSScrollView` and no `NSScroller` anywhere in that subtree, so `lineLimit` clips and there is nothing to scroll. Focusing the field installs a field editor 12,800pt tall inside the 109.5pt frame. `TextEditor` produces `AppKitScrollView` -> `PlatformTextView` with a live `NSScroller` instead, and a synthesized wheel event moves it from 0 to 6473.5.

**2. Read-only removed the last way out.** `MultiLineEditorView` and `SingleLineEditorView` applied `.disabled(context.isReadOnly)`, which sets `isEnabled = false` on the `NSTextField`, so a read-only value could not be selected, caret-scrolled or copied. `FieldDetailView` hid the entire field menu on the same flag, so there was no Copy Value either. A large value on a query result with no writable table was unreachable by any route.

**3. The routing asked the column type, not the value.** `ColumnType.isLongText` is six exact string comparisons (TEXT, TINYTEXT, MEDIUMTEXT, LONGTEXT, CLOB, NTEXT), so a 40 KB value in `VARCHAR(10000)`, `NVARCHAR(MAX)`, `NCLOB`, `CITEXT` or ClickHouse's `Nullable(String)` got a one-line field. Adding more names cannot fix it: `ColumnTypeClassifier.classify` computes `stripWrappers(rawTypeName)` for the lookup and then returns `factory(rawTypeName)` with the unstripped name, so `Nullable(String)` is stored literally.

## What changed

- `TextValueEditor`, a shared `NSViewRepresentable` over `NSTextView` in an `NSScrollView`. Read-only is `isEditable = false` with `isSelectable = true`, never `.disabled`.
- `MultiLineEditorView` renders it inside `ResizableEditorContainer` with a persisted height under `rowInspectorTextFieldHeight`, the same shape the JSON field already uses, plus an Open in Window button.
- `FieldEditorResolver` picks the multi-line editor from the value as well as the type: a line break, or more than 80 characters, which is two lines' worth (between 32 and 46 subheadline characters fit one line at the inspector's minimum width).
- `SingleLineEditorView` renders a read-only value as selectable text rather than a disabled field.
- `FieldMenuContent` splits `canMutate` from the copy actions, so a read-only field keeps Copy Value and loses Set NULL, Set DEFAULT, Set EMPTY and SQL Functions, which were previously all-or-nothing.
- `TextViewerWindowController` for the pop-out, on a new `ValueViewerWindowController` extracted from the JSON and PHP controllers, which were near-identical copies of the same window bookkeeping.
- `StartupCommandsEditor` and `AIRulesEditor`, two more hand-rolled copies of the same `NSTextView.scrollableTextView()` representable, now use `TextValueEditor`. Net 101 lines removed across the four.

## Why not `TextEditor`

Measured, not assumed. `TextEditor` on macOS 14 leaves AppKit's substitutions on and SwiftUI has no API to reach them. Reading the `NSTextView` it produces:

```
.autocorrectionDisabled(true) -> smartQuotes=true smartDashes=true
                                 textReplacement=true spellCorrection=false
```

`.autocorrectionDisabled(true)` clears spelling correction alone. A value editor built on it would save a typed straight quote as U+201C and a typed `--` as U+2014, silently rewriting the stored value. `.disabled()` also leaves the underlying `NSTextView` `editable=true` and first-responder eligible, so there is no clean read-only-but-selectable mode. This is why `StartupCommandsEditor` and `AIRulesEditor` already hand-rolled the representable, and `TextValueEditor` is now the one copy.

## Two choices worth flagging

**The editor is picked from the stored value, once per field, not from the live draft.** Recomputing it as you type would swap the view type the moment a draft crossed 80 characters, and SwiftUI rebuilds the child on a `switch` branch change, so focus and the caret would go with it. The cost is that pasting a very large value into a field that resolved short keeps the text field for that editing session; it stays selectable, copyable and caret-scrollable, and reading the row back after Save gives it the text view.

**The pop-out is a window, not an Expand in Sidebar.** JSON and PHP have both. The inspector's minimum width is 270pt, and every reference client pushes a large value to a bigger surface rather than a narrow side pane, DataGrip explicitly so. The sidebar-expand state is also a stored column index that a table switch can leave pointing at an unrelated column, and this change does not add a third copy of it.

**`SourceEditor` was not reused.** `JsonEditorView` gets scrolling for free from `CodeEditSourceEditor`, but that is a code editor: tree-sitter parsing, a gutter and code-shaped key handling, for prose in a 270pt pane. The app's own precedent for plain text is the `NSTextView` representable that `StartupCommandsEditor` and `AIRulesEditor` already had.

## Why nothing is truncated

The cost of a text view is driven by the longest paragraph, not the total size, so a display cap was considered and rejected. Measured at the inspector's width, layout plus display:

| value | before, `TextField(axis: .vertical)` | after, `NSTextView` |
| --- | --- | --- |
| 100 KB on one line | 105 ms | 38 ms |
| 1 MB on one line | 999 ms | 213 ms |
| 5 MB on one line | did not finish in 2 minutes | 1,029 ms |
| 1 MB over 22,000 lines | n/a | 1.0 ms |

TextKit 1 with `allowsNonContiguousLayout` is not a rescue: it costs 277 ms at 1 MB and 1,420 ms at 5 MB just to set the string, and the same per keystroke. Wrapping one enormous paragraph is a platform limit, so the change shows the whole value and is faster than what shipped at every size rather than hiding the limit behind a custom truncation notice.

## Before / After

Same query, same steps, both real builds, captured from `InspectorLongTextFieldUITests` driving the app: `SELECT hex(zeroblob(999));` against the sample database, one row selected, Details tab open. The value is 1,998 characters and the result set has no writable table, so this is the read-only path the report is about.

**Before** (`dd7b252cf`): one greyed line ending in an ellipsis. It is a `TextField` under `.disabled(true)`, so it takes no first responder: the remaining 1,950 characters cannot be scrolled to, selected or copied, and the field menu was hidden on the same flag so there was no Copy Value either.

**After**: the value wraps in a scrolling text view, in normal text colour rather than the disabled grey, with the drag handle that resizes it and remembers the height, and the pop-out button that opens it in its own window.

The same difference is machine-checkable, which is what the new UI test asserts. Running it against the base build fails with:

```
A 1500+ character value must render in a text view, which scrolls, rather than in a
text field, which clips. Text view lengths present: [26]
```

26 is the query editor. On the base build the 1,998 character value is in no text view at all; on this branch the assertion passes.

## Verified

- `verify.sh build`: PASS.
- `verify.sh test` over `FieldEditorResolverTests`, `ResizableFieldMetricsTests`, `FieldEditorContextPolicyTests`, `TextValueEditorDefaultsTests`, `MultiRowEditStateTests`, `MultiRowEditStateJsonTests`, `TableViewCoordinatorPopoverDismissalTests`, `ColumnTypeTests`: 177 cases, 177 passed.
- `verify.sh uitest InspectorLongTextFieldUITests`: a 4,000 character value from the sample database must land in a text view, which scrolls, rather than a text field, which clips. The element type is the only thing that separates the fix from the bug, since both report the same accessibility value.
- `swiftlint --strict` over `TablePro`, `TableProTests` and `TableProUITests`: 0 violations.

A review pass over the finished diff found six things, all fixed here and covered by the numbers above. The one that mattered was mine: the new empty-state placeholder reported a stored `''` as `NULL`, which a database client must never do, so it now returns nothing where the stored value really is the empty string. The rest: `allowsUndo` was left off the text view, so Command Z walked past the field and reached the app's row-edit undo; the always-on hover menu sat on top of the type picker's own chevron; Tab wrote a tab character into the value instead of moving to the next field; the popped-out Text window ignored Escape while the JSON and PHP windows close on it; and a sentence promising `Cmd+F` inside a field was wrong, because that key is bound to `performFind:`, which `NSTextView` does not implement, so the sentence is gone.

New unit coverage: the value-driven routing rules including `NCLOB`, `nvarchar(max)` and `Nullable(String)`, the threshold boundary, JSON and picker columns keeping their own editors, the read-only menu policy, the placeholder never echoing a stored value, and every automatic substitution being off on the text view.
