### PR TITLE
docs(claude-md): scope test verification by the types a change touches

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -166,6 +166,10 @@ This is not a convenience. A raw `xcodebuild` failure returns roughly 10,000 cha
 
 Non-obvious rules that decide whether the result means anything: run only the suites you touched and their neighbours, never the whole target; run the steps serially; and build the `plugins` aggregate yourself if the change touched a registry-only plugin, because PR CI never compiles those.
 
+**"The suites you touched" means the suites that own the types you changed, not the suites you edited.** Grep for the type before you pick the list: a shared model has tests you never opened. Editing `PersistedTab.init(from:)` broke `TabDiskStateDecodingTests`, a suite that exists to pin exactly the behaviour the edit changed, and the branch went green locally and red on CI. `grep -rl "TypeName" TableProTests` takes a second and names the suites that will judge you.
+
+**When CI fails and local passed, do not reach for the whole target.** A local full run of `TableProTests` reports around 60 failures that have nothing to do with the change: quarantined suites, locale, pasteboard, network and timer-dependent cases. Compare against a baseline instead. Read the CI log for the count of real failures, then run the suspect suites on a worktree at the merge base; a suite that fails in both is not yours.
+
 Where the fix rests on how a dependency behaves, finish with the before-and-after probe from "Measure, do not assume". A probe that reproduces the bug on the old path and shows every case correct on the new one is the strongest evidence a PR can carry.
 
 UI tests have their own trap list, including an accessibility tree that differs between this machine and the CI runner, and a SwiftUI container identifier that silently erases every child's. Read `references/verification.md` before writing one.


### PR DESCRIPTION
Phase 4 says to run "the suites you touched and their neighbours, never the whole target". Read literally, that means the suites whose files you edited. It should mean the suites that own the types you changed, and the difference just cost a red CI run.

## What happened

A change to `PersistedTab.init(from:)` in #2386 made an unknown `tabType` decode as `.query` instead of throwing. The comment justifying it claimed the throw "would fail the whole aggregate file". That was never checked and is false: `TabDiskState.init(from:)` decodes through `[LossyTab].compactMap(\.value)`, so a bad tab is dropped and the rest survive.

`TabDiskStateDecodingTests` exists to pin exactly that, in a test named "Drops tabs with an unknown legacy tab type and keeps the valid ones". Nobody ran it, because no file in that suite was edited. Local was green across fifteen suites; CI was red.

The change was also strictly worse than what it replaced. A tab written by a newer build would come back as an empty query tab carrying a title like `Procedure: public.f(date)` rather than being dropped.

## Two rules added

**Scope the suite list by type, not by file.** `grep -rl "TypeName" TableProTests` names the suites that will judge the change, and it takes a second. A shared model always has tests you never opened.

**When CI fails and local passed, do not reach for the whole target.** A local full run of `TableProTests` reports around 60 failures with nothing to do with the change: quarantined suites, locale, pasteboard, network and timer-dependent cases. That number drowns the one failure that matters. Compare against a baseline instead: read the CI log for the real count, then run the suspect suites on a worktree at the merge base. A suite that fails in both is not yours.

That second rule was worth writing down because chasing it is what turned a one-line revert into a long detour. The local full run showed 64 failures; CI recorded exactly one issue. Running `StructureChangeManagerUndoTests` and `SaveCompletionTests` on a merge-base worktree reproduced their failures there too, which settled them as noise in one step.

## Verification

The rule is prose in `SKILL.md`; there is nothing to build or test. `git diff` is four added lines.

Follows #2387, which made `docs/STYLE.md` discoverable and added `verify.sh docs`.
