### PR TITLE
fix(i18n): translate every catalog entry that shipped with no translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Row inspector fields, cell popovers and the Compare row diff follow the data grid font. (#2393)
 - The connection color as a filled badge behind the connection name, with the database icon back to its engine color. (#2398)
 - Deeper fills on tag badges and the connection name badge. (#2398)
+- Turkish, Vietnamese, Simplified Chinese and Traditional Chinese cover every string that was still in English.
 
 ### Fixed
 

--- a/TablePro/InfoPlist.xcstrings
+++ b/TablePro/InfoPlist.xcstrings
@@ -16,6 +16,30 @@
             "state" : "translated",
             "value" : "TablePro는 선택한 프로젝트 폴더에서 데이터베이스 설정을 읽습니다."
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro, seçtiğiniz proje klasöründen veritabanı ayarlarını okur."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro đọc cài đặt cơ sở dữ liệu từ thư mục dự án bạn chọn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 会从你选择的项目文件夹中读取数据库设置。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 會從你選擇的專案資料夾中讀取資料庫設定。"
+          }
         }
       }
     },
@@ -33,6 +57,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "TablePro는 선택한 프로젝트 폴더에서 데이터베이스 설정을 읽습니다."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro, seçtiğiniz proje klasöründen veritabanı ayarlarını okur."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro đọc cài đặt cơ sở dữ liệu từ thư mục dự án bạn chọn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 会从你选择的项目文件夹中读取数据库设置。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 會從你選擇的專案資料夾中讀取資料庫設定。"
           }
         }
       }
@@ -52,6 +100,30 @@
             "state" : "translated",
             "value" : "TablePro는 선택한 프로젝트 폴더에서 데이터베이스 설정을 읽습니다."
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro, seçtiğiniz proje klasöründen veritabanı ayarlarını okur."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro đọc cài đặt cơ sở dữ liệu từ thư mục dự án bạn chọn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 会从你选择的项目文件夹中读取数据库设置。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 會從你選擇的專案資料夾中讀取資料庫設定。"
+          }
         }
       }
     },
@@ -69,6 +141,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "TablePro는 Bonjour(.local) 호스트 이름을 포함하여 로컬 네트워크에서 실행되는 데이터베이스 서버 및 SSH 터널에 연결합니다."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro, Bonjour (.local) sunucu adları dahil olmak üzere yerel ağınızda çalışan veritabanı sunucularına ve SSH tünellerine bağlanır."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro kết nối tới các máy chủ cơ sở dữ liệu và SSH tunnel chạy trên mạng cục bộ của bạn, bao gồm cả tên máy Bonjour (.local)."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 会连接到运行在你本地网络上的数据库服务器和 SSH 隧道，包括 Bonjour（.local）主机名。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 會連線到執行在你區域網路上的資料庫伺服器和 SSH 通道，包括 Bonjour（.local）主機名稱。"
           }
         }
       }

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -3,6 +3,12 @@
   "strings" : {
     "" : {
       "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -380,6 +386,30 @@
             "value" : "%1$@ %2$@을(를) 삭제한 뒤 다시 만들기 때문에, 이에 의존하는 항목은 다시 만들어질 때까지 실패합니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@ silinip yeniden oluşturulur, bu yüzden ona bağlı olan her şey yeniden var olana kadar başarısız olur."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@ bị xóa rồi tạo lại, nên mọi thứ phụ thuộc vào nó sẽ lỗi cho đến khi nó tồn tại trở lại."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@ 会被删除后重新创建，因此依赖它的对象在它重新存在之前都会失败。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@ 會先刪除再重新建立，因此依賴它的項目在重新存在之前都會失敗。"
+          }
         }
       }
     },
@@ -423,6 +453,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ (ORA-%2$ld)."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ (ORA-%2$ld)."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ (ORA-%2$ld)."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@（ORA-%2$ld）。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@（ORA-%2$ld）。"
           }
         }
       }
@@ -546,6 +600,30 @@
             "state" : "translated",
             "value" : "%1$@/%2$@"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ / %2$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ trên %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ / %2$@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ / %2$@"
+          }
         }
       }
     },
@@ -555,6 +633,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이 페이지에서 %2$@개 중 %1$@개"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bu sayfada %1$@ / %2$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ trên %2$@ ở trang này"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本页 %1$@ / %2$@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本頁 %1$@ / %2$@"
           }
         }
       }
@@ -600,6 +702,30 @@
             "state" : "translated",
             "value" : "플러그인: %1$@. 서명자: %2$@ (팀 ID %3$@). Apple의 공증을 받았습니다. TablePro에서 만든 플러그인이 아닙니다.\n\n데이터베이스 플러그인은 TablePro의 일부로 실행되며 사용자가 여는 모든 연결의 자격 증명을 읽을 수 있습니다. 해당 접근 권한을 부여해도 되는 개발자만 신뢰하십시오.\n\n개발자를 신뢰하면 현재와 이후에 이 개발자가 서명하는 모든 플러그인에 적용됩니다. 설정 > 플러그인에서 언제든지 신뢰를 해제할 수 있습니다."
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@, %2$@ tarafından imzalandı (Takım Kimliği %3$@) ve Apple tarafından onaylandı. TablePro bunu yazmadı.\n\nBir veritabanı eklentisi TablePro'nun parçası olarak çalışır ve açtığınız her bağlantının kimlik bilgilerini okuyabilir. Bu geliştiriciye yalnızca ona bu erişimi vermeye razıysanız güvenin.\n\nGüven, bu geliştiricinin şimdi ve sonra imzaladığı her eklenti için geçerlidir. Ayarlar > Eklentiler bölümünden geri alabilirsiniz."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ được ký bởi %2$@ (Team ID %3$@) và đã được Apple công chứng. TablePro không viết nó.\n\nMột plugin cơ sở dữ liệu chạy như một phần của TablePro và có thể đọc thông tin đăng nhập của mọi kết nối bạn mở. Chỉ tin cậy nhà phát triển này nếu bạn sẵn sàng cấp quyền truy cập đó.\n\nViệc tin cậy áp dụng cho mọi plugin mà nhà phát triển này ký, bây giờ và về sau. Bạn có thể thu hồi trong Cài đặt > Plugin."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ 由 %2$@（团队 ID %3$@）签名并经 Apple 公证。它不是 TablePro 编写的。\n\n数据库插件作为 TablePro 的一部分运行，可以读取你打开的每个连接的凭据。只有在你愿意授予该访问权限时才信任此开发者。\n\n信任适用于该开发者现在和以后签名的每个插件。你可以在“设置 > 插件”中撤销。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ 由 %2$@（團隊 ID %3$@）簽署並經 Apple 公證。它不是 TablePro 編寫的。\n\n資料庫外掛作為 TablePro 的一部分執行，可以讀取你開啟的每個連線的認證資訊。只有在你願意授予該存取權時才信任此開發者。\n\n信任適用於該開發者現在與日後簽署的每個外掛。你可以在「設定 > 外掛」中撤銷。"
+          }
         }
       }
     },
@@ -643,6 +769,30 @@
           "stringUnit" : {
             "value" : "%1$@ → %2$@",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ → %2$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ → %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ → %2$@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ → %2$@"
           }
         }
       }
@@ -764,6 +914,30 @@
             "value" : "%2$d개 중 %1$d개를 이번 실행에서 허용함",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bu çalıştırma için %1$d / %2$d izin verildi"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d trên %2$d được cho phép trong lần chạy này"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本次运行已允许 %1$d / %2$d"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本次執行已允許 %1$d / %2$d"
+          }
         }
       }
     },
@@ -773,6 +947,30 @@
           "stringUnit" : {
             "value" : "%2$d개 중 %1$d개 포함됨",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d / %2$d dahil edildi"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã bao gồm %1$d trên %2$d"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已包含 %1$d / %2$d"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已納入 %1$d / %2$d"
           }
         }
       }
@@ -818,6 +1016,30 @@
             "value" : "%2$d개 테이블 중 %1$d개를 비교합니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%2$d tablodan %1$d tanesi karşılaştırılacak."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d trên %2$d bảng sẽ được so sánh."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将比较 %2$d 个表中的 %1$d 个。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將比較 %2$d 個資料表中的 %1$d 個。"
+          }
         }
       }
     },
@@ -828,6 +1050,30 @@
             "value" : "구문 %1$d개는 이번 실행에서 제외되며, %2$@은(는) 해당 항목을 그대로 유지합니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d ifade bu çalıştırmanın dışında kalır ve %2$@ bunlar için mevcut hâlini korur."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d câu lệnh nằm ngoài lần chạy này và %2$@ giữ nguyên những gì đang có cho chúng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d 条语句不参与本次运行，%2$@ 中相关内容保持原样。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d 條陳述式不參與本次執行，%2$@ 中相關內容維持原狀。"
+          }
         }
       }
     },
@@ -837,6 +1083,30 @@
           "stringUnit" : {
             "value" : "구문 %1$d개 중 %2$d개를 실행합니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d ifade, %2$d tanesi çalışacak."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d câu lệnh, %2$d sẽ chạy."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共 %1$d 条语句，将运行 %2$d 条。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共 %1$d 條陳述式，將執行 %2$d 條。"
           }
         }
       }
@@ -1283,6 +1553,30 @@
             "value" : "%@은(는) 드라이버가 메타데이터를 제공하지 않아 비교할 수 없습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ karşılaştırılamaz, çünkü sürücüsü meta veri sunmuyor."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể so sánh %@ vì driver của nó không cung cấp metadata."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法比较 %@，因为其驱动不提供元数据。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法比較 %@，因為其驅動程式不提供中繼資料。"
+          }
         }
       }
     },
@@ -1360,6 +1654,30 @@
           "stringUnit" : {
             "value" : "%@은(는) 하나의 연결로 양쪽을 읽기 때문에 자체 데이터베이스 두 개를 동시에 비교할 수 없습니다. 대상에는 다른 연결을 사용하십시오.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ kendi iki veritabanını aynı anda karşılaştıramaz, çünkü ikisini de tek bağlantı üzerinden okur. Hedef için ikinci bir bağlantı kullanın."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ không thể so sánh hai cơ sở dữ liệu của chính nó cùng lúc, vì nó đọc cả hai qua một kết nối. Hãy dùng kết nối thứ hai cho đích."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 无法同时比较自身的两个数据库，因为它通过一个连接读取两者。请为目标使用第二个连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 無法同時比較自身的兩個資料庫，因為它透過一個連線讀取兩者。請為目標使用第二個連線。"
           }
         }
       }
@@ -1439,6 +1757,30 @@
             "value" : "%@은(는) 비교할 수 있는 구조 메타데이터를 제공하지 않습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ karşılaştırılabilir yapı meta verisi bildirmiyor."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ không cung cấp metadata cấu trúc để so sánh."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 不提供可用于比较的结构元数据。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 不提供可用於比較的結構中繼資料。"
+          }
         }
       }
     },
@@ -1448,6 +1790,30 @@
           "stringUnit" : {
             "value" : "%@은(는) 데이터 비교에 필요한 키 순서 행 읽기를 지원하지 않습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@, veri karşılaştırmasının gerektirdiği anahtar sırasına göre satır okumayı desteklemiyor."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ không hỗ trợ đọc dòng theo thứ tự khóa, điều mà so sánh dữ liệu cần."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 不支持按键顺序读取行，而数据比较需要这一点。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 不支援依鍵順序讀取列，而資料比較需要這項功能。"
           }
         }
       }
@@ -1746,6 +2112,30 @@
           "stringUnit" : {
             "value" : "%@은(는) 더 이상 저장된 연결이 아닙니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ artık kayıtlı bir bağlantı değil."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ không còn là kết nối đã lưu."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已不再是已保存的连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已不再是已儲存的連線。"
           }
         }
       }
@@ -3148,6 +3538,30 @@
             "value" : "%d바이트",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d bayt"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d byte"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 字节"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 位元組"
+          }
         }
       }
     },
@@ -3215,6 +3629,30 @@
           "stringUnit" : {
             "value" : "변경 %d개",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d değişiklik"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d thay đổi"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 项更改"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 項變更"
           }
         }
       }
@@ -3500,6 +3938,30 @@
             "value" : "%d개 포함됨",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d dahil"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d được bao gồm"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已包含 %d 项"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已納入 %d 項"
+          }
         }
       }
     },
@@ -3509,6 +3971,30 @@
           "stringUnit" : {
             "value" : "%d개 제외됨",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d hariç"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d bị bỏ ra"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已排除 %d 项"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已排除 %d 項"
           }
         }
       }
@@ -3714,6 +4200,30 @@
             "value" : "테이블 1개 중 %d개를 비교합니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 tablodan %d tanesi karşılaştırılacak."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d trên 1 bảng sẽ được so sánh."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将比较 1 个表中的 %d 个。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將比較 1 個資料表中的 %d 個。"
+          }
         }
       }
     },
@@ -3879,6 +4389,30 @@
             "value" : "%d개 행은 키 열이 NULL이라 제외되었습니다. 비교하려면 NULL이 없는 키를 선택하십시오.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d satır anahtar sütununda NULL tutuyor ve dışarıda bırakıldı. Bunları karşılaştırmak için NULL içermeyen bir anahtar seçin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d dòng có NULL ở cột khóa nên đã bị bỏ ra. Chọn khóa không có NULL để so sánh chúng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 行的键列为 NULL，已被排除。请选择不含 NULL 的键来比较它们。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 列的鍵欄位為 NULL，已被排除。請選擇不含 NULL 的鍵來比較它們。"
+          }
         }
       }
     },
@@ -3906,6 +4440,30 @@
           "stringUnit" : {
             "value" : "%d개 행이 일치합니다. 일치하는 행은 목록에 넣지 않고 개수만 세므로, 차이점이 목록에서 밀려나지 않습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d satır eşleşiyor. Eşleşen satırlar listelenmez, sayılır; böylece bir fark bu listeden dışarı itilmez."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d dòng khớp nhau. Các dòng khớp chỉ được đếm chứ không liệt kê, nên khác biệt không bao giờ bị đẩy khỏi danh sách này."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 行相同。相同的行只计数不列出，因此差异不会被挤出此列表。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 列相同。相同的列只計數不列出，因此差異不會被擠出此清單。"
           }
         }
       }
@@ -3984,6 +4542,30 @@
           "stringUnit" : {
             "value" : "구문 %d개가 데이터를 파괴하며 아직 허용되지 않았습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d ifade veriyi yok eder ve henüz izin verilmedi."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d câu lệnh sẽ hủy dữ liệu và chưa được cho phép."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 条语句会销毁数据，尚未被允许。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 條陳述式會銷毀資料，尚未被允許。"
           }
         }
       }
@@ -4511,6 +5093,30 @@
             "state" : "translated",
             "value" : "일치 항목 %lld개"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld eşleşme"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld kết quả khớp"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 个匹配"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 個符合項目"
+          }
         }
       }
     },
@@ -4520,6 +5126,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "일치하는 행 %lld개"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld eşleşen satır"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld dòng khớp"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 个匹配行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 個相符的列"
           }
         }
       }
@@ -6953,6 +7583,30 @@
             "value" : "구문 1개는 이번 실행에서 제외되며, %@은(는) 해당 항목을 그대로 유지합니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 ifade bu çalıştırmanın dışında kalır ve %@ bunun için mevcut hâlini korur."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 câu lệnh nằm ngoài lần chạy này và %@ giữ nguyên những gì đang có cho nó."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 条语句不参与本次运行，%@ 中相关内容保持原样。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 條陳述式不參與本次執行，%@ 中相關內容維持原狀。"
+          }
         }
       }
     },
@@ -6963,6 +7617,30 @@
             "value" : "구문 1개가 데이터를 파괴하며 아직 허용되지 않았습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 ifade veriyi yok eder ve henüz izin verilmedi."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 câu lệnh sẽ hủy dữ liệu và chưa được cho phép."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 条语句会销毁数据，尚未被允许。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 條陳述式會銷毀資料，尚未被允許。"
+          }
         }
       }
     },
@@ -6972,6 +7650,30 @@
           "stringUnit" : {
             "value" : "구문 1개 중 %d개를 실행합니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 ifade, %d tanesi çalışacak."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 câu lệnh, %d sẽ chạy."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共 1 条语句，将运行 %d 条。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共 1 條陳述式，將執行 %d 條。"
           }
         }
       }
@@ -8214,6 +8916,30 @@
             "value" : "비교에서 제외한 열도 삽입과 업데이트에는 그대로 기록됩니다. 두 목록 중 하나를 바꾸면 다시 비교해야 합니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştırmanın dışında bırakılan bir sütun, ekleme ve güncellemede yine de yazılır. Listelerden birini değiştirmek yeni bir karşılaştırma gerektirir."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cột bị bỏ khỏi so sánh vẫn được ghi khi chèn và cập nhật. Thay đổi một trong hai danh sách cần so sánh lại."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "被排除在比较之外的列，在插入和更新时仍会写入。更改任一列表都需要重新比较。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "被排除在比較之外的欄位，在插入和更新時仍會寫入。變更任一清單都需要重新比較。"
+          }
         }
       }
     },
@@ -8257,6 +8983,30 @@
           "stringUnit" : {
             "value" : "비교가 이미 실행 중입니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bir karşılaştırma zaten çalışıyor."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã có một phiên so sánh đang chạy."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已有比较正在运行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已有比較正在執行。"
           }
         }
       }
@@ -8678,6 +9428,30 @@
             "value" : "실행이 이미 진행 중입니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bir çalıştırma zaten sürüyor."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã có một lần chạy đang diễn ra."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已有运行正在进行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已有執行正在進行。"
+          }
         }
       }
     },
@@ -8790,6 +9564,30 @@
             "value" : "동기화가 아직 실행 중입니다",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bir eşitleme hâlâ çalışıyor"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vẫn còn một phiên đồng bộ đang chạy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步仍在运行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步仍在執行"
+          }
         }
       }
     },
@@ -8799,6 +9597,30 @@
           "stringUnit" : {
             "value" : "트랜잭션은 건너뛰고 계속하기와 함께 쓸 수 없습니다. 두 가지를 함께 쓰면 대상이 절반만 적용된 상태로 남습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bir işlem, atla ve devam et ile birleştirilemez: ikisi birlikte hedefi yarı uygulanmış bırakır."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể kết hợp giao dịch với bỏ qua và tiếp tục: cùng nhau chúng sẽ để đích ở trạng thái áp dụng dở dang."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "事务不能与“跳过并继续”组合：两者一起会让目标处于应用了一半的状态。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "交易不能與「略過並繼續」組合：兩者一起會讓目標處於套用一半的狀態。"
           }
         }
       }
@@ -13462,6 +14284,30 @@
             "value" : "모든 행",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tüm Satırlar"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tất cả dòng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有列"
+          }
         }
       }
     },
@@ -13983,6 +14829,30 @@
             "value" : "적용하기 전에 경고 탭에서 보류된 구문을 모두 허용하거나, 해당 구문을 만든 객체를 제외하십시오.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uygulamadan önce Uyarılar sekmesinde tutulan her ifadeye izin verin veya bunları üreten nesneleri hariç tutun."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trước khi áp dụng, hãy cho phép mọi câu lệnh bị giữ lại ở tab Cảnh báo, hoặc loại trừ các đối tượng đã tạo ra chúng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用前，请在“警告”标签中允许每条被保留的语句，或排除产生它们的对象。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用前，請在「警告」標籤中允許每條被保留的陳述式，或排除產生它們的物件。"
+          }
         }
       }
     },
@@ -14060,6 +14930,30 @@
           "stringUnit" : {
             "value" : "구문 허용은 이번 실행에만 적용되며 저장되지 않습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bir ifadeye izin vermek yalnızca bu çalıştırma için geçerlidir. Asla kaydedilmez."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Việc cho phép một câu lệnh chỉ áp dụng cho lần chạy này. Nó không bao giờ được lưu."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许某条语句仅对本次运行有效，永远不会被保存。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許某條陳述式僅對本次執行有效，永遠不會被儲存。"
           }
         }
       }
@@ -15128,6 +16022,30 @@
             "value" : "%2$@에 %1$@(으)로 적용했습니다. 구문 %3$d개.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%2$@ tarihinde %1$@ üzerine uygulandı. %3$d ifade."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã áp dụng vào %1$@ lúc %2$@. %3$d câu lệnh."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已于 %2$@ 应用到 %1$@。共 %3$d 条语句。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已於 %2$@ 套用到 %1$@。共 %3$d 條陳述式。"
+          }
         }
       }
     },
@@ -15143,6 +16061,30 @@
           "stringUnit" : {
             "value" : "%2$@에 %1$@(으)로 적용했습니다. 구문 1개.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%2$@ tarihinde %1$@ üzerine uygulandı. 1 ifade."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã áp dụng vào %1$@ lúc %2$@. 1 câu lệnh."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已于 %2$@ 应用到 %1$@。共 1 条语句。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已於 %2$@ 套用到 %1$@。共 1 條陳述式。"
           }
         }
       }
@@ -15223,6 +16165,30 @@
             "value" : "구문 %1$d개를 %2$@에 적용하시겠습니까?",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d ifade %2$@ üzerine uygulansın mı?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Áp dụng %1$d câu lệnh vào %2$@?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将 %1$d 条语句应用到 %2$@？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要將 %1$d 條陳述式套用到 %2$@ 嗎？"
+          }
         }
       }
     },
@@ -15239,6 +16205,30 @@
             "value" : "%@ 동기화를 %@에 적용",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ eşitlemesini %2$@ üzerine uygula"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Áp dụng đồng bộ %1$@ vào %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将 %1$@ 同步应用到 %2$@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將 %1$@ 同步套用到 %2$@"
+          }
         }
       }
     },
@@ -15248,6 +16238,30 @@
           "stringUnit" : {
             "value" : "구문 1개를 %@에 적용하시겠습니까?",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 ifade %@ üzerine uygulansın mı?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Áp dụng 1 câu lệnh vào %@?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将 1 条语句应用到 %@？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要將 1 條陳述式套用到 %@ 嗎？"
           }
         }
       }
