### PR TITLE
perf(plugin-mysql): bound a capped read at the server with SQL_SELECT_LIMIT (#2427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Whole MySQL and MariaDB result set fetched before a capped query returned its first rows. (#2427)
+- KILL sent to a different server when a MySQL or MariaDB connection's host is spelled `localhost`.
 - Save reporting the number of statements it ran as the number of rows it changed.
 - An edit or a delete on a table with no primary key changing every identical row. (#2107)
 - The same statements committed twice when Cmd+S is pressed again during a slow save.

--- a/Plugins/MySQLDriverPlugin/MariaDBPluginConnection.swift
+++ b/Plugins/MySQLDriverPlugin/MariaDBPluginConnection.swift
@@ -167,6 +167,22 @@ final class MariaDBPluginConnection: @unchecked Sendable {
     private var _isShuttingDown: Bool = false
     private var _cachedServerVersion: String?
 
+    /// The session's `SQL_SELECT_LIMIT` as this connection last confirmed it, `nil` while it still
+    /// holds `baselineSelectLimit`. Only ever touched from `queue`, which every statement path runs on.
+    private var appliedSelectLimit: UInt64?
+
+    /// What the session held before this connection first took the variable over, so restoring it
+    /// gives back a limit the server, an `init_connect` or the connection's own startup SQL had set
+    /// rather than overwriting it with `DEFAULT`. Read lazily, because startup commands run after
+    /// `connect()` returns. `nil` means it has not been captured, or could not be.
+    private var baselineSelectLimit: UInt64?
+    private var hasCapturedBaselineSelectLimit = false
+
+    /// Whether the connection that actually succeeded negotiated TLS. `.preferred` falls back to
+    /// plaintext, so the configured mode does not say what the transport ended up being, and the
+    /// `KILL` connection has to repeat what worked rather than what was asked for.
+    private var effectiveSSLEnforced = false
+
     var isConnected: Bool {
         stateLock.lock()
         defer { stateLock.unlock() }
@@ -245,6 +261,11 @@ final class MariaDBPluginConnection: @unchecked Sendable {
             if let versionPtr = mysql_get_server_info(handle) {
                 self._cachedServerVersion = String(cString: versionPtr)
             }
+
+            self.effectiveSSLEnforced = mysql_get_ssl_cipher(handle) != nil
+            self.appliedSelectLimit = nil
+            self.baselineSelectLimit = nil
+            self.hasCapturedBaselineSelectLimit = false
 
             self.stateLock.lock()
             self.mysql = handle
@@ -388,6 +409,18 @@ final class MariaDBPluginConnection: @unchecked Sendable {
         killQueryOnServer(threadId: mysql_thread_id(mysql))
     }
 
+    /// The kill has to reach the server the query is running on, which means repeating the transport
+    /// the primary connection chose. Without `MYSQL_OPT_PROTOCOL` a host spelled `localhost` resolves
+    /// to the default unix socket and the `port` argument is ignored, so `KILL QUERY` lands on a
+    /// different server, where that thread id belongs to somebody else's session.
+    ///
+    /// It carries the same credentials, so it may not be a weaker channel than the primary. TLS is
+    /// enforced whenever the primary's own connection negotiated it, and left unset otherwise so the
+    /// connector can still negotiate opportunistically; `MYSQL_OPT_SSL_ENFORCE` set to 0 does not mean
+    /// "no preference", it turns TLS off outright. Reading the configured mode instead of what the
+    /// connection actually got would break `.preferred`, the default, on a server with no TLS: the
+    /// primary succeeds through its plaintext fallback and every kill after it repeats the attempt
+    /// that already failed.
     private func killQueryOnServer(threadId: UInt) {
         guard threadId > 0 else { return }
 
@@ -399,8 +432,32 @@ final class MariaDBPluginConnection: @unchecked Sendable {
         mysql_options(killConn, MYSQL_OPT_READ_TIMEOUT, &killTimeout)
         mysql_options(killConn, MYSQL_OPT_WRITE_TIMEOUT, &killTimeout)
 
+        var killProtocol = UInt32(MYSQL_PROTOCOL_TCP.rawValue)
+        mysql_options(killConn, MYSQL_OPT_PROTOCOL, &killProtocol)
+
         var killAllowLocalInfile: UInt32 = 0
         mysql_options(killConn, MYSQL_OPT_LOCAL_INFILE, &killAllowLocalInfile)
+
+        if effectiveSSLEnforced {
+            var killSSLEnforce: my_bool = 1
+            mysql_options(killConn, MYSQL_OPT_SSL_ENFORCE, &killSSLEnforce)
+            var killSSLVerify: my_bool = sslConfig.verifiesCertificate ? 1 : 0
+            mysql_options(killConn, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &killSSLVerify)
+            if sslConfig.verifiesCertificate, !sslConfig.caCertificatePath.isEmpty {
+                _ = sslConfig.caCertificatePath.withCString { mysql_options(killConn, MYSQL_OPT_SSL_CA, $0) }
+            }
+            if !sslConfig.clientCertificatePath.isEmpty {
+                _ = sslConfig.clientCertificatePath.withCString { mysql_options(killConn, MYSQL_OPT_SSL_CERT, $0) }
+            }
+            if !sslConfig.clientKeyPath.isEmpty {
+                _ = sslConfig.clientKeyPath.withCString { mysql_options(killConn, MYSQL_OPT_SSL_KEY, $0) }
+            }
+        }
+
+        if enableCleartextPlugin {
+            var killEnableCleartext: my_bool = 1
+            mysql_options(killConn, MYSQL_ENABLE_CLEARTEXT_PLUGIN, &killEnableCleartext)
+        }
 
         let killResult = host.withCString { hostPtr in
             user.withCString { userPtr in
@@ -416,12 +473,89 @@ final class MariaDBPluginConnection: @unchecked Sendable {
 
         if killResult != nil {
             let killQuery = "KILL QUERY \(threadId)"
-            _ = killQuery.withCString { queryPtr in
+            let killStatus = killQuery.withCString { queryPtr in
                 mysql_real_query(killConn, queryPtr, UInt(killQuery.utf8.count))
             }
+            if killStatus != 0 {
+                logger.warning("KILL QUERY \(threadId) rejected: \(self.errorMessage(from: killConn))")
+            }
+        } else {
+            logger.warning("KILL QUERY \(threadId) could not connect: \(self.errorMessage(from: killConn))")
         }
 
         mysql_close(killConn)
+    }
+
+    private func errorMessage(from mysql: UnsafeMutablePointer<MYSQL>) -> String {
+        let code = mysql_errno(mysql)
+        guard let messagePtr = mysql_error(mysql) else { return "error \(code)" }
+        return "\(code) \(String(cString: messagePtr))"
+    }
+
+    // MARK: - Server-Side Row Cap
+
+    /// `SQL_SELECT_LIMIT` is session state, so it is reconciled before every statement rather than
+    /// left set: it bounds any later `SELECT` on this connection, `information_schema` and
+    /// `SHOW FULL COLUMNS` included. The cache moves only once the server confirms the change, so a
+    /// failed reset is something the next statement retries rather than a silent truncation.
+    /// Taken the first time this connection is about to own the variable, not at connect: the
+    /// connection's startup commands run after `connect()` returns, so a `SET SESSION
+    /// SQL_SELECT_LIMIT` among them would otherwise be captured too late to be restored and lost.
+    private func captureBaselineSelectLimit(from mysql: UnsafeMutablePointer<MYSQL>) {
+        guard !hasCapturedBaselineSelectLimit else { return }
+        hasCapturedBaselineSelectLimit = true
+
+        let probe = mysqlSelectLimitProbeStatement()
+        let status = probe.withCString { probePtr in
+            mysql_real_query(mysql, probePtr, UInt(probe.utf8.count))
+        }
+        guard status == 0, let result = mysql_store_result(mysql) else { return }
+        defer { mysql_free_result(result) }
+        guard let row = mysql_fetch_row(result), let valuePtr = row[0] else { return }
+        baselineSelectLimit = UInt64(String(cString: valuePtr))
+    }
+
+    private func reconcileSelectLimit(
+        rowCap: Int?,
+        statement query: String,
+        on mysql: UnsafeMutablePointer<MYSQL>
+    ) throws {
+        /// Only trustworthy while this connection holds no limit of its own: a statement misread as
+        /// single-row would otherwise keep a stale cap installed and end early under it, and the
+        /// client would compare that short count against the current cap and call it complete.
+        if appliedSelectLimit == nil, rowCap != nil, mysqlStatementReturnsAtMostOneRow(query) {
+            return
+        }
+
+        let desired = mysqlClampedRowCap(rowCap).map { mysqlSelectLimitRows(forRowCap: $0) }
+        let statement: String
+        switch mysqlSelectLimitAction(applied: appliedSelectLimit, desired: desired) {
+        case .none:
+            return
+        case .apply(let rows):
+            captureBaselineSelectLimit(from: mysql)
+            statement = mysqlSelectLimitStatement(rows: rows)
+        case .reset:
+            statement = baselineSelectLimit.map { mysqlSelectLimitStatement(rows: $0) }
+                ?? mysqlSelectLimitResetStatement()
+        }
+
+        let status = statement.withCString { statementPtr in
+            mysql_real_query(mysql, statementPtr, UInt(statement.utf8.count))
+        }
+        if let discarded = mysql_store_result(mysql) {
+            mysql_free_result(discarded)
+        }
+        guard status == 0 else {
+            let error = getError()
+            logger.warning("SQL_SELECT_LIMIT not reconciled: \(self.errorMessage(from: mysql))")
+            /// Failing to install a cap costs only the client-side fallback. Failing to move one that
+            /// is already installed would run the statement under a stricter limit than it asked for
+            /// and report the short result as complete.
+            guard appliedSelectLimit == nil else { throw error }
+            return
+        }
+        appliedSelectLimit = desired
     }
 
     private static func isExpectedInterruption(errno: UInt32, wasTruncated: Bool) -> Bool {
@@ -460,6 +594,9 @@ final class MariaDBPluginConnection: @unchecked Sendable {
 
         let generation = cancellationGate.beginQuery()
         defer { cancellationGate.endQuery(generation) }
+
+        try reconcileSelectLimit(rowCap: rowCap, statement: query, on: mysql)
+        if cancellationGate.isCancelled(generation) { throw CancellationError() }
 
         let queryStatus = query.withCString { queryPtr in
             mysql_real_query(mysql, queryPtr, UInt(query.utf8.count))
@@ -523,8 +660,9 @@ final class MariaDBPluginConnection: @unchecked Sendable {
         var rows: [[PluginCellValue]] = []
         rows.reserveCapacity(min(1_000, PluginRowLimits.emergencyMax))
 
-        let maxRows = rowCap.map { min(max($0, 1), PluginRowLimits.emergencyMax) } ?? PluginRowLimits.emergencyMax
-        var truncated = false
+        let maxRows = mysqlClampedRowCap(rowCap) ?? PluginRowLimits.emergencyMax
+        let fetchLimit = maxRows == PluginRowLimits.emergencyMax ? maxRows : maxRows + 1
+        var serverSentMore = false
 
         while let rowPtr = mysql_fetch_row(resultPtr) {
             if cancellationGate.isCancelled(generation) {
@@ -533,8 +671,8 @@ final class MariaDBPluginConnection: @unchecked Sendable {
                 throw CancellationError()
             }
 
-            if rows.count >= maxRows {
-                truncated = true
+            if rows.count >= fetchLimit {
+                serverSentMore = true
                 break
             }
 
@@ -566,8 +704,17 @@ final class MariaDBPluginConnection: @unchecked Sendable {
             rows.append(row)
         }
 
+        let outcome = mysqlBoundedFetchOutcome(
+            fetchedRows: rows.count,
+            rowCap: maxRows,
+            serverSentMore: serverSentMore
+        )
+        let truncated = outcome.isTruncated
         if truncated {
             logger.warning("Result set truncated at \(maxRows) rows")
+            rows.removeLast(rows.count - outcome.keptRows)
+        }
+        if outcome.serverIgnoredLimit {
             killQueryOnServer(threadId: mysql_thread_id(mysql))
             while mysql_fetch_row(resultPtr) != nil {}
         }
@@ -578,7 +725,7 @@ final class MariaDBPluginConnection: @unchecked Sendable {
         }
 
         let fetchErrno = mysql_errno(mysql)
-        if fetchErrno != 0, !Self.isExpectedInterruption(errno: fetchErrno, wasTruncated: truncated) {
+        if fetchErrno != 0, !Self.isExpectedInterruption(errno: fetchErrno, wasTruncated: outcome.serverIgnoredLimit) {
             let error = getError()
             mysql_free_result(resultPtr)
             throw error
@@ -712,8 +859,9 @@ final class MariaDBPluginConnection: @unchecked Sendable {
         }
 
         var rows: [[PluginCellValue]] = []
-        let maxRows = rowCap.map { min(max($0, 1), PluginRowLimits.emergencyMax) } ?? PluginRowLimits.emergencyMax
-        var truncated = false
+        let maxRows = mysqlClampedRowCap(rowCap) ?? PluginRowLimits.emergencyMax
+        let fetchLimit = maxRows == PluginRowLimits.emergencyMax ? maxRows : maxRows + 1
+        var serverSentMore = false
 
         while true {
             let fetchStatus = mysql_stmt_fetch(stmt)
@@ -726,8 +874,8 @@ final class MariaDBPluginConnection: @unchecked Sendable {
                 throw CancellationError()
             }
 
-            if rows.count >= maxRows {
-                truncated = true
+            if rows.count >= fetchLimit {
+                serverSentMore = true
                 break
             }
 
@@ -772,11 +920,17 @@ final class MariaDBPluginConnection: @unchecked Sendable {
             rows.append(row)
         }
 
-        if truncated {
+        let outcome = mysqlBoundedFetchOutcome(
+            fetchedRows: rows.count,
+            rowCap: maxRows,
+            serverSentMore: serverSentMore
+        )
+        if outcome.isTruncated {
             logger.warning("Prepared statement result truncated at \(maxRows) rows")
+            rows.removeLast(rows.count - outcome.keptRows)
         }
 
-        return (rows: rows, isTruncated: truncated)
+        return (rows: rows, isTruncated: outcome.isTruncated)
     }
 
     private func executeParameterizedQuerySync(
@@ -790,6 +944,9 @@ final class MariaDBPluginConnection: @unchecked Sendable {
 
         let generation = cancellationGate.beginQuery()
         defer { cancellationGate.endQuery(generation) }
+
+        try reconcileSelectLimit(rowCap: rowCap, statement: query, on: mysql)
+        if cancellationGate.isCancelled(generation) { throw CancellationError() }
 
         guard let stmt = mysql_stmt_init(mysql) else {
             throw MariaDBPluginError(code: 0, message: "Failed to initialize prepared statement", sqlState: nil)
@@ -912,6 +1069,13 @@ final class MariaDBPluginConnection: @unchecked Sendable {
 
                 guard !abort.isAborted else {
                     continuation.finish()
+                    return
+                }
+
+                do {
+                    try reconcileSelectLimit(rowCap: nil, statement: queryToRun, on: mysql)
+                } catch {
+                    continuation.finish(throwing: error)
                     return
                 }
 

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
@@ -135,6 +135,12 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         )
     }
 
+    /// The read is already bounded at its source: the connection caps the statement with
+    /// `SQL_SELECT_LIMIT` before running it, so the server never produces the rows past the cap.
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> PluginQueryResult? {
+        try await executeUserQuery(query: query, rowCap: rowCap, parameters: nil)
+    }
+
     func executeParameterized(query: String, parameters: [PluginCellValue]) async throws -> PluginQueryResult {
         guard let conn = mariadbConnection else {
             throw MariaDBPluginError.notConnected

--- a/Plugins/MySQLDriverPlugin/MySQLSelectLimitStatement.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLSelectLimitStatement.swift
@@ -1,0 +1,149 @@
+//
+//  MySQLSelectLimitStatement.swift
+//  MySQLDriverPlugin
+//
+
+import Foundation
+import TableProPluginKit
+
+internal enum MySQLSelectLimitAction: Equatable {
+    case none
+    case apply(UInt64)
+    case reset
+}
+
+internal struct MySQLBoundedFetchOutcome: Equatable {
+    let keptRows: Int
+    let isTruncated: Bool
+    let serverIgnoredLimit: Bool
+}
+
+internal func mysqlSelectLimitStatement(rows: UInt64) -> String {
+    "SET SQL_SELECT_LIMIT = \(rows)"
+}
+
+internal func mysqlSelectLimitResetStatement() -> String {
+    "SET SQL_SELECT_LIMIT = DEFAULT"
+}
+
+/// The explicit `LIMIT` is what lets the probe answer while the session limit is 0, where an
+/// unbounded `SELECT` would return no rows at all and read as a failed probe.
+internal func mysqlSelectLimitProbeStatement() -> String {
+    "SELECT @@sql_select_limit LIMIT 1"
+}
+
+internal func mysqlSelectLimitAction(applied: UInt64?, desired: UInt64?) -> MySQLSelectLimitAction {
+    guard applied != desired else { return .none }
+    guard let desired else { return .reset }
+    return .apply(desired)
+}
+
+internal func mysqlClampedRowCap(_ rowCap: Int?) -> Int? {
+    guard let rowCap, rowCap > 0 else { return nil }
+    return min(rowCap, PluginRowLimits.emergencyMax)
+}
+
+/// One row past the cap, so a result that ends on its own still says whether more rows existed.
+internal func mysqlSelectLimitRows(forRowCap rowCap: Int) -> UInt64 {
+    UInt64(rowCap) + 1
+}
+
+private let mysqlStatementScanLimit = 10_000
+
+/// Everything a row cap could bind, with comments, string literals and quoted identifiers removed so
+/// a keyword spelled inside one is never read as syntax.
+internal func mysqlStrippedStatementBody(_ sql: String) -> String {
+    let source = Array(sql.prefix(mysqlStatementScanLimit).unicodeScalars)
+    var body = String.UnicodeScalarView()
+    var index = 0
+
+    func peek(_ offset: Int) -> Unicode.Scalar? {
+        let position = index + offset
+        return position < source.count ? source[position] : nil
+    }
+
+    func skipToLineEnd() {
+        while index < source.count, source[index] != "\n" { index += 1 }
+    }
+
+    func skipQuoted(by terminator: Unicode.Scalar) {
+        index += 1
+        while index < source.count {
+            let scalar = source[index]
+            if scalar == "\\", peek(1) != nil {
+                index += 2
+                continue
+            }
+            if scalar == terminator {
+                if peek(1) == terminator {
+                    index += 2
+                    continue
+                }
+                index += 1
+                return
+            }
+            index += 1
+        }
+    }
+
+    while index < source.count {
+        let scalar = source[index]
+        switch scalar {
+        case "-" where peek(1) == "-":
+            skipToLineEnd()
+        case "#":
+            skipToLineEnd()
+        case "/" where peek(1) == "*":
+            index += 2
+            while index < source.count, !(source[index] == "*" && peek(1) == "/") { index += 1 }
+            index = min(index + 2, source.count)
+            body.append(" ")
+        case "'", "\"", "`":
+            skipQuoted(by: scalar)
+            body.append(" ")
+        default:
+            body.append(scalar)
+            index += 1
+        }
+    }
+
+    return String(body)
+}
+
+private func mysqlBodyMatches(_ body: String, _ pattern: String) -> Bool {
+    body.range(of: pattern, options: [.regularExpression, .caseInsensitive]) != nil
+}
+
+/// Installing the cap costs a `SET`, and a `SET` resets what `ROW_COUNT()` reports, so
+/// `UPDATE t SET ...; SELECT ROW_COUNT()` answered 0 rather than the UPDATE's count. Measured on
+/// MariaDB 12.3.2 and MySQL 8.4.11. A statement that can only ever return one row cannot be bound by
+/// any cap, so it is left to run against the session exactly as it stands.
+///
+/// Answering false when the statement really is single-row costs a redundant `SET`. Answering true
+/// when it is not would leave a cap unreconciled, which is why the caller only trusts this while it
+/// holds no limit of its own.
+internal func mysqlStatementReturnsAtMostOneRow(_ sql: String) -> Bool {
+    let body = mysqlStrippedStatementBody(sql)
+    guard mysqlBodyMatches(body, "^\\s*SELECT\\b") else { return false }
+    guard !mysqlBodyMatches(body, "\\b(UNION|INTERSECT|EXCEPT)\\b") else { return false }
+    guard !mysqlBodyMatches(body, "\\bVALUES\\b") else { return false }
+    guard let fromRange = body.range(
+        of: "\\bFROM\\b", options: [.regularExpression, .caseInsensitive]
+    ) else {
+        return true
+    }
+    return mysqlBodyMatches(String(body[fromRange.lowerBound...]), "^FROM\\s+DUAL\\s*$")
+}
+
+internal func mysqlBoundedFetchOutcome(
+    fetchedRows: Int,
+    rowCap: Int,
+    serverSentMore: Bool
+) -> MySQLBoundedFetchOutcome {
+    let truncated = serverSentMore || fetchedRows > rowCap
+    return MySQLBoundedFetchOutcome(
+        keptRows: truncated ? rowCap : fetchedRows,
+        isTruncated: truncated,
+        serverIgnoredLimit: serverSentMore
+    )
+}

--- a/TableProTests/Core/Database/BoundedQueryTests.swift
+++ b/TableProTests/Core/Database/BoundedQueryTests.swift
@@ -79,6 +79,30 @@ struct BoundedQueryTests {
         #expect(result.rows.count == 10)
         #expect(result.isTruncated)
     }
+
+    /// MySQL and Kafka bound the read inside `executeUserQuery` and opt in by delegating to it, so
+    /// the hook must answer with a result rather than nil. Returning nil would leave the caller on
+    /// the buffered fallback and the opt-in would look present while doing nothing.
+    @Test("A driver bounded at its source answers the hook instead of falling back")
+    func sourceBoundedDriverAnswersTheHook() async throws {
+        let driver = SourceBoundedStubDriver(rowCount: 50)
+
+        let result = try await driver.executeBoundedQuery(query: "SELECT * FROM t", rowCap: 10)
+
+        #expect(result != nil)
+        #expect(result?.rows.count == 10)
+        #expect(result?.isTruncated == true)
+    }
+
+    @Test("A driver bounded at its source reports a short result untruncated")
+    func sourceBoundedDriverBelowCap() async throws {
+        let driver = SourceBoundedStubDriver(rowCount: 4)
+
+        let result = try await driver.executeBoundedQuery(query: "SELECT * FROM t", rowCap: 10)
+
+        #expect(result?.rows.count == 4)
+        #expect(result?.isTruncated == false)
+    }
 }
 
 @Suite("PluginBoundedStream collector")
@@ -216,6 +240,39 @@ private final class NonBoundedStubDriver: PluginDatabaseDriver, @unchecked Senda
             rowsAffected: 0,
             executionTime: 0
         )
+    }
+
+    func fetchTables(schema: String?) async throws -> [PluginTableInfo] { [] }
+    func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] { [] }
+    func fetchIndexes(table: String, schema: String?) async throws -> [PluginIndexInfo] { [] }
+    func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] { [] }
+    func fetchTableDDL(table: String, schema: String?) async throws -> String { "" }
+    func fetchViewDefinition(view: String, schema: String?) async throws -> String { "" }
+    func fetchTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata {
+        PluginTableMetadata(tableName: table)
+    }
+    func fetchDatabases() async throws -> [String] { [] }
+    func fetchDatabaseMetadata(_ database: String) async throws -> PluginDatabaseMetadata {
+        PluginDatabaseMetadata(name: database)
+    }
+}
+
+private final class SourceBoundedStubDriver: PluginDatabaseDriver, @unchecked Sendable {
+    private let inner: NonBoundedStubDriver
+
+    init(rowCount: Int) {
+        inner = NonBoundedStubDriver(rowCount: rowCount)
+    }
+
+    func connect() async throws {}
+    func disconnect() {}
+
+    func execute(query: String) async throws -> PluginQueryResult {
+        try await inner.execute(query: query)
+    }
+
+    func executeBoundedQuery(query: String, rowCap: Int) async throws -> PluginQueryResult? {
+        try await executeUserQuery(query: query, rowCap: rowCap, parameters: nil)
     }
 
     func fetchTables(schema: String?) async throws -> [PluginTableInfo] { [] }

--- a/TableProTests/Plugins/MySQLSelectLimitTests.swift
+++ b/TableProTests/Plugins/MySQLSelectLimitTests.swift
@@ -1,0 +1,167 @@
+//
+//  MySQLSelectLimitTests.swift
+//  TableProTests
+//
+
+import TableProPluginKit
+import Testing
+
+@Suite("MySQL Server-Side Row Cap")
+struct MySQLSelectLimitTests {
+    @Test("The statement asks for one row past the cap")
+    func statementAsksForOneRowPastTheCap() {
+        let statement = mysqlSelectLimitStatement(rows: mysqlSelectLimitRows(forRowCap: 1_000))
+        #expect(statement == "SET SQL_SELECT_LIMIT = 1001")
+    }
+
+    @Test("The reset restores the server default rather than a number")
+    func resetRestoresTheServerDefault() {
+        #expect(mysqlSelectLimitResetStatement() == "SET SQL_SELECT_LIMIT = DEFAULT")
+    }
+
+    @Test("A cap is clamped to the emergency ceiling and a missing cap stays missing")
+    func capIsClamped() {
+        #expect(mysqlClampedRowCap(1_000) == 1_000)
+        #expect(mysqlClampedRowCap(nil) == nil)
+        #expect(mysqlClampedRowCap(0) == nil)
+        #expect(mysqlClampedRowCap(-1) == nil)
+        #expect(mysqlClampedRowCap(PluginRowLimits.emergencyMax + 1) == PluginRowLimits.emergencyMax)
+    }
+
+    @Test("Reconciling to the value already applied issues nothing")
+    func alreadyAppliedIssuesNothing() {
+        #expect(mysqlSelectLimitAction(applied: 1_001, desired: 1_001) == .none)
+        #expect(mysqlSelectLimitAction(applied: nil, desired: nil) == .none)
+    }
+
+    @Test("Reconciling to a different cap applies it")
+    func differentCapIsApplied() {
+        #expect(mysqlSelectLimitAction(applied: nil, desired: 1_001) == .apply(1_001))
+        #expect(mysqlSelectLimitAction(applied: 1_001, desired: 501) == .apply(501))
+    }
+
+    /// The reset is what keeps a capped read from truncating the next `information_schema` query on
+    /// the same connection, so an uncapped statement after a capped one must always issue it.
+    @Test("Reconciling to no cap resets the session")
+    func noCapResetsTheSession() {
+        #expect(mysqlSelectLimitAction(applied: 1_001, desired: nil) == .reset)
+    }
+
+    @Test("A result inside the cap is not truncated")
+    func resultInsideTheCapIsNotTruncated() {
+        let outcome = mysqlBoundedFetchOutcome(fetchedRows: 42, rowCap: 1_000, serverSentMore: false)
+        #expect(outcome.keptRows == 42)
+        #expect(outcome.isTruncated == false)
+        #expect(outcome.serverIgnoredLimit == false)
+    }
+
+    @Test("A result of exactly the cap is not truncated")
+    func exactlyTheCapIsNotTruncated() {
+        let outcome = mysqlBoundedFetchOutcome(fetchedRows: 1_000, rowCap: 1_000, serverSentMore: false)
+        #expect(outcome.keptRows == 1_000)
+        #expect(outcome.isTruncated == false)
+    }
+
+    /// The server is asked for `cap + 1`, so the extra row arriving is the only signal that more rows
+    /// existed. It is counted and then dropped.
+    @Test("One row past the cap means truncated, and that row is dropped")
+    func oneRowPastTheCapMeansTruncated() {
+        let outcome = mysqlBoundedFetchOutcome(fetchedRows: 1_001, rowCap: 1_000, serverSentMore: false)
+        #expect(outcome.keptRows == 1_000)
+        #expect(outcome.isTruncated == true)
+        #expect(outcome.serverIgnoredLimit == false)
+    }
+
+    /// `CALL`, and a statement carrying its own larger `LIMIT`, are not bounded by the session
+    /// variable, so the client still has to stop the read and the server still has to be told.
+    @Test("Rows arriving past the requested limit mean the server ignored it")
+    func serverIgnoringTheLimitIsReported() {
+        let outcome = mysqlBoundedFetchOutcome(fetchedRows: 1_001, rowCap: 1_000, serverSentMore: true)
+        #expect(outcome.keptRows == 1_000)
+        #expect(outcome.isTruncated == true)
+        #expect(outcome.serverIgnoredLimit == true)
+    }
+
+    @Test("A cap of one keeps one row and still detects more")
+    func capOfOne() {
+        #expect(mysqlBoundedFetchOutcome(fetchedRows: 1, rowCap: 1, serverSentMore: false).isTruncated == false)
+        let overflow = mysqlBoundedFetchOutcome(fetchedRows: 2, rowCap: 1, serverSentMore: false)
+        #expect(overflow.keptRows == 1)
+        #expect(overflow.isTruncated == true)
+    }
+
+    @Test("An empty result is not truncated")
+    func emptyResultIsNotTruncated() {
+        let outcome = mysqlBoundedFetchOutcome(fetchedRows: 0, rowCap: 1_000, serverSentMore: false)
+        #expect(outcome.keptRows == 0)
+        #expect(outcome.isTruncated == false)
+    }
+
+    /// Installing the cap costs a `SET`, and a `SET` resets what `ROW_COUNT()` reports, so
+    /// `UPDATE t SET ...; SELECT ROW_COUNT()` answered 0 instead of the UPDATE's count. Measured on
+    /// MariaDB 12.3.2 and MySQL 8.4.11.
+    @Test("A single-row expression needs no server-side cap")
+    func singleRowExpressionsNeedNoCap() {
+        #expect(mysqlStatementReturnsAtMostOneRow("SELECT ROW_COUNT()"))
+        #expect(mysqlStatementReturnsAtMostOneRow("SELECT LAST_INSERT_ID()"))
+        #expect(mysqlStatementReturnsAtMostOneRow("SELECT 1"))
+        #expect(mysqlStatementReturnsAtMostOneRow("  select  @@sql_select_limit  "))
+    }
+
+    /// `FROM DUAL` is MySQL's own spelling for "no table", so it stays a single-row expression.
+    @Test("FROM DUAL is still a single-row expression")
+    func fromDualIsSingleRow() {
+        #expect(mysqlStatementReturnsAtMostOneRow("SELECT ROW_COUNT() FROM DUAL"))
+        #expect(mysqlStatementReturnsAtMostOneRow("select 1 from dual"))
+    }
+
+    @Test("A statement that reads a table is not a single-row expression")
+    func tableReadsAreNotSingleRow() {
+        #expect(mysqlStatementReturnsAtMostOneRow("SELECT * FROM big") == false)
+        #expect(mysqlStatementReturnsAtMostOneRow("select id\nfrom events\nwhere id > 1") == false)
+        #expect(mysqlStatementReturnsAtMostOneRow("SELECT a FROM(SELECT 1 AS a) t") == false)
+        #expect(mysqlStatementReturnsAtMostOneRow("WITH x AS (SELECT * FROM t) SELECT * FROM x") == false)
+    }
+
+    /// The reviewed draft skipped the cap for anything without a `FROM`, which left a stale cap
+    /// installed in front of a multi-row constant query and reported the short result as complete.
+    @Test("A set operation or VALUES is not a single-row expression even with no FROM")
+    func setOperationsAreNotSingleRow() {
+        #expect(mysqlStatementReturnsAtMostOneRow("SELECT 1 UNION ALL SELECT 2") == false)
+        #expect(mysqlStatementReturnsAtMostOneRow("SELECT 1 UNION SELECT 2") == false)
+        #expect(mysqlStatementReturnsAtMostOneRow("VALUES ROW(1), ROW(2)") == false)
+        #expect(mysqlStatementReturnsAtMostOneRow("TABLE big") == false)
+    }
+
+    /// A keyword inside a comment or a literal is text, not syntax.
+    @Test("A keyword inside a comment or a literal is not read as syntax")
+    func commentsAndLiteralsAreNotSyntax() {
+        #expect(mysqlStatementReturnsAtMostOneRow("SELECT ROW_COUNT() /* FROM the prior update */"))
+        #expect(mysqlStatementReturnsAtMostOneRow("SELECT ROW_COUNT(), 'FROM'"))
+        #expect(mysqlStatementReturnsAtMostOneRow("SELECT ROW_COUNT() -- FROM big"))
+        #expect(mysqlStatementReturnsAtMostOneRow("SELECT ROW_COUNT() # UNION ALL SELECT 2"))
+        #expect(mysqlStatementReturnsAtMostOneRow("SELECT `from`, `union`"))
+        #expect(mysqlStatementReturnsAtMostOneRow("SELECT 'it''s FROM here'"))
+    }
+
+    @Test("A statement that is not a SELECT is never treated as a single-row expression")
+    func nonSelectStatementsAreNotSingleRow() {
+        #expect(mysqlStatementReturnsAtMostOneRow("UPDATE t SET v = 1") == false)
+        #expect(mysqlStatementReturnsAtMostOneRow("SHOW WARNINGS") == false)
+        #expect(mysqlStatementReturnsAtMostOneRow("") == false)
+    }
+
+    @Test("Stripping removes comments and quoted text and keeps the rest")
+    func strippingRemovesQuotedText() {
+        #expect(mysqlStrippedStatementBody("SELECT 1 -- FROM big").contains("FROM") == false)
+        #expect(mysqlStrippedStatementBody("SELECT /* FROM */ 1").contains("FROM") == false)
+        #expect(mysqlStrippedStatementBody("SELECT 'FROM' FROM t").contains("FROM"))
+    }
+
+    /// The probe carries its own `LIMIT` so it still answers when the session limit is 0, where an
+    /// unbounded read would return no rows and read as a failed probe.
+    @Test("The baseline probe carries its own LIMIT")
+    func baselineProbeCarriesItsOwnLimit() {
+        #expect(mysqlSelectLimitProbeStatement() == "SELECT @@sql_select_limit LIMIT 1")
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -410,6 +410,7 @@ targets:
       - Plugins/MySQLDriverPlugin/MySQLGeneratedColumnClassification.swift
       - Plugins/MySQLDriverPlugin/MySQLObjectQueries.swift
       - Plugins/MySQLDriverPlugin/MySQLQueryTimeoutStatement.swift
+      - Plugins/MySQLDriverPlugin/MySQLSelectLimitStatement.swift
       - Plugins/MySQLDriverPlugin/MySQLSocketTimeout.swift
       - Plugins/MySQLDriverPlugin/MySQLStatementClassification.swift
       - Plugins/MySQLDriverPlugin/MySQLTransactionStatement.swift

--- a/scripts/check-mysql-select-limit.sh
+++ b/scripts/check-mysql-select-limit.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+#
+# Check that SQL_SELECT_LIMIT still means what the MySQL driver assumes it means.
+#
+# The driver caps a query-tab read by setting the session variable SQL_SELECT_LIMIT to one row past
+# the cap, instead of stopping the read on the client and then killing the statement from a second
+# connection. That is only safe because of a handful of server behaviours that no test in the repo
+# can reach: the variable must bound the outermost result and nothing else, an explicit LIMIT in the
+# statement must win, DML that carries a SELECT must copy every row, and DEFAULT must restore. If a
+# server release changed any of those, a capped read would silently return wrong data rather than
+# fewer rows, so this re-measures them against a live server.
+#
+# Verified against MariaDB 12.3.2 and MySQL 8.4.11.
+#
+# Usage:
+#   MYSQL_PWD=secret scripts/check-mysql-select-limit.sh [host] [port] [user]
+#
+# The password is read from MYSQL_PWD only. It is never taken as an argument, because an argument
+# lands in this script's own argv and usually in shell history too.
+#
+# TLS is negotiated normally. Pass --insecure to turn it off, which is refused for anything but a
+# loopback host.
+#
+# Needs a mysql or mariadb client and an account that can create a database. It creates a scratch
+# database of its own and drops only that one. Exits non-zero on a disagreement.
+
+set -uo pipefail
+
+INSECURE=0
+args=()
+for arg in "$@"; do
+    case "$arg" in
+        --insecure) INSECURE=1 ;;
+        *) args+=("$arg") ;;
+    esac
+done
+set -- ${args[@]+"${args[@]}"}
+
+HOST="${1:-127.0.0.1}"
+PORT="${2:-3306}"
+USER="${3:-root}"
+ROWS=5000
+CAP=5
+
+if [ "$INSECURE" = "1" ]; then
+    case "$HOST" in
+        127.0.0.1 | ::1 | localhost) ;;
+        *)
+            echo "--insecure is only allowed against a loopback host, not $HOST" >&2
+            exit 2
+            ;;
+    esac
+fi
+
+CLIENT=""
+for candidate in mariadb mysql; do
+    if command -v "$candidate" > /dev/null 2>&1; then
+        CLIENT="$candidate"
+        break
+    fi
+done
+[ -n "$CLIENT" ] || {
+    echo "neither mariadb nor mysql client found" >&2
+    exit 2
+}
+
+client_args=(-h "$HOST" -P "$PORT" -u "$USER")
+[ "$INSECURE" = "1" ] && client_args+=(--skip-ssl)
+
+run() { "$CLIENT" "${client_args[@]}" -N -B -e "$1" 2> /dev/null; }
+run_db() { "$CLIENT" "${client_args[@]}" -N -B "$DB" -e "$1" 2> /dev/null; }
+
+run "SELECT 1" > /dev/null || {
+    echo "cannot reach $USER@$HOST:$PORT" >&2
+    exit 2
+}
+
+SERVER="$(run 'SELECT VERSION()')"
+echo "server: $SERVER"
+
+# A fixed name would let this drop somebody's existing database, so it takes a name nothing else
+# holds and arms the cleanup only once the CREATE has succeeded. CREATE DATABASE without IF NOT
+# EXISTS is what makes the collision an error rather than an adoption.
+DB="tablepro_select_limit_check_$$_${RANDOM}"
+run "CREATE DATABASE \`$DB\`" > /dev/null
+[ "$(run "SELECT COUNT(*) FROM information_schema.schemata WHERE SCHEMA_NAME = '$DB'")" = "1" ] || {
+    echo "could not create the scratch database $DB" >&2
+    exit 2
+}
+cleanup() { run "DROP DATABASE IF EXISTS \`$DB\`" > /dev/null; }
+trap cleanup EXIT
+# Doubling beats a recursive CTE here: MySQL caps one with cte_max_recursion_depth and MariaDB with
+# max_recursive_iterations, and neither server knows the other's name for it.
+run_db "
+CREATE TABLE big (id INT PRIMARY KEY AUTO_INCREMENT, note VARCHAR(32));
+CREATE TABLE dest (id INT, note VARCHAR(32));
+INSERT INTO big (note) VALUES ('r'),('r'),('r'),('r'),('r'),('r'),('r'),('r'),('r'),('r');
+" > /dev/null
+while [ "$(run_db 'SELECT COUNT(*) FROM big')" -lt "$ROWS" ] 2> /dev/null; do
+    run_db "INSERT INTO big (note) SELECT note FROM big" > /dev/null || break
+done
+
+ROWS="$(run_db 'SELECT COUNT(*) FROM big')"
+[ -n "$ROWS" ] && [ "$ROWS" -ge 100 ] 2> /dev/null || {
+    echo "could not seed the scratch table (got ${ROWS:-none} rows)" >&2
+    exit 2
+}
+echo "seeded $ROWS rows"
+
+failures=0
+
+expect_rows() {
+    local label="$1" expected="$2" sql="$3"
+    local actual
+    actual="$(run_db "SET SQL_SELECT_LIMIT=$CAP; $sql" | wc -l | tr -d ' ')"
+    if [ "$actual" = "$expected" ]; then
+        printf '  ok    %-52s %s rows\n' "$label" "$actual"
+    else
+        printf '  FAIL  %-52s expected %s rows, got %s\n' "$label" "$expected" "$actual"
+        failures=$((failures + 1))
+    fi
+}
+
+expect_value() {
+    local label="$1" expected="$2" sql="$3"
+    local actual
+    actual="$(run_db "$sql")"
+    if [ "$actual" = "$expected" ]; then
+        printf '  ok    %-52s %s\n' "$label" "$actual"
+    else
+        printf '  FAIL  %-52s expected %s, got %s\n' "$label" "$expected" "${actual:-none}"
+        failures=$((failures + 1))
+    fi
+}
+
+echo "bounds the outermost result (SQL_SELECT_LIMIT=$CAP):"
+expect_rows "plain SELECT" "$CAP" "SELECT id FROM big"
+expect_rows "UNION ALL" "$CAP" "SELECT id FROM big UNION ALL SELECT id FROM big"
+expect_rows "parenthesised UNION ALL" "$CAP" "(SELECT id FROM big) UNION ALL (SELECT id FROM big)"
+expect_rows "information_schema SELECT" "$CAP" "SELECT TABLE_NAME FROM information_schema.columns"
+
+echo "an explicit LIMIT wins, in both directions:"
+expect_rows "LIMIT below the session value" 3 "SELECT id FROM big LIMIT 3"
+expect_rows "LIMIT above the session value" 50 "SELECT id FROM big LIMIT 50"
+
+echo "leaves everything that is not the outermost result alone:"
+expect_value "scalar subquery" "$ROWS" \
+    "SET SQL_SELECT_LIMIT=$CAP; SELECT (SELECT COUNT(*) FROM big)"
+expect_value "derived table" "$ROWS" \
+    "SET SQL_SELECT_LIMIT=$CAP; SELECT COUNT(*) FROM (SELECT * FROM big) t"
+expect_value "common table expression" "$ROWS" \
+    "SET SQL_SELECT_LIMIT=$CAP; SELECT COUNT(*) FROM (WITH x AS (SELECT * FROM big) SELECT * FROM x) y"
+expect_value "INSERT ... SELECT copies every row" "$ROWS" \
+    "SET SQL_SELECT_LIMIT=$CAP; TRUNCATE dest; INSERT INTO dest SELECT * FROM big; SELECT COUNT(*) FROM dest"
+expect_value "REPLACE ... SELECT copies every row" "$ROWS" \
+    "SET SQL_SELECT_LIMIT=$CAP; TRUNCATE dest; REPLACE INTO dest SELECT * FROM big; SELECT COUNT(*) FROM dest"
+expect_value "CREATE TABLE ... SELECT copies every row" "$ROWS" \
+    "SET SQL_SELECT_LIMIT=$CAP; DROP TABLE IF EXISTS ctas; CREATE TABLE ctas AS SELECT * FROM big; SELECT COUNT(*) FROM ctas"
+
+# Counted as rows the client actually received. A COUNT(*) here would pass even if the reset did
+# nothing, because the session limit bounds the one-row outer result and not the derived table.
+echo "DEFAULT restores the session:"
+expect_rows "reset clears the cap" "$ROWS" \
+    "SET SQL_SELECT_LIMIT=DEFAULT; SELECT id FROM big"
+
+if [ "$failures" -ne 0 ]; then
+    echo
+    echo "$failures disagreement(s) against $SERVER." >&2
+    echo "MySQLSelectLimitStatement.swift and MariaDBPluginConnection's bounded read rest on these." >&2
+    exit 1
+fi
+
+echo
+echo "all checks agree with $SERVER"


### PR DESCRIPTION
Fixes #2427.

## What is actually wrong

TablePro bounds a large MySQL or MariaDB read **on the client**, then tries to stop the *server* through a side channel: a brand-new connection issuing `KILL QUERY`. When that side channel is refused, misrouted or simply slow, the whole result set still crosses the network before the first row reaches the grid. The parameterized path never even tries.

#2430 added the `executeBoundedQuery` hook and its body claimed MySQL "already did ... Unchanged". It did not. `grep executeBoundedQuery Plugins/MySQLDriverPlugin/` finds nothing, so the PluginKit default returns nil and every MySQL query falls back to `executeUserQuery`. The claim was about the older client-side cap in `executeUserQuery`, which is the mechanism that is broken.

The side channel is unavoidable *given that design*, and I measured why:

| | |
|---|---|
| `mysql_kill()` on the live connection, mid-result | errno 2014 `Commands out of sync` |
| `mariadb_cancel(MYSQL *)` | rc = -1, and it kills the **connection** (errno 2026, then 2006 `Server has gone away`) |

So a second connection genuinely is the only way to stop a result set that is already streaming. Which is the argument for never starting one.

**MySQL and MariaDB expose a server-side row cap, `SQL_SELECT_LIMIT`, and TablePro has never used it.** It is what MySQL Connector/J implements `Statement.setMaxRows()` with (`ConnectionImpl.java:2388-2394`), which is how DBeaver bounds a MySQL read on its default path.

## Measured, end to end, through the real plugin bundle

A Swift harness loads a built `MySQLDriver.tableplugin` and calls the driver directly. Baseline is the plugin built from `5f162aa79`, the merge base. Local MariaDB 12.3.2, 2,000,000-row InnoDB table, `SELECT * FROM big`, cap 1,000, loopback.

**A server that allows the second connection:**

| | before | after |
|---|---|---|
| `executeBoundedQuery` | `nil`, the hook is dead | **2.2 ms**, 1,000 rows, truncated, `columnMeta` intact |
| `executeUserQuery` | 36.7 ms | **1.8 ms** |
| `SELECT ... LIMIT 1000` (the ceiling) | 2.0 ms | 2.1 ms |

**A server that refuses it** (a user at `MAX_USER_CONNECTIONS 1`, standing in for AWS RDS denying plain `KILL`, a proxy where `mysql_thread_id` names the wrong backend, or a connection limit):

| | before | after |
|---|---|---|
| `executeUserQuery` | **679.0 ms** | **1.6 ms** |

That 679 ms is 138 MB of rows nobody asked for. On a 100 Mbit link it is about 11 seconds, which is the reporter's "around 10 seconds".

Deleting the client-side drain loop would not have helped: `mysql_free_result` on an unbuffered result reads the tail itself, 0.813 s against 0.818 s. The cost belongs to the server still sending.

The parameterized path was worse, because it applied the cap and then issued no `KILL` and no drain at all, leaving `mysql_stmt_close` to pay for everything: **875 ms**, against 0.9 ms with the limit set.

## The change

`MariaDBPluginConnection` gains one concept: **a statement that arrives with a row cap asks the server to stop at `cap + 1` before it runs.** The invariant that makes it safe is that a `rowCap` already means the caller discards rows past the cap, so a server-side limit is a no-op on what the caller sees; it only stops the rows being produced.

- `MySQLSelectLimitStatement.swift` holds the pure statement builders and the two decisions worth testing: what to reconcile to, and what a fetch count means.
- `reconcileSelectLimit` runs before every statement on the primary handle, from the connection's serial queue, and moves its cached value **only when the server confirms the change**. Failing to install a cap costs only the client-side fallback and is logged. Failing to move one that is already installed throws, because running the statement under a stricter limit than it asked for and reporting the short result as complete is silent data loss.
- The cap is not installed in front of a statement that can only ever return one row, and only while this connection holds no limit of its own. A `SET` resets what `ROW_COUNT()` reports, so `UPDATE t SET ...; SELECT ROW_COUNT()` would have answered 0 rather than 3, measured on both engines. The test strips comments, string literals and quoted identifiers first, so a keyword spelled inside one is never read as syntax, and `FROM DUAL` still counts as no table.
- The session's own `SQL_SELECT_LIMIT` is captured lazily, the first time this connection is about to take the variable over. At connect would be too early: the connection's startup commands run after `connect()` returns, so a `SET SESSION SQL_SELECT_LIMIT` among them would have been lost rather than restored.
- Reconciling before every statement, rather than leaving the variable set, is what keeps a capped read from truncating the next `information_schema` query on the same connection. Measured: it does apply to those. Back-to-back capped reads at one cap still issue one `SET` and none after, which is Connector/J's own optimisation.
- The client reads one row past the cap so the result reaches its natural end. `killQueryOnServer` and the drain survive but now fire only when the server ignored the limit: a `CALL`, or a statement carrying its own larger `LIMIT`, both measured uncapped by the variable.
- `MySQLPluginDriver.executeBoundedQuery` delegates to the capped read, the one-line idiom `KafkaPluginDriver.swift:200` already ships for a driver bounded at its source. Not `boundedQueryFromStream`, which cannot carry `columnMeta`.

### Why `SQL_SELECT_LIMIT` is safe here

Measured on **both** MariaDB 12.3.2 and MySQL 8.4.11, and committed as `scripts/check-mysql-select-limit.sh` so a server upgrade re-checks it rather than trusting this paragraph:

- Bounds the outermost result: top-level `SELECT`, `UNION [ALL]`, `VALUES`, `TABLE t`, an `information_schema` `SELECT`.
- Leaves everything else alone: scalar subqueries, derived tables, CTEs, `INSERT ... SELECT`, `CREATE TABLE ... SELECT`, `REPLACE ... SELECT`. All copied every one of their rows with the limit set.
- An explicit `LIMIT` always wins, above and below the session value.
- `SET SQL_SELECT_LIMIT = DEFAULT` restores. It is not transactional, so `ROLLBACK` does not restore it and `USE <db>` does not clear it; the reconcile is the only thing that touches it.

Your SQL still reaches the server exactly as you wrote it. Nothing is rewritten.

### Honest limit

This bounds the rows the server *returns*. It cannot make a blocking plan node finish sooner. On the same table, `ORDER BY` on an unindexed column went 925 ms to 462 ms, and `GROUP BY` stayed at about 11.3 s for every variant including an explicit `LIMIT`, because `mysql_real_query` blocks before row 1. We do not have @Nisgrak's SQL. If it is a `GROUP BY`, this removes the transfer but not the wait, and that 11.3 s is uncomfortably close to the reported number, so the query would be worth seeing.

## Also fixed

`killQueryOnServer` set no `MYSQL_OPT_PROTOCOL`, while the primary connect sets `MYSQL_PROTOCOL_TCP`. Measured with the shipped library: with the host spelled `localhost` the primary reaches `localhost via TCP/IP` and the kill connection reaches `Localhost via UNIX socket`, ignoring the `port` argument entirely. Against a second local instance on another port it still went down the default socket, so `KILL QUERY <threadId>` landed on a different server, where that thread id belongs to somebody else's session. It now repeats the primary's transport and its cleartext-auth option, and logs a refused connect or a rejected `KILL` instead of discarding it silently.

## Rejected

- **Rewriting the SQL to append a `LIMIT`.** TablePlus does this and it is TablePlus #1683 (a trailing `--` swallows it) and #2422 (a leading comment skips it).
- **`SET STATEMENT SQL_SELECT_LIMIT=n FOR <stmt>`.** Works and self-restores, but MariaDB-only, and still text rewriting.
- **A read-only server cursor** (`STMT_ATTR_CURSOR_TYPE` = `CURSOR_TYPE_READ_ONLY` with `STMT_ATTR_PREFETCH_ROWS`), the other classic server-side bound. Measured: `mysql_stmt_execute` alone costs **805 ms** because the server materialises the whole result into an internal temporary table before returning. It makes the server do more work, not less.
- **`CLIENT_MULTI_STATEMENTS`** to fold the `SET` into one round trip. The connection passes `client_flag = 0` today, and widening the injection surface to save a round trip is a bad trade.

## Verification

| Step | Result |
|---|---|
| `verify.sh build` | PASS |
| `verify.sh test MySQLSelectLimitTests BoundedQueryTests PluginStreamAbortTests MySQLQueryTimeoutTests QueryExecutorTests` | PASS, 75 cases |
| `verify.sh lint Plugins/MySQLDriverPlugin TableProTests/Plugins` | 0 violations |
| `MySQLDriver` scheme | BUILD SUCCEEDED |
| `shellcheck --severity=warning scripts/check-mysql-select-limit.sh` | clean |
| `scripts/check-mysql-select-limit.sh` | all checks agree, on MariaDB 12.3.2 and MySQL 8.4.11 |
| End-to-end harness, before and after | the tables above |
| Codex `review` | 5 findings, all acted on |
| Codex `adversarial-review` | 6 findings, all acted on |

New tests: `MySQLSelectLimitTests` over the reconcile decision and the fetch-count outcome, including the case a reviewer caught in the draft, where leaving the client cap at `cap` rather than `cap + 1` would have kept the `KILL` firing on every capped `SELECT`. Two cases added to `BoundedQueryTests` for a driver bounded at its source, so the hook returning nil (the opt-in present but doing nothing) fails.

No UI automation: the flow needs a live MariaDB with a multi-million-row table and no deterministic fixture exists for it. No screenshots: nothing visual changed, the row cap affordance already shipped.

`swiftformat` could not run: the local binary rejects `--ifdefindent` from `.swiftformat`. SwiftLint is clean.

No PluginKit change, so no ABI bump and no plugin re-release. MySQL is a bundled plugin and ships with the app.

## What the review changed

Codex reviewed the diff and found five things. All five were real and all five are fixed; the measurements are in this PR because they came out of chasing them.

1. **A hidden `SET` clobbers `ROW_COUNT()`.** Measured 3 to 0 on MariaDB 12.3.2 and MySQL 8.4.11. Fixed by not installing the cap on a statement that reads no row source. `SHOW WARNINGS` turned out to survive the `SET`, so that half of the finding did not hold.
2. **A failed reconcile still ran the user's SQL.** A stale, stricter limit would end an uncapped `SELECT` at `oldCap + 1` rows and report it complete. It now throws, and the cancellation gate is rechecked after the hidden `SET`.
3. **The reset discarded a session limit the connection arrived with.** Now captured at connect and restored.
4. **The live-server check could not detect a broken reset.** It counted `SELECT COUNT(*) FROM (SELECT ...)`, whose one-row outer result is not bounded by the session limit, so it passed either way. It now counts rows the client actually received.
5. **The check script put the password in `argv`.** It goes through the environment now.

A sixth came out of reviewing my own diff for the security pass: the kill connection had gained `MYSQL_ENABLE_CLEARTEXT_PLUGIN` without mirroring the primary's TLS, so cleartext auth could have gone over a plaintext channel.

Then `adversarial-review` attacked the result and returned "do not ship" with six more. All six were real:

1. **A stale cap could be reported as a complete result.** Run a query at cap 5, raise the Row Cap setting, then run a multi-row query with no `FROM`: the draft skipped reconciliation entirely, the server ended at the old limit, and the client called the short result complete. The skip now applies only while the connection holds no limit of its own, so a misread statement can cost a redundant `SET` but never a silent truncation.
2. **`SELECT ROW_COUNT() FROM DUAL`, and `FROM` inside a comment or a literal, defeated the first version of that test.** It is now a proper scan that strips comments, strings and quoted identifiers, and it recognises set operations and `VALUES` rather than just looking for `FROM`.
3. **The kill connection forced TLS from the configured mode.** `.preferred` is the default and falls back to plaintext, so on a server without TLS the primary would connect and every `KILL` after it would repeat the attempt that had already failed, breaking Stop. It now reproduces what the primary actually negotiated, read from `mysql_get_ssl_cipher`.
4. **The baseline was captured too early and could not see a limit of 0.** Fixed by capturing lazily and giving the probe its own `LIMIT 1`, since an unbounded probe returns no rows at all when the session limit is 0 and reads as a failed probe.
5. **The check script would have dropped a pre-existing database of the same name.** It now creates a uniquely named one, fails rather than adopting a collision, and arms its cleanup only after the create succeeded. Verified: a planted `tablepro_select_limit_check` survives a run untouched.
6. **The check script took the password as an argument and always disabled TLS.** The password now comes from `MYSQL_PWD` only, and TLS is negotiated normally unless `--insecure` is passed, which is refused for anything but a loopback host.

The three behaviours those findings named are now measured against the baseline plugin, and match it: `ROW_COUNT()` after an `UPDATE` of 3 rows returns 3, `ROW_COUNT() FROM DUAL` returns 3, and a 7-row constant query run after a cap of 5 returns 7 rows with `truncated=false`.

## Found while investigating, not shipped here

Each was verified by an adversarial pass that tried to refute it, and each has a reproduction. None is a regression from this change.

1. **User Stop blocks the main thread for up to 5 seconds.** `DatabaseManager` is `@MainActor` and `cancelRunningQuery(reach: .userStop)` is deliberately synchronous; for MySQL that runs a blocking `mysql_real_connect`. Measured against an unroutable host: 5,001 ms, the `MYSQL_OPT_CONNECT_TIMEOUT`. PostgreSQL's `PQcancel` costs 70-160 ms by comparison. `MariaDBPluginConnection.swift:384`.
2. **`mysqlStatementIsReadOnly` treats every `SELECT` as replayable.** After a dropped connection `executeWithReconnect` re-runs it, so `SELECT NEXTVAL(seq)` burns a second sequence value and `SELECT GET_LOCK(...)` re-acquires. `MySQLStatementClassification.swift:6`.
3. **The shipped `Libs/libmariadb_arm64.a` is Connector/C 3.4.4 while the vendored header declares `MARIADB_PACKAGE_VERSION 3.4.8`.**
4. **`[Unreleased]` in `CHANGELOG.md` carries two `### Fixed` headings.** `CLAUDE.md` says a section appears at most once per version. Left alone here because restructuring it would conflict with every in-flight branch.

https://claude.ai/code/session_01KsqHrFwJxUW6eWozYjT8JZ
