### PR TITLE
fix(welcome): get past onboarding before asserting the support link

### DIFF
--- a/TablePro/Views/Connection/WelcomeActionsPanel.swift
+++ b/TablePro/Views/Connection/WelcomeActionsPanel.swift
@@ -93,38 +93,17 @@ struct WelcomeActionsPanel: View {
     /// The badge follows entitlement and the support link follows whether anything has been paid,
     /// which are different questions: a license the server has not confirmed in 30 days still
     /// pauses Pro features, and its owner is still not someone to ask for a purchase.
-    ///
-    /// Unlicensed is the widest this line ever gets, and it is the only state that draws two link
-    /// buttons: `Activate License` and `Support TablePro` side by side all but fill the panel's
-    /// 240pt. An `HStack` that cannot fit its children compresses them instead of overflowing, and
-    /// a link button whose label compresses to nothing leaves the accessibility tree with it, so
-    /// the link stops being reachable before it visibly disappears. Stacking is the fallback rather
-    /// than the layout, so the line keeps its shape wherever it does fit.
     private var licenseLine: some View {
-        ViewThatFits(in: .horizontal) {
-            HStack(spacing: 6) {
-                licenseBadge
+        HStack(spacing: 6) {
+            licenseBadge
 
-                if isProspect {
-                    Text(verbatim: "·")
-                        .foregroundStyle(.tertiary)
-                    SupportPromptLink()
-                }
-            }
-
-            VStack(spacing: 4) {
-                licenseBadge
-
-                if isProspect {
-                    SupportPromptLink()
-                }
+            if LicenseManager.shared.supportAudience == .prospect {
+                Text(verbatim: "·")
+                    .foregroundStyle(.tertiary)
+                SupportPromptLink()
             }
         }
         .font(.subheadline)
-    }
-
-    private var isProspect: Bool {
-        LicenseManager.shared.supportAudience == .prospect
     }
 
     /// Exhaustive on purpose. This used to read `status.isValid`, so the one status that means

--- a/TableProUITests/SupportWindowUITests.swift
+++ b/TableProUITests/SupportWindowUITests.swift
@@ -13,6 +13,22 @@ final class SupportWindowUITests: UITestCase {
         return app
     }
 
+    /// Every case gets a fresh sandbox, and a sandbox that has never completed onboarding opens the
+    /// welcome window on `OnboardingContentView`. The window carries the `welcome` identifier
+    /// either way, so a test that only waits for the window is satisfied by a screen holding
+    /// nothing but Skip, three page dots and Continue.
+    ///
+    /// The defaults suite is per-sandbox, so seeding `hasCompletedOnboarding` through a launch
+    /// argument cannot work: `NSArgumentDomain` reaches the standard domain alone, and an override
+    /// aimed at a suite opened by name is an ordinary argument nothing reads. Skip is the supported
+    /// way past it and costs one click.
+    private func dismissOnboarding(in app: XCUIApplication) {
+        let skip = app.windows["welcome"].links["Skip"]
+        XCTAssertTrue(skip.waitToExist(timeout: 10), "A fresh sandbox must open the welcome window on onboarding")
+        XCTAssertTrue(waitUntilHittable(skip, timeout: 5))
+        skip.click()
+    }
+
     private func openSupportWindow(in app: XCUIApplication) -> XCUIElement {
         let item = app.menuBars.menuItems["Support TablePro"]
         XCTAssertTrue(item.waitToExist(timeout: 10), "Support TablePro must be in the Help menu")
@@ -52,6 +68,7 @@ final class SupportWindowUITests: UITestCase {
     /// the one that has to stay a line of text: no alert, no sheet, nothing over the window.
     func testTheWelcomeWindowCarriesTheStandingLink() throws {
         let app = try launchShowingWelcome()
+        dismissOnboarding(in: app)
         let link = app.windows["welcome"].descendants(matching: .any)["support-prompt-link"]
 
         XCTAssertTrue(link.waitToExist(timeout: 10), "An unlicensed welcome window must offer the link")


### PR DESCRIPTION
Fixes `testTheWelcomeWindowCarriesTheStandingLink` for real, and reverts #2421, which was based on a wrong diagnosis and did not fix it.

## Evidence

The failure attachment in the xcresult carries the accessibility tree XCUITest saw. `windows["welcome"]` was this:

```
Window (Main), identifier: welcome, title: Welcome to TablePro
    StaticText, value: Welcome to TablePro
    StaticText, value: A fast, lightweigh...
    Link,   label: Skip
    Button, label: Page 1
    Button, label: Page 2
    Button, label: Page 3
    Button, label: Continue
```

That is `OnboardingContentView`. `WelcomeActionsPanel` is not in the tree at all, so neither is `support-prompt-link`.

## Cause

`WelcomeViewModel.swift:182`:

```swift
self.showOnboarding = !services.appSettingsStorage.hasCompletedOnboarding()
```

and `WelcomeWindowView.swift:23` picks `OnboardingContentView` over `welcomeContent` on that flag. Every UI case gets a fresh sandbox, so onboarding has never been completed and the welcome window always opens on it. The window carries the `welcome` identifier either way, which is why `launchShowingWelcome()` was satisfied while the link lookup was not.

The app was never wrong. Someone still in onboarding has not reached the actions panel, and the test asserted against a screen the app was deliberately not showing.

## Fix

Click Skip before asserting.

Seeding `hasCompletedOnboarding` through a launch argument does not work here and would have failed silently: `AppStorageEnvironment` opens a per-sandbox suite by name under isolation, and `NSArgumentDomain` reaches the standard domain alone. That is the same hazard `UITestCase.launchApp` already documents in the other direction for `-AppleLanguages`.

## Reverting #2421

#2421 changed `licenseLine` to `ViewThatFits` on the theory that the line overflowed the 240pt panel and compressed the link out of the accessibility tree. The tree above shows the panel was never rendered, so that theory was wrong. Its doc comment asserts a cause that does not exist, which is worse than no change, so this reverts the file to its state at 08a62c39c.

For the record, #2421 merged before its `Build for testing` job finished, so its UI suite never ran. That is the same pattern as #2422.

## Testing

`testTheWelcomeWindowCarriesTheStandingLink` is the test, and it is currently the only thing blocking the v0.68.0 release build. This PR is verified by that case going green, and by the other four cases in the suite staying green. Local UI runs are not available in this environment (`Timed out while enabling automation mode`).

Please let CI finish before merging this one.

https://claude.ai/code/session_01DBDRXfDuGrLJV2HrM2d4M4