@@ -15740,6 +16754,30 @@
             "value" : "%@에 적용",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ üzerine uygula"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Áp dụng vào %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用到 %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用到 %@"
+          }
         }
       }
     },
@@ -15783,6 +16821,30 @@
           "stringUnit" : {
             "value" : "대상에 적용…",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hedefe Uygula…"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Áp dụng vào đích…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用到目标…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用到目標…"
           }
         }
       }
@@ -15828,6 +16890,30 @@
             "value" : "%@에 적용하는 중…",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ üzerine uygulanıyor…"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang áp dụng vào %@…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在应用到 %@…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在套用到 %@…"
+          }
         }
       }
     },
@@ -15837,6 +16923,30 @@
           "stringUnit" : {
             "value" : "적용…",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uygula…"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Áp dụng…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "套用…"
           }
         }
       }
@@ -17529,6 +18639,30 @@
             "value" : "자동 증가 시작값",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otomatik artış başlangıcı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giá trị khởi đầu tự động tăng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动递增起始值"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動遞增起始值"
+          }
         }
       }
     },
@@ -18406,6 +19540,30 @@
             "value" : "이진 콘텐츠",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İkili içerik"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nội dung nhị phân"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "二进制内容"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "二進位內容"
+          }
         }
       }
     },
@@ -18928,6 +20086,30 @@
           "stringUnit" : {
             "value" : "대상을 맞추는 SQL 생성",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hedefi hizaya getiren SQL'i oluştur"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tạo SQL để đưa đích về đúng trạng thái"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生成让目标保持一致的 SQL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "產生讓目標保持一致的 SQL"
           }
         }
       }
@@ -19623,6 +20805,30 @@
           "stringUnit" : {
             "value" : "CREATE 구문",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CREATE ifadesi"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Câu lệnh CREATE"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CREATE 语句"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CREATE 陳述式"
           }
         }
       }
@@ -20427,6 +21633,30 @@
           "stringUnit" : {
             "value" : "스크립트가 끝나기 전에 취소되었습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Betik bitmeden iptal edildi."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã hủy trước khi script chạy xong."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "脚本完成前已取消。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "指令稿完成前已取消。"
           }
         }
       }
@@ -21817,6 +23047,30 @@
             "value" : "다른 행을 보려면 필터를 변경하십시오.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diğer satırları görmek için filtreyi değiştirin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thay đổi bộ lọc để xem các dòng khác."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更改筛选条件以查看其他行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "變更篩選條件以查看其他列。"
+          }
         }
       }
     },
@@ -21863,6 +23117,30 @@
             "value" : "변경 사항",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Değişiklikler"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thay đổi"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更改"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "變更"
+          }
         }
       }
     },
@@ -21879,6 +23157,30 @@
             "value" : "%@을(를) %@에서 %@(으)로 변경하면 기존 값이 잘릴 수 있습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ sütununu %2$@ türünden %3$@ türüne değiştirmek mevcut değerleri kısaltabilir."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đổi %1$@ từ %2$@ sang %3$@ có thể cắt ngắn các giá trị hiện có."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将 %1$@ 从 %2$@ 改为 %3$@ 可能会截断现有值。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將 %1$@ 從 %2$@ 改為 %3$@ 可能會截斷現有值。"
+          }
         }
       }
     },
@@ -21889,6 +23191,30 @@
             "value" : "%@의 콜레이션을 변경하면 정렬 순서와 고유성이 달라질 수 있습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ karşılaştırmasını değiştirmek sıralama düzenini ve benzersizliği değiştirebilir."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đổi đối chiếu của %@ có thể thay đổi thứ tự sắp xếp và tính duy nhất."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更改 %@ 的排序规则可能会改变排序顺序和唯一性。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "變更 %@ 的定序可能會改變排序順序和唯一性。"
+          }
         }
       }
     },
@@ -21898,6 +23224,30 @@
           "stringUnit" : {
             "value" : "기본 키를 변경하면 테이블을 다시 만들며, 값이 중복되면 실패할 수 있습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Birincil anahtarı değiştirmek tabloyu yeniden oluşturur ve yinelenen değerlerde başarısız olabilir."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đổi khóa chính sẽ dựng lại bảng và có thể thất bại khi có giá trị trùng lặp."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更改主键会重建表，并可能因重复值而失败。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "變更主鍵會重建資料表，並可能因重複值而失敗。"
           }
         }
       }
@@ -22600,6 +23950,30 @@
             "value" : "%@ 선택",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ seçin"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择 %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇 %@"
+          }
         }
       }
     },
@@ -23053,6 +24427,30 @@
             "value" : "데이터를 비교하기 전에 키 열을 선택하십시오.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Veriyi karşılaştırmadan önce bir anahtar sütun seçin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn cột khóa trước khi so sánh dữ liệu."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比较数据前请先选择键列。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比較資料前請先選擇鍵欄位。"
+          }
         }
       }
     },
@@ -23268,6 +24666,30 @@
             "value" : "먼저 원본과 대상을 선택하십시오.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Önce bir kaynak ve bir hedef seçin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hãy chọn nguồn và đích trước."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请先选择来源和目标。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請先選擇來源和目標。"
+          }
         }
       }
     },
@@ -23277,6 +24699,30 @@
           "stringUnit" : {
             "value" : "원본과 대상을 선택한 다음 비교하십시오.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bir kaynak ve bir hedef seçin, sonra karşılaştırın."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn nguồn và đích, rồi so sánh chúng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择来源和目标，然后比较它们。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇來源和目標，然後比較它們。"
           }
         }
       }
@@ -23288,6 +24734,30 @@
             "value" : "먼저 원본 또는 대상을 선택하십시오.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Önce bir kaynak ya da bir hedef seçin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hãy chọn nguồn hoặc đích trước."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请先选择来源或目标。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請先選擇來源或目標。"
+          }
         }
       }
     },
@@ -23297,6 +24767,30 @@
           "stringUnit" : {
             "value" : "비교할 원본을 선택하십시오.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştırmanın yapılacağı kaynağı seçin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn nguồn để so sánh từ đó."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择作为比较起点的来源。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇作為比較起點的來源。"
           }
         }
       }
@@ -23308,6 +24802,30 @@
             "value" : "비교 대상을 선택하십시오.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştırılacak hedefi seçin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn đích để so sánh với."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择用于比较的目标。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇用於比較的目標。"
+          }
         }
       }
     },
@@ -23317,6 +24835,30 @@
           "stringUnit" : {
             "value" : "기록할 대상을 선택하십시오.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yazılacak hedefi seçin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn đích để ghi vào."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择要写入的目标。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇要寫入的目標。"
           }
         }
       }
@@ -25729,6 +27271,30 @@
             "state" : "translated",
             "value" : "윈도우 닫기"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pencereyi Kapat"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đóng cửa sổ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭窗口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉視窗"
+          }
         }
       }
     },
@@ -25945,6 +27511,30 @@
           "stringUnit" : {
             "value" : "지금 닫으면 구문 사이에서 실행이 중단됩니다. 이미 실행된 구문은 적용된 상태로 남습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Şimdi kapatmak çalıştırmayı ifadeler arasında durdurur. Zaten çalışmış ifadeler uygulanmış kalır."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đóng bây giờ sẽ dừng lần chạy giữa các câu lệnh. Những câu lệnh đã chạy vẫn được giữ nguyên."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "现在关闭会在语句之间停止运行。已经执行的语句仍保持已应用。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在關閉會在陳述式之間停止執行。已經執行的陳述式仍保持已套用。"
           }
         }
       }
@@ -26569,6 +28159,30 @@
             "value" : "콜레이션 및 문자 집합",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştırma ve karakter kümesi"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đối chiếu và bộ ký tự"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排序规则和字符集"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "定序和字集"
+          }
         }
       }
     },
@@ -26578,6 +28192,30 @@
           "stringUnit" : {
             "value" : "콜레이션 또는 문자 집합 변경",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştırma veya karakter kümesi değişikliği"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thay đổi đối chiếu hoặc bộ ký tự"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排序规则或字符集更改"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "定序或字集變更"
           }
         }
       }
@@ -27046,6 +28684,30 @@
             "value" : "열 순서",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sütun sırası"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thứ tự cột"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列顺序"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位順序"
+          }
         }
       }
     },
@@ -27055,6 +28717,30 @@
           "stringUnit" : {
             "value" : "열 순서가 다릅니다. 열 순서를 바꾸는 구문은 생성되지 않습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sütun sırası farklı. Sütunları yeniden sıralamak için ifade üretilmez."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thứ tự cột khác nhau. Không có câu lệnh nào được tạo để sắp xếp lại cột."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列顺序不同。不会为重排列生成任何语句。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位順序不同。不會為重新排列欄位產生任何陳述式。"
           }
         }
       }
@@ -27544,6 +29230,30 @@
             "value" : "주석 및 소유자",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yorumlar ve sahipler"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chú thích và chủ sở hữu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "注释和所有者"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "註解和擁有者"
+          }
         }
       }
     },
@@ -27662,6 +29372,30 @@
             "value" : "%@을(를) 비교하고 변경 사항을 %@에 기록합니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ karşılaştırılır ve değişiklikler %2$@ üzerine yazılır."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "So sánh %1$@ và ghi thay đổi vào %2$@."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比较 %1$@ 并将更改写入 %2$@。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比較 %1$@ 並將變更寫入 %2$@。"
+          }
         }
       }
     },
@@ -27671,6 +29405,30 @@
           "stringUnit" : {
             "value" : "비교 및 동기화",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştır ve Eşitle"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "So sánh & Đồng bộ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比较与同步"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比較與同步"
           }
         }
       }
@@ -27682,6 +29440,30 @@
             "value" : "데이터베이스 비교 및 동기화…",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Veritabanlarını Karşılaştır ve Eşitle…"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "So sánh & Đồng bộ cơ sở dữ liệu…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比较与同步数据库…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比較與同步資料庫…"
+          }
         }
       }
     },
@@ -27691,6 +29473,30 @@
           "stringUnit" : {
             "value" : "비교 및 동기화에는 라이선스가 필요합니다",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştır ve Eşitle bir lisans gerektirir"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "So sánh & Đồng bộ cần có giấy phép"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比较与同步需要许可证"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比較與同步需要授權"
           }
         }
       }
@@ -27702,6 +29508,30 @@
             "value" : "지금 비교",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Şimdi Karşılaştır"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "So sánh ngay"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即比较"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即比較"
+          }
         }
       }
     },
@@ -27711,6 +29541,30 @@
           "stringUnit" : {
             "value" : "비교는 양쪽이 공유하는 테이블을 나열합니다. 비교할 테이블을 선택한 다음 비교를 누르십시오.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştırma, iki tarafın da paylaştığı tabloları listeler. Karşılaştırılacak tabloları seçin, sonra Karşılaştır'a basın."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "So sánh liệt kê các bảng có ở cả hai bên. Chọn các bảng cần so sánh, rồi nhấn So sánh."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比较会列出双方共有的表。选择要比较的表，然后点按“比较”。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比較會列出雙方共有的資料表。選擇要比較的資料表，然後按下「比較」。"
           }
         }
       }
@@ -27722,6 +29576,30 @@
             "value" : "구조 또는 데이터 비교",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yapıyı veya veriyi karşılaştır"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "So sánh cấu trúc hoặc dữ liệu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比较结构或数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比較結構或資料"
+          }
         }
       }
     },
@@ -27731,6 +29609,30 @@
           "stringUnit" : {
             "value" : "두 연결 사이의 구조 또는 데이터를 비교하고 동기화 스크립트를 생성합니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İki bağlantı arasında yapıyı veya veriyi karşılaştırın ve eşitleme betiğini oluşturun."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "So sánh cấu trúc hoặc dữ liệu giữa hai kết nối và tạo script đồng bộ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比较两个连接之间的结构或数据，并生成同步脚本。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比較兩個連線之間的結構或資料，並產生同步指令稿。"
           }
         }
       }
@@ -27742,6 +29644,30 @@
             "value" : "두 데이터베이스 비교",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İki veritabanını karşılaştır"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "So sánh hai cơ sở dữ liệu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比较这两个数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比較這兩個資料庫"
+          }
         }
       }
     },
@@ -27752,6 +29678,30 @@
             "value" : "먼저 두 데이터베이스를 비교하십시오.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Önce iki veritabanını karşılaştırın."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hãy so sánh hai cơ sở dữ liệu trước."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请先比较这两个数据库。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請先比較這兩個資料庫。"
+          }
         }
       }
     },
@@ -27761,6 +29711,30 @@
           "stringUnit" : {
             "value" : "다음과 비교/동기화…",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Şununla Karşılaştır/Eşitle…"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "So sánh/Đồng bộ với…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "与之比较/同步…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "與之比較/同步…"
           }
         }
       }
@@ -27778,6 +29752,30 @@
             "value" : "%1$@을(를) 비교했습니다. 차이점 %2$d개. 아무것도 기록되지 않았습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ karşılaştırıldı. %2$d fark. Hiçbir şey yazılmadı."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã so sánh %1$@. %2$d khác biệt. Chưa ghi gì cả."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已比较 %1$@。%2$d 处差异。尚未写入任何内容。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已比較 %1$@。%2$d 處差異。尚未寫入任何內容。"
+          }
         }
       }
     },
@@ -27787,6 +29785,30 @@
           "stringUnit" : {
             "value" : "%@을(를) 비교했습니다. 차이점 1개. 아무것도 기록되지 않았습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ karşılaştırıldı. 1 fark. Hiçbir şey yazılmadı."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã so sánh %@. 1 khác biệt. Chưa ghi gì cả."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已比较 %@。1 处差异。尚未写入任何内容。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已比較 %@。1 處差異。尚未寫入任何內容。"
           }
         }
       }
@@ -27798,6 +29820,30 @@
             "value" : "비교한 열",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştırılan sütunlar"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cột được so sánh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已比较的列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已比較的欄位"
+          }
         }
       }
     },
@@ -27808,6 +29854,30 @@
             "value" : "비교만 했습니다. 아무것도 기록되지 않았습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yalnızca karşılaştırılıyor. Hiçbir şey yazılmadı."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chỉ so sánh. Chưa ghi gì cả."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅比较。尚未写入任何内容。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅比較。尚未寫入任何內容。"
+          }
         }
       }
     },
@@ -27817,6 +29887,30 @@
           "stringUnit" : {
             "value" : "비교 옵션…",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştırma Seçenekleri…"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tùy chọn so sánh…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比较选项…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比較選項…"
           }
         }
       }
@@ -27861,6 +29955,30 @@
           "stringUnit" : {
             "value" : "비교가 취소되었습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştırma iptal edildi."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã hủy so sánh."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已取消比较。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已取消比較。"
           }
         }
       }
@@ -28178,6 +30296,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "쓰기 확인"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yazmaları Onayla"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xác nhận ghi"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "确认写入"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確認寫入"
           }
         }
       }
@@ -29413,6 +31555,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "연결 실패: %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bağlantı başarısız: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết nối thất bại: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连接失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線失敗：%@"
           }
         }
       }
@@ -32347,6 +34513,30 @@
             "value" : "비교할 수 없음",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştırılamadı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể so sánh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法比较"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法比較"
+          }
         }
       }
     },
@@ -32560,6 +34750,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이 서버와 Oracle 네이티브 네트워크 암호화를 완료할 수 없습니다. 서버에서 드라이버가 지원하지 않는 암호화 또는 체크섬 알고리즘을 요구할 수 있습니다."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu sunucuyla Oracle yerel ağ şifrelemesi tamamlanamadı. Sürücünün desteklemediği bir şifreleme veya sağlama algoritması gerekiyor olabilir."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể hoàn tất mã hóa mạng gốc của Oracle với máy chủ này. Có thể nó yêu cầu thuật toán mã hóa hoặc checksum mà driver không hỗ trợ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法与此服务器完成 Oracle 原生网络加密。它可能需要驱动不支持的加密或校验和算法。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法與此伺服器完成 Oracle 原生網路加密。它可能需要驅動程式不支援的加密或總和檢查碼演算法。"
           }
         }
       }
@@ -33849,6 +36063,30 @@
             "value" : "%1$@ %2$@ 생성",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@ oluştur"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tạo %1$@ %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "创建 %1$@ %2$@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立 %1$@ %2$@"
+          }
         }
       }
     },
@@ -34551,6 +36789,30 @@
           "stringUnit" : {
             "value" : "테이블 %@ 생성",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ tablosunu oluştur"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tạo bảng %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "创建表 %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立資料表 %@"
           }
         }
       }
@@ -36071,6 +38333,30 @@
             "value" : "데이터 비교",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Veri Karşılaştırması"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "So sánh dữ liệu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数据比较"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料比較"
+          }
         }
       }
     },
@@ -36251,6 +38537,30 @@
           "stringUnit" : {
             "value" : "데이터 손실",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Veri kaybı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mất dữ liệu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数据丢失"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料遺失"
           }
         }
       }
@@ -38283,6 +40593,30 @@
             "value" : "정의",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tanımlar"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Định nghĩa"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "定义"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "定義"
+          }
         }
       }
     },
@@ -38292,6 +40626,30 @@
           "stringUnit" : {
             "value" : "정의는 구조를 비교합니다",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tanımlar Yapı Karşılaştırmasında"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Định nghĩa thuộc so sánh cấu trúc"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "定义属于结构比较"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "定義屬於結構比較"
           }
         }
       }
@@ -39254,6 +41612,30 @@
             "value" : "삭제는 기본적으로 꺼져 있으므로, 첫 실행에서는 대상의 행을 제거할 수 없습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Silme varsayılan olarak kapalıdır, bu yüzden ilk çalıştırma hedeften satır kaldıramaz."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa mặc định tắt, nên lần chạy đầu tiên không thể xóa dòng khỏi đích."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除默认关闭，因此首次运行不会从目标中删除任何行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除預設關閉，因此首次執行不會從目標中刪除任何列。"
+          }
         }
       }
     },
@@ -39270,6 +41652,30 @@
             "value" : "%2$@에서 행 %1$@ 삭제",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%2$@ içinden %1$@ satırını sil"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa dòng %1$@ khỏi %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从 %2$@ 删除行 %1$@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從 %2$@ 刪除列 %1$@"
+          }
         }
       }
     },
@@ -39279,6 +41685,30 @@
           "stringUnit" : {
             "value" : "원본에 없는 행 삭제",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaynakta olmayan satırları sil"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa các dòng mà nguồn không có"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除来源中没有的行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除來源中沒有的列"
           }
         }
       }
@@ -39567,6 +41997,30 @@
           "stringUnit" : {
             "value" : "%2$@에서 행 %1$@을(를) 삭제하면 영구적으로 제거됩니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%2$@ içinden %1$@ satırını silmek onu kalıcı olarak kaldırır."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa dòng %1$@ khỏi %2$@ sẽ loại bỏ nó vĩnh viễn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从 %2$@ 删除行 %1$@ 会将其永久移除。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從 %2$@ 刪除列 %1$@ 會將其永久移除。"
           }
         }
       }
@@ -40054,6 +42508,30 @@
             "value" : "세부사항",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ayrıntı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chi tiết"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "详情"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "詳細資訊"
+          }
         }
       }
     },
@@ -40302,6 +42780,30 @@
             "value" : "차이점",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fark"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khác biệt"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "差异"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "差異"
+          }
         }
       }
     },
@@ -40311,6 +42813,30 @@
           "stringUnit" : {
             "value" : "다름",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Farklı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khác nhau"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有差异"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有差異"
           }
         }
       }
@@ -41896,6 +44422,30 @@
             "value" : "%1$@ %2$@ 삭제",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@ sil"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa %1$@ %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除 %1$@ %2$@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除 %1$@ %2$@"
+          }
         }
       }
     },
@@ -42840,6 +45390,30 @@
             "value" : "테이블 %@ 삭제",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ tablosunu sil"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa bảng %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除表 %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除資料表 %@"
+          }
         }
       }
     },
@@ -42918,6 +45492,30 @@
             "value" : "%1$@ %2$@을(를) 삭제하면 대상에서 제거됩니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@ silmek onu hedeften kaldırır."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa %1$@ %2$@ sẽ loại bỏ nó khỏi đích."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除 %1$@ %2$@ 会将其从目标中移除。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除 %1$@ %2$@ 會將其從目標中移除。"
+          }
         }
       }
     },
@@ -42927,6 +45525,30 @@
           "stringUnit" : {
             "value" : "열 %@을(를) 삭제하면 해당 데이터가 영구적으로 제거됩니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ sütununu silmek verisini kalıcı olarak kaldırır."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa cột %@ sẽ loại bỏ dữ liệu của nó vĩnh viễn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除列 %@ 会永久移除其数据。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除欄位 %@ 會永久移除其資料。"
           }
         }
       }
@@ -42938,6 +45560,30 @@
             "value" : "인덱스 %@을(를) 삭제하면 기존 쿼리가 느려질 수 있습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ indeksini silmek mevcut sorguları yavaşlatabilir."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa chỉ mục %@ có thể làm chậm các truy vấn hiện có."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除索引 %@ 可能会拖慢现有查询。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除索引 %@ 可能會拖慢現有查詢。"
+          }
         }
       }
     },
@@ -42948,6 +45594,30 @@
             "value" : "구체화 뷰 %@을(를) 삭제하면 저장된 행이 버려지며, 다시 만들어야 합니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ materyalize görünümünü silmek saklanan satırlarını atar; bunların yeniden oluşturulması gerekir."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa materialized view %@ sẽ bỏ các dòng đã lưu của nó, và chúng phải được dựng lại."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除物化视图 %@ 会丢弃其存储的行，这些行必须重建。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除具體化檢視表 %@ 會捨棄其儲存的列，這些列必須重建。"
+          }
         }
       }
     },
@@ -42957,6 +45627,30 @@
           "stringUnit" : {
             "value" : "테이블 %@을(를) 삭제하면 테이블과 모든 행이 영구적으로 제거됩니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ tablosunu silmek tabloyu ve tüm satırlarını kalıcı olarak kaldırır."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa bảng %@ sẽ loại bỏ vĩnh viễn bảng và toàn bộ dòng của nó."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除表 %@ 会永久移除该表及其所有行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除資料表 %@ 會永久移除該資料表及其所有列。"
           }
         }
       }
