### PR TITLE
fix(sidebar): put the workspace rail's connection color on a dot instead of a slab behind the label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Row inspector fields, cell popovers and the Compare row diff follow the data grid font. (#2393)
 - The connection color as a filled badge behind the connection name, with the database icon back to its engine color. (#2398)
 - Deeper fills on tag badges and the connection name badge. (#2398)
+- The connection color in the workspace rail as a dot on the engine icon, kept visible on the selected row. (#2398)
 
 ### Fixed
 
 - A connection's color and name not reaching the toolbar and workspace rail until the next reconnect. (#2398)
 - An invisible connection dot in the query history drawer and the compare status strip. (#2398)
+- A failed connection's warning icon in the workspace rail wearing the database engine's color. (#2398)
 - The JSON viewer keeping its old font after a font, theme or text-size change. (#2393)
 - Hex dumps wrapping mid-line instead of keeping their columns aligned. (#2393)
 - A second of delay opening the inline editor on a result with hundreds of columns. (#2381)

--- a/TablePro/Core/Services/Infrastructure/WorkspaceRailCellView.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspaceRailCellView.swift
@@ -6,32 +6,44 @@
 import AppKit
 import SwiftUI
 
-/// One workspace: the engine's glyph above the container it browses, over the connection's own
-/// colour.
+/// One workspace: a glyph above the container it browses, with the connection's own colour as a
+/// dot on the glyph's corner.
 ///
-/// The glyph carries the engine and the band behind the label carries the user's pick. This cell
-/// used to put both on the glyph, on the reasoning that "the colour is the icon", which is how
-/// Finder carries a tag. That holds for a Finder icon, which is a neutral document or folder shape
-/// with no colour of its own to lose. An engine glyph is not neutral: it is a brand mark that is
-/// already a colour meaning something else, so the two readings competed for one shape and the
-/// engine's lost. Picking a colour only shifted the glyph's hue, which is the complaint #2398
-/// reports. State stays on the glyph's shape, not on either colour, so it still survives colour
-/// blindness and Increase Contrast, and the colour's name joins the tooltip and the accessibility
-/// label so it is never the only channel. The label truncates in the middle, which the HIG
-/// recommends for narrow columns because it keeps both ends of the name recognisable, and
-/// the full name, host and container stay in the tooltip and the accessibility label.
+/// Three channels share this cell and each owns a different property of the same glyph. Its SHAPE
+/// is the connection's state, because a colour-only difference between failed and disconnected is
+/// invisible to anyone who cannot tell red from grey. Its COLOUR is the engine when connected and
+/// the state's own colour when not. The user's identity colour is a separate dot, so it never has
+/// to win an argument with either.
+///
+/// The dot is what Finder puts on a tag row and what this app already puts beside a connection in
+/// the welcome list and the connection switcher, measured at 12.5pt and 8pt respectively. It
+/// replaced a full-width filled band behind the label, which was the loudest element in the window,
+/// stacked on top of the selection fill, and read as destructive rather than as a label (#2398).
+///
+/// Unlike the glyph tint, the dot stays lit on the selected row: the HIG's sidebar guidance is that
+/// a fixed colour set to clarify an icon is not overridden by the system, and the selected row is
+/// the one whose identity the user most needs to confirm. A rim in the selection's own label colour
+/// is what keeps it legible against the accent fill, which seven of the eight palette colours
+/// otherwise fail 3:1 against.
+///
+/// The label keeps its single line and its middle truncation. Wrapping to two was tried and is
+/// worse: underscore is Unicode class AL and offers no break, so `tablepro_license` breaks at the
+/// width limit into `tablepro_licens` and an orphaned `e`. The HIG's reason for middle truncation
+/// in a narrow column stands, and the full name is in the tooltip and the accessibility label.
 @MainActor
 internal final class WorkspaceRailCellView: NSTableCellView {
     internal static let reuseIdentifier = NSUserInterfaceItemIdentifier("WorkspaceRailCell")
 
     private let icon = NSImageView()
     private let label = NSTextField(labelWithString: "")
-    private let identityBand = NSView()
+    private let identityDot = NSView()
     private var iconWidthConstraint: NSLayoutConstraint?
     private var iconHeightConstraint: NSLayoutConstraint?
+    private var dotWidthConstraint: NSLayoutConstraint?
+    private var dotHeightConstraint: NSLayoutConstraint?
     private var appliedTint: NSColor?
     /// Held as the palette entry rather than a resolved colour, because `systemRed` and the rest
-    /// differ between light and dark: resolving at configure time would freeze the band at the
+    /// differ between light and dark: resolving at configure time would freeze the dot at the
     /// appearance the row was built in and `viewDidChangeEffectiveAppearance` would repaint it with
     /// the stale value.
     private var identityColor: ConnectionColor?
@@ -59,14 +71,13 @@ internal final class WorkspaceRailCellView: NSTableCellView {
         label.allowsExpansionToolTips = true
         label.cell?.truncatesLastVisibleLine = true
 
-        identityBand.translatesAutoresizingMaskIntoConstraints = false
-        identityBand.wantsLayer = true
-        identityBand.layer?.cornerRadius = Self.identityBandCornerRadius
-        identityBand.layer?.cornerCurve = .continuous
+        identityDot.translatesAutoresizingMaskIntoConstraints = false
+        identityDot.wantsLayer = true
+        identityDot.layer?.borderWidth = Self.identityDotRimWidth
 
         addSubview(icon)
-        addSubview(identityBand)
         addSubview(label)
+        addSubview(identityDot)
         imageView = icon
         textField = label
 
@@ -74,6 +85,11 @@ internal final class WorkspaceRailCellView: NSTableCellView {
         let height = icon.heightAnchor.constraint(equalToConstant: 24)
         iconWidthConstraint = width
         iconHeightConstraint = height
+
+        let dotWidth = identityDot.widthAnchor.constraint(equalToConstant: Self.identityDotSize(forIcon: 24))
+        let dotHeight = identityDot.heightAnchor.constraint(equalToConstant: Self.identityDotSize(forIcon: 24))
+        dotWidthConstraint = dotWidth
+        dotHeightConstraint = dotHeight
 
         NSLayoutConstraint.activate([
             icon.centerXAnchor.constraint(equalTo: centerXAnchor),
@@ -85,36 +101,48 @@ internal final class WorkspaceRailCellView: NSTableCellView {
             label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 2),
             label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -2),
 
-            identityBand.leadingAnchor.constraint(equalTo: leadingAnchor),
-            identityBand.trailingAnchor.constraint(equalTo: trailingAnchor),
-            identityBand.topAnchor.constraint(equalTo: label.topAnchor, constant: -Self.identityBandInset),
-            identityBand.bottomAnchor.constraint(equalTo: label.bottomAnchor, constant: Self.identityBandInset),
+            dotWidth,
+            dotHeight,
+            identityDot.centerXAnchor.constraint(equalTo: icon.trailingAnchor),
+            identityDot.centerYAnchor.constraint(equalTo: icon.bottomAnchor),
         ])
     }
 
-    private static let identityBandCornerRadius: CGFloat = 4
-    private static let identityBandInset: CGFloat = 2
+    /// Sized against the glyph rather than fixed, so it keeps the same proportion at every
+    /// System Settings sidebar icon size. At the medium rail this is 9pt, between the 8pt dot the
+    /// welcome list already draws and the 12.5pt one measured on a Finder tag.
+    internal static func identityDotSize(forIcon iconSize: CGFloat) -> CGFloat {
+        (iconSize * 0.375).rounded()
+    }
+
+    private static let identityDotRimWidth: CGFloat = 1.5
 
     internal func configure(entry: WorkspaceRailEntry, layout: WorkspaceRailMetrics.Layout) {
         iconWidthConstraint?.constant = layout.iconSize
         iconHeightConstraint?.constant = layout.iconSize
 
+        let dotSize = Self.identityDotSize(forIcon: layout.iconSize)
+        dotWidthConstraint?.constant = dotSize
+        dotHeightConstraint?.constant = dotSize
+        identityDot.layer?.cornerRadius = dotSize / 2
+
         label.font = .systemFont(ofSize: layout.fontSize)
         label.stringValue = entry.container.isEmpty ? entry.connection.name : entry.container
 
-        appliedTint = NSColor(entry.connection.brandColor)
+        appliedTint = Self.glyphTint(for: entry)
         identityColor = entry.connection.identityColor
         icon.image = Self.glyph(for: entry)
+        identityDot.isHidden = identityColor == nil
         applyTint()
 
         toolTip = Self.tooltipText(for: entry)
         setAccessibilityLabel(Self.voiceOverLabel(for: entry))
     }
 
-    /// On the selected row `NSTableCellView` already tints the image view for contrast, so
-    /// the connection colour steps aside rather than competing with the selection fill, which
-    /// it loses against at every accent colour. The identity band steps aside with it, for the
-    /// same reason: a fill of its own under the selection fill reads as two overlapping bands.
+    /// On the selected row `NSTableCellView` already tints the image view for contrast, so the
+    /// glyph steps aside rather than competing with the selection fill, which it loses against at
+    /// every accent colour. The identity dot does not step aside with it: it is the one thing on
+    /// the row the selection cannot restate, and its rim is what carries it over the accent fill.
     override var backgroundStyle: NSView.BackgroundStyle {
         didSet { applyTint() }
     }
@@ -125,21 +153,34 @@ internal final class WorkspaceRailCellView: NSTableCellView {
     }
 
     private func applyTint() {
-        guard backgroundStyle != .emphasized else {
-            icon.contentTintColor = nil
-            identityBand.layer?.backgroundColor = nil
-            label.textColor = nil
-            return
-        }
+        let isEmphasized = backgroundStyle == .emphasized
         effectiveAppearance.performAsCurrentDrawingAppearance {
-            icon.contentTintColor = appliedTint
-            guard let fill = identityColor?.labelledFill else {
-                identityBand.layer?.backgroundColor = nil
-                label.textColor = nil
-                return
-            }
-            identityBand.layer?.backgroundColor = NSColor(fill).cgColor
-            label.textColor = NSColor(Color.legibleForeground(on: fill))
+            icon.contentTintColor = isEmphasized ? nil : appliedTint
+
+            guard let hue = identityColor?.indicatorColor else { return }
+            identityDot.layer?.backgroundColor = NSColor(hue).cgColor
+            /// The rim punches the dot out of whatever sits behind it. On the selected row that is
+            /// the accent fill, which red, blue, purple, pink and grey all fail 3:1 against, so the
+            /// rim takes the colour AppKit itself uses for content on a selection.
+            identityDot.layer?.borderColor = isEmphasized
+                ? NSColor.alternateSelectedControlTextColor.cgColor
+                : NSColor.windowBackgroundColor.cgColor
+        }
+    }
+
+    /// The glyph's colour follows what its shape is saying. Tinting every state with the engine's
+    /// brand colour, which is what this used to do, painted a failed PostgreSQL connection's
+    /// warning triangle PostgreSQL blue: the one glyph that exists to raise an alarm wore the
+    /// calmest colour on the row. Identity never reaches here, so a connection the user named Red
+    /// and a connection that failed stay distinguishable.
+    internal static func glyphTint(for entry: WorkspaceRailEntry) -> NSColor {
+        switch entry.status {
+        case .error:
+            return .systemRed
+        case .disconnected:
+            return .secondaryLabelColor
+        case .connecting, .connected:
+            return NSColor(entry.connection.brandColor)
         }
     }
 

--- a/TableProTests/Core/Services/WorkspaceRailCellRenderingTests.swift
+++ b/TableProTests/Core/Services/WorkspaceRailCellRenderingTests.swift
@@ -1,0 +1,102 @@
+//
+//  WorkspaceRailCellRenderingTests.swift
+//  TableProTests
+//
+//  The rail shipped a full-width saturated slab behind its label once, which no assertion caught
+//  because every test read model state and none of them looked at the cell. These render the cell
+//  and read pixels back.
+//
+
+import AppKit
+import Foundation
+import SwiftUI
+@testable import TablePro
+import Testing
+
+@Suite("Workspace rail cell rendering")
+@MainActor
+struct WorkspaceRailCellRenderingTests {
+    private static let layout = WorkspaceRailMetrics.medium
+
+    private func cell(color: ConnectionColor, status: ConnectionStatus = .connected) -> WorkspaceRailCellView {
+        var connection = TestFixtures.makeConnection(database: "app")
+        connection.name = "production"
+        connection.color = color
+        let entry = WorkspaceRailEntry(
+            workspace: WorkspaceID(connectionId: connection.id, container: "app"),
+            connection: connection,
+            status: status,
+            containerTarget: .database
+        )
+
+        let view = WorkspaceRailCellView(frame: NSRect(
+            x: 0, y: 0, width: Self.layout.width, height: Self.layout.rowHeight
+        ))
+        view.configure(entry: entry, layout: Self.layout)
+        view.layoutSubtreeIfNeeded()
+        view.displayIfNeeded()
+        return view
+    }
+
+    /// Measured: `cacheDisplay` does capture a layer-backed subview, and `CALayer.render(in:)`
+    /// returns an empty bitmap for this tree whether or not the root is layer-backed.
+    private func render(_ view: NSView) -> NSBitmapImageRep? {
+        guard let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds) else { return nil }
+        view.cacheDisplay(in: view.bounds, to: rep)
+        return rep
+    }
+
+    private func pixelCount(_ rep: NSBitmapImageRep, matching predicate: (NSColor) -> Bool) -> Int {
+        var count = 0
+        for y in 0 ..< rep.pixelsHigh {
+            for x in 0 ..< rep.pixelsWide {
+                guard let raw = rep.colorAt(x: x, y: y),
+                      let color = raw.usingColorSpace(.sRGB),
+                      color.alphaComponent > 0.5 else { continue }
+                if predicate(color) { count += 1 }
+            }
+        }
+        return count
+    }
+
+    private func isRedish(_ color: NSColor) -> Bool {
+        color.redComponent > 0.55 && color.greenComponent < 0.45 && color.blueComponent < 0.45
+    }
+
+    /// The defect this suite exists for. The band covered the label's whole width; a dot may not
+    /// cover more than a small fraction of the cell, whatever colour the user picks.
+    @Test("The identity colour never covers more than a fraction of the cell")
+    func identityStaysSmall() throws {
+        let view = cell(color: .red)
+        let rep = try #require(render(view))
+        let total = rep.pixelsWide * rep.pixelsHigh
+        let painted = pixelCount(rep, matching: isRedish)
+
+        #expect(painted > 0, "the identity colour did not render at all")
+        #expect(
+            Double(painted) / Double(total) < 0.05,
+            "identity covers \(painted) of \(total) pixels, which is a fill rather than a dot"
+        )
+    }
+
+    /// The rail used to drop identity entirely on the selected row, which is the row whose identity
+    /// the user most needs to confirm.
+    @Test("The identity colour survives selection")
+    func identitySurvivesSelection() throws {
+        let view = cell(color: .red)
+        view.backgroundStyle = .emphasized
+        view.layoutSubtreeIfNeeded()
+        view.displayIfNeeded()
+        let rep = try #require(render(view))
+
+        #expect(pixelCount(rep, matching: isRedish) > 0, "identity vanished on the selected row")
+    }
+
+    @Test("A connection with no colour paints no identity")
+    func uncolouredPaintsNothing() throws {
+        let view = cell(color: .none)
+        let rep = try #require(render(view))
+
+        #expect(pixelCount(rep, matching: isRedish) == 0)
+    }
+}

--- a/TableProTests/Core/Services/WorkspaceRailStoreTests.swift
+++ b/TableProTests/Core/Services/WorkspaceRailStoreTests.swift
@@ -1,4 +1,6 @@
+import AppKit
 import Foundation
+import SwiftUI
 @testable import TablePro
 import Testing
 
@@ -280,6 +282,61 @@ struct WorkspaceRailCellTextTests {
             status: status,
             containerTarget: containerTarget
         )
+    }
+
+    /// The regression this exists to stop: the glyph used to take the engine's brand colour in
+    /// every state, so a failed PostgreSQL connection's warning triangle rendered PostgreSQL blue.
+    @Test("A failed connection's glyph is not the engine's brand colour")
+    func failedGlyphIsNotBrandColoured() {
+        let failed = WorkspaceRailCellView.glyphTint(for: makeEntry(status: .error("boom")))
+        let connected = WorkspaceRailCellView.glyphTint(for: makeEntry(status: .connected))
+
+        #expect(failed == .systemRed)
+        #expect(failed != connected)
+    }
+
+    @Test("A disconnected connection's glyph recedes rather than wearing a brand colour")
+    func disconnectedGlyphRecedes() {
+        let disconnected = WorkspaceRailCellView.glyphTint(for: makeEntry(status: .disconnected))
+        let connected = WorkspaceRailCellView.glyphTint(for: makeEntry(status: .connected))
+
+        #expect(disconnected == .secondaryLabelColor)
+        #expect(disconnected != connected)
+    }
+
+    /// Identity never reaches the glyph, so naming a connection Red cannot make a healthy
+    /// connection look like a failed one.
+    @Test("The identity colour never reaches the glyph tint")
+    func identityStaysOffTheGlyph() {
+        var connection = TestFixtures.makeConnection(database: "app")
+        connection.color = .red
+        let entry = WorkspaceRailEntry(
+            workspace: WorkspaceID(connectionId: connection.id, container: "app"),
+            connection: connection,
+            status: .connected,
+            containerTarget: .database
+        )
+
+        #expect(WorkspaceRailCellView.glyphTint(for: entry) == NSColor(connection.brandColor))
+    }
+
+    /// The dot sits between the 8pt one the welcome list draws and the 12.5pt one measured on a
+    /// Finder tag, and scales with the sidebar icon size rather than being fixed.
+    private static let railLayouts: [WorkspaceRailMetrics.Layout] = [
+        WorkspaceRailMetrics.small,
+        WorkspaceRailMetrics.medium,
+        WorkspaceRailMetrics.large,
+    ]
+
+    @Test("The identity dot scales with the icon and stays in the shipped size range")
+    func identityDotScalesWithIcon() {
+        let sizes = Self.railLayouts
+            .map(\.iconSize)
+            .map(WorkspaceRailCellView.identityDotSize(forIcon:))
+
+        #expect(sizes == sizes.sorted())
+        #expect(sizes.allSatisfy { $0 >= 7 && $0 <= 12.5 })
+        #expect(WorkspaceRailCellView.identityDotSize(forIcon: 24) == 9)
     }
 
     @Test("The tooltip spells out what the truncated labels cannot")

--- a/docs/customization/appearance.mdx
+++ b/docs/customization/appearance.mdx
@@ -92,7 +92,7 @@ Every key is optional. A group you leave out falls back to Default Light, and a 
 
 Assign one in the connection form under **Customization > Appearance > Color**: None, Red, Orange, Yellow, Green, Blue, Purple, Pink, or Gray. With None, no color cue appears. Connection groups take a color the same way, from their right-click menu on the welcome window.
 
-The color fills a badge behind the connection name in the toolbar, and a band behind the label in the workspace rail. In the welcome window list and the connection switcher, it is a dot beside the name. The color's name is in the connection's tooltip and its VoiceOver label.
+The color fills a badge behind the connection name in the toolbar. In the workspace rail it is a dot on the corner of the database icon, and it stays visible on the selected row. In the welcome window list and the connection switcher, it is a dot beside the name. The color's name is in the connection's tooltip and its VoiceOver label.
 
 The database icon keeps its engine's own color everywhere, whichever color the connection carries.
 


### PR DESCRIPTION
Follow-up to #2401. That PR gave the connection colour its own surface in the toolbar, which was right, and then put a full-width opaque slab behind the label in the workspace rail, which was not. In the running app the slab was the loudest element in the window, stacked on top of the selection fill, drew maximum attention to a label truncated to `tabl...nse`, and read as destructive rather than as a label.

## What Apple actually does

Measured on this machine rather than recalled.

**Finder, Tags section**: a saturated filled dot, 12.5pt across, 22pt leading inset, beside a plain neutral label. The row background is never tinted with the tag colour; the row fill is reserved for selection.

**Reminders, My Lists**: a user-named, user-coloured sidebar item, which is the closest analogue to a connection. The colour is a 24x24pt filled circular tile holding a white glyph, the label is neutral, and the row background is the selection. The tile samples `#F1A946` where `systemOrange` is `#FF9230`, so Apple softens the palette rather than using it raw.

Neither fills a row behind its label. This app had already reached the same answer twice on its own: `WelcomeConnectionRow` and `ConnectionSwitcherPopover` both draw an 8pt dot.

## The change

The colour is a dot on the corner of the engine glyph, sized from the icon so it tracks the System Settings sidebar icon size: 8/9/11pt against icons of 20/24/28. It carries a 1.5pt rim.

Three channels now own three different properties of one glyph, and none of them argue:

- **Shape** is the connection's state, unchanged. A warning triangle, a bolt, or the engine's mark.
- **Colour** is the engine when connected, and the state's own colour when not.
- **The dot** is the user's identity colour, on a separate element.

**The dot stays lit on the selected row.** The slab did the opposite, and so did the glyph tint before it. The HIG's sidebar guidance is that a fixed colour set to clarify an icon is not overridden by the system, and the selected row is the one whose identity the user most needs to confirm. The rim is what carries it: measured, red, blue, purple, pink and grey all fail 3:1 against `selectedContentBackgroundColor`, so the dot cannot rely on its own hue there. On the selected row the rim takes `alternateSelectedControlTextColor`, which is the colour AppKit itself uses for content on a selection.

## Two pre-existing defects fixed with it

Both were found while researching this and both live in the same method.

**A failed connection's warning triangle wore the engine's brand colour.** `appliedTint` was `NSColor(brandColor)` unconditionally, applied to whatever `glyph(for:)` returned, so a failed PostgreSQL connection rendered a *blue* warning triangle: the one glyph that exists to raise an alarm wore the calmest colour on the row. Glyph colour now follows what the shape is saying: `systemRed` for a failure, `secondaryLabelColor` for disconnected, the engine's colour only when connected.

**Red meant three things at once.** Redis's brand `#DC382D`, the identity palette's red, and a failed connection. Identity no longer reaches the glyph, so a connection the user named Red and a connection that failed stay distinguishable.

## What I tried and backed out

Wrapping the label to two lines, to kill the `tabl...nse` truncation. It measures as fitting, and it looks broken: underscore is Unicode class AL and offers no break opportunity, so `tablepro_license` breaks at the width limit into `tablepro_licens` and an orphaned `e`. The existing single-line middle truncation has a documented HIG rationale for narrow columns and the full name is already in the tooltip and the accessibility label, so it stays. `WorkspaceRailMetrics` is untouched.

## Verification

- `build` PASS, `swiftlint lint --strict` clean on both the app and the changed tests
- `test` PASS, 29 of 29 across `WorkspaceRailStoreTests`, `WorkspaceRailCellRenderingTests` and `ConnectionIdentityColorTests`
- both docs scripts pass

New `WorkspaceRailCellRenderingTests` renders the cell and reads pixels back, because the slab shipped past a suite that only ever read model state. It asserts the identity colour covers under 5% of the cell, that it survives selection, and that an uncoloured connection paints none. A note for whoever writes the next one: measured, `cacheDisplay` does capture a layer-backed subview and `CALayer.render(in:)` returns an empty bitmap for this tree, which is the opposite of what I assumed first.

`WorkspaceRailStoreTests` gains four: the failed glyph is not the brand colour, the disconnected glyph recedes, identity never reaches the glyph tint, and the dot scales with the icon inside the 8pt-to-12.5pt range the two measured Apple surfaces bracket.

## Screenshots

I rendered the cell offscreen at every palette colour, plus selected and failed states, and looked at it before committing. That is how the two-line label was caught. Not attached here: it is a synthetic render of one cell, not the app. Worth a real before-and-after in the app if a reviewer wants one.
