### PR TITLE
fix(perf): stop filesystem and memory-pressure callbacks inheriting the main actor

### DIFF
--- a/.claude/skills/fix-issue/scripts/worktree.sh
+++ b/.claude/skills/fix-issue/scripts/worktree.sh
@@ -64,7 +64,12 @@ for archive in "$MAIN_ROOT"/Libs/*.a; do
     [ -e "$archive" ] && ln -sf "$archive" "$DIR/Libs/$(basename "$archive")"
 done
 link "$MAIN_ROOT/Libs/dylibs" "$DIR/Libs/dylibs"
-link "$MAIN_ROOT/Libs/ios" "$DIR/Libs/ios"
+# Libs/ios/checksums.sha256 is tracked, so git already created Libs/ios as a real directory and
+# a symlink named after it would land inside as Libs/ios/ios. Link the xcframeworks themselves.
+mkdir -p "$DIR/Libs/ios"
+for framework in "$MAIN_ROOT"/Libs/ios/*.xcframework; do
+    [ -e "$framework" ] && ln -sfn "$framework" "$DIR/Libs/ios/$(basename "$framework")"
+done
 link "$MAIN_ROOT/Native/DamengBridge/lib" "$DIR/Native/DamengBridge/lib"
 
 missing=""
@@ -72,9 +77,10 @@ missing=""
 [ -e "$DIR/Libs/dylibs" ] || missing="$missing Libs/dylibs"
 [ -e "$DIR/Native/DamengBridge/lib" ] || missing="$missing Native/DamengBridge/lib"
 ls "$DIR"/Libs/*.a > /dev/null 2>&1 || missing="$missing Libs/*.a"
+ls "$DIR"/Libs/ios/*.xcframework > /dev/null 2>&1 || missing="$missing Libs/ios/*.xcframework"
 if [ -n "$missing" ]; then
     echo "warning: not linked, the main checkout does not have them:$missing" >&2
 fi
 
 echo "$DIR"
-echo "note: Libs/dylibs and Libs/ios show as untracked here because the .gitignore entries end in a slash and these are symlinks. Stage explicit paths." >&2
+echo "note: Libs/dylibs shows as untracked here because its .gitignore entry ends in a slash and it is a symlink. Stage explicit paths." >&2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scroll position lost when switching away from a table tab and back. (#2424)
 - A table statistics command on every switch between two table tabs. (#2424)
 - Another table's size and row count in Table Info when its statistics arrive late. (#2424)
+- Crash when a file changes in a linked SQL folder. (#2432)
+- Crash when a file changes in a linked connection folder, and on quit with one configured.
+- iOS: crash the first time the system reports memory pressure.
 
 ## [0.68.0] - 2026-08-25
 

--- a/TablePro/Core/Services/Export/LinkedFolderWatcher.swift
+++ b/TablePro/Core/Services/Export/LinkedFolderWatcher.swift
@@ -142,13 +142,13 @@ final class LinkedFolderWatcher {
                 queue: .global(qos: .utility)
             )
 
-            source.setEventHandler { [weak self] in
+            source.setEventHandler { @Sendable [weak self] in
                 Task { @MainActor [weak self] in
                     self?.scheduleDebouncedRescan()
                 }
             }
 
-            source.setCancelHandler {
+            source.setCancelHandler { @Sendable in
                 close(fd)
             }
 

--- a/TablePro/Core/Services/SQL/SQLFolderWatcher.swift
+++ b/TablePro/Core/Services/SQL/SQLFolderWatcher.swift
@@ -20,6 +20,14 @@ internal final class SQLFolderWatcher {
     @ObservationIgnored private var debounceTask: Task<Void, Never>?
     @ObservationIgnored private var hasStarted = false
 
+    nonisolated private static let eventCallback: FSEventStreamCallback = { _, info, _, _, _, _ in
+        guard let info else { return }
+        let watcher = Unmanaged<SQLFolderWatcher>.fromOpaque(info).takeUnretainedValue()
+        Task { @MainActor in
+            watcher.scheduleDebouncedRescan()
+        }
+    }
+
     private init() {}
 
     func start() {
@@ -65,13 +73,7 @@ internal final class SQLFolderWatcher {
 
         guard let stream = FSEventStreamCreate(
             kCFAllocatorDefault,
-            { _, info, _, _, _, _ in
-                guard let info else { return }
-                let watcher = Unmanaged<SQLFolderWatcher>.fromOpaque(info).takeUnretainedValue()
-                Task { @MainActor in
-                    watcher.scheduleDebouncedRescan()
-                }
-            },
+            Self.eventCallback,
             &context,
             paths,
             FSEventStreamEventId(kFSEventStreamEventIdSinceNow),

--- a/TablePro/Core/Utilities/MemoryPressureAdvisor.swift
+++ b/TablePro/Core/Utilities/MemoryPressureAdvisor.swift
@@ -20,14 +20,16 @@ internal enum MemoryPressureAdvisor {
             eventMask: [.warning, .critical, .normal],
             queue: .main
         )
-        source.setEventHandler {
-            let event = source.data
-            let wasPressured = isUnderPressure
-            isUnderPressure = event.contains(.warning) || event.contains(.critical)
-            if isUnderPressure && !wasPressured {
-                logger.info("Memory pressure detected — reducing tab eviction budget")
-            } else if !isUnderPressure && wasPressured {
-                logger.info("Memory pressure resolved — restoring tab eviction budget")
+        source.setEventHandler { @Sendable in
+            MainActor.assumeIsolated {
+                let event = source.data
+                let wasPressured = isUnderPressure
+                isUnderPressure = event.contains(.warning) || event.contains(.critical)
+                if isUnderPressure && !wasPressured {
+                    logger.info("Memory pressure detected, reducing tab eviction budget")
+                } else if !isUnderPressure && wasPressured {
+                    logger.info("Memory pressure resolved, restoring tab eviction budget")
+                }
             }
         }
         source.activate()

--- a/TableProMobile/TableProMobile/Platform/MemoryPressureMonitor.swift
+++ b/TableProMobile/TableProMobile/Platform/MemoryPressureMonitor.swift
@@ -14,7 +14,7 @@ final class MemoryPressureMonitor {
 
     private(set) var currentLevel: Level = .normal
 
-    private static let logger = Logger(subsystem: "com.TablePro", category: "MemoryPressureMonitor")
+    nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "MemoryPressureMonitor")
     private var source: DispatchSourceMemoryPressure?
 
     private init() {}
@@ -27,7 +27,7 @@ final class MemoryPressureMonitor {
             queue: .global(qos: .utility)
         )
 
-        newSource.setEventHandler { [weak self] in
+        newSource.setEventHandler { @Sendable [weak self] in
             let event = newSource.data
             let level: Level
             if event.contains(.critical) {

--- a/TableProMobile/TableProMobileTests/OffMainActorHandlerGuardTests.swift
+++ b/TableProMobile/TableProMobileTests/OffMainActorHandlerGuardTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+
+@Suite("Off-main-actor callback isolation")
+struct OffMainActorHandlerGuardTests {
+    @Test("Every Dispatch source handler declares its own isolation")
+    func dispatchSourceHandlersDeclareTheirIsolation() throws {
+        let offenders = try Self.offenders { lines in
+            lines.indices.filter { index in
+                let line = lines[index]
+                guard Self.dispatchHandlerSetters.contains(where: line.contains), line.contains("{") else {
+                    return false
+                }
+                guard !line.contains("@Sendable") else { return false }
+                return !Self.nextNonEmptyLine(in: lines, after: index).hasPrefix("@Sendable")
+            }
+        }
+        #expect(
+            offenders.isEmpty,
+            """
+            Dispatch calls a source handler on the source's own queue, and DispatchSourceHandler is \
+            not @Sendable, so a closure literal written inside a @MainActor type inherits an \
+            isolation that queue cannot honour and the process traps before the body runs. Write \
+            `{ @Sendable in ... }` and hop with `Task { @MainActor in ... }`: \(offenders.sorted())
+            """
+        )
+    }
+
+    private static let dispatchHandlerSetters = [
+        "setEventHandler",
+        "setCancelHandler",
+        "setRegistrationHandler",
+    ]
+
+    private static func nextNonEmptyLine(in lines: [String], after index: Int) -> String {
+        lines[(index + 1)...]
+            .lazy
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .first { !$0.isEmpty } ?? ""
+    }
+
+    private static func offenders(_ rule: ([String]) -> [Int]) throws -> [String] {
+        let sourceRoot = try repoRoot().appendingPathComponent("TableProMobile/TableProMobile")
+        guard let enumerator = FileManager.default.enumerator(
+            at: sourceRoot,
+            includingPropertiesForKeys: [.isRegularFileKey]
+        ) else { return [] }
+
+        var matches: [String] = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            let lines = try String(contentsOf: url, encoding: .utf8).components(separatedBy: .newlines)
+            matches += rule(lines).map { "\(url.lastPathComponent):\($0 + 1)" }
+        }
+        return matches
+    }
+
+    private static func repoRoot(file: StaticString = #filePath) throws -> URL {
+        var directory = URL(fileURLWithPath: "\(file)").deletingLastPathComponent()
+        while directory.path != "/" {
+            if FileManager.default.fileExists(atPath: directory.appendingPathComponent("CLAUDE.md").path) {
+                return directory
+            }
+            directory = directory.deletingLastPathComponent()
+        }
+        throw HandlerGuardError.repoRootNotFound
+    }
+
+    private enum HandlerGuardError: Error {
+        case repoRootNotFound
+    }
+}

--- a/TableProTests/Core/Concurrency/OffMainActorHandlerGuardTests.swift
+++ b/TableProTests/Core/Concurrency/OffMainActorHandlerGuardTests.swift
@@ -1,0 +1,131 @@
+//
+//  OffMainActorHandlerGuardTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@Suite("Off-main-actor callback isolation")
+struct OffMainActorHandlerGuardTests {
+    @Test("Every Dispatch source handler declares its own isolation")
+    func dispatchSourceHandlersDeclareTheirIsolation() throws {
+        let offenders = try Self.offenders(Self.dispatchHandlerOffenders)
+        #expect(
+            offenders.isEmpty,
+            """
+            Dispatch calls a source handler on the source's own queue, and DispatchSourceHandler is \
+            not @Sendable, so a closure literal written inside a @MainActor type inherits an \
+            isolation that queue cannot honour and the process traps before the body runs. Write \
+            `{ @Sendable in ... }` and hop with `Task { @MainActor in ... }` or \
+            `MainActor.assumeIsolated`: \(offenders.sorted())
+            """
+        )
+    }
+
+    @Test("Every FSEvents callback is declared where it cannot inherit an actor")
+    func fsEventsCallbacksCannotInheritAnActor() throws {
+        let offenders = try Self.offenders(Self.fsEventsOffenders)
+        #expect(
+            offenders.isEmpty,
+            """
+            An FSEvents callback runs on the stream's dispatch queue. Written inline inside a \
+            @MainActor type it inherits main-actor isolation and traps there, so declare it as a \
+            `nonisolated private static let` of type `FSEventStreamCallback` and pass that: \
+            \(offenders.sorted())
+            """
+        )
+    }
+
+    private static let appSourceRoots = [
+        "TablePro",
+        "TableProMobile/TableProMobile",
+        "Plugins",
+        "Packages/TableProCore/Sources",
+    ]
+
+    private static let dispatchHandlerSetters = [
+        "setEventHandler",
+        "setCancelHandler",
+        "setRegistrationHandler",
+    ]
+
+    private static func dispatchHandlerOffenders(in lines: [String]) -> [Int] {
+        lines.indices.filter { index in
+            let line = lines[index]
+            guard dispatchHandlerSetters.contains(where: line.contains), line.contains("{") else { return false }
+            guard !line.contains("@Sendable") else { return false }
+            return !nextNonEmptyLine(in: lines, after: index).hasPrefix("@Sendable")
+        }
+    }
+
+    private static func fsEventsOffenders(in lines: [String]) -> [Int] {
+        var offending: [Int] = []
+        var argumentDepth = 0
+        for (index, line) in lines.enumerated() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            let arguments = line.range(of: "FSEventStreamCreate(").map { String(line[$0.upperBound...]) }
+            if argumentDepth > 0, trimmed.hasPrefix("{"), !trimmed.contains("@Sendable") {
+                offending.append(index)
+            } else if let arguments, arguments.contains("{"), !arguments.contains("@Sendable") {
+                offending.append(index)
+            }
+            if declaresIsolatedCallback(lines, index) {
+                offending.append(index)
+            }
+            guard argumentDepth > 0 || arguments != nil else { continue }
+            argumentDepth += line.filter { $0 == "(" }.count - line.filter { $0 == ")" }.count
+            argumentDepth = max(argumentDepth, 0)
+        }
+        return offending
+    }
+
+    private static func declaresIsolatedCallback(_ lines: [String], _ index: Int) -> Bool {
+        let line = lines[index]
+        guard line.contains("FSEventStreamCallback"), line.contains("="), !line.contains("nonisolated") else {
+            return false
+        }
+        return line.contains("= {") || nextNonEmptyLine(in: lines, after: index).hasPrefix("{")
+    }
+
+    private static func nextNonEmptyLine(in lines: [String], after index: Int) -> String {
+        lines[(index + 1)...]
+            .lazy
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .first { !$0.isEmpty } ?? ""
+    }
+
+    private static func offenders(_ rule: ([String]) -> [Int]) throws -> [String] {
+        let root = try repoRoot()
+        var matches: [String] = []
+        for relativePath in appSourceRoots {
+            let sourceRoot = root.appendingPathComponent(relativePath)
+            guard let enumerator = FileManager.default.enumerator(
+                at: sourceRoot,
+                includingPropertiesForKeys: [.isRegularFileKey]
+            ) else { continue }
+
+            for case let url as URL in enumerator
+                where url.pathExtension == "swift" && !url.lastPathComponent.hasSuffix("Tests.swift") {
+                let lines = try String(contentsOf: url, encoding: .utf8).components(separatedBy: .newlines)
+                matches += rule(lines).map { "\(url.lastPathComponent):\($0 + 1)" }
+            }
+        }
+        return matches
+    }
+
+    private static func repoRoot(file: StaticString = #filePath) throws -> URL {
+        var directory = URL(fileURLWithPath: "\(file)").deletingLastPathComponent()
+        while directory.path != "/" {
+            if FileManager.default.fileExists(atPath: directory.appendingPathComponent("CLAUDE.md").path) {
+                return directory
+            }
+            directory = directory.deletingLastPathComponent()
+        }
+        throw HandlerGuardError.repoRootNotFound
+    }
+
+    private enum HandlerGuardError: Error {
+        case repoRootNotFound
+    }
+}


### PR DESCRIPTION
Fixes #2432.

## The bug

With a Linked SQL Folder configured, any filesystem change inside it quits the app. The reporter hits it by creating a `.sql` file in the folder or saving an edit to one, but the trigger is the filesystem event, not TablePro's own write, so an external editor touching the same folder does it too. The write completes first, which is why the file lands on disk and the app dies a moment later.

## Root cause

Under the Swift 6 language mode a closure literal written lexically inside a `@MainActor` type inherits main-actor isolation. When that closure is handed to an API whose handler type is **not** `@Sendable`, Swift bridges it through a thunk carrying a dynamic isolation precondition (SE-0423). Dispatch then calls the handler on the source's own queue, the precondition fails, and the process traps before the body runs.

Two such handler types are in play, both read from the SDK:

- `DispatchSourceHandler` is `@convention(block) () -> Void` (`Dispatch.swiftinterface:246`), used by `setEventHandler` / `setCancelHandler` / `setRegistrationHandler`.
- `FSEventStreamCallback` is a C function pointer.

`DispatchQueue.async`, `NWConnection.stateUpdateHandler`, `Process.terminationHandler` and `FileHandle.readabilityHandler` are all `@Sendable` or `NS_SWIFT_SENDABLE`, so they are unaffected.

I reproduced it with a standalone probe replicating `SQLFolderWatcher.setupEventStream`: a `@MainActor @Observable` class, `FSEventStreamCreate` with the callback written inline, `FSEventStreamSetDispatchQueue(stream, .global(qos: .utility))`. It SIGTRAPs on the first filesystem event with a backtrace matching the crash report frame for frame:

```
0 libdispatch          _dispatch_assert_queue_fail
1 libdispatch          dispatch_assert_queue$V2.cold.1
2 libdispatch          dispatch_assert_queue
3 libswift_Concurrency _swift_task_checkIsolatedSwift
4 libswift_Concurrency swift_task_isCurrentExecutorWithFlagsImpl
5 <app>                closure #1 in ProbeWatcher.start
7 FSEvents             implementation_callback_rpc
...                    _dispatch_source_invoke / _dispatch_workloop_worker_thread
queue = 'com.apple.root.utility-qos'
```

It first shipped in 0.67.0. `3368af95a` (#2311) adopted the Swift 6 language mode and touched this file only to mark its logger `nonisolated`; under Swift 5 the same check warns instead of trapping, which is why the code sat there unnoticed. The reporter's guess of 0.66 predates that commit.

## Blast radius

The reported crash is one instance of four. A sweep of the repo for a non-`@Sendable` handler registered on a non-main queue inside a `@MainActor` type found:

| Site | Queue | Before |
| --- | --- | --- |
| `SQLFolderWatcher.swift:68` FSEvents callback | `.utility` | traps, the reported bug |
| `LinkedFolderWatcher.swift:145` `setEventHandler` | `.utility` | traps when a linked connection folder changes |
| `LinkedFolderWatcher.swift:151` `setCancelHandler` | `.utility` | traps on every `reload()` and on quit |
| `MemoryPressureMonitor.swift:30` (iOS) `setEventHandler` | `.utility` | traps on the first memory-pressure event |
| `MemoryPressureAdvisor.swift:23` | `.main` | safe, but only because the queue happens to match |

`LinkedFolderWatcher` is the same file `DatabaseFileWatcher` was fixed alongside in #2312; that sweep missed it. The iOS monitor was forked from the macOS advisor and changed the queue without changing the closure, so it inherited the bug the original never had.

Each shape was measured on its own, unfixed and fixed, by compiling and running it.

## The fix

`SQLFolderWatcher`'s callback moves out of the argument list into a `nonisolated private static let eventCallback: FSEventStreamCallback`. That is stronger than annotating in place: a closure with a contextual C-convention type cannot inherit isolation at all, so the fix cannot be undone by deleting one keyword, and it matches the `nonisolated private static let logger` already in that file.

The three Dispatch handlers take `@Sendable` on the literal, which is the shape `DatabaseFileWatcher.swift:74/:81` already uses. The iOS monitor also needs `nonisolated` on its `private static let logger`, because a `@Sendable` handler can no longer reach a main-actor-isolated static.

`MemoryPressureAdvisor` is not broken today, but it is normalised to `{ @Sendable in MainActor.assumeIsolated { ... } }`. Its correctness currently rests on an unwritten fact about its queue; stating it means every Dispatch handler in the repo now reads the same way, and the guard below needs no exception list.

## Guard

This bug class has now shipped twice, so two source-scanning tests close it. A runtime reproduction is not an option: the failure is a process-level SIGTRAP, so a test that reproduced it would abort the XCTest host and mark every unrelated suite failed. A subprocess fixture could sidestep that but needs a compiled probe binary in the test bundle, which is a new target for a rule a scan already expresses.

`TableProTests/Core/Concurrency/OffMainActorHandlerGuardTests.swift` scans `TablePro/`, `TableProMobile/TableProMobile/`, `Plugins/` and `Packages/TableProCore/Sources/`. `TableProMobile/TableProMobileTests/OffMainActorHandlerGuardTests.swift` scans the iOS sources again, because the macOS workflow's change filter excludes `TableProMobile/**` and the iOS workflow runs only `TableProMobileTests`, so a mobile-only pull request would otherwise never run the guard. It carries only the Dispatch rule; `FSEventStreamCreate` is macOS-only.

SwiftLint cannot do this job: `.swiftlint.yml` sets `included: [TablePro]`, so it never sees the other three roots.

The rules cover the shapes this API actually gets written in: a trailing closure on the setter line, an FSEvents callback inline anywhere in the argument list including on the `FSEventStreamCreate(` line itself, and a `FSEventStreamCallback` declaration whose closure opens on the next line. `@Sendable` written on the line after the brace is accepted rather than flagged. A handler passed as an already-built value rather than a literal is not covered; no such code exists in the repo.

Both tests were checked against the unfixed tree. Reintroducing the two defects fails them, and they name the exact offending lines:

```
OffMainActorHandlerGuardTests/dispatchSourceHandlersDeclareTheirIsolation() failed
OffMainActorHandlerGuardTests/fsEventsCallbacksCannotInheritAnActor() failed
```

## Also in this PR

`worktree.sh` could never link the iOS xcframeworks. `Libs/ios/checksums.sha256` is tracked, so `git worktree add` creates a real `Libs/ios` directory, and `ln -sfn "$MAIN_ROOT/Libs/ios" "$DIR/Libs/ios"` therefore landed the symlink inside it as `Libs/ios/ios`. Every worktree failed the iOS build with "There is no XCFramework found at .../MariaDB.xcframework", and the script's own missing-check never looked at `Libs/ios`, so it never warned. It now links each `.xcframework` individually, the way it already links the `.a` archives, and checks for them. This blocked verifying the iOS half of the fix.

## Verification

- `generate`: PASS
- `build` (TablePro, Debug): PASS
- `test` `OffMainActorHandlerGuardTests` `MemoryPressureAdvisorTests` `EvictionTests` `WelcomeViewModelTests`: PASS, 40 of 40
- Negative check: with both defects reintroduced, both guard tests fail; restored, both pass
- `lint` over `TablePro/`, the two new test directories and the iOS platform directory: 0 violations
- iOS: `MemoryPressureMonitor.swift` and the new mobile guard test both typecheck clean with `swiftc -swift-version 6` against the iOS simulator SDK. The full `xcodebuild test` could not run on this machine: it fails inside the `oracle-nio` dependency with `unknown attribute 'usableFromInlinenonisolated'` from a `@TaskLocal` macro expansion, before any app source compiles. That is a toolchain mismatch with the locally installed Xcode beta, unrelated to this change; iOS CI pins Xcode 26.4.1 and is the real verdict.

No UI automation: none of this has a user-visible surface to drive, and the failure it fixes is a process abort. No screenshots for the same reason. No docs change, and no PluginKit ABI surface is touched.

## Reported, not fixed here

`FileTextLoader.loadHeader` (`FileTextLoader.swift:44`) reads exactly 4096 bytes and falls back to `.isoLatin1` when the strict UTF-8 decode fails. Latin-1 never fails, so a valid UTF-8 `.sql` file over 4 KB whose byte 4096 splits a multi-byte sequence is indexed as `iso-8859-1`: the sidebar row shows a false "Non-UTF-8 file" badge, `-- @name:` frontmatter is mojibaked, and a non-ASCII `-- @keyword:` can never match what the user types. Confirmed by probe, deterministic per file, and it survives every rescan. `SQLFolderWatcher.scanFolder` is its only caller, so it sits in the subsystem this PR edits, but it is independent of the crash and left for a separate change.