@@ -47192,6 +49886,30 @@
             "value" : "비교한 모든 객체가 일치합니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştırılan her nesne eşleşiyor."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mọi đối tượng được so sánh đều khớp."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有被比较的对象都相同。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有被比較的物件都相同。"
+          }
         }
       }
     },
@@ -47201,6 +49919,30 @@
           "stringUnit" : {
             "value" : "공유하는 모든 열이 생성 열이므로 기록할 내용이 없습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paylaşılan her sütun üretilmiş sütundur, bu yüzden yazılacak bir şey yok."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mọi cột chung đều là cột được sinh ra, nên không có gì để ghi."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有共有的列都是生成列，因此没有需要写入的内容。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有共有的欄位都是產生欄位，因此沒有需要寫入的內容。"
           }
         }
       }
@@ -47280,6 +50022,30 @@
             "value" : "정확한 값",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tam değer"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giá trị chính xác"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "精确值"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "精確值"
+          }
         }
       }
     },
@@ -47358,6 +50124,30 @@
             "value" : "제외",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hariç Tut"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loại trừ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排除"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排除"
+          }
         }
       }
     },
@@ -47367,6 +50157,30 @@
           "stringUnit" : {
             "value" : "모든 테이블 제외",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Her Tabloyu Hariç Tut"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loại trừ mọi bảng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排除所有表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排除所有資料表"
           }
         }
       }
@@ -47992,6 +50806,30 @@
           "stringUnit" : {
             "value" : "실행",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çalıştırma"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thực thi"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "执行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行"
           }
         }
       }
@@ -51091,6 +53929,30 @@
             "state" : "translated",
             "value" : "연결을 설정하지 못했습니다"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bağlantı kurulamadı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thiết lập được kết nối"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法建立连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法建立連線"
+          }
         }
       }
     },
@@ -53480,6 +56342,30 @@
             "value" : "이름으로 필터링",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ada göre filtrele"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lọc theo tên"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按名称筛选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "依名稱篩選"
+          }
         }
       }
     },
@@ -54347,6 +57233,30 @@
             "state" : "translated",
             "value" : "불러온 행에서 찾기"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yüklenen satırlarda bul"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tìm trong các dòng đã tải"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在已加载的行中查找"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在已載入的列中尋找"
+          }
         }
       }
     },
@@ -54458,6 +57368,30 @@
           "stringUnit" : {
             "value" : "완료됨",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bitti"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã xong"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已完成"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已完成"
           }
         }
       }
@@ -54879,6 +57813,30 @@
             "value" : "접기",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Katla"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thu gọn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "折叠"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "摺疊"
+          }
         }
       }
     },
@@ -55278,6 +58236,30 @@
           "stringUnit" : {
             "value" : "외래 키 %@은(는) 대상의 %@과(와) 일치하지만 이름이 다릅니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ yabancı anahtarı hedefteki %2$@ ile eşleşiyor ama adları farklı."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khóa ngoại %1$@ khớp với %2$@ trên đích nhưng tên khác nhau."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外键 %1$@ 与目标上的 %2$@ 相同，但名称不同。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外鍵 %1$@ 與目標上的 %2$@ 相同，但名稱不同。"
           }
         }
       }
@@ -55972,6 +58954,30 @@
             "value" : "스크립트 생성",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Betik Oluştur"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tạo script"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生成脚本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "產生指令稿"
+          }
         }
       }
     },
@@ -56050,6 +59056,30 @@
             "value" : "먼저 스크립트를 생성하십시오.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Önce betiği oluşturun."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hãy tạo script trước."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请先生成脚本。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請先產生指令稿。"
+          }
         }
       }
     },
@@ -56059,6 +59089,30 @@
           "stringUnit" : {
             "value" : "무엇이 실행될지 정확히 보려면 스크립트를 생성하십시오.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tam olarak neyin çalışacağını görmek için betiği oluşturun."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tạo script để xem chính xác những gì sẽ chạy."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生成脚本以准确查看将要运行的内容。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "產生指令稿以準確查看將要執行的內容。"
           }
         }
       }
@@ -57093,6 +60147,30 @@
             "value" : "그룹화 기준",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grupla"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhóm theo"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分组方式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分組方式"
+          }
         }
       }
     },
@@ -57136,6 +60214,30 @@
           "stringUnit" : {
             "value" : "차이점 또는 객체 유형으로 결과 그룹화",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sonuçları farka veya nesne türüne göre grupla"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhóm kết quả theo khác biệt hoặc loại đối tượng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按差异或对象类型对结果分组"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "依差異或物件類型將結果分組"
           }
         }
       }
@@ -57215,6 +60317,30 @@
             "value" : "차이 있음",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fark Var"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Có khác biệt"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "存在差异"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "存在差異"
+          }
         }
       }
     },
@@ -57259,6 +60385,30 @@
             "value" : "보류됨",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutuldu"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bị giữ lại"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已保留"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已保留"
+          }
         }
       }
     },
@@ -57268,6 +60418,30 @@
           "stringUnit" : {
             "value" : "보류됨",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutuldu"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bị giữ lại"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已保留"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已保留"
           }
         }
       }
@@ -58649,6 +61823,30 @@
             "value" : "동일",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aynı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giống hệt"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完全相同"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完全相同"
+          }
         }
       }
     },
@@ -58658,6 +61856,30 @@
           "stringUnit" : {
             "value" : "식별자 대소문자",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tanımlayıcı büyük/küçük harf"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kiểu chữ của định danh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标识符大小写"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "識別碼大小寫"
           }
         }
       }
@@ -60219,6 +63441,30 @@
             "value" : "포함",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dahil Et"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bao gồm"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "納入"
+          }
         }
       }
     },
@@ -60262,6 +63508,30 @@
           "stringUnit" : {
             "value" : "모든 테이블 포함",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Her Tabloyu Dahil Et"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bao gồm mọi bảng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含所有表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "納入所有資料表"
           }
         }
       }
@@ -60342,6 +63612,30 @@
             "value" : "스크립트를 생성하려면 객체를 하나 이상 포함하십시오.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bir betik oluşturmak için en az bir nesne dahil edin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hãy bao gồm ít nhất một đối tượng để tạo script cho nó."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请至少包含一个对象，才能为其生成脚本。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請至少納入一個物件，才能為其產生指令稿。"
+          }
         }
       }
     },
@@ -60351,6 +63645,30 @@
           "stringUnit" : {
             "value" : "스크립트를 생성하려면 테이블을 하나 이상 포함하십시오.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bir betik oluşturmak için en az bir tablo dahil edin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hãy bao gồm ít nhất một bảng để tạo script cho nó."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请至少包含一个表，才能为其生成脚本。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請至少納入一個資料表，才能為其產生指令稿。"
           }
         }
       }
@@ -60500,6 +63818,30 @@
             "value" : "이 그룹의 모든 객체 포함",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu gruptaki her nesneyi dahil et"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bao gồm mọi đối tượng trong nhóm này"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含此分组中的所有对象"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "納入此分組中的所有物件"
+          }
         }
       }
     },
@@ -60509,6 +63851,30 @@
           "stringUnit" : {
             "value" : "이 그룹의 모든 테이블 포함",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu gruptaki her tabloyu dahil et"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bao gồm mọi bảng trong nhóm này"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含此分组中的所有表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "納入此分組中的所有資料表"
           }
         }
       }
@@ -60656,6 +64022,30 @@
             "value" : "이 객체 포함",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu nesneyi dahil et"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bao gồm đối tượng này"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含此对象"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "納入此物件"
+          }
         }
       }
     },
@@ -60665,6 +64055,30 @@
           "stringUnit" : {
             "value" : "이 행 포함",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu satırı dahil et"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bao gồm dòng này"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含此行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "納入此列"
           }
         }
       }
@@ -60676,6 +64090,30 @@
             "value" : "행을 보려면 이 테이블을 포함하고 다시 비교하십시오.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Satırlarını görmek için bu tabloyu dahil edin ve yeniden karşılaştırın."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hãy bao gồm bảng này rồi so sánh lại để xem các dòng của nó."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含此表并重新比较，即可查看它的行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "納入此資料表並重新比較，即可查看它的列。"
+          }
         }
       }
     },
@@ -60685,6 +64123,30 @@
           "stringUnit" : {
             "value" : "이 테이블을 비교에 포함",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu tabloyu karşılaştırmaya dahil et"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bao gồm bảng này trong so sánh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将此表包含在比较中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將此資料表納入比較"
           }
         }
       }
@@ -60872,6 +64334,30 @@
           "stringUnit" : {
             "value" : "인덱스 %@은(는) 대상의 %@과(와) 일치하지만 이름이 다릅니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ indeksi hedefteki %2$@ ile eşleşiyor ama adları farklı."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chỉ mục %1$@ khớp với %2$@ trên đích nhưng tên khác nhau."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "索引 %1$@ 与目标上的 %2$@ 相同，但名称不同。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "索引 %1$@ 與目標上的 %2$@ 相同，但名稱不同。"
           }
         }
       }
@@ -61612,6 +65098,30 @@
             "value" : "%2$@에 행 %1$@ 삽입",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ satırını %2$@ içine ekle"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chèn dòng %1$@ vào %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将行 %1$@ 插入 %2$@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將列 %1$@ 插入 %2$@"
+          }
         }
       }
     },
@@ -61621,6 +65131,30 @@
           "stringUnit" : {
             "value" : "대상에 없는 행 삽입",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hedefte eksik olan satırları ekle"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chèn các dòng mà đích còn thiếu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "插入目标中缺少的行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "插入目標中缺少的列"
           }
         }
       }
@@ -63926,6 +67460,30 @@
             "state" : "translated",
             "value" : "Kerberos 인증 실패: %@"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kerberos kimlik doğrulaması başarısız: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xác thực Kerberos thất bại: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kerberos 认证失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kerberos 驗證失敗：%@"
+          }
         }
       }
     },
@@ -64106,6 +67664,30 @@
             "value" : "키 열 %@이(가) 양쪽에 모두 있지는 않습니다. 다른 키를 선택하십시오.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ anahtar sütunu iki tarafta da yok. Farklı bir anahtar seçin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cột khóa %@ không có ở cả hai bên. Hãy chọn khóa khác."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "键列 %@ 并非双方都有。请选择其他键。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鍵欄位 %@ 並非雙方都有。請選擇其他鍵。"
+          }
         }
       }
     },
@@ -64115,6 +67697,30 @@
           "stringUnit" : {
             "value" : "키 열",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anahtar sütunlar"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cột khóa"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "键列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鍵欄位"
           }
         }
       }
@@ -68533,6 +72139,30 @@
             "value" : "손실이 있는 타입 변경",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kayıplı tür değişikliği"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thay đổi kiểu gây mất dữ liệu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有损的类型更改"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有損的型別變更"
+          }
         }
       }
     },
@@ -69202,6 +72832,30 @@
             "value" : "대상을 원본으로, 원본을 대상으로 바꿉니다",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hedefi kaynak, kaynağı hedef yap"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đổi đích thành nguồn và nguồn thành đích"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "把目标变成来源，把来源变成目标"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "把目標變成來源，把來源變成目標"
+          }
         }
       }
     },
@@ -69211,6 +72865,30 @@
           "stringUnit" : {
             "value" : "기존 행에 NULL이 있으면 %@을(를) NOT NULL로 만드는 작업은 실패합니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ sütununu NOT NULL yapmak, mevcut herhangi bir satır NULL tutuyorsa başarısız olur."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đặt %@ thành NOT NULL sẽ thất bại nếu có dòng hiện tại chứa NULL."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果现有任何行为 NULL，将 %@ 设为 NOT NULL 会失败。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果現有任何列為 NULL，將 %@ 設為 NOT NULL 會失敗。"
           }
         }
       }
@@ -73130,6 +76808,30 @@
             "value" : "NULL은 NULL과만 같음",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NULL yalnızca NULL'a eşittir"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NULL chỉ bằng NULL"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NULL 只等于 NULL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NULL 只等於 NULL"
+          }
         }
       }
     },
@@ -75236,6 +78938,30 @@
             "state" : "translated",
             "value" : "다음 일치 항목"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sonraki eşleşme"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết quả khớp tiếp theo"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一个匹配"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一個符合項目"
+          }
         }
       }
     },
@@ -75517,6 +79243,30 @@
           "stringUnit" : {
             "value" : "아직 비교하지 않음",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Henüz Karşılaştırma Yok"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa có so sánh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚无比较"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚無比較"
           }
         }
       }
@@ -75800,6 +79550,30 @@
             "value" : "차이 없음",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fark Yok"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có khác biệt"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有差异"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有差異"
+          }
         }
       }
     },
@@ -76049,6 +79823,30 @@
             "value" : "Microsoft Entra ID 액세스 토큰이 제공되지 않았습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Microsoft Entra ID erişim belirteci sağlanmadı."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có access token Microsoft Entra ID nào được cung cấp."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未提供 Microsoft Entra ID 访问令牌。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未提供 Microsoft Entra ID 存取權杖。"
+          }
         }
       }
     },
@@ -76128,6 +79926,30 @@
           "stringUnit" : {
             "value" : "객체 없음",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nesne Yok"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có đối tượng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无对象"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無物件"
           }
         }
       }
@@ -76448,6 +80270,30 @@
             "state" : "translated",
             "value" : "결과 없음"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sonuç Yok"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có kết quả"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无结果"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無結果"
+          }
         }
       }
     },
@@ -76457,6 +80303,30 @@
           "stringUnit" : {
             "value" : "일치하는 행 없음",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eşleşen Satır Yok"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có dòng nào khớp"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有匹配的行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有相符的列"
           }
         }
       }
@@ -76538,6 +80408,30 @@
             "value" : "아직 스크립트 없음",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Henüz Betik Yok"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa có script"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚无脚本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚無指令稿"
+          }
         }
       }
     },
@@ -76581,6 +80475,30 @@
           "stringUnit" : {
             "value" : "선택된 테이블 없음",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tablo Seçilmedi"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa chọn bảng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未选择表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未選擇資料表"
           }
         }
       }
@@ -76626,6 +80544,30 @@
           "stringUnit" : {
             "value" : "아직 테이블 없음",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Henüz Tablo Yok"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa có bảng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚无表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚無資料表"
           }
         }
       }
@@ -76704,6 +80646,30 @@
           "stringUnit" : {
             "value" : "경고 없음",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uyarı Yok"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có cảnh báo"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有警告"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有警告"
           }
         }
       }
@@ -77062,6 +81028,30 @@
             "value" : "공통된 열이 없습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ortak sütun yok."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có cột chung."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有共有的列。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有共有的欄位。"
+          }
         }
       }
     },
@@ -77071,6 +81061,30 @@
           "stringUnit" : {
             "value" : "아직 비교하지 않았습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Henüz karşılaştırma yok."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa có so sánh."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚无比较。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚無比較。"
           }
         }
       }
@@ -77874,6 +81888,30 @@
             "state" : "translated",
             "value" : "일치 항목 없음"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eşleşme yok"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có kết quả khớp"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有匹配"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有符合項目"
+          }
         }
       }
     },
@@ -78506,6 +82544,30 @@
             "state" : "translated",
             "value" : "아직 신뢰하는 플러그인 개발자가 없습니다."
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Henüz güvenilen eklenti geliştiricisi yok."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa tin cậy nhà phát triển plugin nào."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚未信任任何插件开发者。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚未信任任何外掛開發者。"
+          }
         }
       }
     },
@@ -78585,6 +82647,30 @@
           "stringUnit" : {
             "value" : "기본 키가 없습니다. 이 테이블을 비교하려면 키 열을 선택하십시오.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Birincil anahtar yok. Bu tabloyu karşılaştırmak için anahtar sütunlar seçin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có khóa chính. Hãy chọn cột khóa để so sánh bảng này."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有主键。请选择键列来比较此表。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有主鍵。請選擇鍵欄位來比較此資料表。"
           }
         }
       }
@@ -79177,6 +83263,30 @@
             "value" : "이 원본과 대상에 저장된 설정이 없습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu kaynak ve hedef için kayıtlı kurulum yok."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có thiết lập nào đã lưu cho nguồn và đích này."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此来源和目标没有已保存的设置。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此來源和目標沒有已儲存的設定。"
+          }
         }
       }
     },
@@ -79532,6 +83642,30 @@
             "value" : "비교한 테이블이 없습니다. 비교할 테이블을 선택한 다음 비교를 누르십시오.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hiçbir tablo karşılaştırılmadı. Karşılaştırılacak tabloları seçin, sonra Karşılaştır'a basın."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa có bảng nào được so sánh. Chọn các bảng cần so sánh, rồi nhấn So sánh."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有比较任何表。选择要比较的表，然后点按“比较”。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有比較任何資料表。選擇要比較的資料表，然後按下「比較」。"
+          }
         }
       }
     },
@@ -79883,6 +84017,30 @@
             "value" : "선택 없음",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hiçbiri seçilmedi"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa chọn gì"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未选择任何项"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未選擇任何項目"
+          }
         }
       }
     },
@@ -79961,6 +84119,30 @@
             "value" : "비교하지 않음",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştırılmadı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa so sánh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未比较"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未比較"
+          }
         }
       }
     },
@@ -79970,6 +84152,30 @@
           "stringUnit" : {
             "value" : "아직 비교하지 않음",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Henüz Karşılaştırılmadı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa so sánh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚未比较"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚未比較"
           }
         }
       }
@@ -80048,6 +84254,30 @@
           "stringUnit" : {
             "value" : "비교하지 않음",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştırılmadı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa so sánh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未比较"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未比較"
           }
         }
       }
@@ -80196,6 +84426,30 @@
             "state" : "translated",
             "value" : "SQL Server에 연결되지 않았습니다"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL Server'a bağlı değil"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa kết nối tới SQL Server"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未连接到 SQL Server"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未連線到 SQL Server"
+          }
         }
       }
     },
@@ -80307,6 +84561,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이 페이지에 없음"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu sayfada değil"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có ở trang này"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不在本页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不在本頁"
           }
         }
       }
@@ -80556,6 +84834,30 @@
             "value" : "대상에서 지원하지 않음",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hedef tarafından desteklenmiyor"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đích không hỗ trợ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目标不支持"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標不支援"
+          }
         }
       }
     },
@@ -80736,6 +85038,30 @@
             "value" : "참고",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notlar"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ghi chú"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "备注"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "備註"
+          }
         }
       }
     },
@@ -80781,6 +85107,30 @@
             "value" : "이 스크립트에는 %@의 데이터를 파괴하는 내용이 없습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu betikte %@ içindeki veriyi yok eden hiçbir şey yok."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có gì trong script này hủy dữ liệu trong %@."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此脚本中没有任何内容会销毁 %@ 中的数据。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此指令稿中沒有任何內容會銷毀 %@ 中的資料。"
+          }
         }
       }
     },
@@ -80790,6 +85140,30 @@
           "stringUnit" : {
             "value" : "실행 중인 작업이 없습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çalışan bir şey yok."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có gì đang chạy."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有正在运行的内容。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有正在執行的內容。"
           }
         }
       }
@@ -80801,6 +85175,30 @@
             "value" : "적용할 항목이 선택되지 않았습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uygulanacak bir şey seçilmedi."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa chọn gì để áp dụng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未选择任何要应用的内容。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未選擇任何要套用的內容。"
+          }
         }
       }
     },
@@ -80811,6 +85209,30 @@
             "value" : "적용하기 전에는 아무것도 기록되지 않습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uygula'ya kadar hiçbir şey yazılmaz."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có gì được ghi cho đến khi Áp dụng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在点按“应用”之前不会写入任何内容。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在按下「套用」之前不會寫入任何內容。"
+          }
         }
       }
     },
@@ -80820,6 +85242,30 @@
           "stringUnit" : {
             "value" : "표시할 내용 없음",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gösterilecek Bir Şey Yok"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có gì để hiển thị"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无内容可显示"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無內容可顯示"
           }
         }
       }
@@ -80968,6 +85414,30 @@
           "stringUnit" : {
             "value" : "숫자 허용 오차",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sayısal tolerans"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dung sai số"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数值容差"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "數值容差"
           }
         }
       }
@@ -81184,6 +85654,30 @@
             "value" : "객체 유형",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nesne Türü"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loại đối tượng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "对象类型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "物件類型"
+          }
         }
       }
     },
@@ -81229,6 +85723,30 @@
           "stringUnit" : {
             "value" : "비교할 객체",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştırılacak Nesneler"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đối tượng cần so sánh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要比较的对象"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要比較的物件"
           }
         }
       }
@@ -81513,6 +86031,30 @@
             "value" : "오류 발생 시",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hata durumunda"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khi có lỗi"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "出错时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "發生錯誤時"
+          }
         }
       }
     },
@@ -81557,6 +86099,30 @@
             "value" : "원본에만 있음",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yalnızca Kaynakta"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chỉ có ở nguồn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅在来源中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅在來源中"
+          }
         }
       }
     },
@@ -81566,6 +86132,30 @@
           "stringUnit" : {
             "value" : "대상에만 있음",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yalnızca Hedefte"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chỉ có ở đích"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅在目标中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅在目標中"
           }
         }
       }
@@ -81577,6 +86167,30 @@
             "state" : "translated",
             "value" : "처음 %1$lld개의 노드만 불러와 이 값을 전부 검색하지 못했습니다. 모든 내용을 검색하려면 %2$@ 옵션으로 전환하십시오."
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yalnızca ilk %1$lld düğüm yüklendi, bu yüzden bu değer tümüyle aranmadı. Tamamını aramak için %2$@ görünümüne geçin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chỉ %1$lld nút đầu tiên được tải, nên giá trị này chưa được tìm toàn bộ. Chuyển sang %2$@ để tìm toàn bộ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只加载了前 %1$lld 个节点，因此未完整搜索此值。切换到 %2$@ 以搜索全部内容。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只載入了前 %1$lld 個節點，因此未完整搜尋此值。切換到 %2$@ 以搜尋全部內容。"
+          }
         }
       }
     },
