### PR TITLE
fix(welcome): keep the support link reachable when the license line cannot fit

### DIFF
--- a/TablePro/Views/Connection/WelcomeActionsPanel.swift
+++ b/TablePro/Views/Connection/WelcomeActionsPanel.swift
@@ -93,17 +93,38 @@ struct WelcomeActionsPanel: View {
     /// The badge follows entitlement and the support link follows whether anything has been paid,
     /// which are different questions: a license the server has not confirmed in 30 days still
     /// pauses Pro features, and its owner is still not someone to ask for a purchase.
+    ///
+    /// Unlicensed is the widest this line ever gets, and it is the only state that draws two link
+    /// buttons: `Activate License` and `Support TablePro` side by side all but fill the panel's
+    /// 240pt. An `HStack` that cannot fit its children compresses them instead of overflowing, and
+    /// a link button whose label compresses to nothing leaves the accessibility tree with it, so
+    /// the link stops being reachable before it visibly disappears. Stacking is the fallback rather
+    /// than the layout, so the line keeps its shape wherever it does fit.
     private var licenseLine: some View {
-        HStack(spacing: 6) {
-            licenseBadge
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 6) {
+                licenseBadge
 
-            if LicenseManager.shared.supportAudience == .prospect {
-                Text(verbatim: "·")
-                    .foregroundStyle(.tertiary)
-                SupportPromptLink()
+                if isProspect {
+                    Text(verbatim: "·")
+                        .foregroundStyle(.tertiary)
+                    SupportPromptLink()
+                }
+            }
+
+            VStack(spacing: 4) {
+                licenseBadge
+
+                if isProspect {
+                    SupportPromptLink()
+                }
             }
         }
         .font(.subheadline)
+    }
+
+    private var isProspect: Bool {
+        LicenseManager.shared.supportAudience == .prospect
     }
 
     /// Exhaustive on purpose. This used to read `status.isValid`, so the one status that means


### PR DESCRIPTION
Fixes `testTheWelcomeWindowCarriesTheStandingLink`, which has failed on every `main` run since #2416 introduced it and is currently blocking the v0.68.0 release build.

## What fails

`SupportWindowUITests.testTheWelcomeWindowCarriesTheStandingLink` cannot find `support-prompt-link` inside `windows["welcome"]`. It fails on both retry attempts, on three consecutive `main` runs (04:41, 05:28, 08:08 on 2026-08-25), so it is deterministic rather than flaky.

## What was ruled out

The other four cases in the same suite pass, which eliminates most of the surface:

| Case | Result | What it proves |
|---|---|---|
| `testAConnectionWindowCarriesTheStandingLink` | pass | `supportAudience == .prospect` on CI, and `SupportPromptLink` publishes its identifier |
| `testHelpMenuOpensTheSupportWindowWithBothActions` | pass | The support window and its actions are fine |
| `testCommandWClosesTheSupportWindow` | pass | Window lifecycle is fine |
| `testLaunchingUnlicensedShowsNothingUntilTheUserAsks` | pass | Nothing suppresses the link deliberately |

Also ruled out: no `accessibilityIdentifier` on any ancestor in `WelcomeActionsPanel` or `WelcomeWindowView`, so this is not the container-identifier clobber; and `UITestCase.launchApp` seeds no license, while `LicenseManager` is `@Observable` with `license` nil and `status` `.unlicensed` at init, so `supportAudience` is `.prospect` from the first render.

That leaves `WelcomeActionsPanel.licenseLine`.

## Cause

The panel is `.frame(width: 240)`. Unlicensed is the only state that draws two link buttons on that line, and it is the widest the line ever gets: `Activate License` and `Support TablePro` at `.subheadline`, plus a separator and two 6pt gaps, come to roughly 224pt of the 240pt available. An `HStack` that cannot fit its children compresses them rather than overflowing, and a link button whose label compresses to nothing leaves the accessibility tree with it. The link stops being reachable before it visibly disappears, which is why this reads as a test failure rather than a visual bug, and why it reproduces on the runner but not necessarily on a developer machine where text metrics differ slightly.

## Fix

`ViewThatFits(in: .horizontal)` with the existing `HStack` first and a stacked fallback second. Where the line fits it is unchanged, so there is no visual difference on a normal Mac; where it does not, the two controls stack instead of one of them being compressed out of existence.

## Testing

`testTheWelcomeWindowCarriesTheStandingLink` is the test for this and already exists, so this PR is verified by that case going green. Local UI runs are not possible in this environment (`Timed out while enabling automation mode`), which is why this is a PR rather than a direct push to the release tag.

No CHANGELOG entry: #2416 is itself unreleased and its `Added` entry already covers the link, per the rule against a `Fixed` entry for unreleased work.

https://claude.ai/code/session_01DBDRXfDuGrLJV2HrM2d4M4