### PR TITLE
perf(datagrid): keep a tab's formatted cells across a tab switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Stall on switching between two loaded table tabs, growing with the rows they hold. (#2424)
+- Scroll position lost when switching away from a table tab and back. (#2424)
+- A table statistics command on every switch between two table tabs. (#2424)
+- Another table's size and row count in Table Info when its statistics arrive late. (#2424)
+
 ## [0.68.0] - 2026-08-25
 
 ### Added

--- a/TablePro/Core/DataGrid/DataGridDisplayState.swift
+++ b/TablePro/Core/DataGrid/DataGridDisplayState.swift
@@ -1,0 +1,50 @@
+//
+//  DataGridDisplayState.swift
+//  TablePro
+//
+//  The formatted-cell cache and viewport anchor a tab keeps while its grid is unmounted.
+//
+
+import AppKit
+import Foundation
+
+/// What a display cache was built from.
+///
+/// A cache that outlives its grid has to carry the inputs that decided its text, because nothing
+/// invalidates it while no grid is mounted to notice them change.
+struct DataGridDisplayIdentity: Equatable {
+    let bufferEpoch: Int
+    let resultSetId: UUID?
+    let columns: [String]
+    let columnTypes: [ColumnType]
+    let displayFormats: [ValueDisplayFormat?]
+    let dateFormat: DateFormatOption
+    let nullDisplay: String
+    let smartValueDetection: Bool
+}
+
+/// Whether the rows under a mounted grid were replaced, as opposed to the grid being rebuilt over
+/// the same rows. A remount is not a content change and must not discard formatted text.
+struct DataGridContentIdentity: Equatable {
+    let reloadVersion: Int
+    let contentRevision: Int
+}
+
+/// The per-result state a mounted grid derives, kept by an owner that outlives the view.
+///
+/// SwiftUI destroys `TableViewCoordinator` whenever the grid leaves the view tree, and the editor
+/// mounts the grid as `.id(tab.id)`, so every tab switch threw away a whole result's formatted text
+/// and rebuilt it: `CellDisplayFormatter` over every loaded row of every column, on the main actor,
+/// growing with the rows the tab held. The owner keeps this the same way it already keeps the value
+/// filter and the resolved display order. (#2424)
+@MainActor
+final class DataGridDisplayState {
+    let cache = RowDisplayCache()
+    var contentIdentity: DataGridContentIdentity?
+    var firstVisibleRow: Int = 0
+    /// The two derived values a coordinator compares against to decide the cache is stale. A fresh
+    /// coordinator starts both empty, so without carrying them the first update of every remount
+    /// reports a schema and a format change and clears the text it was just handed.
+    var identitySchema: ColumnIdentitySchema?
+    var displayFormats: [ValueDisplayFormat?]?
+}

--- a/TablePro/Core/DataGrid/DataGridPrewarmWindow.swift
+++ b/TablePro/Core/DataGrid/DataGridPrewarmWindow.swift
@@ -1,0 +1,23 @@
+//
+//  DataGridPrewarmWindow.swift
+//  TablePro
+//
+//  The slice of a result the data grid formats ahead of the viewport.
+//
+
+import Foundation
+
+/// The rows the background prewarm may format, as a function of the rows on screen.
+///
+/// Kept apart from the coordinator so the bound can be asserted without an `NSTableView`.
+enum DataGridPrewarmWindow {
+    static let margin = 250
+
+    static func rows(around visible: Range<Int>, displayCount: Int) -> Range<Int> {
+        guard displayCount > 0 else { return 0..<0 }
+        let lower = max(0, min(visible.lowerBound, displayCount) - margin)
+        let upper = min(displayCount, max(visible.lowerBound, visible.upperBound) + margin)
+        guard lower < upper else { return 0..<0 }
+        return lower..<upper
+    }
+}

--- a/TablePro/Models/Query/TabSession.swift
+++ b/TablePro/Models/Query/TabSession.swift
@@ -32,10 +32,17 @@ final class TabSession: Identifiable {
     /// which cannot distinguish two different results of the same size.
     var dataRevision: Int
 
+    /// Bumped only when the buffer is replaced wholesale, which `dataRevision` cannot express: it
+    /// also moves for an in-place edit, and a row id survives one of those. Row ids are positional,
+    /// so a new page hands the same ids to different rows, and anything derived per row id has to
+    /// be dropped exactly then and kept across an edit.
+    var bufferEpoch: Int
+
     init(id: UUID = UUID()) {
         self.id = id
         self.tableRows = TableRows()
         self.isEvicted = false
         self.dataRevision = 0
+        self.bufferEpoch = 0
     }
 }

--- a/TablePro/Models/Query/TabSessionRegistry.swift
+++ b/TablePro/Models/Query/TabSessionRegistry.swift
@@ -42,6 +42,7 @@ final class TabSessionRegistry {
         session.tableRows = rows
         session.isEvicted = false
         session.dataRevision &+= 1
+        session.bufferEpoch &+= 1
     }
 
     /// A mutation of what the tab already holds, so it cannot resurrect a tab that holds nothing.
@@ -68,6 +69,7 @@ final class TabSessionRegistry {
         session.tableRows = TableRows()
         session.isEvicted = false
         session.dataRevision &+= 1
+        session.bufferEpoch &+= 1
     }
 
     func isEvicted(_ tabId: UUID) -> Bool {
@@ -85,6 +87,7 @@ final class TabSessionRegistry {
         session.tableRows.discardRowsKeepingMetadata()
         session.isEvicted = true
         session.dataRevision &+= 1
+        session.bufferEpoch &+= 1
     }
 
     private func ensureSession(for tabId: UUID) -> TabSession {

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -893,7 +893,8 @@ struct MainEditorContentView: View {
             ),
             sortState: sortStateBinding(for: tab),
             columnLayout: columnLayoutBinding(for: tab),
-            valueFilter: valueFilterBinding(for: tab)
+            valueFilter: valueFilterBinding(for: tab),
+            displayState: coordinator.displayState(for: tab)
         )
         .id(tabId)
         .frame(maxHeight: .infinity, alignment: .top)

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+GridDisplay.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+GridDisplay.swift
@@ -30,7 +30,66 @@ struct DisplayOrderCacheEntry {
     }
 }
 
+/// A tab's formatted-cell text, kept across the grid remounts a tab switch causes, plus the inputs
+/// that decided it.
+struct DisplayStateCacheEntry {
+    let identity: DataGridDisplayIdentity
+    let state: DataGridDisplayState
+    var lastUsed: Int
+}
+
 extension MainContentCoordinator {
+    /// The formatted text and viewport anchor for a tab's result, kept here because the grid that
+    /// derives them is destroyed and rebuilt on every tab switch.
+    ///
+    /// A stale entry is replaced rather than repaired: the cache is keyed by row id, row ids are
+    /// positional, and a new page reuses the ids of the one before it, so anything that can change
+    /// what a position holds has to be part of the identity. It keys on `bufferEpoch` rather than
+    /// `dataRevision` for exactly that reason: an in-place edit keeps every row id, and the grid
+    /// already drops the one row it touched, so replacing the whole entry there would re-format the
+    /// page after every keystroke that commits. (#2424)
+    func displayState(for tab: QueryTab) -> DataGridDisplayState {
+        let settings = AppSettingsManager.shared.dataGrid
+        let tableRows = tabSessionRegistry.existingTableRows(for: tab.id)
+        let identity = DataGridDisplayIdentity(
+            bufferEpoch: tabSessionRegistry.session(for: tab.id)?.bufferEpoch ?? 0,
+            resultSetId: tab.display.activeResultSetId,
+            columns: tableRows?.columns ?? [],
+            columnTypes: tableRows?.columnTypes ?? [],
+            displayFormats: displayFormats(for: tab),
+            dateFormat: settings.dateFormat,
+            nullDisplay: settings.nullDisplay,
+            smartValueDetection: settings.enableSmartValueDetection
+        )
+
+        displayStateClock &+= 1
+        if let cached = displayStateCache[tab.id], cached.identity == identity {
+            displayStateCache[tab.id]?.lastUsed = displayStateClock
+            return cached.state
+        }
+        let state = DataGridDisplayState()
+        displayStateCache[tab.id] = DisplayStateCacheEntry(
+            identity: identity,
+            state: state,
+            lastUsed: displayStateClock
+        )
+        pruneDisplayStateCache()
+        return state
+    }
+
+    /// Each entry holds a whole result's formatted text, budgeted at 64 MB by `RowDisplayCache`, so
+    /// the tabs the user is actually moving between keep theirs and the rest give it back. The
+    /// budget is the one inactive row data already uses, so the two do not disagree about how many
+    /// background tabs are worth keeping.
+    private func pruneDisplayStateCache() {
+        let budget = MemoryPressureAdvisor.budgetForInactiveTabs() + 1
+        guard displayStateCache.count > budget else { return }
+        let ordered = displayStateCache.sorted { $0.value.lastUsed > $1.value.lastUsed }
+        for entry in ordered.dropFirst(budget) {
+            displayStateCache.removeValue(forKey: entry.key)
+        }
+    }
+
     /// The rows the grid is displaying, in display order, or nil when that is the storage order.
     ///
     /// Resolved from the tab rather than from the mounted grid. SwiftUI destroys an

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+SchemaLoading.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+SchemaLoading.swift
@@ -7,6 +7,13 @@ import Combine
 import Foundation
 import os
 
+/// One tab's Table Info numbers, stamped with what they were read against.
+struct TableMetadataCacheEntry {
+    let tableName: String
+    let lastExecutedAt: Date?
+    let metadata: TableMetadata
+}
+
 extension MainContentCoordinator {
     /// Whether the connection is far enough along for the object list to load.
     ///
@@ -122,7 +129,24 @@ extension MainContentCoordinator {
         }
     }
 
-    func loadTableMetadata(tableName: String) async {
+    /// Whether the Table Info panel already holds this tab's numbers.
+    ///
+    /// The panel used to be backed by one latest-wins slot, so alternating between two tabs missed
+    /// it on every switch and ran a statistics command (`collStats` on MongoDB) each time. The entry
+    /// is keyed by tab and stamped with the tab's last execution, so a reload, a page or a filter
+    /// refetches while a plain switch does not. (#2424)
+    func hasCurrentTableMetadata(for tab: QueryTab, tableName: String) -> Bool {
+        guard let entry = tableMetadataCache[tab.id] else { return false }
+        return entry.tableName == tableName && entry.lastExecutedAt == tab.execution.lastExecutedAt
+    }
+
+    func loadTableMetadata(tableName: String, for tab: QueryTab) async {
+        if let entry = tableMetadataCache[tab.id],
+           entry.tableName == tableName,
+           entry.lastExecutedAt == tab.execution.lastExecutedAt {
+            tableMetadata = entry.metadata
+            return
+        }
         guard let scope = selectedTabScope else {
             Self.logger.error("Skipped table metadata load: no database bound to the selected tab")
             return
@@ -131,7 +155,16 @@ extension MainContentCoordinator {
             let metadata = try await services.databaseManager.withMetadataDriver(scope: scope) { driver in
                 try await driver.fetchTableMetadata(tableName: tableName)
             }
-            self.tableMetadata = metadata
+            tableMetadataCache[tab.id] = TableMetadataCacheEntry(
+                tableName: tableName,
+                lastExecutedAt: tab.execution.lastExecutedAt,
+                metadata: metadata
+            )
+            /// The fetch is not cancellable, so a `.task` the user has already navigated away from
+            /// still completes. Without this the numbers of the collection they left land in the
+            /// panel of the one they are looking at, under its name, and stay there.
+            guard tabManager.selectedTabId == tab.id else { return }
+            tableMetadata = metadata
         } catch {
             Self.logger.error("Failed to load table metadata: \(error.localizedDescription, privacy: .public)")
         }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TabClosing.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TabClosing.swift
@@ -35,6 +35,8 @@ extension MainContentCoordinator {
     func cleanupTabCaches(openTabIds: Set<UUID>) {
         prune(&displayFormatsCache, keeping: openTabIds)
         prune(&displayOrderCache, keeping: openTabIds)
+        prune(&displayStateCache, keeping: openTabIds)
+        prune(&tableMetadataCache, keeping: openTabIds)
         prune(&createTableDrafts, keeping: openTabIds)
         prune(&navigationHistories, keeping: openTabIds)
         prune(&pendingRowAnchors, keeping: openTabIds)
@@ -59,6 +61,8 @@ extension MainContentCoordinator {
     /// retargeted at all; this is what keeps the caches honest once one without work has been.
     func releaseRetargetedTabState(for tabId: UUID) {
         pendingRowAnchors.removeValue(forKey: tabId)
+        displayStateCache.removeValue(forKey: tabId)
+        tableMetadataCache.removeValue(forKey: tabId)
         structureSessions.removeValue(forKey: tabId)?.releaseViewWiring()
         createTableDrafts.removeValue(forKey: tabId)
         tabsWithStagedPrincipals.remove(tabId)
@@ -85,6 +89,8 @@ extension MainContentCoordinator {
         createTableDrafts.removeValue(forKey: tab.id)
         navigationHistories.removeValue(forKey: tab.id)
         pendingRowAnchors.removeValue(forKey: tab.id)
+        displayStateCache.removeValue(forKey: tab.id)
+        tableMetadataCache.removeValue(forKey: tab.id)
         guard isSelectedTab(tab) else { return }
         changeManager.clearChangesAndUndoHistory()
         toolbarState.hasStructureChanges = false

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
@@ -118,7 +118,11 @@ extension MainContentCoordinator {
                 "[switch] handleTabChange phases: saveOutgoing=\(saveMs)ms restoreIncoming=\(restoreMs)ms"
             )
 
-            changeManager.reloadVersion += 1
+            // No `reloadVersion` bump here. It is the change manager's throw-away-and-fetch-again
+            // signal and it is shared by every tab in the window, so bumping it on a switch told
+            // the incoming grid its rows had changed and made it re-format the whole result. The
+            // reload a switch does need is already forced by the freshly mounted grid's zero row
+            // count, and a real content change still arrives through `configureForTable`. (#2424)
             lazyLoadCurrentTabIfNeeded()
         } else {
             toolbarState.isTableTab = false
@@ -164,6 +168,7 @@ extension MainContentCoordinator {
             tab.loadEpoch &+= 1
         }
         tabSessionRegistry.evict(for: tabId)
+        displayStateCache.removeValue(forKey: tabId)
         return true
     }
 

--- a/TablePro/Views/Main/Extensions/MainContentView+Helpers.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Helpers.swift
@@ -13,10 +13,12 @@ extension MainContentView {
     // MARK: - Helper Methods
 
     func loadTableMetadataIfNeeded() async {
-        guard let tableName = currentTab?.tableContext.tableName,
-            coordinator.tableMetadata?.tableName != tableName
+        guard let tab = currentTab,
+            let tableName = tab.tableContext.tableName,
+            !(coordinator.tableMetadata?.tableName == tableName
+                && coordinator.hasCurrentTableMetadata(for: tab, tableName: tableName))
         else { return }
-        await coordinator.loadTableMetadata(tableName: tableName)
+        await coordinator.loadTableMetadata(tableName: tableName, for: tab)
     }
 
     func handleConnectionStatusChange() {

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -240,6 +240,9 @@ final class MainContentCoordinator {
 
     @ObservationIgnored var displayFormatsCache: [UUID: DisplayFormatsCacheEntry] = [:]
     @ObservationIgnored var displayOrderCache: [UUID: DisplayOrderCacheEntry] = [:]
+    @ObservationIgnored var displayStateCache: [UUID: DisplayStateCacheEntry] = [:]
+    @ObservationIgnored var tableMetadataCache: [UUID: TableMetadataCacheEntry] = [:]
+    @ObservationIgnored var displayStateClock = 0
 
     @ObservationIgnored let schemaColumns = SchemaColumnStore()
     @ObservationIgnored var columnScopeRequeryTask: Task<Void, Never>?
@@ -880,6 +883,8 @@ final class MainContentCoordinator {
         createTableDrafts.removeAll()
         displayFormatsCache.removeAll()
         displayOrderCache.removeAll()
+        displayStateCache.removeAll()
+        tableMetadataCache.removeAll()
         schemaColumns.removeAll()
         columnScopeRequeryTask?.cancel()
 

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -69,7 +69,12 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     var displayIDs: [RowID]? { valueFilteredIDs }
     private(set) var columnDisplayFormats: [ValueDisplayFormat?] = []
     private(set) var currentFindMatch: FindMatch?
-    private let displayCache = RowDisplayCache()
+    /// Owned by whoever outlives this coordinator when there is one, so a remount reuses the text it
+    /// already formatted instead of formatting the whole result again. A grid with no owner keeps
+    /// its own, which is all a structure or create-table grid ever needs. (#2424)
+    private(set) var displayState = DataGridDisplayState()
+    var displayCache: RowDisplayCache { displayState.cache }
+    private var pendingScrollAnchorRow: Int?
     weak var delegate: (any DataGridViewDelegate)?
     weak var activeFKPreviewPopover: NSPopover?
     weak var activeCellEditorPopover: NSPopover?
@@ -111,6 +116,51 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     /// Takes an owner-driven filter change without writing it back, which a plain assignment would.
     func adoptValueFilter(_ state: GridValueFilterState) {
         storedValueFilterState = state
+    }
+
+    /// Takes over the formatted text and viewport anchor the owner kept while no grid was mounted.
+    ///
+    /// The owner hands back a fresh state whenever the inputs that decide the text have moved, so
+    /// there is nothing to validate here.
+    func adoptDisplayState(_ state: DataGridDisplayState) {
+        guard state !== displayState else { return }
+        displayState = state
+        pendingScrollAnchorRow = state.firstVisibleRow
+        /// Both directions, because either side can be the one that knows. A fresh coordinator
+        /// takes the schema and formats the state carries, so its first update does not report them
+        /// as a change and clear the text. A state handed over while the grid stays mounted carries
+        /// neither, and the writers that would fill them are change-gated and will not fire, so it
+        /// takes them from here instead and the next remount still restores.
+        if let schema = state.identitySchema {
+            identitySchema = schema
+        } else {
+            state.identitySchema = identitySchema
+        }
+        if let formats = state.displayFormats {
+            columnDisplayFormats = formats
+        } else {
+            state.displayFormats = columnDisplayFormats
+        }
+    }
+
+    var scrollAnchorRow: Int { pendingScrollAnchorRow ?? 0 }
+
+    /// Records where the user was looking, so returning to this tab does not start at the first row.
+    func recordScrollAnchor() {
+        guard let tableView else { return }
+        let visible = tableView.rows(in: tableView.visibleRect)
+        displayState.firstVisibleRow = max(0, visible.location)
+    }
+
+    /// `scrollRowToVisible` only guarantees visibility, so from a grid scrolled to the top it puts
+    /// the anchor at the bottom of the viewport rather than back where the user left it.
+    func restoreScrollAnchor() {
+        guard let tableView, let row = pendingScrollAnchorRow else { return }
+        pendingScrollAnchorRow = nil
+        guard row > 0, row < tableView.numberOfRows else { return }
+        let origin = tableView.rect(ofRow: row).origin
+        let x = tableView.enclosingScrollView?.contentView.bounds.origin.x ?? 0
+        tableView.scroll(NSPoint(x: x, y: origin.y))
     }
 
     func invalidateColumnIndexCache() {
@@ -459,11 +509,11 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     var pendingColumnLayoutPersistence: PendingColumnLayoutPersistence?
     var columnLayoutPersistenceGeneration = 0
     var lastUpdateSnapshot: DataGridUpdateSnapshot?
-    private var prewarmTask: Task<Void, Never>?
-    private var prewarmResumeTask: Task<Void, Never>?
-    private var scrollObservers: [NSObjectProtocol] = []
-    private static let prewarmFrameBudget: Duration = .milliseconds(2)
-    private static let prewarmResumeDelay: Duration = .milliseconds(300)
+    var prewarmTask: Task<Void, Never>?
+    var prewarmResumeTask: Task<Void, Never>?
+    var scrollObservers: [NSObjectProtocol] = []
+    static let prewarmFrameBudget: Duration = .milliseconds(2)
+    static let prewarmResumeDelay: Duration = .milliseconds(300)
 
     static let rowViewIdentifier = NSUserInterfaceItemIdentifier("TableRowView")
     let visualIndex = RowVisualIndex()
@@ -812,6 +862,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     private func applyDisplayFormats(_ formats: [ValueDisplayFormat?]) -> Bool {
         let remappedValueFilters = remapValueFilters(from: columnDisplayFormats, to: formats)
         columnDisplayFormats = formats
+        displayState.displayFormats = formats
         displayCache.removeAll()
         delegate?.dataGridDisplayFormatChanged()
         return remappedValueFilters
@@ -890,105 +941,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         startBackgroundPrewarm()
     }
 
-    func preWarmDisplayCache(upTo rowCount: Int) {
-        let tableRows = tableRowsProvider()
-        let displayCount = displayIDs?.count ?? tableRows.count
-        let count = min(rowCount, displayCount)
-        guard count > 0 else { return }
-        for displayIndex in 0..<count {
-            cacheDisplayRow(at: displayIndex, in: tableRows)
-        }
-    }
-
-    /// Fills displayCache off the scroll hot path so viewFor:row: stays a cache hit.
-    func startBackgroundPrewarm() {
-        prewarmResumeTask?.cancel()
-        prewarmResumeTask = nil
-        prewarmTask?.cancel()
-        prewarmTask = Task { @MainActor [weak self] in
-            await self?.runBackgroundPrewarm()
-        }
-    }
-
-    /// Pauses prewarm during live scroll; resumes after a debounce so rapid scrolls do not restart it repeatedly.
-    func attachScrollObservers(scrollView: NSScrollView) {
-        detachScrollObservers()
-        let start = NotificationCenter.default.addObserver(
-            forName: NSScrollView.willStartLiveScrollNotification,
-            object: scrollView,
-            queue: .main
-        ) { [weak self] _ in
-            MainActor.assumeIsolated {
-                self?.pausePrewarmForScroll()
-            }
-        }
-        let end = NotificationCenter.default.addObserver(
-            forName: NSScrollView.didEndLiveScrollNotification,
-            object: scrollView,
-            queue: .main
-        ) { [weak self] _ in
-            MainActor.assumeIsolated {
-                self?.schedulePrewarmResume()
-            }
-        }
-        /// The clip view rather than the scroll view's live-scroll pair, because it is the only one
-        /// that also reports a programmatic scroll: `scrollRowToVisible`, which is how VoiceOver
-        /// reaches a row that is not on screen.
-        scrollView.contentView.postsBoundsChangedNotifications = true
-        let bounds = NotificationCenter.default.addObserver(
-            forName: NSView.boundsDidChangeNotification,
-            object: scrollView.contentView,
-            queue: .main
-        ) { [weak self] _ in
-            MainActor.assumeIsolated {
-                self?.remountAccessibilityCells()
-            }
-        }
-        scrollObservers = [start, end, bounds]
-    }
-
-    private func detachScrollObservers() {
-        for observer in scrollObservers {
-            NotificationCenter.default.removeObserver(observer)
-        }
-        scrollObservers.removeAll()
-    }
-
-    private func pausePrewarmForScroll() {
-        prewarmResumeTask?.cancel()
-        prewarmResumeTask = nil
-        prewarmTask?.cancel()
-        prewarmTask = nil
-    }
-
-    private func schedulePrewarmResume() {
-        prewarmResumeTask?.cancel()
-        prewarmResumeTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: Self.prewarmResumeDelay)
-            guard !Task.isCancelled, let self else { return }
-            self.startBackgroundPrewarm()
-        }
-    }
-
-    private func runBackgroundPrewarm() async {
-        var nextIndex = 0
-        while !Task.isCancelled {
-            let tableRows = tableRowsProvider()
-            let displayCount = displayIDs?.count ?? tableRows.count
-            guard nextIndex < displayCount else { return }
-
-            let deadline = ContinuousClock.now.advanced(by: Self.prewarmFrameBudget)
-            while nextIndex < displayCount {
-                if Task.isCancelled { return }
-                cacheDisplayRow(at: nextIndex, in: tableRows)
-                nextIndex += 1
-                if ContinuousClock.now >= deadline { break }
-            }
-            await Task.yield()
-        }
-    }
-
-    private func cacheDisplayRow(at displayIndex: Int, in tableRows: TableRows) {
+    func cacheDisplayRow(at displayIndex: Int, in tableRows: TableRows) {
         guard let row = displayRow(at: displayIndex, in: tableRows) else { return }
         guard displayCache.box(forID: row.id) == nil else { return }
 
@@ -1265,6 +1218,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
 
         guard schemaChanged else { return false }
         identitySchema = nextSchema
+        displayState.identitySchema = nextSchema
         displayCache.removeAll()
         invalidateColumnIndexCache()
         return true

--- a/TablePro/Views/Results/DataGridView.swift
+++ b/TablePro/Views/Results/DataGridView.swift
@@ -48,6 +48,10 @@ struct DataGridView: NSViewRepresentable {
     /// menu's row commands all read it with no grid mounted. A grid with no owner keeps the filter
     /// on its own coordinator, which is all a structure or create-table grid ever needs. (#2251)
     var valueFilter: Binding<GridValueFilterState>?
+    /// The formatted text and viewport anchor for this result, owned the same way and for the same
+    /// reason as the value filter above. The owner hands back a fresh instance whenever the inputs
+    /// that decide the text have moved, so adopting one is always safe. (#2424)
+    var displayState: DataGridDisplayState?
     var contentRevision: Int = 0
 
     // MARK: - NSViewRepresentable
@@ -104,6 +108,9 @@ struct DataGridView: NSViewRepresentable {
         coordinator.valueFilterBinding = valueFilter
         if let valueFilter {
             coordinator.adoptValueFilter(valueFilter.wrappedValue)
+        }
+        if let displayState {
+            coordinator.adoptDisplayState(displayState)
         }
         coordinator.delegate = delegate
         coordinator.syncDisplayFormats(displayFormats)
@@ -174,6 +181,9 @@ struct DataGridView: NSViewRepresentable {
             coordinator.adoptValueFilter(valueFilter.wrappedValue)
             coordinator.recomputeValueFilteredIDs()
         }
+        if let displayState {
+            coordinator.adoptDisplayState(displayState)
+        }
 
         let latestRows = tableRowsProvider()
         let rowDisplayCount = coordinator.valueFilteredIDs?.count ?? latestRows.count
@@ -200,8 +210,15 @@ struct DataGridView: NSViewRepresentable {
         )
 
         if snapshot != coordinator.lastUpdateSnapshot {
-            let contentChanged = snapshot.reloadVersion != coordinator.lastUpdateSnapshot?.reloadVersion
-                || snapshot.contentRevision != coordinator.lastUpdateSnapshot?.contentRevision
+            // Read from the retained state rather than from `lastUpdateSnapshot`, which is nil on a
+            // freshly mounted coordinator and would therefore report every remount as a content
+            // change and discard the text the owner just handed over.
+            let contentIdentity = DataGridContentIdentity(
+                reloadVersion: changeManager.reloadVersion,
+                contentRevision: contentRevision
+            )
+            let contentChanged = coordinator.displayState.contentIdentity != contentIdentity
+            coordinator.displayState.contentIdentity = contentIdentity
             applyStructuralUpdate(
                 tableView: tableView,
                 coordinator: coordinator,
@@ -282,7 +299,7 @@ struct DataGridView: NSViewRepresentable {
 
         if oldRowCount == 0, rowDisplayCount > 0, rowHeight > 0 {
             let visibleRows = Int(tableView.visibleRect.height / rowHeight) + 5
-            coordinator.preWarmDisplayCache(upTo: visibleRows)
+            coordinator.preWarmDisplayCache(rowCount: visibleRows, from: coordinator.scrollAnchorRow)
         }
 
         coordinator.updateCache()
@@ -332,6 +349,7 @@ struct DataGridView: NSViewRepresentable {
         if needsFullReload || remappedValueFilters {
             coordinator.selectionController.clear()
             tableView.reloadData()
+            coordinator.restoreScrollAnchor()
             coordinator.startBackgroundPrewarm()
         } else if displayFormatsChanged {
             coordinator.reloadAfterDisplayFormatChange()
@@ -439,6 +457,7 @@ struct DataGridView: NSViewRepresentable {
 
     static func dismantleNSView(_ nsView: NSScrollView, coordinator: TableViewCoordinator) {
         coordinator.overlayEditor?.dismiss(commit: true)
+        coordinator.recordScrollAnchor()
         coordinator.flushPendingColumnLayoutPersistence()
         coordinator.settingsCancellable = nil
         coordinator.themeCancellable = nil

--- a/TablePro/Views/Results/Extensions/DataGridView+Prewarm.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Prewarm.swift
@@ -1,0 +1,132 @@
+//
+//  DataGridView+Prewarm.swift
+//  TablePro
+//
+//  Filling the grid's formatted-text cache ahead of the viewport, and following the viewport as it
+//  moves.
+//
+
+import AppKit
+import Foundation
+
+extension TableViewCoordinator {
+    func preWarmDisplayCache(rowCount: Int, from startIndex: Int = 0) {
+        let tableRows = tableRowsProvider()
+        let displayCount = displayIDs?.count ?? tableRows.count
+        let lower = max(0, min(startIndex, displayCount))
+        let upper = min(displayCount, lower + max(0, rowCount))
+        guard lower < upper else { return }
+        for displayIndex in lower..<upper {
+            cacheDisplayRow(at: displayIndex, in: tableRows)
+        }
+    }
+
+    /// The rows the background prewarm is allowed to format, anchored on the viewport.
+    ///
+    /// A grid mounts on every tab switch, and an unanchored prewarm formatted every loaded row of
+    /// every column each time, so arriving at an already-loaded tab cost more the more rows it
+    /// held. A miss outside the window is filled by `displayValue(forID:column:rawValue:columnType:)`
+    /// while the row draws, so the window bounds the work without bounding what the grid can show.
+    func currentPrewarmWindow(displayCount: Int) -> Range<Int> {
+        guard let tableView else {
+            return DataGridPrewarmWindow.rows(around: 0..<0, displayCount: displayCount)
+        }
+        let visible = tableView.rows(in: tableView.visibleRect)
+        let lower = max(0, visible.location)
+        let upper = max(lower, visible.location + visible.length)
+        return DataGridPrewarmWindow.rows(around: lower..<upper, displayCount: displayCount)
+    }
+
+    /// Fills displayCache off the scroll hot path so viewFor:row: stays a cache hit.
+    func startBackgroundPrewarm() {
+        prewarmResumeTask?.cancel()
+        prewarmResumeTask = nil
+        prewarmTask?.cancel()
+        prewarmTask = Task { @MainActor [weak self] in
+            await self?.runBackgroundPrewarm()
+        }
+    }
+
+    /// Pauses prewarm during live scroll; resumes after a debounce so rapid scrolls do not restart it repeatedly.
+    func attachScrollObservers(scrollView: NSScrollView) {
+        detachScrollObservers()
+        let start = NotificationCenter.default.addObserver(
+            forName: NSScrollView.willStartLiveScrollNotification,
+            object: scrollView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.pausePrewarmForScroll()
+            }
+        }
+        let end = NotificationCenter.default.addObserver(
+            forName: NSScrollView.didEndLiveScrollNotification,
+            object: scrollView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.schedulePrewarmResume()
+            }
+        }
+        /// The clip view rather than the scroll view's live-scroll pair, because it is the only one
+        /// that also reports a programmatic scroll: `scrollRowToVisible`, which is how VoiceOver
+        /// reaches a row that is not on screen, and how Find Next and paging move the viewport. The
+        /// prewarm window is anchored on the viewport, so those have to re-anchor it too.
+        scrollView.contentView.postsBoundsChangedNotifications = true
+        let bounds = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.remountAccessibilityCells()
+                self?.schedulePrewarmResume()
+            }
+        }
+        scrollObservers = [start, end, bounds]
+    }
+
+    func detachScrollObservers() {
+        for observer in scrollObservers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        scrollObservers.removeAll()
+    }
+
+    func pausePrewarmForScroll() {
+        prewarmResumeTask?.cancel()
+        prewarmResumeTask = nil
+        prewarmTask?.cancel()
+        prewarmTask = nil
+    }
+
+    func schedulePrewarmResume() {
+        prewarmResumeTask?.cancel()
+        prewarmResumeTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: Self.prewarmResumeDelay)
+            guard !Task.isCancelled, let self else { return }
+            self.startBackgroundPrewarm()
+        }
+    }
+
+    func runBackgroundPrewarm() async {
+        var nextIndex: Int?
+        while !Task.isCancelled {
+            let tableRows = tableRowsProvider()
+            let displayCount = displayIDs?.count ?? tableRows.count
+            let window = currentPrewarmWindow(displayCount: displayCount)
+            var index = max(nextIndex ?? window.lowerBound, window.lowerBound)
+            guard index < window.upperBound else { return }
+
+            let deadline = ContinuousClock.now.advanced(by: Self.prewarmFrameBudget)
+            while index < window.upperBound {
+                if Task.isCancelled { return }
+                cacheDisplayRow(at: index, in: tableRows)
+                index += 1
+                if ContinuousClock.now >= deadline { break }
+            }
+            nextIndex = index
+            await Task.yield()
+        }
+    }
+}

--- a/TableProTests/Core/DataGrid/DataGridPrewarmWindowTests.swift
+++ b/TableProTests/Core/DataGrid/DataGridPrewarmWindowTests.swift
@@ -1,0 +1,50 @@
+//
+//  DataGridPrewarmWindowTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("Data grid prewarm window")
+struct DataGridPrewarmWindowTests {
+    @Test("The window is bounded by the margin, not by the number of loaded rows")
+    func windowDoesNotGrowWithRowCount() {
+        let small = DataGridPrewarmWindow.rows(around: 0..<25, displayCount: 1_000)
+        let large = DataGridPrewarmWindow.rows(around: 0..<25, displayCount: 250_000)
+        #expect(small.count == large.count)
+        #expect(large.count <= 25 + 2 * DataGridPrewarmWindow.margin)
+    }
+
+    @Test("The window follows the viewport instead of starting at the first row")
+    func windowFollowsTheViewport() {
+        let window = DataGridPrewarmWindow.rows(around: 5_000..<5_025, displayCount: 20_000)
+        #expect(window.contains(5_000))
+        #expect(window.contains(5_024))
+        #expect(!window.contains(0))
+    }
+
+    @Test("The window is clamped to the loaded rows at both ends")
+    func windowIsClampedToLoadedRows() {
+        let atTop = DataGridPrewarmWindow.rows(around: 0..<10, displayCount: 40)
+        #expect(atTop == 0..<40)
+
+        let atBottom = DataGridPrewarmWindow.rows(around: 990..<1_000, displayCount: 1_000)
+        #expect(atBottom.upperBound == 1_000)
+        #expect(atBottom.lowerBound == 740)
+    }
+
+    @Test("An empty result has nothing to prewarm")
+    func emptyResultHasNoWindow() {
+        #expect(DataGridPrewarmWindow.rows(around: 0..<0, displayCount: 0).isEmpty)
+    }
+
+    @Test("A grid with no viewport yet prewarms from the first row")
+    func unmeasuredViewportStartsAtTheTop() {
+        let window = DataGridPrewarmWindow.rows(around: 0..<0, displayCount: 10_000)
+        #expect(window.lowerBound == 0)
+        #expect(window.upperBound == DataGridPrewarmWindow.margin)
+    }
+}

--- a/TableProTests/Views/Main/MainContentCoordinatorDisplayStateTests.swift
+++ b/TableProTests/Views/Main/MainContentCoordinatorDisplayStateTests.swift
@@ -1,0 +1,155 @@
+//
+//  MainContentCoordinatorDisplayStateTests.swift
+//  TableProTests
+//
+
+import AppKit
+import CodeEditSourceEditor
+import Foundation
+import SwiftUI
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+@Suite("MainContentCoordinator retained grid display state")
+@MainActor
+struct MainContentCoordinatorDisplayStateTests {
+    private func makeCoordinator() -> (MainContentCoordinator, QueryTabManager) {
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: TestFixtures.makeConnection(),
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        return (coordinator, tabManager)
+    }
+
+    private func addTableTab(to tabManager: QueryTabManager, tableName: String) -> QueryTab {
+        var tab = QueryTab(
+            title: tableName,
+            query: "SELECT * FROM \(tableName)",
+            tabType: .table,
+            tableName: tableName
+        )
+        tab.execution.lastExecutedAt = Date()
+        tabManager.tabs.append(tab)
+        tabManager.selectedTabId = tab.id
+        return tab
+    }
+
+    private func seedRows(
+        _ coordinator: MainContentCoordinator,
+        for tabId: UUID,
+        columns: [String] = ["id", "name"]
+    ) {
+        let rows = (0..<3).map { i in columns.map { PluginCellValue.text("\($0)_\(i)") } }
+        let tableRows = TableRows.from(
+            queryRows: rows,
+            columns: columns,
+            columnTypes: Array(repeating: .text(rawType: nil), count: columns.count)
+        )
+        coordinator.setActiveTableRows(tableRows, for: tabId)
+    }
+
+    @Test("Two tabs keep their own formatted text, and a switch between them reuses both")
+    func alternatingTabsReuseTheirOwnState() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let first = addTableTab(to: tabManager, tableName: "orders")
+        let second = addTableTab(to: tabManager, tableName: "customers")
+        seedRows(coordinator, for: first.id)
+        seedRows(coordinator, for: second.id)
+
+        let firstState = coordinator.displayState(for: tabManager.tabs[0])
+        let secondState = coordinator.displayState(for: tabManager.tabs[1])
+        #expect(firstState !== secondState)
+
+        #expect(coordinator.displayState(for: tabManager.tabs[0]) === firstState)
+        #expect(coordinator.displayState(for: tabManager.tabs[1]) === secondState)
+        #expect(coordinator.displayState(for: tabManager.tabs[0]) === firstState)
+    }
+
+    @Test("Replacing a tab's rows replaces its formatted text")
+    func newRowsReplaceTheState() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let tab = addTableTab(to: tabManager, tableName: "orders")
+        seedRows(coordinator, for: tab.id)
+        let before = coordinator.displayState(for: tabManager.tabs[0])
+
+        seedRows(coordinator, for: tab.id)
+        #expect(coordinator.displayState(for: tabManager.tabs[0]) !== before)
+    }
+
+    @Test("An in-place edit keeps the text formatted for the rest of the page")
+    func inPlaceEditKeepsTheState() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let tab = addTableTab(to: tabManager, tableName: "orders")
+        seedRows(coordinator, for: tab.id)
+        let before = coordinator.displayState(for: tabManager.tabs[0])
+
+        coordinator.tabSessionRegistry.updateTableRows(for: tab.id) { _ in }
+        #expect(coordinator.displayState(for: tabManager.tabs[0]) === before)
+    }
+
+    @Test("A different set of columns replaces the formatted text")
+    func newColumnsReplaceTheState() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let tab = addTableTab(to: tabManager, tableName: "orders")
+        seedRows(coordinator, for: tab.id, columns: ["id", "name"])
+        let before = coordinator.displayState(for: tabManager.tabs[0])
+
+        coordinator.tabSessionRegistry.setTableRows(
+            TableRows.from(
+                queryRows: [[.text("1")]],
+                columns: ["id"],
+                columnTypes: [.text(rawType: nil)]
+            ),
+            for: tab.id
+        )
+        #expect(coordinator.displayState(for: tabManager.tabs[0]) !== before)
+    }
+
+    @Test("Evicting a tab's rows drops the text formatted from them")
+    func evictionDropsTheState() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let first = addTableTab(to: tabManager, tableName: "orders")
+        let second = addTableTab(to: tabManager, tableName: "customers")
+        seedRows(coordinator, for: first.id)
+        seedRows(coordinator, for: second.id)
+        _ = coordinator.displayState(for: tabManager.tabs[0])
+        #expect(coordinator.displayStateCache[first.id] != nil)
+
+        #expect(coordinator.evictReloadableTableRows(for: first.id))
+        #expect(coordinator.displayStateCache[first.id] == nil)
+    }
+
+    @Test("Closed tabs take their formatted text with them")
+    func closingATabPrunesTheState() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let first = addTableTab(to: tabManager, tableName: "orders")
+        let second = addTableTab(to: tabManager, tableName: "customers")
+        seedRows(coordinator, for: first.id)
+        seedRows(coordinator, for: second.id)
+        _ = coordinator.displayState(for: tabManager.tabs[0])
+        _ = coordinator.displayState(for: tabManager.tabs[1])
+
+        coordinator.cleanupTabCaches(openTabIds: [second.id])
+        #expect(coordinator.displayStateCache[first.id] == nil)
+        #expect(coordinator.displayStateCache[second.id] != nil)
+    }
+
+    @Test("A tab switch is not a content change")
+    func switchingDoesNotReportAContentChange() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let first = addTableTab(to: tabManager, tableName: "orders")
+        let second = addTableTab(to: tabManager, tableName: "customers")
+        seedRows(coordinator, for: first.id)
+        seedRows(coordinator, for: second.id)
+
+        let before = coordinator.changeManager.reloadVersion
+        tabManager.selectedTabId = first.id
+        coordinator.handleTabChange(from: second.id, to: first.id, tabs: tabManager.tabs)
+        #expect(coordinator.changeManager.reloadVersion == before)
+    }
+}

--- a/TableProTests/Views/Main/MainContentCoordinatorTableMetadataTests.swift
+++ b/TableProTests/Views/Main/MainContentCoordinatorTableMetadataTests.swift
@@ -1,0 +1,142 @@
+//
+//  MainContentCoordinatorTableMetadataTests.swift
+//  TableProTests
+//
+
+import AppKit
+import CodeEditSourceEditor
+import Foundation
+import SwiftUI
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+@Suite("MainContentCoordinator table metadata cache")
+@MainActor
+struct MainContentCoordinatorTableMetadataTests {
+    private func makeCoordinator() -> (MainContentCoordinator, QueryTabManager) {
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: TestFixtures.makeConnection(),
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        return (coordinator, tabManager)
+    }
+
+    private func addTableTab(to tabManager: QueryTabManager, tableName: String) -> QueryTab {
+        var tab = QueryTab(
+            title: tableName,
+            query: "SELECT * FROM \(tableName)",
+            tabType: .table,
+            tableName: tableName
+        )
+        tab.execution.lastExecutedAt = Date()
+        tabManager.tabs.append(tab)
+        tabManager.selectedTabId = tab.id
+        return tab
+    }
+
+    private func metadata(_ tableName: String, rowCount: Int64) -> TableMetadata {
+        TableMetadata(
+            tableName: tableName,
+            dataSize: nil,
+            indexSize: nil,
+            totalSize: nil,
+            avgRowLength: nil,
+            rowCount: rowCount,
+            comment: nil,
+            engine: nil,
+            collation: nil,
+            createTime: nil,
+            updateTime: nil
+        )
+    }
+
+    @Test("Alternating between two tables fetches once per table, not once per switch")
+    func alternatingTabsHitTheCache() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let orders = addTableTab(to: tabManager, tableName: "orders")
+        let customers = addTableTab(to: tabManager, tableName: "customers")
+
+        #expect(!coordinator.hasCurrentTableMetadata(for: orders, tableName: "orders"))
+        coordinator.tableMetadataCache[orders.id] = TableMetadataCacheEntry(
+            tableName: "orders",
+            lastExecutedAt: orders.execution.lastExecutedAt,
+            metadata: metadata("orders", rowCount: 10)
+        )
+        coordinator.tableMetadataCache[customers.id] = TableMetadataCacheEntry(
+            tableName: "customers",
+            lastExecutedAt: customers.execution.lastExecutedAt,
+            metadata: metadata("customers", rowCount: 20)
+        )
+
+        #expect(coordinator.hasCurrentTableMetadata(for: orders, tableName: "orders"))
+        #expect(coordinator.hasCurrentTableMetadata(for: customers, tableName: "customers"))
+    }
+
+    @Test("Re-running the tab's query makes its cached numbers stale")
+    func reExecutingInvalidatesTheEntry() {
+        let (coordinator, tabManager) = makeCoordinator()
+        var orders = addTableTab(to: tabManager, tableName: "orders")
+        coordinator.tableMetadataCache[orders.id] = TableMetadataCacheEntry(
+            tableName: "orders",
+            lastExecutedAt: orders.execution.lastExecutedAt,
+            metadata: metadata("orders", rowCount: 10)
+        )
+
+        orders.execution.lastExecutedAt = Date(timeIntervalSince1970: 1)
+        #expect(!coordinator.hasCurrentTableMetadata(for: orders, tableName: "orders"))
+    }
+
+    @Test("Retargeting a tab to another table makes its cached numbers stale")
+    func retargetingInvalidatesTheEntry() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let orders = addTableTab(to: tabManager, tableName: "orders")
+        coordinator.tableMetadataCache[orders.id] = TableMetadataCacheEntry(
+            tableName: "orders",
+            lastExecutedAt: orders.execution.lastExecutedAt,
+            metadata: metadata("orders", rowCount: 10)
+        )
+
+        #expect(!coordinator.hasCurrentTableMetadata(for: orders, tableName: "customers"))
+    }
+
+    @Test("A cached entry paints the panel without reaching the database")
+    func cachedEntryPaintsThePanel() async {
+        let (coordinator, tabManager) = makeCoordinator()
+        let orders = addTableTab(to: tabManager, tableName: "orders")
+        coordinator.tableMetadataCache[orders.id] = TableMetadataCacheEntry(
+            tableName: "orders",
+            lastExecutedAt: orders.execution.lastExecutedAt,
+            metadata: metadata("orders", rowCount: 42)
+        )
+
+        await coordinator.loadTableMetadata(tableName: "orders", for: orders)
+        #expect(coordinator.tableMetadata?.tableName == "orders")
+        #expect(coordinator.tableMetadata?.rowCount == 42)
+    }
+
+    @Test("Closed tabs take their cached numbers with them")
+    func closingATabPrunesTheEntry() {
+        let (coordinator, tabManager) = makeCoordinator()
+        let orders = addTableTab(to: tabManager, tableName: "orders")
+        let customers = addTableTab(to: tabManager, tableName: "customers")
+        coordinator.tableMetadataCache[orders.id] = TableMetadataCacheEntry(
+            tableName: "orders",
+            lastExecutedAt: orders.execution.lastExecutedAt,
+            metadata: metadata("orders", rowCount: 10)
+        )
+        coordinator.tableMetadataCache[customers.id] = TableMetadataCacheEntry(
+            tableName: "customers",
+            lastExecutedAt: customers.execution.lastExecutedAt,
+            metadata: metadata("customers", rowCount: 20)
+        )
+
+        coordinator.cleanupTabCaches(openTabIds: [customers.id])
+        #expect(coordinator.tableMetadataCache[orders.id] == nil)
+        #expect(coordinator.tableMetadataCache[customers.id] != nil)
+    }
+}

--- a/TableProTests/Views/Results/TableViewCoordinatorDisplayStateTests.swift
+++ b/TableProTests/Views/Results/TableViewCoordinatorDisplayStateTests.swift
@@ -1,0 +1,141 @@
+//
+//  TableViewCoordinatorDisplayStateTests.swift
+//  TableProTests
+//
+
+import AppKit
+import Foundation
+import SwiftUI
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+@Suite("TableViewCoordinator retained display state")
+@MainActor
+struct TableViewCoordinatorDisplayStateTests {
+    private static let rows = TableRows(
+        rows: [Row(id: .existing(0), values: [.text("A")])],
+        columns: ["name"],
+        columnTypes: [.text(rawType: nil)]
+    )
+
+    /// The order `DataGridView.makeNSView` runs in. The two calls after the adopt are what used to
+    /// discard the text it had just been handed, because a fresh coordinator reports the first
+    /// schema and the first format list it sees as a change.
+    private func mount(
+        displayState: DataGridDisplayState? = nil,
+        displayFormats: [ValueDisplayFormat?] = []
+    ) -> TableViewCoordinator {
+        let coordinator = TableViewCoordinator(
+            changeManager: AnyChangeManager(DataChangeManager()),
+            isEditable: true,
+            selectedRowIndices: .constant([]),
+            delegate: nil,
+            layoutPersister: FakeDisplayStatePersister()
+        )
+        var rows = Self.rows
+        coordinator.tableRowsProvider = { rows }
+        coordinator.tableRowsMutator = { mutation in mutation(&rows) }
+        if let displayState {
+            coordinator.adoptDisplayState(displayState)
+        }
+        coordinator.syncDisplayFormats(displayFormats)
+        coordinator.rebuildColumnMetadataCache(from: rows)
+        coordinator.updateCache()
+        return coordinator
+    }
+
+    private func text(_ coordinator: TableViewCoordinator, raw: String) -> String? {
+        coordinator.displayValue(
+            forID: .existing(0),
+            column: 0,
+            rawValue: .text(raw),
+            columnType: .text(rawType: nil)
+        )
+    }
+
+    @Test("A remount reuses the formatted text the previous grid produced")
+    func remountReusesFormattedText() {
+        let state = DataGridDisplayState()
+        let first = mount(displayState: state)
+        #expect(text(first, raw: "A") == "A")
+
+        let remounted = mount(displayState: state)
+        #expect(text(remounted, raw: "B") == "A")
+    }
+
+    @Test("A remount with a display format applied still reuses the formatted text")
+    func remountWithDisplayFormatsReusesFormattedText() {
+        let formats: [ValueDisplayFormat?] = [.raw]
+        let state = DataGridDisplayState()
+        let first = mount(displayState: state, displayFormats: formats)
+        #expect(text(first, raw: "A") == "A")
+
+        let remounted = mount(displayState: state, displayFormats: formats)
+        #expect(text(remounted, raw: "B") == "A")
+    }
+
+    @Test("A grid with no owner formats from scratch on every mount")
+    func unownedGridDoesNotShareText() {
+        let first = mount()
+        #expect(text(first, raw: "A") == "A")
+
+        let second = mount()
+        #expect(text(second, raw: "B") == "B")
+    }
+
+    @Test("Adopting a state takes over its viewport anchor")
+    func adoptingTakesOverTheViewportAnchor() {
+        let state = DataGridDisplayState()
+        state.firstVisibleRow = 3_200
+        #expect(mount(displayState: state).scrollAnchorRow == 3_200)
+    }
+
+    @Test("Restoring an anchor puts the row back at the top of a real scroll view")
+    func restoringAnAnchorScrollsTheGrid() {
+        let rowCount = 1_000
+        let coordinator = TableViewCoordinator(
+            changeManager: AnyChangeManager(DataChangeManager()),
+            isEditable: true,
+            selectedRowIndices: .constant([]),
+            delegate: nil,
+            layoutPersister: FakeDisplayStatePersister()
+        )
+        let rows = TableRows.from(
+            queryRows: (0..<rowCount).map { [PluginCellValue.text("row \($0)")] },
+            columns: ["name"],
+            columnTypes: [.text(rawType: nil)]
+        )
+        coordinator.tableRowsProvider = { rows }
+
+        let tableView = NSTableView(frame: NSRect(x: 0, y: 0, width: 400, height: 400))
+        tableView.rowHeight = 24
+        tableView.addTableColumn(NSTableColumn(identifier: NSUserInterfaceItemIdentifier("name")))
+        tableView.dataSource = coordinator
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 400, height: 400))
+        scrollView.documentView = tableView
+        scrollView.layoutSubtreeIfNeeded()
+        coordinator.tableView = tableView
+        coordinator.updateCache()
+        tableView.reloadData()
+
+        let state = DataGridDisplayState()
+        state.firstVisibleRow = 500
+        coordinator.adoptDisplayState(state)
+        coordinator.restoreScrollAnchor()
+
+        #expect(scrollView.contentView.bounds.origin.y == tableView.rect(ofRow: 500).origin.y)
+        /// Consumed by the restore, so a later update over the same rows does not drag the user
+        /// back to where they were two switches ago.
+        #expect(coordinator.scrollAnchorRow == 0)
+    }
+}
+
+private final class FakeDisplayStatePersister: ColumnLayoutPersisting {
+    func load(for key: ColumnLayoutTableKey) -> ColumnLayoutState? { nil }
+
+    func save(_ layout: ColumnLayoutState, for key: ColumnLayoutTableKey) {}
+
+    func clear(for key: ColumnLayoutTableKey) {}
+}

--- a/TableProUITests/WarmTabSwitchUITests.swift
+++ b/TableProUITests/WarmTabSwitchUITests.swift
@@ -1,0 +1,89 @@
+//
+//  WarmTabSwitchUITests.swift
+//  TableProUITests
+//
+
+import AppKit
+import XCTest
+
+/// Issue #2424. A warm switch between two loaded table tabs used to rebuild the whole grid and
+/// re-format every loaded cell. The formatted text is now kept per tab and the switch no longer
+/// reports a content change, so the guard here is that a tab still comes back with its own rows
+/// rather than blank or holding the other tab's.
+final class WarmTabSwitchUITests: UITestCase {
+    func testAlternatingBetweenTwoLoadedTableTabsKeepsEachTabsOwnRows() throws {
+        let app = try launchWithSampleDatabase()
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitToExist(timeout: 30))
+
+        openKeptTab("Album", in: window)
+        let albumReadout = try settledReadout(in: window, describing: "Album")
+
+        openKeptTab("Artist", in: window)
+        let artistReadout = try settledReadout(in: window, describing: "Artist")
+
+        XCTAssertNotEqual(
+            albumReadout, artistReadout,
+            "The two tables must differ in what their status bar reports, or the test cannot tell them apart"
+        )
+
+        for _ in 0..<3 {
+            selectTab(titled: "Album", in: window)
+            XCTAssertTrue(
+                waitForPredicate(timeout: 15) { readout(in: window) == albumReadout },
+                "Returning to Album must show Album's rows again, not a blank grid. Read: \(readout(in: window) ?? "nil")"
+            )
+
+            selectTab(titled: "Artist", in: window)
+            XCTAssertTrue(
+                waitForPredicate(timeout: 15) { readout(in: window) == artistReadout },
+                "Returning to Artist must show Artist's rows again. Read: \(readout(in: window) ?? "nil")"
+            )
+        }
+    }
+
+    private func openKeptTab(_ table: String, in window: XCUIElement) {
+        let row = objectBrowserRow(table, in: window)
+        XCTAssertTrue(row.waitToExist(timeout: 20), "The object browser must list \(table)")
+        row.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).doubleClick()
+        Thread.sleep(forTimeInterval: NSEvent.doubleClickInterval)
+    }
+
+    private func selectTab(titled title: String, in window: XCUIElement) {
+        let tab = window.descendants(matching: .any)
+            .matching(identifier: "editor-tab")
+            .containing(NSPredicate(format: "label CONTAINS %@ OR value CONTAINS %@", title, title))
+            .firstMatch
+        XCTAssertTrue(tab.waitToExist(timeout: 15), "The editor tab strip must carry a tab for \(title)")
+        clickAtCenter(tab)
+        Thread.sleep(forTimeInterval: NSEvent.doubleClickInterval)
+    }
+
+    private func readout(in window: XCUIElement) -> String? {
+        let element = window.staticTexts["result-status-readout"].firstMatch
+        guard element.exists else { return nil }
+        let text = (element.value as? String) ?? element.label
+        return text.isEmpty ? nil : text
+    }
+
+    /// The readout is filled in stages as a table loads, and the polling is tight enough that an
+    /// intermediate value can look stable across two of them. Settling is measured in wall clock
+    /// instead: the same string has to survive a full second of samples.
+    private func settledReadout(in window: XCUIElement, describing table: String) throws -> String {
+        var previous: String?
+        var stableSince = Date()
+        XCTAssertTrue(
+            waitForPredicate(timeout: 30) {
+                let current = readout(in: window)
+                if current != previous {
+                    previous = current
+                    stableSince = Date()
+                    return false
+                }
+                return current != nil && Date().timeIntervalSince(stableSince) >= 1
+            },
+            "\(table) must finish loading before the switch test begins"
+        )
+        return try XCTUnwrap(readout(in: window))
+    }
+}


### PR DESCRIPTION
Fixes #2424.

## Root cause

A warm switch between two loaded table tabs re-derived the formatted display text for **every**
loaded cell of the incoming tab. Two mechanisms guaranteed it.

The grid is mounted as `DataGridView(...).id(tabId)` (`MainEditorContentView.swift:898`), so a
switch destroys the `TableViewCoordinator` and with it `private let displayCache = RowDisplayCache()`
(`DataGridCoordinator.swift:72`), which holds the formatted string of every cell of the result.
`makeNSView` deliberately leaves `cachedRowCount` at 0, so the first `updateNSView` always reaches
`reloadData()` followed by `startBackgroundPrewarm()`. `runBackgroundPrewarm` then walked every
display row from index 0 to the end and formatted every column of each, on the main actor. That is
O(loaded rows x columns) per switch, unbounded in the loaded data. The default page is 1,000 rows.

Separately, `handleTabChange` bumped `changeManager.reloadVersion` on every switch. That counter is
the change manager's throw-away-and-fetch-again signal and it is shared by every tab in the window,
so it also reads as "this grid's rows changed" whatever the switch was.

MongoDB is the worst case because `BsonDocumentFlattener` serialises nested documents and arrays to
JSON text, so its cells are kilobytes rather than tens of bytes. The mechanism is engine-agnostic.

## Measured

A `-O` harness running exact copies of the shipping `CellDisplayFormatter` text path and
`String.sanitizedForCellDisplay` over the cell shapes MongoDB produces. This is the work that was
repaid on every switch:

| result shape | per switch |
| --- | --- |
| 1,000 rows x 25 cols, 432-char cells | 23.5 ms |
| 1,000 rows x 25 cols, 4,056-char cells | **215.5 ms** |
| 5,000 rows x 25 cols, 4,056-char cells | **1,092.8 ms** |
| 500 rows x 12 cols, 20,036-char cells | **1,161.1 ms** |

## The fix

The formatted text is derived per result and reusable, so it belongs to an owner that outlives the
view. `DataGridView` already does this for the value filter, for the same reason and in the same
file (#2251), and `MainContentCoordinator` already keeps `displayOrderCache` and
`displayFormatsCache` per tab.

1. **`MainContentCoordinator.displayStateCache`** holds a `DataGridDisplayState` per tab: the
   `RowDisplayCache` plus the viewport anchor. It is stamped with everything that decides the text
   (`bufferEpoch`, result set, columns, column types, display formats, date format, null display,
   smart detection) and replaced wholesale when any of those move, because row ids are positional
   and a new page reuses the ids of the one before it. Pruned by the existing tab-close hooks,
   dropped on eviction and retarget, released in `teardown()`.
2. **The prewarm is anchored on the viewport** instead of running the whole result, and re-anchors
   off the clip view's `boundsDidChangeNotification`, the only notification that also reports the
   programmatic scrolls Find Next, paging and VoiceOver make. A miss outside the window was already
   filled on demand by `displayValue(forID:column:rawValue:columnType:)` while the row draws, and
   the prewarm was already cancelled outright during a live scroll, so the eager pass bought very
   little. This also removes the same cost from first load, on every driver.
3. **A tab switch is no longer a content change.** The `reloadVersion` bump is gone; the reload a
   switch needs is already forced by the fresh grid's zero row count, and a real content change
   still arrives through `configureForTable`. `contentChanged` now compares a per-tab identity
   carried on the retained state rather than `lastUpdateSnapshot`, which is nil on a fresh
   coordinator and therefore reported every remount as a content change.
4. **The scroll position is restored.** `docs/features/tabs.mdx` already told users that "switching
   keeps SQL, cursor, results, scroll position, sort, filters, and pending changes"; nothing
   persisted a grid scroll offset anywhere, so that sentence was not true. The anchor rides on the
   same per-tab state, and `restoreScrollAnchor` positions by `rect(ofRow:)` rather than
   `scrollRowToVisible`, which only guarantees visibility and from a grid scrolled to the top puts
   the anchor at the bottom of the viewport.
5. **Table Info no longer runs a statistics command per switch.** `coordinator.tableMetadata` was a
   single latest-wins slot, so alternating between two tables missed its guard every time and ran a
   MongoDB `collStats` on each switch. It is now keyed per tab and stamped with the tab's last
   execution, so a reload, a page or a filter refetches while a plain switch does not. The
   assignment is also gated on the tab still being selected: the fetch is not cancellable, so a slow
   `collStats` for the collection you left used to land in the panel of the one you are looking at,
   under its name, and stay there.

Three things this change had to get right, each of which broke it in an intermediate state.

A fresh coordinator reports the first schema and the first display-format list it sees as a change
and clears the cache, so `identitySchema` and `columnDisplayFormats` ride on the retained state.
Adoption syncs them in both directions, because either side can be the one that knows: a fresh
coordinator takes them from the state, and a state handed over while the grid stays mounted takes
them from the coordinator, since the writers that would fill them are change-gated and will not fire.

The entry is keyed on a new `TabSession.bufferEpoch` rather than on `dataRevision`. `dataRevision`
also moves for an in-place edit, and a row id survives one of those, so keying on it would replace
the whole entry and re-format the page after every commit. `bufferEpoch` moves only when the buffer
is replaced wholesale, which is exactly when positional row ids start meaning something else.

Retained entries are bounded by `MemoryPressureAdvisor.budgetForInactiveTabs()`, least recently used
first, so the tabs being alternated between keep their text and the rest give it back.

## Verified

- `verify.sh build` PASS.
- `verify.sh test` PASS over the suites that own the changed types, found by grep rather than
  guessed: `TableViewCoordinatorDisplayCacheTests`, `TableViewCoordinatorRowCountCacheTests`,
  `TableViewCoordinatorLayoutTests`, `TableViewCoordinatorValueFilterTests`, `RowDisplayCacheTests`,
  `DataGridColumnPoolTests`, `DataGridColumnWidthOwnershipTests`,
  `MainContentCoordinatorTabSwitchTests`, `MainContentCoordinatorLazyLoadTests`,
  `DataGridSelectionTests`, `TabSessionRegistryTests`, `TabSessionTests`,
  `TabSessionRegistryTableRowsTests`, plus the four new suites. 211 cases, all passing.
- `verify.sh lint` PASS, 0 violations.
- New unit coverage: the prewarm window does not grow with the row count and follows the viewport; a
  remount reuses the text the previous grid produced, including with a display format applied; a
  grid with no owner still formats from scratch; the retained state is replaced when rows, columns
  or formats move and dropped on eviction and tab close; a tab switch does not bump the counter that
  reads as a content change; the metadata entry is per tab and goes stale on re-execution and
  retarget.
- New `TableProUITests/WarmTabSwitchUITests`: two kept table tabs, alternated three times, asserting
  each tab comes back with its own rows rather than blank or the other tab's.

No before/after screenshots: the change is a stall and a scroll offset, neither of which a still
frame shows. The measured table above and the UI test are the evidence in their place.

The Codex reviewer was out of workspace credits, so the second-model pass ran through
`Skill(code-review)` instead. It found four issues, all fixed above: the `contentRevision` wiring
made every cell edit clear the cell selection and reload the table; a state adopted mid-life never
received the schema and formats, which silently disabled reuse for that tab; the retained entries
had no bound across tabs; and the UI test could latch an intermediate readout as its baseline.