@@ -81586,6 +86200,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "처음 %1$lld개의 노드만 불러왔습니다. 전체 값을 보려면 %2$@ 옵션으로 전환하십시오."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yalnızca ilk %1$lld düğüm yüklendi. Değerin tamamını görmek için %2$@ görünümüne geçin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chỉ %1$lld nút đầu tiên được tải. Chuyển sang %2$@ để xem toàn bộ giá trị."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只加载了前 %1$lld 个节点。切换到 %2$@ 以查看完整值。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只載入了前 %1$lld 個節點。切換到 %2$@ 以查看完整值。"
           }
         }
       }
@@ -82659,6 +87297,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "스키마 열기…"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Şemayı Aç…"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mở schema…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开 Schema…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟綱要…"
           }
         }
       }
@@ -87808,6 +92470,30 @@
             "state" : "translated",
             "value" : "이 개발자가 서명한 플러그인은 다음에 TablePro를 시작할 때부터 로드되지 않습니다."
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu geliştiricinin imzaladığı eklentiler, TablePro'nun bir sonraki açılışında yüklenmeyi bırakır."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Các plugin do nhà phát triển này ký sẽ ngừng được tải trong lần khởi động TablePro tiếp theo."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此开发者签名的插件将在下次启动 TablePro 时停止加载。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此開發者簽署的外掛將在下次啟動 TablePro 時停止載入。"
+          }
         }
       }
     },
@@ -89408,6 +94094,30 @@
             "state" : "translated",
             "value" : "이전 일치 항목"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Önceki eşleşme"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết quả khớp trước"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一个匹配"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一個符合項目"
+          }
         }
       }
     },
@@ -89657,6 +94367,30 @@
           "stringUnit" : {
             "value" : "기본 키 변경",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Birincil anahtar değişikliği"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thay đổi khóa chính"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主键更改"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主鍵變更"
           }
         }
       }
@@ -91850,6 +96584,30 @@
             "state" : "translated",
             "value" : "쿼리 실행 실패"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sorgu çalıştırma başarısız"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thực thi truy vấn thất bại"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查询执行失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢執行失敗"
+          }
         }
       }
     },
@@ -91895,6 +96653,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "쿼리 실패: %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sorgu başarısız: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Truy vấn thất bại: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查询失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢失敗：%@"
           }
         }
       }
@@ -92228,6 +97010,30 @@
             "state" : "translated",
             "value" : "쿼리가 취소되었습니다"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sorgu iptal edildi"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Truy vấn đã bị hủy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查询已取消"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢已取消"
+          }
         }
       }
     },
@@ -92549,6 +97355,30 @@
           "stringUnit" : {
             "value" : "종료하면 %@에 대한 실행이 중단됩니다. 이미 실행된 구문은 적용된 상태로 남습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çıkmak %@ üzerindeki çalıştırmayı durdurur. Zaten çalışmış ifadeler uygulanmış kalır."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thoát sẽ dừng lần chạy trên %@. Những câu lệnh đã chạy vẫn được giữ nguyên."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出会停止对 %@ 的运行。已经执行的语句仍保持已应用。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結束會停止對 %@ 的執行。已經執行的陳述式仍保持已套用。"
           }
         }
       }
@@ -93415,6 +98245,30 @@
           "stringUnit" : {
             "value" : "읽기 전용입니다. 변경 사항을 기록하려면 다른 연결을 선택하십시오.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salt okunur. Değişikliklerin yazılacağı farklı bir bağlantı seçin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chỉ đọc. Hãy chọn kết nối khác để ghi thay đổi."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只读。请选择其他连接来写入更改。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "唯讀。請選擇其他連線來寫入變更。"
           }
         }
       }
@@ -96836,6 +101690,30 @@
             "value" : "%1$@ %2$@ 교체",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@ değiştir"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thay thế %1$@ %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "替换 %1$@ %2$@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取代 %1$@ %2$@"
+          }
         }
       }
     },
@@ -99991,6 +104869,30 @@
             "value" : "행은 데이터를 비교합니다",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Satırlar Veri Karşılaştırmasında"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dòng thuộc so sánh dữ liệu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行属于数据比较"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列屬於資料比較"
+          }
         }
       }
     },
@@ -100411,6 +105313,30 @@
             "value" : "트랜잭션으로 실행",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bir işlem içinde çalıştır"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chạy trong một giao dịch"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在事务中运行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在交易中執行"
+          }
         }
       }
     },
@@ -100522,6 +105448,30 @@
           "stringUnit" : {
             "value" : "대상에 대해 스크립트 실행",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Betiği hedef üzerinde çalıştır"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chạy script trên đích"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "对目标运行此脚本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "對目標執行此指令稿"
           }
         }
       }
@@ -103009,6 +107959,30 @@
             "value" : "동일",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aynı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giống nhau"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "相同"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "相同"
+          }
         }
       }
     },
@@ -103992,6 +108966,30 @@
             "value" : "저장된 비교",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kayıtlı Karşılaştırmalar"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "So sánh đã lưu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已保存的比较"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已儲存的比較"
+          }
         }
       }
     },
@@ -104206,6 +109204,30 @@
           "stringUnit" : {
             "value" : "저장…",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaydet…"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lưu…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存…"
           }
         }
       }
@@ -104765,6 +109787,30 @@
             "value" : "스크립트",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Betik"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Script"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "脚本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "指令稿"
+          }
         }
       }
     },
@@ -104774,6 +109820,30 @@
           "stringUnit" : {
             "value" : "스크립트 생성이 취소되었습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Betik oluşturma iptal edildi."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã hủy việc tạo script."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已取消生成脚本。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已取消產生指令稿。"
           }
         }
       }
@@ -104921,6 +109991,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "모든 행 검색"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tüm Satırlarda Ara"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tìm trong tất cả dòng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索所有行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋所有列"
           }
         }
       }
@@ -105966,6 +111060,30 @@
             "value" : "선택",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seç"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇"
+          }
         }
       }
     },
@@ -106594,6 +111712,30 @@
             "value" : "행 차이를 보려면 테이블을 선택하십시오.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Satır farklarını görmek için bir tablo seçin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn một bảng để xem khác biệt theo dòng của nó."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择一个表以查看它的行差异。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇一個資料表以查看它的列差異。"
+          }
         }
       }
     },
@@ -106739,6 +111881,30 @@
           "stringUnit" : {
             "value" : "양쪽 정의를 보려면 객체를 선택하십시오.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tanımını iki tarafta da görmek için bir nesne seçin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn một đối tượng để xem định nghĩa của nó ở cả hai bên."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择一个对象以查看它在双方的定义。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇一個物件以查看它在雙方的定義。"
           }
         }
       }
@@ -107370,6 +112536,30 @@
           "stringUnit" : {
             "value" : "시퀀스",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sequence"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sequence"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "序列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "序列"
           }
         }
       }
@@ -108868,6 +114058,30 @@
             "value" : "표시",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Göster"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hiển thị"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示"
+          }
         }
       }
     },
@@ -109324,6 +114538,30 @@
           "stringUnit" : {
             "value" : "동일한 객체 표시",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aynı Nesneleri Göster"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hiện các đối tượng giống hệt"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示完全相同的对象"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示完全相同的物件"
           }
         }
       }
@@ -110299,6 +115537,30 @@
           "stringUnit" : {
             "value" : "이 텍스트가 이름에 포함된 객체만 표시합니다",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yalnızca adı bu metni içeren nesneleri göster"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chỉ hiện các đối tượng có tên chứa văn bản này"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只显示名称包含此文本的对象"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只顯示名稱包含此文字的物件"
           }
         }
       }
@@ -112163,6 +117425,30 @@
             "value" : "건너뛰고 계속하기",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atla ve devam et"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bỏ qua và tiếp tục"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳过并继续"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "略過並繼續"
+          }
         }
       }
     },
@@ -112617,6 +117903,30 @@
           "stringUnit" : {
             "value" : "지금 선택한 열로 아직 비교하지 않은 테이블이 있습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bazı tablolar şu anda seçili sütunlarla karşılaştırılmadı."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Một số bảng chưa được so sánh với các cột đang chọn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有些表尚未按当前选择的列进行比较。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有些資料表尚未按目前選擇的欄位進行比較。"
           }
         }
       }
@@ -113869,6 +119179,30 @@
             "value" : "이미 실행된 구문은 %@에 적용된 상태로 남습니다. 현재 상태를 보려면 다시 비교하십시오.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zaten çalışmış ifadeler %@ üzerinde uygulanmış kalır. Durumu görmek için yeniden karşılaştırın."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Những câu lệnh đã chạy vẫn được áp dụng trên %@. Hãy so sánh lại để xem tình trạng hiện tại."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已经执行的语句仍应用在 %@ 上。请重新比较以查看当前状态。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已經執行的陳述式仍套用在 %@ 上。請重新比較以查看目前狀態。"
+          }
         }
       }
     },
@@ -114465,6 +119799,30 @@
             "value" : "비교 중지",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştırmayı Durdur"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dừng so sánh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止比较"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止比較"
+          }
         }
       }
     },
@@ -114543,6 +119901,30 @@
             "state" : "translated",
             "value" : "신뢰 해제"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Güvenmeyi Bırak"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ngừng tin cậy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止信任"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止信任"
+          }
         }
       }
     },
@@ -114552,6 +119934,30 @@
           "stringUnit" : {
             "value" : "중지하고 닫기",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Durdur ve Kapat"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dừng và đóng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止并关闭"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止並關閉"
           }
         }
       }
@@ -114563,6 +119969,30 @@
             "value" : "중지하고 종료",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Durdur ve Çık"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dừng và thoát"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止并退出"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止並結束"
+          }
         }
       }
     },
@@ -114573,6 +120003,30 @@
             "value" : "중지하고 실행된 내용 유지",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Durdur ve çalışanı koru"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dừng và giữ những gì đã chạy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止并保留已运行的部分"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止並保留已執行的部分"
+          }
         }
       }
     },
@@ -114582,6 +120036,30 @@
           "stringUnit" : {
             "value" : "중지하고 롤백",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Durdur ve geri al"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dừng và khôi phục"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止并回滚"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止並復原"
           }
         }
       }
@@ -114661,6 +120139,30 @@
             "state" : "translated",
             "value" : "%@에 대한 신뢰를 해제하시겠습니까?"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ için güven kaldırılsın mı?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ngừng tin cậy %@?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止信任 %@？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要停止信任 %@ 嗎？"
+          }
         }
       }
     },
@@ -114670,6 +120172,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이 개발자에 대한 신뢰를 해제하시겠습니까?"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu geliştiriciye güven kaldırılsın mı?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ngừng tin cậy nhà phát triển này?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止信任此开发者？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要停止信任此開發者嗎？"
           }
         }
       }
@@ -114715,6 +120241,30 @@
             "value" : "스토리지 엔진",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depolama motoru"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Storage engine"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "存储引擎"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存引擎"
+          }
         }
       }
     },
@@ -114724,6 +120274,30 @@
           "stringUnit" : {
             "value" : "스토리지 엔진 변경",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depolama motoru değişikliği"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thay đổi storage engine"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "存储引擎更改"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存引擎變更"
           }
         }
       }
@@ -114740,6 +120314,30 @@
           "stringUnit" : {
             "value" : "스토리지 엔진이 다릅니다. 원본은 %@, 대상은 %@입니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depolama motoru farklı: kaynakta %1$@, hedefte %2$@."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Storage engine khác nhau: %1$@ ở nguồn, %2$@ ở đích."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "存储引擎不同：来源为 %1$@，目标为 %2$@。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存引擎不同：來源為 %1$@，目標為 %2$@。"
           }
         }
       }
@@ -114921,6 +120519,30 @@
             "value" : "구조 비교",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yapı Karşılaştırması"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "So sánh cấu trúc"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "结构比较"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結構比較"
+          }
         }
       }
     },
@@ -114936,6 +120558,30 @@
           "stringUnit" : {
             "value" : "구조 동기화에는 같은 데이터베이스 타입이 필요합니다. %@과(와) %@은(는) 비교할 수 있지만 스크립트는 생성되지 않습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yapı eşitlemesi eşleşen veritabanı türleri gerektirir. %1$@ ve %2$@ karşılaştırılabilir ama betik üretilmez."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đồng bộ cấu trúc cần các loại cơ sở dữ liệu giống nhau. %1$@ và %2$@ có thể được so sánh, nhưng không có script nào được tạo."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "结构同步需要相同的数据库类型。%1$@ 和 %2$@ 可以比较，但不会生成脚本。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結構同步需要相同的資料庫類型。%1$@ 和 %2$@ 可以比較，但不會產生指令稿。"
           }
         }
       }
@@ -115257,6 +120903,30 @@
             "value" : "요약",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Özet"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tóm tắt"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "摘要"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "摘要"
+          }
         }
       }
     },
@@ -115301,6 +120971,30 @@
             "value" : "바꾸기",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Değiştir"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hoán đổi"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "互换"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "互換"
+          }
         }
       }
     },
@@ -115310,6 +121004,30 @@
           "stringUnit" : {
             "value" : "원본과 대상 바꾸기",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaynak ve Hedefi Değiştir"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hoán đổi nguồn và đích"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "互换来源和目标"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "互換來源和目標"
           }
         }
       }
@@ -115800,6 +121518,30 @@
             "value" : "행 차이를 보려면 비교를 데이터로 전환하십시오.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Satır farklarını görmek için karşılaştırmayı Veri'ye geçirin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chuyển so sánh sang Dữ liệu để xem khác biệt theo dòng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将比较切换到“数据”以查看行差异。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將比較切換到「資料」以查看列差異。"
+          }
         }
       }
     },
@@ -115809,6 +121551,30 @@
           "stringUnit" : {
             "value" : "정의를 보려면 비교를 구조로 전환하십시오.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tanımları görmek için karşılaştırmayı Yapı'ya geçirin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chuyển so sánh sang Cấu trúc để xem định nghĩa."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将比较切换到“结构”以查看定义。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將比較切換到「結構」以查看定義。"
           }
         }
       }
@@ -116445,6 +122211,30 @@
             "state" : "translated",
             "value" : "동기화 토큰이 만료되었습니다. 전체 동기화를 수행합니다."
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eşitleme belirtecinin süresi doldu. Tam eşitleme yapılacak."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token đồng bộ đã hết hạn. Sẽ thực hiện đồng bộ toàn bộ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步令牌已过期。将执行一次完整同步。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步權杖已過期。將執行一次完整同步。"
+          }
         }
       }
     },
@@ -116528,6 +122318,30 @@
           "stringUnit" : {
             "value" : "%@에서 %@(으)로 데이터를 동기화합니다. 값 형식은 엔진마다 다를 수 있으므로, 적용하기 전에 스크립트를 확인하십시오.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Veri %1$@ kaynağından %2$@ hedefine eşitleniyor. Değer biçimlendirmesi motorlar arasında farklı olabilir; uygulamadan önce betiği gözden geçirin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang đồng bộ dữ liệu từ %1$@ sang %2$@. Cách định dạng giá trị có thể khác nhau giữa các engine; hãy xem lại script trước khi áp dụng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在将数据从 %1$@ 同步到 %2$@。不同引擎的值格式可能不同；应用前请检查脚本。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在將資料從 %1$@ 同步到 %2$@。不同引擎的值格式可能不同；套用前請檢查指令稿。"
           }
         }
       }
@@ -117058,6 +122872,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "TLS 핸드셰이크 실패: %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TLS el sıkışması başarısız: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bắt tay TLS thất bại: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TLS 握手失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TLS 交握失敗：%@"
           }
         }
       }
@@ -117624,6 +123462,30 @@
             "value" : "테이블 콜레이션이 다릅니다. 원본은 %@, 대상은 %@입니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tablo karşılaştırması farklı: kaynakta %1$@, hedefte %2$@."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đối chiếu của bảng khác nhau: %1$@ ở nguồn, %2$@ ở đích."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表的排序规则不同：来源为 %1$@，目标为 %2$@。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表的定序不同：來源為 %1$@，目標為 %2$@。"
+          }
         }
       }
     },
@@ -117770,6 +123632,30 @@
           "stringUnit" : {
             "value" : "테이블 재생성",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tablo yeniden oluşturma"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dựng lại bảng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重建表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重建資料表"
           }
         }
       }
@@ -118125,6 +124011,30 @@
             "value" : "테이블은 항상 포함됩니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tablolar her zaman yer alır."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bảng luôn tham gia."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表始终参与比较。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表始終參與比較。"
+          }
         }
       }
     },
@@ -118134,6 +124044,30 @@
           "stringUnit" : {
             "value" : "첫 실행에서 모든 행을 읽지 않도록, 테이블은 비교에서 빠진 상태로 시작합니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tablolar karşılaştırmanın dışında başlar, böylece ilk çalıştırma her satırı akıtmaz."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bảng khởi đầu ở ngoài so sánh, nên lần chạy đầu tiên không đọc toàn bộ dòng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表默认不在比较范围内，因此首次运行不会流式读取每一行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表預設不在比較範圍內，因此首次執行不會串流讀取每一列。"
           }
         }
       }
@@ -118554,6 +124488,30 @@
           "stringUnit" : {
             "value" : "대상: %@",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hedef: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đích: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目标：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標：%@"
           }
         }
       }
@@ -119422,6 +125380,30 @@
             "value" : "%1$@이(가) 키 %2$@ 부근에서 비교가 예상한 것과 다른 순서로 행을 정렬했습니다. 숫자 키나 바이트 값으로 정렬되는 키를 선택하십시오.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@, satırları karşılaştırmanın beklediğinden farklı sıraladı, %2$@ anahtarının yakınında. Sayısal bir anahtar ya da bayt değerine göre sıralanan bir anahtar seçin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ đã sắp xếp các dòng khác với những gì so sánh mong đợi, gần khóa %2$@. Hãy chọn khóa dạng số, hoặc khóa sắp xếp theo giá trị byte."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ 对行的排序与比较预期不同，出现在键 %2$@ 附近。请选择数值型键，或按字节值排序的键。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ 對列的排序與比較預期不同，出現在鍵 %2$@ 附近。請選擇數值型鍵，或按位元組值排序的鍵。"
+          }
         }
       }
     },
@@ -119976,6 +125958,30 @@
             "value" : "Microsoft Entra ID 액세스 토큰이 드라이버에서 거부되었습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Microsoft Entra ID erişim belirteci sürücü tarafından reddedildi."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Access token Microsoft Entra ID bị driver từ chối."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驱动拒绝了该 Microsoft Entra ID 访问令牌。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驅動程式拒絕了該 Microsoft Entra ID 存取權杖。"
+          }
         }
       }
     },
@@ -119985,6 +125991,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Oracle 리스너가 연결을 거부했습니다(ORA-%ld)."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle dinleyicisi bağlantıyı reddetti (ORA-%ld)."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle listener đã từ chối kết nối (ORA-%ld)."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle 侦听器拒绝了此连接（ORA-%ld）。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle 接聽程式拒絕了此連線（ORA-%ld）。"
           }
         }
       }
@@ -119996,6 +126026,30 @@
             "state" : "translated",
             "value" : "Oracle 리스너가 연결을 거부했습니다."
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle dinleyicisi bağlantıyı reddetti."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle listener đã từ chối kết nối."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle 侦听器拒绝了此连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle 接聽程式拒絕了此連線。"
+          }
         }
       }
     },
@@ -120005,6 +126059,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Oracle 서버가 로그인 핸드셰이크 중 연결을 종료했습니다."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle sunucusu oturum açma el sıkışması sırasında bağlantıyı kapattı."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Máy chủ Oracle đã đóng kết nối trong quá trình bắt tay đăng nhập."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle 服务器在登录握手期间关闭了连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle 伺服器在登入交握期間關閉了連線。"
           }
         }
       }
@@ -120792,6 +126870,30 @@
             "value" : "드라이버가 이 객체의 정의를 반환하지 않아 이름만 비교했습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sürücü bu nesnenin tanımını döndürmedi, bu yüzden yalnızca adı karşılaştırıldı."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Driver không trả về định nghĩa của đối tượng này, nên chỉ tên của nó được so sánh."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驱动未返回此对象的定义，因此只比较了它的名称。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驅動程式未傳回此物件的定義，因此只比較了它的名稱。"
+          }
         }
       }
     },
@@ -120835,6 +126937,30 @@
           "stringUnit" : {
             "value" : "필터 필드가 도구 막대에 없습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtre alanı araç çubuğunda değil."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trường bộ lọc không có trên thanh công cụ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "筛选字段不在工具栏中。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篩選欄位不在工具列中。"
           }
         }
       }
@@ -121202,6 +127328,30 @@
             "state" : "translated",
             "value" : "리스너가 요청한 SID를 인식하지 못합니다"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dinleyici istenen SID'yi tanımıyor"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listener không biết SID được yêu cầu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "侦听器不认识请求的 SID"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接聽程式不認識請求的 SID"
+          }
         }
       }
     },
@@ -121211,6 +127361,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "리스너가 요청한 서비스 이름을 인식하지 못합니다"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dinleyici istenen hizmet adını tanımıyor"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listener không biết tên dịch vụ được yêu cầu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "侦听器不认识请求的服务名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接聽程式不認識請求的服務名稱"
           }
         }
       }
@@ -121222,6 +127396,30 @@
             "state" : "translated",
             "value" : "리스너에 요청한 서비스를 처리할 수 있는 핸들러가 없습니다"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dinleyicide istenen hizmet için kullanılabilir işleyici yok"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listener không có handler khả dụng cho dịch vụ được yêu cầu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "侦听器没有可用于所请求服务的处理程序"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接聽程式沒有可用於所請求服務的處理常式"
+          }
         }
       }
     },
@@ -121232,6 +127430,30 @@
             "state" : "translated",
             "value" : "리스너가 요청한 서비스에 대한 새 연결을 차단하고 있습니다"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dinleyici istenen hizmete yeni bağlantıları engelliyor"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listener đang chặn các kết nối mới tới dịch vụ được yêu cầu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "侦听器正在阻止到所请求服务的新连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接聽程式正在阻擋到所請求服務的新連線"
+          }
         }
       }
     },
