### PR TITLE
fix(sync): report an unverified license as paused rather than missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Sync Paused, a separate state for a license the app could not check, offering to check again rather than to buy.
 - The PRO badge beside a gated control names what the feature does and links to the pricing page.
 - Beancount postings preserve their own flag, price, and resolved lot date and label in the SQL projection.
 - Beancount connections report the active `rledger` or Python Beancount version instead of a generic backend name.
@@ -45,6 +46,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The welcome window offering Activate License to a Mac that already holds one and has just been offline.
+- iCloud Sync reporting that a license is required when the license was only unverified.
+- iCloud Sync still reporting a live sync after the license was removed from that Mac.
+- The sync status returning to Synced when sync was turned off while a sync was running.
+- The license server never being contacted again after removing and re-adding a license in one session.
+- The Activations error staying on screen after a later refresh loaded the list.
+- A renewal warning counting down zero days above a status that already reads Expired.
 - The connections strip disappearing when you click the entry you came from.
 - Cancelling a close from the connections strip leaving the window on the connection it revealed.
 - Save on a bulk tab close applying to the tab on screen instead of the tabs being closed.

--- a/Packages/TableProCore/Sources/TableProSyncTransport/SyncStatus.swift
+++ b/Packages/TableProCore/Sources/TableProSyncTransport/SyncStatus.swift
@@ -24,5 +24,10 @@ public enum DisableReason: Equatable, Sendable {
     case noAccount
     case licenseRequired
     case licenseExpired
+
+    /// A license this Mac holds but has not confirmed with the server inside the grace period.
+    /// Separate from `licenseRequired` because the way out is the network, not a purchase, and
+    /// offering to activate a license the person already owns is the one thing that cannot help.
+    case licenseUnverified
     case userDisabled
 }

--- a/Packages/TableProCore/Tests/TableProSyncTests/SyncStatusTests.swift
+++ b/Packages/TableProCore/Tests/TableProSyncTests/SyncStatusTests.swift
@@ -17,6 +17,7 @@ struct SyncStatusTests {
         DisableReason.noAccount,
         DisableReason.licenseRequired,
         DisableReason.licenseExpired,
+        DisableReason.licenseUnverified,
         DisableReason.userDisabled
     ])
     func disabledIsNotEnabled(_ reason: DisableReason) {
@@ -45,5 +46,6 @@ struct SyncStatusTests {
         #expect(SyncStatus.disabled(.noAccount) != .disabled(.userDisabled))
         #expect(SyncStatus.error(.tokenExpired) != .error(.networkUnavailable))
         #expect(SyncStatus.disabled(.noAccount) == .disabled(.noAccount))
+        #expect(SyncStatus.disabled(.licenseUnverified) != .disabled(.licenseRequired))
     }
 }

