### PR TITLE
fix: unbreak main, a compile error and an empty xcodebuild argument

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -302,6 +302,12 @@ jobs:
       - name: Run unit tests
         run: |
           set -o pipefail
+          # To a file on its own line, not through a process substitution. `< <(...)` discards the
+          # producer's exit status, so the script refusing an entry that would skip nothing printed
+          # its diagnostic, exited 1, and the step carried on to run the whole suite unskipped and
+          # report success. The refusal the comment above promises never once failed a job.
+          SKIP_FILE="${RUNNER_TEMP:-.}/quarantine-skip-args.txt"
+          scripts/ci/quarantine-args.sh .github/macos-test-quarantine.txt TableProTests "$XCTESTRUN" "$TEST_DESTINATION" > "$SKIP_FILE"
           # A read loop, not mapfile: the macOS runner's /bin/bash is 3.2, which has neither
           # mapfile nor readarray, and a `run:` block gets that bash.
           SKIP_ARGS=()
@@ -311,12 +317,12 @@ jobs:
             # fine; one empty string is not.
             [ -n "$arg" ] || continue
             SKIP_ARGS+=("$arg")
-          done < <(scripts/ci/quarantine-args.sh .github/macos-test-quarantine.txt TableProTests "$XCTESTRUN" "$TEST_DESTINATION")
+          done < "$SKIP_FILE"
           xcodebuild test-without-building \
             -xctestrun "$XCTESTRUN" \
             -destination "$TEST_DESTINATION" \
             -only-testing:TableProTests \
-            "${SKIP_ARGS[@]}" \
+            ${SKIP_ARGS[@]+"${SKIP_ARGS[@]}"} \
             -parallel-testing-enabled NO \
             -resultBundlePath TestResults.xcresult \
             | xcbeautify --renderer github-actions
@@ -384,17 +390,22 @@ jobs:
           SHARD_COUNT: ${{ matrix.of }}
         run: |
           set -o pipefail
+          # To a file on its own line, so a failure of the lister fails the step. A process
+          # substitution discards its exit status, which reads here as "the shard selected nothing".
+          ONLY_FILE="${RUNNER_TEMP:-.}/shard-only-args.txt"
+          scripts/ci/list-tests.sh \
+            --xctestrun "$XCTESTRUN" \
+            --target TableProUITests \
+            --quarantine .github/macos-ui-test-quarantine.txt \
+            --shard "$SHARD/$SHARD_COUNT" > "$ONLY_FILE"
           # A read loop, not mapfile: the macOS runner's /bin/bash is 3.2, which has neither.
           ONLY_ARGS=()
           while IFS= read -r arg; do
+            # The count check below cannot see an empty argument: one blank line makes the count 1
+            # and xcodebuild then reads that empty argument as a build action.
+            [ -n "$arg" ] || continue
             ONLY_ARGS+=("$arg")
-          done < <(
-            scripts/ci/list-tests.sh \
-              --xctestrun "$XCTESTRUN" \
-              --target TableProUITests \
-              --quarantine .github/macos-ui-test-quarantine.txt \
-              --shard "$SHARD/$SHARD_COUNT"
-          )
+          done < "$ONLY_FILE"
           [ "${#ONLY_ARGS[@]}" -gt 0 ] || { echo "::error::shard $SHARD selected no cases"; exit 1; }
           echo "shard $SHARD of $SHARD_COUNT runs ${#ONLY_ARGS[@]} cases"
           xcodebuild test-without-building \

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -306,6 +306,10 @@ jobs:
           # mapfile nor readarray, and a `run:` block gets that bash.
           SKIP_ARGS=()
           while IFS= read -r arg; do
+            # A blank line would become a literal empty argument, and xcodebuild reads that as a
+            # build action and refuses the whole run. An empty array expands to nothing and is
+            # fine; one empty string is not.
+            [ -n "$arg" ] || continue
             SKIP_ARGS+=("$arg")
           done < <(scripts/ci/quarantine-args.sh .github/macos-test-quarantine.txt TableProTests "$XCTESTRUN" "$TEST_DESTINATION")
           xcodebuild test-without-building \