@@ -121241,6 +127463,30 @@
           "stringUnit" : {
             "value" : "비교에 포함할 객체 유형은 옵션에서 설정합니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştırmaya katılan nesne türleri Seçenekler'de ayarlanır."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Các loại đối tượng tham gia so sánh được đặt trong Tùy chọn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "参与比较的对象类型在“选项”中设置。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "參與比較的物件類型在「選項」中設定。"
           }
         }
       }
@@ -121697,6 +127943,30 @@
             "state" : "translated",
             "value" : "쿼리가 설정된 제한 시간 내에 완료되지 않아 연결을 재설정했습니다. 쿼리를 다시 실행하십시오."
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sorgu yapılandırılan zaman aşımı içinde bitmedi, bu yüzden bağlantı sıfırlandı. Sorguyu yeniden çalıştırın."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Truy vấn không hoàn tất trong thời gian chờ đã cấu hình, nên kết nối đã bị đặt lại. Hãy chạy lại truy vấn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查询未在配置的超时时间内完成，因此连接已重置。请重新运行该查询。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢未在設定的逾時時間內完成，因此連線已重設。請重新執行該查詢。"
+          }
         }
       }
     },
@@ -121775,6 +128045,30 @@
             "value" : "실행이 롤백되었습니다. %@은(는) 변경되지 않았습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çalıştırma geri alındı. %@ değişmedi."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lần chạy đã được khôi phục. %@ không thay đổi."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本次运行已回滚。%@ 未发生更改。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本次執行已復原。%@ 未發生變更。"
+          }
         }
       }
     },
@@ -121784,6 +128078,30 @@
           "stringUnit" : {
             "value" : "스크립트가 이미 실행되었습니다. 대상의 현재 상태를 보려면 다시 비교하십시오.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Betik zaten çalıştı. Hedefin durumunu görmek için yeniden karşılaştırın."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Script đã chạy rồi. Hãy so sánh lại để xem tình trạng của đích."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "脚本已经运行过了。请重新比较以查看目标的当前状态。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "指令稿已經執行過了。請重新比較以查看目標的目前狀態。"
           }
         }
       }
@@ -121897,6 +128215,30 @@
             "state" : "translated",
             "value" : "서버에서 예상하지 못한 메시지를 보내 연결을 재설정했습니다. 쿼리를 다시 실행하십시오."
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sunucu beklenmeyen bir mesaj gönderdi ve bağlantı sıfırlandı. Sorguyu yeniden çalıştırın."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Máy chủ đã gửi một thông điệp không mong đợi và kết nối đã bị đặt lại. Hãy chạy lại truy vấn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服务器发送了意外消息，连接已重置。请重新运行该查询。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伺服器傳送了非預期的訊息，連線已重設。請重新執行該查詢。"
+          }
         }
       }
     },
@@ -121941,6 +128283,30 @@
             "value" : "원본과 대상이 같은 데이터베이스입니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaynak ve hedef aynı veritabanı."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nguồn và đích là cùng một cơ sở dữ liệu."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "来源和目标是同一个数据库。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "來源和目標是同一個資料庫。"
+          }
         }
       }
     },
@@ -121951,6 +128317,30 @@
             "value" : "원본 드라이버는 비교를 위해 행을 스트리밍할 수 없습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaynak sürücü karşılaştırma için satır akıtamıyor."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Driver nguồn không thể đọc dòng theo luồng để so sánh."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "来源驱动无法为比较流式读取行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "來源驅動程式無法為比較串流讀取列。"
+          }
         }
       }
     },
@@ -121960,6 +128350,30 @@
           "stringUnit" : {
             "value" : "구문은 실행되었지만 트랜잭션을 커밋할 수 없었습니다: %@",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İfadeler çalıştı ama işlem tamamlanamadı: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Các câu lệnh đã chạy nhưng không thể commit giao dịch: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语句已执行，但事务无法提交：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "陳述式已執行，但交易無法提交：%@"
           }
         }
       }
@@ -122077,6 +128491,30 @@
             "value" : "대상은 테이블 %@ 생성을 지원하지 않습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hedef %@ tablosunun oluşturulmasını desteklemiyor."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đích không hỗ trợ tạo bảng %@."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目标不支持创建表 %@。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標不支援建立資料表 %@。"
+          }
         }
       }
     },
@@ -122086,6 +128524,30 @@
           "stringUnit" : {
             "value" : "대상 드라이버는 동기화 스크립트를 생성할 수 없습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hedef sürücü eşitleme betiği üretemiyor."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Driver đích không thể tạo script đồng bộ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目标驱动无法生成同步脚本。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標驅動程式無法產生同步指令稿。"
           }
         }
       }
@@ -122097,6 +128559,30 @@
             "value" : "대상 드라이버는 동기화 스크립트를 실행할 수 없습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hedef sürücü eşitleme betiği çalıştıramıyor."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Driver đích không thể chạy script đồng bộ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目标驱动无法运行同步脚本。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標驅動程式無法執行同步指令稿。"
+          }
         }
       }
     },
@@ -122106,6 +128592,30 @@
           "stringUnit" : {
             "value" : "대상 드라이버는 비교를 위해 행을 스트리밍할 수 없습니다.",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hedef sürücü karşılaştırma için satır akıtamıyor."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Driver đích không thể đọc dòng theo luồng để so sánh."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目标驱动无法为比较流式读取行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標驅動程式無法為比較串流讀取列。"
           }
         }
       }
@@ -122631,6 +129141,30 @@
             "value" : "이 두 엔진은 스크립트를 공유할 수 없습니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu iki motor bir betiği paylaşamaz."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hai engine này không thể dùng chung một script."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这两个引擎无法共用一个脚本。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這兩個引擎無法共用一個指令稿。"
+          }
         }
       }
     },
@@ -122883,6 +129417,30 @@
             "state" : "translated",
             "value" : "이 Oracle 서버는 릴리스 11.1보다 이전 버전이며 데이터베이스 드라이버에서 지원하지 않습니다."
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu Oracle sunucusu, veritabanı sürücüsünün desteklemediği 11.1 sürümünden daha eski."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Máy chủ Oracle này cũ hơn bản 11.1, phiên bản mà driver cơ sở dữ liệu không hỗ trợ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此 Oracle 服务器早于 11.1 版，数据库驱动不支持。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此 Oracle 伺服器早於 11.1 版，資料庫驅動程式不支援。"
+          }
         }
       }
     },
@@ -123003,6 +129561,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이 계정은 데이터베이스 드라이버가 지원하지 않는 암호 검증 형식을 사용합니다."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu hesap, veritabanı sürücüsünün desteklemediği bir parola doğrulayıcı kullanıyor."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tài khoản này dùng password verifier mà driver cơ sở dữ liệu không hỗ trợ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此账户使用了数据库驱动不支持的口令校验器。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此帳戶使用了資料庫驅動程式不支援的密碼驗證器。"
           }
         }
       }
@@ -123186,6 +129768,30 @@
             "state" : "translated",
             "value" : "이 기기에서 이 연결의 CA 인증서를 읽을 수 없습니다(%@). 인증서 파일은 기기 간에 동기화되지 않으므로 이 기기에 인증서를 추가하거나 SSL 모드를 필수(Required)로 낮추십시오."
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu bağlantının CA sertifikası bu cihazda okunamıyor (%@). Sertifika dosyaları cihazlar arasında eşitlenmez, bu yüzden sertifikayı buraya ekleyin ya da SSL modunu Zorunlu'ya düşürün."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không đọc được chứng chỉ CA của kết nối này trên thiết bị này (%@). Tệp chứng chỉ không đồng bộ giữa các thiết bị, nên hãy thêm chứng chỉ tại đây hoặc hạ chế độ SSL xuống Required."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此连接的 CA 证书在本设备上不可读（%@）。证书文件不会在设备之间同步，请在此处添加证书，或将 SSL 模式降为“必需”。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線的 CA 憑證在本裝置上無法讀取（%@）。憑證檔案不會在裝置之間同步，請在此處加入憑證，或將 SSL 模式降為「必要」。"
+          }
         }
       }
     },
@@ -123196,6 +129802,30 @@
             "state" : "translated",
             "value" : "이 기기에서 이 연결의 클라이언트 인증서를 읽을 수 없습니다(%@). 인증서 파일은 기기 간에 동기화되지 않으므로 연결하기 전에 이 기기에 인증서를 추가하십시오."
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu bağlantının istemci sertifikası bu cihazda okunamıyor (%@). Sertifika dosyaları cihazlar arasında eşitlenmez, bu yüzden bağlanmadan önce sertifikayı buraya ekleyin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không đọc được chứng chỉ máy khách của kết nối này trên thiết bị này (%@). Tệp chứng chỉ không đồng bộ giữa các thiết bị, nên hãy thêm chứng chỉ tại đây trước khi kết nối."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此连接的客户端证书在本设备上不可读（%@）。证书文件不会在设备之间同步，请先在此处添加证书再连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線的用戶端憑證在本裝置上無法讀取（%@）。憑證檔案不會在裝置之間同步，請先在此處加入憑證再連線。"
+          }
         }
       }
     },
@@ -123205,6 +129835,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이 기기에서 이 연결의 클라이언트 키를 읽을 수 없습니다(%@). 키 파일은 기기 간에 동기화되지 않으므로 연결하기 전에 이 기기에 키를 추가하십시오."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu bağlantının istemci anahtarı bu cihazda okunamıyor (%@). Anahtar dosyaları cihazlar arasında eşitlenmez, bu yüzden bağlanmadan önce anahtarı buraya ekleyin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không đọc được khóa máy khách của kết nối này trên thiết bị này (%@). Tệp khóa không đồng bộ giữa các thiết bị, nên hãy thêm khóa tại đây trước khi kết nối."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此连接的客户端密钥在本设备上不可读（%@）。密钥文件不会在设备之间同步，请先在此处添加密钥再连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線的用戶端金鑰在本裝置上無法讀取（%@）。金鑰檔案不會在裝置之間同步，請先在此處加入金鑰再連線。"
           }
         }
       }
@@ -124249,6 +130903,30 @@
             "value" : "이 목록은 개수가 제한된 미리 보기입니다. 적용은 여기 나열된 행뿐 아니라 모든 차이점을 포함합니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu liste sınırlı bir önizlemedir. Uygula, yalnızca burada listelenen satırları değil her farkı kapsar."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Danh sách này là bản xem trước có giới hạn. Áp dụng bao trùm mọi khác biệt, không chỉ các dòng liệt kê ở đây."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此列表是有上限的预览。“应用”涵盖每一处差异，而不只是这里列出的行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此清單是有上限的預覽。「套用」涵蓋每一處差異，而不只是這裡列出的列。"
+          }
         }
       }
     },
@@ -124566,6 +131244,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 개발자가 서명한 플러그인입니다. 이 개발자는 아직 신뢰하지 않았습니다."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu eklenti %@ tarafından imzalandı; bu geliştiriciye henüz güvenmediniz."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plugin này được ký bởi %@, một nhà phát triển mà bạn chưa tin cậy."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此插件由 %@ 签名，你尚未信任该开发者。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此外掛由 %@ 簽署，你尚未信任該開發者。"
           }
         }
       }
@@ -125791,6 +132493,30 @@
             "state" : "translated",
             "value" : "Kerberos 인증을 완료하는 동안 시간이 초과되었습니다. Kerberos KDC(도메인 컨트롤러)에 연결할 수 없거나, 서버의 SPN이 없거나, 이 기기의 시계가 맞지 않을 수 있습니다. 도메인에 대한 네트워크 연결을 확인하거나 SQL Server 인증을 사용하십시오."
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kerberos kimlik doğrulaması zaman aşımına uğradı. Kerberos KDC'si (etki alanı denetleyicisi) erişilemez olabilir, sunucunun SPN'i eksik olabilir ya da bu cihazın saati kaymış olabilir. Etki alanına ağ bağlantınızı kontrol edin veya SQL Server Kimlik Doğrulaması'nı kullanın."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hết thời gian chờ khi hoàn tất xác thực Kerberos. Có thể KDC Kerberos (domain controller) không truy cập được, SPN của máy chủ bị thiếu, hoặc đồng hồ của thiết bị này bị lệch. Hãy kiểm tra mạng tới domain, hoặc dùng SQL Server Authentication."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成 Kerberos 认证超时。可能是 Kerberos KDC（域控制器）无法访问、服务器的 SPN 缺失，或本设备的时钟不准。请检查到域的网络，或改用 SQL Server 身份验证。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成 Kerberos 驗證逾時。可能是 Kerberos KDC（網域控制站）無法連線、伺服器的 SPN 遺失，或本裝置的時鐘不準。請檢查到網域的網路，或改用 SQL Server 驗證。"
+          }
         }
       }
     },
@@ -125841,6 +132567,30 @@
             "state" : "translated",
             "value" : "서버에 연결하는 동안 시간이 초과되었습니다. 호스트와 포트가 올바른지, 서버에 연결할 수 있고 서버가 연결을 수락하는지 확인하십시오."
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sunucuya bağlanırken zaman aşımı oluştu. Sunucuyu, portu ve sunucunun erişilebilir olup bağlantı kabul ettiğini kontrol edin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hết thời gian chờ khi kết nối tới máy chủ. Hãy kiểm tra host, cổng, và xem máy chủ có truy cập được và đang nhận kết nối không."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连接服务器超时。请检查主机、端口，以及服务器是否可达并接受连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線伺服器逾時。請檢查主機、連接埠，以及伺服器是否可連線並接受連線。"
+          }
         }
       }
     },
@@ -125850,6 +132600,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Oracle 로그인 핸드셰이크 중 시간이 초과되었습니다. 서버가 네트워크 연결을 수락했지만 로그인을 완료하지 않았습니다."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle oturum açma el sıkışması sırasında zaman aşımı oluştu. Sunucu ağ bağlantısını kabul etti ama oturum açmayı tamamlamadı."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hết thời gian chờ trong quá trình bắt tay đăng nhập Oracle. Máy chủ đã chấp nhận kết nối mạng nhưng không hoàn tất đăng nhập."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle 登录握手超时。服务器接受了网络连接，但没有完成登录。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle 登入交握逾時。伺服器接受了網路連線，但沒有完成登入。"
           }
         }
       }
@@ -125861,6 +132635,30 @@
             "value" : "비교할 타임스탬프 자릿수",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karşılaştırılan zaman damgası basamakları"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Số chữ số timestamp được so sánh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "参与比较的时间戳位数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "參與比較的時間戳記位數"
+          }
         }
       }
     },
@@ -125870,6 +132668,30 @@
           "stringUnit" : {
             "value" : "타임스탬프 정밀도",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zaman damgası hassasiyeti"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Độ chính xác timestamp"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "时间戳精度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "時間戳記精度"
           }
         }
       }
@@ -127439,6 +134261,30 @@
             "value" : "트리거",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tetikleyici"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trigger"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "触发器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "觸發器"
+          }
         }
       }
     },
@@ -127859,6 +134705,30 @@
             "state" : "translated",
             "value" : "신뢰하고 설치"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Güven ve Kur"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tin cậy và cài đặt"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "信任并安装"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "信任並安裝"
+          }
         }
       }
     },
@@ -127868,6 +134738,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@의 플러그인을 신뢰하시겠습니까?"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ eklentilerine güvenilsin mi?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tin cậy các plugin từ %@?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "信任来自 %@ 的插件？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要信任來自 %@ 的外掛嗎？"
           }
         }
       }
@@ -127912,6 +134806,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "신뢰하는 플러그인 개발자"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Güvenilen Eklenti Geliştiricileri"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhà phát triển plugin được tin cậy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已信任的插件开发者"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已信任的外掛開發者"
           }
         }
       }
@@ -130422,6 +137340,30 @@
             "value" : "%2$@의 행 %1$@ 업데이트",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%2$@ içindeki %1$@ satırını güncelle"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cập nhật dòng %1$@ trong %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新 %2$@ 中的行 %1$@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新 %2$@ 中的列 %1$@"
+          }
         }
       }
     },
@@ -130431,6 +137373,30 @@
           "stringUnit" : {
             "value" : "다른 행 업데이트",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Farklı olan satırları güncelle"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cập nhật các dòng khác nhau"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新存在差异的行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新存在差異的列"
           }
         }
       }
@@ -131977,6 +138943,30 @@
             "value" : "값 종류가 다름",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Değer türü farklı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loại giá trị khác nhau"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "值的种类不同"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "值的種類不同"
+          }
         }
       }
     },
@@ -132576,6 +139566,30 @@
             "value" : "계정 보기",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hesabı Görüntüle"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xem tài khoản"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看账户"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看帳戶"
+          }
         }
       }
     },
@@ -133106,6 +140120,30 @@
             "value" : "경고",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uyarılar"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cảnh báo"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "警告"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "警告"
+          }
         }
       }
     },
@@ -133288,6 +140326,30 @@
             "value" : "여기서 켠 항목은 두 구조를 비교할 때 무시됩니다. 이 항목들은 환경마다 다른 것이 정상입니다.",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Burada açılanlar, iki yapı karşılaştırılırken yok sayılır. Bunlar ortamlar arasında tasarım gereği farklılaşır."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Những gì được bật ở đây sẽ bị bỏ qua khi so sánh hai cấu trúc. Chúng vốn khác nhau giữa các môi trường."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这里开启的项目在比较两个结构时会被忽略。它们在不同环境之间本来就会有差别。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這裡開啟的項目在比較兩個結構時會被忽略。它們在不同環境之間本來就會有差別。"
+          }
         }
       }
     },
@@ -133297,6 +140359,30 @@
           "stringUnit" : {
             "value" : "%@에 대해 실행된 내용",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ üzerinde ne çalıştı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Những gì đã chạy trên %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 %@ 上运行了什么"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 %@ 上執行了什麼"
           }
         }
       }
@@ -133308,6 +140394,30 @@
             "value" : "비교할 대상",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neler Karşılaştırılacak"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "So sánh những gì"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比较哪些内容"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比較哪些內容"
+          }
         }
       }
     },
@@ -133318,6 +140428,30 @@
             "value" : "무엇을 어떻게 비교할지",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neler karşılaştırılacak ve nasıl"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "So sánh những gì và như thế nào"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比较哪些内容，以及如何比较"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "比較哪些內容，以及如何比較"
+          }
         }
       }
     },
@@ -133327,6 +140461,30 @@
           "stringUnit" : {
             "value" : "%@에 대해 실행될 내용",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ üzerinde ne çalışacak"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Những gì sẽ chạy trên %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将在 %@ 上运行什么"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將在 %@ 上執行什麼"
           }
         }
       }
@@ -133511,6 +140669,30 @@
             "value" : "텍스트의 공백",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metindeki boşluklar"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khoảng trắng trong văn bản"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文本中的空白字符"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字中的空白字元"
+          }
         }
       }
     },
@@ -133591,6 +140773,30 @@
             "value" : "변경됩니다",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Değiştirilecek"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sẽ được thay đổi"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将被更改"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將被變更"
+          }
         }
       }
     },
@@ -133669,6 +140875,30 @@
             "value" : "변경되지 않습니다",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Değişmeyecek"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sẽ không thay đổi"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不会更改"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不會變更"
+          }
         }
       }
     },
@@ -133678,6 +140908,30 @@
           "stringUnit" : {
             "value" : "실행됨",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çalışacak"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sẽ chạy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将运行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將執行"
           }
         }
       }
@@ -134992,6 +142246,30 @@
             "value" : "쿼리",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bir sorgu"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "một truy vấn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查询"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢"
+          }
         }
       }
     },
@@ -135035,6 +142313,30 @@
           "stringUnit" : {
             "value" : "내보내기",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bir dışa aktarma"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "một lần xuất dữ liệu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导出"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯出"
           }
         }
       }
@@ -136559,6 +143861,30 @@
             "state" : "translated",
             "value" : "iCloud에서 변경 사항 %d개를 거부했습니다. 변경 사항은 이 기기에 유지되며 다시 시도됩니다: %@"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud %1$d değişikliği reddetti. Bunlar bu cihazda kalır ve yeniden denenir: %2$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud đã từ chối %1$d thay đổi. Chúng vẫn ở trên thiết bị này và sẽ thử lại: %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 拒绝了 %1$d 项更改。它们保留在本设备上，稍后会重试：%2$@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 拒絕了 %1$d 項變更。它們保留在本裝置上，稍後會重試：%2$@"
+          }
         }
       }
     },
@@ -136602,6 +143928,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "iCloud 저장 공간이 가득 찼습니다. iCloud에서 공간을 확보한 후 다시 시도하십시오."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud depolama alanı dolu. iCloud'da yer açıp yeniden deneyin."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dung lượng iCloud đã đầy. Hãy giải phóng dung lượng trong iCloud rồi thử lại."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 存储空间已满。请在 iCloud 中释放空间后重试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 儲存空間已滿。請在 iCloud 中釋放空間後重試。"
           }
         }
       }
@@ -137674,6 +145024,30 @@
             "value" : "원본",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kaynak"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "nguồn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "来源"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "來源"
+          }
         }
       }
     },
@@ -138028,6 +145402,30 @@
             "value" : "대상",
             "state" : "translated"
           }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "hedef"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "đích"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目标"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標"
+          }
         }
       }
     },
@@ -138071,6 +145469,30 @@
           "stringUnit" : {
             "value" : "대상",
             "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "hedef"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "đích"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目标"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標"
           }
         }
       }

--- a/TableProMobile/TableProMobile/AppShortcuts.xcstrings
+++ b/TableProMobile/TableProMobile/AppShortcuts.xcstrings
@@ -19,6 +19,30 @@
               "${applicationName}에서 행 추가"
             ]
           }
+        },
+        "vi" : {
+          "stringSet" : {
+            "state" : "translated",
+            "values" : [
+              "Thêm một dòng trong ${applicationName}"
+            ]
+          }
+        },
+        "zh-Hans" : {
+          "stringSet" : {
+            "state" : "translated",
+            "values" : [
+              "在 ${applicationName} 中添加一行"
+            ]
+          }
+        },
+        "zh-Hant" : {
+          "stringSet" : {
+            "state" : "translated",
+            "values" : [
+              "在 ${applicationName} 中新增一列"
+            ]
+          }
         }
       }
     },
