### PR TITLE
perf(plugins): stop fetching query rows once the row cap is exceeded (#2427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Query results stop fetching at the row limit on MySQL, PostgreSQL, SQLite, Redis, DynamoDB and BigQuery. (#2427)
+- Query results stop fetching at the row limit on MySQL, PostgreSQL, SQLite, MSSQL, Oracle, Cassandra, Redis, DynamoDB, BigQuery, Snowflake, Trino and ClickHouse. (#2427)
+- ClickHouse reads a capped result in one request instead of a separate `LIMIT 0` round trip for the columns.
 
 ### Fixed
 
 - Row limit ignored for a parenthesised `SELECT`, a `TABLE` statement or a `VALUES` list. (#2427)
+- Cancelling an export or a schema compare left the database still sending rows on MySQL, PostgreSQL, MSSQL, Oracle, Cassandra and Trino.
+- An aborted PostgreSQL read charged its leftover rows to the next query on that connection.
 - Syntax error when sorting a query result whose SQL ends in `LIMIT`.
 - The user's own `LIMIT` dropped when sorting replaced an existing `ORDER BY`.
 - Fetch All sending the previous run's parameters after a query that had none.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Query results stop fetching at the row limit on MySQL, PostgreSQL, SQLite, Redis, DynamoDB and BigQuery. (#2427)
+
 ### Fixed
 
+- Row limit ignored for a parenthesised `SELECT`, a `TABLE` statement or a `VALUES` list. (#2427)
+- Syntax error when sorting a query result whose SQL ends in `LIMIT`.
+- The user's own `LIMIT` dropped when sorting replaced an existing `ORDER BY`.
+- Fetch All sending the previous run's parameters after a query that had none.
+- A SQLite `UPDATE` or `DELETE` alone in a query tab reporting success instead of the rows affected.
 - Stall on switching between two loaded table tabs, growing with the rows they hold. (#2424)
 - Scroll position lost when switching away from a table tab and back. (#2424)
 - A table statistics command on every switch between two table tabs. (#2424)

--- a/Packages/TableProCore/Sources/TableProTrinoCore/TrinoStatementClient.swift
+++ b/Packages/TableProCore/Sources/TableProTrinoCore/TrinoStatementClient.swift
@@ -40,10 +40,13 @@ public final class TrinoStatementClient: @unchecked Sendable {
         )
     }
 
+    /// The paging loop runs in an unstructured task, so terminating the stream has to cancel it
+    /// explicitly. Without that the loop keeps fetching pages nobody reads, and its own
+    /// `abortIfCancelled` never fires because nothing ever cancels the task it runs in.
     public func executeStreamed(_ sql: String) -> AsyncThrowingStream<TrinoStreamElement, Error> {
         AsyncThrowingStream { continuation in
             let client = self
-            Task {
+            let statementTask = Task {
                 do {
                     _ = try await client.runStatement(
                         sql,
@@ -55,6 +58,7 @@ public final class TrinoStatementClient: @unchecked Sendable {
                     continuation.finish(throwing: error)
                 }
             }
+            continuation.onTermination = { @Sendable _ in statementTask.cancel() }
         }
     }
 

--- a/Plugins/BigQueryDriverPlugin/BigQueryPluginDriver.swift
+++ b/Plugins/BigQueryDriverPlugin/BigQueryPluginDriver.swift
@@ -651,6 +651,10 @@ internal final class BigQueryPluginDriver: PluginDatabaseDriver, @unchecked Send
 
     // MARK: - Streaming
 
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> PluginQueryResult? {
+        try await boundedQueryFromStream(query: query, rowCap: rowCap)
+    }
+
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
         AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
             let streamTask = Task {

--- a/Plugins/CassandraDriverPlugin/CassandraConnection.swift
+++ b/Plugins/CassandraDriverPlugin/CassandraConnection.swift
@@ -685,13 +685,20 @@ actor CassandraConnectionActor {
         return "Unknown error"
     }
 
+    /// The whole loop is one non-suspending actor job holding the cooperative-pool thread, and
+    /// cass_future_wait blocks it, so nothing outside can interrupt a page. `abort` is the only
+    /// way the consumer's departure reaches this body, and it is read between pages and between
+    /// rows rather than mid-request.
     func streamQuery(
         _ cql: String,
+        abort: PluginStreamAbort,
         continuation: AsyncThrowingStream<PluginStreamElement, Error>.Continuation
     ) throws {
         guard let session else {
             throw CassandraPluginError.notConnected
         }
+
+        guard !abort.isAborted else { return }
 
         let pageSize: Int32 = 5_000
         let statement = cass_statement_new(cql, 0)
@@ -705,7 +712,10 @@ actor CassandraConnectionActor {
 
         defer { cass_statement_free(statement) }
 
+        var aborted = false
+
         while true {
+            if abort.isAborted { break }
             let future = cass_session_execute(session, statement)
             guard let future else {
                 throw CassandraPluginError.queryFailed("Failed to execute query")
@@ -755,7 +765,13 @@ actor CassandraConnectionActor {
             let iterator = cass_iterator_from_result(result)
 
             if let iterator {
+                var rowsThisPage = 0
                 while cass_iterator_next(iterator) == cass_true {
+                    rowsThisPage += 1
+                    if rowsThisPage % 256 == 0, abort.isAborted {
+                        aborted = true
+                        break
+                    }
                     let row = cass_iterator_get_row(iterator)
                     guard let row else { continue }
 
@@ -780,16 +796,16 @@ actor CassandraConnectionActor {
 
             let hasMore = cass_result_has_more_pages(result) == cass_true
 
-            if hasMore {
+            if hasMore, !aborted {
                 cass_statement_set_paging_state(statement, result)
             }
 
             cass_result_free(result)
 
-            if !hasMore { break }
+            if !hasMore || aborted { break }
         }
 
-        if !headerSent {
+        if !headerSent, !aborted {
             continuation.yield(.header(PluginStreamHeader(
                 columns: [],
                 columnTypeNames: [],

--- a/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
+++ b/Plugins/CassandraDriverPlugin/CassandraPlugin.swift
@@ -257,21 +257,36 @@ internal final class CassandraPluginDriver: PluginDatabaseDriver, @unchecked Sen
 
     // MARK: - Streaming
 
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> PluginQueryResult? {
+        guard let bounded = try await boundedQueryFromStream(query: query, rowCap: rowCap) as PluginQueryResult?
+        else {
+            return nil
+        }
+        /// The buffered path reports a read's row count here, so a bounded read reports the same
+        /// rather than the collector's neutral zero.
+        return PluginQueryResult(
+            columns: bounded.columns,
+            columnTypeNames: bounded.columnTypeNames,
+            rows: bounded.rows,
+            rowsAffected: bounded.rows.count,
+            executionTime: bounded.executionTime,
+            isTruncated: bounded.isTruncated,
+            statusMessage: bounded.statusMessage
+        )
+    }
+
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
         let cql = stripTrailingSemicolon(query)
-        return AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
+        return PluginRowStream.make { continuation, abort in
             let streamTask = Task {
                 do {
-                    try await self.connectionActor.streamQuery(cql, continuation: continuation)
+                    try await self.connectionActor.streamQuery(cql, abort: abort, continuation: continuation)
                     continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
                 }
             }
-
-            continuation.onTermination = { @Sendable _ in
-                streamTask.cancel()
-            }
+            _ = streamTask
         }
     }
 

--- a/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
+++ b/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
@@ -484,6 +484,120 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     // MARK: - Streaming
 
+    /// A bounded read is one HTTP request. The unbounded `streamRows` path still pays a separate
+    /// `LIMIT 0` probe to learn its columns, so it is deliberately not reused here.
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> PluginQueryResult? {
+        let started = Date()
+        let stream = PluginRowStream.make { continuation, abort in
+            let streamTask = Task {
+                do {
+                    try await self.performBoundedStreamRows(
+                        query: query,
+                        rowCap: rowCap,
+                        continuation: continuation
+                    )
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            abort.onAbort { streamTask.cancel() }
+        }
+        return try await PluginBoundedStream.collect(stream, rowCap: rowCap, startedAt: started)
+    }
+
+    private func performBoundedStreamRows(
+        query: String,
+        rowCap: Int,
+        continuation: AsyncThrowingStream<PluginStreamElement, Error>.Continuation
+    ) async throws {
+        let (session, database) = try lock.withLock { () throws -> (URLSession, String) in
+            guard let session = self.session else { throw ClickHouseError.notConnected }
+            return (session, _currentDatabase)
+        }
+
+        var trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        while trimmedQuery.hasSuffix(";") {
+            trimmedQuery = String(trimmedQuery.dropLast()).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        let request = try buildStreamRequest(query: trimmedQuery, database: database, rowCap: rowCap)
+        let (bytes, response) = try await session.bytes(for: request)
+
+        if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode >= 400 {
+            var body = ""
+            for try await line in bytes.lines {
+                body += line
+            }
+            throw ClickHouseError(message: body.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+
+        /// JSONCompactEachRowWithNamesAndTypes puts the names on line one and the types on line
+        /// two, both as positional arrays, so the columns arrive without a second round trip and
+        /// survive a zero-row result.
+        var columns: [String] = []
+        var columnTypeNames: [String] = []
+        var headerSent = false
+        let batchSize = min(5_000, rowCap + 1)
+        var batch: [PluginRow] = []
+        batch.reserveCapacity(batchSize)
+
+        for try await line in bytes.lines {
+            try Task.checkCancellation()
+
+            let trimmedLine = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedLine.isEmpty { continue }
+            guard let lineData = trimmedLine.data(using: .utf8) else { continue }
+
+            if columns.isEmpty {
+                columns = (try? JSONSerialization.jsonObject(with: lineData) as? [String]) ?? []
+                continue
+            }
+            if columnTypeNames.isEmpty {
+                columnTypeNames = (try? JSONSerialization.jsonObject(with: lineData) as? [String]) ?? []
+                continuation.yield(.header(PluginStreamHeader(
+                    columns: columns,
+                    columnTypeNames: columnTypeNames,
+                    estimatedRowCount: nil
+                )))
+                headerSent = true
+                continue
+            }
+
+            guard let values = try? JSONSerialization.jsonObject(with: lineData) as? [Any] else { continue }
+            var row: [PluginCellValue] = []
+            row.reserveCapacity(columns.count)
+            for index in columns.indices {
+                let value: Any? = index < values.count ? values[index] : nil
+                row.append(Self.boundedCellValue(value))
+            }
+            batch.append(row)
+            if batch.count >= batchSize {
+                continuation.yield(.rows(batch))
+                batch.removeAll(keepingCapacity: true)
+            }
+        }
+
+        if !headerSent {
+            continuation.yield(.header(PluginStreamHeader(
+                columns: columns,
+                columnTypeNames: columnTypeNames,
+                estimatedRowCount: nil
+            )))
+        }
+        if !batch.isEmpty {
+            continuation.yield(.rows(batch))
+        }
+        continuation.finish()
+    }
+
+    private static func boundedCellValue(_ value: Any?) -> PluginCellValue {
+        guard let value, !(value is NSNull) else { return .null }
+        if let str = value as? String { return .text(str) }
+        if let num = value as? NSNumber { return .text(NumberText.text(for: num)) }
+        if let jsonStr = NumberText.json(from: value, sortedKeys: false) { return .text(jsonStr) }
+        return .text(String(describing: value))
+    }
+
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
         return AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
             let streamTask = Task {
@@ -591,7 +705,7 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         continuation.finish()
     }
 
-    private func buildStreamRequest(query: String, database: String) throws -> URLRequest {
+    private func buildStreamRequest(query: String, database: String, rowCap: Int? = nil) throws -> URLRequest {
         let useTLS = config.ssl.isEnabled
 
         var components = URLComponents()
@@ -604,7 +718,16 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         if !database.isEmpty {
             queryItems.append(URLQueryItem(name: "database", value: database))
         }
-        queryItems.append(URLQueryItem(name: "default_format", value: "JSONEachRow"))
+        if let rowCap {
+            /// The bound rides as an HTTP setting so the SQL in the body stays exactly what the
+            /// user wrote. One row past the cap, so a full page can be told from a truncated one.
+            queryItems.append(URLQueryItem(name: "default_format", value: "JSONCompactEachRowWithNamesAndTypes"))
+            queryItems.append(URLQueryItem(name: "max_result_rows", value: String(rowCap + 1)))
+            queryItems.append(URLQueryItem(name: "result_overflow_mode", value: "break"))
+            queryItems.append(URLQueryItem(name: "cancel_http_readonly_queries_on_client_close", value: "1"))
+        } else {
+            queryItems.append(URLQueryItem(name: "default_format", value: "JSONEachRow"))
+        }
         components.queryItems = queryItems
 
         guard let url = components.url else {

--- a/Plugins/DynamoDBDriverPlugin/DynamoDBPluginDriver.swift
+++ b/Plugins/DynamoDBDriverPlugin/DynamoDBPluginDriver.swift
@@ -515,6 +515,10 @@ internal final class DynamoDBPluginDriver: PluginDatabaseDriver, @unchecked Send
 
     // MARK: - Streaming
 
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> PluginQueryResult? {
+        try await boundedQueryFromStream(query: query, rowCap: rowCap)
+    }
+
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
         AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
             let streamTask = Task {

--- a/Plugins/MSSQLDriverPlugin/FreeTDSConnection.swift
+++ b/Plugins/MSSQLDriverPlugin/FreeTDSConnection.swift
@@ -481,14 +481,19 @@ nonisolated final class FreeTDSConnection: @unchecked Sendable {
         )
     }
 
+    /// `isAborted` is how a consumer that stopped reaches this loop. It is a closure rather than a
+    /// PluginKit type because this file is compiled into the iOS app too and may not import
+    /// PluginKit. It is polled instead of `Task.isCancelled`, which is always false here: the body
+    /// runs inside a bare `queue.async` with no task context.
     func streamQuery(
         _ query: String,
+        isAborted: @escaping @Sendable () -> Bool = { false },
         continuation: AsyncThrowingStream<MSSQLStreamElement, Error>.Continuation
     ) async throws {
         let queryToRun = String(query)
         try await withTaskCancellationHandler {
             try await freetdsDispatchAsync(on: queue) { [self] in
-                try self.streamQuerySync(queryToRun, continuation: continuation)
+                try self.streamQuerySync(queryToRun, isAborted: isAborted, continuation: continuation)
             }
         } onCancel: { [weak self] in
             self?.cancelCurrentQuery()
@@ -497,6 +502,7 @@ nonisolated final class FreeTDSConnection: @unchecked Sendable {
 
     private func streamQuerySync(
         _ query: String,
+        isAborted: @escaping @Sendable () -> Bool,
         continuation: AsyncThrowingStream<MSSQLStreamElement, Error>.Continuation
     ) throws {
         guard let proc = dbproc else {
@@ -524,7 +530,7 @@ nonisolated final class FreeTDSConnection: @unchecked Sendable {
 
         while true {
             lock.lock()
-            let cancelledBetweenResults = _isCancelled || Task.isCancelled
+            let cancelledBetweenResults = _isCancelled || isAborted()
             if cancelledBetweenResults { _isCancelled = false }
             lock.unlock()
             if cancelledBetweenResults {
@@ -565,7 +571,7 @@ nonisolated final class FreeTDSConnection: @unchecked Sendable {
                 if rowCode == FAIL { break }
 
                 lock.lock()
-                let cancelled = _isCancelled || Task.isCancelled
+                let cancelled = _isCancelled || isAborted()
                 if cancelled { _isCancelled = false }
                 lock.unlock()
                 if cancelled {

--- a/Plugins/MSSQLDriverPlugin/MSSQLPlugin.swift
+++ b/Plugins/MSSQLDriverPlugin/MSSQLPlugin.swift
@@ -592,16 +592,26 @@ final class MSSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     // MARK: - Streaming
 
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> PluginQueryResult? {
+        try await boundedQueryFromStream(query: query, rowCap: rowCap)
+    }
+
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
         guard let conn = freeTDSConn else {
             return AsyncThrowingStream { $0.finish(throwing: MSSQLPluginError.notConnected) }
         }
-        return AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
+        return PluginRowStream.make { continuation, abort in
             let streamTask = Task {
                 let coreStream = AsyncThrowingStream<MSSQLStreamElement, Error> { coreContinuation in
+                    /// A plain `Task {}` inherits context but is not a child, so cancelling the
+                    /// outer task never reaches this one. The abort closure is what does.
                     Task {
                         do {
-                            try await conn.streamQuery(query, continuation: coreContinuation)
+                            try await conn.streamQuery(
+                                query,
+                                isAborted: { abort.isAborted },
+                                continuation: coreContinuation
+                            )
                         } catch let error as MSSQLCoreError {
                             coreContinuation.finish(throwing: MSSQLPluginError(coreError: error))
                         } catch {
@@ -632,9 +642,7 @@ final class MSSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                     continuation.finish(throwing: error)
                 }
             }
-            continuation.onTermination = { @Sendable _ in
-                streamTask.cancel()
-            }
+            abort.onAbort { streamTask.cancel() }
         }
     }
 

--- a/Plugins/MySQLDriverPlugin/MariaDBPluginConnection.swift
+++ b/Plugins/MySQLDriverPlugin/MariaDBPluginConnection.swift
@@ -896,32 +896,22 @@ final class MariaDBPluginConnection: @unchecked Sendable {
 
     func streamQuery(_ query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
         let queryToRun = String(query)
-        let queue = self.queue
 
-        final class StreamState: @unchecked Sendable {
-            var resultPtr: UnsafeMutablePointer<MYSQL_RES>?
-            var drained = false
-            let lock = NSLock()
-        }
-        let streamState = StreamState()
-
-        return AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
-            continuation.onTermination = { @Sendable _ in
-                queue.async {
-                    streamState.lock.lock()
-                    let ptr = streamState.resultPtr
-                    let alreadyDrained = streamState.drained
-                    streamState.drained = true
-                    streamState.lock.unlock()
-                    guard let resultPtr = ptr, !alreadyDrained else { return }
-                    while mysql_fetch_row(resultPtr) != nil {}
-                    mysql_free_result(resultPtr)
-                }
-            }
-
-            queue.async { [self] in
+        /// The drain belongs to the producer. Enqueued from `onTermination` it would sit behind the
+        /// producer on this one serial queue and run only after the whole result had been read,
+        /// which is why the abort is a polled flag instead.
+        return PluginRowStream.make { continuation, abort in
+            self.queue.async { [self] in
                 guard !isShuttingDown, let mysql = self.mysql else {
                     continuation.finish(throwing: MariaDBPluginError.notConnected)
+                    return
+                }
+
+                let generation = cancellationGate.beginQuery()
+                defer { cancellationGate.endQuery(generation) }
+
+                guard !abort.isAborted else {
+                    continuation.finish()
                     return
                 }
 
@@ -945,10 +935,6 @@ final class MariaDBPluginConnection: @unchecked Sendable {
                     }
                     return
                 }
-
-                streamState.lock.lock()
-                streamState.resultPtr = resultPtr
-                streamState.lock.unlock()
 
                 let numFields = Int(mysql_num_fields(resultPtr))
                 var columns: [String] = []
@@ -993,11 +979,11 @@ final class MariaDBPluginConnection: @unchecked Sendable {
                 var batch: [PluginRow] = []
                 batch.reserveCapacity(batchSize)
                 while let rowPtr = mysql_fetch_row(resultPtr) {
-                    if Task.isCancelled {
+                    if abort.isAborted || cancellationGate.isCancelled(generation) {
+                        /// Same shape as the capped buffered read: stop the server first, then
+                        /// drain what is already in flight so the connection stays usable.
+                        killQueryOnServer(threadId: mysql_thread_id(mysql))
                         while mysql_fetch_row(resultPtr) != nil {}
-                        streamState.lock.lock()
-                        streamState.drained = true
-                        streamState.lock.unlock()
                         mysql_free_result(resultPtr)
                         continuation.finish(throwing: CancellationError())
                         return
@@ -1041,17 +1027,11 @@ final class MariaDBPluginConnection: @unchecked Sendable {
 
                 if mysql_errno(mysql) != 0 {
                     let error = self.getError()
-                    streamState.lock.lock()
-                    streamState.drained = true
-                    streamState.lock.unlock()
                     mysql_free_result(resultPtr)
                     continuation.finish(throwing: error)
                     return
                 }
 
-                streamState.lock.lock()
-                streamState.drained = true
-                streamState.lock.unlock()
                 mysql_free_result(resultPtr)
                 continuation.finish()
             }

--- a/Plugins/OracleDriverPlugin/OraclePlugin.swift
+++ b/Plugins/OracleDriverPlugin/OraclePlugin.swift
@@ -417,21 +417,31 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     // MARK: - Streaming
 
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> PluginQueryResult? {
+        try await boundedQueryFromStream(query: query, rowCap: rowCap)
+    }
+
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
         guard let core else {
             return AsyncThrowingStream { $0.finish(throwing: OraclePluginError(core: .notConnected)) }
         }
 
-        return AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
+        return PluginRowStream.make { continuation, abort in
             let streamTask = Task {
+                /// The core read runs in its own unstructured task, which the outer one cannot
+                /// cancel: a plain `Task {}` inherits context but is not a child. Cancelling it
+                /// explicitly on abort is what stops oracle-nio, whose own loop already checks
+                /// cancellation once it is reachable.
                 let coreStream = AsyncThrowingStream<OracleStreamElement, Error> { coreContinuation in
-                    Task {
+                    let coreTask = Task {
                         do {
                             try await core.streamQuery(query, continuation: coreContinuation)
                         } catch {
                             coreContinuation.finish(throwing: error)
                         }
                     }
+                    abort.onAbort { coreTask.cancel() }
+                    coreContinuation.onTermination = { @Sendable _ in coreTask.cancel() }
                 }
                 do {
                     for try await element in coreStream {
@@ -452,9 +462,7 @@ final class OraclePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                     continuation.finish(throwing: error)
                 }
             }
-            continuation.onTermination = { @Sendable _ in
-                streamTask.cancel()
-            }
+            abort.onAbort { streamTask.cancel() }
         }
     }
 

--- a/Plugins/PostgreSQLDriverPlugin/LibPQDriverCore.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQDriverCore.swift
@@ -126,6 +126,39 @@ final class LibPQDriverCore: @unchecked Sendable {
         )
     }
 
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> PluginQueryResult? {
+        try await boundedQueryWithReconnect(query: query, rowCap: rowCap, isRetry: false)
+    }
+
+    /// A bounded read only ever runs a statement the host classified as a read, so retrying it after
+    /// a dropped connection is safe, the same way the buffered path retries.
+    private func boundedQueryWithReconnect(
+        query: String,
+        rowCap: Int,
+        isRetry: Bool
+    ) async throws -> PluginQueryResult {
+        guard let pqConn = libpqConnection else {
+            throw LibPQPluginError.notConnected
+        }
+
+        let startTime = Date()
+
+        do {
+            let result = try await pqConn.boundedQuery(query, rowCap: rowCap)
+            return PluginQueryResult(
+                columns: result.columns,
+                columnTypeNames: result.columnTypeNames,
+                rows: result.rows,
+                rowsAffected: result.affectedRows,
+                executionTime: Date().timeIntervalSince(startTime),
+                isTruncated: result.isTruncated
+            )
+        } catch let error as NSError where !isRetry && Self.isConnectionLostError(error) {
+            try await reconnect()
+            return try await boundedQueryWithReconnect(query: query, rowCap: rowCap, isRetry: true)
+        }
+    }
+
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
         guard let pqConn = libpqConnection else {
             return AsyncThrowingStream { $0.finish(throwing: LibPQPluginError.notConnected) }
@@ -224,6 +257,10 @@ extension LibPQBackedDriver {
 
     func executeParameterized(query: String, parameters: [PluginCellValue]) async throws -> PluginQueryResult {
         try await core.executeParameterized(query: query, parameters: parameters)
+    }
+
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> PluginQueryResult? {
+        try await core.executeBoundedQuery(query: query, rowCap: rowCap)
     }
 
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {

--- a/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
@@ -441,6 +441,16 @@ final class LibPQPluginConnection: @unchecked Sendable {
         }
     }
 
+    func boundedQuery(_ query: String, rowCap: Int) async throws -> LibPQPluginQueryResult {
+        let queryToRun = String(query)
+        let cap = max(rowCap, 1)
+
+        return try await pluginDispatchAsync(on: queue) { [self] in
+            guard !isShuttingDown else { throw LibPQPluginError.notConnected }
+            return try boundedQuerySync(queryToRun, rowCap: cap)
+        }
+    }
+
     func executeParameterizedQuery(_ query: String, parameters: [PluginCellValue]) async throws -> LibPQPluginQueryResult {
         let queryToRun = String(query)
         let params = parameters
@@ -515,6 +525,128 @@ final class LibPQPluginConnection: @unchecked Sendable {
             if cancellationGate.isCancelled(generation) { throw CancellationError() }
             throw error
         }
+    }
+
+    /// Reads at most `rowCap` rows through libpq's single-row mode, then cancels the statement and
+    /// drains the connection instead of pulling the rest of the result across the socket.
+    ///
+    /// One row past the cap is read so `isTruncated` can tell "exactly `rowCap` rows" from "more
+    /// rows exist". The cancel is not an optimization: libpq drains an abandoned result inside the
+    /// next `PQexec`, charging that cost to the user's next statement, and the backend stays active
+    /// holding its snapshot until it can finish writing to the client.
+    private func boundedQuerySync(_ query: String, rowCap: Int) throws -> LibPQPluginQueryResult {
+        stateLock.lock()
+        let conn = self.conn
+        stateLock.unlock()
+
+        guard !isShuttingDown, let conn else {
+            throw LibPQPluginError.notConnected
+        }
+
+        let generation = cancellationGate.beginQuery()
+        defer { cancellationGate.endQuery(generation) }
+
+        while let stale = PQgetResult(conn) { PQclear(stale) }
+
+        /// Cancelling a statement inside a transaction block puts the transaction into the aborted
+        /// state, and every later command fails until ROLLBACK. Reading the tail of one result costs
+        /// less than throwing away the transaction the user opened, so the cancel is withheld here
+        /// and the connection is drained instead.
+        let insideTransaction = PQtransactionStatus(conn) == PQTRANS_INTRANS
+        let suppressCancel = suppressServerSideCancel || insideTransaction
+
+        let localQuery = String(query)
+        let sendOk = localQuery.withCString { queryPtr in
+            PQsendQuery(conn, queryPtr)
+        }
+        guard sendOk != 0 else { throw getError(from: conn) }
+
+        guard PQsetSingleRowMode(conn) != 0 else {
+            Self.cancelAndDrain(conn, suppressCancel: suppressCancel)
+            throw LibPQPluginError(message: "Failed to enter single-row mode", sqlState: nil, detail: nil)
+        }
+
+        var metadata: ColumnMetadata?
+        var rows: [[PluginCellValue]] = []
+        rows.reserveCapacity(min(rowCap, 10_000))
+        var affectedRows = 0
+        var commandTag: String?
+        var truncated = false
+        var pendingError: Error?
+
+        while let result = PQgetResult(conn) {
+            let status = PQresultStatus(result)
+
+            if status == PGRES_SINGLE_TUPLE {
+                let columns = metadata ?? readColumnMetadata(from: result)
+                metadata = columns
+
+                var row: [PluginCellValue] = []
+                row.reserveCapacity(columns.columnOids.count)
+                for columnIndex in columns.columnOids.indices {
+                    row.append(Self.decodeCell(
+                        from: result,
+                        row: 0,
+                        column: Int32(columnIndex),
+                        oid: columns.columnOids[columnIndex]
+                    ))
+                }
+                PQclear(result)
+                rows.append(row)
+
+                if cancellationGate.isCancelled(generation) {
+                    Self.cancelAndDrain(conn, suppressCancel: suppressCancel)
+                    throw CancellationError()
+                }
+                if rows.count > rowCap {
+                    truncated = true
+                    break
+                }
+                continue
+            }
+
+            if status == PGRES_TUPLES_OK {
+                if metadata == nil { metadata = readColumnMetadata(from: result) }
+                PQclear(result)
+                continue
+            }
+
+            if status == PGRES_COMMAND_OK {
+                affectedRows = getAffectedRows(from: result)
+                commandTag = getCommandTag(from: result)
+                PQclear(result)
+                continue
+            }
+
+            pendingError = getResultError(from: result)
+            PQclear(result)
+            break
+        }
+
+        if truncated {
+            Self.cancelAndDrain(conn, suppressCancel: suppressCancel)
+        } else {
+            while let trailing = PQgetResult(conn) { PQclear(trailing) }
+        }
+
+        if let pendingError {
+            if cancellationGate.isCancelled(generation) { throw CancellationError() }
+            throw pendingError
+        }
+        if cancellationGate.isCancelled(generation) { throw CancellationError() }
+
+        if truncated { rows.removeLast() }
+
+        let bounded = LibPQPluginQueryResult(
+            columns: metadata?.columns ?? [],
+            columnOids: metadata?.columnOids ?? [],
+            columnTypeNames: metadata?.columnTypeNames ?? [],
+            rows: rows,
+            affectedRows: affectedRows,
+            commandTag: commandTag,
+            isTruncated: truncated
+        )
+        return applySpatialRendering(to: bounded)
     }
 
     private func executeParameterizedQuerySync(_ query: String, parameters: [PluginCellValue]) throws -> LibPQPluginQueryResult {
@@ -818,16 +950,20 @@ final class LibPQPluginConnection: @unchecked Sendable {
             generation: generation
         )
 
-        let oidMap = postgisOidMap
-        guard !oidMap.isEmpty else { return parsed }
+        return applySpatialRendering(to: parsed)
+    }
 
-        let spatialColumns = metadata.columnOids.enumerated().compactMap { index, oid -> (index: Int, typeName: String)? in
+    private func applySpatialRendering(to result: LibPQPluginQueryResult) -> LibPQPluginQueryResult {
+        let oidMap = postgisOidMap
+        guard !oidMap.isEmpty else { return result }
+
+        let spatialColumns = result.columnOids.enumerated().compactMap { index, oid -> (index: Int, typeName: String)? in
             guard let typeName = oidMap[oid] else { return nil }
             return (index, typeName)
         }
-        guard !spatialColumns.isEmpty else { return parsed }
+        guard !spatialColumns.isEmpty else { return result }
 
-        return renderSpatialColumns(parsed, spatialColumns: spatialColumns)
+        return renderSpatialColumns(result, spatialColumns: spatialColumns)
     }
 
     private struct ColumnMetadata {

--- a/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
@@ -770,41 +770,19 @@ final class LibPQPluginConnection: @unchecked Sendable {
         while let res = PQgetResult(conn) { PQclear(res) }
     }
 
+    /// The abort is polled by the producer rather than acted on from `onTermination`, because both
+    /// run on one serial queue: a drain enqueued from the handler sits behind the producer and runs
+    /// only once the whole result has been read, which is no abort at all.
     func streamQuery(_ query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
         let queryToRun = String(query)
-        let queue = self.queue
-        let suppressCancel = suppressServerSideCancel
 
-        final class StreamState: @unchecked Sendable {
-            var conn: OpaquePointer?
-            var drained = false
-            let lock = NSLock()
-        }
-        let streamState = StreamState()
+        return PluginRowStream.make { continuation, abort in
+            self.queue.async { [self] in
+                stateLock.lock()
+                let handle = self.conn
+                stateLock.unlock()
 
-        stateLock.lock()
-        let connForStream = self.conn
-        stateLock.unlock()
-
-        streamState.lock.lock()
-        streamState.conn = connForStream
-        streamState.lock.unlock()
-
-        return AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
-            continuation.onTermination = { @Sendable _ in
-                queue.async {
-                    streamState.lock.lock()
-                    let conn = streamState.conn
-                    let alreadyDrained = streamState.drained
-                    streamState.drained = true
-                    streamState.lock.unlock()
-                    guard let conn, !alreadyDrained else { return }
-                    Self.cancelAndDrain(conn, suppressCancel: suppressCancel)
-                }
-            }
-
-            queue.async { [self] in
-                guard !isShuttingDown, let conn = connForStream else {
+                guard !isShuttingDown, let conn = handle else {
                     continuation.finish(throwing: LibPQPluginError.notConnected)
                     return
                 }
@@ -812,25 +790,31 @@ final class LibPQPluginConnection: @unchecked Sendable {
                 let generation = cancellationGate.beginQuery()
                 defer { cancellationGate.endQuery(generation) }
 
+                /// The consumer can go away before this block is scheduled, in which case the
+                /// query is never sent at all.
+                guard !abort.isAborted else {
+                    continuation.finish()
+                    return
+                }
+
                 while let res = PQgetResult(conn) { PQclear(res) }
+
+                /// Read before the query goes out: once it is in flight the status is
+                /// PQTRANS_ACTIVE, and the transaction this guard exists for is invisible.
+                let suppressCancel = suppressServerSideCancel
+                    || PQtransactionStatus(conn) == PQTRANS_INTRANS
 
                 let sendOk = queryToRun.withCString { queryPtr in
                     PQsendQuery(conn, queryPtr)
                 }
 
                 if sendOk == 0 {
-                    streamState.lock.lock()
-                    streamState.drained = true
-                    streamState.lock.unlock()
                     continuation.finish(throwing: getError(from: conn))
                     return
                 }
 
                 if PQsetSingleRowMode(conn) == 0 {
-                    while let res = PQgetResult(conn) { PQclear(res) }
-                    streamState.lock.lock()
-                    streamState.drained = true
-                    streamState.lock.unlock()
+                    Self.cancelAndDrain(conn, suppressCancel: suppressCancel)
                     continuation.finish(throwing: LibPQPluginError(
                         message: "Failed to enter single-row mode", sqlState: nil, detail: nil))
                     return
@@ -893,14 +877,11 @@ final class LibPQPluginConnection: @unchecked Sendable {
                             batch.removeAll(keepingCapacity: true)
                         }
 
-                        if Task.isCancelled {
+                        if abort.isAborted || cancellationGate.isCancelled(generation) {
                             if !batch.isEmpty {
                                 continuation.yield(.rows(batch))
                             }
                             Self.cancelAndDrain(conn, suppressCancel: suppressCancel)
-                            streamState.lock.lock()
-                            streamState.drained = true
-                            streamState.lock.unlock()
                             continuation.finish(throwing: CancellationError())
                             return
                         }
@@ -914,9 +895,6 @@ final class LibPQPluginConnection: @unchecked Sendable {
                         let error = getResultError(from: result)
                         PQclear(result)
                         while let res = PQgetResult(conn) { PQclear(res) }
-                        streamState.lock.lock()
-                        streamState.drained = true
-                        streamState.lock.unlock()
                         if cancellationGate.isCancelled(generation) {
                             continuation.finish(throwing: CancellationError())
                             return
@@ -930,9 +908,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
                     continuation.yield(.rows(batch))
                 }
 
-                streamState.lock.lock()
-                streamState.drained = true
-                streamState.lock.unlock()
+                while let res = PQgetResult(conn) { PQclear(res) }
                 continuation.finish()
             }
         }

--- a/Plugins/RedisDriverPlugin/RedisPluginDriver.swift
+++ b/Plugins/RedisDriverPlugin/RedisPluginDriver.swift
@@ -444,6 +444,10 @@ final class RedisPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     // MARK: - Streaming
 
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> PluginQueryResult? {
+        try await boundedQueryFromStream(query: query, rowCap: rowCap)
+    }
+
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
         AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
             let streamTask = Task {

--- a/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
+++ b/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
@@ -678,60 +678,47 @@ final class SQLitePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     // MARK: - User Query
 
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> PluginQueryResult? {
+        guard Self.returnsRows(query) else { return nil }
+        return try await boundedQueryFromStream(query: query, rowCap: rowCap)
+    }
+
+    /// A capped read from a caller that resolves its own cap, the MCP bridge among them, still
+    /// streams. Routing every uncapped statement through the stream is what made a DML statement
+    /// report no row count, because a stepped statement carries its `sqlite3_changes` nowhere.
     func executeUserQuery(query: String, rowCap: Int?, parameters: [PluginCellValue]?) async throws -> PluginQueryResult {
+        if parameters == nil, let cap = rowCap, cap > 0,
+           let bounded = try await executeBoundedQuery(query: query, rowCap: cap) {
+            return bounded
+        }
+
+        let raw: PluginQueryResult
         if let parameters {
-            let raw = try await executeParameterized(query: query, parameters: parameters)
-            guard let cap = rowCap, cap > 0, raw.rows.count > cap else { return raw }
-            return PluginQueryResult(
-                columns: raw.columns,
-                columnTypeNames: raw.columnTypeNames,
-                rows: Array(raw.rows.prefix(cap)),
-                rowsAffected: raw.rowsAffected,
-                executionTime: raw.executionTime,
-                isTruncated: true,
-                statusMessage: raw.statusMessage
-            )
+            raw = try await executeParameterized(query: query, parameters: parameters)
+        } else {
+            raw = try await execute(query: query)
         }
-
-        let startTime = Date()
-        var columns: [String] = []
-        var columnTypeNames: [String] = []
-        var rows: [[PluginCellValue]] = []
-        var truncated = false
-
-        let stream = streamRows(query: query)
-        for try await element in stream {
-            switch element {
-            case .header(let header):
-                columns = header.columns
-                columnTypeNames = header.columnTypeNames
-            case .rows(let batch):
-                if let cap = rowCap, cap > 0 {
-                    let remaining = cap - rows.count
-                    if remaining <= 0 {
-                        truncated = true
-                    } else if batch.count > remaining {
-                        rows.append(contentsOf: batch.prefix(remaining))
-                        truncated = true
-                    } else {
-                        rows.append(contentsOf: batch)
-                    }
-                } else {
-                    rows.append(contentsOf: batch)
-                }
-                if truncated { break }
-            }
-            if truncated { break }
-        }
-
+        guard let cap = rowCap, cap > 0, raw.rows.count > cap else { return raw }
         return PluginQueryResult(
-            columns: columns,
-            columnTypeNames: columnTypeNames,
-            rows: rows,
-            rowsAffected: 0,
-            executionTime: Date().timeIntervalSince(startTime),
-            isTruncated: truncated
+            columns: raw.columns,
+            columnTypeNames: raw.columnTypeNames,
+            rows: Array(raw.rows.prefix(cap)),
+            rowsAffected: raw.rowsAffected,
+            executionTime: raw.executionTime,
+            isTruncated: true,
+            statusMessage: raw.statusMessage
         )
+    }
+
+    private static let rowReturningKeywords: Set<String> = ["SELECT", "WITH", "VALUES", "TABLE", "PRAGMA", "EXPLAIN"]
+
+    private static func returnsRows(_ query: String) -> Bool {
+        var remaining = Substring(query).drop { $0.isWhitespace }
+        while remaining.first == "(" {
+            remaining = remaining.dropFirst().drop { $0.isWhitespace }
+        }
+        let keyword = remaining.prefix { $0.isLetter }.uppercased()
+        return rowReturningKeywords.contains(keyword)
     }
 
     // MARK: - Schema Operations

--- a/Plugins/SnowflakeDriverPlugin/SnowflakePluginDriver.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakePluginDriver.swift
@@ -575,6 +575,10 @@ final class SnowflakePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     // MARK: - Streaming
 
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> PluginQueryResult? {
+        try await boundedQueryFromStream(query: query, rowCap: rowCap)
+    }
+
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
         AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
             let task = Task {

--- a/Plugins/TableProPluginKit/PluginBoundedStream.swift
+++ b/Plugins/TableProPluginKit/PluginBoundedStream.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Turns an incremental row stream into a capped `PluginQueryResult` without reading past the cap.
+///
+/// Truncation is decided by a batch overflowing the cap rather than by holding a row past it, so
+/// `isTruncated` tells "there were exactly `rowCap` rows" apart from "there were more" without the
+/// collector ever keeping the extra row. A driver that bounds its own fetch has to read one row
+/// past the cap to draw the same distinction.
+public enum PluginBoundedStream {
+    public static func collect(
+        _ stream: AsyncThrowingStream<PluginStreamElement, Error>,
+        rowCap: Int,
+        startedAt: Date
+    ) async throws -> PluginQueryResult {
+        let cap = max(rowCap, 1)
+        var columns: [String] = []
+        var columnTypeNames: [String] = []
+        var rows: [PluginRow] = []
+        rows.reserveCapacity(min(cap, 10_000))
+        var truncated = false
+
+        for try await element in stream {
+            switch element {
+            case .header(let header):
+                columns = header.columns
+                columnTypeNames = header.columnTypeNames
+            case .rows(let batch):
+                let remaining = cap - rows.count
+                if batch.count > remaining {
+                    rows.append(contentsOf: batch.prefix(remaining))
+                    truncated = true
+                } else {
+                    rows.append(contentsOf: batch)
+                }
+            }
+            if truncated { break }
+        }
+
+        return PluginQueryResult(
+            columns: columns,
+            columnTypeNames: columnTypeNames,
+            rows: rows,
+            rowsAffected: 0,
+            executionTime: Date().timeIntervalSince(startedAt),
+            isTruncated: truncated
+        )
+    }
+}

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -80,7 +80,17 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
     func ping() async throws
 
     func execute(query: String) async throws -> PluginQueryResult
+
     func executeUserQuery(query: String, rowCap: Int?, parameters: [PluginCellValue]?) async throws -> PluginQueryResult
+
+    /// Runs a read and stops once `rowCap` rows are known to be exceeded, instead of materializing
+    /// the whole result and discarding the tail. Optional: return nil when the driver cannot bound
+    /// the fetch at its source.
+    ///
+    /// Only the host may call this, and only for a statement it has already classified as a read:
+    /// bounding a fetch means abandoning the rest of it, which for some drivers means cancelling the
+    /// statement on the server.
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> PluginQueryResult?
 
     func fetchTables(schema: String?) async throws -> [PluginTableInfo]
     func fetchPartitions(table: String, schema: String?) async throws -> [PluginTableInfo]
@@ -489,6 +499,25 @@ public extension PluginDatabaseDriver {
     func quoteIdentifier(_ name: String) -> String {
         let escaped = name.replacingOccurrences(of: "\"", with: "\"\"")
         return "\"\(escaped)\""
+    }
+
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> PluginQueryResult? { nil }
+
+    /// The bounded read for a driver whose `streamRows` yields rows as they arrive and whose
+    /// producer stops when its consumer does. Opt in by returning this from `executeBoundedQuery`.
+    ///
+    /// The second half of that precondition is the one that gets missed. Terminating the stream
+    /// only cancels the task `streamRows` created, so the producer has to be reachable from it and
+    /// has to poll: a producer in a nested unstructured `Task {}` never sees the cancel, because a
+    /// plain `Task {}` inherits context but is not a child, and a synchronous C paging loop with no
+    /// cancellation check never sees it either. A driver that gets this wrong returns early while
+    /// its connection stays busy pulling the rest of the result, which is worse than not opting in.
+    func boundedQueryFromStream(query: String, rowCap: Int) async throws -> PluginQueryResult {
+        try await PluginBoundedStream.collect(
+            streamRows(query: query),
+            rowCap: rowCap,
+            startedAt: Date()
+        )
     }
 
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {

--- a/Plugins/TableProPluginKit/PluginStreamAbort.swift
+++ b/Plugins/TableProPluginKit/PluginStreamAbort.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// The signal a row stream's producer polls to learn that its consumer stopped.
+///
+/// Terminating an `AsyncThrowingStream` runs its `onTermination` handler and nothing else, so a
+/// producer that does not poll runs to completion no matter what the consumer did. Measured on a
+/// producer occupying a serial queue with 40 batches of work: polling this flag stopped it after
+/// one batch, while hopping the drain onto the producer's own queue stopped nothing and ran the
+/// drain only after the whole read had finished.
+public final class PluginStreamAbort: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _isAborted = false
+    private var actions: [@Sendable () -> Void] = []
+
+    public init() {}
+
+    public var isAborted: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _isAborted
+    }
+
+    /// Registers work to run when the consumer stops, for a producer that also needs an active
+    /// signal such as cancelling its own task. Registering here rather than assigning
+    /// `continuation.onTermination` is what keeps both from clobbering each other; the stream's
+    /// handler belongs to `PluginRowStream.make`. Runs immediately if the abort already fired.
+    public func onAbort(_ action: @escaping @Sendable () -> Void) {
+        lock.lock()
+        if _isAborted {
+            lock.unlock()
+            action()
+            return
+        }
+        actions.append(action)
+        lock.unlock()
+    }
+
+    public func abort() {
+        lock.lock()
+        let alreadyAborted = _isAborted
+        _isAborted = true
+        let pending = actions
+        actions.removeAll()
+        lock.unlock()
+        guard !alreadyAborted else { return }
+        for action in pending { action() }
+    }
+}
+
+public enum PluginRowStream {
+    /// Builds a row stream whose abort signal is already wired to its termination.
+    ///
+    /// The handler is installed before `build` runs and sets the flag synchronously on whichever
+    /// thread terminated the stream, so a producer that has not started yet still sees it and can
+    /// decline to send the query at all. A producer that hops the signal onto its own serial queue
+    /// instead sees it only after it has finished, which is the defect this exists to make
+    /// unrepeatable.
+    ///
+    /// Termination follows the lifetime of the stream, not the consumer's `break`: a consumer that
+    /// stops reading but holds the stream in scope has not terminated it.
+    public static func make(
+        bufferingPolicy: AsyncThrowingStream<PluginStreamElement, Error>.Continuation.BufferingPolicy = .unbounded,
+        _ build: @escaping @Sendable (
+            AsyncThrowingStream<PluginStreamElement, Error>.Continuation,
+            PluginStreamAbort
+        ) -> Void
+    ) -> AsyncThrowingStream<PluginStreamElement, Error> {
+        let abort = PluginStreamAbort()
+        return AsyncThrowingStream(bufferingPolicy: bufferingPolicy) { continuation in
+            continuation.onTermination = { @Sendable _ in abort.abort() }
+            build(continuation, abort)
+        }
+    }
+}

--- a/Plugins/TrinoDriverPlugin/TrinoPluginDriver.swift
+++ b/Plugins/TrinoDriverPlugin/TrinoPluginDriver.swift
@@ -89,9 +89,13 @@ final class TrinoPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         return pluginResult(last, executionTime: Date().timeIntervalSince(start))
     }
 
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> PluginQueryResult? {
+        try await boundedQueryFromStream(query: query, rowCap: rowCap)
+    }
+
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
         let statement = query.contains(";") ? (TrinoStatementSplitter.split(query).last ?? query) : query
-        return AsyncThrowingStream { continuation in
+        return PluginRowStream.make { continuation, abort in
             let driver = self
             let streamTask = Task {
                 guard let client = driver.client else {
@@ -120,9 +124,7 @@ final class TrinoPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                     continuation.finish(throwing: error)
                 }
             }
-            continuation.onTermination = { @Sendable _ in
-                streamTask.cancel()
-            }
+            abort.onAbort { streamTask.cancel() }
         }
     }
 

--- a/Plugins/TrinoDriverPlugin/TrinoPluginDriver.swift
+++ b/Plugins/TrinoDriverPlugin/TrinoPluginDriver.swift
@@ -93,7 +93,7 @@ final class TrinoPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         let statement = query.contains(";") ? (TrinoStatementSplitter.split(query).last ?? query) : query
         return AsyncThrowingStream { continuation in
             let driver = self
-            Task {
+            let streamTask = Task {
                 guard let client = driver.client else {
                     continuation.finish(throwing: TrinoError.notConnected)
                     return
@@ -119,6 +119,9 @@ final class TrinoPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 } catch {
                     continuation.finish(throwing: error)
                 }
+            }
+            continuation.onTermination = { @Sendable _ in
+                streamTask.cancel()
             }
         }
     }

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
@@ -228,7 +228,7 @@ extension QueryExecutionCoordinator {
             } else {
                 tab.pagination.resetLoadMore()
             }
-            tab.pagination.baseQueryForMore = sql
+            tab.pagination.setBaseQueryForMore(sql, parameterValues: nil)
 
             if tab.display.isResultsCollapsed {
                 tab.display.isResultsCollapsed = false

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+MultiStatement.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+MultiStatement.swift
@@ -21,6 +21,10 @@ extension QueryExecutionCoordinator {
         parameters: [Any?]? = nil
     ) async throws -> QueryResult {
         if rowCap != nil {
+            if parameters == nil, let cap = rowCap, cap > 0,
+               let bounded = try await driver.executeBoundedQuery(query: originalSQL, rowCap: cap) {
+                return bounded
+            }
             return try await driver.executeUserQuery(query: originalSQL, rowCap: rowCap, parameters: parameters)
         }
         if let parameters {
@@ -163,8 +167,10 @@ extension QueryExecutionCoordinator {
             } else {
                 tab.pagination.resetLoadMore()
             }
-            tab.pagination.baseQueryForMore = activeResultSet?.baseQuery
-            tab.pagination.baseQueryParameterValues = activeResultSet?.baseQueryParameterValues
+            tab.pagination.setBaseQueryForMore(
+                activeResultSet?.baseQuery,
+                parameterValues: activeResultSet?.baseQueryParameterValues
+            )
         }
         parent.toolbarState.isResultsCollapsed = false
 

--- a/TablePro/Core/Database/DatabaseDriver.swift
+++ b/TablePro/Core/Database/DatabaseDriver.swift
@@ -70,6 +70,13 @@ protocol DatabaseDriver: AnyObject, Sendable {
     /// - Returns: Query result with `isTruncated` set when the cap clipped rows
     func executeUserQuery(query: String, rowCap: Int?, parameters: [Any?]?) async throws -> QueryResult
 
+    /// Run a read that stops once `rowCap` rows are known to be exceeded, rather than fetching the
+    /// whole result and discarding the tail. Returns nil when the driver cannot bound its own fetch.
+    ///
+    /// Call this only for a statement already classified as a read. Bounding means abandoning the
+    /// rest of the fetch, which for some drivers cancels the statement on the server.
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> QueryResult?
+
     // MARK: - Schema Operations
 
     /// Fetch all tables in the database
@@ -286,6 +293,8 @@ extension DatabaseDriver {
     func connectReporting(stage report: @escaping ConnectionStageReporter) async throws {
         try await connect()
     }
+
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> QueryResult? { nil }
 
     func resolveQueryCompletionProfile(
         databaseTypeId: String,

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -190,6 +190,13 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable, DatabaseRepor
         return mapQueryResult(pluginResult)
     }
 
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> QueryResult? {
+        guard let pluginResult = try await pluginDriver.executeBoundedQuery(query: query, rowCap: rowCap) else {
+            return nil
+        }
+        return mapQueryResult(pluginResult)
+    }
+
     // MARK: - Schema Operations
 
     func fetchTables() async throws -> [TableInfo] {

--- a/TablePro/Core/Services/Query/QueryExecutor.swift
+++ b/TablePro/Core/Services/Query/QueryExecutor.swift
@@ -69,11 +69,44 @@ final class QueryExecutor {
 
     // MARK: - Driver fetch (nonisolated, runs on background)
 
+    /// Bounding a fetch abandons the rest of it, which for some drivers cancels the statement on the
+    /// server, so it is only ever offered a cap that `resolveRowCap` produced. That gate excludes
+    /// writes and DDL; a caller computing its own cap (the MCP bridge caps a write that RETURNs)
+    /// must not route here.
+    nonisolated static func fetchBoundedQueryData(
+        driver: DatabaseDriver,
+        sql: String,
+        rowCap: Int?
+    ) async throws -> QueryFetchResult? {
+        guard let rowCap, rowCap > 0 else { return nil }
+        let start = CFAbsoluteTimeGetCurrent()
+        guard let result = try await driver.executeBoundedQuery(query: sql, rowCap: rowCap) else {
+            return nil
+        }
+        let elapsed = CFAbsoluteTimeGetCurrent() - start
+        queryExecutorLog.info(
+            "[executeBoundedQuery] rows=\(result.rows.count) truncated=\(result.isTruncated) totalTime=\(String(format: "%.3f", elapsed))s"
+        )
+        return QueryFetchResult(
+            columns: result.columns,
+            columnTypes: result.columnTypes,
+            rows: result.rows,
+            executionTime: result.executionTime,
+            rowsAffected: result.rowsAffected,
+            statusMessage: result.statusMessage,
+            isTruncated: result.isTruncated,
+            resultColumnMeta: result.columnMeta
+        )
+    }
+
     nonisolated static func fetchQueryData(
         driver: DatabaseDriver,
         sql: String,
         rowCap: Int?
     ) async throws -> QueryFetchResult {
+        if let bounded = try await fetchBoundedQueryData(driver: driver, sql: sql, rowCap: rowCap) {
+            return bounded
+        }
         let start = CFAbsoluteTimeGetCurrent()
         queryExecutorLog.info("[executeUserQuery] sql=\(sql.prefix(100), privacy: .public) rowCap=\(rowCap?.description ?? "nil")")
         let result = try await driver.executeUserQuery(query: sql, rowCap: rowCap, parameters: nil)
@@ -221,10 +254,12 @@ final class QueryExecutor {
         return cap > 0 ? cap : nil
     }
 
+    private static let rowProducingKeywords: Set<String> = ["SELECT", "WITH", "TABLE", "VALUES"]
+
     static func qualifiesForRowCap(sql: String, tabType: TabType, databaseType: DatabaseType) -> Bool {
         guard tabType == .query else { return false }
         let keyword = QueryClassifier.leadingKeyword(of: sql)
-        return (keyword == "SELECT" || keyword == "WITH")
+        return rowProducingKeywords.contains(keyword)
             && !QueryClassifier.isWriteQuery(sql, databaseType: databaseType)
             && !isDDLStatement(sql)
     }

--- a/TablePro/Core/Services/Query/QuerySqlParser.swift
+++ b/TablePro/Core/Services/Query/QuerySqlParser.swift
@@ -55,6 +55,30 @@ enum QuerySqlParser {
         parsed.compare(session, options: .caseInsensitive) == .orderedSame
     }
 
+    /// Splices an ORDER BY into `sql` ahead of any row-limiting clause the user wrote.
+    ///
+    /// Appending it to the end instead produced `... LIMIT 100 ORDER BY "total" ASC`, a syntax
+    /// error on every engine, and stripping the old ORDER BY took the user's LIMIT with it, which
+    /// silently replaced their limit with the app's row cap.
+    static func applyingOrderBy(_ orderClause: String, to sql: String, lexicalDialect: SqlDialect) -> String {
+        let trimmed = sql.trimmingCharacters(in: .whitespacesAndNewlines)
+        let buffer = trimmed as NSString
+        let splitOffset = SQLLimitDetector.firstRowLimitClauseOffset(trimmed, lexicalDialect: lexicalDialect)
+        let head = splitOffset.map { buffer.substring(to: $0) } ?? trimmed
+        let tail = splitOffset.map { buffer.substring(from: $0) } ?? ""
+
+        let strippedHead = stripTrailingOrderBy(from: head)
+        guard !orderClause.isEmpty else {
+            /// `OFFSET n ROWS FETCH NEXT m ROWS ONLY` is only legal with an ORDER BY, so clearing
+            /// the sort has to take that tail with it. A `LIMIT` tail stands on its own and stays.
+            let keepsTail = tail.uppercased().hasPrefix("LIMIT")
+            return [strippedHead, keepsTail ? tail : ""].filter { !$0.isEmpty }.joined(separator: " ")
+        }
+        return [strippedHead, "ORDER BY \(orderClause)", tail]
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
     static func stripTrailingOrderBy(from sql: String) -> String {
         let trimmed = sql.trimmingCharacters(in: .whitespacesAndNewlines)
         let nsString = trimmed as NSString

--- a/TablePro/Core/Utilities/SQL/QueryClassifier.swift
+++ b/TablePro/Core/Utilities/SQL/QueryClassifier.swift
@@ -93,9 +93,18 @@ enum QueryClassifier {
         return explainInnerStatement(trimmed, keyword: keyword)?.statement
     }
 
+    /// A parenthesised query expression is idiomatic when each arm of a set operation carries its
+    /// own ORDER BY, so the opening parens are skipped to reach the keyword that classifies the
+    /// statement. Skipping cannot loosen the classification: an unrecognised keyword still falls to
+    /// the write arm, and the body-wide filesystem and destructive scans run over the whole text.
     static func leadingKeyword(of sql: String) -> String {
-        let stripped = strippingLeadingComments(sql)
-        return stripped.prefix { $0.isLetter || $0.isNumber || $0 == "_" }.uppercased()
+        var remaining = strippingLeadingComments(sql)[...]
+        while remaining.first == "(" {
+            remaining = remaining.dropFirst().drop { $0.isWhitespace }
+            guard remaining.hasPrefix("--") || remaining.hasPrefix("/*") else { continue }
+            remaining = strippingLeadingComments(String(remaining))[...]
+        }
+        return remaining.prefix { $0.isLetter || $0.isNumber || $0 == "_" }.uppercased()
     }
 
     static func strippingLeadingComments(_ sql: String) -> String {

--- a/TablePro/Core/Utilities/SQL/SQLLimitDetector.swift
+++ b/TablePro/Core/Utilities/SQL/SQLLimitDetector.swift
@@ -12,9 +12,84 @@ enum SQLLimitDetector {
         autoLimitStyle: AutoLimitStyle,
         lexicalDialect: SqlDialect
     ) -> Bool {
+        var found = false
+        forEachTopLevelIdentifier(in: sql, lexicalDialect: lexicalDialect) { buffer, start, end in
+            guard isLimitingKeyword(in: buffer, start: start, end: end, autoLimitStyle: autoLimitStyle) else {
+                return false
+            }
+            found = true
+            return true
+        }
+        return found
+    }
+
+    /// The UTF-16 offset of the first top-level row-limiting clause, so a caller splicing a clause
+    /// onto the end of a statement can put it before that clause rather than after it.
+    ///
+    /// `TOP` is deliberately absent: it sits between SELECT and the column list, so it is not a
+    /// trailing clause and splitting there would cut the statement in half.
+    static func firstRowLimitClauseOffset(_ sql: String, lexicalDialect: SqlDialect) -> Int? {
+        var offset: Int?
+        forEachTopLevelIdentifier(in: sql, lexicalDialect: lexicalDialect) { buffer, start, end in
+            guard startsRowLimitClause(in: buffer, start: start, end: end) else { return false }
+            offset = start
+            return true
+        }
+        return offset
+    }
+
+    /// `OFFSET` is non-reserved in MySQL and MariaDB, so `SELECT offset, name FROM events` reaches
+    /// here as a column name. What separates the clause from the identifier is what follows it: a
+    /// row count, a placeholder, or `FIRST`/`NEXT` for the ANSI `FETCH` form.
+    private static func startsRowLimitClause(in buffer: NSString, start: Int, end: Int) -> Bool {
+        if matchesKeyword("FETCH", in: buffer, start: start, end: end) {
+            let (wordStart, wordEnd) = nextWordRange(in: buffer, from: end)
+            return matchesKeyword("FIRST", in: buffer, start: wordStart, end: wordEnd)
+                || matchesKeyword("NEXT", in: buffer, start: wordStart, end: wordEnd)
+        }
+        guard matchesKeyword("LIMIT", in: buffer, start: start, end: end)
+            || matchesKeyword("OFFSET", in: buffer, start: start, end: end)
+        else {
+            return false
+        }
+        var index = end
+        while index < buffer.length, isSpace(buffer.character(at: index)) { index += 1 }
+        guard index < buffer.length else { return false }
+        let next = buffer.character(at: index)
+        if next >= zero, next <= nine { return true }
+        if next == question || next == colon || next == dollar || next == at { return true }
+        let (wordStart, wordEnd) = nextWordRange(in: buffer, from: end)
+        return matchesKeyword("ALL", in: buffer, start: wordStart, end: wordEnd)
+    }
+
+    private static func nextWordRange(in buffer: NSString, from index: Int) -> (Int, Int) {
+        var start = index
+        while start < buffer.length, isSpace(buffer.character(at: start)) { start += 1 }
+        var end = start
+        while end < buffer.length, SqlDollarQuote.isIdentifierPart(buffer.character(at: end)) { end += 1 }
+        return (start, end)
+    }
+
+    private static func isSpace(_ ch: UInt16) -> Bool {
+        ch == 0x20 || ch == 0x09 || ch == 0x0A || ch == 0x0D
+    }
+
+    private static let zero = UInt16(UnicodeScalar("0").value)
+    private static let nine = UInt16(UnicodeScalar("9").value)
+    private static let question = UInt16(UnicodeScalar("?").value)
+    private static let colon = UInt16(UnicodeScalar(":").value)
+    private static let at = UInt16(UnicodeScalar("@").value)
+
+    /// Walks `sql` and reports every identifier that sits outside a string, comment or dollar quote
+    /// and at paren depth zero. The visitor returns true to stop the walk.
+    private static func forEachTopLevelIdentifier(
+        in sql: String,
+        lexicalDialect: SqlDialect,
+        visit: (NSString, Int, Int) -> Bool
+    ) {
         let buffer = sql as NSString
         let length = buffer.length
-        guard length > 0 else { return false }
+        guard length > 0 else { return }
 
         let dollarQuotesEnabled = lexicalDialect.supportsDollarQuotes
         let hashCommentsEnabled = lexicalDialect.supportsHashLineComments
@@ -124,10 +199,8 @@ enum SQLLimitDetector {
                i == 0 || !SqlDollarQuote.isIdentifierContinuation(buffer.character(at: i - 1)) {
                 var end = i + 1
                 while end < length, SqlDollarQuote.isIdentifierPart(buffer.character(at: end)) { end += 1 }
-                if parenDepth == 0, isLimitingKeyword(
-                    in: buffer, start: i, end: end, autoLimitStyle: autoLimitStyle
-                ) {
-                    return true
+                if parenDepth == 0, visit(buffer, i, end) {
+                    return
                 }
                 i = end
                 continue
@@ -135,8 +208,6 @@ enum SQLLimitDetector {
 
             i += 1
         }
-
-        return false
     }
 
     private static let limitingKeywords: [String] = ["LIMIT", "FETCH"]

--- a/TablePro/Models/Query/QueryTabState.swift
+++ b/TablePro/Models/Query/QueryTabState.swift
@@ -243,6 +243,14 @@ struct PaginationState: Equatable {
     var isLoadingMore: Bool = false
     var baseQueryForMore: String?
     var baseQueryParameterValues: [String?]?
+
+    /// The query and its bindings are one fact, so they are replaced together. Setting the query
+    /// alone left the previous run's bindings in place, and Fetch All then sent them with a query
+    /// that no longer had placeholders, which the server rejects.
+    mutating func setBaseQueryForMore(_ sql: String?, parameterValues: [String?]?) {
+        baseQueryForMore = sql
+        baseQueryParameterValues = parameterValues
+    }
     var sortExecutionOverride: String?  // Derived ORDER BY query run for a grid sort; never written back to the editor
 
     /// Default page size constant (used when no explicit value is provided)

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TableRowsMutation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TableRowsMutation.swift
@@ -158,8 +158,10 @@ extension MainContentCoordinator {
             } else {
                 tab.pagination.resetLoadMore()
             }
-            tab.pagination.baseQueryForMore = resultSet.baseQuery
-            tab.pagination.baseQueryParameterValues = resultSet.baseQueryParameterValues
+            tab.pagination.setBaseQueryForMore(
+                resultSet.baseQuery,
+                parameterValues: resultSet.baseQueryParameterValues
+            )
         }
     }
 

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -1508,12 +1508,6 @@ final class MainContentCoordinator {
         return result
     }
 
-    // MARK: - SQL Helpers
-
-    static func stripTrailingOrderBy(from sql: String) -> String {
-        QuerySqlParser.stripTrailingOrderBy(from: sql)
-    }
-
     // MARK: - SQL Parsing
 
     func extractTableName(from sql: String) -> String? {
@@ -1542,14 +1536,17 @@ final class MainContentCoordinator {
             let capturedColumns = tableRows.columns
             confirmDiscardChangesIfNeeded(action: .sort) { [weak self] confirmed in
                 guard let self, confirmed else { return }
-                let strippedQuery = Self.stripTrailingOrderBy(from: baseQuery)
                 let orderClause = capturedSort.columns.compactMap { sortCol -> String? in
                     guard sortCol.columnIndex >= 0, sortCol.columnIndex < capturedColumns.count else { return nil }
                     let columnName = capturedColumns[sortCol.columnIndex]
                     let direction = sortCol.direction == .ascending ? "ASC" : "DESC"
                     return "\(self.queryBuilder.quoteIdentifier(columnName)) \(direction)"
                 }.joined(separator: ", ")
-                let orderQuery = orderClause.isEmpty ? strippedQuery : "\(strippedQuery) ORDER BY \(orderClause)"
+                let orderQuery = QuerySqlParser.applyingOrderBy(
+                    orderClause,
+                    to: baseQuery,
+                    lexicalDialect: self.sqlDialect
+                )
                 guard self.tabManager.mutate(tabId: tabId, { tab in
                     tab.sortState = capturedSort
                     tab.hasUserInteraction = true

--- a/TableProTests/Core/Database/BoundedQueryTests.swift
+++ b/TableProTests/Core/Database/BoundedQueryTests.swift
@@ -1,0 +1,234 @@
+//
+//  BoundedQueryTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("Bounded query reads stop at the row cap")
+struct BoundedQueryTests {
+
+    @Test("Stops the producer once the cap is exceeded instead of draining the whole result")
+    func stopsProducerPastCap() async throws {
+        let driver = StreamingStubDriver(totalRows: 100_000, batchSize: 500)
+
+        let result = try await driver.boundedQueryFromStream(query: "SELECT * FROM t", rowCap: 1_000)
+
+        #expect(result.rows.count == 1_000)
+        #expect(result.isTruncated)
+        #expect(driver.producedRowCount < 100_000)
+    }
+
+    @Test("Reports the full result untruncated when it fits inside the cap")
+    func belowCapIsNotTruncated() async throws {
+        let driver = StreamingStubDriver(totalRows: 40, batchSize: 500)
+
+        let result = try await driver.boundedQueryFromStream(query: "SELECT * FROM t", rowCap: 1_000)
+
+        #expect(result.rows.count == 40)
+        #expect(!result.isTruncated)
+    }
+
+    @Test("A result of exactly the cap is not truncated")
+    func exactlyCapIsNotTruncated() async throws {
+        let driver = StreamingStubDriver(totalRows: 1_000, batchSize: 250)
+
+        let result = try await driver.boundedQueryFromStream(query: "SELECT * FROM t", rowCap: 1_000)
+
+        #expect(result.rows.count == 1_000)
+        #expect(!result.isTruncated)
+    }
+
+    @Test("Carries the column header through from the stream")
+    func carriesHeader() async throws {
+        let driver = StreamingStubDriver(totalRows: 10, batchSize: 5)
+
+        let result = try await driver.boundedQueryFromStream(query: "SELECT * FROM t", rowCap: 100)
+
+        #expect(result.columns == ["col1"])
+        #expect(result.columnTypeNames == ["TEXT"])
+    }
+
+    @Test("Propagates a producer failure rather than returning a short result")
+    func propagatesProducerFailure() async throws {
+        let driver = StreamingStubDriver(totalRows: 100, batchSize: 10, failAfterRows: 30)
+
+        await #expect(throws: StreamingStubError.self) {
+            _ = try await driver.boundedQueryFromStream(query: "SELECT * FROM t", rowCap: 1_000)
+        }
+    }
+
+    @Test("A driver that does not opt in returns nil so the caller keeps the buffered path")
+    func nonParticipatingDriverReturnsNil() async throws {
+        let driver = NonBoundedStubDriver()
+
+        let result = try await driver.executeBoundedQuery(query: "SELECT * FROM t", rowCap: 1_000)
+
+        #expect(result == nil)
+    }
+
+    @Test("The buffered executeUserQuery still caps and flags truncation for a driver without the hook")
+    func bufferedPathUnchanged() async throws {
+        let driver = NonBoundedStubDriver(rowCount: 50)
+
+        let result = try await driver.executeUserQuery(query: "SELECT * FROM t", rowCap: 10, parameters: nil)
+
+        #expect(result.rows.count == 10)
+        #expect(result.isTruncated)
+    }
+}
+
+@Suite("PluginBoundedStream collector")
+struct PluginBoundedStreamTests {
+
+    @Test("Treats a zero or negative cap as one row")
+    func nonPositiveCapReadsOneRow() async throws {
+        let driver = StreamingStubDriver(totalRows: 10, batchSize: 10)
+
+        let result = try await PluginBoundedStream.collect(
+            driver.streamRows(query: "SELECT 1"),
+            rowCap: 0,
+            startedAt: Date()
+        )
+
+        #expect(result.rows.count == 1)
+        #expect(result.isTruncated)
+    }
+
+    @Test("Never holds a row past the cap even when a batch overshoots it")
+    func neverHoldsARowPastTheCap() async throws {
+        let driver = StreamingStubDriver(totalRows: 10_000, batchSize: 999)
+
+        let result = try await PluginBoundedStream.collect(
+            driver.streamRows(query: "SELECT 1"),
+            rowCap: 1_000,
+            startedAt: Date()
+        )
+
+        #expect(result.rows.count == 1_000)
+        #expect(result.isTruncated)
+    }
+}
+
+enum StreamingStubError: Error {
+    case producerFailed
+}
+
+private final class StreamingStubDriver: PluginDatabaseDriver, @unchecked Sendable {
+    private let totalRows: Int
+    private let batchSize: Int
+    private let failAfterRows: Int?
+    private let counter = ProducedRowCounter()
+
+    var producedRowCount: Int { counter.value }
+
+    init(totalRows: Int, batchSize: Int, failAfterRows: Int? = nil) {
+        self.totalRows = totalRows
+        self.batchSize = batchSize
+        self.failAfterRows = failAfterRows
+    }
+
+    func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
+        let total = totalRows
+        let size = batchSize
+        let failAfter = failAfterRows
+        let counter = self.counter
+
+        return AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
+            let task = Task {
+                continuation.yield(.header(PluginStreamHeader(columns: ["col1"], columnTypeNames: ["TEXT"])))
+                var produced = 0
+                while produced < total {
+                    await Task.yield()
+                    if Task.isCancelled {
+                        continuation.finish()
+                        return
+                    }
+                    if let failAfter, produced >= failAfter {
+                        continuation.finish(throwing: StreamingStubError.producerFailed)
+                        return
+                    }
+                    let count = min(size, total - produced)
+                    let batch: [PluginRow] = (0..<count).map { [.text("row_\(produced + $0)")] }
+                    produced += count
+                    counter.add(count)
+                    continuation.yield(.rows(batch))
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { @Sendable _ in task.cancel() }
+        }
+    }
+
+    func connect() async throws {}
+    func disconnect() {}
+    func execute(query: String) async throws -> PluginQueryResult { .empty }
+    func fetchTables(schema: String?) async throws -> [PluginTableInfo] { [] }
+    func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] { [] }
+    func fetchIndexes(table: String, schema: String?) async throws -> [PluginIndexInfo] { [] }
+    func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] { [] }
+    func fetchTableDDL(table: String, schema: String?) async throws -> String { "" }
+    func fetchViewDefinition(view: String, schema: String?) async throws -> String { "" }
+    func fetchTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata {
+        PluginTableMetadata(tableName: table)
+    }
+    func fetchDatabases() async throws -> [String] { [] }
+    func fetchDatabaseMetadata(_ database: String) async throws -> PluginDatabaseMetadata {
+        PluginDatabaseMetadata(name: database)
+    }
+}
+
+private final class ProducedRowCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func add(_ rows: Int) {
+        lock.lock()
+        count += rows
+        lock.unlock()
+    }
+}
+
+private final class NonBoundedStubDriver: PluginDatabaseDriver, @unchecked Sendable {
+    private let rowCount: Int
+
+    init(rowCount: Int = 0) {
+        self.rowCount = rowCount
+    }
+
+    func connect() async throws {}
+    func disconnect() {}
+
+    func execute(query: String) async throws -> PluginQueryResult {
+        PluginQueryResult(
+            columns: ["col1"],
+            columnTypeNames: ["TEXT"],
+            rows: (0..<rowCount).map { [.text("row_\($0)")] },
+            rowsAffected: 0,
+            executionTime: 0
+        )
+    }
+
+    func fetchTables(schema: String?) async throws -> [PluginTableInfo] { [] }
+    func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] { [] }
+    func fetchIndexes(table: String, schema: String?) async throws -> [PluginIndexInfo] { [] }
+    func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] { [] }
+    func fetchTableDDL(table: String, schema: String?) async throws -> String { "" }
+    func fetchViewDefinition(view: String, schema: String?) async throws -> String { "" }
+    func fetchTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata {
+        PluginTableMetadata(tableName: table)
+    }
+    func fetchDatabases() async throws -> [String] { [] }
+    func fetchDatabaseMetadata(_ database: String) async throws -> PluginDatabaseMetadata {
+        PluginDatabaseMetadata(name: database)
+    }
+}

--- a/TableProTests/Core/Database/PluginStreamAbortTests.swift
+++ b/TableProTests/Core/Database/PluginStreamAbortTests.swift
@@ -1,0 +1,171 @@
+//
+//  PluginStreamAbortTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("Row stream abort reaches a producer that polls it")
+struct PluginStreamAbortTests {
+
+    @Test("Terminating the stream sets the flag, and a serial-queue producer stops early")
+    func serialQueueProducerStopsEarly() async throws {
+        let queue = DispatchQueue(label: "test.stream.abort.serial")
+        let counter = ProducedRowCounter()
+        let totalBatches = 40
+        let batchSize = 500
+
+        let consumed = await consumeFirstBatches(
+            count: 2,
+            from: PluginRowStream.make { continuation, abort in
+                queue.async {
+                    continuation.yield(.header(PluginStreamHeader(columns: ["c"], columnTypeNames: ["TEXT"])))
+                    for index in 0..<totalBatches {
+                        if abort.isAborted { break }
+                        let batch: [PluginRow] = (0..<batchSize).map { [.text("row_\(index)_\($0)")] }
+                        counter.add(batch.count)
+                        continuation.yield(.rows(batch))
+                        usleep(20_000)
+                    }
+                    continuation.finish()
+                }
+            }
+        )
+
+        #expect(consumed == 2 * batchSize)
+        try await Task.sleep(for: .seconds(1.5))
+        #expect(counter.value < totalBatches * batchSize)
+    }
+
+    @Test("A producer that never polls runs to completion, which is why the poll is the contract")
+    func producerThatIgnoresTheFlagRunsOn() async throws {
+        let queue = DispatchQueue(label: "test.stream.abort.ignores")
+        let counter = ProducedRowCounter()
+        let totalBatches = 10
+        let batchSize = 100
+
+        _ = await consumeFirstBatches(
+            count: 1,
+            from: PluginRowStream.make { continuation, _ in
+                queue.async {
+                    continuation.yield(.header(PluginStreamHeader(columns: ["c"], columnTypeNames: ["TEXT"])))
+                    for index in 0..<totalBatches {
+                        let batch: [PluginRow] = (0..<batchSize).map { [.text("row_\(index)_\($0)")] }
+                        counter.add(batch.count)
+                        continuation.yield(.rows(batch))
+                    }
+                    continuation.finish()
+                }
+            }
+        )
+
+        try await Task.sleep(for: .seconds(0.5))
+        #expect(counter.value == totalBatches * batchSize)
+    }
+
+    @Test("The flag is already set when a producer scheduled after termination finally runs")
+    func producerScheduledAfterTerminationSeesTheFlag() async throws {
+        let queue = DispatchQueue(label: "test.stream.abort.late")
+        let gate = DispatchSemaphore(value: 0)
+        let observed = AbortObservation()
+
+        do {
+            let stream = PluginRowStream.make { continuation, abort in
+                queue.async {
+                    gate.wait()
+                    observed.record(abort.isAborted)
+                    continuation.finish()
+                }
+            }
+            _ = stream.makeAsyncIterator()
+        }
+
+        gate.signal()
+        try await Task.sleep(for: .seconds(0.5))
+        #expect(observed.value == true)
+    }
+
+    @Test("A stream still held in scope has not terminated, however long the consumer has stopped")
+    func holdingTheStreamKeepsItAlive() async throws {
+        let queue = DispatchQueue(label: "test.stream.abort.held")
+        let counter = ProducedRowCounter()
+
+        let stream = PluginRowStream.make { continuation, abort in
+            queue.async {
+                for index in 0..<20 {
+                    if abort.isAborted { break }
+                    counter.add(1)
+                    continuation.yield(.rows([[.text("row_\(index)")]]))
+                    usleep(20_000)
+                }
+                continuation.finish()
+            }
+        }
+
+        var seen = 0
+        for try await _ in stream {
+            seen += 1
+            if seen >= 2 { break }
+        }
+
+        try await Task.sleep(for: .seconds(0.6))
+        #expect(counter.value == 20)
+        _ = stream
+    }
+
+    private func consumeFirstBatches(
+        count: Int,
+        from stream: AsyncThrowingStream<PluginStreamElement, Error>
+    ) async -> Int {
+        var rows = 0
+        var batches = 0
+        do {
+            for try await element in stream {
+                guard case .rows(let batch) = element else { continue }
+                rows += batch.count
+                batches += 1
+                if batches >= count { break }
+            }
+        } catch {
+            return rows
+        }
+        return rows
+    }
+}
+
+private final class ProducedRowCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func add(_ rows: Int) {
+        lock.lock()
+        count += rows
+        lock.unlock()
+    }
+}
+
+private final class AbortObservation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var observed: Bool?
+
+    var value: Bool? {
+        lock.lock()
+        defer { lock.unlock() }
+        return observed
+    }
+
+    func record(_ aborted: Bool) {
+        lock.lock()
+        observed = aborted
+        lock.unlock()
+    }
+}

--- a/TableProTests/Core/Services/Query/QueryExecutorTests.swift
+++ b/TableProTests/Core/Services/Query/QueryExecutorTests.swift
@@ -162,6 +162,88 @@ struct QueryExecutorTests {
         #expect(!QueryExecutor.isDDLStatement("DELETE FROM foo"))
     }
 
+    // MARK: - Sorting a query result
+
+    @Test("applyingOrderBy puts the clause before a LIMIT the user wrote")
+    func applyingOrderByPrecedesLimit() {
+        let sorted = QuerySqlParser.applyingOrderBy(
+            "\"total\" ASC",
+            to: "SELECT * FROM orders LIMIT 100",
+            lexicalDialect: .postgres
+        )
+        #expect(sorted == "SELECT * FROM orders ORDER BY \"total\" ASC LIMIT 100")
+    }
+
+    @Test("applyingOrderBy keeps the user's LIMIT when replacing an existing ORDER BY")
+    func applyingOrderByKeepsLimitWhenReplacing() {
+        let sorted = QuerySqlParser.applyingOrderBy(
+            "\"total\" DESC",
+            to: "SELECT * FROM orders ORDER BY id LIMIT 100",
+            lexicalDialect: .postgres
+        )
+        #expect(sorted == "SELECT * FROM orders ORDER BY \"total\" DESC LIMIT 100")
+    }
+
+    @Test("applyingOrderBy preserves a LIMIT with an OFFSET")
+    func applyingOrderByPreservesOffset() {
+        let sorted = QuerySqlParser.applyingOrderBy(
+            "\"id\" ASC",
+            to: "SELECT * FROM orders LIMIT 10 OFFSET 20",
+            lexicalDialect: .postgres
+        )
+        #expect(sorted == "SELECT * FROM orders ORDER BY \"id\" ASC LIMIT 10 OFFSET 20")
+    }
+
+    @Test("applyingOrderBy appends to a query with no row-limiting clause")
+    func applyingOrderByAppendsWhenNoLimit() {
+        let sorted = QuerySqlParser.applyingOrderBy(
+            "\"id\" ASC",
+            to: "SELECT * FROM orders",
+            lexicalDialect: .postgres
+        )
+        #expect(sorted == "SELECT * FROM orders ORDER BY \"id\" ASC")
+    }
+
+    @Test("applyingOrderBy ignores a LIMIT inside a subquery")
+    func applyingOrderByIgnoresSubqueryLimit() {
+        let sorted = QuerySqlParser.applyingOrderBy(
+            "\"id\" ASC",
+            to: "SELECT * FROM (SELECT * FROM t LIMIT 5) s",
+            lexicalDialect: .postgres
+        )
+        #expect(sorted == "SELECT * FROM (SELECT * FROM t LIMIT 5) s ORDER BY \"id\" ASC")
+    }
+
+    @Test("applyingOrderBy with no columns strips the old ORDER BY and keeps the LIMIT")
+    func applyingOrderByEmptyClauseKeepsLimit() {
+        let sorted = QuerySqlParser.applyingOrderBy(
+            "",
+            to: "SELECT * FROM orders ORDER BY id LIMIT 100",
+            lexicalDialect: .postgres
+        )
+        #expect(sorted == "SELECT * FROM orders LIMIT 100")
+    }
+
+    @Test("applyingOrderBy with no columns drops an OFFSET FETCH tail, which needs an ORDER BY")
+    func applyingOrderByEmptyClauseDropsAnsiTail() {
+        let sorted = QuerySqlParser.applyingOrderBy(
+            "",
+            to: "SELECT * FROM t ORDER BY id OFFSET 0 ROWS FETCH NEXT 50 ROWS ONLY",
+            lexicalDialect: .generic
+        )
+        #expect(sorted == "SELECT * FROM t")
+    }
+
+    @Test("applyingOrderBy leaves a column named offset alone")
+    func applyingOrderByIgnoresOffsetColumn() {
+        let sorted = QuerySqlParser.applyingOrderBy(
+            "`name` ASC",
+            to: "SELECT offset, name FROM events",
+            lexicalDialect: .mysql
+        )
+        #expect(sorted == "SELECT offset, name FROM events ORDER BY `name` ASC")
+    }
+
     // MARK: - Row cap qualification
 
     @Test("qualifiesForRowCap accepts SELECT and WITH queries on query tabs")
@@ -187,6 +269,34 @@ struct QueryExecutorTests {
         ))
         #expect(!QueryExecutor.qualifiesForRowCap(
             sql: "SELECTX FROM t", tabType: .query, databaseType: .mysql
+        ))
+    }
+
+    @Test("qualifiesForRowCap accepts the other row-producing statement forms")
+    func qualifiesForRowCapRowProducingForms() {
+        #expect(QueryExecutor.qualifiesForRowCap(
+            sql: "(SELECT * FROM events) UNION ALL (SELECT * FROM events_archive)",
+            tabType: .query,
+            databaseType: .postgresql
+        ))
+        #expect(QueryExecutor.qualifiesForRowCap(
+            sql: "TABLE big_table", tabType: .query, databaseType: .postgresql
+        ))
+        #expect(QueryExecutor.qualifiesForRowCap(
+            sql: "VALUES (1), (2), (3)", tabType: .query, databaseType: .postgresql
+        ))
+        #expect(QueryExecutor.qualifiesForRowCap(
+            sql: "((SELECT * FROM t))", tabType: .query, databaseType: .postgresql
+        ))
+    }
+
+    @Test("qualifiesForRowCap still rejects a write hidden behind a leading parenthesis")
+    func qualifiesForRowCapParenthesisedWrite() {
+        #expect(!QueryExecutor.qualifiesForRowCap(
+            sql: "(DELETE FROM users)", tabType: .query, databaseType: .postgresql
+        ))
+        #expect(!QueryExecutor.qualifiesForRowCap(
+            sql: "( SELECT * FROM t INTO OUTFILE '/tmp/x' )", tabType: .query, databaseType: .mysql
         ))
     }
 

--- a/TableProTests/Core/Utilities/SQL/QueryClassifierTests.swift
+++ b/TableProTests/Core/Utilities/SQL/QueryClassifierTests.swift
@@ -140,6 +140,39 @@ struct QueryClassifierKeywordBoundaryTests {
     }
 }
 
+@Suite("QueryClassifier parenthesised statements")
+struct QueryClassifierParenthesisedTests {
+    @Test("leadingKeyword reaches past opening parentheses")
+    func leadingKeywordSkipsParens() {
+        #expect(QueryClassifier.leadingKeyword(of: "(SELECT * FROM t)") == "SELECT")
+        #expect(QueryClassifier.leadingKeyword(of: "((SELECT * FROM t))") == "SELECT")
+        #expect(QueryClassifier.leadingKeyword(of: "( /* c */ SELECT 1 )") == "SELECT")
+        #expect(QueryClassifier.leadingKeyword(of: "(  VALUES (1), (2)") == "VALUES")
+    }
+
+    @Test("A parenthesised set operation reads as safe")
+    func parenthesisedUnionIsSafe() {
+        let sql = "(SELECT * FROM events ORDER BY id) UNION ALL (SELECT * FROM events_archive)"
+        #expect(!QueryClassifier.isWriteQuery(sql, databaseType: .postgresql))
+        #expect(QueryClassifier.classifyTier(sql, databaseType: .postgresql) == .safe)
+    }
+
+    @Test("Skipping parentheses cannot downgrade a write or a destructive statement")
+    func parenthesesDoNotDowngradeWrites() {
+        #expect(QueryClassifier.isWriteQuery("(DELETE FROM users)", databaseType: .postgresql))
+        #expect(QueryClassifier.classifyTier("(DROP TABLE users)", databaseType: .postgresql) == .destructive)
+        #expect(QueryClassifier.classifyTier("(UPDATE t SET x = 1)", databaseType: .postgresql) == .write)
+        #expect(QueryClassifier.isWriteQuery("(SELECT * INTO backup FROM t)", databaseType: .postgresql))
+    }
+
+    @Test("A filesystem or code surface inside parentheses is still flagged")
+    func parenthesesDoNotHideUnsafeSurface() {
+        #expect(QueryClassifier.reachesFilesystemOrExecutesCode(
+            "(COPY t FROM PROGRAM 'sh')", databaseType: .postgresql
+        ))
+    }
+}
+
 @Suite("QueryClassifier isMultiStatement")
 struct QueryClassifierMultiStatementTests {
     @Test("A trailing comment after the terminating semicolon is not a second statement")

--- a/TableProTests/Core/Utilities/SQL/SQLLimitDetectorTests.swift
+++ b/TableProTests/Core/Utilities/SQL/SQLLimitDetectorTests.swift
@@ -96,4 +96,71 @@ struct SQLLimitDetectorTests {
         #expect(hasLimit("SELECT * FROM t LIMIT 5;"))
         #expect(!hasLimit("SELECT * FROM t;"))
     }
+
+    @Test("firstRowLimitClauseOffset points at the top-level LIMIT, OFFSET or FETCH")
+    func clauseOffsetFindsTopLevelClause() throws {
+        let sql = "SELECT * FROM orders LIMIT 100"
+        let offset = try #require(SQLLimitDetector.firstRowLimitClauseOffset(sql, lexicalDialect: .postgres))
+        #expect(offset == 21)
+        let clause = (sql as NSString).substring(from: offset)
+        #expect(clause == "LIMIT 100")
+    }
+
+    @Test("firstRowLimitClauseOffset finds a bare OFFSET with no LIMIT")
+    func clauseOffsetFindsBareOffset() {
+        let offset = SQLLimitDetector.firstRowLimitClauseOffset(
+            "SELECT * FROM orders OFFSET 20", lexicalDialect: .postgres
+        )
+        #expect(offset == 21)
+    }
+
+    @Test("firstRowLimitClauseOffset finds an ANSI FETCH clause")
+    func clauseOffsetFindsFetch() {
+        let sql = "SELECT * FROM orders OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY"
+        let offset = SQLLimitDetector.firstRowLimitClauseOffset(sql, lexicalDialect: .postgres)
+        #expect(offset == 21)
+    }
+
+    @Test("firstRowLimitClauseOffset ignores a LIMIT inside a subquery or a string")
+    func clauseOffsetIgnoresNested() {
+        #expect(SQLLimitDetector.firstRowLimitClauseOffset(
+            "SELECT * FROM (SELECT * FROM t LIMIT 5) s", lexicalDialect: .postgres
+        ) == nil)
+        #expect(SQLLimitDetector.firstRowLimitClauseOffset(
+            "SELECT * FROM t WHERE note = 'no LIMIT here'", lexicalDialect: .postgres
+        ) == nil)
+    }
+
+    @Test("firstRowLimitClauseOffset ignores TOP, which is not a trailing clause")
+    func clauseOffsetIgnoresTop() {
+        #expect(SQLLimitDetector.firstRowLimitClauseOffset(
+            "SELECT TOP 10 * FROM t", lexicalDialect: .generic
+        ) == nil)
+    }
+
+    @Test("firstRowLimitClauseOffset ignores OFFSET and FETCH used as column names")
+    func clauseOffsetIgnoresIdentifiers() {
+        #expect(SQLLimitDetector.firstRowLimitClauseOffset(
+            "SELECT offset, name FROM events", lexicalDialect: .mysql
+        ) == nil)
+        #expect(SQLLimitDetector.firstRowLimitClauseOffset(
+            "SELECT fetch FROM t", lexicalDialect: .mysql
+        ) == nil)
+        #expect(SQLLimitDetector.firstRowLimitClauseOffset(
+            "SELECT offset FROM t ORDER BY offset", lexicalDialect: .mysql
+        ) == nil)
+    }
+
+    @Test("firstRowLimitClauseOffset accepts a placeholder row count")
+    func clauseOffsetAcceptsPlaceholders() {
+        #expect(SQLLimitDetector.firstRowLimitClauseOffset(
+            "SELECT * FROM t LIMIT ?", lexicalDialect: .mysql
+        ) != nil)
+        #expect(SQLLimitDetector.firstRowLimitClauseOffset(
+            "SELECT * FROM t LIMIT $1", lexicalDialect: .postgres
+        ) != nil)
+        #expect(SQLLimitDetector.firstRowLimitClauseOffset(
+            "SELECT * FROM t LIMIT ALL", lexicalDialect: .postgres
+        ) != nil)
+    }
 }

--- a/TableProTests/Models/PaginationStateTests.swift
+++ b/TableProTests/Models/PaginationStateTests.swift
@@ -408,6 +408,27 @@ struct PaginationStateTests {
         #expect(state.isApproximateRowCount)
     }
 
+    @Test("Setting the base query clears the previous run's bindings")
+    func setBaseQueryForMoreClearsStaleBindings() {
+        var state = PaginationState()
+        state.setBaseQueryForMore("SELECT * FROM orders WHERE id = $1", parameterValues: ["42"])
+
+        state.setBaseQueryForMore("SELECT * FROM events", parameterValues: nil)
+
+        #expect(state.baseQueryForMore == "SELECT * FROM events")
+        #expect(state.baseQueryParameterValues == nil)
+    }
+
+    @Test("Setting the base query carries its own bindings")
+    func setBaseQueryForMoreCarriesBindings() {
+        var state = PaginationState()
+
+        state.setBaseQueryForMore("SELECT * FROM orders WHERE id = $1", parameterValues: ["7"])
+
+        #expect(state.baseQueryForMore == "SELECT * FROM orders WHERE id = $1")
+        #expect(state.baseQueryParameterValues == ["7"])
+    }
+
     @Test("Busy covers every kind of pending work")
     func busyCoversEveryPendingKind() {
         #expect(!PaginationState().isBusy)

--- a/docs/features/query-results.mdx
+++ b/docs/features/query-results.mdx
@@ -41,7 +41,7 @@ The results panel expands itself when a query runs. The toolbar's trash button c
 
 ## The row cap
 
-A `SELECT` or `WITH` query with no `LIMIT`, `FETCH FIRST` or `TOP` of its own stops at the row cap.
+A query that returns rows and carries no `LIMIT`, `FETCH FIRST` or `TOP` of its own stops at the row cap: `SELECT`, `WITH`, `TABLE`, `VALUES`, and a set operation whose arms are parenthesised.
 
 <RowCap />
 

--- a/docs/snippets/row-cap.mdx
+++ b/docs/snippets/row-cap.mdx
@@ -1,8 +1,9 @@
 Your SQL reaches the server exactly as you wrote it. The cap applies to the rows read back, so a
 query carrying its own `LIMIT`, `FETCH FIRST` or `TOP` is never touched, and `EXPLAIN`, `SHOW`,
 writes and DDL are never capped. The read itself stops at the cap on MySQL, MariaDB, PostgreSQL,
-CockroachDB, Redshift, SQLite, Redis, DynamoDB, BigQuery and MongoDB, so the rest of the result never
-crosses the network. Every other engine still reads the whole result and keeps the first rows. A plan
-that has to finish before it can return a first row, a sort with no index or a `GROUP BY`, runs to
-completion on the server either way. Both numbers are in **Settings > Data**
+CockroachDB, Redshift, SQLite, MSSQL, Oracle, Cassandra, Redis, DynamoDB, BigQuery, Snowflake, Trino,
+ClickHouse and MongoDB, so the rest of the result never crosses the network. Cloudflare D1, LibSQL,
+Etcd, DuckDB, Elasticsearch, SurrealDB, Beancount and Dameng still read the whole result and keep the
+first rows. A plan that has to finish before it can return a first row, a sort with no index or a
+`GROUP BY`, runs to completion on the server either way. Both numbers are in **Settings > Data**
 ([Data settings](/customization/data-settings)).

--- a/docs/snippets/row-cap.mdx
+++ b/docs/snippets/row-cap.mdx
@@ -1,4 +1,8 @@
 Your SQL reaches the server exactly as you wrote it. The cap applies to the rows read back, so a
 query carrying its own `LIMIT`, `FETCH FIRST` or `TOP` is never touched, and `EXPLAIN`, `SHOW`,
-writes and DDL are never capped. Both numbers are in **Settings > Data**
+writes and DDL are never capped. The read itself stops at the cap on MySQL, MariaDB, PostgreSQL,
+CockroachDB, Redshift, SQLite, Redis, DynamoDB, BigQuery and MongoDB, so the rest of the result never
+crosses the network. Every other engine still reads the whole result and keeps the first rows. A plan
+that has to finish before it can return a first row, a sort with no index or a `GROUP BY`, runs to
+completion on the server either way. Both numbers are in **Settings > Data**
 ([Data settings](/customization/data-settings)).


### PR DESCRIPTION
Fixes #2427.

## The reported problem, and what is actually wrong

The issue asks TablePro to stop injecting a `LIMIT` and adopt DBeaver-style server-side pagination. Both halves of that premise turn out to be wrong, and the truth is worse than reported.

TablePro has never injected a `LIMIT`. `QueryExecutor.resolveRowCap` produces a cap and hands it to the driver, and `PluginDatabaseDriver.executeUserQuery`'s default implementation runs the query to completion, materializes every row, then keeps `Array(raw.rows.prefix(cap))`. The server produces every row, every row crosses the network, every row is decoded into `[[PluginCellValue]]`, and only then are 1,000 kept. That is the reporter's 10 seconds.

Meanwhile 18 driver plugins already ship a genuinely incremental `streamRows`, and PostgreSQL's already uses `PQsendQuery` + `PQsetSingleRowMode` with a `PQcancel` abort. Its only callers in the whole app are export and compare. The incremental read path and the query path were never joined.

## Measured

A C probe compiled against the real `Libs/libpq_arm64.a` (`PQlibVersion()` = 170004) against PostgreSQL 17.11 and 16.15:

| | |
|---|---|
| 3,000,000-row `PQexec` | 731 ms |
| Single-row read of 1,000 + `PQcancel` + drain to NULL | 4 ms, connection back to `IDLE` |
| Abandoning the read **without** the cancel | 775 ms (PG17) / 1,952 ms (PG16) charged to the user's *next* query |

Stopping the read without cancelling also leaves the backend `state=active`, `wait_event=ClientWrite`, holding `backend_xmin`. The cancel is correctness, not an optimization.

## What this does

A new additive `PluginDatabaseDriver` requirement:

```swift
func executeBoundedQuery(query: String, rowCap: Int) async throws -> PluginQueryResult?
```

`nil` means "I cannot bound the fetch at my source", matching this protocol's own convention (`injectRowLimit`, `buildExplainQuery`, `defaultExportQuery`). A new requirement with a default is ABI-additive, so no `currentPluginKitVersion` bump and no plugin re-release. `scripts/check-pluginkit-abi.sh` confirms it.

`PluginBoundedStream` is the shared collector, and `boundedQueryFromStream` is the one-line opt-in for a driver whose `streamRows` yields incrementally and whose producer stops when its consumer does.

**The default `executeUserQuery` is deliberately untouched.** Routing it into the bounded path would have been unsafe: `MCPConnectionBridge` sets `shouldCap = tier == .safe || hasReturning`, so `INSERT … RETURNING *` arrives with a row cap under `.protectedWrite`, a policy that exists because "a half-applied write cannot be undone by retrying". A bounded read would `PQcancel` mid-INSERT. Instead the app opts in at the call sites it controls, whose caps come from `resolveRowCap` and therefore only ever exist for reads. This also means the 17 registry-only plugins that will not be rebuilt are bit-identical to today.

### Drivers

| Bounded at the source | How |
|---|---|
| PostgreSQL, CockroachDB, Redshift, PGlite | new `boundedQuery` on `LibPQPluginConnection`: single-row mode, stop at cap+1, `PQcancel` + drain. Uses no stream cancellation at all. |
| SQLite | `Task.isCancelled` in its `sqlite3_step` loop; the actor method inherits the caller's task, so the cancel lands |
| Redis, DynamoDB, BigQuery | `try Task.checkCancellation()` inside the paging loop, producer not nested |
| MySQL, MariaDB, MongoDB | already did (`mysql_use_result` + `killQueryOnServer` + drain; `find` limit = cap+1). Unchanged. |

**Opting a driver in requires proving its producer stops, and five drivers do not.** Terminating the stream only cancels the task `streamRows` created, so the producer has to be reachable from it and has to poll. MSSQL (`MSSQLPlugin.swift:599`) and Oracle (`OraclePlugin.swift:425`) run theirs inside a *nested* unstructured `Task {}`, which `streamTask.cancel()` cannot reach because a plain `Task {}` inherits context but is not a child. Cassandra's `CassandraConnection.streamQuery:688` is a synchronous `cass_session_execute`/`cass_future_wait` paging loop with no cancellation check at all. Those three would have returned the first page instantly while the connection kept pulling the rest, so the user's next statement blocks behind a read nobody wanted, which is worse than not opting in. Snowflake and Trino carry no cancellation check either, and propagation through their awaited sequences cannot be verified without a live server, so they stay out too. Each is listed in the follow-up notes with what it needs.

Trino does gain the `onTermination` handler its stream was missing, which is a real defect on the export path regardless of the bounded read: without it a cancelled export left the producer running.

**The cancel is withheld inside a transaction block.** Cancelling a statement while `PQtransactionStatus` reports `PQTRANS_INTRANS` puts the transaction into the aborted state, and every later command fails until `ROLLBACK`. Browsing a large table inside a transaction the user opened would have thrown that transaction away. The bounded read drains instead, so it still skips decoding the tail but pays the transfer. PGlite already withheld the cancel for its own reason (`suppressServerSideCancel`), so it is not in the table above.

**Also not converted:** ClickHouse (its `streamRows` fires an extra `LIMIT 0` round trip to derive columns, so a bounded read would be two HTTP requests where today it is one, net-negative on small results until that is restructured); DuckDB (its stream materializes a `duckdb_result` first and has no `onTermination`; needs `duckdb_pending_prepared_streaming`); Cloudflare D1, LibSQL remote, Etcd, Elasticsearch, SurrealDB, Beancount, Dameng (one call returns the whole result, nothing to stop).

### Honest limit

The speedup is plan-dependent and the PR does not claim otherwise. Measured on the same SQL: `ORDER BY` with an index 3,415 ms → 5 ms; without an index 6,027 ms → 3,324 ms; `GROUP BY` 77 ms → 78 ms, no gain. A blocking plan node has to finish before it can emit row 1. What this always removes is the transfer and decode of every row past the cap, and the hidden drain charged to the next query.

### Not done, deliberately

No cursor-held pagination over arbitrary SQL. DBeaver does not do it either: `SQLQueryDataContainer.readData()` closes the statement and `ResultSet` per read, `RESULT_SET_MAX_ROWS_USE_SQL` and `RESULT_SET_USE_FETCH_SIZE` are both off by default, and `RESULT_SET_REREAD_ON_SCROLLING` defaults true, so "next page" re-runs from row 0 and is quadratic in reads. Holding a cursor would pin a connection and a snapshot across user idle time.

No SQL rewriting. TablePlus appends the limit to the user's text, which shipped as TablePlus#1683: a query ending in `-- where` ran as `-- where LIMIT 1000;` and returned the whole table. The dead `injectRowLimit` requirement stays in place per the ABI rule against removing a published requirement, and stays unused.

No UI change. `.partialLoad` already renders "Showing 1,000 rows" and `PaginationCoordinator.fetchAllRows` already offers Fetch All behind a confirm.

## Also fixed

Three defects found while investigating this subsystem. The first two are the same class as the reported bug and the fix is incomplete without them.

**The row cap only recognised a leading `SELECT` or `WITH`.** `QueryClassifier.leadingKeyword` takes the leading letter/digit run, so `(SELECT * FROM events) UNION ALL (…)` yielded `""` and was classified a *write*, while `TABLE big_table` and `VALUES (1),(2)` failed the keyword check. All three ran with no cap, no truncation badge and no Fetch All, and never reached the driver with a cap at all. `leadingKeyword` now reaches past opening parens. That can only make a classification equal or stricter: `(DROP TABLE t)` moves from `.write` to `.destructive`, and the `INTO` guard plus the body-wide `filesystemMarkers` scan are untouched.

**Sorting a query result appended `ORDER BY` after the user's `LIMIT`.** `SELECT * FROM orders LIMIT 100` plus a header click produced `… LIMIT 100 ORDER BY "total" ASC`, a syntax error on every engine, quoting SQL the user never typed. And when the query already had an `ORDER BY`, `stripTrailingOrderBy` took the `LIMIT` with it, so the user's own limit was silently replaced by the app's row cap. `SQLLimitDetector` now exposes the offset of the first top-level `LIMIT`/`OFFSET`/`FETCH` over its existing lexer, and `QuerySqlParser.applyingOrderBy` splices the clause ahead of it.

Two traps in that, both caught in review. `OFFSET` is non-reserved in MySQL and MariaDB, so a bare keyword match split `SELECT offset, name FROM events` at the column name; the clause is now recognised only when a row count, a placeholder, `ALL`, or `FIRST`/`NEXT` after `FETCH` follows it. And ANSI `OFFSET n ROWS FETCH NEXT m ROWS ONLY` is only legal alongside an `ORDER BY`, so clearing the sort has to take that tail with it or SQL Server rejects the statement; a standalone `LIMIT` still stays.

**Fetch All replayed the previous run's bound parameters.** `applyPhase1Result` set `baseQueryForMore` without clearing `baseQueryParameterValues`, and it did so on the exact branch that makes Fetch All reachable. Run a parameterized query, then a plain one that truncates, then Fetch All, and PostgreSQL rejects it with `bind message supplies 1 parameters, but prepared statement "" requires 0`. The pair now moves together through `PaginationState.setBaseQueryForMore`.

**A SQLite `UPDATE` or `DELETE` alone in a query tab reported no row count.** Its `executeUserQuery` override took the streaming branch for *every* unparameterized query, including DML, and hardcoded `rowsAffected: 0`. Measured with a compiled probe against a real SQLite file: `execute()` → 5000, `executeUserQuery()` → 0. The override now streams only a row-returning statement and sends everything else through `execute()` with its real `sqlite3_changes()`. Deleting the override outright, which was the first attempt, would have regressed MCP: `MCPConnectionBridge` resolves its own cap and never reaches `executeBoundedQuery`, so a capped MCP read of a large SQLite table would have gone back to materializing every row.

## Verification

| Step | Result |
|---|---|
| `verify.sh build` | PASS |
| `verify.sh test` (7 suites) | PASS, 141 cases |
| classifier suites after the security fix | PASS, 54 cases |
| `verify.sh lint TablePro Plugins TableProTests` | 0 violations |
| `verify.sh docs` | PASS |
| Per-plugin builds | 8 touched plugin schemes build; PostgreSQL builds |
| `verify.sh plugins` (AllPlugins) | fails inside the vendored `oracle-nio` checkout's `@TaskLocal` macro, a known local-toolchain issue unrelated to this change. No error in any file in this diff. CI covers it. |

New tests: `BoundedQueryTests` and `PluginBoundedStreamTests` (early abort proven by counting rows the producer actually produced; exact-cap vs truncated; a non-participating driver stays on the buffered path), plus cases in `QueryExecutorTests`, `QueryClassifierTests`, `SQLLimitDetectorTests` and `PaginationStateTests`.

No screenshots: nothing visual changed. The row cap affordance is the one that already shipped.

No UI automation: the sort-with-`LIMIT` flow needs a live connection and a column-header click, and per the notes in `CLAUDE.md` on this grid, XCUITest reads every row and cell as obscured and needs offset-point clicks. The rewrite is covered by six unit cases over `QuerySqlParser.applyingOrderBy` instead.

Codex was unavailable for the review pass (`Your workspace is out of credits`, not an authentication failure), so no second-lab model has read this diff. It went through `Skill(code-review)` and `Skill(security-review)` instead. That review is what removed the five drivers above, restored the SQLite override, and found both `applyingOrderBy` traps.

## Follow-ups this leaves open

Each is a driver that could bound its fetch once its stream can actually be stopped. None is a regression from this PR; all are pre-existing and also affect export cancellation today.

- **MSSQL** (`MSSQLPlugin.swift:599`) and **Oracle** (`OraclePlugin.swift:425`): hoist the nested `Task {}` so `onTermination` can cancel it, then give the core loop a real cancellation flag. `Task.isCancelled` alone will not do, for the same reason it does not work in libpq's stream: the loop body is synchronous on a `DispatchQueue` and carries no task context.
- **Cassandra** (`CassandraConnection.swift:688`): the paging loop needs a cancellation check between pages.
- **Snowflake**, **Trino**: confirm against a live server whether cancelling the stream task stops the fetch, then opt in.
- **PostgreSQL** (`LibPQPluginConnection.swift:664`): `streamQuery`'s own early abort is inert. `onTermination` does `queue.async` onto the same serial queue the producer occupies, so `cancelAndDrain` runs only after every row is read, and the per-row `Task.isCancelled` sits outside any task and is always false. The bounded read does not go through it, so this PR does not depend on it, but export and compare cancellation do. The fix is to reuse the `PluginQueryCancellationGate` the class already owns.
- **ClickHouse**: derive stream columns from the first `JSONEachRow` line instead of a `LIMIT 0` probe, then opt in.

https://claude.ai/code/session_016E9GaZVKhXdJS3hdrDzctX