--- a/TablePro/Core/Services/Licensing/LicenseManager.swift
+++ b/TablePro/Core/Services/Licensing/LicenseManager.swift
@@ -41,8 +41,19 @@ final class LicenseManager {
     /// Current cached license (nil = unlicensed)
     private(set) var license: License?
 
-    /// Current license status
-    private(set) var status: LicenseStatus = .unlicensed
+    /// Current license status.
+    ///
+    /// Every write announces itself, so no caller has to remember to. `deactivate` wrote this
+    /// directly and skipped the announcement, which left `SyncCoordinator`, its only observer,
+    /// reporting a healthy sync for a license that no longer existed until the next launch.
+    /// The observer subscribes with `.receive(on: RunLoop.main)`, so this cannot re-enter a
+    /// mutation that is still in progress.
+    private(set) var status: LicenseStatus = .unlicensed {
+        didSet {
+            guard status != oldValue else { return }
+            AppEvents.shared.licenseStatusDidChange.send(())
+        }
+    }
 
     /// Whether a network operation is in progress
     private(set) var isValidating: Bool = false
@@ -219,7 +230,7 @@ final class LicenseManager {
             storage.saveLicense(newLicense)
 
             license = newLicense
-            acceptServerConfirmation()
+            adoptActivatedLicense()
 
             Self.logger.info("License activated for \(payloadData.email)")
         } catch let error as LicenseError {
@@ -262,7 +273,7 @@ final class LicenseManager {
             storage.saveLicense(newLicense)
 
             license = newLicense
-            acceptServerConfirmation()
+            adoptActivatedLicense()
 
             Self.logger.info("Joined team via invitation for \(payloadData.email)")
         } catch let error as LicenseError {
@@ -315,8 +326,18 @@ final class LicenseManager {
     // MARK: - Re-validation
 
     var isExpiringSoon: Bool {
-        guard let days = license?.daysUntilExpiry else { return false }
-        return days >= 0 && days <= 7
+        guard let license else { return false }
+        return Self.isExpiringSoon(daysUntilExpiry: license.daysUntilExpiry, isExpired: license.isExpired)
+    }
+
+    /// Whether the renewal warning applies, which a license that has already lapsed does not.
+    ///
+    /// `daysUntilExpiry` counts whole days, so a license that ran out this morning still reports
+    /// zero until tomorrow. Without the expiry check the pane warned "License expires in 0 day(s)"
+    /// directly above "Status: Expired", stating both readings of the same date at once.
+    nonisolated static func isExpiringSoon(daysUntilExpiry: Int?, isExpired: Bool) -> Bool {
+        guard !isExpired, let daysUntilExpiry else { return false }
+        return daysUntilExpiry >= 0 && daysUntilExpiry <= 7
     }
 
     var daysUntilExpiry: Int? {
@@ -385,6 +406,18 @@ final class LicenseManager {
         }
     }
 
+    /// Takes up a license this Mac has just activated.
+    ///
+    /// Restarting periodic validation is the point. `deactivate` cancels that task and nils it, and
+    /// the only other caller is a one-shot at launch, so a deactivate followed by an activate in
+    /// the same session left the process never contacting the server again. It cannot live in
+    /// `acceptServerConfirmation`, which `revalidate` also calls from inside the very task this
+    /// would cancel.
+    private func adoptActivatedLicense() {
+        acceptServerConfirmation()
+        startPeriodicValidation()
+    }
+
     private func acceptServerConfirmation() {
         serverRejection = nil
         lastServerContact = Date()
@@ -402,9 +435,6 @@ final class LicenseManager {
 
     /// Evaluate current license status based on expiration, grace period, and signature validity
     private func evaluateStatus() {
-        let previousStatus = status
-        defer { notifyIfChanged(from: previousStatus) }
-
         guard let license else {
             status = .unlicensed
             return
@@ -451,11 +481,5 @@ final class LicenseManager {
         }
 
         return .active
-    }
-
-    private func notifyIfChanged(from previousStatus: LicenseStatus) {
-        if status != previousStatus {
-            AppEvents.shared.licenseStatusDidChange.send(())
-        }
     }
 }

--- a/TablePro/Core/Sync/SyncCoordinator.swift
+++ b/TablePro/Core/Sync/SyncCoordinator.swift
@@ -33,6 +33,10 @@ final class SyncCoordinator {
     @ObservationIgnored private var syncTask: Task<Void, Never>?
     @ObservationIgnored private var hasStarted = false
 
+    /// Bumped every time something other than a sync run decides the status, so a run that has been
+    /// suspended across the network can tell whether its outcome is still the current answer.
+    @ObservationIgnored private var statusGeneration = 0
+
     init(services: AppServices = .live) {
         self.services = services
         self.changeTracker = services.syncTracker
@@ -93,6 +97,7 @@ final class SyncCoordinator {
             return
         }
 
+        let generation = statusGeneration
         syncStatus = .syncing
 
         do {
@@ -109,21 +114,36 @@ final class SyncCoordinator {
             await performPull()
 
             if let pushError {
-                syncStatus = .error(SyncError.from(pushError))
+                settle(.error(SyncError.from(pushError)), from: generation)
                 return
             }
 
             lastSyncDate = Date()
             metadataStorage.lastSyncDate = lastSyncDate
-            syncStatus = .idle
+            settle(.idle, from: generation)
             metadataStorage.pruneTombstones(olderThan: 30)
 
             Self.logger.info("Sync completed successfully")
         } catch {
             let syncError = SyncError.from(error)
-            syncStatus = .error(syncError)
+            settle(.error(syncError), from: generation)
             Self.logger.error("Sync failed: \(error.localizedDescription)")
         }
+    }
+
+    /// Publishes the outcome of a sync run, unless something decided the status while it was in
+    /// flight.
+    ///
+    /// A run reads `canSync()` once on entry and then suspends across the whole CloudKit round
+    /// trip, so turning sync off, or losing the license, used to be overwritten by the returning
+    /// run: the indicator went back to "Synced" for a sync that would now be refused. Whoever
+    /// decided last wins, and a stale run reports nothing.
+    private func settle(_ outcome: SyncStatus, from generation: Int) {
+        guard generation == statusGeneration else {
+            Self.logger.info("Discarding a sync outcome the status moved on from")
+            return
+        }
+        syncStatus = outcome
     }
 
     /// Triggered by remote push notification
@@ -226,7 +246,7 @@ final class SyncCoordinator {
     /// Called when user disables sync in settings
     func disableSync() {
         syncTask?.cancel()
-        syncStatus = .disabled(.userDisabled)
+        decide(.disabled(.userDisabled))
     }
 
     // MARK: - Status
@@ -235,29 +255,51 @@ final class SyncCoordinator {
         let licenseManager = services.licenseManager
 
         guard licenseManager.isFeatureAvailable(.iCloudSync) else {
-            switch licenseManager.status {
-            case .expired:
-                syncStatus = .disabled(.licenseExpired)
-            default:
-                syncStatus = .disabled(.licenseRequired)
-            }
+            decide(.disabled(Self.licenseDisableReason(for: licenseManager.status)))
             return
         }
 
         let syncSettings = services.appSettingsStorage.loadSync()
         guard syncSettings.enabled else {
-            syncStatus = .disabled(.userDisabled)
+            decide(.disabled(.userDisabled))
             return
         }
 
         guard iCloudAccountAvailable else {
-            syncStatus = .disabled(.noAccount)
+            decide(.disabled(.noAccount))
             return
         }
 
         // If we were in an error or disabled state, transition to idle
         if !syncStatus.isSyncing {
-            syncStatus = .idle
+            decide(.idle)
+        }
+    }
+
+    /// Settles the status from outside a sync run, and retires whatever run is in flight.
+    ///
+    /// The branch that leaves a running sync alone deliberately does not come through here: it has
+    /// decided nothing, so invalidating the run would leave the status stuck on Syncing with
+    /// nothing left to move it.
+    private func decide(_ status: SyncStatus) {
+        statusGeneration += 1
+        syncStatus = status
+    }
+
+    /// Why sync is off, for a license that does not currently unlock it.
+    ///
+    /// Exhaustive on purpose. The arm that used to be `default:` swallowed `.validationFailed`,
+    /// which is a paying customer the app has not reached the server about, and told them a license
+    /// was required. A new `LicenseStatus` case has to be answered here rather than inheriting the
+    /// wrong answer.
+    nonisolated static func licenseDisableReason(for status: LicenseStatus) -> DisableReason {
+        switch status {
+        case .expired:
+            return .licenseExpired
+        case .validationFailed:
+            return .licenseUnverified
+        case .active, .unlicensed, .suspended, .deactivated:
+            return .licenseRequired
         }
     }
 

--- a/TablePro/Views/Components/SyncStatusIndicator.swift
+++ b/TablePro/Views/Components/SyncStatusIndicator.swift
@@ -51,6 +51,8 @@ struct SyncStatusIndicator: View {
             return "icloud.slash"
         case .disabled(.licenseRequired), .disabled(.licenseExpired):
             return "xmark.icloud"
+        case .disabled(.licenseUnverified):
+            return "exclamationmark.icloud"
         case .disabled(.userDisabled):
             return "icloud.slash"
         }
@@ -68,6 +70,8 @@ struct SyncStatusIndicator: View {
             return String(localized: "No iCloud")
         case .disabled(.licenseRequired), .disabled(.licenseExpired):
             return String(localized: "Sync Off")
+        case .disabled(.licenseUnverified):
+            return String(localized: "Sync Paused")
         case .disabled(.userDisabled):
             return ""
         }
@@ -106,15 +110,21 @@ struct SyncStatusIndicator: View {
             return String(localized: "Pro license required for iCloud Sync")
         case .disabled(.licenseExpired):
             return String(localized: "License expired, sync paused")
+        case .disabled(.licenseUnverified):
+            return String(localized: "License not verified in 30 days, sync paused. Click to check again.")
         case .disabled(.userDisabled):
             return ""
         }
     }
 
+    /// An unverified license is the one degraded state activation cannot mend, so it retries the
+    /// check instead of opening a sheet that asks for a key the person already gave.
     private func handleTap() {
         switch syncCoordinator.syncStatus {
         case .disabled(.licenseRequired), .disabled(.licenseExpired):
             onActivateLicense()
+        case .disabled(.licenseUnverified):
+            Task { await LicenseManager.shared.revalidate() }
         default:
             WindowOpener.shared.openSettings(tab: .account)
         }

--- a/TablePro/Views/Connection/WelcomeActionsPanel.swift
+++ b/TablePro/Views/Connection/WelcomeActionsPanel.swift
@@ -95,16 +95,7 @@ struct WelcomeActionsPanel: View {
     /// pauses Pro features, and its owner is still not someone to ask for a purchase.
     private var licenseLine: some View {
         HStack(spacing: 6) {
-            if LicenseManager.shared.status.isValid {
-                Label(String(localized: "Pro"), systemImage: "checkmark.seal.fill")
-                    .font(.subheadline.weight(.medium))
-                    .foregroundStyle(.green)
-            } else {
-                Button(action: onActivateLicense) {
-                    Text(String(localized: "Activate License"))
-                }
-                .buttonStyle(.link)
-            }
+            licenseBadge
 
             if LicenseManager.shared.supportAudience == .prospect {
                 Text(verbatim: "·")
@@ -113,5 +104,28 @@ struct WelcomeActionsPanel: View {
             }
         }
         .font(.subheadline)
+    }
+
+    /// Exhaustive on purpose. This used to read `status.isValid`, so the one status that means
+    /// "a paying customer who has been offline" was offered an activation sheet that needs the
+    /// network to succeed, which is the one thing it could not do.
+    @ViewBuilder
+    private var licenseBadge: some View {
+        switch LicenseManager.shared.status {
+        case .active:
+            Label(String(localized: "Pro"), systemImage: "checkmark.seal.fill")
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.green)
+        case .validationFailed:
+            Label(String(localized: "Pro"), systemImage: "exclamationmark.seal.fill")
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.orange)
+                .help(String(localized: "License not verified in 30 days. Connect to the internet to check it."))
+        case .unlicensed, .expired, .suspended, .deactivated:
+            Button(action: onActivateLicense) {
+                Text(String(localized: "Activate License"))
+            }
+            .buttonStyle(.link)
+        }
     }
 }

--- a/TablePro/Views/Settings/AccountSettingsView.swift
+++ b/TablePro/Views/Settings/AccountSettingsView.swift
@@ -18,23 +18,47 @@ struct AccountSettingsView: View {
         .formStyle(.grouped)
         .scrollContentBackground(.hidden)
         .overlay {
-            if case .disabled(.licenseExpired) = syncCoordinator.syncStatus {
+            switch syncCoordinator.syncStatus {
+            case .disabled(.licenseExpired):
                 licensePausedBanner
+            case .disabled(.licenseUnverified):
+                licenseUnverifiedBanner
+            default:
+                EmptyView()
             }
         }
     }
 
     private var licensePausedBanner: some View {
+        banner(String(localized: "Sync paused, Pro license expired")) {
+            Link(String(localized: "Renew License…"), destination: SupportLinks.pricing(.licenseSettings))
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+        }
+    }
+
+    /// A license the server has not confirmed for 30 days is not a license to buy again, so the
+    /// banner offers the check rather than a purchase.
+    private var licenseUnverifiedBanner: some View {
+        banner(String(localized: "Sync paused, license not verified")) {
+            Button(String(localized: "Check Status")) {
+                Task { await LicenseManager.shared.revalidate() }
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+            .disabled(LicenseManager.shared.isValidating)
+        }
+    }
+
+    private func banner(_ message: String, @ViewBuilder action: () -> some View) -> some View {
         VStack {
             HStack {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundStyle(.orange)
-                Text(String(localized: "Sync paused, Pro license expired"))
+                Text(message)
                     .font(.callout)
                 Spacer()
-                Link(String(localized: "Renew License…"), destination: SupportLinks.pricing(.licenseSettings))
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
+                action()
             }
             .padding(12)
             .themeMaterial(.banner, .ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))

--- a/TablePro/Views/Settings/Sections/LicenseSection.swift
+++ b/TablePro/Views/Settings/Sections/LicenseSection.swift
@@ -55,7 +55,7 @@ struct LicenseSection: View {
 
             LabeledContent("Status:") {
                 Text(licenseManager.status.displayName)
-                    .foregroundStyle(licenseManager.status.isValid ? .green : .red)
+                    .foregroundStyle(Self.statusColor(for: licenseManager.status))
             }
 
             if let expiresAt = license.expiresAt {
@@ -190,6 +190,19 @@ struct LicenseSection: View {
 
     // MARK: - Actions
 
+    /// Red is for a license that is gone. A license the app has simply not been able to check is
+    /// not gone, and painting it red told a paying customer their license had failed.
+    static func statusColor(for status: LicenseStatus) -> Color {
+        switch status {
+        case .active:
+            return .green
+        case .validationFailed:
+            return .orange
+        case .unlicensed, .expired, .suspended, .deactivated:
+            return .red
+        }
+    }
+
     private func maskedKey(_ key: String) -> String {
         let parts = key.split(separator: "-")
         guard parts.count == 5 else { return key }
@@ -210,6 +223,7 @@ struct LicenseSection: View {
             )
             activations = response.activations
             maxActivations = response.maxActivations
+            activationLoadError = nil
         } catch {
             Self.logger.debug("Failed to load activations: \(error.localizedDescription)")
             activationLoadError = error.localizedDescription

--- a/TableProTests/Core/Sync/LicenseSyncPresentationTests.swift
+++ b/TableProTests/Core/Sync/LicenseSyncPresentationTests.swift
@@ -1,0 +1,72 @@
+//
+//  LicenseSyncPresentationTests.swift
+//  TablePro
+//
+//  The grids that used to be `default:` arms. Each one had exactly one status it answered wrongly,
+//  and it was the same status every time: a paying customer the app has not reached the server
+//  about.
+//
+
+import Foundation
+import SwiftUI
+import TableProSyncTransport
+@testable import TablePro
+import Testing
+
+@Suite("License state presentation")
+struct LicenseSyncPresentationTests {
+    private static let everyStatus: [LicenseStatus] = [
+        .unlicensed, .active, .expired, .suspended, .deactivated, .validationFailed
+    ]
+
+    @Test("An unverified license pauses sync as its own reason, not as one that needs buying")
+    func unverifiedLicenseHasItsOwnDisableReason() {
+        #expect(SyncCoordinator.licenseDisableReason(for: .validationFailed) == .licenseUnverified)
+        #expect(SyncCoordinator.licenseDisableReason(for: .expired) == .licenseExpired)
+    }
+
+    @Test("Every other status still asks for a license")
+    func remainingStatusesRequireALicense() {
+        for status in [LicenseStatus.unlicensed, .suspended, .deactivated, .active] {
+            #expect(SyncCoordinator.licenseDisableReason(for: status) == .licenseRequired)
+        }
+    }
+
+    @Test("No status maps to a reason that would offer the wrong way out")
+    func everyStatusIsAnswered() {
+        let reasons = Self.everyStatus.map { SyncCoordinator.licenseDisableReason(for: $0) }
+
+        #expect(reasons.count == Self.everyStatus.count)
+        #expect(!reasons.contains(.noAccount))
+        #expect(!reasons.contains(.userDisabled))
+    }
+
+    @Test("An unverified license reads as a warning, never as a failure")
+    func statusColorSeparatesUnverifiedFromGone() {
+        #expect(LicenseSection.statusColor(for: .active) == .green)
+        #expect(LicenseSection.statusColor(for: .validationFailed) == .orange)
+
+        for status in [LicenseStatus.unlicensed, .expired, .suspended, .deactivated] {
+            #expect(LicenseSection.statusColor(for: status) == .red)
+        }
+    }
+
+    @Test("A license that already lapsed is not expiring soon")
+    func expiredLicenseIsNotExpiringSoon() {
+        #expect(!LicenseManager.isExpiringSoon(daysUntilExpiry: 0, isExpired: true))
+        #expect(!LicenseManager.isExpiringSoon(daysUntilExpiry: -3, isExpired: true))
+    }
+
+    @Test("The renewal warning covers the last seven days and stops there")
+    func expiringSoonWindow() {
+        #expect(LicenseManager.isExpiringSoon(daysUntilExpiry: 0, isExpired: false))
+        #expect(LicenseManager.isExpiringSoon(daysUntilExpiry: 7, isExpired: false))
+        #expect(!LicenseManager.isExpiringSoon(daysUntilExpiry: 8, isExpired: false))
+        #expect(!LicenseManager.isExpiringSoon(daysUntilExpiry: -1, isExpired: false))
+    }
+
+    @Test("A lifetime license never warns about renewal")
+    func lifetimeLicenseNeverExpiresSoon() {
+        #expect(!LicenseManager.isExpiringSoon(daysUntilExpiry: nil, isExpired: false))
+    }
+}

--- a/docs/features/icloud-sync.mdx
+++ b/docs/features/icloud-sync.mdx
@@ -46,3 +46,5 @@ If nothing syncs, confirm iCloud is signed in and iCloud Drive is enabled, then 
 Signing into a different iCloud account clears TablePro's sync metadata, so the next sync is a full fetch rather than a delta. Expect it to take longer once.
 
 When a license expires, sync stops and local data stays where it is. Re-activate to resume.
+
+A license TablePro has not been able to check for 30 days pauses sync separately, under **Sync Paused** rather than **Sync Off**. Click the indicator, or **Check Status** on the banner in **Settings > Account**, to try the server again. Local data stays where it is either way.

--- a/docs/features/licensing.mdx
+++ b/docs/features/licensing.mdx
@@ -42,7 +42,7 @@ Until then, **Support TablePro** also sits at the bottom of the welcome window a
 
 Open **Settings > Account** (`Cmd+,`), paste your license key (`XXXXX-XXXXX-XXXXX-XXXXX-XXXXX`), and click **Activate**.
 
-The welcome window has an **Activate License** link to the same dialog, and shows a green **Pro** badge once a license is active. The field also takes a team invite code, which TablePro tells apart from a key on its own. See [Team Plan](/features/team).
+The welcome window has an **Activate License** link to the same dialog, and shows a green **Pro** badge once a license is active. The badge turns orange when the license has not been checked in 30 days; the link does not come back, because activating again cannot help a Mac that is offline. The field also takes a team invite code, which TablePro tells apart from a key on its own. See [Team Plan](/features/team).
 
 <Frame caption="License section in Settings > Account">
   <img className="block dark:hidden" src="/images/license-settings.png" alt="License settings showing email, masked key, status, tier, and activations" />
@@ -65,7 +65,7 @@ Activation stores a signed license on your Mac, and the license key goes to the 
 
 - Every launch re-verifies the signature offline, with no network. Tier, status, and expiry all come from the signed license, so editing the copy on disk changes nothing.
 - Every 7 days the app re-validates with the license server in the background.
-- If the server is unreachable, the license keeps working for 30 days after the last successful validation. After that the status becomes Validation Failed and Pro features pause until a validation succeeds.
+- If the server is unreachable, the license keeps working for 30 days after the last successful validation. After that the status becomes Validation Failed, shown in orange rather than red, and Pro features pause until a validation succeeds. Nothing in that state asks for a license key: the way out is a working connection.
 - If the server answers that the license is suspended, expired, or no longer activated on this Mac, Pro features pause at that check. The 30-day grace period only covers a server TablePro could not reach.
 
 **Check Status** in **Settings > Account** re-validates on demand, and a gated screen offers **Retry Validation**. When a license expires within 7 days, the Account tab shows a renewal warning linking to tablepro.app.


### PR DESCRIPTION
Seven defects in how the app reports license state, all found while investigating #2416 and all verified against the source before being fixed. Six of them share one cause.

## The cause

`LicenseStatus` has six cases, and `resolveStatus` keeps a signed-active license at `.active` through the whole 30-day offline grace period before returning `.validationFailed`. So `.validationFailed` does not mean "no license". It means **a paying customer the app has not been able to reach the server about**.

Four different surfaces collapsed those six cases by hand, and each got that one case wrong in its own way:

| Surface | Predicate | What an offline licensed Mac saw |
|---|---|---|
| Welcome window | `status.isValid` | **Activate License**, opening a sheet that needs the network it does not have |
| iCloud Sync | `default:` arm | "Pro license required for iCloud Sync", tapping through to the same sheet |
| Settings status row | `isValid ? .green : .red` | Red, reading as a failure rather than a pause |
| Feature gate | `ProFeatureAccess` | Correct, and left untouched |

Every one of those was a `default:` or a boolean standing in for a decision. They are now exhaustive switches with no default arm, so a seventh `LicenseStatus` case has to be answered rather than inheriting the wrong answer.

`DisableReason` gains `.licenseUnverified` to carry the distinction into sync, presented as **Sync Paused** rather than **Sync Off**, and every route out of it offers to check the license again instead of offering to buy one. Activation is the one thing that cannot help someone who already owns the license and is offline.

## The race this uncovered

`deactivate()` wrote `status` directly and skipped the only sender of `licenseStatusDidChange`, so `SyncCoordinator`, its sole observer, kept reporting a healthy sync for a license that no longer existed until the next launch. `status` now announces every change from its own `didSet`, so no caller has to remember to.

That fix alone would have made a second bug reachable. `syncNow()` reads `canSync()` once on entry, then suspends across the whole CloudKit round trip and writes its terminal status unconditionally. Turn sync off mid-sync, or lose the license mid-sync, and the returning run put the indicator back to "Synced" for a sync that would now be refused. A per-run generation token fixes it: whoever decides last wins, and a stale run reports nothing.

The generation is deliberately **not** bumped by the one branch of `evaluateStatus()` that leaves a running sync alone. That branch has decided nothing, and invalidating the run there would strand the status on "Syncing" with nothing left to move it. (I introduced exactly that bug in the first draft of this change and caught it in self-review.)

Measured before relying on it: an `@Observable` class can carry `private(set) var x { didSet }`; the observer fires on every write including writes from a method called by `init`, `withObservationTracking` still fires alongside it, and a `!=` guard suppresses no-op writes. `SyncCoordinator.observeLicenseChanges` subscribes with `.receive(on: RunLoop.main)`, so the `didSet` can never run the subscriber synchronously inside a mutation.

## Three more, same subsystem

- **`deactivate()` killed periodic validation permanently.** It cancels `revalidationTask` and nils it, and the only other caller is a one-shot at launch, so removing a license and adding it back in the same session left the process never contacting the server again. Both activation paths now adopt the license through `adoptActivatedLicense()`. It cannot live in `acceptServerConfirmation()`, which `revalidate()` also calls from inside the very task that would be cancelled.
- **The Activations error was a latch.** A later successful refresh left the red error line on screen, telling a licensed user their activations failed to load while they were looking at them.
- **`isExpiringSoon` ignored expiry.** `daysUntilExpiry` counts whole days, so a license that lapsed this morning still reports zero until tomorrow, and the pane showed "License expires in 0 day(s)" directly above "Status: Expired".

## Overlap with `refactor/license-settings-pane`

That branch is rewriting the license settings pane and has uncommitted work covering some of the same ground: a `LicensePresentation.swift` that classifies `LicenseStatus` for the pane, a `clearLocalLicense()` that routes deactivation through `evaluateStatus()`, and an `adoptActivatedLicense()` restarting periodic validation.

This branch deliberately adds **no** classifier type, so that vocabulary stays theirs. Where the two touch the same lines, expect a small manual merge in `LicenseManager.swift` (the `didSet` sink versus their `clearLocalLicense`) and in `LicenseSection.swift` (the status colour). Everything else here is in files that branch does not touch.

## Verified

| Step | Result |
|---|---|
| `verify.sh generate` | PASS |
| `verify.sh build` | PASS |
| `verify.sh test` (7 suites) | PASS |
| `swift test` (TableProSyncTests) | PASS |
| `verify.sh docs` | PASS |
| `swiftlint lint --strict` | clean |

`LicenseSyncPresentationTests` covers the grids that used to be default arms: every `LicenseStatus` to a `DisableReason`, every status to a colour, and the `isExpiringSoon` window including an already-expired license and a lifetime one. `SyncStatusTests` gains the new reason.

No UI automation: the states this changes need a real license in one of four server-controlled conditions, which a UI test cannot arrange.