@@ -38,6 +62,30 @@
             "state" : "translated",
             "values" : [
               "${applicationName}에서 여러 행 추가"
+            ]
+          }
+        },
+        "vi" : {
+          "stringSet" : {
+            "state" : "translated",
+            "values" : [
+              "Thêm nhiều dòng trong ${applicationName}"
+            ]
+          }
+        },
+        "zh-Hans" : {
+          "stringSet" : {
+            "state" : "translated",
+            "values" : [
+              "在 ${applicationName} 中添加多行"
+            ]
+          }
+        },
+        "zh-Hant" : {
+          "stringSet" : {
+            "state" : "translated",
+            "values" : [
+              "在 ${applicationName} 中新增多列"
             ]
           }
         }
@@ -61,6 +109,33 @@
             "values" : [
               "${applicationName}에서 ${connection} 열기",
               "${applicationName}에서 ${connection}에 연결"
+            ]
+          }
+        },
+        "vi" : {
+          "stringSet" : {
+            "state" : "translated",
+            "values" : [
+              "Mở ${connection} trong ${applicationName}",
+              "Kết nối tới ${connection} trong ${applicationName}"
+            ]
+          }
+        },
+        "zh-Hans" : {
+          "stringSet" : {
+            "state" : "translated",
+            "values" : [
+              "在 ${applicationName} 中打开 ${connection}",
+              "在 ${applicationName} 中连接到 ${connection}"
+            ]
+          }
+        },
+        "zh-Hant" : {
+          "stringSet" : {
+            "state" : "translated",
+            "values" : [
+              "在 ${applicationName} 中開啟 ${connection}",
+              "在 ${applicationName} 中連線到 ${connection}"
             ]
           }
         }

--- a/TableProMobile/TableProMobile/InfoPlist.xcstrings
+++ b/TableProMobile/TableProMobile/InfoPlist.xcstrings
@@ -16,6 +16,24 @@
             "state" : "translated",
             "value" : "TablePro는 저장된 데이터베이스 연결 및 자격 증명을 보호하기 위해 Face ID를 사용합니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro dùng Face ID để bảo vệ các kết nối cơ sở dữ liệu và thông tin đăng nhập đã lưu của bạn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 使用面容 ID 来保护你已保存的数据库连接和凭据。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 使用 Face ID 來保護你已儲存的資料庫連線和認證資訊。"
+          }
         }
       }
     },
@@ -33,6 +51,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "TablePro는 Bonjour(.local) 호스트 이름을 포함하여 로컬 네트워크에서 실행되는 데이터베이스 서버 및 SSH 터널에 연결합니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro kết nối tới các máy chủ cơ sở dữ liệu và SSH tunnel chạy trên mạng cục bộ của bạn, bao gồm cả tên máy Bonjour (.local)."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 会连接到运行在你本地网络上的数据库服务器和 SSH 隧道，包括 Bonjour（.local）主机名。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 會連線到執行在你區域網路上的資料庫伺服器和 SSH 通道，包括 Bonjour（.local）主機名稱。"
           }
         }
       }

--- a/TableProMobile/TableProMobile/Localizable.xcstrings
+++ b/TableProMobile/TableProMobile/Localizable.xcstrings
@@ -3,6 +3,12 @@
   "strings" : {
     "" : {
       "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30,6 +36,24 @@
             "state" : "translated",
             "value" : "%1$@ (%2$@)"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ (%2$@)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@（%2$@）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@（%2$@）"
+          }
         }
       }
     },
@@ -39,6 +63,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ (ORA-%2$ld)."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ (ORA-%2$ld)."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@（ORA-%2$ld）。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@（ORA-%2$ld）。"
           }
         }
       }
@@ -112,6 +154,24 @@
             "state" : "translated",
             "value" : "%@ 연결에서는 단축어를 통한 행 추가를 지원하지 않습니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết nối %@ không hỗ trợ thêm dòng từ Phím tắt."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 连接不支持通过“快捷指令”添加行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 連線不支援透過「捷徑」新增列。"
+          }
         }
       }
     },
@@ -128,6 +188,24 @@
             "state" : "translated",
             "value" : "%1$@에 %2$@ 열이 없습니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ không có cột nào tên %2$@."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ 中没有名为 %2$@ 的列。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ 中沒有名為 %2$@ 的欄位。"
+          }
         }
       }
     },
@@ -137,6 +215,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "읽기 전용인 %@에 행을 추가할 수 없습니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ chỉ đọc nên không thể thêm dòng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 为只读，因此无法添加行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 為唯讀，因此無法新增列。"
           }
         }
       }
@@ -358,6 +454,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@, 포트 %lld"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@, cổng %2$lld"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@，端口 %2$lld"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@，連接埠 %2$lld"
           }
         }
       }
@@ -661,6 +775,24 @@
             "state" : "translated",
             "value" : "1개 행"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 dòng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 列"
+          }
         }
       }
     },
@@ -698,6 +830,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "동기화 충돌이 감지되어 해결이 필요합니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phát hiện xung đột đồng bộ và cần được giải quyết."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "检测到同步冲突，需要解决。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "偵測到同步衝突，需要解決。"
           }
         }
       }
@@ -799,6 +949,24 @@
             "state" : "translated",
             "value" : "%2$@에 행 %1$lld개를 추가하시겠습니까?"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thêm %1$lld dòng vào %2$@?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向 %2$@ 添加 %1$lld 行？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要向 %2$@ 新增 %1$lld 列嗎？"
+          }
         }
       }
     },
@@ -865,6 +1033,24 @@
             "state" : "translated",
             "value" : "테이블에 행 추가"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thêm dòng vào bảng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向表添加行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向資料表新增列"
+          }
         }
       }
     },
@@ -874,6 +1060,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "‘테이블에 행 추가’는 하나의 행만 입력할 수 있습니다. 여러 행을 추가하려면 ‘테이블에 여러 행 추가’를 사용하십시오."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“Thêm dòng vào bảng” cần đúng một dòng. Dùng “Thêm nhiều dòng vào bảng” cho nhiều dòng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“向表添加行”只接受一行。多行请使用“向表添加多行”。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「向資料表新增列」只接受一列。多列請使用「向資料表新增多列」。"
           }
         }
       }
@@ -885,6 +1089,24 @@
             "state" : "translated",
             "value" : "테이블에 여러 행 추가"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thêm nhiều dòng vào bảng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向表添加多行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向資料表新增多列"
+          }
         }
       }
     },
@@ -894,6 +1116,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "TablePro에서 연결 추가"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thêm một kết nối trong TablePro"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 TablePro 中添加连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 TablePro 中新增連線"
           }
         }
       }
@@ -933,6 +1173,24 @@
             "state" : "translated",
             "value" : "${table}에 행 추가"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thêm một dòng vào ${table}"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向 ${table} 添加一行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向 ${table} 新增一列"
+          }
         }
       }
     },
@@ -942,6 +1200,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "저장된 연결의 테이블에 여러 행을 추가합니다. 행을 JSON 배열, CSV 텍스트 또는 파일로 제공하십시오."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thêm nhiều dòng vào một bảng trên kết nối đã lưu. Cung cấp các dòng dưới dạng mảng JSON, văn bản CSV hoặc tệp."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向已保存连接上的表添加多行。以 JSON 数组、CSV 文本或文件形式提供这些行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向已儲存連線上的資料表新增多列。以 JSON 陣列、CSV 文字或檔案形式提供這些列。"
           }
         }
       }
@@ -953,6 +1229,24 @@
             "state" : "translated",
             "value" : "%@에 행 하나를 추가하시겠습니까?"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thêm một dòng vào %@?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向 %@ 添加一行？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要向 %@ 新增一列嗎？"
+          }
         }
       }
     },
@@ -963,6 +1257,24 @@
             "state" : "translated",
             "value" : "저장된 연결의 테이블에 행 하나를 추가합니다. 행을 JSON 객체 또는 CSV 행으로 제공하십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thêm một dòng vào một bảng trên kết nối đã lưu. Cung cấp dòng dưới dạng đối tượng JSON hoặc một dòng CSV."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向已保存连接上的表添加一行。以 JSON 对象或一行 CSV 形式提供该行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向已儲存連線上的資料表新增一列。以 JSON 物件或一列 CSV 形式提供該列。"
+          }
         }
       }
     },
@@ -972,6 +1284,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "${table}에 여러 행 추가"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thêm các dòng vào ${table}"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向 ${table} 添加多行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向 ${table} 新增多列"
           }
         }
       }
@@ -989,6 +1319,24 @@
             "state" : "translated",
             "value" : "%2$@에 행 %1$lld개를 추가했습니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã thêm %1$lld dòng vào %2$@."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已向 %2$@ 添加 %1$lld 行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已向 %2$@ 新增 %1$lld 列。"
+          }
         }
       }
     },
@@ -998,6 +1346,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@에 행 하나를 추가했습니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã thêm một dòng vào %@."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已向 %@ 添加一行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已向 %@ 新增一列。"
           }
         }
       }
@@ -1262,6 +1628,24 @@
             "state" : "translated",
             "value" : "알 수 없는 동기화 오류가 발생했습니다: %@"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã xảy ra lỗi đồng bộ không xác định: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "发生未知同步错误：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "發生未知的同步錯誤：%@"
+          }
         }
       }
     },
@@ -1524,6 +1908,24 @@
             "state" : "translated",
             "value" : "자동"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tự động"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動"
+          }
         }
       }
     },
@@ -1561,6 +1963,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "파란색"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xanh dương"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "蓝色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "藍色"
           }
         }
       }
@@ -1600,6 +2020,24 @@
             "state" : "translated",
             "value" : "CA 인증서"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chứng chỉ CA"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CA 证书"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CA 憑證"
+          }
         }
       }
     },
@@ -1609,6 +2047,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "CA 인증서를 찾을 수 없습니다: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không tìm thấy chứng chỉ CA: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到CA证书：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到 CA 憑證：%@"
           }
         }
       }
@@ -1704,6 +2160,24 @@
             "state" : "translated",
             "value" : "인증서"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chứng chỉ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "证书"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "憑證"
+          }
         }
       }
     },
@@ -1714,6 +2188,24 @@
             "state" : "translated",
             "value" : "인증서 암호"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mật khẩu chứng chỉ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "证书密码"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "憑證密碼"
+          }
         }
       }
     },
@@ -1723,6 +2215,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "인증서는 이 기기에만 저장되며 동기화되지 않습니다. PKCS#12 파일을 가져오면 클라이언트 인증서와 개인 키가 모두 입력됩니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chứng chỉ chỉ nằm trên thiết bị này và không bao giờ được đồng bộ. Một tệp PKCS#12 điền cả chứng chỉ máy khách lẫn khóa của nó."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "证书只保留在本设备上，永不同步。一个 PKCS#12 文件会同时填入客户端证书及其密钥。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "憑證只保留在本裝置上，永不同步。一個 PKCS#12 檔案會同時填入用戶端憑證及其金鑰。"
           }
         }
       }
@@ -1930,6 +2440,24 @@
             "state" : "translated",
             "value" : "파일 선택"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn tệp"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇檔案"
+          }
         }
       }
     },
@@ -2136,6 +2664,24 @@
             "state" : "translated",
             "value" : "클라이언트 인증서"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chứng chỉ máy khách"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "客户端证书"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用戶端憑證"
+          }
         }
       }
     },
@@ -2145,6 +2691,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "클라이언트 키"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khóa máy khách"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "客户端密钥"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用戶端金鑰"
           }
         }
       }
@@ -2156,6 +2720,24 @@
             "state" : "translated",
             "value" : "클라이언트 인증서"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chứng chỉ máy khách"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "客户端证书"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用戶端憑證"
+          }
         }
       }
     },
@@ -2166,6 +2748,24 @@
             "state" : "translated",
             "value" : "클라이언트 인증서를 찾을 수 없습니다: %@"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không tìm thấy chứng chỉ client: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到客户端证书：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到用戶端憑證：%@"
+          }
         }
       }
     },
@@ -2175,6 +2775,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "클라이언트 키를 찾을 수 없습니다: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không tìm thấy khóa client: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到客户端私钥：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到用戶端金鑰：%@"
           }
         }
       }
@@ -2298,6 +2916,24 @@
             "state" : "translated",
             "value" : "쓰기 확인"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xác nhận ghi"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "确认写入"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確認寫入"
+          }
         }
       }
     },
@@ -2336,6 +2972,24 @@
             "state" : "translated",
             "value" : "그래도 연결"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vẫn kết nối"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仍然连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仍要連線"
+          }
         }
       }
     },
@@ -2345,6 +2999,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "연결 방식"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết nối bằng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连接方式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線方式"
           }
         }
       }
@@ -2523,6 +3195,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "연결 실패: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết nối thất bại: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连接失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線失敗：%@"
           }
         }
       }
@@ -2898,6 +3588,24 @@
             "state" : "translated",
             "value" : "이 서버와 Oracle 네이티브 네트워크 암호화를 완료할 수 없습니다. 서버에서 드라이버가 지원하지 않는 암호화 또는 체크섬 알고리즘을 요구할 수 있습니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể hoàn tất mã hóa mạng gốc của Oracle với máy chủ này. Có thể nó yêu cầu thuật toán mã hóa hoặc checksum mà driver không hỗ trợ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法与此服务器完成 Oracle 原生网络加密。它可能需要驱动不支持的加密或校验和算法。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法與此伺服器完成 Oracle 原生網路加密。它可能需要驅動程式不支援的加密或總和檢查碼演算法。"
+          }
         }
       }
     },
@@ -2908,6 +3616,24 @@
             "state" : "translated",
             "value" : "데이터베이스에 연결할 수 없습니다: %@"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể kết nối tới cơ sở dữ liệu: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法连接到数据库：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法連線到資料庫：%@"
+          }
         }
       }
     },
@@ -2917,6 +3643,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@의 열을 읽을 수 없습니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể đọc các cột của %@."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法读取 %@ 的列。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法讀取 %@ 的欄位。"
           }
         }
       }
@@ -3236,6 +3980,24 @@
             "state" : "translated",
             "value" : "데이터베이스 또는 스키마"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cơ sở dữ liệu hoặc Schema"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数据库或模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫或綱要"
+          }
         }
       }
     },
@@ -3245,6 +4007,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "다음 데이터베이스 유형이 설치되어 있지 않습니다: \"%@\""
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loại cơ sở dữ liệu \"%@\" chưa được cài đặt"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数据库类型 \"%@\" 未安装"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫類型「%@」未安裝"
           }
         }
       }
@@ -3311,6 +4091,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "복호화 실패: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giải mã thất bại: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解密失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解密失敗：%@"
           }
         }
       }
@@ -4136,6 +4934,24 @@
             "state" : "translated",
             "value" : "코드 %@을(를) 브라우저에 입력하여 로그인을 완료하십시오. 코드는 클립보드에 복사되어 있습니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhập mã %@ trong trình duyệt để hoàn tất đăng nhập. Mã đã có trong bộ nhớ tạm."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在浏览器中输入代码 %@ 以完成登录。它已复制到剪贴板。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在瀏覽器中輸入代碼 %@ 以完成登入。它已複製到剪貼簿。"
+          }
         }
       }
     },
@@ -4173,6 +4989,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "인증서 파일을 내보낼 때 사용한 암호를 입력하십시오."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhập mật khẩu đã dùng khi xuất tệp chứng chỉ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "输入导出证书文件时使用的密码。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入匯出憑證檔案時使用的密碼。"
           }
         }
       }
@@ -4380,6 +5214,24 @@
             "state" : "translated",
             "value" : "실패"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thất bại"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "失敗"
+          }
         }
       }
     },
@@ -4389,6 +5241,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "연결 데이터를 인코딩하지 못했습니다"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể mã hóa dữ liệu kết nối"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法编码连接数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法編碼連線資料"
           }
         }
       }
@@ -4400,6 +5270,24 @@
             "state" : "translated",
             "value" : "동기화 데이터를 인코딩하지 못했습니다: %@"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể mã hoá dữ liệu đồng bộ: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步数据编码失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步資料編碼失敗：%@"
+          }
         }
       }
     },
@@ -4409,6 +5297,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "연결을 설정하지 못했습니다"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thiết lập được kết nối"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法建立连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法建立連線"
           }
         }
       }
@@ -4449,6 +5355,24 @@
             "state" : "translated",
             "value" : "연결 파일을 해석하지 못했습니다: %@"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể phân tích tệp kết nối: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法解析连接文件：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法解析連線檔案：%@"
+          }
         }
       }
     },
@@ -4458,6 +5382,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "파일을 읽지 못했습니다: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đọc tệp thất bại: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "读取文件失败: %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "讀取檔案失敗：%@"
           }
         }
       }
@@ -4581,6 +5523,24 @@
             "state" : "translated",
             "value" : "파일을 쓰지 못했습니다: %@"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể ghi tệp: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "写入文件失败: %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寫入檔案失敗：%@"
+          }
         }
       }
     },
@@ -4702,6 +5662,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "로그인 마치기"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hoàn tất đăng nhập"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成登录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成登入"
           }
         }
       }
@@ -4909,6 +5887,24 @@
             "state" : "translated",
             "value" : "회색"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xám"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "灰色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "灰色"
+          }
         }
       }
     },
@@ -4918,6 +5914,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "녹색"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xanh lá"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "绿色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "綠色"
           }
         }
       }
@@ -5154,6 +6168,24 @@
             "state" : "translated",
             "value" : "이 서버에서 Redis 6 이상의 ACL 사용자를 사용하는 경우 사용자 이름 필드를 입력하십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nếu máy chủ này dùng người dùng ACL của Redis 6 trở lên, hãy điền trường Tên người dùng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果此服务器使用 Redis 6 或更高版本的 ACL 用户，请填写“用户名”字段。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果此伺服器使用 Redis 6 或更新版本的 ACL 使用者，請填寫「使用者名稱」欄位。"
+          }
         }
       }
     },
@@ -5248,6 +6280,24 @@
             "state" : "translated",
             "value" : "파일 가져오기"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhập tệp"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入檔案"
+          }
         }
       }
     },
@@ -5257,6 +6307,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "PKCS#12 가져오기"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhập PKCS#12"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入 PKCS#12"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入 PKCS#12"
           }
         }
       }
@@ -5351,6 +6419,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "암호가 올바르지 않습니다"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cụm mật khẩu không đúng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密码短语不正确"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密碼短語不正確"
           }
         }
       }
@@ -5530,6 +6616,24 @@
             "state" : "translated",
             "value" : "점프 호스트 키를 찾을 수 없습니다: %@"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không tìm thấy khóa của jump host: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到跳板主机密钥：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到跳板主機金鑰：%@"
+          }
         }
       }
     },
@@ -5539,6 +6643,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kerberos 인증 실패: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xác thực Kerberos thất bại: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kerberos 认证失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kerberos 驗證失敗：%@"
           }
         }
       }
@@ -5833,6 +6955,24 @@
             "state" : "translated",
             "value" : "로컬 네트워크 접근 권한이 필요합니다. 설정 > 개인정보 보호 및 보안 > 로컬 네트워크에서 TablePro를 켜십시오. 이미 켜져 있다면 기기를 재시동하거나 iOS 18.6 이상으로 업데이트하십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cần quyền truy cập Mạng cục bộ. Mở Cài đặt > Quyền riêng tư & Bảo mật > Mạng cục bộ và bật TablePro. Nếu đã bật, hãy khởi động lại thiết bị hoặc cập nhật lên iOS 18.6 trở lên."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要本地网络访问权限。请打开“设置 > 隐私与安全性 > 本地网络”并开启 TablePro。如果已开启，请重启设备或升级到 iOS 18.6 或更高版本。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要區域網路存取權。請開啟「設定 > 隱私權與安全性 > 區域網路」並開啟 TablePro。如果已開啟，請重新啟動裝置或更新至 iOS 18.6 或更新版本。"
+          }
         }
       }
     },
@@ -5983,6 +7123,24 @@
             "state" : "translated",
             "value" : "대/소문자 구분"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phân biệt hoa thường"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "区分大小写"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "區分大小寫"
+          }
         }
       }
     },
@@ -5992,6 +7150,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Microsoft Entra ID 로그인 필요"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yêu cầu đăng nhập Microsoft Entra ID"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要 Microsoft Entra ID 登录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要 Microsoft Entra ID 登入"
           }
         }
       }
@@ -6114,6 +7290,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "네트워크를 사용할 수 없습니다. 연결이 복원되면 변경 사항이 동기화됩니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mạng không khả dụng. Các thay đổi sẽ được đồng bộ khi có kết nối trở lại."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "网络不可用。恢复连接后将自动同步更改。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網路無法使用。連線恢復後將自動同步變更。"
           }
         }
       }
@@ -6489,6 +7683,24 @@
             "value" : "Microsoft Entra ID 액세스 토큰이 제공되지 않았습니다.",
             "state" : "translated"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có access token Microsoft Entra ID nào được cung cấp."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未提供 Microsoft Entra ID 访问令牌。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未提供 Microsoft Entra ID 存取權杖。"
+          }
         }
       }
     },
@@ -6667,6 +7879,24 @@
             "state" : "translated",
             "value" : "추가할 데이터가 제공되지 않았습니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có dữ liệu nào được cung cấp để thêm."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有提供要添加的数据。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有提供要新增的資料。"
+          }
         }
       }
     },
@@ -6761,6 +7991,24 @@
             "state" : "translated",
             "value" : "일반"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bình thường"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正常"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般"
+          }
         }
       }
     },
@@ -6799,6 +8047,24 @@
             "state" : "translated",
             "value" : "SQL Server에 연결되지 않았습니다"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa kết nối tới SQL Server"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未连接到 SQL Server"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未連線到 SQL Server"
+          }
         }
       }
     },
@@ -6809,6 +8075,24 @@
             "state" : "translated",
             "value" : "데이터베이스에 연결되지 않았습니다"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa kết nối cơ sở dữ liệu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未连接到数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未連線到資料庫"
+          }
         }
       }
     },
@@ -6818,6 +8102,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "설정되지 않음"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chưa đặt"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未设置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未設定"
           }
         }
       }
@@ -7193,6 +8495,24 @@
             "state" : "translated",
             "value" : "Oracle"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle"
+          }
         }
       }
     },
