### PR TITLE
fix(connections): give the connection color its own surface instead of the engine glyph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The data grid draws its own column separators. (#2381)
 - The inline cell editor scrolls a long line instead of wrapping it. (#2381)
 - Row inspector fields, cell popovers and the Compare row diff follow the data grid font. (#2393)
+- The connection color as a filled badge behind the connection name, with the database icon back to its engine color. (#2398)
+- Deeper fills on tag badges and the connection name badge. (#2398)
 
 ### Fixed
 
+- A connection's color and name not reaching the toolbar and workspace rail until the next reconnect. (#2398)
+- An invisible connection dot in the query history drawer and the compare status strip. (#2398)
 - The JSON viewer keeping its old font after a font, theme or text-size change. (#2393)
 - Hex dumps wrapping mid-line instead of keeping their columns aligned. (#2393)
 - A second of delay opening the inline editor on a result with hundreds of columns. (#2381)

--- a/TablePro/Core/Database/DatabaseManager+Sessions.swift
+++ b/TablePro/Core/Database/DatabaseManager+Sessions.swift
@@ -512,17 +512,41 @@ extension DatabaseManager {
         connectionUpdatedCancellable = AppEvents.shared.connectionUpdated
             .receive(on: RunLoop.main)
             .sink { [weak self] connectionId in
-                self?.reconcileSafeModeLevel(for: connectionId)
+                self?.reconcileStoredRecord(for: connectionId)
             }
     }
 
-    func reconcileSafeModeLevel(for connectionId: UUID?) {
+    func reconcileStoredRecord(for connectionId: UUID?) {
         let targetIds = connectionId.map { [$0] } ?? Array(activeSessions.keys)
         for id in targetIds {
-            guard activeSessions[id] != nil,
+            guard let session = activeSessions[id],
                   let stored = connectionStorage.loadConnection(id: id) else { continue }
+            adoptStoredRecord(stored, keepingRuntimeStateOf: session, for: id)
             setSafeModeLevel(stored.safeModeLevel, for: id)
         }
+    }
+
+    /// The stored record owns every field the connection form can edit. A live session owns only
+    /// what it switched at runtime, which is the browsed database and the safe-mode level, so those
+    /// two are carried over and the rest is taken from storage.
+    ///
+    /// This used to reconcile `safeModeLevel` alone, which left everything else on the session
+    /// frozen at connect time. `WorkspaceRailStore.resolve` reads `session.connection` for any live
+    /// session, so renaming or recolouring a connection changed nothing in the rail until the next
+    /// reconnect (#2398).
+    private func adoptStoredRecord(
+        _ stored: DatabaseConnection,
+        keepingRuntimeStateOf session: ConnectionSession,
+        for connectionId: UUID
+    ) {
+        var reconciled = stored
+        reconciled.database = session.connection.database
+        reconciled.safeModeLevel = session.connection.safeModeLevel
+        guard reconciled != session.connection else { return }
+
+        var updated = session
+        updated.connection = reconciled
+        setSession(updated, for: connectionId)
     }
 
     func setSafeModeLevel(_ level: SafeModeLevel, for connectionId: UUID) {

--- a/TablePro/Core/Database/DatabaseManager+Sessions.swift
+++ b/TablePro/Core/Database/DatabaseManager+Sessions.swift
@@ -521,27 +521,31 @@ extension DatabaseManager {
         for id in targetIds {
             guard let session = activeSessions[id],
                   let stored = connectionStorage.loadConnection(id: id) else { continue }
-            adoptStoredRecord(stored, keepingRuntimeStateOf: session, for: id)
+            adoptDisplayFields(from: stored, into: session, for: id)
             setSafeModeLevel(stored.safeModeLevel, for: id)
         }
     }
 
-    /// The stored record owns every field the connection form can edit. A live session owns only
-    /// what it switched at runtime, which is the browsed database and the safe-mode level, so those
-    /// two are carried over and the rest is taken from storage.
+    /// Carries the fields a live session only ever *displays* across from storage, and nothing else.
     ///
-    /// This used to reconcile `safeModeLevel` alone, which left everything else on the session
-    /// frozen at connect time. `WorkspaceRailStore.resolve` reads `session.connection` for any live
-    /// session, so renaming or recolouring a connection changed nothing in the rail until the next
-    /// reconnect (#2398).
-    private func adoptStoredRecord(
-        _ stored: DatabaseConnection,
-        keepingRuntimeStateOf session: ConnectionSession,
+    /// This used to reconcile `safeModeLevel` alone, so everything else stayed frozen at connect
+    /// time. `WorkspaceRailStore.resolve` reads `session.connection` for any live session, which
+    /// made a rename or a recolour invisible in the rail until the next reconnect (#2398).
+    ///
+    /// The allowlist is deliberately narrow, and adopting the whole stored record instead would be
+    /// unsafe: `reconnectOntoDatabase` builds its reconnect from `session.connection`, so letting
+    /// an edited host, port, username or SSH config reach a live session would let the health
+    /// monitor silently reconnect an open window, with its tabs, to a different server. An edit to
+    /// those fields belongs to the next connect the user asks for, not to the one already running.
+    private func adoptDisplayFields(
+        from stored: DatabaseConnection,
+        into session: ConnectionSession,
         for connectionId: UUID
     ) {
-        var reconciled = stored
-        reconciled.database = session.connection.database
-        reconciled.safeModeLevel = session.connection.safeModeLevel
+        var reconciled = session.connection
+        reconciled.name = stored.name
+        reconciled.color = stored.color
+        reconciled.tagIds = stored.tagIds
         guard reconciled != session.connection else { return }
 
         var updated = session

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -368,6 +368,10 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     }
 
     /// `nil` is the documented bulk-update payload, so it has to repaint too.
+    ///
+    /// The toolbar takes the record here and not from its panes: `ConnectionToolbarState` is built
+    /// once per session and `refreshPanes` only reassigns SwiftUI root views, so without this line
+    /// the titlebar kept the name and colour the connection had when it was opened (#2398).
     private func handleConnectionRecordChange(_ changedId: UUID?) {
         let stored = ConnectionStorage.shared.loadConnections()
         var repaint = false
@@ -377,6 +381,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
             guard let record = stored.first(where: { $0.id == connectionId })
                 ?? DatabaseManager.shared.activeSessions[connectionId]?.connection else { continue }
             workspace.payloadConnection = record
+            workspace.sessionState?.toolbarState.update(from: record)
             refreshPanes(of: workspace)
             if workspaces.selectedConnectionId == connectionId { repaint = true }
         }

--- a/TablePro/Core/Services/Infrastructure/WorkspaceRailCellView.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspaceRailCellView.swift
@@ -6,12 +6,18 @@
 import AppKit
 import SwiftUI
 
-/// One workspace: a tinted engine glyph above the container it browses.
+/// One workspace: the engine's glyph above the container it browses, over the connection's own
+/// colour.
 ///
-/// The connection's colour tints the glyph rather than painting a separate stripe, which is
-/// how AppKit and every first-party sidebar carry a user-chosen colour: the colour is the
-/// icon. State is carried by the glyph's shape, not by its colour, so it survives colour
-/// blindness and Increase Contrast. The label truncates in the middle, which the HIG
+/// The glyph carries the engine and the band behind the label carries the user's pick. This cell
+/// used to put both on the glyph, on the reasoning that "the colour is the icon", which is how
+/// Finder carries a tag. That holds for a Finder icon, which is a neutral document or folder shape
+/// with no colour of its own to lose. An engine glyph is not neutral: it is a brand mark that is
+/// already a colour meaning something else, so the two readings competed for one shape and the
+/// engine's lost. Picking a colour only shifted the glyph's hue, which is the complaint #2398
+/// reports. State stays on the glyph's shape, not on either colour, so it still survives colour
+/// blindness and Increase Contrast, and the colour's name joins the tooltip and the accessibility
+/// label so it is never the only channel. The label truncates in the middle, which the HIG
 /// recommends for narrow columns because it keeps both ends of the name recognisable, and
 /// the full name, host and container stay in the tooltip and the accessibility label.
 @MainActor
@@ -20,9 +26,15 @@ internal final class WorkspaceRailCellView: NSTableCellView {
 
     private let icon = NSImageView()
     private let label = NSTextField(labelWithString: "")
+    private let identityBand = NSView()
     private var iconWidthConstraint: NSLayoutConstraint?
     private var iconHeightConstraint: NSLayoutConstraint?
     private var appliedTint: NSColor?
+    /// Held as the palette entry rather than a resolved colour, because `systemRed` and the rest
+    /// differ between light and dark: resolving at configure time would freeze the band at the
+    /// appearance the row was built in and `viewDidChangeEffectiveAppearance` would repaint it with
+    /// the stale value.
+    private var identityColor: ConnectionColor?
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -47,7 +59,13 @@ internal final class WorkspaceRailCellView: NSTableCellView {
         label.allowsExpansionToolTips = true
         label.cell?.truncatesLastVisibleLine = true
 
+        identityBand.translatesAutoresizingMaskIntoConstraints = false
+        identityBand.wantsLayer = true
+        identityBand.layer?.cornerRadius = Self.identityBandCornerRadius
+        identityBand.layer?.cornerCurve = .continuous
+
         addSubview(icon)
+        addSubview(identityBand)
         addSubview(label)
         imageView = icon
         textField = label
@@ -66,8 +84,16 @@ internal final class WorkspaceRailCellView: NSTableCellView {
             label.topAnchor.constraint(equalTo: icon.bottomAnchor, constant: 3),
             label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 2),
             label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -2),
+
+            identityBand.leadingAnchor.constraint(equalTo: leadingAnchor),
+            identityBand.trailingAnchor.constraint(equalTo: trailingAnchor),
+            identityBand.topAnchor.constraint(equalTo: label.topAnchor, constant: -Self.identityBandInset),
+            identityBand.bottomAnchor.constraint(equalTo: label.bottomAnchor, constant: Self.identityBandInset),
         ])
     }
+
+    private static let identityBandCornerRadius: CGFloat = 4
+    private static let identityBandInset: CGFloat = 2
 
     internal func configure(entry: WorkspaceRailEntry, layout: WorkspaceRailMetrics.Layout) {
         iconWidthConstraint?.constant = layout.iconSize
@@ -76,7 +102,8 @@ internal final class WorkspaceRailCellView: NSTableCellView {
         label.font = .systemFont(ofSize: layout.fontSize)
         label.stringValue = entry.container.isEmpty ? entry.connection.name : entry.container
 
-        appliedTint = NSColor(entry.connection.displayColor)
+        appliedTint = NSColor(entry.connection.brandColor)
+        identityColor = entry.connection.identityColor
         icon.image = Self.glyph(for: entry)
         applyTint()
 
@@ -86,7 +113,8 @@ internal final class WorkspaceRailCellView: NSTableCellView {
 
     /// On the selected row `NSTableCellView` already tints the image view for contrast, so
     /// the connection colour steps aside rather than competing with the selection fill, which
-    /// it loses against at every accent colour.
+    /// it loses against at every accent colour. The identity band steps aside with it, for the
+    /// same reason: a fill of its own under the selection fill reads as two overlapping bands.
     override var backgroundStyle: NSView.BackgroundStyle {
         didSet { applyTint() }
     }
@@ -99,10 +127,19 @@ internal final class WorkspaceRailCellView: NSTableCellView {
     private func applyTint() {
         guard backgroundStyle != .emphasized else {
             icon.contentTintColor = nil
+            identityBand.layer?.backgroundColor = nil
+            label.textColor = nil
             return
         }
         effectiveAppearance.performAsCurrentDrawingAppearance {
             icon.contentTintColor = appliedTint
+            guard let fill = identityColor?.labelledFill else {
+                identityBand.layer?.backgroundColor = nil
+                label.textColor = nil
+                return
+            }
+            identityBand.layer?.backgroundColor = NSColor(fill).cgColor
+            label.textColor = NSColor(Color.legibleForeground(on: fill))
         }
     }
 
@@ -146,6 +183,9 @@ internal final class WorkspaceRailCellView: NSTableCellView {
         if !entry.container.isEmpty {
             parts.append(entry.container)
         }
+        if let identity = connection.identityColor {
+            parts.append(String(format: String(localized: "Color: %@"), identity.displayName))
+        }
         return parts.joined(separator: " · ")
     }
 
@@ -155,6 +195,9 @@ internal final class WorkspaceRailCellView: NSTableCellView {
             parts.append(String(format: containerFormat(for: entry.containerTarget), entry.container))
         }
         parts.append(statusDescription(for: entry.status))
+        if let identity = entry.connection.identityColor {
+            parts.append(String(format: String(localized: "color %@"), identity.displayName))
+        }
         return parts.joined(separator: ", ")
     }
 

--- a/TablePro/Extensions/Color+Emphasis.swift
+++ b/TablePro/Extensions/Color+Emphasis.swift
@@ -67,7 +67,7 @@ internal extension NSColor {
 
         var tooDim: CGFloat = 0
         var tooBright = brightness
-        var tuned = NSColor(hue: hue, saturation: saturation, brightness: 0, alpha: alpha)
+        var tuned: NSColor?
         for _ in 0 ..< Self.labelTuningSteps {
             let candidate = NSColor(hue: hue, saturation: saturation, brightness: (tooDim + tooBright) / 2, alpha: alpha)
             if candidate.contrastWithDerivedLabel >= minimumRatio {
@@ -77,7 +77,11 @@ internal extension NSColor {
                 tooBright = (tooDim + tooBright) / 2
             }
         }
-        return tuned
+        /// At the ratios this app asks for, the first candidate always passes and the search only
+        /// refines it. A caller naming a ratio no brightness of this hue can reach would otherwise
+        /// be handed pure black, silently losing the hue, so an unreachable target keeps the colour
+        /// it was given and leaves the contrast decision with the caller.
+        return tuned ?? self
     }
 
     /// Enough halvings of the brightness range to land inside a step no 8-bit channel can express.

--- a/TablePro/Extensions/Color+Emphasis.swift
+++ b/TablePro/Extensions/Color+Emphasis.swift
@@ -23,7 +23,12 @@ internal extension Color {
     /// that puts black on system blue and system red, which no Mac control does. This sits high
     /// enough to keep white on the saturated hues and still flips on yellow, mint, teal and
     /// orange, where white genuinely disappears. Every palette colour is held to 3:1 by test.
-    private static let darkLabelThreshold: CGFloat = 0.3
+    static let darkLabelThreshold: CGFloat = 0.3
+
+    /// What WCAG 2.2 asks of text below 18pt, or below 14pt bold. Every font the toolbar and the
+    /// welcome list put on a fill is smaller than both, so a fill carrying a label is held here
+    /// rather than at the 3:1 that covers an icon or a border.
+    static let minimumLabelContrast: CGFloat = 4.5
 }
 
 internal extension NSColor {
@@ -33,6 +38,50 @@ internal extension NSColor {
             + 0.7152 * Self.linearized(rgb.greenComponent)
             + 0.0722 * Self.linearized(rgb.blueComponent)
     }
+
+    /// The contrast this fill would reach against the label `Color.legibleForeground(on:)` picks
+    /// for it.
+    var contrastWithDerivedLabel: CGFloat {
+        let fill = relativeLuminance
+        let label: CGFloat = fill > Color.darkLabelThreshold ? 0 : 1
+        return (max(label, fill) + 0.05) / (min(label, fill) + 0.05)
+    }
+
+    /// The same hue, dimmed only as far as its derived label needs to clear `minimumRatio`.
+    ///
+    /// `legibleForeground(on:)` picks black or white from luminance alone, and that is enough for
+    /// an icon or a border at 3:1 but not for a label at 4.5:1: measured against the connection
+    /// palette, red, blue, purple, pink and grey leave their label between 3.2:1 and 4.2:1, while
+    /// orange, yellow and green already clear it with a black label and are returned untouched.
+    /// Lowering brightness in HSB holds hue and saturation, so the fill still reads as the colour
+    /// the user picked; the worst case keeps 83% of its brightness.
+    func tunedForLegibleLabel(minimumRatio: CGFloat = Color.minimumLabelContrast) -> NSColor {
+        guard let srgb = usingColorSpace(.sRGB) else { return self }
+        guard srgb.contrastWithDerivedLabel < minimumRatio else { return self }
+
+        var hue: CGFloat = 0
+        var saturation: CGFloat = 0
+        var brightness: CGFloat = 0
+        var alpha: CGFloat = 0
+        srgb.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
+
+        var tooDim: CGFloat = 0
+        var tooBright = brightness
+        var tuned = NSColor(hue: hue, saturation: saturation, brightness: 0, alpha: alpha)
+        for _ in 0 ..< Self.labelTuningSteps {
+            let candidate = NSColor(hue: hue, saturation: saturation, brightness: (tooDim + tooBright) / 2, alpha: alpha)
+            if candidate.contrastWithDerivedLabel >= minimumRatio {
+                tuned = candidate
+                tooDim = (tooDim + tooBright) / 2
+            } else {
+                tooBright = (tooDim + tooBright) / 2
+            }
+        }
+        return tuned
+    }
+
+    /// Enough halvings of the brightness range to land inside a step no 8-bit channel can express.
+    private static let labelTuningSteps = 12
 
     private static func linearized(_ channel: CGFloat) -> CGFloat {
         channel <= 0.03928 ? channel / 12.92 : pow((channel + 0.055) / 1.055, 2.4)

--- a/TablePro/Models/Connection/ConnectionToolbarState.swift
+++ b/TablePro/Models/Connection/ConnectionToolbarState.swift
@@ -171,14 +171,22 @@ final class ConnectionToolbarState {
 
     // MARK: - Update Methods
 
-    /// Update state from a DatabaseConnection model
+    /// Update state from a DatabaseConnection model.
+    ///
+    /// Guarded field by field like every other write on this object. This runs on the
+    /// `connectionUpdated` path, which fires on any connection save and on a bulk `nil` after an
+    /// iCloud pull, so an unguarded write would invalidate every window's toolbar on a change that
+    /// touched nothing it displays.
     func update(from connection: DatabaseConnection) {
-        connectionName = connection.name
-        databaseType = connection.type
-        brandColor = connection.brandColor
-        identityColor = connection.identityColor
-        tagIds = connection.tagIds
-        databaseGroupingStrategy = PluginManager.shared.databaseGroupingStrategy(for: connection.type)
+        if connectionName != connection.name { connectionName = connection.name }
+        if databaseType != connection.type { databaseType = connection.type }
+        if brandColor != connection.brandColor { brandColor = connection.brandColor }
+        if identityColor != connection.identityColor { identityColor = connection.identityColor }
+        if tagIds != connection.tagIds { tagIds = connection.tagIds }
+
+        let strategy = PluginManager.shared.databaseGroupingStrategy(for: connection.type)
+        if databaseGroupingStrategy != strategy { databaseGroupingStrategy = strategy }
+
         syncFromSession(for: connection)
     }
 

--- a/TablePro/Models/Connection/ConnectionToolbarState.swift
+++ b/TablePro/Models/Connection/ConnectionToolbarState.swift
@@ -75,8 +75,11 @@ final class ConnectionToolbarState {
     /// everything else follows the engine's switchable containers.
     var databaseGroupingStrategy: GroupingStrategy = .byDatabase
 
-    /// Custom display color for the connection (uses database type color if not set)
-    var displayColor: Color = .init(nsColor: .systemOrange)
+    /// The engine's own colour, which the engine glyph wears on every connection.
+    var brandColor: Color = .init(nsColor: .systemOrange)
+
+    /// The colour the user assigned to this connection, `nil` when they assigned none.
+    var identityColor: ConnectionColor?
 
     /// Current connection state
     var connectionState: ToolbarConnectionState = .disconnected
@@ -172,7 +175,8 @@ final class ConnectionToolbarState {
     func update(from connection: DatabaseConnection) {
         connectionName = connection.name
         databaseType = connection.type
-        displayColor = connection.displayColor
+        brandColor = connection.brandColor
+        identityColor = connection.identityColor
         tagIds = connection.tagIds
         databaseGroupingStrategy = PluginManager.shared.databaseGroupingStrategy(for: connection.type)
         syncFromSession(for: connection)
@@ -226,7 +230,8 @@ final class ConnectionToolbarState {
         currentDatabase = ""
         currentSchema = nil
         databaseGroupingStrategy = .byDatabase
-        displayColor = databaseType.themeColor
+        brandColor = databaseType.themeColor
+        identityColor = nil
         connectionState = .disconnected
         lastQueryDuration = nil
         clickHouseProgress = nil

--- a/TablePro/Models/Connection/DatabaseConnection.swift
+++ b/TablePro/Models/Connection/DatabaseConnection.swift
@@ -339,6 +339,19 @@ enum ConnectionColor: String, CaseIterable, Identifiable, Codable {
 
     /// Whether this represents "no custom color"
     var isDefault: Bool { self == .none }
+
+    /// The hue itself, for a dot, a swatch or a glyph tint. `nil` rather than `color`'s `.clear`
+    /// when the user picked nothing, so a caller cannot paint a transparent indicator and leave a
+    /// hole where the cue should be.
+    var indicatorColor: Color? { isDefault ? nil : color }
+
+    /// The same hue, dimmed only as far as a label sitting on it needs. Use this wherever text is
+    /// drawn on the colour; `indicatorColor` stays at full brightness everywhere else, which is
+    /// why the picker swatch and the fill can differ by a few percent without disagreeing.
+    var labelledFill: Color? {
+        guard !isDefault else { return nil }
+        return Color(nsColor: NSColor(color).tunedForLegibleLabel())
+    }
 }
 
 // MARK: - Database Connection
@@ -548,9 +561,21 @@ struct DatabaseConnection: Identifiable, Hashable {
         }
     }
 
-    /// Returns the display color (custom color or database type color)
-    @MainActor var displayColor: Color {
-        color.isDefault ? type.themeColor : color.color
+    /// The engine's own colour. It answers "which database is this" and never changes with the
+    /// user's pick, so the glyph that carries it keeps meaning the same thing on every connection.
+    @MainActor var brandColor: Color {
+        type.themeColor
+    }
+
+    /// The colour the user assigned to tell this connection apart from the others, `nil` when they
+    /// assigned none.
+    ///
+    /// These two used to be one property that returned the brand colour until a pick replaced it,
+    /// which spent the pick recolouring an already-branded glyph: the only visible change was a
+    /// hue shift on a 14pt icon, and the engine lost its own colour to pay for it. They are
+    /// separate because they answer different questions and belong on different surfaces (#2398).
+    var identityColor: ConnectionColor? {
+        color.isDefault ? nil : color
     }
 }
 

--- a/TablePro/Models/Connection/DatabaseConnection.swift
+++ b/TablePro/Models/Connection/DatabaseConnection.swift
@@ -348,9 +348,24 @@ enum ConnectionColor: String, CaseIterable, Identifiable, Codable {
     /// The same hue, dimmed only as far as a label sitting on it needs. Use this wherever text is
     /// drawn on the colour; `indicatorColor` stays at full brightness everywhere else, which is
     /// why the picker swatch and the fill can differ by a few percent without disagreeing.
+    ///
+    /// The tuning runs inside a dynamic provider rather than at the point of call, because
+    /// `tunedForLegibleLabel` ends at `NSColor(hue:saturation:brightness:alpha:)`, which is a
+    /// concrete colour in whatever appearance happened to be current. Resolving eagerly froze it:
+    /// measured, a tuned red stayed `#DB393B` in both appearances while an untouched orange still
+    /// moved between `#FF8D28` and `#FF9230`, so half the palette followed a Light/Dark switch and
+    /// half did not. A provider is resolved by AppKit against the appearance it is drawn in, so no
+    /// call site has to remember to observe the colour scheme.
     var labelledFill: Color? {
         guard !isDefault else { return nil }
-        return Color(nsColor: NSColor(color).tunedForLegibleLabel())
+        let palette = color
+        return Color(nsColor: NSColor(name: nil) { appearance in
+            var tuned = NSColor.clear
+            appearance.performAsCurrentDrawingAppearance {
+                tuned = NSColor(palette).tunedForLegibleLabel()
+            }
+            return tuned
+        })
     }
 }
 

--- a/TablePro/ViewModels/HistoryPanelViewModel.swift
+++ b/TablePro/ViewModels/HistoryPanelViewModel.swift
@@ -227,7 +227,7 @@ struct HistoryConnectionDirectory: Sendable {
     static let live = HistoryConnectionDirectory { connectionId in
         guard let connection = ConnectionStorage.shared.loadConnections().first(where: { $0.id == connectionId })
         else { return nil }
-        return HistoryConnectionLabel(name: connection.name, color: connection.color)
+        return HistoryConnectionLabel(name: connection.name, color: connection.identityColor)
     }
 
     static let none = HistoryConnectionDirectory { _ in nil }

--- a/TablePro/Views/Compare/CompareWindowContentView.swift
+++ b/TablePro/Views/Compare/CompareWindowContentView.swift
@@ -75,7 +75,7 @@ internal struct CompareStatusStrip: View {
                 Divider().frame(height: 14)
                 HStack(spacing: 6) {
                     Circle()
-                        .fill(target.color.color)
+                        .fill(target.color.indicatorColor ?? Color.secondary.opacity(0.35))
                         .frame(width: 9, height: 9)
                         .accessibilityHidden(true)
                     Text(String(format: String(localized: "Target: %@"), target.qualifiedDescription))

--- a/TablePro/Views/Connection/WelcomeConnectionRow.swift
+++ b/TablePro/Views/Connection/WelcomeConnectionRow.swift
@@ -42,13 +42,21 @@ struct WelcomeConnectionRow: View {
     /// stays the engine's own colour. It is a dot and not the toolbar's filled capsule because a
     /// row can be selected, and a fill of its own would compete with the selection band; the dot
     /// steps aside through `selectionAwareTint` the way the connection switcher's already does.
+    ///
+    /// An uncoloured connection gets a neutral dot rather than no dot, so every name in the list
+    /// starts at the same x and the column keeps a straight left edge. The connection switcher
+    /// resolves it the same way.
     @ViewBuilder
     private var identityDot: some View {
-        if let identity = connection.identityColor, let indicator = identity.indicatorColor {
-            Circle()
-                .selectionAwareTint(indicator)
-                .frame(width: 8, height: 8)
-                .accessibilityLabel(String(format: String(localized: "Color: %@"), identity.displayName))
+        let identity = connection.identityColor
+        let dot = Circle()
+            .selectionAwareTint(identity?.indicatorColor ?? .secondary)
+            .frame(width: 8, height: 8)
+
+        if let identity {
+            dot.accessibilityLabel(String(format: String(localized: "Color: %@"), identity.displayName))
+        } else {
+            dot.accessibilityHidden(true)
         }
     }
 

--- a/TablePro/Views/Connection/WelcomeConnectionRow.swift
+++ b/TablePro/Views/Connection/WelcomeConnectionRow.swift
@@ -38,19 +38,37 @@ struct WelcomeConnectionRow: View {
             : String(localized: "Add to Favorites")
     }
 
+    /// A row carries the identity colour beside the name rather than on the engine glyph, which
+    /// stays the engine's own colour. It is a dot and not the toolbar's filled capsule because a
+    /// row can be selected, and a fill of its own would compete with the selection band; the dot
+    /// steps aside through `selectionAwareTint` the way the connection switcher's already does.
+    @ViewBuilder
+    private var identityDot: some View {
+        if let identity = connection.identityColor, let indicator = identity.indicatorColor {
+            Circle()
+                .selectionAwareTint(indicator)
+                .frame(width: 8, height: 8)
+                .accessibilityLabel(String(format: String(localized: "Color: %@"), identity.displayName))
+        }
+    }
+
     var body: some View {
         let meta = metadata
         return HStack {
             connection.type.iconImage
                 .renderingMode(.template)
                 .font(.title3)
-                .foregroundStyle(connection.displayColor)
+                .foregroundStyle(connection.brandColor)
                 .frame(width: 18, height: 18)
 
             VStack(alignment: .leading, spacing: 1) {
-                Text(connection.name)
-                    .font(.body)
-                    .foregroundStyle(.primary)
+                HStack(spacing: 6) {
+                    identityDot
+
+                    Text(connection.name)
+                        .font(.body)
+                        .foregroundStyle(.primary)
+                }
 
                 HStack(spacing: 6) {
                     Text(connection.connectionSubtitle)

--- a/TablePro/Views/Main/Extensions/MainContentView+Modifiers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Modifiers.swift
@@ -8,24 +8,6 @@
 
 import SwiftUI
 
-// MARK: - Toolbar Tint Modifier
-
-/// Applies a subtle color tint to the window toolbar when a connection color is set.
-struct ToolbarTintModifier: ViewModifier {
-    let connectionColor: ConnectionColor
-
-    @ViewBuilder
-    func body(content: Content) -> some View {
-        if connectionColor.isDefault {
-            content
-        } else {
-            content
-                .toolbarBackground(connectionColor.color.opacity(0.12), for: .windowToolbar)
-                .toolbarBackground(.visible, for: .windowToolbar)
-        }
-    }
-}
-
 // MARK: - Preview
 
 #Preview("With Connection") {

--- a/TablePro/Views/Toolbar/ConnectionStatusView.swift
+++ b/TablePro/Views/Toolbar/ConnectionStatusView.swift
@@ -15,7 +15,8 @@ struct ConnectionStatusView: View {
     let databaseVersion: String?
     let scopeComponents: [ConnectionScopeComponent]
     let connectionName: String
-    let displayColor: Color
+    let brandColor: Color
+    var identityColor: ConnectionColor?
     var safeModeLevel: SafeModeLevel = .silent
     /// The chooser each component opens needs a live connection, and a component anchors its own
     /// popover so the list appears against the word it belongs to rather than against the toolbar
@@ -43,19 +44,38 @@ struct ConnectionStatusView: View {
         HStack(spacing: 6) {
             databaseType.iconImage
                 .renderingMode(.template)
-                .foregroundStyle(displayColor)
+                .foregroundStyle(brandColor)
                 .frame(width: engineIconSize, height: engineIconSize)
 
-            Text(connectionName)
-                .font(.callout.weight(.medium))
-                .foregroundStyle(.primary)
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .fixedSize(horizontal: true, vertical: false)
+            connectionNameLabel
         }
         .help(connectionTooltip)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(connectionAccessibilityLabel)
+    }
+
+    /// The connection colour's one surface in this window. It fills the name rather than tinting
+    /// the engine glyph beside it, because that glyph is already the engine's own colour and a
+    /// second meaning painted over it reads as a hue shift instead of a signal (#2398). The scope
+    /// chips stay plain for the same reason: one filled shape per window, so the fill means
+    /// exactly one thing.
+    @ViewBuilder
+    private var connectionNameLabel: some View {
+        let name = Text(connectionName)
+            .font(.callout.weight(.medium))
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .fixedSize(horizontal: true, vertical: false)
+
+        if let fill = identityColor?.labelledFill {
+            name
+                .foregroundStyle(Color.legibleForeground(on: fill))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 2)
+                .background(fill, in: Capsule())
+        } else {
+            name.foregroundStyle(.primary)
+        }
     }
 
     /// Nested scopes read outermost first with a chevron between them, the way Xcode separates its
@@ -168,12 +188,19 @@ struct ConnectionStatusView: View {
         return databaseType.rawValue
     }
 
+    /// The colour rides in the text of both, because a fill that carries meaning cannot be the only
+    /// channel that carries it: the HIG asks for a second cue for anyone who cannot tell red from
+    /// green, and VoiceOver has no way to read a background at all.
     private var connectionTooltip: String {
-        String(format: String(localized: "%@ • %@"), connectionName, formattedDatabaseInfo)
+        let base = String(format: String(localized: "%@ • %@"), connectionName, formattedDatabaseInfo)
+        guard let identityColor else { return base }
+        return String(format: String(localized: "%1$@ • Color: %2$@"), base, identityColor.displayName)
     }
 
     private var connectionAccessibilityLabel: String {
-        String(format: String(localized: "Connection: %@, %@"), connectionName, formattedDatabaseInfo)
+        let base = String(format: String(localized: "Connection: %@, %@"), connectionName, formattedDatabaseInfo)
+        guard let identityColor else { return base }
+        return String(format: String(localized: "%1$@, color %2$@"), base, identityColor.displayName)
     }
 }
 
@@ -194,7 +221,8 @@ private func previewComponent(
         databaseVersion: "11.1.2",
         scopeComponents: [previewComponent(.database, "production_db", "Database")],
         connectionName: "Production Database",
-        displayColor: .cyan
+        brandColor: .cyan,
+        identityColor: .red
     )
     .padding()
     .background(Color(nsColor: .windowBackgroundColor))
@@ -206,7 +234,7 @@ private func previewComponent(
         databaseVersion: "8.0.35",
         scopeComponents: [previewComponent(.database, "dev_db", "Database")],
         connectionName: "Development",
-        displayColor: .orange
+        brandColor: .orange
     )
     .padding()
     .background(Color(nsColor: .windowBackgroundColor))
@@ -221,7 +249,8 @@ private func previewComponent(
             previewComponent(.schema, "public", "Schema"),
         ],
         connectionName: "Analytics DB",
-        displayColor: .blue
+        brandColor: .blue,
+        identityColor: .yellow
     )
     .padding()
     .background(Color(nsColor: .windowBackgroundColor))
@@ -234,7 +263,8 @@ private func previewComponent(
         databaseVersion: "3.45.0",
         scopeComponents: [previewComponent(.database, "chinook.db", "Database", switchable: false)],
         connectionName: "Local",
-        displayColor: .green
+        brandColor: .green,
+        identityColor: .purple
     )
     .padding()
     .background(Color(nsColor: .windowBackgroundColor))

--- a/TablePro/Views/Toolbar/ConnectionSwitcherPopover.swift
+++ b/TablePro/Views/Toolbar/ConnectionSwitcherPopover.swift
@@ -224,7 +224,7 @@ struct ConnectionSwitcherPopover: View {
         )
         return HStack(spacing: 8) {
             Circle()
-                .selectionAwareTint(connection.displayColor)
+                .selectionAwareTint(connection.identityColor?.indicatorColor ?? .secondary)
                 .frame(width: 8, height: 8)
 
             VStack(alignment: .leading, spacing: 1) {

--- a/TablePro/Views/Toolbar/TableProToolbarView.swift
+++ b/TablePro/Views/Toolbar/TableProToolbarView.swift
@@ -45,7 +45,8 @@ struct ToolbarPrincipalContent: View {
                 databaseVersion: state.databaseVersion,
                 scopeComponents: state.scopeComponents,
                 connectionName: state.connectionName,
-                displayColor: state.displayColor,
+                brandColor: state.brandColor,
+                identityColor: state.identityColor,
                 safeModeLevel: state.safeModeLevel,
                 coordinator: coordinator
             )
@@ -107,19 +108,17 @@ struct ToolbarPrincipalContent: View {
         }
     }
 
-    /// A tag with no colour fills with `clear`, and a label derived from a transparent fill comes
-    /// back white and disappears, so an uncoloured tag takes the standard control fill instead of
-    /// a derived one.
+    /// `labelledFill` is `nil` for an uncoloured tag rather than the transparent fill the raw
+    /// palette entry returns, which a derived label would read as white and disappear into, so the
+    /// uncoloured case takes the standard control fill and the standard label.
     private func tagBadge(_ tag: ConnectionTag) -> some View {
-        Text(tag.name.uppercased())
+        let fill = tag.color.labelledFill
+        return Text(tag.name.uppercased())
             .font(.caption.weight(.semibold))
-            .foregroundStyle(tag.color.isDefault ? .primary : Color.legibleForeground(on: tag.color.color))
+            .foregroundStyle(fill.map(Color.legibleForeground(on:)) ?? .primary)
             .lineLimit(1)
             .padding(.horizontal, 8)
             .padding(.vertical, 3)
-            .background(
-                tag.color.isDefault ? Color(nsColor: .quaternarySystemFill) : tag.color.color,
-                in: Capsule()
-            )
+            .background(fill ?? Color(nsColor: .quaternarySystemFill), in: Capsule())
     }
 }

--- a/TableProTests/Core/Storage/SafeModeMigrationTests.swift
+++ b/TableProTests/Core/Storage/SafeModeMigrationTests.swift
@@ -320,6 +320,58 @@ struct SafeModeMigrationTests {
         )
     }
 
+    /// The reconcile used to copy `safeModeLevel` alone, so every other field on a live session
+    /// stayed at whatever it was when the connection was opened. `WorkspaceRailStore.resolve` reads
+    /// `session.connection` for any live session, so a rename or a recolour was invisible in the
+    /// rail until the next reconnect (#2398).
+    @Test("A colour picked while the connection is open reaches the open session")
+    func reconcileAppliesColorToLiveSession() {
+        let id = UUID()
+        let connection = makeConnection(id: id, name: "Production", safeModeLevel: .silent)
+        storage.addConnection(connection)
+
+        let manager = DatabaseManager(connectionStorage: storage)
+        manager.injectSession(ConnectionSession(connection: connection), for: id)
+        defer { manager.removeSession(for: id) }
+
+        var edited = connection
+        edited.color = .red
+        edited.name = "Production (renamed)"
+        storage.updateConnection(edited)
+
+        #expect(manager.session(for: id)?.connection.identityColor == nil)
+
+        manager.reconcileStoredRecord(for: id)
+
+        #expect(manager.session(for: id)?.connection.identityColor == .red)
+        #expect(manager.session(for: id)?.connection.name == "Production (renamed)")
+    }
+
+    /// The session owns the database it switched to; storage still holds the one the connection was
+    /// configured with. Adopting the stored record wholesale would silently move a browsing session
+    /// back to the configured database, so the reconcile has to carry this one field over.
+    @Test("The reconcile keeps the database the session switched to")
+    func reconcileKeepsSwitchedDatabase() {
+        let id = UUID()
+        let connection = makeConnection(id: id, name: "Production", safeModeLevel: .silent)
+        storage.addConnection(connection)
+
+        let manager = DatabaseManager(connectionStorage: storage)
+        var live = connection
+        live.database = "analytics"
+        manager.injectSession(ConnectionSession(connection: live), for: id)
+        defer { manager.removeSession(for: id) }
+
+        var edited = connection
+        edited.color = .blue
+        storage.updateConnection(edited)
+
+        manager.reconcileStoredRecord(for: id)
+
+        #expect(manager.session(for: id)?.connection.database == "analytics")
+        #expect(manager.session(for: id)?.connection.identityColor == .blue)
+    }
+
     @Test("An edit saved from the connection form reaches the open session")
     func reconcileAppliesConnectionFormEditToLiveSession() {
         let id = UUID()
@@ -336,7 +388,7 @@ struct SafeModeMigrationTests {
 
         #expect(manager.session(for: id)?.safeModeLevel == .readOnly)
 
-        manager.reconcileSafeModeLevel(for: id)
+        manager.reconcileStoredRecord(for: id)
 
         #expect(manager.session(for: id)?.safeModeLevel == .safeMode)
         #expect(manager.session(for: id)?.connection.safeModeLevel == .safeMode)
@@ -366,7 +418,7 @@ struct SafeModeMigrationTests {
         storage.updateConnection(editedFirst)
         storage.updateConnection(editedSecond)
 
-        manager.reconcileSafeModeLevel(for: nil)
+        manager.reconcileStoredRecord(for: nil)
 
         #expect(manager.session(for: firstId)?.safeModeLevel == .silent)
         #expect(manager.session(for: secondId)?.safeModeLevel == .alert)
@@ -379,7 +431,7 @@ struct SafeModeMigrationTests {
         storage.addConnection(connection)
 
         let manager = DatabaseManager(connectionStorage: storage)
-        manager.reconcileSafeModeLevel(for: id)
+        manager.reconcileStoredRecord(for: id)
 
         #expect(manager.session(for: id) == nil)
         #expect(storage.loadConnection(id: id)?.safeModeLevel == .readOnly)

--- a/TableProTests/Core/Storage/SafeModeMigrationTests.swift
+++ b/TableProTests/Core/Storage/SafeModeMigrationTests.swift
@@ -347,11 +347,12 @@ struct SafeModeMigrationTests {
         #expect(manager.session(for: id)?.connection.name == "Production (renamed)")
     }
 
-    /// The session owns the database it switched to; storage still holds the one the connection was
-    /// configured with. Adopting the stored record wholesale would silently move a browsing session
-    /// back to the configured database, so the reconcile has to carry this one field over.
-    @Test("The reconcile keeps the database the session switched to")
-    func reconcileKeepsSwitchedDatabase() {
+    /// `reconnectOntoDatabase` builds its reconnect from `session.connection`, so a host, port or
+    /// username edit that reached a live session would let the health monitor silently reconnect an
+    /// open window to a different server. The reconcile carries display fields only; the connect
+    /// target belongs to the next connect the user asks for.
+    @Test("The reconcile never moves a live session's connect target")
+    func reconcileKeepsConnectTarget() {
         let id = UUID()
         let connection = makeConnection(id: id, name: "Production", safeModeLevel: .silent)
         storage.addConnection(connection)
@@ -364,12 +365,19 @@ struct SafeModeMigrationTests {
 
         var edited = connection
         edited.color = .blue
+        edited.host = "production.example.com"
+        edited.port = 5_432
+        edited.username = "someone_else"
         storage.updateConnection(edited)
 
         manager.reconcileStoredRecord(for: id)
 
-        #expect(manager.session(for: id)?.connection.database == "analytics")
-        #expect(manager.session(for: id)?.connection.identityColor == .blue)
+        let session = manager.session(for: id)
+        #expect(session?.connection.identityColor == .blue)
+        #expect(session?.connection.host == "127.0.0.1")
+        #expect(session?.connection.port == 3_306)
+        #expect(session?.connection.username == "root")
+        #expect(session?.connection.database == "analytics")
     }
 
     @Test("An edit saved from the connection form reaches the open session")

--- a/TableProTests/Theme/ConnectionIdentityColorTests.swift
+++ b/TableProTests/Theme/ConnectionIdentityColorTests.swift
@@ -1,0 +1,218 @@
+//
+//  ConnectionIdentityColorTests.swift
+//  TableProTests
+//
+//  A connection answers two colour questions that used to share one property: which engine is this
+//  (the brand colour, on the glyph) and which connection is this (the user's pick, on its own
+//  surface). Collapsing them spent the pick recolouring an already-branded glyph, so the only
+//  visible change was a hue shift on a 14pt icon (#2398).
+//
+
+import AppKit
+import Foundation
+import SwiftUI
+@testable import TablePro
+import Testing
+
+@Suite("Connection identity colour")
+@MainActor
+struct ConnectionIdentityColorTests {
+    private static let appearances: [NSAppearance.Name] = [
+        .aqua,
+        .darkAqua,
+        .accessibilityHighContrastAqua,
+        .accessibilityHighContrastDarkAqua,
+    ]
+
+    private static let assignableColors = ConnectionColor.allCases.filter { !$0.isDefault }
+
+    private func contrast(of fill: Color) -> CGFloat {
+        let foreground = NSColor(Color.legibleForeground(on: fill)).relativeLuminance
+        let background = NSColor(fill).relativeLuminance
+        return (max(foreground, background) + 0.05) / (min(foreground, background) + 0.05)
+    }
+
+    private func connection(colored color: ConnectionColor) -> DatabaseConnection {
+        var connection = DatabaseConnection(name: "Production")
+        connection.color = color
+        return connection
+    }
+
+    // MARK: - The two colours never substitute for each other
+
+    @Test("A connection with no colour reports no identity colour")
+    func uncolouredConnectionHasNoIdentity() {
+        #expect(connection(colored: .none).identityColor == nil)
+    }
+
+    @Test("A coloured connection reports the colour the user picked")
+    func colouredConnectionReportsThePick() {
+        for color in Self.assignableColors {
+            #expect(connection(colored: color).identityColor == color)
+        }
+    }
+
+    /// The regression this whole change exists to prevent: the brand colour must not move when the
+    /// user picks a colour, because the glyph that wears it identifies the engine on every
+    /// connection and cannot also mean something per-connection.
+    @Test("The brand colour is the engine's on every connection, coloured or not")
+    func brandColourIgnoresTheUserPick() {
+        let uncoloured = connection(colored: .none)
+        for color in Self.assignableColors {
+            #expect(connection(colored: color).brandColor == uncoloured.brandColor)
+        }
+    }
+
+    // MARK: - The palette entry that means "no colour" is never a paintable colour
+
+    /// `ConnectionColor.color` returns `.clear` for `.none`, and a caller that fills with it paints
+    /// a transparent hole where the cue should be. Both accessors return `nil` instead so the type
+    /// stops the mistake rather than a guard at each call site. The history drawer and the compare
+    /// status strip both shipped that hole.
+    @Test("Neither accessor hands back a paintable colour for the uncoloured entry")
+    func uncolouredEntryHasNoPaintableColour() {
+        #expect(ConnectionColor.none.indicatorColor == nil)
+        #expect(ConnectionColor.none.labelledFill == nil)
+    }
+
+    @Test("Every assignable colour has both an indicator and a fill")
+    func assignableColorsHaveBoth() {
+        for color in Self.assignableColors {
+            #expect(color.indicatorColor != nil, "\(color.rawValue) has no indicator colour")
+            #expect(color.labelledFill != nil, "\(color.rawValue) has no labelled fill")
+        }
+    }
+
+    @Test("The indicator keeps the palette hue untouched")
+    func indicatorIsTheRawHue() {
+        for color in Self.assignableColors {
+            #expect(color.indicatorColor == color.color)
+        }
+    }
+
+    // MARK: - Contrast
+
+    /// The toolbar puts a 13pt `.callout` name on this fill and the workspace rail puts its label
+    /// on it, so WCAG 2.2 asks 4.5:1 rather than the 3:1 that covers an icon or a border.
+    /// `LegibleForegroundTests` holds `color` itself at 3:1, which is the right bar for a dot or a
+    /// glyph tint; this is the bar for a fill that carries text.
+    @Test("Every labelled fill clears 4.5:1 against its own label in every appearance")
+    func labelledFillsClearTextContrast() {
+        for name in Self.appearances {
+            guard let appearance = NSAppearance(named: name) else { continue }
+            appearance.performAsCurrentDrawingAppearance {
+                for color in Self.assignableColors {
+                    guard let fill = color.labelledFill else {
+                        Issue.record("\(color.rawValue) has no labelled fill")
+                        continue
+                    }
+                    #expect(
+                        contrast(of: fill) >= Color.minimumLabelContrast,
+                        "\(color.rawValue) reaches only \(contrast(of: fill)) in \(name.rawValue)"
+                    )
+                }
+            }
+        }
+    }
+
+    /// Measured, orange, yellow and green already clear 4.5:1 with a black label, so tuning must
+    /// leave them exactly where they are. A tuner that dimmed every hue would make the palette
+    /// duller for no contrast gained, which is the objection this design had to answer.
+    @Test("A fill that already clears the bar is returned unchanged")
+    func alreadyLegibleFillsAreUntouched() {
+        for name in Self.appearances {
+            guard let appearance = NSAppearance(named: name) else { continue }
+            appearance.performAsCurrentDrawingAppearance {
+                for color in Self.assignableColors where NSColor(color.color).contrastWithDerivedLabel >= Color
+                    .minimumLabelContrast {
+                    #expect(
+                        Self.resolvesAlike(color.labelledFill, color.color),
+                        "\(color.rawValue) was dimmed in \(name.rawValue) despite already clearing the bar"
+                    )
+                }
+            }
+        }
+    }
+
+    /// `Color` compares by how it was built, not by what it resolves to, so a system colour and the
+    /// same colour round-tripped through `NSColor` are never `==`. Measured: `Color.orange` and
+    /// `Color(nsColor: NSColor(Color.orange))` compare unequal with identical sRGB components.
+    private static func resolvesAlike(_ lhs: Color?, _ rhs: Color) -> Bool {
+        guard let lhs,
+              let left = NSColor(lhs).usingColorSpace(.sRGB),
+              let right = NSColor(rhs).usingColorSpace(.sRGB) else { return false }
+        return abs(left.redComponent - right.redComponent) < 0.0001
+            && abs(left.greenComponent - right.greenComponent) < 0.0001
+            && abs(left.blueComponent - right.blueComponent) < 0.0001
+    }
+
+    /// Tuning lowers brightness and nothing else, so the fill still reads as the colour the user
+    /// picked from the swatch. Measured, the worst case keeps 83% of its brightness.
+    @Test("Tuning holds the hue and only ever dims")
+    func tuningHoldsHue() {
+        for name in Self.appearances {
+            guard let appearance = NSAppearance(named: name) else { continue }
+            appearance.performAsCurrentDrawingAppearance {
+                for color in Self.assignableColors {
+                    guard let fillColor = color.labelledFill,
+                          let base = NSColor(color.color).usingColorSpace(.sRGB),
+                          let tuned = NSColor(fillColor).usingColorSpace(.sRGB) else {
+                        Issue.record("\(color.rawValue) did not resolve in \(name.rawValue)")
+                        continue
+                    }
+
+                    let before = Self.components(of: base)
+                    let after = Self.components(of: tuned)
+
+                    #expect(abs(after.hue - before.hue) < 0.001, "\(color.rawValue) shifted hue in \(name.rawValue)")
+                    #expect(after.brightness <= before.brightness + 0.001, "\(color.rawValue) brightened")
+                    #expect(after.alpha == 1, "\(color.rawValue) is not opaque")
+                }
+            }
+        }
+    }
+
+    private static func components(of color: NSColor) -> (hue: CGFloat, brightness: CGFloat, alpha: CGFloat) {
+        var hue: CGFloat = 0
+        var saturation: CGFloat = 0
+        var brightness: CGFloat = 0
+        var alpha: CGFloat = 0
+        color.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
+        return (hue, brightness, alpha)
+    }
+}
+
+/// `.toolbarBackground(_:for:)` styles a toolbar SwiftUI itself installs, and it reaches that
+/// toolbar by flowing up to the root view of a `Window` scene. TablePro runs the AppKit lifecycle
+/// with no SwiftUI scene at all and installs a real `NSToolbar` in `MainWindowToolbar`, so the
+/// modifier has nothing to act on. It sat in the app unused for four months after the toolbar
+/// migration removed its last call site, which made "raise the tint opacity" look like a one-line
+/// fix for #2398 when it would have changed nothing on screen.
+@Suite("Toolbar background modifier stays out of the app target")
+struct ToolbarBackgroundGuardTests {
+    private static let repositoryRoot: URL = {
+        var url = URL(fileURLWithPath: #filePath)
+        for _ in 0 ..< 3 {
+            url.deleteLastPathComponent()
+        }
+        return url
+    }()
+
+    @Test("No source file reaches for a SwiftUI toolbar background")
+    func appTargetHasNoToolbarBackground() throws {
+        let root = Self.repositoryRoot.appendingPathComponent("TablePro")
+        let enumerator = try #require(FileManager.default.enumerator(at: root, includingPropertiesForKeys: nil))
+
+        var offenders: [String] = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            guard let source = try? String(contentsOf: url, encoding: .utf8) else { continue }
+            guard source.contains(".toolbarBackground(") else { continue }
+            offenders.append(url.lastPathComponent)
+        }
+
+        #expect(
+            offenders.isEmpty,
+            "These reach a SwiftUI toolbar the app does not have: \(offenders.sorted())"
+        )
+    }
+}

--- a/TableProTests/Theme/LegibleForegroundTests.swift
+++ b/TableProTests/Theme/LegibleForegroundTests.swift
@@ -45,6 +45,10 @@ struct LegibleForegroundTests {
     /// The palette is the one a tag or a connection can actually be given, resolved in every
     /// appearance the app can render in. `.gray` used to be the one colour left out, and it is the
     /// default a new tag gets.
+    ///
+    /// 3:1 is the right bar for `color` itself, which paints dots, swatches and glyph tints. A fill
+    /// that carries text is held to 4.5:1 by `ConnectionIdentityColorTests`, against `labelledFill`
+    /// rather than against this value: five of these eight hues reach only 3.2:1 to 4.2:1 here.
     @Test("Every connection palette colour keeps a readable label in every appearance")
     func connectionPaletteStaysReadable() {
         for name in Self.appearances {

--- a/docs/customization/appearance.mdx
+++ b/docs/customization/appearance.mdx
@@ -90,9 +90,11 @@ Every key is optional. A group you leave out falls back to Default Light, and a 
 
 ## Connection colors
 
-Assign one in the connection form under **Customization > Appearance > Color**: None, Red, Orange, Yellow, Green, Blue, Purple, Pink, or Gray. With None, the connection takes its database type's brand color from the driver plugin. Connection groups take a color the same way, from their right-click menu on the welcome window.
+Assign one in the connection form under **Customization > Appearance > Color**: None, Red, Orange, Yellow, Green, Blue, Purple, Pink, or Gray. With None, no color cue appears. Connection groups take a color the same way, from their right-click menu on the welcome window.
 
-The color shows on the toolbar connection status indicator, the connection switcher popover, the sidebar connection header, and the welcome window list.
+The color fills a badge behind the connection name in the toolbar, and a band behind the label in the workspace rail. In the welcome window list and the connection switcher, it is a dot beside the name. The color's name is in the connection's tooltip and its VoiceOver label.
+
+The database icon keeps its engine's own color everywhere, whichever color the connection carries.
 
 <Tip>
 Use red for production databases as a visual reminder to be careful with queries.


### PR DESCRIPTION
Fixes #2398.

The reporter says the connection color "is reflected in the left sidebar and the top connection icon, but it is not very obvious because the icons are originally colored", and asks for a background behind the connection name.

Three separate causes, all confirmed in the code.

## 1. The color was spent recoloring an already-branded glyph

`DatabaseConnection.displayColor` was `color.isDefault ? type.themeColor : color.color`. One property answered two different questions, "which engine is this" and "which connection is this", and every consumer painted the answer onto the same pixel: the database type icon. Picking a color therefore *replaced* the engine's brand color rather than adding a signal, so the only visible change was a hue shift on a 14pt icon, and the engine lost its own color to pay for it.

Four consumers: `ConnectionStatusView`, `WelcomeConnectionRow`, `WorkspaceRailCellView`, `ConnectionSwitcherPopover`.

Split into `brandColor` (always the engine's) and `identityColor: ConnectionColor?` (nil when the user picked none, never falling back to the brand color).

## 2. The window-chrome tint has been dead code since April

`dc0093243` ("refactor: AppKit-native window/toolbar management for main editor", #768, 2026-04-18) removed `.modifier(ToolbarTintModifier(connectionColor:))` and left the comment "Connection color tint is not yet ported". It was never ported. `ToolbarTintModifier` had zero call sites for four months, so there was no tint at all, at any opacity, and raising its `0.12` would have shipped no visible change.

It could not have been revived as written either: `.toolbarBackground(_:for: .windowToolbar)` styles a toolbar SwiftUI itself installs and reaches it by flowing up to a `Window` scene's root view. The app runs the AppKit lifecycle with no SwiftUI scene and installs a real `NSToolbar` in `MainWindowToolbar`. Deleted, with a source-scanning guard test so it cannot come back silently.

## 3. Neither the toolbar nor the rail repainted while connected

This one would have made the whole fix invisible at the moment the user picks a color.

- `ConnectionToolbarState` is built once per session at `SessionStateFactory`. Its only writer, `update(from:)`, is reachable from `init` and from `initializeToolbar()`, whose sole caller `initializeView()` has no callers at all. `handleConnectionRecordChange` only reassigned SwiftUI root views and never touched it.
- `DatabaseManager.observeConnectionUpdates` reconciled `safeModeLevel` and nothing else, while `WorkspaceRailStore.resolve` reads `session.connection` for any live session.

So editing a live connection's color, or its name, changed nothing until reconnect. Both paths now take the stored record; the session keeps only the two fields it actually owns at runtime, the browsed database and the safe-mode level.

## The design

The reporter's literal ask, a translucent wash over the toolbar background, is what the HIG rules out and what measurement rules out.

- Toolbars: "Reduce the use of toolbar backgrounds and tinted controls. Any custom backgrounds... might overlay or interfere with background effects that the system provides."
- Color: "Avoid using the same color to mean different things." "Avoid relying solely on color to differentiate between objects."

And a wash sits over a material whose backdrop is the wallpaper, so no contrast ratio can be guaranteed for it, and it collapses under Reduce Transparency.

What Apple ships for this exact problem is Safari Profiles: the profile's color and symbol in a named toolbar button, with the toolbar material and window frame left alone. TablePlus puts the color on its toolbar status item and Postico "highlights the status display" the same way. TablePro already shipped the shape too, in `tagBadge`.

So the color now fills a capsule behind the connection name in the toolbar, and a band behind the label in the workspace rail. In the welcome list and the connection switcher it is a dot beside the name, the Finder-tag idiom, because those rows can be selected and a fill of their own would fight the selection band. The scope chips stay neutral: one filled shape per window.

`WorkspaceRailCellView`'s header comment argued the opposite ("the colour is the icon"), so this PR refutes it in place rather than reversing it silently: that premise holds for a Finder icon, a neutral document or folder shape with no color of its own to lose, and fails for a brand mark that is already a color meaning something else.

Color is never the only channel. `ConnectionColor.displayName` now joins the tooltip and the accessibility label on every identity surface.

## Contrast

Text on a fill needs 4.5:1 (WCAG 2.2 SC 1.4.3). Measured against the palette with the label `legibleForeground(on:)` picks, five of the eight only reach 3.2:1 to 4.2:1:

| | light | dark |
|---|---|---|
| red | 3.57 | 3.43 |
| blue | 3.52 | 3.23 |
| purple | 4.17 | 3.63 |
| pink | 3.65 | 3.52 |
| gray | 3.26 | 7.31 |
| orange / yellow / green | 9.09 / 13.89 / 9.46 | 9.41 / 14.87 / 10.39 |

Also measured: `accessibilityHighContrastAqua` resolves `systemRed` and the rest identically to `.aqua`, so the palette does not self-adjust for Increase Contrast.

`ConnectionColor.labelledFill` lowers brightness in HSB, holding hue and saturation, only as far as the derived label needs. Orange, yellow and green already clear the bar with a black label and are returned untouched. The rest keep 83% to 96% of their brightness, so they still read as the color that was picked:

| | fill → tuned | brightness kept |
|---|---|---|
| purple | `#CB30E0` → `#C22ED6` | 96% |
| pink | `#FF2D55` → `#E2284B` | 89% |
| red | `#FF383C` → `#E03135` | 88% |
| blue | `#0088FF` → `#0076DE` | 87% |
| gray | `#8E8E93` → `#76767A` | 83% |

`ConnectionColor.color` is untouched, so the picker swatch, dots and glyph tints keep full saturation. Only a fill that carries text uses `labelledFill`. The existing tag badge adopts it too, because it had the identical defect at 10pt.

## Also fixed, because the model change makes them unrepresentable

`ConnectionColor.none` renders as `Color.clear`, so a render site that filled with it painted a transparent hole. `indicatorColor` and `labelledFill` return `nil` instead, which fixes two shipped instances found while investigating:

- The query history drawer painted an invisible dot for every default-colored connection. Its `.secondary` fallback was unreachable because the directory always passed a non-nil color.
- The compare status strip did the same, while its own sibling `CompareEndpointPicker.swatch` guarded `.none` correctly. The strip is the surface that says which database is about to be written to.

## Verification

- `build` PASS
- `test` PASS, 81 of 81 across `ConnectionIdentityColorTests`, `ToolbarBackgroundGuardTests`, `LegibleForegroundTests`, `WorkspaceRailStoreTests`, `ConnectionToolbarStateTests`, `SafeModeMigrationTests`, `HistoryRowTintTests`, `GroupMenuEntriesTests`, `DataGridCellSelectionFillTests`, `CompareEndpointPickerModelTests`, `DatabaseTypeBrandColorTests`, `MultiConnectionTests`
- `swiftlint lint --strict` clean
- `docs/scripts/check-writing-style.sh` and `check-docs-against-source.py` both pass

New tests: every `labelledFill` clears 4.5:1 in all four appearances; tuning only ever dims and never shifts hue; an already-legible fill is returned unchanged; `brandColor` does not move when a color is picked; neither accessor hands back a paintable color for `.none`; a color or name picked while connected reaches the live session, and the session's switched database survives the reconcile; no source file reaches for `.toolbarBackground(`.

## Screenshots

Not captured. The change is visible in the toolbar, the workspace rail and the welcome list, and a faithful before-and-after needs the app driven to an open connection on both this branch and a build of `main`. Rendering the views offscreen would show the new state but not an honest "before". Worth capturing before merge if a reviewer wants them.

## Not done here

- The workspace rail band and the toolbar capsule are covered by unit tests, not `TableProUITests`. Both surfaces need a live connection and the rail only appears when a window hosts more than one, so neither runs deterministically without a seeded fixture.
- Mobile parity. `ConnectionColor` has two declarations (`DatabaseConnection.swift` and `TableProModels/ConnectionColor.swift`) and `TableProMobile` carries a third color mapping of its own that maps `.none` to grey rather than clear. Left alone deliberately; noted so it is not mistaken for an oversight.
