### PR TITLE
fix(docs): keep every snippet alone on its line so seven pages stop returning 500

### DIFF
--- a/docs/external-api/mcp-prompts.mdx
+++ b/docs/external-api/mcp-prompts.mdx
@@ -24,7 +24,9 @@ Picking `explain_table` from your client's prompt menu makes TablePro read the t
 
 The result is a `description` and one user message. Argument values must be scalars: a number or a boolean is read as its text, an array or object is rejected. An argument the prompt does not declare is rejected with `-32602`, as is a missing required one.
 
-<MCPGates what="render" /> The read is recorded in the activity log.
+<MCPGates what="render" />
+
+The read is recorded in the activity log.
 
 ## Shared arguments
 

--- a/docs/external-api/mcp-resources.mdx
+++ b/docs/external-api/mcp-resources.mdx
@@ -5,7 +5,11 @@ description: Read-only resources for connections, schema, tables, and query hist
 
 import MCPGates from "/snippets/mcp-gates.mdx";
 
-Eight URIs, all read-only, all JSON. A client reads them to find its way around before it calls a tool. <MCPGates what="read" /> Reads count against the caller's [request rate](/external-api/tokens#rate-limits) like anything else.
+Eight URIs, all read-only, all JSON. A client reads them to find its way around before it calls a tool.
+
+<MCPGates what="read" />
+
+Reads count against the caller's [request rate](/external-api/tokens#rate-limits) like anything else.
 
 ## Discovery
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -64,7 +64,9 @@ Its driver is probably not installed yet. The database type chooser badges regis
 </Accordion>
 
 <Accordion title="Why does a driver need downloading?">
-<DriverCounts /> Each one must match the SHA-256 checksum in the registry manifest and carry a valid code signature before it loads.
+<DriverCounts />
+
+Each one must match the SHA-256 checksum in the registry manifest and carry a valid code signature before it loads.
 </Accordion>
 
 <Accordion title="Why does a plugin need updating after I update the app?">

--- a/docs/features/change-tracking.mdx
+++ b/docs/features/change-tracking.mdx
@@ -5,7 +5,9 @@ description: Queue cell edits, row inserts and deletions, review the SQL, then s
 
 import StagedUntilSave from "/snippets/staged-until-save.mdx";
 
-<StagedUntilSave what="Cell edits, inserts and deletes" /> The toolbar counts what is pending, modified cells stay highlighted, `Cmd+Shift+P` shows the statements the queue will produce, and `Cmd+S` runs them. The queue belongs to the tab, so switching tabs leaves it alone.
+<StagedUntilSave what="Cell edits, inserts and deletes" />
+
+The toolbar counts what is pending, modified cells stay highlighted, `Cmd+Shift+P` shows the statements the queue will produce, and `Cmd+S` runs them. The queue belongs to the tab, so switching tabs leaves it alone.
 
 <Frame caption="Data grid with pending changes highlighted">
   <img className="block dark:hidden" src="/images/change-tracking.png" alt="Pending edits, inserts, and deletions highlighted in the data grid" />

--- a/docs/features/plugins.mdx
+++ b/docs/features/plugins.mdx
@@ -5,7 +5,9 @@ description: Install database drivers, import and export formats, and themes fro
 
 import DriverCounts from "/snippets/driver-counts.mdx";
 
-Pick a database type badged **Not Installed** in the chooser and the download runs before the connection opens, with no restart. <DriverCounts />
+Pick a database type badged **Not Installed** in the chooser and the download runs before the connection opens, with no restart.
+
+<DriverCounts />
 
 ## Bundled plugins
 

--- a/docs/features/table-structure.mdx
+++ b/docs/features/table-structure.mdx
@@ -55,7 +55,9 @@ Right-click a foreign key and choose **Open [table]** to jump to the referenced 
 
 ## Saving changes
 
-<StagedUntilSave what="Column, index and key changes" /> [Change Tracking](/features/change-tracking) covers the queue, undo (`Cmd+Z`) and redo (`Cmd+Shift+Z`). A save runs on the tab's own connection, database, and schema, the ones it was opened on, and never moves the sidebar or the toolbar.
+<StagedUntilSave what="Column, index and key changes" />
+
+[Change Tracking](/features/change-tracking) covers the queue, undo (`Cmd+Z`) and redo (`Cmd+Shift+Z`). A save runs on the tab's own connection, database, and schema, the ones it was opened on, and never moves the sidebar or the toolbar.
 
 - **Save Changes** (`Cmd+S` or the toolbar checkmark) applies the queue. Changes that can lose data, dropping a column, changing a type, adding NOT NULL, changing the primary key, first show a confirmation listing each one.
 - **Preview SQL** (`Cmd+Shift+P`) shows the generated statements without executing them.

--- a/docs/scripts/check-links.py
+++ b/docs/scripts/check-links.py
@@ -29,16 +29,22 @@ def nav_pages(node, out, collecting=False):
 
 
 IMPORT = re.compile(r'^import\s+(\w+)\s+from\s+"(/snippets/[^"]+)"', re.M)
-CONTINUES = re.compile(r"^[,;:)]|^(and|or|but|so|then|which|while|with)\b")
 
 
 def check_snippets(path, raw, failures):
-    """A snippet may end a line, but the sentence may not carry on past it.
+    """A snippet has to be the only thing on its line.
 