@@ -7202,6 +8522,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "주황색"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cam"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "橙色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "橘色"
           }
         }
       }
@@ -7437,6 +8775,24 @@
             "state" : "translated",
             "value" : "암호는 종단 간 암호화된 iCloud 키체인을 통해 동기화됩니다. 새로 저장할 때만 적용됩니다. 암호를 다시 저장하면 해당 암호의 동기화 상태가 업데이트됩니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mật khẩu đồng bộ qua iCloud Keychain, vốn được mã hóa đầu cuối. Chỉ ảnh hưởng đến các lần lưu mới. Hãy lưu lại mật khẩu để cập nhật đồng bộ của nó."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密码通过端到端加密的 iCloud 钥匙串同步。仅影响新的保存。重新保存密码以更新其同步。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密碼透過端對端加密的 iCloud 鑰匙圈同步。僅影響新的儲存。重新儲存密碼以更新其同步。"
+          }
         }
       }
     },
@@ -7447,6 +8803,24 @@
             "state" : "translated",
             "value" : "붙여넣기"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dán"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "粘贴"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "貼上"
+          }
         }
       }
     },
@@ -7456,6 +8830,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "키 붙여넣기"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dán khóa"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "粘贴密钥"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "貼上金鑰"
           }
         }
       }
@@ -7495,6 +8887,24 @@
             "state" : "translated",
             "value" : "BEGIN 및 END 줄을 포함한 전체 PEM 블록을 붙여넣으십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dán toàn bộ khối PEM, bao gồm cả dòng BEGIN và END."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "粘贴完整的 PEM 块，包括 BEGIN 和 END 行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "貼上完整的 PEM 區塊，包括 BEGIN 和 END 行。"
+          }
         }
       }
     },
@@ -7532,6 +8942,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "분홍색"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hồng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "粉色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "粉紅色"
           }
         }
       }
@@ -7684,6 +9112,24 @@
             "state" : "translated",
             "value" : "개인 키"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khóa riêng tư"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "私钥"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "私密金鑰"
+          }
         }
       }
     },
@@ -7694,6 +9140,24 @@
             "state" : "translated",
             "value" : "JSON 객체 또는 객체 배열을 제공하십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hãy cung cấp một đối tượng JSON hoặc một mảng các đối tượng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请提供一个 JSON 对象或对象数组。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請提供一個 JSON 物件或物件陣列。"
+          }
         }
       }
     },
@@ -7703,6 +9167,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "보라색"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tím"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "紫色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "紫色"
           }
         }
       }
@@ -7799,6 +9281,24 @@
             "state" : "translated",
             "value" : "쿼리 실행 실패"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thực thi truy vấn thất bại"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查询执行失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢執行失敗"
+          }
         }
       }
     },
@@ -7808,6 +9308,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "쿼리 실패: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Truy vấn thất bại: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查询失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢失敗：%@"
           }
         }
       }
@@ -7847,6 +9365,24 @@
             "state" : "translated",
             "value" : "쿼리가 취소되었습니다"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Truy vấn đã bị hủy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查询已取消"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢已取消"
+          }
         }
       }
     },
@@ -7856,6 +9392,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "빠른 연결"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết nối nhanh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速連線"
           }
         }
       }
@@ -7867,6 +9421,24 @@
             "state" : "translated",
             "value" : "데이터베이스에 빠르게 연결합니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết nối nhanh tới các cơ sở dữ liệu của bạn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速连接到你的数据库。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速連線到你的資料庫。"
+          }
         }
       }
     },
@@ -7876,6 +9448,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "읽기 전용"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chỉ đọc"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只读"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "唯讀"
           }
         }
       }
@@ -7915,6 +9505,24 @@
             "state" : "translated",
             "value" : "빨간색"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đỏ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "红色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "紅色"
+          }
         }
       }
     },
@@ -7925,6 +9533,24 @@
             "state" : "translated",
             "value" : "Redis 인증 실패: %1$@ %2$@"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xác thực Redis thất bại: %1$@ %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redis 认证失败：%1$@ %2$@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redis 驗證失敗：%1$@ %2$@"
+          }
         }
       }
     },
@@ -7934,6 +9560,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Redis 인증 실패: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xác thực Redis thất bại: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redis 认证失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redis 驗證失敗：%@"
           }
         }
       }
@@ -8028,6 +9672,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "제거"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gỡ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除"
           }
         }
       }
@@ -8292,6 +9954,24 @@
             "state" : "translated",
             "value" : "역할"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vai trò"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "角色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "角色"
+          }
         }
       }
     },
@@ -8330,6 +10010,24 @@
             "state" : "translated",
             "value" : "행(JSON 또는 CSV)"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dòng (JSON hoặc CSV)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行（JSON 或 CSV）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列（JSON 或 CSV）"
+          }
         }
       }
     },
@@ -8367,6 +10065,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "여러 행(JSON 또는 CSV)"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Các dòng (JSON hoặc CSV)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "多行（JSON 或 CSV）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "多列（JSON 或 CSV）"
           }
         }
       }
@@ -8519,6 +10235,24 @@
             "state" : "translated",
             "value" : "SID"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SID"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SID"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SID"
+          }
         }
       }
     },
@@ -8529,12 +10263,48 @@
             "state" : "translated",
             "value" : "SID를 찾을 수 없음"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không tìm thấy SID"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到 SID"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到 SID"
+          }
         }
       }
     },
     "SQL" : {
       "localizations" : {
         "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "SQL"
@@ -8576,6 +10346,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SSH 호스트 키 변경됨"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khóa máy chủ SSH đã thay đổi"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 主机密钥已更改"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 主機金鑰已變更"
           }
         }
       }
@@ -8754,6 +10542,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "SSH 개인 키를 찾을 수 없습니다: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không tìm thấy private key SSH: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到 SSH 私钥：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到 SSH 私密金鑰：%@"
           }
         }
       }
@@ -9185,6 +10991,24 @@
             "state" : "translated",
             "value" : "서비스 이름"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tên dịch vụ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服务名称"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服務名稱"
+          }
         }
       }
     },
@@ -9194,6 +11018,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "서비스 이름을 찾을 수 없음"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không tìm thấy tên dịch vụ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到服务名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到服務名稱"
           }
         }
       }
@@ -9401,6 +11243,24 @@
             "state" : "translated",
             "value" : "로그인"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đăng nhập"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登入"
+          }
         }
       }
     },
@@ -9410,6 +11270,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "브라우저에서 Microsoft Entra ID에 로그인하시겠습니까?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đăng nhập Microsoft Entra ID bằng trình duyệt?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要用浏览器登录 Microsoft Entra ID 吗？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要用瀏覽器登入 Microsoft Entra ID 嗎？"
           }
         }
       }
@@ -9758,6 +11636,24 @@
             "state" : "translated",
             "value" : "암호 동기화"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đồng bộ mật khẩu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步密码"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步密碼"
+          }
         }
       }
     },
@@ -9796,6 +11692,24 @@
             "state" : "translated",
             "value" : "동기화 토큰이 만료되었습니다. 전체 동기화를 수행합니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token đồng bộ đã hết hạn. Sẽ thực hiện đồng bộ toàn bộ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步令牌已过期。将执行一次完整同步。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步權杖已過期。將執行一次完整同步。"
+          }
         }
       }
     },
@@ -9833,6 +11747,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "동기화 영역을 찾을 수 없습니다. 전체 동기화를 수행합니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không tìm thấy vùng đồng bộ. Sẽ thực hiện đồng bộ toàn bộ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到同步区域。将执行完整同步。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到同步區域。將執行完整同步。"
           }
         }
       }
@@ -9899,6 +11831,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "TLS 핸드셰이크 실패: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bắt tay TLS thất bại: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TLS 握手失败：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TLS 交握失敗：%@"
           }
         }
       }
@@ -9995,6 +11945,24 @@
             "state" : "translated",
             "value" : "TablePro"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro"
+          }
         }
       }
     },
@@ -10004,6 +11972,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "TablePro가 해당 파일을 읽을 수 없습니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro không đọc được tệp đó."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 无法读取该文件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 無法讀取該檔案。"
           }
         }
       }
@@ -10020,6 +12006,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "TablePro는 이전에 %1$@에 연결한 적이 없습니다.\n\n%2$@ 키 지문:\n%3$@\n\n예상한 지문과 일치할 때만 이 서버를 신뢰하십시오."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro chưa từng kết nối tới %1$@.\n\nVân tay khóa %2$@:\n%3$@\n\nChỉ tin cậy máy chủ này nếu vân tay khớp với vân tay bạn mong đợi."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 之前未连接过 %1$@。\n\n%2$@ 密钥指纹：\n%3$@\n\n只有当指纹与你预期的一致时才信任此服务器。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 之前未連線過 %1$@。\n\n%2$@ 金鑰指紋：\n%3$@\n\n只有當指紋與你預期的一致時才信任此伺服器。"
           }
         }
       }
@@ -10227,6 +12231,24 @@
             "state" : "translated",
             "value" : "해당 연결이 더 이상 TablePro에 없습니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết nối đó không còn tồn tại trong TablePro."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该连接在 TablePro 中已不存在。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該連線在 TablePro 中已不存在。"
+          }
         }
       }
     },
@@ -10236,6 +12258,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이 파일에는 개인 키가 아닌 인증서가 들어 있습니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tệp đó chứa chứng chỉ, không phải khóa riêng tư."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该文件包含的是证书，不是私钥。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該檔案包含的是憑證，不是私密金鑰。"
           }
         }
       }
@@ -10247,6 +12287,24 @@
             "state" : "translated",
             "value" : "이 파일에는 인증서가 아닌 개인 키가 들어 있습니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tệp đó chứa khóa riêng tư, không phải chứng chỉ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该文件包含的是私钥，不是证书。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該檔案包含的是私密金鑰，不是憑證。"
+          }
         }
       }
     },
@@ -10256,6 +12314,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이 파일은 PEM 인증서가 아닙니다. .pem 또는 .crt 파일을 선택하거나 인증서 내용을 붙여넣으십시오."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tệp đó không phải chứng chỉ PEM. Hãy chọn tệp .pem hoặc .crt, hoặc dán nội dung của nó."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该文件不是 PEM 证书。请选择 .pem 或 .crt 文件，或粘贴其内容。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該檔案不是 PEM 憑證。請選擇 .pem 或 .crt 檔案，或貼上其內容。"
           }
         }
       }
@@ -10267,6 +12343,24 @@
             "state" : "translated",
             "value" : "이 개인 키는 암호로 보호되어 있습니다. 암호를 제거하거나 대신 PKCS#12 파일을 가져오십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khóa riêng tư đó được bảo vệ bằng passphrase. Hãy gỡ passphrase hoặc nhập tệp PKCS#12 thay thế."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该私钥受密码短语保护。请移除密码短语，或改为导入 PKCS#12 文件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該私密金鑰受密碼短語保護。請移除密碼短語，或改為匯入 PKCS#12 檔案。"
+          }
         }
       }
     },
@@ -10276,6 +12370,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이 텍스트에 인증서 또는 키가 없습니다. BEGIN 및 END 줄을 포함한 전체 PEM 블록을 붙여넣으십시오."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Văn bản đó không chứa chứng chỉ hay khóa nào. Hãy dán toàn bộ khối PEM, bao gồm cả dòng BEGIN và END."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该文本中没有证书或密钥。请粘贴完整的 PEM 块，包括 BEGIN 和 END 行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該文字中沒有憑證或金鑰。請貼上完整的 PEM 區塊，包括 BEGIN 和 END 行。"
           }
         }
       }
@@ -10287,6 +12399,24 @@
             "state" : "translated",
             "value" : "이 연결의 CA 인증서가 없습니다. 연결의 SSL 설정에서 다시 가져오십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thiếu chứng chỉ CA cho kết nối này. Hãy nhập lại trong cài đặt SSL của kết nối."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此连接的 CA 证书缺失。请在连接的 SSL 设置中重新导入。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線的 CA 憑證遺失。請在連線的 SSL 設定中重新匯入。"
+          }
         }
       }
     },
@@ -10296,6 +12426,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "CSV 데이터에 헤더 행이 없습니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dữ liệu CSV không có dòng tiêu đề."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该 CSV 数据没有标题行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該 CSV 資料沒有標題列。"
           }
         }
       }
@@ -10307,6 +12455,24 @@
             "state" : "translated",
             "value" : "JSON 배열에는 객체만 포함해야 합니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mảng JSON chỉ được chứa các đối tượng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON 数组只能包含对象。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON 陣列只能包含物件。"
+          }
         }
       }
     },
@@ -10316,6 +12482,24 @@
           "stringUnit" : {
             "value" : "Microsoft Entra ID 액세스 토큰이 드라이버에서 거부되었습니다.",
             "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Access token Microsoft Entra ID bị driver từ chối."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驱动拒绝了该 Microsoft Entra ID 访问令牌。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驅動程式拒絕了該 Microsoft Entra ID 存取權杖。"
           }
         }
       }
@@ -10327,6 +12511,24 @@
             "state" : "translated",
             "value" : "Oracle 리스너가 연결을 거부했습니다(ORA-%ld)."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle listener đã từ chối kết nối (ORA-%ld)."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle 侦听器拒绝了此连接（ORA-%ld）。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle 接聽程式拒絕了此連線（ORA-%ld）。"
+          }
         }
       }
     },
@@ -10337,6 +12539,24 @@
             "state" : "translated",
             "value" : "Oracle 리스너가 연결을 거부했습니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle listener đã từ chối kết nối."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle 侦听器拒绝了此连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle 接聽程式拒絕了此連線。"
+          }
         }
       }
     },
@@ -10346,6 +12566,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Oracle 서버가 로그인 핸드셰이크 중 연결을 종료했습니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Máy chủ Oracle đã đóng kết nối trong quá trình bắt tay đăng nhập."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle 服务器在登录握手期间关闭了连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle 伺服器在登入交握期間關閉了連線。"
           }
         }
       }
@@ -10413,6 +12651,24 @@
             "state" : "translated",
             "value" : "인증서를 이 기기의 키체인에 저장할 수 없습니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể lưu chứng chỉ vào keychain của thiết bị này."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法将证书保存到本设备的钥匙串。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法將憑證儲存到本裝置的鑰匙圈。"
+          }
         }
       }
     },
@@ -10422,6 +12678,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "인증서 파일을 읽을 수 없습니다. 암호가 맞는지, 파일이 PKCS#12 인증서인지 확인하십시오."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể đọc tệp chứng chỉ. Hãy kiểm tra mật khẩu và xác nhận tệp là chứng chỉ PKCS#12."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法读取证书文件。请检查密码，并确认该文件是 PKCS#12 证书。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法讀取憑證檔案。請檢查密碼，並確認該檔案是 PKCS#12 憑證。"
           }
         }
       }
@@ -10433,6 +12707,24 @@
             "state" : "translated",
             "value" : "이 연결의 클라이언트 인증서가 없습니다. 연결의 SSL 설정에서 다시 가져오십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thiếu chứng chỉ máy khách cho kết nối này. Hãy nhập lại trong cài đặt SSL của kết nối."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此连接的客户端证书缺失。请在连接的 SSL 设置中重新导入。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線的用戶端憑證遺失。請在連線的 SSL 設定中重新匯入。"
+          }
         }
       }
     },
@@ -10442,6 +12734,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이 연결의 클라이언트 키가 없습니다. 연결의 SSL 설정에서 다시 가져오십시오."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thiếu khóa máy khách cho kết nối này. Hãy nhập lại trong cài đặt SSL của kết nối."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此连接的客户端密钥缺失。请在连接的 SSL 设置中重新导入。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線的用戶端金鑰遺失。請在連線的 SSL 設定中重新匯入。"
           }
         }
       }
@@ -10453,6 +12763,24 @@
             "state" : "translated",
             "value" : "데이터를 읽을 수 없습니다: %@"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể đọc dữ liệu: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法读取数据：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法讀取資料：%@"
+          }
         }
       }
     },
@@ -10462,6 +12790,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@에 삽입할 값이 입력 데이터에 없습니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dữ liệu không có giá trị nào để chèn vào %@."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该数据没有可插入 %@ 的值。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該資料沒有可插入 %@ 的值。"
           }
         }
       }
@@ -10501,6 +12847,24 @@
             "state" : "translated",
             "value" : "암호화된 파일이 손상되었거나 불완전합니다"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tệp mã hóa bị hỏng hoặc không đầy đủ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加密文件已损坏或不完整"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加密的檔案已損毀或不完整"
+          }
         }
       }
     },
@@ -10510,6 +12874,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "파일이 UTF-8 텍스트가 아닙니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tệp không phải văn bản UTF-8."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该文件不是 UTF-8 文本。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該檔案不是 UTF-8 文字。"
           }
         }
       }
@@ -10527,6 +12909,24 @@
             "state" : "translated",
             "value" : "%1$@의 호스트 키가 변경되었습니다.\n\n서버가 다시 구축되었거나 누군가 연결을 가로채고 있을 수 있습니다.\n\n이전 지문:\n%2$@\n\n현재 지문:\n%3$@"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khóa máy chủ của %1$@ đã thay đổi.\n\nĐiều này có thể nghĩa là máy chủ được dựng lại, hoặc có ai đó đang chặn kết nối.\n\nVân tay trước đây:\n%2$@\n\nVân tay hiện tại:\n%3$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ 的主机密钥已更改。\n\n这可能意味着服务器被重建，也可能有人正在拦截此连接。\n\n之前的指纹：\n%2$@\n\n当前的指纹：\n%3$@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ 的主機金鑰已變更。\n\n這可能表示伺服器被重建，也可能有人正在攔截此連線。\n\n之前的指紋：\n%2$@\n\n目前的指紋：\n%3$@"
+          }
         }
       }
     },
@@ -10536,6 +12936,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "리스너가 요청한 SID를 인식하지 못합니다"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listener không biết SID được yêu cầu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "侦听器不认识请求的 SID"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接聽程式不認識請求的 SID"
           }
         }
       }
@@ -10547,6 +12965,24 @@
             "state" : "translated",
             "value" : "리스너가 요청한 서비스 이름을 인식하지 못합니다"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listener không biết tên dịch vụ được yêu cầu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "侦听器不认识请求的服务名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接聽程式不認識請求的服務名稱"
+          }
         }
       }
     },
@@ -10556,6 +12992,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "리스너에서 이 SID를 인식하지 못합니다. 12c 이상 데이터베이스는 일반적으로 서비스 이름으로 연결합니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listener không biết SID này. Các cơ sở dữ liệu từ 12c trở đi thường được truy cập bằng tên dịch vụ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "侦听器不认识此 SID。12c 及以后的数据库通常改用服务名连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接聽程式不認識此 SID。12c 及以後的資料庫通常改用服務名稱連線。"
           }
         }
       }
@@ -10567,6 +13021,24 @@
             "state" : "translated",
             "value" : "리스너에서 이 서비스 이름을 인식하지 못합니다. DBA에게 확인하거나 이전 버전 데이터베이스인 경우 SID로 전환하십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listener không biết tên dịch vụ này. Hãy hỏi DBA của bạn, hoặc chuyển sang SID nếu đây là cơ sở dữ liệu cũ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "侦听器不认识此服务名。请与你的 DBA 确认，或在较旧的数据库上改用 SID。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接聽程式不認識此服務名稱。請與你的 DBA 確認，或在較舊的資料庫上改用 SID。"
+          }
         }
       }
     },
@@ -10577,6 +13049,24 @@
             "state" : "translated",
             "value" : "리스너에 요청한 서비스를 처리할 수 있는 핸들러가 없습니다"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listener không có handler khả dụng cho dịch vụ được yêu cầu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "侦听器没有可用于所请求服务的处理程序"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接聽程式沒有可用於所請求服務的處理常式"
+          }
         }
       }
     },
@@ -10586,6 +13076,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "리스너가 요청한 서비스에 대한 새 연결을 차단하고 있습니다"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listener đang chặn các kết nối mới tới dịch vụ được yêu cầu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "侦听器正在阻止到所请求服务的新连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接聽程式正在阻擋到所請求服務的新連線"
           }
         }
       }
@@ -10624,6 +13132,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "쿼리가 설정된 제한 시간 내에 완료되지 않아 연결을 재설정했습니다. 쿼리를 다시 실행하십시오."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Truy vấn không hoàn tất trong thời gian chờ đã cấu hình, nên kết nối đã bị đặt lại. Hãy chạy lại truy vấn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查询未在配置的超时时间内完成，因此连接已重置。请重新运行该查询。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢未在設定的逾時時間內完成，因此連線已重設。請重新執行該查詢。"
           }
         }
       }
@@ -10691,6 +13217,24 @@
             "state" : "translated",
             "value" : "서버에서 예상하지 못한 메시지를 보내 연결을 재설정했습니다. 쿼리를 다시 실행하십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Máy chủ đã gửi một thông điệp không mong đợi và kết nối đã bị đặt lại. Hãy chạy lại truy vấn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服务器发送了意外消息，连接已重置。请重新运行该查询。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伺服器傳送了非預期的訊息，連線已重設。請重新執行該查詢。"
+          }
         }
       }
     },
@@ -10701,6 +13245,24 @@
             "state" : "translated",
             "value" : "서버의 호스트 키가 변경되었습니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khóa máy chủ của server đã thay đổi."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服务器的主机密钥已更改。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伺服器的主機金鑰已變更。"
+          }
         }
       }
     },
@@ -10710,6 +13272,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "서버의 호스트 키를 신뢰하지 않았습니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khóa máy chủ của server không được tin cậy."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服务器的主机密钥未被信任。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伺服器的主機金鑰未被信任。"
           }
         }
       }
@@ -10777,6 +13357,24 @@
             "state" : "translated",
             "value" : "텍스트 인코딩이 올바르지 않습니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bảng mã văn bản không hợp lệ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文本编码无效。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字編碼無效。"
+          }
         }
       }
     },
@@ -10786,6 +13384,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이 Oracle 서버는 릴리스 11.1보다 이전 버전이며 데이터베이스 드라이버에서 지원하지 않습니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Máy chủ Oracle này cũ hơn bản 11.1, phiên bản mà driver cơ sở dữ liệu không hỗ trợ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此 Oracle 服务器早于 11.1 版，数据库驱动不支持。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此 Oracle 伺服器早於 11.1 版，資料庫驅動程式不支援。"
           }
         }
       }
