### PR TITLE
test: allow the format-only separator string in the Turkish coverage guard

### DIFF
--- a/TableProTests/Models/TurkishLocalizationCoverageTests.swift
+++ b/TableProTests/Models/TurkishLocalizationCoverageTests.swift
@@ -26,7 +26,7 @@ struct TurkishLocalizationCoverageTests {
     /// specifiers. `CLAUDE.md` says not to localize technical terms, so these are the exception the
     /// check is built around rather than a backlog.
     private static let identicalByDesign: Set<String> = [
-        "%1$@ (%2$@)", "%1$@ +%2$lld", "%1$@: %2$@", "%@ %@", "%@ (%@@%@)", "%@ (%lld/%lld)",
+        "%1$@ (%2$@)", "%1$@ +%2$lld", "%1$@: %2$@", "%1$@ · %2$@", "%@ %@", "%@ (%@@%@)", "%@ (%lld/%lld)",
         "%@ → %@.%@", "%@. %@", "%@. %@. %@", "%@: %@, %@", "%lld / %lld", "%lld / ~%lld",
         "(%lld %@)", ", %@", "<1 ms", "db %d", "v%@ · %@",
         "API Token", "Access Key ID", "Account ID", "Application Default Credentials",


### PR DESCRIPTION
`main` is red. `TurkishLocalizationCoverageTests.turkishTranslationsAreNotEnglish` fails, and because a `pull_request` event tests `refs/pull/N/merge`, every open PR inherits it through the merge ref and shows the same failure.

```
Recorded an issue (Expectation failed: (untranslated → ["%1$@ · %2$@"]).isEmpty → false)
Suite "Turkish localization coverage" failed with 1 issue(s)
```

## Cause

b05128fcc, `feat(explain): save and diff query plans (#2380)`, added `%1$@ · %2$@` to `Localizable.xcstrings` marked `state: "translated"` with the value identical to the key. It is correctly identical: two format specifiers and a middle dot, with nothing in it to translate. It just was not added to `identicalByDesign`, whose doc comment already covers "strings made only of format specifiers" and which already carries the close siblings `%1$@ (%2$@)`, `%1$@: %2$@` and `v%@ · %@` with the same separator.

Ran the guard's logic verbatim over each catalog version:

| catalog | `untranslated` |
| --- | --- |
| 42149e61b, the parent | `[]` |
| b05128fcc | `["%1$@ · %2$@"]` |

## Why it is one line and not a rule

The obvious generalisation is to stop hand-maintaining that class: strip printf specifiers from the key and skip the entry when no Latin letter remains. I checked it against the catalog before writing it and it is unsafe. Two live key classes carry real Turkish while having no Latin letters: `%@×` translates to `%@ kez`, and `1,000` / `10,000` / `500,000` translate to `1.000` / `10.000` / `500.000`. Today only the unrelated `key.contains(" ")` guard keeps them in scope. Spell one as `%@ ×` and the rule would silently exempt a string a human should have judged, which is the opposite of what this guard is for.

So the allowlist stays hand-maintained, and this is one entry added to it.

## Verification

`verify.sh test TurkishLocalizationCoverageTests KoreanLocalizationSourceTests` on this branch: 16 executed, 16 passed. `verify.sh lint TableProTests`: 0 violations. The branch is based on b05128fcc, so its catalog is the one CI actually reads and the run genuinely reproduces the failure before the change and passes after it.

No CHANGELOG entry: the change is test-only and nothing user-facing moves.

## Two things worth separate attention

The same entry is marked `translated` with an identical value in `ko`, `vi`, `zh-Hans` and `zh-Hant` as well, but only Turkish has this guard. `KoreanLocalizationSourceTests` only asserts the Korean value is non-empty, and there is no Vietnamese or Chinese suite at all. Ported as-is, the check would flag 27 entries in `vi`, 8 in `zh-Hans`, 7 in `zh-Hant` and 5 in `ko`. That is a coverage gap rather than a translation gap, and it is its own change.

Separately, the string extraction that runs during a local build adds entries the committed catalog does not have. Two of them, `No Matching Favorites` and `Referenced table`, are marked `translated` in Turkish while still holding their English text, so they will fail this same guard the moment that churn is committed. Those two look like real translation gaps rather than allowlist candidates.
