### PR TITLE
fix(tabs): draw the selected editor tab in an opaque fill instead of Liquid Glass (#2439)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep Open for a preview tab, by double-clicking it in the tab strip or from its contextual menu. (#2436)
 - Kafka driver plugin: topics in the grid, consumer group lag, and KafkaQL for seeking and producing. (#2419)
 
+### Changed
+
+- Editor tabs drawn as a segmented tab picker rather than in Liquid Glass, on every macOS version. (#2439)
+
+### Fixed
+
+- Active editor tab indistinguishable from the inactive ones in light appearance. (#2439)
+- Active editor tab drawn darker than its track on macOS 27, and inverting when the window lost focus.
+- Editor tab selection changing with the desktop picture behind the window.
+- Editor tab strip tests reporting four appearances while running plain Aqua and Dark Aqua twice.
+
 ## [0.68.1] - 2026-08-26
 
 ### Changed

--- a/TablePro/Views/Main/EditorTabStrip.swift
+++ b/TablePro/Views/Main/EditorTabStrip.swift
@@ -22,11 +22,15 @@ import UniformTypeIdentifiers
 /// concentric at their ends, the selected one inset two points inside the track, which is why it
 /// never overruns the track's curve.
 ///
-/// Track, selected tab and new-tab button are all glass, which is what the system does too, but
-/// the track and the tab on it are not the same glass. Two `.regular` surfaces stacked carry no
-/// step of their own, because each samples the backdrop under the window rather than the glass it
-/// sits on, so the selection would be whatever the content behind the strip happened to be.
-/// `EditorTabStripEmphasis` holds them apart, and carries the measurements that set the distance.
+/// The track and the selected tab are opaque fills, and only the new-tab button is
+/// glass. A selection cannot be drawn in glass, because glass takes its colour from whatever is
+/// behind the window and a selection has to mean the same thing over every wallpaper. Measured
+/// across twenty arrangements on macOS 27, every glass surface nested in, beside, or unioned with
+/// another one rendered *darker* than its track in light appearance, and the pair that shipped
+/// inverted again whenever the window lost key. That is also what Apple asks for: "avoid applying
+/// the material to both layers. Instead, use fills, transparency, and vibrancy for the top
+/// elements" (WWDC25 session 219). The band is already the system's glass, so these fills are the
+/// top layer on it rather than a second pane of it.
 internal struct EditorTabStrip: View {
     internal let tabManager: QueryTabManager
     /// The dimension this engine's tabs are anchored to, so a label can name the container it
@@ -136,13 +140,13 @@ internal struct EditorTabStrip: View {
                 }
             }
             .frame(height: EditorTabStripLayout.tabHeight)
-            /// Clipped to the same capsule the tabs are drawn as, so a tab scrolled under the
+            /// Clipped to the same shape the tabs are drawn as, so a tab scrolled under the
             /// track's rounded end is cut by that curve instead of squaring it off.
-            .clipShape(Capsule(style: .continuous))
+            .clipShape(EditorTabStripLayout.tabShape)
             .padding(EditorTabStripLayout.trackPadding)
         }
         .frame(height: EditorTabStripLayout.trackHeight)
-        .trackSurface(prefersSolidSurfaces: prefersSolidSurfaces)
+        .trackSurface()
         .onDrop(of: [.text], delegate: EditorTabStripDropReset(draggingTabId: $draggingTabId))
     }
 
@@ -157,7 +161,6 @@ internal struct EditorTabStrip: View {
             isSelected: tabManager.selectedTab?.id == tab.id,
             isHovered: hoveredTabId == tab.id,
             isWindowActive: isWindowActive,
-            prefersSolidSurfaces: prefersSolidSurfaces,
             showsLeadingSeparator: EditorTabStripLayout.showsSeparator(
                 before: index,
                 tabIds: tabManager.tabs.map(\.id),
@@ -233,8 +236,7 @@ internal struct EditorTabStrip: View {
         controlActiveState != .inactive
     }
 
-    /// One reader for the whole strip, so a track and the tab on it can never disagree about
-    /// whether they are glass.
+    /// Read only by the new-tab button now, which is the one surface still allowed to be glass.
     private var prefersSolidSurfaces: Bool {
         if let surfaceStyle { return surfaceStyle == .solid }
         return EditorTabStripEmphasis.prefersSolidSurfaces(
@@ -306,7 +308,6 @@ private struct EditorTabStripItem: View {
     let isSelected: Bool
     let isHovered: Bool
     let isWindowActive: Bool
-    let prefersSolidSurfaces: Bool
     let showsLeadingSeparator: Bool
     let position: Int
     let count: Int
@@ -401,8 +402,7 @@ private struct EditorTabStripItem: View {
         .tabSurface(
             isSelected: isSelected,
             isHovered: isHovered,
-            isWindowActive: isWindowActive,
-            prefersSolidSurfaces: prefersSolidSurfaces
+            isWindowActive: isWindowActive
         )
     }
 
@@ -556,36 +556,22 @@ private struct EditorTabStripNewButton: View {
 }
 
 private extension View {
-    /// The track is a material, not a wash. Sampling the system's own bar against three different
-    /// chrome colours shows it converging on a fixed tone rather than tinting whatever is behind
-    /// it: about 78 percent opaque over rgb(77) in dark, and 85 percent over rgb(228) in light.
-    /// `secondarySystemFill` is a white wash in dark and a black one in light, so it lands within a
-    /// few points of the system in dark and inverts in light, a track darker than the titlebar it
-    /// sits in.
-    ///
-    /// The tint is what makes it a *track* rather than a second pane at the same height as the tab
-    /// on it. `EditorTabStripEmphasis` carries the measurements.
-    ///
-    /// The glass goes on the track's own content rather than behind it as a `.background`, because
-    /// a `GlassEffectContainer` raises the glass it holds above the container's other content: a
-    /// track drawn as a sibling layer paints over the tabs it is supposed to sit under.
-    @ViewBuilder
-    func trackSurface(prefersSolidSurfaces: Bool) -> some View {
-        if #available(macOS 26.0, *), !prefersSolidSurfaces {
-            glassEffect(.regular.tint(EditorTabStripEmphasis.trackTint), in: Capsule(style: .continuous))
-        } else {
-            background(
-                Capsule(style: .continuous)
-                    .fill(EditorTabStripPalette.trackFill)
-                    .overlay(
-                        Capsule(style: .continuous)
-                            .strokeBorder(
-                                EditorTabStripPalette.trackEdge,
-                                lineWidth: EditorTabStripLayout.hairline
-                            )
-                    )
-            )
-        }
+    /// An opaque tone rather than a wash, for the same reason the system's own track is one: a
+    /// wash tints whatever is behind it, and the track has to stay below the selected tab whatever
+    /// that happens to be. The system's own tab bar measures a track of rgb(232) in light against
+    /// this fill's rgb(220), and rgb(71) in dark against this fill's rgb(70).
+    func trackSurface() -> some View {
+        background(
+            EditorTabStripLayout.trackShape
+                .fill(EditorTabStripPalette.trackFill)
+                .overlay(
+                    EditorTabStripLayout.trackShape
+                        .strokeBorder(
+                            EditorTabStripPalette.trackEdge,
+                            lineWidth: EditorTabStripLayout.hairline
+                        )
+                )
+        )
     }
 
     /// The selected tab is the one pane of glass the system raises out of the track. An unselected
@@ -595,45 +581,41 @@ private extension View {
     func tabSurface(
         isSelected: Bool,
         isHovered: Bool,
-        isWindowActive: Bool,
-        prefersSolidSurfaces: Bool
+        isWindowActive: Bool
     ) -> some View {
         if isSelected {
-            selectedTabSurface(prefersSolidSurfaces: prefersSolidSurfaces)
+            selectedTabSurface()
         } else if isHovered, isWindowActive {
-            background(Capsule(style: .continuous).fill(EditorTabStripPalette.hoverFill))
+            background(EditorTabStripLayout.tabShape.fill(EditorTabStripPalette.hoverFill))
         } else {
             self
         }
     }
 
-    /// Glass on macOS 26 and later, and the flat control fill that preceded it before that.
-    /// `controlBackgroundColor` is not the fallback: it matches the window background exactly in
-    /// dark mode, so the raised tab would read as a hole punched in its own track.
+    /// A fill and a rim, which is how the system draws a raised segment. A vertical section
+    /// through a selected segment reads track 236, rim 215, highlight 255, body 242: the fill
+    /// carries six levels and the edge carries twenty-one. Only the fill was drawn here before,
+    /// which is why the selection read as flat even at the distance the system uses.
+    ///
+    /// `controlBackgroundColor` is not the fill: it matches the window background exactly in dark,
+    /// so the raised tab would read as a hole punched in its own track.
     ///
     /// The fill does not step down for a background window. Reaching for the track's own
-    /// `unemphasizedSelectedContentBackgroundColor` there left the two identical, and the shadow
-    /// that was supposed to cover for it was drawn in light alone and clipped away by the track's
-    /// own 24pt capsule anyway, so a background window showed no selected tab at all. The system
-    /// keeps its selected tab drawn in a background window; only the labels step down, which they
-    /// already do in `titleColor`.
-    ///
-    /// The rim is the half of the selection that survives a background window on glass, where
-    /// macOS attenuates the tint.
-    @ViewBuilder
-    func selectedTabSurface(prefersSolidSurfaces: Bool) -> some View {
-        if #available(macOS 26.0, *), !prefersSolidSurfaces {
-            glassEffect(.regular.tint(EditorTabStripEmphasis.selectionTint), in: Capsule(style: .continuous))
+    /// `unemphasizedSelectedContentBackgroundColor` there left the two identical, so a background
+    /// window showed no selected tab at all. The system keeps its selected tab drawn there; only
+    /// the labels step down, which they already do in `titleColor`.
+    func selectedTabSurface() -> some View {
+        background(
+            EditorTabStripLayout.tabShape
+                .fill(EditorTabStripPalette.selectedFill)
                 .overlay(
-                    Capsule(style: .continuous)
+                    EditorTabStripLayout.tabShape
                         .strokeBorder(
-                            EditorTabStripEmphasis.selectionEdge,
-                            lineWidth: EditorTabStripEmphasis.selectionEdgeWidth
+                            EditorTabStripPalette.selectionEdge,
+                            lineWidth: EditorTabStripLayout.hairline
                         )
                 )
-        } else {
-            background(Capsule(style: .continuous).fill(EditorTabStripPalette.selectedFill))
-        }
+        )
     }
 
     /// The one genuine press target in the strip, so this is where interactive glass belongs.

--- a/TablePro/Views/Main/EditorTabStripLayout.swift
+++ b/TablePro/Views/Main/EditorTabStripLayout.swift
@@ -5,12 +5,13 @@
 
 import CoreGraphics
 import Foundation
+import SwiftUI
 
 /// The geometry and visibility rules of the editor tab strip, kept apart from the view so they
-/// can be tested. Every number here was measured off `NSTabBar`, the private control Finder's own
-/// tab bar is built from, rather than designed: a runtime probe of its view tree on macOS 27 gives
-/// a 36pt titlebar accessory holding a 28pt bar, whose track is inset 8pt, then 4pt of gap, then a
-/// 28pt new-tab button, then 8pt to the trailing edge.
+/// can be tested. Every number here was measured off `NSTabBar`, the private control the system's
+/// own window tab bar is built from, rather than designed: a runtime probe of its view tree on
+/// macOS 27 gives a 36pt titlebar accessory holding a 28pt bar, whose track is inset 8pt, then 4pt
+/// of gap, then a 28pt new-tab button, then 8pt to the trailing edge.
 internal enum EditorTabStripLayout {
     internal static let unseenDotDiameter: CGFloat = 6
 
@@ -34,6 +35,14 @@ internal enum EditorTabStripLayout {
     internal static let hairline: CGFloat = 0.5
 
     internal static var bandBottomClearance: CGFloat { bandHeight - trackHeight }
+
+    /// Fully rounded, because that is what the system's own tab bar is: the runtime
+    /// probe reports `cornerRadius = 12` on each 24pt `NSGlassEffectView` tab, which is exactly
+    /// half its height, and a corner fit of the 28pt track lands at 12 to 14pt. An in-content
+    /// `NSSegmentedControl` is the shallower shape, `(height - 4) / 4`, but that is a different
+    /// control in a different place; this strip is the titlebar tab bar.
+    internal static var trackShape: Capsule { Capsule(style: .continuous) }
+    internal static var tabShape: Capsule { Capsule(style: .continuous) }
 
     /// Tabs share the track equally, and stop shrinking at a width that still fits a name so a
     /// long list scrolls instead of collapsing into slivers. The system staggers widths slightly

--- a/TablePro/Views/Main/EditorTabStripSurfaces.swift
+++ b/TablePro/Views/Main/EditorTabStripSurfaces.swift
@@ -5,22 +5,24 @@
 
 import SwiftUI
 
-/// Read off the system's own tab bar rather than chosen. Every value is a semantic `NSColor` so
-/// the light appearance inverts with the system instead of needing a second hand-tuned palette.
+/// The strip's surfaces.
 ///
-/// These are also what the strip falls back to when it may not use glass at all, which is why the
-/// selected fill is a tone of its own rather than the track's. Sharing one constant between the
-/// two is what left a background window with no selection: both resolved to opaque rgb(220) in
-/// light and rgb(70) in dark, a delta of exactly zero.
+/// Every value is a semantic `NSColor`, so the light appearance inverts with the system instead of
+/// needing a second hand-tuned palette, and so nothing here has to be retuned when Apple moves a
+/// tone. The pair was checked against the system's own tab bar rather than chosen: `NSTabBar`
+/// measures a track of rgb(232) and a selected tab of rgb(253) in light, and rgb(71) and rgb(74)
+/// in dark. These resolve to rgb(220) and rgb(255) in light, and rgb(70) and rgb(116) in dark.
 internal enum EditorTabStripPalette {
-    /// An opaque tone rather than an alpha wash for the same reason the system's material is:
-    /// measured at rgb(220) light and rgb(70) dark, against a system track of rgb(228) and
-    /// rgb(77), it is the closest system colour that stays lighter than the chrome in both.
+    /// Measured at rgb(220) light and rgb(70) dark. The system's own tab track measures rgb(232)
+    /// and rgb(71), so this is within a level of it in dark and slightly deeper in light.
     internal static var trackFill: Color { Color(nsColor: .unemphasizedSelectedContentBackgroundColor) }
-    /// Measured at rgb(255) light and rgb(115) dark over the track, so the selected tab stands
-    /// 35 and 45 levels clear of it whether or not the window is in front. The system keeps its
-    /// own selected tab drawn in a background window too; only the labels step down.
+
+    /// Opaque white in light, and white at alpha 0.247 in dark. That asymmetry is the whole reason
+    /// the selection cannot invert: in light it is the ceiling, so no track can rise above it, and
+    /// in dark it composites *over* whatever the track resolved to, so it always lifts. The step
+    /// is a property of the colour rather than of a tuned distance.
     internal static var selectedFill: Color { Color(nsColor: .controlColor) }
+
     /// Half the weight of a separator. `separatorColor` was twice the measured edge and read as a
     /// drawn outline rather than the lit rim the system puts there.
     ///
@@ -29,63 +31,43 @@ internal enum EditorTabStripPalette {
     /// one CI builds with, rejects `quinaryLabelColor` outright as renamed to this. Take the
     /// spelling CI accepts and ignore the beta's deprecation hint.
     internal static var trackEdge: Color { Color(nsColor: .quinaryLabel) }
+
+    /// The system darkens a hovered tab rather than lightening it, in light appearance: a rendered
+    /// `NSTabBar` measures rgb(220) under the pointer against a rgb(232) track, and this resolves
+    /// to rgb(210) against rgb(220). The direction is deliberate and matches, so it is left alone.
     internal static var hoverFill: Color { Color(nsColor: .tertiarySystemFill) }
+
     internal static var separator: Color { Color(nsColor: .separatorColor) }
+
+    /// The rim is the other half of how the system draws a raised tab, and the half this strip was
+    /// missing. A vertical section through a selected segment reads track 236, rim 215, highlight
+    /// 255, body 242: the fill carries six levels and the edge carries twenty-one. Only the fill
+    /// was drawn here before, which is why the selection read as flat.
+    internal static var selectionEdge: Color { Color(nsColor: .separatorColor) }
 }
 
 /// Which of the two surface sets the strip draws.
 ///
-/// The app resolves this from the environment. A test pins it, because a tinted `glassEffect`
-/// cannot be rasterised at all: `cacheDisplay` comes back with an empty bitmap for the entire
-/// hosting view, the strip's own titles and close button included, not merely for the glass.
+/// The app resolves this from the environment. A test pins it, because a `glassEffect` cannot be
+/// rasterised at all: `cacheDisplay` comes back with an empty bitmap for the entire hosting view,
+/// the strip's own titles and close button included, not merely for the glass.
 internal enum EditorTabStripSurfaceStyle {
     case glass
     case solid
 }
 
-/// How far apart the track and the selected tab are held when both are glass.
+/// Whether the strip may use Liquid Glass at all.
 ///
-/// Liquid Glass samples the backdrop beneath a stack, never the glass it sits on, so a `.regular`
-/// capsule inside a `.regular` track carries no step of its own. Measured on the shipping strip,
-/// the selected tab was rgb(248) against a track of rgb(250) in light, a contrast of 1.017 to 1,
-/// and across a backdrop sweep the step turned over: +57 levels above black, -1 above white.
+/// Only the new-tab button asks any more. The track and the selected tab are opaque, because a
+/// selection drawn in glass cannot hold its own sign: measured across twenty
+/// arrangements on macOS 27, every glass surface nested in, beside, or unioned with another one
+/// rendered *darker* than its track in light appearance, and the shipped pair inverted again when
+/// the window lost key. Glass takes its colour from whatever is behind the window, and a selection
+/// has to mean the same thing over every wallpaper.
 ///
-/// The system never stacks one material on itself. A runtime probe of `NSTabBar` on macOS 27 gives
-/// an `NSSubduedGlassEffectView` track carrying plain `NSGlassEffectView` tabs, measured at
-/// rgb(236) and rgb(253) in light and rgb(83) and rgb(89) in dark. `NSGlassEffectViewStyle`
-/// publishes only `regular` and `clear`, so that subdued style is out of reach.
-///
-/// These two tints stand in for it. Both surfaces sample the same backdrop and are pushed in
-/// opposite directions, so the step between them stops being a function of what the window is
-/// over: measured from a black backdrop to a white one, the worst case is 1.189 to 1 in dark and
-/// 1.183 to 1 in light, above the system's own 1.098 and 1.161, and the sign never turns over.
-///
-/// Both are neutral because `Glass.regular` discards hue: a red track against a green selection
-/// measures exactly like no tint at all. Only lightness reaches the surface, which is what the
-/// Human Interface Guidelines ask for anyway, colour on the background rather than on the text.
+/// The rule itself belongs to `SolidSurfacePreference`, which the six views that reach both
+/// settings through `themeMaterial` also use.
 internal enum EditorTabStripEmphasis {
-    internal static let trackTint = Color.black.opacity(0.12)
-    internal static let selectionTint = Color.white.opacity(0.22)
-
-    /// Ink rather than material, so it survives what the tints do not. macOS attenuates a glass
-    /// tint in a window that is not key, measured at rgb(134) falling to rgb(94) for the selected
-    /// tab, and the system's own bar gives up there too: its selected tab reads seven levels
-    /// darker than its track in a background window. The rim is the part of the selection that
-    /// survives, and it is a shape rather than a colour, which is the channel Apple's
-    /// differentiate-without-colour criteria ask for.
-    internal static var selectionEdge: Color { Color(nsColor: .separatorColor) }
-
-    /// One device pixel on the 2x displays this chrome is drawn for.
-    internal static let selectionEdgeWidth: CGFloat = 0.5
-
-    /// Glass answers to neither Increase Contrast nor Reduce Transparency. Rendering the strip
-    /// under `accessibilityHighContrastAqua` and `accessibilityHighContrastDarkAqua` produces
-    /// pixels identical to plain aqua and darkAqua, measured. So the strip leaves glass behind for
-    /// the opaque surfaces above, which carry 1.371 to 1 in light and 1.991 to 1 in dark.
-    ///
-    /// The rule itself belongs to `SolidSurfacePreference`, which the six views that reach both
-    /// settings through `themeMaterial` also use. Glass has no `Material` to swap, so the strip
-    /// answers the same question with a different surface rather than a second rule.
     internal static func prefersSolidSurfaces(
         reduceTransparency: Bool,
         contrast: ColorSchemeContrast

--- a/TableProTests/Views/Main/EditorTabStripGlassGuardTests.swift
+++ b/TableProTests/Views/Main/EditorTabStripGlassGuardTests.swift
@@ -1,0 +1,88 @@
+//
+//  EditorTabStripGlassGuardTests.swift
+//  TableProTests
+//
+//  A source scan, because the thing it guards cannot be rasterised: a `glassEffect` renders in the
+//  window server, and `cacheDisplay` returns an empty bitmap for the whole hosting view rather
+//  than for the glass alone. The property is structural anyway, so a scan states it directly.
+//
+
+import Foundation
+import Testing
+
+@Suite("Editor tab strip glass")
+struct EditorTabStripGlassGuardTests {
+    /// The strip may carry exactly one Liquid Glass surface, and it is the new-tab button.
+    ///
+    /// The track and the selected tab were both glass, tinted apart, and the step between them
+    /// turned out to be a function of the wallpaper behind the window: measured across twenty
+    /// arrangements on macOS 27, every glass surface nested in, beside, or unioned with another
+    /// rendered darker than its track in light appearance, and the shipped pair inverted again
+    /// whenever the window lost key (#2439). Apple asks for the same shape in WWDC25 session 219,
+    /// "avoid applying the material to both layers. Instead, use fills, transparency, and vibrancy
+    /// for the top elements", and macOS 27's own `NSSegmentedControlRole.tabs` draws this control
+    /// with opaque fills.
+    @Test("Only the new-tab button is drawn in glass")
+    func onlyTheNewTabButtonUsesGlass() throws {
+        let source = try Self.stripSource()
+        let lines = source.components(separatedBy: .newlines)
+        let glassLines = lines.indices.filter { lines[$0].contains("glassEffect(") }
+
+        #expect(
+            glassLines.count == 1,
+            """
+            The editor tab strip may draw exactly one glass surface, the new-tab button. A track \
+            or a selected tab drawn in glass takes its colour from whatever is behind the window, \
+            so the selection stops meaning the same thing over every wallpaper: \
+            \(glassLines.map { "line \($0 + 1)" })
+            """
+        )
+
+        let owner = glassLines.first.map { index -> String in
+            lines[...index].reversed().first { $0.contains("func ") } ?? ""
+        }
+        #expect(
+            owner?.contains("newTabSurface") == true,
+            "The strip's one glass surface must belong to newTabSurface, not \(owner ?? "nothing")"
+        )
+    }
+
+    /// Fully rounded, because the system's own tab bar is. Its runtime view tree reports
+    /// `cornerRadius = 12` on each 24pt tab, exactly half the height, and a corner fit of the 28pt
+    /// track lands at 12 to 14pt. An earlier pass took the shallower `(height - 4) / 4` radius from
+    /// an in-content `NSSegmentedControl`, which is a different control in a different place.
+    @Test("The track and its tabs stay fully rounded")
+    func surfacesAreFullyRounded() throws {
+        let source = try Self.stripSource()
+        let lines = source.components(separatedBy: .newlines)
+        let shaped = lines.indices.filter {
+            lines[$0].contains("RoundedRectangle(") || lines[$0].contains("cornerRadius:")
+        }
+
+        #expect(
+            shaped.isEmpty,
+            """
+            The strip's surfaces take EditorTabStripLayout's capsule shapes, matching the system \
+            tab bar's own half-height corner radius: \(shaped.map { "line \($0 + 1)" })
+            """
+        )
+    }
+
+    private static func stripSource(file: StaticString = #filePath) throws -> String {
+        var directory = URL(fileURLWithPath: "\(file)").deletingLastPathComponent()
+        while directory.path != "/" {
+            let candidate = directory.appendingPathComponent("CLAUDE.md")
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                let strip = directory
+                    .appendingPathComponent("TablePro/Views/Main/EditorTabStrip.swift")
+                return try String(contentsOf: strip, encoding: .utf8)
+            }
+            directory = directory.deletingLastPathComponent()
+        }
+        throw GlassGuardError.repoRootNotFound
+    }
+
+    private enum GlassGuardError: Error {
+        case repoRootNotFound
+    }
+}

--- a/TableProTests/Views/Main/EditorTabStripSurfacesTests.swift
+++ b/TableProTests/Views/Main/EditorTabStripSurfacesTests.swift
@@ -2,11 +2,10 @@
 //  EditorTabStripSurfacesTests.swift
 //  TableProTests
 //
-//  The tab strip's selected surface cannot be rasterised on macOS 26 and later, because glass is
-//  composited by the window server rather than drawn into a view's context. What can be pinned is
-//  the arithmetic underneath it: that the track and the selection are pulled in opposite
-//  directions, and that the opaque surfaces the strip falls back to are two colours rather than
-//  one. They were one, and a background window on macOS 14 and 15 showed no selected tab at all.
+//  The strip's track and selected tab are opaque fills, so what these pin is the one
+//  property the selection rests on: that it can never resolve at or below the track, in any
+//  appearance. It used to be a pair of Liquid Glass tints, whose step was a function of the
+//  wallpaper behind the window and inverted outright on macOS 27 (#2439).
 //
 
 import AppKit
@@ -18,11 +17,22 @@ import Testing
 @Suite("Editor tab strip surfaces")
 @MainActor
 struct EditorTabStripSurfacesTests {
+    /// The two appearances that can actually be instantiated, and no more.
+    ///
+    /// This list used to carry `.accessibilityHighContrastAqua` and its dark twin as well, which
+    /// covered nothing: those constants carry the raw values "NSAppearanceNameAccessibilityAqua"
+    /// and "NSAppearanceNameAccessibilityDarkAqua", and `NSAppearance(named:)` resolves both back
+    /// to plain Aqua and DarkAqua, which `NSAppearance.currentDrawing().name` confirms from inside
+    /// the block. So the suite ran the same two appearances twice and reported four.
+    ///
+    /// Spelling the real names out does not rescue it either: "NSAppearanceNameAccessibilityHigh-
+    /// ContrastAqua" instantiates in a plain process and returns nil in the test host, so the
+    /// cases fail rather than cover anything. Increase Contrast is a system setting, not an
+    /// appearance to borrow, which is why the app reads it through `colorSchemeContrast` and why
+    /// `solidSurfacesAnswerBothSettings` below is where that contract is pinned.
     nonisolated private static let appearances: [NSAppearance.Name] = [
         .aqua,
         .darkAqua,
-        .accessibilityHighContrastAqua,
-        .accessibilityHighContrastDarkAqua,
     ]
 
     /// `NSColor.relativeLuminance` drops the alpha component, so a translucent fill has to be laid
@@ -101,37 +111,65 @@ struct EditorTabStripSurfacesTests {
         #expect(measured > 1.25)
     }
 
-    // MARK: - The glass tints
+    // MARK: - The selection can never invert
 
-    /// Neither tint means anything on its own. What holds the selection apart from its track is
-    /// that they are pushed in opposite directions from the same backdrop, which is the one thing
-    /// two `.regular` surfaces cannot do.
-    @Test("The track and the selection are tinted away from each other")
-    func tintsPullInOppositeDirections() {
-        let backdrop = NSColor(srgbRed: 0.5, green: 0.5, blue: 0.5, alpha: 1)
-        let subdued = composite(EditorTabStripEmphasis.trackTint, over: backdrop)
-        let lifted = composite(EditorTabStripEmphasis.selectionTint, over: backdrop)
-
-        #expect(subdued.relativeLuminance < backdrop.relativeLuminance)
-        #expect(lifted.relativeLuminance > backdrop.relativeLuminance)
-        #expect(lifted.relativeLuminance > subdued.relativeLuminance)
+    /// The defect behind #2439, expressed as the property that prevents it. In light appearance
+    /// `controlColor` is opaque white, so it is the ceiling and no track can rise above it; in
+    /// dark it is white at alpha 0.247, so it composites *over* whatever the track resolved to and
+    /// always lifts. Either way the selected tab is lighter than its track, by construction rather
+    /// than by a tuned distance. The Liquid Glass tints it replaced had neither guarantee.
+    @Test(
+        "The selected fill can never resolve at or below the track",
+        arguments: EditorTabStripSurfacesTests.appearances
+    )
+    func selectionNeverInverts(appearance: NSAppearance.Name) {
+        let measured = resolve(appearance) { () -> (CGFloat, CGFloat) in
+            let track = self.composite(EditorTabStripPalette.trackFill, over: .windowBackgroundColor)
+            let selected = self.composite(EditorTabStripPalette.selectedFill, over: track)
+            return (track.relativeLuminance, selected.relativeLuminance)
+        }
+        guard let measured else {
+            Issue.record("The strip's fills did not resolve")
+            return
+        }
+        #expect(measured.1 > measured.0)
     }
 
-    /// `Glass.regular` discards hue and reads only lightness, so a tint that carries a colour
-    /// measures the same as no tint at all and the selection goes back to being whatever the
-    /// backdrop makes it.
-    @Test("Both tints are neutral")
-    func tintsCarryNoHue() {
-        for tint in [EditorTabStripEmphasis.trackTint, EditorTabStripEmphasis.selectionTint] {
-            guard let resolved = NSColor(tint).usingColorSpace(.sRGB) else {
-                Issue.record("A tab strip tint did not resolve")
-                return
-            }
-            #expect(resolved.redComponent == resolved.greenComponent)
-            #expect(resolved.greenComponent == resolved.blueComponent)
-            #expect(resolved.alphaComponent > 0)
-            #expect(resolved.alphaComponent < 1)
+    /// A hovered tab has to stay a hint. The system darkens one in light appearance rather than
+    /// lightening it, so hover and selection travel in opposite directions and the only thing
+    /// worth pinning is that hover never travels further.
+    @Test(
+        "A hovered tab never moves further from the track than the selected one",
+        arguments: EditorTabStripSurfacesTests.appearances
+    )
+    func hoverNeverOutreadsTheSelection(appearance: NSAppearance.Name) {
+        let measured = resolve(appearance) { () -> (CGFloat, CGFloat) in
+            let track = self.composite(EditorTabStripPalette.trackFill, over: .windowBackgroundColor)
+            let hovered = self.composite(EditorTabStripPalette.hoverFill, over: track)
+            let selected = self.composite(EditorTabStripPalette.selectedFill, over: track)
+            return (
+                abs(hovered.relativeLuminance - track.relativeLuminance),
+                abs(selected.relativeLuminance - track.relativeLuminance)
+            )
         }
+        guard let measured else {
+            Issue.record("The strip's fills did not resolve")
+            return
+        }
+        #expect(measured.0 < measured.1)
+    }
+
+    /// The tab is inset inside the track by the padding on every side, so the two capsules stay
+    /// concentric at their ends and the selected one never overruns the track's curve. Both are
+    /// fully rounded, which is what the system's own tab bar draws: its runtime view tree reports
+    /// `cornerRadius = 12` on each 24pt tab, exactly half the height.
+    @Test("The tab is inset inside the track on every side")
+    func tabIsInsetInsideTheTrack() {
+        #expect(
+            EditorTabStripLayout.tabHeight
+                == EditorTabStripLayout.trackHeight - EditorTabStripLayout.trackPadding * 2
+        )
+        #expect(EditorTabStripLayout.trackHeight < EditorTabStripLayout.bandHeight)
     }
 
     // MARK: - Leaving glass behind


### PR DESCRIPTION
Fixes #2439.

## The bug

In light appearance the selected editor tab is indistinguishable from the unselected ones. Dark reads fine, which is what made this look like a tuning problem.

It is not. Measured on the reporter's own macOS 26 screenshots and on this machine's macOS 27 build:

| build | appearance | track | selected | delta | contrast |
| --- | --- | --- | --- | --- | --- |
| macOS 26, reporter | light | 222 | 228 | +6 | 1.058:1 |
| macOS 27, this machine | light | 232 | 220 | **-12** | sign inverted |
| macOS 26, reporter | dark | 25 | 77 | +53 | 2.096:1 |
| macOS 27, this machine | dark | 61 | 122 | +60 | 2.503:1 |

On macOS 27 the selected tab renders **darker** than its track, so it reads as recessed rather than raised. In the real titlebar-accessory context it also flips sign with window activation: +22 when the window is key, -12 when it is not.

## Root cause

The selection was expressed as a Liquid Glass tint. A glass tint's magnitude, and its sign, are a function of what is behind the window and of an undocumented per-release rendering pipeline, and the app controls neither.

Fitted to the reporter's pixels, the law is `selected = track + (255 - track) * alpha`. In light appearance there is almost no headroom left, so a white tint cannot lift: 222 + 33 * 0.22 = 229 against a measured 228. In dark there is plenty: 25 + 230 * 0.22 = 76 against a measured 77.

Three things follow, all measured rather than reasoned:

- **Backdrop.** Over four backdrops on macOS 27 the shipped tints give light `-12 / +20 / +52 / +29` and dark `-21 / +4 / +26 / +13`. The selection changes with the desktop picture.
- **The Clear/Tinted setting.** macOS 26.1 added a Liquid Glass appearance option with no public API to read it. Under Tinted the glass track moves from rgb(232) to rgb(242), costing 43 percent of the remaining margin.
- **No arrangement fixes it.** Twenty arrangements were rendered and sampled on macOS 27: nested tints, untinted, `Glass.clear` on either surface, separate `GlassEffectContainer`s, `glassEffectUnion`, `glassEffectID`, `.interactive()`, a raw `NSGlassEffectView` through `NSViewRepresentable`, and siblings. In light appearance **every one** put the selected tab darker than its track, from -4 to -35. Sibling glass inside one container merges outright: delta exactly 0.

The reason is in the SDK. `Glass` publishes exactly `regular`, `clear`, `identity`, `tint(_:)` and `interactive(_:)`, and `NSGlassEffectViewStyle` publishes only `Regular` and `Clear`. A runtime probe of the system's own `NSTabBar` shows why that is not enough: its track is a private `NSSubduedGlassEffectView`, and its selected tab is separated from the others by a private `_variant` on `NSGlassEffectView` (1 for the selected tab, 13 for the rest). Neither is reachable.

## The fix

The track and the selected tab become opaque fills. Only the new-tab button stays glass, which is the one surface whose tone carries no state.

That is Apple's own instruction for this shape. WWDC 2025 session 219: "always avoid glass on glass ... When placing elements on top of Liquid Glass, avoid applying the material to both layers. Instead, use fills, transparency, and vibrancy for the top elements." The strip sits in a titlebar accessory that is already the system's glass layer, so these fills are the top layer on it rather than a second pane of it.

It is also what Apple shipped after hitting this exact bug. Safari on Tahoe beta 1 and 2 measured track 247 / selected 242, an inverted 1.045:1. Beta 3 fixed it by subduing the track to 221 and lifting the selection to 247.

The colours are the ones the pre-macOS-26 path already used, so the two paths converge on one palette:

| | light | dark |
| --- | --- | --- |
| track, `unemphasizedSelectedContentBackgroundColor` | 220 | 70 |
| selected, `controlColor` | 255 | 116 |

Both are within a couple of levels of the system's own tab bar, which measures 232 / 253 in light and 71 / 74 in dark.

**Why the sign can no longer invert**, by construction rather than by tuning: `controlColor` is opaque white in light, so it is the ceiling and no track can rise above it; in dark it is white at alpha 0.247, so it composites over whatever the track resolved to and always lifts. `EditorTabStripSurfacesTests.selectionNeverInverts` pins exactly that.

The selected tab also gains the hairline rim it was missing. A vertical section through the system's own selected segment reads track 236, rim 215, highlight 255, body 242: the fill carries six levels and the edge carries twenty-one. Only the fill was drawn here before, which is why the selection read as flat even at the distance the system uses.

## Measured result, real app on macOS 27

| appearance | before | after |
| --- | --- | --- |
| light | track 232, selected 220 (**-12**, inverted) | track 220, selected 255 (**+35**, 1.371:1) |
| dark | track 61, selected 122 | track 70, selected 116 (**+46**, 2.019:1) |

Identical across four backdrops, in a key and a background window, and under both Clear and Tinted, because nothing in the pair samples anything any more.

## What did not change, and why

- **Shape stays a capsule.** The system's own tab bar reports `cornerRadius = 12` on each 24pt tab, exactly half its height, and a corner fit of its 28pt track lands at 12 to 14pt. An in-content `NSSegmentedControl` uses the shallower `(height - 4) / 4`, but that is a different control in a different place.
- **Geometry stays 36 / 28 / 24 / 8 / 4 / 2pt**, which is what the `NSTabBar` runtime probe reports.
- **Hover is untouched.** The system darkens a hovered tab in light rather than lightening it: its bar measures rgb(220) under the pointer against a rgb(232) track, and `tertiarySystemFill` gives rgb(210) against rgb(220). The direction already matches.
- **No accent underline.** Apple removed one from Safari's Tahoe tab bar in beta 3 because it confused users, and `controlAccentColor` is user-settable: a yellow accent measures 1.155:1 against this track.

## Also in this commit

`EditorTabStripSurfacesTests` ran four appearances and covered two. `NSAppearance.Name.accessibilityHighContrastAqua` carries the raw value `NSAppearanceNameAccessibilityAqua`, and `NSAppearance(named:)` resolves that back to plain Aqua, which `NSAppearance.currentDrawing().name` confirms from inside the block. Spelling the real name out does not rescue it either: it instantiates in a plain process and returns nil in the test host. Increase Contrast is a system setting rather than an appearance to borrow, so the two dead cases are gone and `solidSurfacesAnswerBothSettings` is where that contract is pinned.

`EditorTabStripEmphasis` loses its two tints and its rim constants, which duplicated `EditorTabStripLayout.hairline`. `prefersSolidSurfaces` no longer threads through `EditorTabStripItem`, since only the new-tab button reads it now.

## Tests

`EditorTabStripGlassGuardTests` is a source scan, because a `glassEffect` cannot be rasterised: `cacheDisplay` returns an empty bitmap for the whole hosting view, not merely for the glass. It asserts the strip declares exactly one glass surface and that it belongs to `newTabSurface`, and that no surface is drawn as a rounded rectangle.

`EditorTabStripSurfacesTests` gains the sign guarantee above, a check that a hovered tab never travels further from the track than the selected one, and a check that the tab stays inset inside the track on every side.

## Verification

- `generate`: PASS
- `build` (TablePro, Debug): PASS
- `test` `EditorTabStripSurfacesTests` `EditorTabStripGlassGuardTests` `EditorTabStripChromeTests` `EditorTabStripGestureConventionTests` `EditorTabActivationTests`: PASS, 36 of 36
- `lint` over `TablePro/Views/Main` and `TableProTests/Views/Main`: 0 violations
- Before and after captured from a running Debug build against a throwaway sandbox, in both appearances, and sampled with a CoreGraphics probe. The numbers above are from those captures.

No UI automation: the defect is a pixel relationship between two fills, which XCUITest cannot read, and the guard test states the structural property directly instead. No docs change, and no PluginKit ABI surface is touched.
