### PR TITLE
feat(perf): persist a privacy-safe local history of table load timings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Triggers as a sidebar section, listed per database and schema alongside Procedures and Functions. (#2383)
 - Read-only source viewer for procedures, functions and triggers, with Copy, Export and Open in Editor. (#2383)
 - Procedures, functions and triggers on MSSQL, Oracle, SQLite, ClickHouse, DuckDB, Snowflake, BigQuery, Cassandra, LibSQL, Cloudflare D1, Teradata and Dameng. (#2383)
+- Local performance history for table loads, kept 7 days in Application Support and never uploaded. (#2395)
 - Procedures, functions and triggers in the quick switcher.
 - Argument signatures on routine rows, shown when two routines in a section share a name.
 - Schema-wide `list_triggers` for MCP clients, and `return_type` and `language` on `list_routines`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,7 @@ To ship one: add the record type or field in CloudKit Console (or `xcrun cktool 
 | Recent tables        | UserDefaults     | `RecentTablesStore` (per connection, keyed by database, last 10 each; device-local). Live value held in `SharedSidebarState`, recorded at the `QueryTabManager` open chokepoint. |
 | History drawer state | UserDefaults     | `HistoryPanelPreferencesStorage` (per connection; visibility, connection scope, source/date/outcome filters; device-local). Live value held in `HistoryPanelState.forConnection`, cleared alongside `SharedSidebarState` when a session ends. |
 | Trusted external links | UserDefaults   | `ExternalConnectionTrustStore` (keyed by database type + host + database + username + URL `name`, never the port; loopback hosts only, enforced on read and write). Consulted by `ExternalConnectionGate` before the external-URL confirmation alert. |
+| Table load timings   | JSON lines       | `TableLoadHistoryStore` (`TableLoadHistory.jsonl`, mode `0600`; 7 days, 10,000 records or 5 MB, oldest first; device-local, never uploaded). Written by `TableLoadTracer` through `TableLoadSummarySink`, which is inert under XCTest. Durations and coarse buckets only: no table, schema, host, username, connection id, query text or error message. |
 
 ### Logging & Debugging
 

--- a/TablePro/Core/Diagnostics/TableLoadHistoryStore.swift
+++ b/TablePro/Core/Diagnostics/TableLoadHistoryStore.swift
@@ -1,0 +1,248 @@
+//
+//  TableLoadHistoryStore.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+/// Where a finished trace goes. The one requirement is that the producer is a synchronous
+/// `@MainActor` method, so this cannot be `async`: the call has to return before any disk work
+/// happens or the measurement pays for its own recording.
+internal protocol TableLoadSummarySink: Sendable {
+    func record(_ record: TableLoadPerformanceRecord)
+}
+
+/// What `TableLoadTracer.shared` gets under XCTest. Dozens of coordinator suites drive
+/// `openTableTab`, which begins real traces, and `AppStorageEnvironment` resolves to the production
+/// directory under a unit-test host, so a live sink would append to the developer's own history on
+/// every test run. Discarding at the sink means no file is opened and nothing needs cleaning up.
+internal struct DiscardingTableLoadSummarySink: TableLoadSummarySink {
+    internal func record(_ record: TableLoadPerformanceRecord) {}
+}
+
+/// A bounded, device-local history of how long table loads took, kept so an intermittent slowdown
+/// can be looked at after it happened rather than only while `log stream` is running.
+///
+/// Newline-delimited JSON rather than the single re-encoded array `ExecutionAuditLog` uses. Two
+/// reasons, both about the caps this store has and that one does not: rewriting the whole array costs
+/// the size of the store on every append, which at the ten thousand records allowed here is megabytes
+/// written per table click; and a write torn by a crash takes the entire array with it, where a torn
+/// final line costs one record. Nothing is held in memory between appends either, because ten
+/// thousand decoded records is a lot of residency for a file the running app never reads.
+internal actor TableLoadHistoryStore: TableLoadSummarySink {
+    internal static let shared = TableLoadHistoryStore()
+
+    internal static let retentionDays = 7
+    internal static let maxRecords = 10_000
+    internal static let maxBytes = 5 * 1_024 * 1_024
+
+    private static let prunePeriod: TimeInterval = 3_600
+    private static let newline = UInt8(ascii: "\n")
+    private static let logger = Logger(subsystem: "com.TablePro", category: "TableLoadHistory")
+
+    /// Fractional seconds, because a store that measures milliseconds and stamps whole seconds
+    /// cannot order a burst of navigation inside one, and the retention pass sorts on this field.
+    private static let timestamps = Date.ISO8601FormatStyle(includingFractionalSeconds: true)
+
+    private let fileURL: URL
+    private var recordCount = 0
+    private var fileBytes = 0
+    private var lastPrunedAt = Date.distantPast
+    private var loaded = false
+
+    internal init(fileURL: URL = TableLoadHistoryStore.defaultFileURL()) {
+        self.fileURL = fileURL
+    }
+
+    /// Resolved through `AppStorageEnvironment` like every other store, so a UI test writes into its
+    /// own sandbox rather than the history of the person running it.
+    internal static func defaultFileURL() -> URL {
+        let directory = AppStorageEnvironment.shared.supportDirectory
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("TableLoadHistory.jsonl")
+    }
+
+    nonisolated internal func record(_ record: TableLoadPerformanceRecord) {
+        Task { await self.append(record) }
+    }
+
+    internal func append(_ record: TableLoadPerformanceRecord) {
+        loadIfNeeded()
+        guard let line = Self.encode(record), writeLine(line) else { return }
+        recordCount += 1
+        fileBytes += line.count
+        pruneIfNeeded()
+    }
+
+    internal func records() -> [TableLoadPerformanceRecord] {
+        loadIfNeeded()
+        return Self.decodeRecords(in: Self.readFile(at: fileURL)).map(\.record)
+    }
+
+    /// Byte-for-byte stable for the same input, so an external report can diff two exports.
+    internal func exportJSON() -> Data {
+        (try? Self.makeEncoder(prettyPrinted: true).encode(records())) ?? Data()
+    }
+
+    /// The first touch in a process reconciles the file against the retention rules, so a history
+    /// left behind by a build that quit before pruning cannot grow past its caps.
+    private func loadIfNeeded() {
+        guard !loaded else { return }
+        loaded = true
+        prune()
+    }
+
+    private func pruneIfNeeded() {
+        let isOverCapacity = recordCount > Self.maxRecords || fileBytes > Self.maxBytes
+        let isStale = Date().timeIntervalSince(lastPrunedAt) > Self.prunePeriod
+        guard isOverCapacity || isStale else { return }
+        prune()
+    }
+
+    /// An undecodable line is dropped rather than refused. A history whose tail was torn by a crash
+    /// has to keep working, because it is diagnostic data and refusing to read it would make the
+    /// store itself the outage. The count is logged rather than swallowed, so a schema change that
+    /// makes an older record unreadable shows up as a number instead of a file that quietly shrank.
+    ///
+    /// The counts are set from the file as read before the rewrite, so a write that fails leaves the
+    /// caps reflecting what is still on disk. Left at zero they would read as under capacity and the
+    /// only retry would be the hourly one, which is an hour of appending with no bound enforced.
+    private func prune() {
+        lastPrunedAt = Date()
+
+        let data = Self.readFile(at: fileURL)
+        guard !data.isEmpty else {
+            recordCount = 0
+            fileBytes = 0
+            return
+        }
+
+        let decoded = Self.decodeRecords(in: data)
+        let unreadable = data.split(separator: Self.newline, omittingEmptySubsequences: true).count - decoded.count
+        if unreadable > 0 {
+            Self.logger.notice(
+                "Dropped \(unreadable, privacy: .public) unreadable line(s) from the table load history"
+            )
+        }
+
+        recordCount = decoded.count
+        fileBytes = data.count
+
+        let cutoff = Date().addingTimeInterval(-Double(Self.retentionDays) * 86_400)
+        var kept = decoded.filter { $0.record.recordedAt >= cutoff }
+        kept.sort { $0.record.recordedAt < $1.record.recordedAt }
+
+        if kept.count > Self.maxRecords {
+            kept.removeFirst(kept.count - Self.maxRecords)
+        }
+
+        var total = kept.reduce(0) { $0 + $1.line.count + 1 }
+        var dropped = 0
+        while total > Self.maxBytes, dropped < kept.count {
+            total -= kept[dropped].line.count + 1
+            dropped += 1
+        }
+        if dropped > 0 {
+            kept.removeFirst(dropped)
+        }
+
+        var output = Data()
+        for entry in kept {
+            output.append(entry.line)
+            output.append(Self.newline)
+        }
+        write(output, recordCount: kept.count)
+    }
+
+    private func write(_ output: Data, recordCount newCount: Int) {
+        do {
+            try output.write(to: fileURL, options: .atomic)
+            recordCount = newCount
+            fileBytes = output.count
+            Self.restrictPermissions(of: fileURL)
+        } catch {
+            Self.logger.error(
+                "Table load history could not be rewritten: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    private func writeLine(_ line: Data) -> Bool {
+        let path = fileURL.path(percentEncoded: false)
+        if !FileManager.default.fileExists(atPath: path) {
+            FileManager.default.createFile(
+                atPath: path,
+                contents: nil,
+                attributes: [.posixPermissions: NSNumber(value: 0o600)]
+            )
+        }
+
+        guard let handle = try? FileHandle(forWritingTo: fileURL) else {
+            Self.logger.error("Table load history could not be opened for writing")
+            return false
+        }
+        defer { try? handle.close() }
+
+        do {
+            try handle.seekToEnd()
+            try handle.write(contentsOf: line)
+            return true
+        } catch {
+            Self.logger.error(
+                "Table load history could not be appended to: \(error.localizedDescription, privacy: .public)"
+            )
+            return false
+        }
+    }
+
+    private static func encode(_ record: TableLoadPerformanceRecord) -> Data? {
+        guard var data = try? makeEncoder(prettyPrinted: false).encode(record) else {
+            logger.error("Table load history record could not be encoded")
+            return nil
+        }
+        data.append(newline)
+        return data
+    }
+
+    private static func decodeRecords(in data: Data) -> [(record: TableLoadPerformanceRecord, line: Data)] {
+        let decoder = makeDecoder()
+        return data.split(separator: newline, omittingEmptySubsequences: true).compactMap { slice in
+            let line = Data(slice)
+            guard let record = try? decoder.decode(TableLoadPerformanceRecord.self, from: line) else { return nil }
+            return (record, line)
+        }
+    }
+
+    internal static func makeEncoder(prettyPrinted: Bool) -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = prettyPrinted
+            ? [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            : [.sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .custom { date, encoder in
+            var container = encoder.singleValueContainer()
+            try container.encode(timestamps.format(date))
+        }
+        return encoder
+    }
+
+    internal static func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let text = try decoder.singleValueContainer().decode(String.self)
+            return try Date(text, strategy: timestamps)
+        }
+        return decoder
+    }
+
+    private static func readFile(at url: URL) -> Data {
+        (try? Data(contentsOf: url)) ?? Data()
+    }
+
+    private static func restrictPermissions(of url: URL) {
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o600)],
+            ofItemAtPath: url.path(percentEncoded: false)
+        )
+    }
+}

--- a/TablePro/Core/Diagnostics/TableLoadPerformanceRecord.swift
+++ b/TablePro/Core/Diagnostics/TableLoadPerformanceRecord.swift
@@ -1,0 +1,158 @@
+//
+//  TableLoadPerformanceRecord.swift
+//  TablePro
+//
+
+import Foundation
+
+internal enum TableLoadRowBucket: String, Sendable, CaseIterable {
+    case none = "0"
+    case upTo100 = "1-100"
+    case upTo1000 = "101-1000"
+    case upTo10000 = "1001-10000"
+    case above10000 = ">10000"
+
+    internal init(rowCount: Int) {
+        switch rowCount {
+        case ..<1: self = .none
+        case ..<101: self = .upTo100
+        case ..<1_001: self = .upTo1000
+        case ..<10_001: self = .upTo10000
+        default: self = .above10000
+        }
+    }
+}
+
+/// A statement that returns no columns is a real result, so it gets a bucket of its own rather than
+/// being folded into the first one and reported as a result that had between one and twenty columns.
+internal enum TableLoadColumnBucket: String, Sendable, CaseIterable {
+    case none = "0"
+    case upTo20 = "1-20"
+    case upTo100 = "21-100"
+    case upTo500 = "101-500"
+    case above500 = ">500"
+
+    internal init(columnCount: Int) {
+        switch columnCount {
+        case ..<1: self = .none
+        case ..<21: self = .upTo20
+        case ..<101: self = .upTo100
+        case ..<501: self = .upTo500
+        default: self = .above500
+        }
+    }
+}
+
+internal enum TableLoadResultSizeBucket: String, Sendable, CaseIterable {
+    case underOneMegabyte = "<1MB"
+    case upTo10Megabytes = "1-10MB"
+    case upTo100Megabytes = "10-100MB"
+    case above100Megabytes = ">100MB"
+
+    private static let megabyte = 1_024 * 1_024
+
+    internal init(byteCount: Int) {
+        switch byteCount {
+        case ..<Self.megabyte: self = .underOneMegabyte
+        case ..<(10 * Self.megabyte): self = .upTo10Megabytes
+        case ..<(100 * Self.megabyte): self = .upTo100Megabytes
+        default: self = .above100Megabytes
+        }
+    }
+}
+
+internal enum TableLoadOpenTabBucket: String, Sendable, CaseIterable {
+    case none = "0"
+    case one = "1"
+    case upTo5 = "2-5"
+    case upTo10 = "6-10"
+    case upTo30 = "11-30"
+    case above30 = ">30"
+
+    internal init(tabCount: Int) {
+        switch tabCount {
+        case ..<1: self = .none
+        case 1: self = .one
+        case ..<6: self = .upTo5
+        case ..<11: self = .upTo10
+        case ..<31: self = .upTo30
+        default: self = .above30
+        }
+    }
+}
+
+/// The build and the OS the measurement came from, so a history that spans an app update can say
+/// whether performance changed with it. Resolved once per process rather than per record.
+internal struct TableLoadRuntimeStamp: Sendable, Equatable {
+    internal static let current = TableLoadRuntimeStamp(
+        appVersion: Bundle.main.appVersion,
+        appBuild: Bundle.main.buildNumber,
+        osVersion: TableLoadRuntimeStamp.systemVersion()
+    )
+
+    internal let appVersion: String
+    internal let appBuild: String
+    internal let osVersion: String
+
+    private static func systemVersion() -> String {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return "macOS \(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+    }
+}
+
+/// One persisted line of the local performance history.
+///
+/// Everything here is either a duration, a coarse bucket, or a version string. The trace it comes
+/// from knows the table name, and the connection behind it knows a host, a port and a username; none
+/// of that is reachable from this type, because a diagnostics file that accumulates for a week has to
+/// be something a user can hand over without reading it first.
+///
+/// The buckets are stored as their raw strings rather than as the enums, so a record written by an
+/// older build still decodes after a bucket is renamed or added. A trace that never fetched a result
+/// leaves the three result buckets absent rather than reporting an empty one, which would be a
+/// measurement it never took.
+internal struct TableLoadPerformanceRecord: Codable, Sendable, Equatable {
+    internal let recordedAt: Date
+    internal let appVersion: String
+    internal let appBuild: String
+    internal let osVersion: String
+    internal let origin: String
+    internal let outcome: String
+    internal let anomalies: [String]
+    internal let databaseTypeId: String
+    internal let usesSSH: Bool
+    internal let totalMs: Double
+    internal let preparationMs: Double?
+    internal let driverFetchMs: Double?
+    internal let resultApplyMs: Double?
+    internal let gridReloadMs: Double?
+    internal let mainRunLoopIdleMs: Double?
+    internal let rowBucket: String?
+    internal let columnBucket: String?
+    internal let resultSizeBucket: String?
+    internal let openTabBucket: String
+
+    internal init(summary: TableLoadTraceSummary, stamp: TableLoadRuntimeStamp, recordedAt: Date) {
+        self.recordedAt = recordedAt
+        self.appVersion = stamp.appVersion
+        self.appBuild = stamp.appBuild
+        self.osVersion = stamp.osVersion
+        self.origin = summary.origin.rawValue
+        self.outcome = summary.outcome.rawValue
+        self.anomalies = summary.anomalies.map(\.rawValue)
+        self.databaseTypeId = summary.environment.databaseTypeId
+        self.usesSSH = summary.environment.usesSSH
+        self.totalMs = TableLoadDuration.milliseconds(summary.total)
+        self.preparationMs = summary.preparation.map(TableLoadDuration.milliseconds)
+        self.driverFetchMs = summary.driverFetch.map(TableLoadDuration.milliseconds)
+        self.resultApplyMs = summary.resultApply.map(TableLoadDuration.milliseconds)
+        self.gridReloadMs = summary.gridReload.map(TableLoadDuration.milliseconds)
+        self.mainRunLoopIdleMs = summary.mainRunLoopIdle.map(TableLoadDuration.milliseconds)
+        self.rowBucket = summary.resultMetrics.map { TableLoadRowBucket(rowCount: $0.rowCount).rawValue }
+        self.columnBucket = summary.resultMetrics.map { TableLoadColumnBucket(columnCount: $0.columnCount).rawValue }
+        self.resultSizeBucket = summary.resultMetrics.map {
+            TableLoadResultSizeBucket(byteCount: $0.estimatedBytes).rawValue
+        }
+        self.openTabBucket = TableLoadOpenTabBucket(tabCount: summary.environment.openTabCount).rawValue
+    }
+}

--- a/TablePro/Core/Diagnostics/TableLoadResultMetrics.swift
+++ b/TablePro/Core/Diagnostics/TableLoadResultMetrics.swift
@@ -1,0 +1,69 @@
+//
+//  TableLoadResultMetrics.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+/// The shape of the result a load produced. The byte size is estimated rather than measured, because
+/// nothing in the driver layer reports one and walking every cell of a wide result is main-actor work
+/// at exactly the instant the trace is timing, which would corrupt the measurement it exists to take.
+///
+/// The sample is ten runs of consecutive rows spread evenly across the result, which is the shape
+/// that survives both ways a result is not uniform: taking the head would be biased by an `ORDER BY`
+/// that puts the large rows at one end, and taking every nth row would alias against a result whose
+/// size repeats with a period the stride happens to divide. A result small enough to walk outright is
+/// walked, so only a result too large to measure cheaply is ever an estimate.
+internal struct TableLoadResultMetrics: Sendable, Equatable {
+    internal static let sampleBlockCount = 10
+    internal static let sampleBlockSize = 10
+    internal static let sampleLimit = sampleBlockCount * sampleBlockSize
+
+    internal let rowCount: Int
+    internal let columnCount: Int
+    internal let estimatedBytes: Int
+
+    internal init(rowCount: Int, columnCount: Int, estimatedBytes: Int) {
+        self.rowCount = rowCount
+        self.columnCount = columnCount
+        self.estimatedBytes = estimatedBytes
+    }
+
+    internal init(rows: [[PluginCellValue]], columnCount: Int) {
+        self.init(
+            rowCount: rows.count,
+            columnCount: columnCount,
+            estimatedBytes: Self.estimateBytes(rows: rows)
+        )
+    }
+
+    internal static func estimateBytes(rows: [[PluginCellValue]]) -> Int {
+        guard !rows.isEmpty else { return 0 }
+        guard rows.count > sampleLimit else {
+            return rows.reduce(0) { $0 + byteCount(of: $1) }
+        }
+
+        let span = rows.count - sampleBlockSize
+        var sampledBytes = 0
+        for block in 0..<sampleBlockCount {
+            let start = span * block / (sampleBlockCount - 1)
+            for index in start..<(start + sampleBlockSize) {
+                sampledBytes += byteCount(of: rows[index])
+            }
+        }
+        return sampledBytes * rows.count / sampleLimit
+    }
+
+    private static func byteCount(of row: [PluginCellValue]) -> Int {
+        row.reduce(0) { $0 + byteCount(of: $1) }
+    }
+
+    private static func byteCount(of value: PluginCellValue) -> Int {
+        switch value {
+        case .null: 0
+        case let .text(text): text.utf8.count
+        case let .bytes(data): data.count
+        }
+    }
+}

--- a/TablePro/Core/Diagnostics/TableLoadTrace.swift
+++ b/TablePro/Core/Diagnostics/TableLoadTrace.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-internal enum TableLoadOrigin: String {
+internal enum TableLoadOrigin: String, Sendable {
     case sidebar
     case newWindowTab
     case restore
@@ -14,7 +14,7 @@ internal enum TableLoadOrigin: String {
     case programmatic
 }
 
-internal enum TableLoadStage: String {
+internal enum TableLoadStage: String, Sendable {
     case openTableTab
     case addFirstTab
     case replaceTabContent
@@ -33,7 +33,7 @@ internal enum TableLoadStage: String {
     case mainRunLoopIdle
 }
 
-internal enum TableLoadAnomaly: String {
+internal enum TableLoadAnomaly: String, Sendable {
     case supersededByNewNavigation
     case blockedByInFlightExecution
     case loadAlreadyInFlight
@@ -82,6 +82,12 @@ internal struct TableLoadTraceRecorder {
         var lastStage: TableLoadStage?
         var startedExecution: Bool
         var isFinished: Bool
+        var stageInstants: [TableLoadStage: ContinuousClock.Instant] = [:]
+        var anomalies: [TableLoadAnomaly] = []
+        var environment: TableLoadEnvironment = .unknown
+        var resultMetrics: TableLoadResultMetrics?
+        var wasSuperseded = false
+        var isSummarized = false
     }
 
     internal static let retainedTraceLimit = 32
@@ -90,6 +96,7 @@ internal struct TableLoadTraceRecorder {
     private var sequenceOrder: [Int] = []
     private var activeSequenceByTab: [UUID: Int] = [:]
     private var evictedSequences: [Int] = []
+    private var completedSummaries: [TableLoadTraceSummary] = []
     private var nextSequence = 1
 
     internal init() {}
@@ -99,6 +106,14 @@ internal struct TableLoadTraceRecorder {
     internal mutating func takeEvictedSequences() -> [Int] {
         defer { evictedSequences.removeAll() }
         return evictedSequences
+    }
+
+    /// The same channel for the persisted history. A trace ends four ways and only one of them is
+    /// `finish`, so the summary is built where the entry actually leaves the live set rather than at
+    /// any single caller, and `isSummarized` makes that at most once per trace whichever path wins.
+    internal mutating func takeCompletedSummaries() -> [TableLoadTraceSummary] {
+        defer { completedSummaries.removeAll() }
+        return completedSummaries
     }
 
     /// Starting a navigation on a tab that still has one in flight is the shape the user
@@ -111,12 +126,13 @@ internal struct TableLoadTraceRecorder {
         tabId: UUID,
         table: String,
         origin: TableLoadOrigin,
+        environment: TableLoadEnvironment = .unknown,
         at instant: ContinuousClock.Instant,
         startedAt: ContinuousClock.Instant? = nil
     ) -> (token: TableLoadTraceToken, superseded: TableLoadTiming?) {
         let superseded = measure(tabId: tabId, at: instant)
         if let previous = activeSequenceByTab[tabId] {
-            entries[previous]?.isFinished = true
+            supersede(sequence: previous, at: instant)
         }
 
         let token = TableLoadTraceToken(sequence: nextSequence, tabId: tabId, table: table)
@@ -128,11 +144,12 @@ internal struct TableLoadTraceRecorder {
             lastEventAt: instant,
             lastStage: nil,
             startedExecution: false,
-            isFinished: false
+            isFinished: false,
+            environment: environment
         )
         sequenceOrder.append(token.sequence)
         activeSequenceByTab[tabId] = token.sequence
-        pruneFinishedTraces()
+        pruneFinishedTraces(at: instant)
         return (token, superseded)
     }
 
@@ -144,8 +161,37 @@ internal struct TableLoadTraceRecorder {
         guard let timing = measure(token: token, at: instant) else { return nil }
         entries[token.sequence]?.lastEventAt = instant
         entries[token.sequence]?.lastStage = stage
+        entries[token.sequence]?.stageInstants[stage] = instant
         if stage == .executeStarted { entries[token.sequence]?.startedExecution = true }
         return timing
+    }
+
+    /// Anomalies belong to the trace, not only to the log line, so they are recorded here rather than
+    /// measured and thrown away: "how often did a load report this" is the question the history exists
+    /// to answer. Repeats are folded, because one navigation can be blocked several times.
+    internal mutating func note(
+        _ anomaly: TableLoadAnomaly,
+        token: TableLoadTraceToken,
+        at instant: ContinuousClock.Instant
+    ) -> TableLoadTiming? {
+        guard let timing = measure(token: token, at: instant) else { return nil }
+        if entries[token.sequence]?.anomalies.contains(anomaly) == false {
+            entries[token.sequence]?.anomalies.append(anomaly)
+        }
+        return timing
+    }
+
+    internal mutating func note(
+        _ anomaly: TableLoadAnomaly,
+        tabId: UUID,
+        at instant: ContinuousClock.Instant
+    ) -> TableLoadTiming? {
+        guard let sequence = activeSequenceByTab[tabId], let entry = entries[sequence] else { return nil }
+        return note(anomaly, token: entry.token, at: instant)
+    }
+
+    internal mutating func setResultMetrics(_ metrics: TableLoadResultMetrics, token: TableLoadTraceToken) {
+        entries[token.sequence]?.resultMetrics = metrics
     }
 
     /// A trace that reached `.executeStarted` owns a query that is still on its way back, so nothing
@@ -180,15 +226,17 @@ internal struct TableLoadTraceRecorder {
 
     internal mutating func finish(
         token: TableLoadTraceToken,
+        outcome: TableLoadOutcome,
         at instant: ContinuousClock.Instant
     ) -> TableLoadTiming? {
         guard let timing = measure(token: token, at: instant) else { return nil }
+        summarize(sequence: token.sequence, outcome: outcome, at: instant)
         entries[token.sequence]?.isFinished = true
         entries[token.sequence]?.lastEventAt = instant
         if activeSequenceByTab[token.tabId] == token.sequence {
             activeSequenceByTab[token.tabId] = nil
         }
-        pruneFinishedTraces()
+        pruneFinishedTraces(at: instant)
         return timing
     }
 
@@ -208,7 +256,12 @@ internal struct TableLoadTraceRecorder {
     /// Finished traces go first so an in-flight one stays addressable by a late result, but an
     /// unfinished trace is still evicted once the window overflows: a navigation abandoned before
     /// it ever executed never finishes, and keeping those would grow the map without bound.
-    private mutating func pruneFinishedTraces() {
+    ///
+    /// An evicted trace is summarized on the way out. A finished one already was, so `summarize`
+    /// declines it; an unfinished one is reported as `evicted`, which is the only record that a
+    /// navigation was still open when the window overflowed. A superseded trace whose result never
+    /// came back is reported as what it was, not as an eviction.
+    private mutating func pruneFinishedTraces(at instant: ContinuousClock.Instant) {
         guard sequenceOrder.count > Self.retainedTraceLimit else { return }
         let finished = sequenceOrder.filter { entries[$0]?.isFinished == true }
         var evictable = finished + sequenceOrder.filter { entries[$0]?.isFinished == false }
@@ -216,6 +269,8 @@ internal struct TableLoadTraceRecorder {
         var evicted: Set<Int> = []
         while overflow > 0, !evictable.isEmpty {
             let sequence = evictable.removeFirst()
+            let outcome: TableLoadOutcome = entries[sequence]?.wasSuperseded == true ? .superseded : .evicted
+            summarize(sequence: sequence, outcome: outcome, at: instant)
             entries[sequence] = nil
             evicted.insert(sequence)
             overflow -= 1
@@ -224,5 +279,64 @@ internal struct TableLoadTraceRecorder {
         sequenceOrder.removeAll { evicted.contains($0) }
         activeSequenceByTab = activeSequenceByTab.filter { !evicted.contains($0.value) }
         evictedSequences.append(contentsOf: evicted)
+    }
+
+    /// A superseded trace stays addressable so its late result can still report against it, and that
+    /// late report is the only source of `resultTableMismatch` and `staleResultDropped`, the two
+    /// findings a history of this kind exists to count. Summarizing here would freeze the record
+    /// before either could arrive, so a trace whose query is still on its way back is left to the
+    /// ending that result gives it. One that never executed can never report again, so it is
+    /// summarized now rather than waiting for an eviction that may never come.
+    private mutating func supersede(sequence: Int, at instant: ContinuousClock.Instant) {
+        guard var entry = entries[sequence] else { return }
+        entry.wasSuperseded = true
+        entry.isFinished = true
+        if !entry.anomalies.contains(.supersededByNewNavigation) {
+            entry.anomalies.append(.supersededByNewNavigation)
+        }
+        entries[sequence] = entry
+
+        guard !entry.startedExecution else { return }
+        summarize(sequence: sequence, outcome: .superseded, at: instant)
+    }
+
+    private mutating func summarize(
+        sequence: Int,
+        outcome: TableLoadOutcome,
+        at instant: ContinuousClock.Instant
+    ) {
+        guard var entry = entries[sequence], !entry.isSummarized else { return }
+        entry.isSummarized = true
+        entries[sequence] = entry
+        completedSummaries.append(Self.summary(for: entry, outcome: outcome, at: instant))
+    }
+
+    /// A phase whose bracketing stage never fired is absent rather than zero. `schemaColumnsBegin`
+    /// and `schemaColumnsEnd` only fire when the first load needs the schema, and a trace cancelled
+    /// before its query ran never reaches the fetch at all, so zero would read as "instant" for work
+    /// that never happened.
+    private static func summary(
+        for entry: Entry,
+        outcome: TableLoadOutcome,
+        at instant: ContinuousClock.Instant
+    ) -> TableLoadTraceSummary {
+        func elapsed(_ from: TableLoadStage, _ to: TableLoadStage) -> Duration? {
+            guard let start = entry.stageInstants[from], let end = entry.stageInstants[to] else { return nil }
+            return start.duration(to: end)
+        }
+
+        return TableLoadTraceSummary(
+            origin: entry.origin,
+            outcome: outcome,
+            anomalies: entry.anomalies,
+            environment: entry.environment,
+            resultMetrics: entry.resultMetrics,
+            total: entry.startedAt.duration(to: instant),
+            preparation: elapsed(.schemaColumnsBegin, .schemaColumnsEnd),
+            driverFetch: elapsed(.driverFetchBegin, .driverFetchEnd),
+            resultApply: elapsed(.applyResultBegin, .gridReloadBegin),
+            gridReload: elapsed(.gridReloadBegin, .gridReloadEnd),
+            mainRunLoopIdle: elapsed(.gridReloadEnd, .mainRunLoopIdle)
+        )
     }
 }

--- a/TablePro/Core/Diagnostics/TableLoadTraceSummary.swift
+++ b/TablePro/Core/Diagnostics/TableLoadTraceSummary.swift
@@ -1,0 +1,63 @@
+//
+//  TableLoadTraceSummary.swift
+//  TablePro
+//
+
+import Foundation
+
+/// The closed vocabulary of ways a table load can end. A persisted history has to carry a set an
+/// external report can group by, which a free-form string cannot be: `finish` used to take one, and
+/// the failure case interpolated a Swift type name into it. The type name now rides in the log-only
+/// `detail`, so the log line is unchanged and the recorded field is closed.
+internal enum TableLoadOutcome: String, Sendable, CaseIterable {
+    case completed
+    case cancelled
+    case failed
+    case superseded
+    case blocked
+    case staleDropped
+    case notConnected
+    case replaceFailed
+    case prepareAbandoned
+    case loadAlreadyInFlight
+    case emptyQuery
+    case safeModePromptAlreadyOpen
+    case safeModeDenied
+    case evicted
+}
+
+/// What the load was running against, pushed in when the trace begins. `TableLoadTracer` is one
+/// process-wide singleton while `MainContentCoordinator` is one per connection session, so reading
+/// this at the ending site would read whichever coordinator happened to be current, not the one the
+/// trace belongs to.
+internal struct TableLoadEnvironment: Sendable, Equatable {
+    internal static let unknown = TableLoadEnvironment(databaseTypeId: "", usesSSH: false, openTabCount: 0)
+
+    internal let databaseTypeId: String
+    internal let usesSSH: Bool
+    internal let openTabCount: Int
+}
+
+/// One completed trace, reduced to durations and coarse shape. Produced by `TableLoadTraceRecorder`
+/// at every ending, and the only thing that crosses out of the diagnostics recorder.
+internal struct TableLoadTraceSummary: Sendable, Equatable {
+    internal let origin: TableLoadOrigin
+    internal let outcome: TableLoadOutcome
+    internal let anomalies: [TableLoadAnomaly]
+    internal let environment: TableLoadEnvironment
+    internal let resultMetrics: TableLoadResultMetrics?
+    internal let total: Duration
+    internal let preparation: Duration?
+    internal let driverFetch: Duration?
+    internal let resultApply: Duration?
+    internal let gridReload: Duration?
+    internal let mainRunLoopIdle: Duration?
+}
+
+internal enum TableLoadDuration {
+    internal static func milliseconds(_ duration: Duration) -> Double {
+        let components = duration.components
+        return Double(components.seconds) * 1_000
+            + Double(components.attoseconds) / 1_000_000_000_000_000
+    }
+}

--- a/TablePro/Core/Diagnostics/TableLoadTracer.swift
+++ b/TablePro/Core/Diagnostics/TableLoadTracer.swift
@@ -13,9 +13,12 @@ import os
 /// (`log stream --level debug --predicate 'subsystem == "com.TablePro"'`). Anomalies that
 /// mislead the user are logged at error level and are always captured. Every trace is also
 /// an Instruments interval under Points of Interest.
+///
+/// Both of those are live only, so a finished trace is additionally summarized to `sink`, which
+/// keeps a bounded local history an intermittent slowdown can be looked at in after the fact.
 @MainActor
 internal final class TableLoadTracer {
-    internal static let shared = TableLoadTracer()
+    internal static let shared = TableLoadTracer(sink: TableLoadTracer.defaultSink())
 
     private struct Interval {
         let id: OSSignpostID
@@ -26,13 +29,25 @@ internal final class TableLoadTracer {
 
     private let logger = Logger(subsystem: "com.TablePro", category: "TableLoad")
     private let signposter = OSSignposter(subsystem: "com.TablePro", category: .pointsOfInterest)
+    private let sink: any TableLoadSummarySink
     private var recorder = TableLoadTraceRecorder()
     private var intervals: [Int: Interval] = [:]
     private var handoffs: [String: ContinuousClock.Instant] = [:]
     private var applyScope: TableLoadTraceToken?
     private let clock = ContinuousClock()
 
-    private init() {}
+    internal init(sink: any TableLoadSummarySink) {
+        self.sink = sink
+    }
+
+    /// A unit test that drives a coordinator opens real table tabs and so begins real traces, and
+    /// `AppStorageEnvironment` resolves to the production directory under a unit-test host. Choosing
+    /// the sink here keeps those traces off the developer's own history without the store having to
+    /// know it is being tested.
+    private static func defaultSink() -> any TableLoadSummarySink {
+        guard NSClassFromString("XCTestCase") == nil else { return DiscardingTableLoadSummarySink() }
+        return TableLoadHistoryStore.shared
+    }
 
     /// A sidebar click that opens a new native window tab finishes in a different coordinator, so the
     /// click instant is parked here and picked up by whichever window ends up doing the load. Without
@@ -52,6 +67,7 @@ internal final class TableLoadTracer {
         tabId: UUID,
         table: String,
         origin: TableLoadOrigin,
+        environment: TableLoadEnvironment,
         connectionId: UUID? = nil
     ) -> TableLoadTraceToken {
         let now = clock.now
@@ -66,6 +82,7 @@ internal final class TableLoadTracer {
             tabId: tabId,
             table: table,
             origin: resolvedOrigin,
+            environment: environment,
             at: now,
             startedAt: startedAt
         )
@@ -73,7 +90,7 @@ internal final class TableLoadTracer {
 
         if let superseded {
             report(.supersededByNewNavigation, timing: superseded, detail: "replacedBy=#\(token.sequence)")
-            endInterval(for: superseded.token, outcome: "superseded")
+            endInterval(for: superseded.token, outcome: TableLoadOutcome.superseded.rawValue)
         }
 
         let signpostID = signposter.makeSignpostID()
@@ -86,7 +103,7 @@ internal final class TableLoadTracer {
         logger.debug(
             "\(Self.prefix(token), privacy: .public) +0.0ms START origin=\(origin.rawValue, privacy: .public)"
         )
-        closeEvictedIntervals()
+        drainCompletedTraces()
         return token
     }
 
@@ -95,7 +112,21 @@ internal final class TableLoadTracer {
     private func closeEvictedIntervals() {
         for sequence in recorder.takeEvictedSequences() {
             guard let interval = intervals.removeValue(forKey: sequence) else { continue }
-            signposter.endInterval("TableLoad", interval.state, "evicted")
+            signposter.endInterval("TableLoad", interval.state, "\(TableLoadOutcome.evicted.rawValue)")
+        }
+    }
+
+    /// Stamped on the main actor because the version strings are resolved once per process and the
+    /// timestamp costs nothing, then handed over. The sink never blocks: everything it does with the
+    /// record happens after this returns.
+    private func drainCompletedTraces() {
+        closeEvictedIntervals()
+        let summaries = recorder.takeCompletedSummaries()
+        guard !summaries.isEmpty else { return }
+        let stamp = TableLoadRuntimeStamp.current
+        let recordedAt = Date()
+        for summary in summaries {
+            sink.record(TableLoadPerformanceRecord(summary: summary, stamp: stamp, recordedAt: recordedAt))
         }
     }
 
@@ -124,26 +155,39 @@ internal final class TableLoadTracer {
     }
 
     internal func anomaly(_ anomaly: TableLoadAnomaly, token: TableLoadTraceToken, detail: String? = nil) {
-        guard let timing = recorder.measure(token: token, at: clock.now) else { return }
+        guard let timing = recorder.note(anomaly, token: token, at: clock.now) else { return }
         report(anomaly, timing: timing, detail: detail)
     }
 
     internal func anomaly(_ anomaly: TableLoadAnomaly, tabId: UUID, detail: String? = nil) {
-        guard let timing = recorder.measure(tabId: tabId, at: clock.now) else { return }
+        guard let timing = recorder.note(anomaly, tabId: tabId, at: clock.now) else { return }
         report(anomaly, timing: timing, detail: detail)
     }
 
-    internal func finish(token: TableLoadTraceToken, outcome: String) {
-        guard let timing = recorder.finish(token: token, at: clock.now) else { return }
+    internal func setResultMetrics(_ metrics: TableLoadResultMetrics, token: TableLoadTraceToken) {
+        recorder.setResultMetrics(metrics, token: token)
+    }
+
+    /// `detail` is written to the log and the signpost but never to the history. It is where an
+    /// error's Swift type name still reaches a developer reading `log stream`, while the recorded
+    /// outcome stays a closed set an external report can group by.
+    internal func finish(token: TableLoadTraceToken, outcome: TableLoadOutcome, detail: String? = nil) {
+        guard let timing = recorder.finish(token: token, outcome: outcome, at: clock.now) else { return }
+        let label = Self.label(for: outcome, detail: detail)
         logger.debug(
             """
             \(Self.prefix(timing.token), privacy: .public) \
             +\(Self.milliseconds(timing.sinceStart), privacy: .public)ms \
-            END outcome=\(outcome, privacy: .public)
+            END outcome=\(label, privacy: .public)
             """
         )
-        endInterval(for: timing.token, outcome: outcome)
-        closeEvictedIntervals()
+        endInterval(for: timing.token, outcome: label)
+        drainCompletedTraces()
+    }
+
+    private static func label(for outcome: TableLoadOutcome, detail: String?) -> String {
+        guard let detail, !detail.isEmpty else { return outcome.rawValue }
+        return "\(outcome.rawValue):\(detail)"
     }
 
     internal func activeToken(for tabId: UUID) -> TableLoadTraceToken? {
@@ -218,9 +262,6 @@ internal final class TableLoadTracer {
     }
 
     private static func milliseconds(_ duration: Duration) -> String {
-        let components = duration.components
-        let value = Double(components.seconds) * 1_000
-            + Double(components.attoseconds) / 1_000_000_000_000_000
-        return String(format: "%.1f", value)
+        String(format: "%.1f", TableLoadDuration.milliseconds(duration))
     }
 }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+LoadTracing.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+LoadTracing.swift
@@ -6,6 +6,17 @@
 import Foundation
 
 extension MainContentCoordinator {
+    /// Captured when the trace begins rather than read when it ends. `TableLoadTracer` is one
+    /// process-wide singleton and a coordinator belongs to one connection session, so an ending site
+    /// would read whichever session happened to be current instead of the one that ran the load.
+    var tableLoadEnvironment: TableLoadEnvironment {
+        TableLoadEnvironment(
+            databaseTypeId: connection.type.rawValue,
+            usesSSH: connection.sshTunnelMode != .disabled,
+            openTabCount: tabManager.tabs.count
+        )
+    }
+
     func traceExecutionStarted(_ token: TableLoadTraceToken?, epoch: Int, isAutoLoad: Bool) {
         guard let token else { return }
         TableLoadTracer.shared.stage(
@@ -27,16 +38,18 @@ extension MainContentCoordinator {
             detail: "site=\(site) hasInFlightQuery=\(currentQueryTask != nil)"
         )
         guard !tracer.hasStartedExecution(token) else { return }
-        tracer.finish(token: token, outcome: "blocked")
+        tracer.finish(token: token, outcome: .blocked)
     }
 
-    func traceNavigationAbandoned(tabId: UUID, reason: String) {
+    func traceNavigationAbandoned(tabId: UUID, outcome: TableLoadOutcome) {
         let tracer = TableLoadTracer.shared
         guard let token = tracer.activeToken(for: tabId), !tracer.hasStartedExecution(token) else { return }
-        tracer.anomaly(.preparationAbandoned, token: token, detail: reason)
-        tracer.finish(token: token, outcome: reason)
+        tracer.anomaly(.preparationAbandoned, token: token, detail: outcome.rawValue)
+        tracer.finish(token: token, outcome: outcome)
     }
 
+    /// The result's shape is handed over after both fetch stages are stamped, so sampling it for a
+    /// size estimate cannot land inside the interval it is describing.
     func traceFetchCompleted(
         _ token: TableLoadTraceToken?,
         began: ContinuousClock.Instant,
@@ -55,6 +68,10 @@ extension MainContentCoordinator {
                 driverMs=\(Int(result.executionTime * 1_000))
                 """
         )
+        tracer.setResultMetrics(
+            TableLoadResultMetrics(rows: result.rows, columnCount: result.columns.count),
+            token: token
+        )
     }
 
     func traceFetchCancelled(
@@ -67,7 +84,7 @@ extension MainContentCoordinator {
         tracer.stage(.driverFetchBegin, token: token, at: began)
         tracer.stage(.driverFetchEnd, token: token, at: ended)
         tracer.anomaly(.executionCancelled, token: token)
-        tracer.finish(token: token, outcome: "cancelled")
+        tracer.finish(token: token, outcome: .cancelled)
     }
 
     func traceStaleResultDropped(_ token: TableLoadTraceToken?) {
@@ -79,7 +96,7 @@ extension MainContentCoordinator {
             token: token,
             detail: "tabOwnedBy=\(owner.map { "#\($0.sequence)" } ?? "none") cancelled=\(Task.isCancelled)"
         )
-        tracer.finish(token: token, outcome: "staleDropped")
+        tracer.finish(token: token, outcome: .staleDropped)
     }
 
     /// A result whose table no longer matches what the tab shows is the defect the user sees as
@@ -110,7 +127,8 @@ extension MainContentCoordinator {
         return tracer.begin(
             tabId: tabId,
             table: tab.tableContext.tableName ?? tab.title,
-            origin: .reExecute
+            origin: .reExecute,
+            environment: tableLoadEnvironment
         )
     }
 
@@ -118,18 +136,18 @@ extension MainContentCoordinator {
         guard let token else { return }
         let tracer = TableLoadTracer.shared
         tracer.anomaly(.connectionNotReady, token: token, detail: "site=ensureConnected")
-        tracer.finish(token: token, outcome: "notConnected")
+        tracer.finish(token: token, outcome: .notConnected)
     }
 
     func traceExecutionFailed(_ token: TableLoadTraceToken?, error: Error) {
         guard let token else { return }
-        TableLoadTracer.shared.finish(token: token, outcome: "failed:\(type(of: error))")
+        TableLoadTracer.shared.finish(token: token, outcome: .failed, detail: "\(type(of: error))")
     }
 
     /// Ends the trace one run loop turn after the grid reload. `reloadData()` only invalidates,
     /// so the cell work it schedules runs later in the same turn; closing the trace on the next
     /// turn is what makes that cost visible instead of hiding it after the last stage.
-    func scheduleTraceCompletion(_ token: TableLoadTraceToken?, outcome: String) {
+    func scheduleTraceCompletion(_ token: TableLoadTraceToken?, outcome: TableLoadOutcome) {
         TableLoadTracer.shared.endApplyScope()
         guard let token else { return }
         DispatchQueue.main.async {

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -113,7 +113,12 @@ extension MainContentCoordinator {
                 saveLastFilters(for: oldTableName)
             }
             if let tabId = tabManager.selectedTabId {
-                let token = TableLoadTracer.shared.begin(tabId: tabId, table: tableName, origin: .inPlace)
+                let token = TableLoadTracer.shared.begin(
+                    tabId: tabId,
+                    table: tableName,
+                    origin: .inPlace,
+                    environment: tableLoadEnvironment
+                )
                 TableLoadTracer.shared.stage(.openTableTab, token: token, detail: "path=inPlace")
             }
             do {
@@ -245,7 +250,12 @@ extension MainContentCoordinator {
             return false
         }
         if let (tab, tabIndex) = tabManager.selectedTabAndIndex {
-            let token = TableLoadTracer.shared.begin(tabId: tab.id, table: tableName, origin: .sidebar)
+            let token = TableLoadTracer.shared.begin(
+                tabId: tab.id,
+                table: tableName,
+                origin: .sidebar,
+                environment: tableLoadEnvironment
+            )
             TableLoadTracer.shared.stage(.openTableTab, token: token, detail: "path=addFirstTab")
             TableLoadTracer.shared.stage(.addFirstTab, token: token)
             tabManager.mutate(at: tabIndex) { tab in
@@ -283,7 +293,12 @@ extension MainContentCoordinator {
         var token: TableLoadTraceToken?
         if let tabId = tabManager.selectedTabId {
             let wasExecuting = tabExecution.isExecuting(tabId)
-            let started = TableLoadTracer.shared.begin(tabId: tabId, table: tableName, origin: .sidebar)
+            let started = TableLoadTracer.shared.begin(
+                tabId: tabId,
+                table: tableName,
+                origin: .sidebar,
+                environment: tableLoadEnvironment
+            )
             token = started
             TableLoadTracer.shared.stage(
                 .openTableTab,
@@ -306,7 +321,7 @@ extension MainContentCoordinator {
             )
         } catch {
             navigationLogger.error("openTableTab replaceTabContent failed: \(error.localizedDescription, privacy: .public)")
-            if let token { TableLoadTracer.shared.finish(token: token, outcome: "replaceFailed") }
+            if let token { TableLoadTracer.shared.finish(token: token, outcome: .replaceFailed) }
             return false
         }
         if let token { TableLoadTracer.shared.stage(.replaceTabContent, token: token) }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TableFirstLoad.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TableFirstLoad.swift
@@ -19,7 +19,7 @@ extension MainContentCoordinator {
                     token: token,
                     detail: "cancelled=\(Task.isCancelled)"
                 )
-                tracer.finish(token: token, outcome: "prepareAbandoned")
+                tracer.finish(token: token, outcome: .prepareAbandoned)
             }
             return
         }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+WindowLifecycle.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+WindowLifecycle.swift
@@ -169,6 +169,7 @@ extension MainContentCoordinator {
             tabId: tab.id,
             table: tab.tableContext.tableName ?? "",
             origin: trigger == .restore ? .restore : .programmatic,
+            environment: tableLoadEnvironment,
             connectionId: connectionId
         )
 
@@ -177,7 +178,7 @@ extension MainContentCoordinator {
         func noteLoadAlreadyInFlight() {
             guard carriedToken == nil else { return }
             tracer.anomaly(.loadAlreadyInFlight, token: traceToken)
-            tracer.finish(token: traceToken, outcome: "loadAlreadyInFlight")
+            tracer.finish(token: traceToken, outcome: .loadAlreadyInFlight)
         }
 
         guard tableLoadTasks[tab.id] == nil else {
@@ -201,7 +202,7 @@ extension MainContentCoordinator {
         guard let session = DatabaseManager.shared.session(for: connectionId),
               session.isConnected else {
             tracer.anomaly(.connectionNotReady, token: traceToken)
-            tracer.finish(token: traceToken, outcome: "notConnected")
+            tracer.finish(token: traceToken, outcome: .notConnected)
             pendingLoadTrigger = trigger
             declineTableLoad(for: tab.id)
             return

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -1099,7 +1099,7 @@ final class MainContentCoordinator {
 
         let sql = tab.content.query
         guard !sql.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            traceNavigationAbandoned(tabId: tab.id, reason: "emptyQuery")
+            traceNavigationAbandoned(tabId: tab.id, outcome: .emptyQuery)
             return
         }
 
@@ -1108,7 +1108,7 @@ final class MainContentCoordinator {
            tab.execution.lastExecutedAt == nil
         {
             guard !isShowingSafeModePrompt else {
-                traceNavigationAbandoned(tabId: tab.id, reason: "safeModePromptAlreadyOpen")
+                traceNavigationAbandoned(tabId: tab.id, outcome: .safeModePromptAlreadyOpen)
                 return
             }
             isShowingSafeModePrompt = true
@@ -1129,7 +1129,7 @@ final class MainContentCoordinator {
                 case .authorized:
                     executeQueryInternal(sql, isAutoLoad: true, trigger: trigger)
                 case .denied(let reason):
-                    traceNavigationAbandoned(tabId: tab.id, reason: "safeModeDenied")
+                    traceNavigationAbandoned(tabId: tab.id, outcome: .safeModeDenied)
                     tabManager.mutate(at: index) { $0.execution.errorMessage = reason }
                 }
             }
@@ -1343,7 +1343,7 @@ final class MainContentCoordinator {
                         anchor: anchor
                     )
 
-                    scheduleTraceCompletion(traceToken, outcome: "completed")
+                    scheduleTraceCompletion(traceToken, outcome: .completed)
                     reportQueryOperation(
                         claim: claim,
                         trigger: trigger,

--- a/TableProTests/Core/Diagnostics/TableLoadHistoryStoreTests.swift
+++ b/TableProTests/Core/Diagnostics/TableLoadHistoryStoreTests.swift
@@ -1,0 +1,290 @@
+//
+//  TableLoadHistoryStoreTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("TableLoadHistoryStore")
+struct TableLoadHistoryStoreTests {
+    private static let stamp = TableLoadRuntimeStamp(
+        appVersion: "0.68.0",
+        appBuild: "1234",
+        osVersion: "macOS 15.2.0"
+    )
+
+    private static let encoder = TableLoadHistoryStore.makeEncoder(prettyPrinted: false)
+
+    private func makeStore() -> (store: TableLoadHistoryStore, fileURL: URL) {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TableLoadHistoryStoreTests.\(UUID().uuidString).jsonl")
+        return (TableLoadHistoryStore(fileURL: fileURL), fileURL)
+    }
+
+    /// Dated relative to now, because opening a store prunes it against the retention window and a
+    /// fixture dated from the epoch would be pruned before the test could look at it.
+    private func moment(_ secondsAgo: Int) -> Date {
+        Date(timeIntervalSinceNow: -Double(secondsAgo))
+    }
+
+    private func record(
+        recordedAt: Date = .now,
+        outcome: TableLoadOutcome = .completed,
+        totalMs: Int = 100,
+        padding: Int = 0
+    ) -> TableLoadPerformanceRecord {
+        TableLoadPerformanceRecord(
+            summary: TableLoadTraceSummary(
+                origin: .sidebar,
+                outcome: outcome,
+                anomalies: [],
+                environment: TableLoadEnvironment(
+                    databaseTypeId: "SQLite" + String(repeating: "x", count: padding),
+                    usesSSH: false,
+                    openTabCount: 2
+                ),
+                resultMetrics: TableLoadResultMetrics(rowCount: 10, columnCount: 4, estimatedBytes: 512),
+                total: .milliseconds(totalMs),
+                preparation: nil,
+                driverFetch: .milliseconds(totalMs / 2),
+                resultApply: nil,
+                gridReload: nil,
+                mainRunLoopIdle: nil
+            ),
+            stamp: Self.stamp,
+            recordedAt: recordedAt
+        )
+    }
+
+    private func write(_ contents: String, to fileURL: URL) throws {
+        try Data(contents.utf8).write(to: fileURL)
+    }
+
+    private func line(for record: TableLoadPerformanceRecord) throws -> String {
+        let data = try Self.encoder.encode(record)
+        return try #require(String(data: data, encoding: .utf8))
+    }
+
+    private func writeLines(_ records: [TableLoadPerformanceRecord], to fileURL: URL) throws {
+        let lines = try records.map { try line(for: $0) }
+        try write(lines.joined(separator: "\n") + "\n", to: fileURL)
+    }
+
+    // MARK: - Round trip
+
+    @Test("An appended record survives a new store over the same file")
+    func appendedRecordSurvivesReopening() async throws {
+        let (store, fileURL) = makeStore()
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        await store.append(record(totalMs: 640))
+
+        let reopened = TableLoadHistoryStore(fileURL: fileURL)
+        let records = await reopened.records()
+        #expect(records.count == 1)
+        #expect(records.first?.totalMs == 640)
+    }
+
+    @Test("Every appended record is kept, in the order they were written")
+    func keepsEveryAppendedRecord() async {
+        let (store, fileURL) = makeStore()
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        for index in 0..<20 {
+            await store.append(record(recordedAt: moment(100 - index), totalMs: index))
+        }
+
+        let records = await store.records()
+        #expect(records.map(\.totalMs) == (0..<20).map(Double.init))
+    }
+
+    @Test("A store with no file behaves as an empty one")
+    func missingFileReadsAsEmpty() async {
+        let (store, fileURL) = makeStore()
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let records = await store.records()
+        #expect(records.isEmpty)
+    }
+
+    @Test("The history file is readable only by its owner")
+    func restrictsFilePermissions() async throws {
+        let (store, fileURL) = makeStore()
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        await store.append(record())
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
+        #expect(permissions.intValue == 0o600)
+    }
+
+    // MARK: - Retention
+
+    @Test("Records past the retention window are dropped when the store is next opened")
+    func dropsRecordsPastTheRetentionWindow() async throws {
+        let (store, fileURL) = makeStore()
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let day = 86_400
+        try writeLines(
+            [
+                record(recordedAt: moment(8 * day), totalMs: 1),
+                record(recordedAt: moment(6 * day), totalMs: 2),
+                record(recordedAt: moment(60), totalMs: 3)
+            ],
+            to: fileURL
+        )
+
+        let records = await store.records()
+        #expect(records.map(\.totalMs) == [2, 3])
+    }
+
+    @Test("The oldest records go first once the count cap is passed")
+    func enforcesTheRecordCapOldestFirst() async throws {
+        let (store, fileURL) = makeStore()
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let overflow = 12
+        let total = TableLoadHistoryStore.maxRecords + overflow
+        try writeLines(
+            (0..<total).map { record(recordedAt: moment(total - $0), totalMs: $0) },
+            to: fileURL
+        )
+
+        let records = await store.records()
+        #expect(records.count == TableLoadHistoryStore.maxRecords)
+        #expect(records.first?.totalMs == Double(overflow))
+        #expect(records.last?.totalMs == Double(total - 1))
+    }
+
+    /// Padded so the byte cap binds before the count cap does, which is the only way to see it act.
+    @Test("The oldest records go first once the byte cap is passed")
+    func enforcesTheByteCapOldestFirst() async throws {
+        let (store, fileURL) = makeStore()
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let padding = 512
+        let lineBytes = try line(for: record(padding: padding)).utf8.count + 1
+        let fitting = TableLoadHistoryStore.maxBytes / lineBytes
+        let total = fitting + 40
+        #expect(total < TableLoadHistoryStore.maxRecords)
+
+        try writeLines(
+            (0..<total).map { record(recordedAt: moment(total - $0), totalMs: $0, padding: padding) },
+            to: fileURL
+        )
+
+        let records = await store.records()
+        #expect(records.count < total)
+        #expect(records.count > 0)
+        #expect(records.last?.totalMs == Double(total - 1))
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let size = try #require(attributes[.size] as? Int)
+        #expect(size <= TableLoadHistoryStore.maxBytes)
+    }
+
+    // MARK: - Corrupt stores
+
+    @Test("A history torn by a crash keeps every line that survived it")
+    func recoversFromATruncatedFinalLine() async throws {
+        let (store, fileURL) = makeStore()
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let intact = try (0..<3).map { try line(for: record(recordedAt: moment(100 - $0), totalMs: $0)) }
+        let torn = try String(line(for: record(totalMs: 99)).dropLast(20))
+        try write(intact.joined(separator: "\n") + "\n" + torn, to: fileURL)
+
+        let records = await store.records()
+        #expect(records.map(\.totalMs) == [0, 1, 2])
+    }
+
+    @Test("A line of garbage in the middle costs only that line")
+    func recoversFromGarbageMidFile() async throws {
+        let (store, fileURL) = makeStore()
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let first = try line(for: record(recordedAt: moment(200), totalMs: 1))
+        let second = try line(for: record(recordedAt: moment(100), totalMs: 2))
+        try write("\(first)\nnot json at all\n\(second)\n", to: fileURL)
+
+        let records = await store.records()
+        #expect(records.map(\.totalMs) == [1, 2])
+    }
+
+    @Test("A file of nothing but garbage reads as empty and still accepts new records")
+    func recoversFromAWhollyUnreadableFile() async throws {
+        let (store, fileURL) = makeStore()
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        try write("}{\n\u{1}\u{2}\u{3}\n[not json\n", to: fileURL)
+
+        let recovered = await store.records()
+        #expect(recovered.isEmpty)
+
+        await store.append(record(totalMs: 7))
+        let records = await store.records()
+        #expect(records.map(\.totalMs) == [7])
+    }
+
+    @Test("An empty file reads as empty")
+    func recoversFromAnEmptyFile() async throws {
+        let (store, fileURL) = makeStore()
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        try write("", to: fileURL)
+
+        let records = await store.records()
+        #expect(records.isEmpty)
+    }
+
+    // MARK: - Export
+
+    @Test("Exporting the same history twice produces the same bytes")
+    func exportIsDeterministic() async {
+        let (store, fileURL) = makeStore()
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        for index in 0..<5 {
+            await store.append(record(recordedAt: moment(50 - index), totalMs: index))
+        }
+
+        let first = await store.exportJSON()
+        let second = await store.exportJSON()
+        #expect(first == second)
+        #expect(first.isEmpty == false)
+    }
+
+    @Test("The export decodes back into the records the store holds")
+    func exportDecodesBackToItsRecords() async throws {
+        let (store, fileURL) = makeStore()
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        await store.append(record(recordedAt: moment(10), totalMs: 42))
+
+        let exported = await store.exportJSON()
+        let decoded = try TableLoadHistoryStore.makeDecoder().decode(
+            [TableLoadPerformanceRecord].self,
+            from: exported
+        )
+
+        #expect(decoded.count == 1)
+        #expect(decoded.first?.totalMs == 42)
+    }
+
+    @Test("An empty history exports an empty array rather than nothing")
+    func exportsAnEmptyArrayForAnEmptyHistory() async throws {
+        let (store, fileURL) = makeStore()
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let exported = await store.exportJSON()
+        let decoded = try TableLoadHistoryStore.makeDecoder().decode(
+            [TableLoadPerformanceRecord].self,
+            from: exported
+        )
+        #expect(decoded.isEmpty)
+    }
+}

--- a/TableProTests/Core/Diagnostics/TableLoadPerformanceRecordTests.swift
+++ b/TableProTests/Core/Diagnostics/TableLoadPerformanceRecordTests.swift
@@ -1,0 +1,253 @@
+//
+//  TableLoadPerformanceRecordTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("TableLoadPerformanceRecord")
+struct TableLoadPerformanceRecordTests {
+    private static let stamp = TableLoadRuntimeStamp(
+        appVersion: "0.68.0",
+        appBuild: "1234",
+        osVersion: "macOS 15.2.0"
+    )
+
+    private func summary(
+        outcome: TableLoadOutcome = .completed,
+        metrics: TableLoadResultMetrics? = nil,
+        openTabCount: Int = 4
+    ) -> TableLoadTraceSummary {
+        TableLoadTraceSummary(
+            origin: .sidebar,
+            outcome: outcome,
+            anomalies: [.staleResultDropped],
+            environment: TableLoadEnvironment(
+                databaseTypeId: "MySQL",
+                usesSSH: true,
+                openTabCount: openTabCount
+            ),
+            resultMetrics: metrics,
+            total: .milliseconds(1_250),
+            preparation: .milliseconds(30),
+            driverFetch: .milliseconds(900),
+            resultApply: nil,
+            gridReload: .milliseconds(120),
+            mainRunLoopIdle: .milliseconds(200)
+        )
+    }
+
+    // MARK: - Buckets
+
+    @Test("Row buckets split at the boundaries the history reports")
+    func rowBucketBoundaries() {
+        #expect(TableLoadRowBucket(rowCount: 0) == .none)
+        #expect(TableLoadRowBucket(rowCount: 1) == .upTo100)
+        #expect(TableLoadRowBucket(rowCount: 100) == .upTo100)
+        #expect(TableLoadRowBucket(rowCount: 101) == .upTo1000)
+        #expect(TableLoadRowBucket(rowCount: 1_000) == .upTo1000)
+        #expect(TableLoadRowBucket(rowCount: 1_001) == .upTo10000)
+        #expect(TableLoadRowBucket(rowCount: 10_000) == .upTo10000)
+        #expect(TableLoadRowBucket(rowCount: 10_001) == .above10000)
+    }
+
+    @Test("Column buckets split at the boundaries the history reports")
+    func columnBucketBoundaries() {
+        #expect(TableLoadColumnBucket(columnCount: 0) == .none)
+        #expect(TableLoadColumnBucket(columnCount: 1) == .upTo20)
+        #expect(TableLoadColumnBucket(columnCount: 20) == .upTo20)
+        #expect(TableLoadColumnBucket(columnCount: 21) == .upTo100)
+        #expect(TableLoadColumnBucket(columnCount: 100) == .upTo100)
+        #expect(TableLoadColumnBucket(columnCount: 101) == .upTo500)
+        #expect(TableLoadColumnBucket(columnCount: 500) == .upTo500)
+        #expect(TableLoadColumnBucket(columnCount: 501) == .above500)
+    }
+
+    @Test("Result size buckets split at the megabyte boundaries")
+    func resultSizeBucketBoundaries() {
+        let megabyte = 1_024 * 1_024
+        #expect(TableLoadResultSizeBucket(byteCount: 0) == .underOneMegabyte)
+        #expect(TableLoadResultSizeBucket(byteCount: megabyte - 1) == .underOneMegabyte)
+        #expect(TableLoadResultSizeBucket(byteCount: megabyte) == .upTo10Megabytes)
+        #expect(TableLoadResultSizeBucket(byteCount: 10 * megabyte - 1) == .upTo10Megabytes)
+        #expect(TableLoadResultSizeBucket(byteCount: 10 * megabyte) == .upTo100Megabytes)
+        #expect(TableLoadResultSizeBucket(byteCount: 100 * megabyte - 1) == .upTo100Megabytes)
+        #expect(TableLoadResultSizeBucket(byteCount: 100 * megabyte) == .above100Megabytes)
+    }
+
+    @Test("Open tab buckets split at the boundaries the history reports")
+    func openTabBucketBoundaries() {
+        #expect(TableLoadOpenTabBucket(tabCount: 0) == .none)
+        #expect(TableLoadOpenTabBucket(tabCount: 1) == .one)
+        #expect(TableLoadOpenTabBucket(tabCount: 2) == .upTo5)
+        #expect(TableLoadOpenTabBucket(tabCount: 5) == .upTo5)
+        #expect(TableLoadOpenTabBucket(tabCount: 6) == .upTo10)
+        #expect(TableLoadOpenTabBucket(tabCount: 10) == .upTo10)
+        #expect(TableLoadOpenTabBucket(tabCount: 11) == .upTo30)
+        #expect(TableLoadOpenTabBucket(tabCount: 30) == .upTo30)
+        #expect(TableLoadOpenTabBucket(tabCount: 31) == .above30)
+    }
+
+    // MARK: - Result size estimation
+
+    private func rows(count: Int, bytesEach: Int) -> [[PluginCellValue]] {
+        (0..<count).map { _ in [.text(String(repeating: "x", count: bytesEach))] }
+    }
+
+    @Test("An empty result estimates nothing rather than dividing by no rows")
+    func emptyResultEstimatesZero() {
+        #expect(TableLoadResultMetrics.estimateBytes(rows: []) == 0)
+        let metrics = TableLoadResultMetrics(rows: [], columnCount: 7)
+        #expect(metrics.rowCount == 0)
+        #expect(metrics.columnCount == 7)
+        #expect(metrics.estimatedBytes == 0)
+    }
+
+    @Test("Rows with no columns weigh nothing")
+    func zeroColumnRowsEstimateZero() {
+        #expect(TableLoadResultMetrics.estimateBytes(rows: [[], [], []]) == 0)
+    }
+
+    @Test("A result small enough to walk is measured exactly")
+    func smallResultIsMeasuredExactly() {
+        let sampleLimit = TableLoadResultMetrics.sampleLimit
+        #expect(TableLoadResultMetrics.estimateBytes(rows: rows(count: 1, bytesEach: 40)) == 40)
+        #expect(TableLoadResultMetrics.estimateBytes(rows: rows(count: 50, bytesEach: 10)) == 500)
+        #expect(
+            TableLoadResultMetrics.estimateBytes(rows: rows(count: sampleLimit, bytesEach: 10))
+                == sampleLimit * 10
+        )
+    }
+
+    @Test("A uniform result larger than the sample estimates its exact size")
+    func uniformLargeResultEstimatesExactly() {
+        #expect(TableLoadResultMetrics.estimateBytes(rows: rows(count: 5_000, bytesEach: 20)) == 100_000)
+    }
+
+    @Test("A null cell weighs nothing and a blob weighs its bytes")
+    func countsEveryCellKind() {
+        let row: [PluginCellValue] = [.null, .text("abcd"), .bytes(Data(repeating: 0, count: 16))]
+        #expect(TableLoadResultMetrics.estimateBytes(rows: [row]) == 20)
+    }
+
+    @Test("Text is weighed in UTF-8 bytes, not characters")
+    func weighsTextInUTF8Bytes() {
+        #expect(TableLoadResultMetrics.estimateBytes(rows: [[.text("héllo")]]) == 6)
+    }
+
+    /// Taking the head would read only the light rows and taking every nth would alias against a
+    /// repeating one, so both shapes are held to the same tolerance.
+    @Test("Neither an ordered result nor a repeating one biases the estimate")
+    func samplingSurvivesOrderedAndRepeatingResults() {
+        let ordered: [[PluginCellValue]] = (0..<1_000).map { index in
+            [.text(String(repeating: "x", count: index < 500 ? 0 : 100))]
+        }
+        let repeating: [[PluginCellValue]] = (0..<1_000).map { index in
+            [.text(String(repeating: "x", count: index.isMultiple(of: 2) ? 100 : 0))]
+        }
+
+        let trueSize = 50_000
+        let tolerance = trueSize / 10
+        #expect(abs(TableLoadResultMetrics.estimateBytes(rows: ordered) - trueSize) <= tolerance)
+        #expect(abs(TableLoadResultMetrics.estimateBytes(rows: repeating) - trueSize) <= tolerance)
+    }
+
+    // MARK: - Record
+
+    @Test("Durations are recorded as milliseconds and an absent phase stays absent")
+    func mapsDurationsToMilliseconds() {
+        let record = TableLoadPerformanceRecord(summary: summary(), stamp: Self.stamp, recordedAt: .now)
+
+        #expect(record.totalMs == 1_250)
+        #expect(record.preparationMs == 30)
+        #expect(record.driverFetchMs == 900)
+        #expect(record.resultApplyMs == nil)
+        #expect(record.gridReloadMs == 120)
+        #expect(record.mainRunLoopIdleMs == 200)
+    }
+
+    @Test("The build, the OS and the load's shape all reach the record")
+    func carriesEnvironmentAndStamp() {
+        let metrics = TableLoadResultMetrics(rowCount: 4_200, columnCount: 60, estimatedBytes: 3_000_000)
+        let record = TableLoadPerformanceRecord(
+            summary: summary(metrics: metrics),
+            stamp: Self.stamp,
+            recordedAt: .now
+        )
+
+        #expect(record.appVersion == "0.68.0")
+        #expect(record.appBuild == "1234")
+        #expect(record.osVersion == "macOS 15.2.0")
+        #expect(record.origin == TableLoadOrigin.sidebar.rawValue)
+        #expect(record.outcome == TableLoadOutcome.completed.rawValue)
+        #expect(record.anomalies == [TableLoadAnomaly.staleResultDropped.rawValue])
+        #expect(record.databaseTypeId == "MySQL")
+        #expect(record.usesSSH)
+        #expect(record.rowBucket == TableLoadRowBucket.upTo10000.rawValue)
+        #expect(record.columnBucket == TableLoadColumnBucket.upTo100.rawValue)
+        #expect(record.resultSizeBucket == TableLoadResultSizeBucket.upTo10Megabytes.rawValue)
+        #expect(record.openTabBucket == TableLoadOpenTabBucket.upTo5.rawValue)
+    }
+
+    @Test("A trace that never fetched reports no result buckets rather than empty ones")
+    func leavesResultBucketsAbsentWithoutAFetch() {
+        let record = TableLoadPerformanceRecord(
+            summary: summary(outcome: .superseded),
+            stamp: Self.stamp,
+            recordedAt: .now
+        )
+
+        #expect(record.rowBucket == nil)
+        #expect(record.columnBucket == nil)
+        #expect(record.resultSizeBucket == nil)
+        #expect(record.openTabBucket == TableLoadOpenTabBucket.upTo5.rawValue)
+    }
+
+    @Test("A record round-trips through the encoding the store writes")
+    func roundTripsThroughJSON() throws {
+        let metrics = TableLoadResultMetrics(rowCount: 12, columnCount: 3, estimatedBytes: 900)
+        let record = TableLoadPerformanceRecord(
+            summary: summary(metrics: metrics),
+            stamp: Self.stamp,
+            recordedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        let encoder = TableLoadHistoryStore.makeEncoder(prettyPrinted: false)
+        let decoder = TableLoadHistoryStore.makeDecoder()
+        let decoded = try decoder.decode(TableLoadPerformanceRecord.self, from: encoder.encode(record))
+
+        #expect(decoded == record)
+    }
+
+    /// The trace this record comes from knows a table name and the connection behind it knows a host,
+    /// a port and a username. None of them may survive into a file that accumulates for a week.
+    @Test("Nothing identifying the query, the table or the server survives into the record")
+    func carriesNothingIdentifying() throws {
+        let secrets = [
+            "employee_salaries",
+            "payroll",
+            "SELECT * FROM employee_salaries",
+            "db.internal.example.com",
+            "5432",
+            "admin",
+            "/Users/someone/Documents/payroll.sql",
+            "connection failed: password authentication failed for user"
+        ]
+        let metrics = TableLoadResultMetrics(rowCount: 12, columnCount: 3, estimatedBytes: 900)
+        let record = TableLoadPerformanceRecord(
+            summary: summary(metrics: metrics),
+            stamp: Self.stamp,
+            recordedAt: .now
+        )
+
+        let data = try TableLoadHistoryStore.makeEncoder(prettyPrinted: false).encode(record)
+        let json = try #require(String(data: data, encoding: .utf8))
+
+        for secret in secrets {
+            #expect(json.contains(secret) == false, "record leaked \(secret)")
+        }
+    }
+}

--- a/TableProTests/Core/Diagnostics/TableLoadTraceRecorderTests.swift
+++ b/TableProTests/Core/Diagnostics/TableLoadTraceRecorderTests.swift
@@ -92,7 +92,7 @@ struct TableLoadTraceRecorderTests {
         let first = recorder.begin(tabId: tabId, table: "users", origin: .sidebar, at: instant(0))
         let second = recorder.begin(tabId: tabId, table: "orders", origin: .sidebar, at: instant(50))
 
-        _ = recorder.finish(token: first.token, at: instant(900))
+        _ = recorder.finish(token: first.token, outcome: .completed, at: instant(900))
 
         #expect(recorder.activeToken(for: tabId) == second.token)
     }
@@ -103,7 +103,7 @@ struct TableLoadTraceRecorderTests {
         let tabId = UUID()
         let started = recorder.begin(tabId: tabId, table: "users", origin: .sidebar, at: instant(0))
 
-        let finished = recorder.finish(token: started.token, at: instant(400))
+        let finished = recorder.finish(token: started.token, outcome: .completed, at: instant(400))
         let timing = try #require(finished)
 
         #expect(timing.sinceStart == .milliseconds(400))
@@ -173,7 +173,7 @@ struct TableLoadTraceRecorderTests {
             let token = recorder.begin(
                 tabId: UUID(), table: "t\(index)", origin: .sidebar, at: instant(index + 1)
             ).token
-            _ = recorder.finish(token: token, at: instant(index + 2))
+            _ = recorder.finish(token: token, outcome: .completed, at: instant(index + 2))
         }
 
         #expect(recorder.entry(for: inFlight.token) != nil)
@@ -188,7 +188,7 @@ struct TableLoadTraceRecorderTests {
             let token = recorder.begin(
                 tabId: UUID(), table: "t\(index)", origin: .sidebar, at: instant(index)
             ).token
-            _ = recorder.finish(token: token, at: instant(index))
+            _ = recorder.finish(token: token, outcome: .completed, at: instant(index))
             tokens.append(token)
         }
 
@@ -208,7 +208,7 @@ struct TableLoadTraceRecorderTests {
     func reportsNoEvictionsWhenUnderTheLimit() {
         var recorder = TableLoadTraceRecorder()
         let started = recorder.begin(tabId: UUID(), table: "users", origin: .sidebar, at: instant(0))
-        _ = recorder.finish(token: started.token, at: instant(10))
+        _ = recorder.finish(token: started.token, outcome: .completed, at: instant(10))
         #expect(recorder.takeEvictedSequences().isEmpty)
     }
 

--- a/TableProTests/Core/Diagnostics/TableLoadTraceSummaryTests.swift
+++ b/TableProTests/Core/Diagnostics/TableLoadTraceSummaryTests.swift
@@ -1,0 +1,271 @@
+//
+//  TableLoadTraceSummaryTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("TableLoadTraceSummary")
+struct TableLoadTraceSummaryTests {
+    private let base = ContinuousClock.now
+
+    private func instant(_ milliseconds: Int) -> ContinuousClock.Instant {
+        base.advanced(by: .milliseconds(milliseconds))
+    }
+
+    private func environment(tabs: Int = 3) -> TableLoadEnvironment {
+        TableLoadEnvironment(databaseTypeId: "PostgreSQL", usesSSH: true, openTabCount: tabs)
+    }
+
+    private func fullyStagedRecorder() -> (recorder: TableLoadTraceRecorder, token: TableLoadTraceToken) {
+        var recorder = TableLoadTraceRecorder()
+        let started = recorder.begin(
+            tabId: UUID(),
+            table: "users",
+            origin: .sidebar,
+            environment: environment(),
+            at: instant(0)
+        )
+        let token = started.token
+        _ = recorder.record(.schemaColumnsBegin, token: token, at: instant(10))
+        _ = recorder.record(.schemaColumnsEnd, token: token, at: instant(40))
+        _ = recorder.record(.driverFetchBegin, token: token, at: instant(50))
+        _ = recorder.record(.driverFetchEnd, token: token, at: instant(250))
+        _ = recorder.record(.applyResultBegin, token: token, at: instant(260))
+        _ = recorder.record(.gridReloadBegin, token: token, at: instant(300))
+        _ = recorder.record(.gridReloadEnd, token: token, at: instant(360))
+        _ = recorder.record(.mainRunLoopIdle, token: token, at: instant(420))
+        return (recorder, token)
+    }
+
+    @Test("Each phase is measured between the stages that bracket it")
+    func measuresEveryPhase() throws {
+        let staged = fullyStagedRecorder()
+        var recorder = staged.recorder
+        _ = recorder.finish(token: staged.token, outcome: .completed, at: instant(420))
+
+        let summaries = recorder.takeCompletedSummaries()
+        let summary = try #require(summaries.first)
+        #expect(summary.total == .milliseconds(420))
+        #expect(summary.preparation == .milliseconds(30))
+        #expect(summary.driverFetch == .milliseconds(200))
+        #expect(summary.resultApply == .milliseconds(40))
+        #expect(summary.gridReload == .milliseconds(60))
+        #expect(summary.mainRunLoopIdle == .milliseconds(60))
+        #expect(summary.outcome == .completed)
+        #expect(summary.origin == .sidebar)
+    }
+
+    @Test("A phase whose stages never fired is absent rather than zero")
+    func absentPhasesStayNil() throws {
+        var recorder = TableLoadTraceRecorder()
+        let started = recorder.begin(tabId: UUID(), table: "users", origin: .sidebar, at: instant(0))
+        _ = recorder.record(.executeStarted, token: started.token, at: instant(10))
+        _ = recorder.finish(token: started.token, outcome: .cancelled, at: instant(90))
+
+        let summaries = recorder.takeCompletedSummaries()
+        let summary = try #require(summaries.first)
+        #expect(summary.total == .milliseconds(90))
+        #expect(summary.preparation == nil)
+        #expect(summary.driverFetch == nil)
+        #expect(summary.resultApply == nil)
+        #expect(summary.gridReload == nil)
+        #expect(summary.mainRunLoopIdle == nil)
+    }
+
+    @Test("A driver fetch that was backdated is still measured between its own instants")
+    func backdatedFetchIsMeasuredFromItsOwnInstants() throws {
+        var recorder = TableLoadTraceRecorder()
+        let started = recorder.begin(tabId: UUID(), table: "users", origin: .sidebar, at: instant(0))
+        _ = recorder.record(.driverFetchBegin, token: started.token, at: instant(20))
+        _ = recorder.record(.driverFetchEnd, token: started.token, at: instant(140))
+        _ = recorder.finish(token: started.token, outcome: .completed, at: instant(600))
+
+        let summaries = recorder.takeCompletedSummaries()
+        let summary = try #require(summaries.first)
+        #expect(summary.driverFetch == .milliseconds(120))
+        #expect(summary.total == .milliseconds(600))
+    }
+
+    @Test("A finished trace produces exactly one summary")
+    func finishProducesOneSummary() {
+        var recorder = TableLoadTraceRecorder()
+        let started = recorder.begin(tabId: UUID(), table: "users", origin: .sidebar, at: instant(0))
+        _ = recorder.finish(token: started.token, outcome: .completed, at: instant(100))
+
+        #expect(recorder.takeCompletedSummaries().count == 1)
+        let drained = recorder.takeCompletedSummaries()
+        #expect(drained.isEmpty)
+    }
+
+    @Test("A superseded trace is summarized by the navigation that replaced it")
+    func supersededTraceIsSummarized() throws {
+        var recorder = TableLoadTraceRecorder()
+        let tabId = UUID()
+        _ = recorder.begin(
+            tabId: tabId,
+            table: "users",
+            origin: .sidebar,
+            environment: environment(),
+            at: instant(0)
+        )
+        _ = recorder.begin(tabId: tabId, table: "orders", origin: .sidebar, at: instant(80))
+
+        let summaries = recorder.takeCompletedSummaries()
+        #expect(summaries.count == 1)
+        let summary = try #require(summaries.first)
+        #expect(summary.outcome == .superseded)
+        #expect(summary.total == .milliseconds(80))
+        #expect(summary.environment.databaseTypeId == "PostgreSQL")
+    }
+
+    /// The superseded trace stays addressable so its late result can still report against it, which
+    /// means `finish` runs on a trace that was already summarized.
+    @Test("Finishing an already superseded trace does not summarize it twice")
+    func supersededThenFinishedStaysOneSummary() throws {
+        var recorder = TableLoadTraceRecorder()
+        let tabId = UUID()
+        let first = recorder.begin(tabId: tabId, table: "users", origin: .sidebar, at: instant(0))
+        _ = recorder.begin(tabId: tabId, table: "orders", origin: .sidebar, at: instant(80))
+        _ = recorder.finish(token: first.token, outcome: .staleDropped, at: instant(900))
+
+        let summaries = recorder.takeCompletedSummaries()
+        #expect(summaries.count == 1)
+        let summary = try #require(summaries.first)
+        #expect(summary.outcome == .superseded)
+    }
+
+    /// The late result is the only source of `resultTableMismatch` and `staleResultDropped`, so a
+    /// summary frozen at the moment of supersession could never carry either.
+    @Test("A superseded trace with a query in flight waits for what its result reports")
+    func supersededTraceWithAQueryInFlightWaitsForItsResult() throws {
+        var recorder = TableLoadTraceRecorder()
+        let tabId = UUID()
+        let first = recorder.begin(tabId: tabId, table: "users", origin: .sidebar, at: instant(0))
+        _ = recorder.record(.executeStarted, token: first.token, at: instant(10))
+        _ = recorder.begin(tabId: tabId, table: "orders", origin: .sidebar, at: instant(80))
+
+        #expect(recorder.takeCompletedSummaries().isEmpty)
+
+        _ = recorder.note(.resultTableMismatch, token: first.token, at: instant(900))
+        _ = recorder.note(.staleResultDropped, token: first.token, at: instant(910))
+        _ = recorder.finish(token: first.token, outcome: .staleDropped, at: instant(920))
+
+        let summaries = recorder.takeCompletedSummaries()
+        #expect(summaries.count == 1)
+        let summary = try #require(summaries.first)
+        #expect(summary.outcome == .staleDropped)
+        #expect(summary.anomalies == [.supersededByNewNavigation, .resultTableMismatch, .staleResultDropped])
+        #expect(summary.total == .milliseconds(920))
+    }
+
+    @Test("A superseded trace whose result never came back is still reported as superseded")
+    func supersededTraceEvictedWithoutItsResultStaysSuperseded() throws {
+        var recorder = TableLoadTraceRecorder()
+        let tabId = UUID()
+        let first = recorder.begin(tabId: tabId, table: "users", origin: .sidebar, at: instant(0))
+        _ = recorder.record(.executeStarted, token: first.token, at: instant(10))
+        _ = recorder.begin(tabId: tabId, table: "orders", origin: .sidebar, at: instant(80))
+        #expect(recorder.takeCompletedSummaries().isEmpty)
+
+        for index in 0..<(TableLoadTraceRecorder.retainedTraceLimit + 5) {
+            _ = recorder.begin(tabId: UUID(), table: "t\(index)", origin: .sidebar, at: instant(100 + index))
+        }
+
+        let summaries = recorder.takeCompletedSummaries()
+        let superseded = summaries.filter { $0.outcome == .superseded }
+        #expect(superseded.count == 1)
+        let summary = try #require(superseded.first)
+        #expect(summary.anomalies == [.supersededByNewNavigation])
+    }
+
+    @Test("A trace still open when it is evicted is reported as evicted")
+    func evictedUnfinishedTraceIsSummarized() throws {
+        var recorder = TableLoadTraceRecorder()
+        let overflow = TableLoadTraceRecorder.retainedTraceLimit + 5
+        for index in 0..<overflow {
+            _ = recorder.begin(tabId: UUID(), table: "t\(index)", origin: .sidebar, at: instant(index))
+        }
+
+        let summaries = recorder.takeCompletedSummaries()
+        #expect(summaries.isEmpty == false)
+        #expect(summaries.allSatisfy { $0.outcome == .evicted })
+        #expect(summaries.count == overflow - TableLoadTraceRecorder.retainedTraceLimit)
+    }
+
+    @Test("A finished trace evicted later is not summarized a second time")
+    func evictionDoesNotResummarizeFinishedTraces() {
+        var recorder = TableLoadTraceRecorder()
+        let overflow = TableLoadTraceRecorder.retainedTraceLimit + 5
+        for index in 0..<overflow {
+            let token = recorder.begin(
+                tabId: UUID(), table: "t\(index)", origin: .sidebar, at: instant(index)
+            ).token
+            _ = recorder.finish(token: token, outcome: .completed, at: instant(index + 1))
+        }
+
+        let summaries = recorder.takeCompletedSummaries()
+        #expect(summaries.count == overflow)
+        #expect(summaries.allSatisfy { $0.outcome == .completed })
+    }
+
+    @Test("Anomalies ride on the trace, and a repeat is folded")
+    func recordsAnomaliesOnce() throws {
+        var recorder = TableLoadTraceRecorder()
+        let started = recorder.begin(tabId: UUID(), table: "users", origin: .sidebar, at: instant(0))
+        _ = recorder.note(.blockedByInFlightExecution, token: started.token, at: instant(10))
+        _ = recorder.note(.blockedByInFlightExecution, token: started.token, at: instant(20))
+        _ = recorder.note(.staleResultDropped, token: started.token, at: instant(30))
+        _ = recorder.finish(token: started.token, outcome: .blocked, at: instant(40))
+
+        let summaries = recorder.takeCompletedSummaries()
+        let summary = try #require(summaries.first)
+        #expect(summary.anomalies == [.blockedByInFlightExecution, .staleResultDropped])
+    }
+
+    @Test("An anomaly noted by tab id lands on that tab's active trace")
+    func notesAnomalyByTabId() throws {
+        var recorder = TableLoadTraceRecorder()
+        let tabId = UUID()
+        let started = recorder.begin(tabId: tabId, table: "users", origin: .sidebar, at: instant(0))
+
+        let noted = recorder.note(.preparationAbandoned, tabId: tabId, at: instant(15))
+        let timing = try #require(noted)
+        #expect(timing.token == started.token)
+
+        _ = recorder.finish(token: started.token, outcome: .prepareAbandoned, at: instant(20))
+        let summaries = recorder.takeCompletedSummaries()
+        let summary = try #require(summaries.first)
+        #expect(summary.anomalies == [.preparationAbandoned])
+    }
+
+    @Test("The result's shape reaches the summary from the fetch that produced it")
+    func carriesResultMetrics() throws {
+        let staged = fullyStagedRecorder()
+        var recorder = staged.recorder
+        recorder.setResultMetrics(
+            TableLoadResultMetrics(rowCount: 480, columnCount: 12, estimatedBytes: 2_048),
+            token: staged.token
+        )
+        _ = recorder.finish(token: staged.token, outcome: .completed, at: instant(420))
+
+        let summaries = recorder.takeCompletedSummaries()
+        let metrics = try #require(summaries.first?.resultMetrics)
+        #expect(metrics.rowCount == 480)
+        #expect(metrics.columnCount == 12)
+        #expect(metrics.estimatedBytes == 2_048)
+    }
+
+    @Test("A trace that never fetched carries no result shape")
+    func leavesResultMetricsAbsentWithoutAFetch() throws {
+        var recorder = TableLoadTraceRecorder()
+        let started = recorder.begin(tabId: UUID(), table: "users", origin: .sidebar, at: instant(0))
+        _ = recorder.finish(token: started.token, outcome: .notConnected, at: instant(30))
+
+        let summaries = recorder.takeCompletedSummaries()
+        let summary = try #require(summaries.first)
+        #expect(summary.resultMetrics == nil)
+    }
+}

--- a/TableProTests/Core/Diagnostics/TableLoadTracerSinkTests.swift
+++ b/TableProTests/Core/Diagnostics/TableLoadTracerSinkTests.swift
@@ -1,0 +1,156 @@
+//
+//  TableLoadTracerSinkTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+private final class RecordingSink: TableLoadSummarySink, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [TableLoadPerformanceRecord] = []
+
+    var records: [TableLoadPerformanceRecord] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func record(_ record: TableLoadPerformanceRecord) {
+        lock.lock()
+        defer { lock.unlock() }
+        storage.append(record)
+    }
+}
+
+@MainActor
+@Suite("TableLoadTracer sink")
+struct TableLoadTracerSinkTests {
+    private func makeTracer() -> (tracer: TableLoadTracer, sink: RecordingSink) {
+        let sink = RecordingSink()
+        return (TableLoadTracer(sink: sink), sink)
+    }
+
+    private var environment: TableLoadEnvironment {
+        TableLoadEnvironment(databaseTypeId: "ClickHouse", usesSSH: true, openTabCount: 7)
+    }
+
+    @Test("A completed load reaches the sink once, with its environment")
+    func completedLoadIsRecordedOnce() throws {
+        let (tracer, sink) = makeTracer()
+        let token = tracer.begin(
+            tabId: UUID(),
+            table: "users",
+            origin: .sidebar,
+            environment: environment
+        )
+        tracer.stage(.applyResultBegin, token: token)
+        tracer.stage(.gridReloadBegin, token: token)
+        tracer.stage(.gridReloadEnd, token: token)
+        tracer.finish(token: token, outcome: .completed)
+
+        #expect(sink.records.count == 1)
+        let record = try #require(sink.records.first)
+        #expect(record.outcome == TableLoadOutcome.completed.rawValue)
+        #expect(record.origin == TableLoadOrigin.sidebar.rawValue)
+        #expect(record.databaseTypeId == "ClickHouse")
+        #expect(record.usesSSH)
+        #expect(record.openTabBucket == TableLoadOpenTabBucket.upTo10.rawValue)
+        #expect(record.gridReloadMs != nil)
+    }
+
+    @Test("A failure records a closed outcome and keeps the error type out of it")
+    func failureRecordsAClosedOutcome() throws {
+        let (tracer, sink) = makeTracer()
+        let token = tracer.begin(tabId: UUID(), table: "users", origin: .sidebar, environment: environment)
+        tracer.finish(token: token, outcome: .failed, detail: "MySQLConnectionError")
+
+        let record = try #require(sink.records.first)
+        #expect(record.outcome == TableLoadOutcome.failed.rawValue)
+        #expect(record.outcome.contains("MySQLConnectionError") == false)
+    }
+
+    @Test("Navigating again on the same tab records the trace it replaced")
+    func supersededLoadIsRecorded() throws {
+        let (tracer, sink) = makeTracer()
+        let tabId = UUID()
+        _ = tracer.begin(tabId: tabId, table: "users", origin: .sidebar, environment: environment)
+        let second = tracer.begin(tabId: tabId, table: "orders", origin: .sidebar, environment: environment)
+
+        #expect(sink.records.count == 1)
+        let first = try #require(sink.records.first)
+        #expect(first.outcome == TableLoadOutcome.superseded.rawValue)
+
+        tracer.finish(token: second, outcome: .completed)
+        #expect(sink.records.count == 2)
+    }
+
+    @Test("A superseded trace whose late result arrives is still recorded only once")
+    func supersededLoadIsNotRecordedTwice() {
+        let (tracer, sink) = makeTracer()
+        let tabId = UUID()
+        let first = tracer.begin(tabId: tabId, table: "users", origin: .sidebar, environment: environment)
+        _ = tracer.begin(tabId: tabId, table: "orders", origin: .sidebar, environment: environment)
+        tracer.finish(token: first, outcome: .staleDropped)
+
+        let outcomes = sink.records.map(\.outcome)
+        #expect(outcomes == [TableLoadOutcome.superseded.rawValue])
+    }
+
+    @Test("The anomalies a trace reported ride along with it")
+    func anomaliesReachTheRecord() throws {
+        let (tracer, sink) = makeTracer()
+        let token = tracer.begin(tabId: UUID(), table: "users", origin: .sidebar, environment: environment)
+        tracer.anomaly(.blockedByInFlightExecution, token: token)
+        tracer.anomaly(.connectionNotReady, token: token)
+        tracer.finish(token: token, outcome: .notConnected)
+
+        let record = try #require(sink.records.first)
+        #expect(record.anomalies == [
+            TableLoadAnomaly.blockedByInFlightExecution.rawValue,
+            TableLoadAnomaly.connectionNotReady.rawValue
+        ])
+    }
+
+    @Test("The result's shape reaches the record through the fetch that produced it")
+    func resultShapeReachesTheRecord() throws {
+        let (tracer, sink) = makeTracer()
+        let token = tracer.begin(tabId: UUID(), table: "users", origin: .reExecute, environment: environment)
+        tracer.setResultMetrics(
+            TableLoadResultMetrics(rowCount: 250, columnCount: 640, estimatedBytes: 0),
+            token: token
+        )
+        tracer.finish(token: token, outcome: .completed)
+
+        let record = try #require(sink.records.first)
+        #expect(record.rowBucket == TableLoadRowBucket.upTo1000.rawValue)
+        #expect(record.columnBucket == TableLoadColumnBucket.above500.rawValue)
+        #expect(record.resultSizeBucket == TableLoadResultSizeBucket.underOneMegabyte.rawValue)
+    }
+
+    @Test("A trace still open when the window overflows is recorded as evicted")
+    func evictedLoadIsRecorded() {
+        let (tracer, sink) = makeTracer()
+        let overflow = TableLoadTraceRecorder.retainedTraceLimit + 3
+        for index in 0..<overflow {
+            _ = tracer.begin(
+                tabId: UUID(),
+                table: "t\(index)",
+                origin: .programmatic,
+                environment: environment
+            )
+        }
+
+        #expect(sink.records.isEmpty == false)
+        #expect(sink.records.allSatisfy { $0.outcome == TableLoadOutcome.evicted.rawValue })
+    }
+
+    @Test("A trace that never began records nothing")
+    func unknownTokenRecordsNothing() {
+        let (tracer, sink) = makeTracer()
+        let stranger = TableLoadTraceToken(sequence: 999, tabId: UUID(), table: "users")
+        tracer.finish(token: stranger, outcome: .completed)
+        #expect(sink.records.isEmpty)
+    }
+}

--- a/docs/security/privacy.mdx
+++ b/docs/security/privacy.mdx
@@ -142,6 +142,10 @@ The execution log records every authorization decision the app makes, from the U
 
 The hash chain is tamper evident, not tamper proof: anyone who can write the file can recompute every hash after the record they changed. It is a JSON file in Application Support, no sync record type covers it, and no code path uploads it.
 
+The table load history records how long each table load took, so a slowdown can be looked at after it happened rather than only while it is happening. One line per load, holding a timestamp, the app version and build, the macOS version, what started the load, the database type, whether the connection went through SSH, how long each phase took (schema, driver fetch, result conversion, grid reload, and the main run loop after it), how the load ended, any anomalies it reported, and four size ranges: rows, columns, result size, and open tabs. Sizes are ranges such as `101-1000` and `1-10MB`, never exact counts.
+
+Nothing identifying is in it: no query text, no rows, no database, schema or table names, no hostnames, ports or usernames, no connection names or IDs, no file paths, no error messages. It is a `.jsonl` file in Application Support, readable only by you, capped at 7 days and at 10,000 records or 5 MB, whichever comes first. No sync record type covers it and no code path uploads it. Delete the file to clear it.
+
 ### Where it lives on disk
 
 Every path here is under `~/Library/Application Support/TablePro/` unless it says otherwise.
@@ -156,6 +160,7 @@ Every path here is under `~/Library/Application Support/TablePro/` unless it say
 | `ai_chats/` | One JSON file per AI conversation, including the context attached to each turn. |
 | `AIChatImages/` | Images pasted into chat. |
 | `ExecutionAudit.json` | The execution log described in this section. |
+| `TableLoadHistory.jsonl` | The table load history described in this section, 7 days. Mode `0600`. |
 | `mcp-audit.db` | The MCP activity log, 90 days, statements as digests. Mode `0600` inside a `0700` directory. |
 | `mcp-handshake.json` | The bound port and the bridge token, mode `0600`. |
 | `TabState/`, `RecentlyClosedTabs/` | Open and recently closed tabs, including their query text. |


### PR DESCRIPTION
## What this adds

A bounded, device-local history of how long table loads took, written when a `TableLoad` trace ends.
`TableLoadTracer` already measured the whole browse path, but only as OSLog debug lines and
Instruments signposts, both of which are live only. #2061 needed a manual runtime capture and #2342
was only diagnosed after the reporter reproduced it and attached logs plus a process sample.

## Why it needed a refactor rather than a write in `finish()`

Three things had to change before a summary could exist at all.

**No phase durations existed.** `TableLoadTraceRecorder.Entry` kept `startedAt`, `lastEventAt` and
`lastStage` and nothing else. It answers "how long since the last stage" and forgets, so five of the
six required durations were not derivable. `Entry` now keeps a per-stage instant map.

**A trace ends four ways and only one of them is `finish()`.** The other three are the superseded
branch inside `begin()`, which called `report()` and `endInterval()` directly; eviction of an
unfinished entry past `retainedTraceLimit`; and eviction of an already-finished one. A write placed
in `finish()` would have dropped every superseded trace, which is one of the four outcomes the issue
names. The recorder now builds the summary at each of those sites into a buffer drained by
`takeCompletedSummaries()`, mirroring the `takeEvictedSequences()` channel it already had, with an
`isSummarized` flag making it at most once per trace.

Supersession is the subtle one. A superseded trace deliberately stays addressable so its late result
can report against it, and that late report is the **only** source of `resultTableMismatch` and
`staleResultDropped`, the two findings a history like this exists to count. Summarizing at the moment
of supersession would freeze the record before either could arrive, so neither could ever appear in
the file. A superseded trace whose query is still in flight therefore defers, and takes the ending
its result gives it; one that never executed can never report again, so it is summarized on the spot
rather than waiting for an eviction that may never come. If it is evicted before its result lands, it
is still recorded as `superseded`, not as an eviction.

**The tracer is process-wide and the metadata is not.** `TableLoadTracer.shared` is one singleton
while `MainContentCoordinator` is one per connection session, so database type, SSH use and tab count
are pushed in at `begin()` rather than read at the ending site, where they would have come from
whichever session happened to be current.

The free-form outcome `String` also became a closed `TableLoadOutcome`. `finish` used to take a
string, and the failure case interpolated a Swift type name into it, which is not a vocabulary an
external report can group by. The type name now rides in a log-only `detail`, so `log stream` output
is byte-identical and the recorded field is closed.

## What a record holds

Timestamp, app version and build, macOS version, load origin, database type, whether SSH was used,
the six phase durations in milliseconds, the outcome, the anomalies, and four size ranges: rows,
columns, result size, open tabs. A phase whose bracketing stage never fired is absent rather than
zero, because `schemaColumnsBegin`/`End` only fire when the first load needs the schema.

It holds no query text, no rows, no database, schema or table names, no hostnames, ports or
usernames, no connection names or IDs, no file paths and no error messages. `TableLoadTraceToken`
carries the raw table name and is never read at the record boundary. A test encodes a fully populated
record and asserts none of those strings appear in it.

## The store

`TableLoadHistoryStore`, an actor taking an injected `fileURL` that defaults under
`AppStorageEnvironment.shared.supportDirectory`, the same shape as `ExecutionAuditLog`. Its
`record(_:)` is `nonisolated` and returns before any disk work, so the `@MainActor` producer never
blocks. Retention is 7 days, 10,000 records or 5 MB, oldest first, applied on first touch and when a
cap is crossed.

Two departures from `ExecutionAuditLog`, both measured on this machine:

- **Newline-delimited JSON, not a re-encoded array.** Rewriting the array costs the size of the store
  on every append: at the 10,000-record cap that is 3.6 MB and 53 ms per table click, against 1.7 us
  to append one 366-byte line. And a write torn by a crash takes an entire JSON array with it, where
  a torn NDJSON tail costs one line. The issue requires that a partially written history never
  prevent launch, and this makes that structural rather than a catch-and-reset.
- **Nothing held in memory between appends.** `ExecutionAuditLog` keeps every record because it has a
  hash chain to verify; this has none, and 10,000 decoded records is a lot of residency for a file
  the running app never reads.

Timestamps carry fractional seconds. A store that measures milliseconds and stamps whole seconds
cannot order a burst of navigation inside one, and the retention pass sorts on that field.

`exportJSON()` returns a pretty-printed, sorted-key, ISO-8601 array, byte-for-byte deterministic for
the same input. Combined with the `.jsonl` file at a documented path, that is the developer-facing
export the issue asks for. No dashboard, no Debug menu, no new user-visible surface, so it has no
production caller by design: the app writes the file and an external script reads it.

## Test isolation

`coordinator.openTableTab(...)` runs in about 36 existing test files and reaches
`TableLoadTracer.shared.begin(...)`, and `AppStorageEnvironment` resolves to the production directory
under a unit-test host. A live sink would therefore have appended to the developer's own history on
every unit-test run, and on CI. `TableLoadTracer.shared` resolves a `DiscardingTableLoadSummarySink`
under XCTest instead, so no file is opened and nothing needs cleaning up. `TableLoadTracer` gained an
`init(sink:)` so the forwarding path is still tested end to end against a recording fake.

## Sampling the result size

Nothing in the driver layer reports a byte count and `PluginQueryResult` has no field for one.
Walking every cell of a 10,000 x 500 result is main-actor work at exactly the instant being timed,
which would corrupt the measurement it exists to take. A result of 100 rows or fewer is walked
outright; a larger one is sampled as ten runs of ten consecutive rows spread evenly across it. Runs
beat a stride, which aliases against a result whose size repeats, and even spacing beats the head,
which an `ORDER BY` biases. Tests hold both shapes to within 10 percent, and both come out exact.

## Notes on the buckets

The issue calls its buckets suggested. Columns and open tabs each gained a `0` case, because a
statement returning no columns is a real result and folding it into `1-20` would make the exported
data say something that did not happen.

## From the self-review passes

`security-review` found nothing. It measured the permissions question rather than reasoning about it:
`Data.write(options: .atomic)` preserves an existing file's mode, and the case where it would create
a fresh `0644` inode is unreachable because `prune()` returns early when the file is absent, so the
inode always pre-exists from `writeLine`'s explicit `0o600`. It also traced that `token.table` reaches
no field of the record, and that `detail:` is log-only.

`code-review` found four things in this change, all fixed here: the frozen-summary problem described
above; whole-second timestamps; a failed atomic rewrite leaving the counters at zero so the caps went
unenforced for up to an hour; and a prune that erased undecodable lines without saying so, which now
logs the count.

## Verified

- `verify.sh build`: PASS
- `verify.sh test` over `TableLoadTraceRecorderTests`, `TableLoadTraceSummaryTests`,
  `TableLoadPerformanceRecordTests`, `TableLoadHistoryStoreTests`, `TableLoadTracerSinkTests`: PASS
- `verify.sh test` over the coordinator suites that drive `openTableTab`: PASS
- `verify.sh lint TablePro TableProTests`: 0 violations
- `verify.sh docs`: PASS
- `~/Library/Application Support/TablePro/TableLoadHistory.jsonl` absent after a full unit-test run

No `TableProUITests` automation: the change adds no user-visible surface to drive. There is nothing
to click and nothing to see, so a UI test could only assert on a file the app writes, which the unit
suites already do deterministically.

## Also found, not fixed here

`TableLoadTracer.report()` writes `token.table`, a raw table name, into the persistent Unified Log at
error level marked `privacy: .public`, and `.blockedByInFlightExecution` fires on ordinary use
(pressing Run while a query is still running). Confirmed by emitting the same shapes through
`Logger(subsystem: "com.TablePro", category: "TableLoad")` and reading them back out of
`log collect`: the error line survives into the collected archive that a sysdiagnose carries, the
debug stage lines do not.

It is out of scope here because the new record never carries `token.table`, and because verification
found it is one of roughly 102 `logger.error` sites app-wide marked `.public`, several of which
already log table and schema names. A change confined to that one line would remove nothing in
practice. It needs its own decision about the app-wide convention.

Fixes #2395