--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -83,6 +83,13 @@ jobs:
       - name: Validate the registry update script
         run: python3 .github/scripts/test_update_registry.py
 
+      # The macOS suite cannot catch this one: the script runs before any test does, and when it
+      # gets this wrong no test runs at all. An empty quarantine list made it print a blank line,
+      # which the caller turned into an empty xcodebuild argument, and main went red for three
+      # commits with `Unknown build action ''`.
+      - name: Validate the test quarantine script
+        run: python3 scripts/ci/test_quarantine_args.py
+
       # A check that guarded a real invariant and ran nowhere. Pure grep over Swift sources, so it
       # belongs on the free Linux runner. The MongoDB filter-shape check is the other one that was
       # orphaned, but it compiles a C probe against Libs/libbson, so it lives in the macOS build

--- a/TablePro/Views/Main/EditorTabStripSurfaces.swift
+++ b/TablePro/Views/Main/EditorTabStripSurfaces.swift
@@ -23,7 +23,12 @@ internal enum EditorTabStripPalette {
     internal static var selectedFill: Color { Color(nsColor: .controlColor) }
     /// Half the weight of a separator. `separatorColor` was twice the measured edge and read as a
     /// drawn outline rather than the lit rim the system puts there.
-    internal static var trackEdge: Color { Color(nsColor: .quinaryLabelColor) }
+    ///
+    /// `quinaryLabel`, not `quinaryLabelColor`. The two spellings swap places between toolchains:
+    /// the Xcode 27 beta deprecates this one in favour of `quinaryLabelColor`, and Xcode 26.4, the
+    /// one CI builds with, rejects `quinaryLabelColor` outright as renamed to this. Take the
+    /// spelling CI accepts and ignore the beta's deprecation hint.
+    internal static var trackEdge: Color { Color(nsColor: .quinaryLabel) }
     internal static var hoverFill: Color { Color(nsColor: .tertiarySystemFill) }
     internal static var separator: Color { Color(nsColor: .separatorColor) }
 }

--- a/scripts/ci/quarantine_args.py
+++ b/scripts/ci/quarantine_args.py
@@ -69,7 +69,14 @@ def main():
 
     if not ok:
         sys.exit(1)
