### PR TITLE
fix(docs): stop a snippet mid-sentence from returning 500, and gate it

### DIFF
--- a/docs/features/query-results.mdx
+++ b/docs/features/query-results.mdx
@@ -36,11 +36,11 @@ The results panel expands itself when a query runs. The toolbar's trash button c
 
 ## The row cap
 
-A `SELECT` or `WITH` query with no `LIMIT`, `FETCH FIRST` or `TOP` of its own stops at the row cap. <RowCap />, and `EXPLAIN`, `SHOW`, writes and DDL are never capped.
+A `SELECT` or `WITH` query with no `LIMIT`, `FETCH FIRST` or `TOP` of its own stops at the row cap.
+
+<RowCap />
 
 When the cap trims a result the status bar reads **Showing N rows** and offers **Fetch All**, which extends the result in place. To skip the cap for one run, press `Cmd+Option+Enter` or choose **Execute Without Limit** from the Execute button's menu.
-
-The cap and its off switch are in [Settings > Data](/customization/data-settings#query-result-row-cap).
 
 ## Statements that return no rows
 

--- a/docs/features/table-structure.mdx
+++ b/docs/features/table-structure.mdx
@@ -55,7 +55,7 @@ Right-click a foreign key and choose **Open [table]** to jump to the referenced 
 
 ## Saving changes
 
-<StagedUntilSave what="Column, index and key changes" />; see [Change Tracking](/features/change-tracking) for the queue, undo (`Cmd+Z`) and redo (`Cmd+Shift+Z`). A save runs on the tab's own connection, database, and schema, the ones it was opened on, and never moves the sidebar or the toolbar.
+<StagedUntilSave what="Column, index and key changes" /> [Change Tracking](/features/change-tracking) covers the queue, undo (`Cmd+Z`) and redo (`Cmd+Shift+Z`). A save runs on the tab's own connection, database, and schema, the ones it was opened on, and never moves the sidebar or the toolbar.
 
 - **Save Changes** (`Cmd+S` or the toolbar checkmark) applies the queue. Changes that can lose data, dropping a column, changing a type, adding NOT NULL, changing the primary key, first show a confirmation listing each one.
 - **Preview SQL** (`Cmd+Shift+P`) shows the generated statements without executing them.

--- a/docs/scripts/check-links.py
+++ b/docs/scripts/check-links.py
@@ -28,6 +28,44 @@ def nav_pages(node, out, collecting=False):
         out.add(node)
 
 
+IMPORT = re.compile(r'^import\s+(\w+)\s+from\s+"(/snippets/[^"]+)"', re.M)
+CONTINUES = re.compile(r"^[,;:)]|^(and|or|but|so|then|which|while|with)\b")
+
+
+def check_snippets(path, raw, failures):
+    """A snippet may end a line, but the sentence may not carry on past it.
+
+    Snippets are block content: several sentences, sometimes a markdown link that wraps. Starting a
+    new sentence after one on the same line renders fine. Continuing the same sentence does not:
+    `features/query-results.mdx` shipped `<RowCap />, and ...`, which built green under
+    `mint validate` and returned HTTP 500 in production.
+    """
+    rel = path.relative_to(DOCS)
+    declared = {}
+    for name, source in IMPORT.findall(raw):
+        declared[name] = source
+        if not (DOCS / source.lstrip("/")).exists():
+            failures.append(f"{rel} imports {source}, which is not in docs/snippets")
+    if not declared:
+        return
+
+    used = "|".join(re.escape(n) for n in declared)
+    in_fence = False
+    for line_no, line in enumerate(raw.splitlines(), 1):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        for match in re.finditer(rf"<({used})\b[^>]*/>", line):
+            trailing = line[match.end():].strip()
+            if trailing and CONTINUES.match(trailing):
+                failures.append(
+                    f"{rel}:{line_no} carries the sentence on past <{match.group(1)} />; "
+                    f"a snippet is block content, so start a new sentence or a new line"
+                )
+
+
 def main() -> int:
     config = json.loads((DOCS / "docs.json").read_text())
     pages = set()
@@ -62,6 +100,7 @@ def main() -> int:
             continue
         rel = path.relative_to(DOCS)
         body = FENCE.sub("", path.read_text())
+        check_snippets(path, body, failures)
         for line_no, line in enumerate(body.splitlines(), 1):
             for target in LINK.findall(line):
                 page, _, anchor = target.partition("#")


### PR DESCRIPTION
`/features/query-results` returns **HTTP 500** on the live site. It has since #2372 merged.

```
$ curl -s -o /dev/null -w '%{http_code}' https://docs.tablepro.app/features/query-results
500
```

The page ended a sentence with a block snippet and then carried on past it:

```mdx
... stops at the row cap. <RowCap />, and `EXPLAIN`, `SHOW`, writes and DDL are never capped.
```

`RowCap` is four lines of prose with a markdown link that wraps. Starting a **new** sentence after
a snippet on the same line renders (five other pages do it and all return 200). Continuing the
same one does not.

The trailing clause was also a duplicate: the snippet already says `EXPLAIN`, `SHOW`, writes and
DDL are never capped. The snippet now owns its own line and the duplicate is gone, along with a
`Settings > Data` line under it that the snippet also already carried.

`features/table-structure.mdx` had the same shape (`<StagedUntilSave … />; see …`) and is fixed the
same way.

## Why nothing caught it

`mint validate`, `broken-links` and `a11y` all passed on this page in CI, and so did the five repo
gates. The 500 only appears when the page is actually served, and nothing was fetching the
deployed site.

`check-links.py` now flags a snippet component whose line carries the sentence on past it, with a
comma, semicolon, colon, or a joining word. It skips code fences, which an earlier draft of the
check did not, and it reports real line numbers rather than post-fence-stripping ones.

Verified by reintroducing the exact line that shipped:

```
FAIL features/query-results.mdx:36 carries the sentence on past <RowCap />;
     a snippet is block content, so start a new sentence or a new line
```

## Rest of the live site

Fetched everything the repo references, after #2372:

| | Result |
|---|---|
| 115 navigation pages | 114 return 200, this one 500 |
| 14 redirects | all 3xx to the declared destination, every destination 200 |
| 221 referenced images | all 200 |
| Logo, both themes | `light.png` inks `#1F1B16`, `dark.png` inks `#F5F1EA`, both 333×72 |
| og:title / og:description / og:image | present and page-specific, which the old invalid `metadata` block never emitted |