@@ -10797,6 +13413,24 @@
             "state" : "translated",
             "value" : "이 계정은 데이터베이스 드라이버가 지원하지 않는 암호 검증 형식을 사용합니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tài khoản này dùng password verifier mà driver cơ sở dữ liệu không hỗ trợ."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此账户使用了数据库驱动不支持的口令校验器。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此帳戶使用了資料庫驅動程式不支援的密碼驗證器。"
+          }
         }
       }
     },
@@ -10806,6 +13440,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이 인증서 파일에는 암호가 필요합니다. 암호 없이 내보낸 인증서 파일은 iOS에서 읽을 수 없습니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tệp chứng chỉ này cần mật khẩu. Tệp chứng chỉ xuất ra mà không có mật khẩu thì không đọc được trên iOS."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此证书文件需要密码。导出时未设置密码的证书文件在 iOS 上无法读取。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此憑證檔案需要密碼。匯出時未設定密碼的憑證檔案在 iOS 上無法讀取。"
           }
         }
       }
@@ -10817,6 +13469,24 @@
             "state" : "translated",
             "value" : "이 인증서에는 TablePro에서 읽을 수 없는 유형의 개인 키가 사용되었습니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chứng chỉ này dùng loại khóa riêng tư mà TablePro không đọc được."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此证书使用了 TablePro 无法读取的私钥类型。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此憑證使用了 TablePro 無法讀取的私密金鑰類型。"
+          }
         }
       }
     },
@@ -10827,6 +13497,24 @@
             "state" : "translated",
             "value" : "이 연결에 클라이언트 인증서는 있지만 개인 키가 없습니다. 둘 다 가져오십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết nối này có chứng chỉ máy khách nhưng không có khóa riêng tư. Hãy nhập cả hai."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此连接有客户端证书但没有私钥。请同时导入两者。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線有用戶端憑證但沒有私密金鑰。請同時匯入兩者。"
+          }
         }
       }
     },
@@ -10836,6 +13524,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이 연결에 클라이언트 키는 있지만 인증서가 없습니다. 둘 다 가져오십시오."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết nối này có khóa máy khách nhưng không có chứng chỉ. Hãy nhập cả hai."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此连接有客户端密钥但没有证书。请同时导入两者。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線有用戶端金鑰但沒有憑證。請同時匯入兩者。"
           }
         }
       }
@@ -10903,6 +13609,24 @@
             "state" : "translated",
             "value" : "이 기기에서 이 연결의 CA 인증서를 읽을 수 없습니다(%@). 인증서 파일은 기기 간에 동기화되지 않으므로 이 기기에 인증서를 추가하거나 SSL 모드를 필수(Required)로 낮추십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không đọc được chứng chỉ CA của kết nối này trên thiết bị này (%@). Tệp chứng chỉ không đồng bộ giữa các thiết bị, nên hãy thêm chứng chỉ tại đây hoặc hạ chế độ SSL xuống Required."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此连接的 CA 证书在本设备上不可读（%@）。证书文件不会在设备之间同步，请在此处添加证书，或将 SSL 模式降为“必需”。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線的 CA 憑證在本裝置上無法讀取（%@）。憑證檔案不會在裝置之間同步，請在此處加入憑證，或將 SSL 模式降為「必要」。"
+          }
         }
       }
     },
@@ -10913,6 +13637,24 @@
             "state" : "translated",
             "value" : "이 기기에서 이 연결의 클라이언트 인증서를 읽을 수 없습니다(%@). 인증서 파일은 기기 간에 동기화되지 않으므로 연결하기 전에 이 기기에 인증서를 추가하십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không đọc được chứng chỉ máy khách của kết nối này trên thiết bị này (%@). Tệp chứng chỉ không đồng bộ giữa các thiết bị, nên hãy thêm chứng chỉ tại đây trước khi kết nối."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此连接的客户端证书在本设备上不可读（%@）。证书文件不会在设备之间同步，请先在此处添加证书再连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線的用戶端憑證在本裝置上無法讀取（%@）。憑證檔案不會在裝置之間同步，請先在此處加入憑證再連線。"
+          }
         }
       }
     },
@@ -10922,6 +13664,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이 기기에서 이 연결의 클라이언트 키를 읽을 수 없습니다(%@). 키 파일은 기기 간에 동기화되지 않으므로 연결하기 전에 이 기기에 키를 추가하십시오."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không đọc được khóa máy khách của kết nối này trên thiết bị này (%@). Tệp khóa không đồng bộ giữa các thiết bị, nên hãy thêm khóa tại đây trước khi kết nối."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此连接的客户端密钥在本设备上不可读（%@）。密钥文件不会在设备之间同步，请先在此处添加密钥再连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此連線的用戶端金鑰在本裝置上無法讀取（%@）。金鑰檔案不會在裝置之間同步，請先在此處加入金鑰再連線。"
           }
         }
       }
@@ -10961,6 +13721,24 @@
             "state" : "translated",
             "value" : "이 파일에 개인 키가 없습니다. 인증서를 개인 키와 함께 내보내십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tệp này không có khóa riêng tư. Hãy xuất chứng chỉ cùng với khóa của nó."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此文件没有私钥。请将证书与其密钥一起导出。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此檔案沒有私密金鑰。請將憑證與其金鑰一起匯出。"
+          }
         }
       }
     },
@@ -10999,6 +13777,24 @@
             "state" : "translated",
             "value" : "이 파일은 암호화되어 있어 암호가 필요합니다"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tệp này được mã hóa và yêu cầu cụm mật khẩu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此文件已加密，需要密码短语"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此檔案已加密，需要通關密語"
+          }
         }
       }
     },
@@ -11009,6 +13805,24 @@
             "state" : "translated",
             "value" : "이 파일은 올바른 TablePro 내보내기 파일이 아닙니다"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tệp này không phải là tệp xuất TablePro hợp lệ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此文件不是有效的 TablePro 导出文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此檔案不是有效的 TablePro 匯出檔"
+          }
         }
       }
     },
@@ -11018,6 +13832,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이 파일을 사용하려면 더 최신 버전의 TablePro가 필요합니다(파일 형식 버전 %d)"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tệp này yêu cầu phiên bản TablePro mới hơn (phiên bản định dạng %d)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此文件需要更新版本的TablePro（格式版本%d）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此檔案需要較新版本的 TablePro（格式版本 %d）"
           }
         }
       }
@@ -11057,6 +13889,24 @@
             "state" : "translated",
             "value" : "이 서버의 기본 사용자에게는 암호가 설정되어 있지 않습니다. 암호 필드를 비우십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Máy chủ này không đặt mật khẩu cho người dùng mặc định. Hãy xóa trống trường Mật khẩu."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此服务器未为默认用户设置密码。请清空“密码”字段。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此伺服器未為預設使用者設定密碼。請清空「密碼」欄位。"
+          }
         }
       }
     },
@@ -11066,6 +13916,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이 서버는 Redis 6 이전 버전이므로 사용자 이름을 사용하지 않습니다. 사용자 이름 필드를 비우십시오."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Máy chủ này cũ hơn Redis 6 và không nhận tên người dùng. Hãy xóa trống trường Tên người dùng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此服务器早于 Redis 6，不接受用户名。请清空“用户名”字段。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此伺服器早於 Redis 6，不接受使用者名稱。請清空「使用者名稱」欄位。"
           }
         }
       }
@@ -11245,6 +14113,24 @@
             "state" : "translated",
             "value" : "Kerberos 인증을 완료하는 동안 시간이 초과되었습니다. Kerberos KDC(도메인 컨트롤러)에 연결할 수 없거나, 서버의 SPN이 없거나, 이 기기의 시계가 맞지 않을 수 있습니다. 도메인에 대한 네트워크 연결을 확인하거나 SQL Server 인증을 사용하십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hết thời gian chờ khi hoàn tất xác thực Kerberos. Có thể KDC Kerberos (domain controller) không truy cập được, SPN của máy chủ bị thiếu, hoặc đồng hồ của thiết bị này bị lệch. Hãy kiểm tra mạng tới domain, hoặc dùng SQL Server Authentication."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成 Kerberos 认证超时。可能是 Kerberos KDC（域控制器）无法访问、服务器的 SPN 缺失，或本设备的时钟不准。请检查到域的网络，或改用 SQL Server 身份验证。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成 Kerberos 驗證逾時。可能是 Kerberos KDC（網域控制站）無法連線、伺服器的 SPN 遺失，或本裝置的時鐘不準。請檢查到網域的網路，或改用 SQL Server 驗證。"
+          }
         }
       }
     },
@@ -11254,6 +14140,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "서버에 연결하는 동안 시간이 초과되었습니다. 호스트와 포트가 올바른지, 서버에 연결할 수 있고 서버가 연결을 수락하는지 확인하십시오."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hết thời gian chờ khi kết nối tới máy chủ. Hãy kiểm tra host, cổng, và xem máy chủ có truy cập được và đang nhận kết nối không."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连接服务器超时。请检查主机、端口，以及服务器是否可达并接受连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線伺服器逾時。請檢查主機、連接埠，以及伺服器是否可連線並接受連線。"
           }
         }
       }
@@ -11265,6 +14169,24 @@
             "state" : "translated",
             "value" : "Oracle 로그인 핸드셰이크 중 시간이 초과되었습니다. 서버가 네트워크 연결을 수락했지만 로그인을 완료하지 않았습니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hết thời gian chờ trong quá trình bắt tay đăng nhập Oracle. Máy chủ đã chấp nhận kết nối mạng nhưng không hoàn tất đăng nhập."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle 登录握手超时。服务器接受了网络连接，但没有完成登录。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oracle 登入交握逾時。伺服器接受了網路連線，但沒有完成登入。"
+          }
         }
       }
     },
@@ -11274,6 +14196,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "행이 너무 많습니다. 한 번에 최대 %lld개까지 추가하십시오."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quá nhiều dòng. Mỗi lần chỉ thêm tối đa %lld dòng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行数过多。每次最多添加 %lld 行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列數過多。每次最多新增 %lld 列。"
           }
         }
       }
@@ -11340,6 +14280,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "신뢰"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tin cậy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "信任"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "信任"
           }
         }
       }
@@ -11492,6 +14450,24 @@
             "state" : "translated",
             "value" : "알 수 없는 SSH 서버"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Máy chủ SSH không xác định"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知的 SSH 服务器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知的 SSH 伺服器"
+          }
         }
       }
     },
@@ -11558,6 +14534,24 @@
             "state" : "translated",
             "value" : "지원되지 않는 암호화 버전 %d"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phiên bản mã hoá %d không được hỗ trợ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支持的加密版本%d"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支援的加密版本 %d"
+          }
         }
       }
     },
@@ -11596,6 +14590,24 @@
             "state" : "translated",
             "value" : "대신 SID 사용"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dùng SID thay thế"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "改用 SID"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "改用 SID"
+          }
         }
       }
     },
@@ -11605,6 +14617,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "대신 서비스 이름 사용"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dùng tên dịch vụ thay thế"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "改用服务名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "改用服務名稱"
           }
         }
       }
@@ -11644,6 +14674,24 @@
             "state" : "translated",
             "value" : "사용자 이름은 Redis 6 이상의 ACL 사용자용입니다. 암호만 사용하는 서버에서는 비워 두십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tên người dùng dành cho người dùng ACL của Redis 6 trở lên. Để trống với các máy chủ chỉ dùng mật khẩu."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用户名用于 Redis 6 及更高版本的 ACL 用户。仅使用密码的服务器请留空。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用者名稱用於 Redis 6 及更新版本的 ACL 使用者。僅使用密碼的伺服器請留空。"
+          }
         }
       }
     },
@@ -11682,6 +14730,24 @@
             "state" : "translated",
             "value" : "CA 확인"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xác minh CA"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "验证 CA"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證 CA"
+          }
         }
       }
     },
@@ -11691,6 +14757,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "신원 확인"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xác minh danh tính"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "验证身份"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證身分"
           }
         }
       }
@@ -11843,6 +14927,24 @@
             "state" : "translated",
             "value" : "이 옵션을 끄면 연결, 그룹 및 태그가 이 기기에만 저장됩니다. 기존 iCloud 데이터는 삭제되지 않습니다. 암호 동기화를 켜지 않는 한 암호도 이 기기에만 저장됩니다."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khi tắt, kết nối, nhóm và thẻ chỉ nằm trên thiết bị này. Dữ liệu iCloud hiện có không bị xóa. Mật khẩu vẫn ở trên thiết bị này trừ khi bạn bật Đồng bộ mật khẩu."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭后，连接、分组和标签只保留在本设备上。已有的 iCloud 数据不会被删除。除非你开启“同步密码”，否则密码只保留在本设备。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉後，連線、群組和標籤只保留在本裝置上。已有的 iCloud 資料不會被刪除。除非你開啟「同步密碼」，否則密碼只保留在本裝置。"
+          }
         }
       }
     },
@@ -11881,6 +14983,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Windows 인증(Kerberos)은 아직 iOS에서 지원되지 않습니다. SQL Server 인증을 사용하거나 Mac 앱에서 연결하십시오."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Windows Authentication (Kerberos) chưa được hỗ trợ trên iOS. Hãy dùng SQL Server Authentication, hoặc kết nối từ ứng dụng Mac."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iOS 上尚不支持 Windows 身份验证（Kerberos）。请使用 SQL Server 身份验证，或从 Mac 应用连接。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iOS 上尚不支援 Windows 驗證（Kerberos）。請使用 SQL Server 驗證，或從 Mac App 連線。"
           }
         }
       }
@@ -11948,6 +15068,24 @@
             "state" : "translated",
             "value" : "노란색"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vàng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "黄色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "黃色"
+          }
         }
       }
     },
@@ -11986,6 +15124,24 @@
             "state" : "translated",
             "value" : "범위 내"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "giữa"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "介于"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "介於"
+          }
         }
       }
     },
@@ -11995,6 +15151,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "연결"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kết nối"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線"
           }
         }
       }
@@ -12006,6 +15180,24 @@
             "state" : "translated",
             "value" : "포함"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "chứa"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含"
+          }
         }
       }
     },
@@ -12015,6 +15207,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "데이터베이스"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "cơ sở dữ liệu"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料庫"
           }
         }
       }
@@ -12026,6 +15236,24 @@
             "state" : "translated",
             "value" : "다음으로 끝남"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kết thúc bằng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "以...结尾"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結尾為"
+          }
         }
       }
     },
@@ -12036,6 +15264,24 @@
             "state" : "translated",
             "value" : "같음"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bằng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等于"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等於"
+          }
         }
       }
     },
@@ -12045,6 +15291,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "보다 큼"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "lớn hơn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大于"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大於"
           }
         }
       }
@@ -12084,6 +15348,24 @@
             "state" : "translated",
             "value" : "iCloud 계정을 사용할 수 없습니다. 시스템 설정에서 iCloud에 로그인하십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tài khoản iCloud không khả dụng. Đăng nhập iCloud trong Cài đặt hệ thống."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 账户不可用。请在系统设置中登录 iCloud。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 帳號無法使用。請在「系統設定」中登入 iCloud。"
+          }
         }
       }
     },
@@ -12100,6 +15382,24 @@
             "state" : "translated",
             "value" : "iCloud에서 변경 사항 %d개를 거부했습니다. 변경 사항은 이 기기에 유지되며 다시 시도됩니다: %@"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud đã từ chối %1$d thay đổi. Chúng vẫn ở trên thiết bị này và sẽ thử lại: %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 拒绝了 %1$d 项更改。它们保留在本设备上，稍后会重试：%2$@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 拒絕了 %1$d 項變更。它們保留在本裝置上，稍後會重試：%2$@"
+          }
         }
       }
     },
@@ -12109,6 +15409,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "iCloud 서버 오류: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lỗi máy chủ iCloud: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 服务器错误：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 伺服器錯誤：%@"
           }
         }
       }
@@ -12120,6 +15438,24 @@
             "state" : "translated",
             "value" : "iCloud 저장 공간이 가득 찼습니다. iCloud에서 공간을 확보한 후 다시 시도하십시오."
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dung lượng iCloud đã đầy. Hãy giải phóng dung lượng trong iCloud rồi thử lại."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 存储空间已满。请在 iCloud 中释放空间后重试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 儲存空間已滿。請在 iCloud 中釋放空間後重試。"
+          }
         }
       }
     },
@@ -12129,6 +15465,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "가져오기"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "nhập"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入"
           }
         }
       }
@@ -12140,6 +15494,24 @@
             "state" : "translated",
             "value" : "IN"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "thuộc"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "属于"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "屬於"
+          }
         }
       }
     },
@@ -12149,6 +15521,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "삽입"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "chèn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "插入"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "插入"
           }
         }
       }
@@ -12160,6 +15550,24 @@
             "state" : "translated",
             "value" : "NULL이 아님"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "không là null"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不为 NULL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不為 NULL"
+          }
         }
       }
     },
@@ -12169,6 +15577,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "NULL임"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "là null"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "为 NULL"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "為 NULL"
           }
         }
       }
@@ -12180,6 +15606,24 @@
             "state" : "translated",
             "value" : "보다 작음"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "nhỏ hơn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小于"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小於"
+          }
         }
       }
     },
@@ -12189,6 +15633,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "LIKE"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "giống"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匹配"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "相符"
           }
         }
       }
@@ -12200,6 +15662,24 @@
             "state" : "translated",
             "value" : "같지 않음"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "không bằng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不等于"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不等於"
+          }
         }
       }
     },
@@ -12209,6 +15689,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "NOT IN"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "không thuộc"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不属于"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不屬於"
           }
         }
       }
@@ -12220,6 +15718,24 @@
             "state" : "translated",
             "value" : "NOT LIKE"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "không giống"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不匹配"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不相符"
+          }
         }
       }
     },
@@ -12229,6 +15745,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "열기"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mở"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟"
           }
         }
       }
@@ -12296,6 +15830,24 @@
             "state" : "translated",
             "value" : "행"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dòng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列"
+          }
         }
       }
     },
@@ -12305,6 +15857,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "행"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "các dòng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "多行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "多列"
           }
         }
       }
@@ -12316,6 +15886,24 @@
             "state" : "translated",
             "value" : "다음으로 시작"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bắt đầu bằng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "以...开头"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開頭為"
+          }
         }
       }
     },
@@ -12325,6 +15913,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "테이블"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bảng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料表"
           }
         }
       }
@@ -12336,12 +15942,48 @@
             "state" : "translated",
             "value" : "≤"
           }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "≤"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "≤"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "≤"
+          }
         }
       }
     },
     "≥" : {
       "localizations" : {
         "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "≥"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "≥"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "≥"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "≥"


### PR DESCRIPTION
Fills every gap in the five string catalogs. 1,875 translation units across Turkish, Vietnamese, Simplified Chinese, Traditional Chinese and Korean.

## What was missing

| Catalog | Languages filled | Units |
| --- | --- | --- |
| `TablePro/Resources/Localizable.xcstrings` | ko, tr, vi, zh-Hans, zh-Hant | 1,237 |
| `TableProMobile/TableProMobile/Localizable.xcstrings` | ko, vi, zh-Hans, zh-Hant | 607 |
| `TablePro/InfoPlist.xcstrings` | tr, vi, zh-Hans, zh-Hant | 16 |
| `TableProMobile/TableProMobile/InfoPlist.xcstrings` | vi, zh-Hans, zh-Hant | 6 |
| `TableProMobile/TableProMobile/AppShortcuts.xcstrings` | vi, zh-Hans, zh-Hant | 9 |

The bulk is Compare & Sync, the plugin trust prompts, the Oracle, Kerberos and Redis error messages, and the iOS certificate import and Add Row Shortcuts flows.

The two `InfoPlist` catalogs and `AppShortcuts` had Korean and nothing else, so the privacy prompts and the Siri phrases were showing in English to Turkish, Vietnamese and both Chinese audiences. Those three catalogs were invisible to a "which languages is this catalog missing?" check that reads only the languages a catalog already declares, which is why they had gone unnoticed.

## How the translations were produced

- 412 unique English strings, translated once each and applied to both catalogs. 101 keys the mobile catalog was missing already had a shipped translation in the Mac catalog, so those were reused verbatim rather than being worded a second way.
- Terminology follows what the catalogs already use, not a fresh choice: `Table` is Tablo / Bảng / 表 / 資料表, `statement` is ifade / câu lệnh / 语句 / 陳述式, `driver` is sürücü / driver / 驱动 / 驅動程式, and row is `dòng` in Vietnamese against 行 and 列 in the two Chinese scripts.
- The filter operators (`in`, `like`, `is null`, `≤`) are translated rather than left as SQL keywords, because their peers in the same picker (`equals`, `between`, `contains`) already are.
- Format specifiers are reordered positionally (`%1$@`, `%2$d`) wherever the target language wants a different word order, and left plain where it does not. No string mixes the two forms.

## Verification

- `StringCatalogIntegrityTests` passes all 6 checks: argument specifiers match the source, `${token}` interpolation survives, trailing ellipses survive, terminal punctuation survives (full-width forms counted), no translation introduces an em dash, no inflection markup leaks into a translation.
- A key-by-key diff against `main` confirms 0 mutated existing units and 0 added or removed keys. Every one of the 12,210 added lines is a new localization block.
- The catalogs stay byte-identical to Xcode's own formatting, so the next Xcode save produces no churn.

The test run first failed on a pre-existing `Cannot find type 'QueryCompletionProfile' in scope`, unrelated to this branch: a source file from d25370d27 was not yet in the generated project. `scripts/generate-project.sh macos` cleared it.

## Left alone deliberately

11 Mac keys still carry `needs_review` in all four languages (the Workspace Rail and Open Quickly strings). They have translations, so they are not missing, and clearing that flag is a review decision rather than a translation one. One is worth a look while someone is in there: `Open Quickly` is `快速打開` in Traditional Chinese, where `快速開啟` is the more conventional wording.

https://claude.ai/code/session_01NuqtiCUXKZn8WuLPgLRK6U