-    print("\n".join(args))
+
+    # Nothing at all when there is nothing to skip, because `print("")` is a blank line and the
+    # caller reads this stdout one line per argument. An empty list therefore reached xcodebuild as
+    # a literal empty argument and it stopped with `Unknown build action ''` before running a
+    # single test. An empty quarantine file is the goal, not an edge case: main went red the
+    # commit the last entry was removed and stayed red.
+    if args:
+        print("\n".join(args))
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_quarantine_args.py
+++ b/scripts/ci/test_quarantine_args.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Tests for quarantine_args.py, whose stdout is read one line per xcodebuild argument.
+
+Run: python3 scripts/ci/test_quarantine_args.py
+
+The first test is the one that matters. `print("\\n".join([]))` is a blank line, the caller turns
+every line into an argument, and xcodebuild reads an empty argument as a build action: `Unknown
+build action ''`, exit 65, before a single test runs. An empty quarantine file is the goal the file
+itself states, so main went red the commit the last entry was removed and stayed red for three
+commits.
+"""
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+from contextlib import redirect_stdout
+
+_spec = importlib.util.spec_from_file_location(
+    "quarantine_args",
+    os.path.join(os.path.dirname(__file__), "quarantine_args.py"),
+)
+quarantine_args = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(quarantine_args)
+
+ENUMERATED = ["TableProTests/SomeSuite/someCase()", "TableProTests/OtherSuite/otherCase()"]
+
+
+def _run(quarantine_text, identifiers=None):
+    """Returns (stdout, exit code or None), the way the shell caller sees it."""
+    with tempfile.TemporaryDirectory() as work:
+        quarantine = os.path.join(work, "quarantine.txt")
+        with open(quarantine, "w", encoding="utf-8") as handle:
+            handle.write(quarantine_text)
+
+        enumeration = os.path.join(work, "tests.json")
+        listed = ENUMERATED if identifiers is None else identifiers
+        with open(enumeration, "w", encoding="utf-8") as handle:
+            json.dump({"values": [{"enabledTests": [{"identifier": i} for i in listed]}]}, handle)
+
+        os.environ["QUARANTINE"] = quarantine
+        os.environ["TARGET"] = "TableProTests"
+        argv = sys.argv
+        sys.argv = ["quarantine_args.py", enumeration]
+        captured = io.StringIO()
+        status = None
+        try:
+            with redirect_stdout(captured):
+                quarantine_args.main()
+        except SystemExit as error:
+            status = error.code
+        finally:
+            sys.argv = argv
+        return captured.getvalue(), status
+
+
+def test_an_empty_list_prints_nothing_at_all():
+    """Not even a newline. One blank line is one empty argument, and xcodebuild refuses the run."""
+    out, status = _run("# every entry has been burned down\n#\n")
+    assert out == "", repr(out)
+    assert status is None, status
+
+
+def test_a_file_of_only_whitespace_prints_nothing():
+    out, status = _run("\n   \n\t\n")
+    assert out == "", repr(out)
+    assert status is None, status
+
+
+def test_no_line_is_ever_empty():
+    """The caller reads one argument per line, so a blank one is unrepresentable by construction."""
+    out, _ = _run("SomeSuite/someCase()\nOtherSuite/otherCase()\n")
+    assert out.splitlines() == [
+        "-skip-testing:TableProTests/SomeSuite/someCase()",
+        "-skip-testing:TableProTests/OtherSuite/otherCase()",
+    ], out
+    assert all(line.strip() for line in out.splitlines()), repr(out)
+
+
+def test_a_whole_suite_is_accepted_without_a_case():
+    out, _ = _run("SomeSuite\n")
+    assert out.splitlines() == ["-skip-testing:TableProTests/SomeSuite"], out
+
+
+def test_an_entry_that_would_skip_nothing_still_fails_the_job():
+    """The guard the script exists for, unchanged by the empty-list fix."""
+    out, status = _run("NoSuchSuite/nope()\n")
+    assert status == 1, status
+    assert out == "", repr(out)
+
+
+def test_a_swift_testing_case_without_its_parentheses_still_fails():
+    out, status = _run("SomeSuite/someCase\n")
+    assert status == 1, status
+    assert out == "", repr(out)
+
+
+if __name__ == "__main__":
+    test_an_empty_list_prints_nothing_at_all()
+    test_a_file_of_only_whitespace_prints_nothing()
+    test_no_line_is_ever_empty()
+    test_a_whole_suite_is_accepted_without_a_case()
+    test_an_entry_that_would_skip_nothing_still_fails_the_job()
+    test_a_swift_testing_case_without_its_parentheses_still_fails()
+    print("All quarantine-args tests passed.")


### PR DESCRIPTION
`main` is red on two independent counts. This fixes both. They are separate commits and can be split if you would rather.

## 1. The build break, which is mine

`fix(tabs): restore the quinaryLabel spelling that Xcode 26.4 compiles`

`#2434` shipped `Color(nsColor: .quinaryLabelColor)` and CI stopped at:

```
error: 'quinaryLabelColor' has been renamed to 'quinaryLabel'
    internal static var trackEdge: Color { Color(nsColor: .quinaryLabelColor) }
```

The two spellings swap places between toolchains. The Xcode 27 beta I develop against marks `quinaryLabel` deprecated and points at `quinaryLabelColor`; Xcode 26.4.1, which CI builds with, rejects `quinaryLabelColor` outright as renamed to `quinaryLabel`. I took the beta's hint on a line I was already moving, and only CI has the toolchain that disagrees. Reverted to the spelling that was there before, with a comment so the next person does not take the same hint.

It is one line and one root cause; the three reported failures are the file, its compile batch and the project.

## 2. The quarantine break, which predates it

`ci: stop an empty test quarantine passing an empty argument to xcodebuild`

The "Run unit tests" step has failed on every `main` run since `3cc00c0a1`, with no test executing:

```
xcodebuild: error: Unknown build action ''.
```

`scripts/ci/quarantine_args.py` ends with `print("\n".join(args))`. With no quarantine entries that is `print("")`, which is a blank line. The workflow reads that stdout one line per argument, so the blank line becomes a literal empty argument and xcodebuild reads an empty argument as a build action.

`3cc00c0a1` emptied `.github/macos-test-quarantine.txt`. The file's own header says "The list is empty. Keep it that way", so the empty list is the goal rather than an edge case, and the run history matches exactly: `036945d51` cut the list to 6 entries and passed; every run from `3cc00c0a1` onward failed.

Measured on the runner's own shell, `/bin/bash 3.2.57`:

| producer emits | resulting argc |
|---|---|
| nothing at all | 0, harmless |
| one blank line | **1, and the argument is the empty string** |

An empty *array* was never the problem; one empty *string* was.

Two changes, because the producer should not emit it and the consumer should not accept it:

- `quarantine_args.py` prints nothing when there is nothing to skip.
- the workflow's read loop skips empty lines, so no producer can inject an empty argument again.

The guard the script exists for is untouched: an entry that would skip nothing still fails the job with its hint, verified.

### Test

`scripts/ci/test_quarantine_args.py`, run by a new Repo Hygiene step next to the existing `test_update_registry.py`. Six cases: an empty list and a whitespace-only file print nothing at all, no emitted line is ever blank, a whole-suite entry still works, and both "would skip nothing" refusals still fail the job.

It is a real regression test. Against the unfixed script it fails with `AssertionError: '\n'`.

Repo Hygiene is the right home: the macOS suite cannot catch this, because the script runs before any test does and when it gets this wrong no test runs at all.

## 3. The guard that had never once failed a job

`ci: fail the test step when the quarantine or shard lister refuses to run`

Found while verifying the fix above, and it is the worse bug of the two.

The comment over the unit test step says the script "refuses to run if any entry would skip nothing". It does refuse: it prints its diagnostic and exits 1. But it is invoked inside a process substitution, `done < <(scripts/ci/quarantine-args.sh ...)`, and bash discards a process substitution's exit status. Measured:

```
bad-quarantine.txt:1: 'NoSuchSuite/nope()' would skip nothing: nothing by that name is enumerated
loop finished, argc=0
step exit=0
```

So an inert quarantine entry printed a warning nobody reads, the array came back empty, and the step ran the whole suite unskipped and reported success. The refusal that the script exists for, and that the comment promises, has never failed a job.

Both loops now redirect to a file on their own line, so `bash -e` sees the failure. Measured end to end on the new block:

| quarantine | argc reaching xcodebuild | step exit |
|---|---|---|
| empty | 0 | 0 |
| one real entry | 1, correct value | 0 |
| an entry that skips nothing | n/a | **1** |

Two smaller things in the same lines:

- The UI shard loop had no empty-line guard, and its `[ "${#ONLY_ARGS[@]}" -gt 0 ]` neighbour is blind to this shape: a blank line makes the count 1, so it reads as protection and is not. Measured on bash 3.2.57. That path cannot fire the bug today, because `list-tests.sh` prints the *runnable* set rather than the quarantined one, so emptying its quarantine maximises output rather than emptying it. The guard is there so it stays that way.
- `"${SKIP_ARGS[@]}"` is now `${SKIP_ARGS[@]+"${SKIP_ARGS[@]}"}`. The array is genuinely empty for the first time, and on bash 3.2 under `set -u` the plain form is an "unbound variable" error. This step runs `bash -e` today, but sibling steps in the same file already use `set -euo pipefail`.

## Verification

- `verify.sh build` PASS
- `verify.sh test EditorTabStripChromeTests EditorTabStripSurfacesTests` PASS, 21 of 21
- `actionlint` clean on both changed workflows, which is what Repo Hygiene runs and is the only thing that checks an inline `run:` block
- Simulated the whole new unit test block against an empty, a valid and an inert quarantine file, and confirmed the exit status in each
- `python3 scripts/ci/test_quarantine_args.py` passes here and fails against the version on `main`
- Reproduced the CI failure locally against the real script before fixing it: empty list, stdout is exactly `\n`, and the read loop builds one empty argument

I could not build against Xcode 26.4.1: only the beta is installed here, which is the whole reason the first bug reached CI. CI is the check for that one.

No CHANGELOG entry: neither change alters anything a user sees. `quinaryLabel` and `quinaryLabelColor` are the same colour.