-    Snippets are block content: several sentences, sometimes a markdown link that wraps. Starting a
-    new sentence after one on the same line renders fine. Continuing the same sentence does not:
-    `features/query-results.mdx` shipped `<RowCap />, and ...`, which built green under
-    `mint validate` and returned HTTP 500 in production.
+    A snippet is block content: several sentences, sometimes a table, sometimes a markdown link
+    that wraps. Mintlify renders it as a block, and any prose sharing the line with it returns
+    HTTP 500 in production while `mint validate` and the Mintlify deploy both report success.
+
+    An earlier version of this check only rejected text that carried the SAME sentence past the
+    snippet, on the premise that "starting a new sentence after one on the same line renders fine".
+    That premise was wrong. `features/table-structure.mdx` was edited to start a new sentence and
+    kept returning 500, and six other pages were down for the same reason: four with a new sentence
+    after the snippet, one with a markdown link after it, and `features/plugins.mdx` with prose
+    BEFORE it, which the old check never looked at. All 24 pages that render put the snippet alone
+    on its line; all 7 that returned 500 did not.
     """
     rel = path.relative_to(DOCS)
     declared = {}
@@ -58,12 +64,15 @@ def check_snippets(path, raw, failures):
         if in_fence:
             continue
         for match in re.finditer(rf"<({used})\b[^>]*/>", line):
-            trailing = line[match.end():].strip()
-            if trailing and CONTINUES.match(trailing):
-                failures.append(
-                    f"{rel}:{line_no} carries the sentence on past <{match.group(1)} />; "
-                    f"a snippet is block content, so start a new sentence or a new line"
-                )
+            before = line[: match.start()].strip()
+            after = line[match.end() :].strip()
+            if not before and not after:
+                continue
+            where = "before and after" if before and after else ("before" if before else "after")
+            failures.append(
+                f"{rel}:{line_no} puts prose {where} <{match.group(1)} /> on the same line; "
+                f"a snippet is block content and returns HTTP 500 unless it is alone on its line"
+            )
 
 
 def main() -> int:

--- a/docs/switching.mdx
+++ b/docs/switching.mdx
@@ -102,7 +102,9 @@ Two other routes exist.
 
 ## If your database is not supported yet
 
-<DriverCounts /> A database missing from the connection form may still be one click away in **Settings > Plugins > Browse**.
+<DriverCounts />
+
+A database missing from the connection form may still be one click away in **Settings > Plugins > Browse**.
 
 <Frame caption="Settings > Plugins > Browse">
   <img className="block dark:hidden" src="/images/settings-plugins-browse.png" alt="Plugin registry browser" />


### PR DESCRIPTION
Seven live docs pages return HTTP 500. `/switching` was the one reported; probing all 115 nav entries found the rest.

```
500  switching
500  faq
500  features/plugins
500  features/change-tracking
500  features/table-structure
500  external-api/mcp-resources
500  external-api/mcp-prompts
```

## Cause

A snippet is block content. Mintlify renders it as a block, and any prose sharing its line returns 500 in production while `mint validate` and the Mintlify deploy both report success.

The correlation is exact across the corpus. Every one of the 24 pages that imports a snippet and renders puts the call alone on its line. Every one of the 7 that returned 500 did not:

| Page | What shared the line |
|---|---|
| `switching`, `faq` | a new sentence after |
| `features/change-tracking`, `external-api/mcp-prompts` | a new sentence after |
| `features/table-structure` | a markdown link after |
| `external-api/mcp-resources` | prose before and a link after |
| `features/plugins` | prose before |

The snippet file itself is never the problem: `driver-counts.mdx` has three pages that render and three that did not, with a byte-identical `<DriverCounts />` call in all six. Props are not the problem either: `registry-plugin.mdx` takes two props and its 17 pages all render.

## Why the existing guard was green

`docs/scripts/check-links.py` already has a `check_snippets` check, added by #2375, and CI already runs it. It was built on a premise stated in its own docstring:

> Starting a new sentence after one on the same line renders fine. Continuing the same sentence does not.

That premise is false. #2375 fixed `features/table-structure.mdx` by replacing `;` with a new sentence starting with a markdown link, and the page kept returning 500 for the next day. The check only matched a `CONTINUES` pattern (a leading comma, semicolon, colon, paren, or one of seven conjunctions), so six of these seven pages passed it, and it never looked at text before the snippet at all, which is what `features/plugins` had.

## What changed

The seven pages put their snippet on its own line.

`check_snippets` now rejects any prose on the line, before or after, and names which side. The docstring carries the evidence rather than the premise:

```
$ python3 docs/scripts/check-links.py      # each variant reintroduced in turn
after-continuation     caught=1     <- the only one the old check caught
after-new-sentence     caught=1
after-link             caught=1
before                 caught=1
```

## Verification

| Step | Result |
|------|--------|
| `docs/scripts/check-links.py` | `ok 115 navigation entries, 115 pages, every link resolves` |
| `docs/scripts/check-writing-style.sh` | `docs/ matches the house style` |
| `docs/scripts/check-docs-against-source.py` | `docs/ agrees with the source` |
| Guard tested by reintroducing all four variants | all four caught |

The 500s are served from a build of `main`, so they clear when this merges and the docs site redeploys. Worth re-probing the seven URLs afterwards.
