### PR TITLE
fix(plugin-mysql): stop blocking the main thread on Stop, and never replay a read with side effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Autocomplete keeping an earlier prefix's ordering after the typed word becomes an exact match. (#2444)
 - Whole MySQL and MariaDB result set fetched before a capped query returned its first rows. (#2427)
 - KILL sent to a different server when a MySQL or MariaDB connection's host is spelled `localhost`.
+- Stop on a MySQL or MariaDB connection freezing the app for up to five seconds when the server stopped answering.
+- A MySQL or MariaDB read re-run after a dropped connection, advancing a sequence or taking a lock twice.
 - Save reporting the number of statements it ran as the number of rows it changed.
 - An edit or a delete on a table with no primary key changing every identical row. (#2107)
 - The same statements committed twice when Cmd+S is pressed again during a slow save.

--- a/Plugins/MySQLDriverPlugin/MariaDBPluginConnection.swift
+++ b/Plugins/MySQLDriverPlugin/MariaDBPluginConnection.swift
@@ -152,6 +152,10 @@ final class MariaDBPluginConnection: @unchecked Sendable {
     private var mysql: UnsafeMutablePointer<MYSQL>?
     private let queue = DispatchQueue(label: "com.TablePro.mariadb.plugin", qos: .userInitiated)
 
+    /// Serial, and separate from `queue`, which the read being cancelled is sitting on. Serial so a
+    /// user pressing Stop repeatedly opens one connection at a time rather than one per press.
+    private let cancelQueue = DispatchQueue(label: "com.TablePro.mariadb.plugin.cancel", qos: .userInitiated)
+
     private let host: String
     private let port: UInt32
     private let user: String
@@ -402,11 +406,23 @@ final class MariaDBPluginConnection: @unchecked Sendable {
 
     // MARK: - Query Cancellation
 
+    /// Stop reaches the server over a second connection, and building one is a TCP connect, a TLS
+    /// handshake and an auth exchange. `DatabaseManager.cancelRunningQuery` calls this synchronously
+    /// from the main actor on purpose, because the user is waiting, so the connect cannot happen
+    /// there: against a host that has stopped answering, which is exactly when someone presses Stop,
+    /// `mysql_real_connect` blocks for the full five-second `MYSQL_OPT_CONNECT_TIMEOUT`.
+    ///
+    /// The half the caller needs is the gate, which is already synchronous: it is what makes the
+    /// in-flight read give up. The kill is server-side cleanup and carries only a thread id, no
+    /// handle, so it is safe to finish on its own queue.
     func cancelCurrentQuery() {
         guard cancellationGate.cancel() != nil else { return }
 
         guard let mysql = mysql else { return }
-        killQueryOnServer(threadId: mysql_thread_id(mysql))
+        let threadId = mysql_thread_id(mysql)
+        cancelQueue.async { [self] in
+            killQueryOnServer(threadId: threadId)
+        }
     }
 
     /// The kill has to reach the server the query is running on, which means repeating the transport

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
@@ -200,7 +200,7 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 columnMeta: result.columnMeta
             )
         } catch let error as MariaDBPluginError
-            where !isRetry && isConnectionLostError(error) && mysqlStatementIsReadOnly(query) {
+            where !isRetry && isConnectionLostError(error) && mysqlStatementIsSafeToReplay(query) {
             try await reconnect()
             return try await executeWithReconnect(query: query, isRetry: true, rowCap: rowCap)
         }

--- a/Plugins/MySQLDriverPlugin/MySQLStatementClassification.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLStatementClassification.swift
@@ -3,6 +3,8 @@
 //  MySQLDriverPlugin
 //
 
+import Foundation
+
 internal func mysqlStatementIsReadOnly(_ query: String) -> Bool {
     let keyword = query
         .drop(while: { $0.isWhitespace })
@@ -14,4 +16,31 @@ internal func mysqlStatementIsReadOnly(_ query: String) -> Bool {
     default:
         return false
     }
+}
+
+/// A `SELECT` can still change the server, and the only caller that asks this is deciding whether a
+/// statement may be run a second time after the connection dropped under it. `SELECT NEXTVAL(seq)`
+/// re-run burns a second sequence value while the grid shows one, and `SELECT GET_LOCK(...)` takes
+/// the lock again. Neither reports anything: the retry looks like a connection that healed itself.
+///
+/// The scan is deliberately crude and only ever errs toward "do not replay", which costs the user a
+/// connection error where they would have got a transparent retry. It cannot see inside a stored
+/// function, so a `SELECT my_function()` that writes is still replayable.
+private let mysqlSideEffectingMarkers: [String] = [
+    "NEXTVAL", "SETVAL", "NEXT VALUE FOR", "PREVIOUS VALUE FOR",
+    "GET_LOCK", "RELEASE_LOCK", "RELEASE_ALL_LOCKS",
+    "INTO OUTFILE", "INTO DUMPFILE", "INTO @",
+    "FOR UPDATE", "FOR SHARE", "LOCK IN SHARE MODE",
+    "UUID_SHORT", "MASTER_POS_WAIT", "SOURCE_POS_WAIT",
+    "BENCHMARK", "SLEEP", ":=",
+]
+
+internal func mysqlStatementIsSafeToReplay(_ query: String) -> Bool {
+    guard mysqlStatementIsReadOnly(query) else { return false }
+    let collapsed = query
+        .uppercased()
+        .components(separatedBy: .whitespacesAndNewlines)
+        .filter { !$0.isEmpty }
+        .joined(separator: " ")
+    return !mysqlSideEffectingMarkers.contains { collapsed.contains($0) }
 }

--- a/TableProTests/Plugins/MySQLStatementClassificationTests.swift
+++ b/TableProTests/Plugins/MySQLStatementClassificationTests.swift
@@ -46,3 +46,69 @@ struct MySQLStatementClassificationTests {
         #expect(!mysqlStatementIsReadOnly("   "))
     }
 }
+
+@Suite("MySQL Replay Safety")
+struct MySQLReplaySafetyTests {
+    /// The only caller asks this to decide whether to run a statement a second time after the
+    /// connection dropped, so a plain read is the only thing that may say yes.
+    @Test("A plain read is safe to replay")
+    func plainReadIsSafeToReplay() {
+        #expect(mysqlStatementIsSafeToReplay("SELECT * FROM users"))
+        #expect(mysqlStatementIsSafeToReplay("SHOW TABLES"))
+        #expect(mysqlStatementIsSafeToReplay("DESCRIBE users"))
+    }
+
+    @Test("A write is never replayed")
+    func writesAreNeverReplayed() {
+        #expect(mysqlStatementIsSafeToReplay("UPDATE users SET name = 'a'") == false)
+        #expect(mysqlStatementIsSafeToReplay("INSERT INTO users VALUES (1)") == false)
+        #expect(mysqlStatementIsSafeToReplay("CALL do_work()") == false)
+    }
+
+    /// MariaDB sequences advance on read, so a replay hands out a value the user never sees.
+    @Test("A sequence read is not replayed")
+    func sequenceReadsAreNotReplayed() {
+        #expect(mysqlStatementIsSafeToReplay("SELECT NEXTVAL(order_seq)") == false)
+        #expect(mysqlStatementIsSafeToReplay("select nextval(order_seq)") == false)
+        #expect(mysqlStatementIsSafeToReplay("SELECT SETVAL(order_seq, 100)") == false)
+        #expect(mysqlStatementIsSafeToReplay("SELECT NEXT VALUE FOR order_seq") == false)
+        #expect(mysqlStatementIsSafeToReplay("SELECT PREVIOUS VALUE FOR order_seq") == false)
+    }
+
+    @Test("A lock function is not replayed")
+    func lockFunctionsAreNotReplayed() {
+        #expect(mysqlStatementIsSafeToReplay("SELECT GET_LOCK('job', 10)") == false)
+        #expect(mysqlStatementIsSafeToReplay("SELECT RELEASE_LOCK('job')") == false)
+        #expect(mysqlStatementIsSafeToReplay("SELECT RELEASE_ALL_LOCKS()") == false)
+    }
+
+    @Test("A read that takes row locks is not replayed")
+    func rowLockingReadsAreNotReplayed() {
+        #expect(mysqlStatementIsSafeToReplay("SELECT * FROM users FOR UPDATE") == false)
+        #expect(mysqlStatementIsSafeToReplay("SELECT * FROM users LOCK IN SHARE MODE") == false)
+        #expect(mysqlStatementIsSafeToReplay("SELECT * FROM users FOR SHARE") == false)
+    }
+
+    @Test("A read that writes somewhere is not replayed")
+    func readsThatWriteAreNotReplayed() {
+        #expect(mysqlStatementIsSafeToReplay("SELECT * FROM users INTO OUTFILE '/tmp/u'") == false)
+        #expect(mysqlStatementIsSafeToReplay("SELECT * FROM users INTO DUMPFILE '/tmp/u'") == false)
+        #expect(mysqlStatementIsSafeToReplay("SELECT id INTO @last FROM users") == false)
+        #expect(mysqlStatementIsSafeToReplay("SELECT @counter := @counter + 1") == false)
+    }
+
+    @Test("A read whose value moves on its own is not replayed")
+    func nonRepeatableReadsAreNotReplayed() {
+        #expect(mysqlStatementIsSafeToReplay("SELECT UUID_SHORT()") == false)
+        #expect(mysqlStatementIsSafeToReplay("SELECT MASTER_POS_WAIT('log', 4)") == false)
+        #expect(mysqlStatementIsSafeToReplay("SELECT SLEEP(30)") == false)
+        #expect(mysqlStatementIsSafeToReplay("SELECT BENCHMARK(1000000, MD5('x'))") == false)
+    }
+
+    /// Line breaks between the words must not hide the marker.
+    @Test("Whitespace between the words does not hide a marker")
+    func whitespaceDoesNotHideAMarker() {
+        #expect(mysqlStatementIsSafeToReplay("SELECT *\n  FROM users\n  FOR   UPDATE") == false)
+        #expect(mysqlStatementIsSafeToReplay("SELECT NEXT\n VALUE\tFOR order_seq") == false)
+    }
+}


### PR DESCRIPTION
Two MySQL driver defects found while investigating #2427. Neither is caused by that work and neither depends on it, so they are here rather than in #2447.

## Stop blocks the main thread for up to five seconds

`DatabaseManager` is `@MainActor`, and `cancelRunningQuery(reach: .userStop)` calls `driver.cancelQuery()` synchronously on purpose. Its own comment says why: "Stop stays synchronous because the user is waiting on it", and it contrasts that against a navigation supersede, which is dispatched off the main thread precisely because "a PostgreSQL cancel opens a second connection to deliver the request, which through an SSH tunnel costs 70-160ms".

MySQL's cancel is not a `PQcancel`. `MariaDBPluginConnection.cancelCurrentQuery` flips the cancellation gate, which is the fast part, and then calls `killQueryOnServer`, which opens a whole new connection: TCP, TLS, auth. Measured with the shipped `Libs/libmariadb_arm64.a` against a host that drops packets, which is exactly the situation that makes somebody press Stop:

| | |
|---|---|
| kill-style connect, server answering, loopback | 12-21 ms |
| kill-style connect, **host not answering** | **5,001 ms** |

That 5,001 ms is the `MYSQL_OPT_CONNECT_TIMEOUT` the function sets, and it is spent on the main thread with the UI frozen.

The half the caller needs is already synchronous. The gate is what makes the in-flight read give up, and it is a lock and a flag. The kill is server-side cleanup, and it carries only a thread id, no handle, so it can finish on its own queue. It moves to one: serial, so a user pressing Stop repeatedly opens one connection at a time rather than one per press.

## A read with side effects is re-run after a dropped connection

`executeWithReconnect` retries a statement when the connection was lost mid-flight, gated on `mysqlStatementIsReadOnly`, which looks at the leading keyword alone. Every `SELECT` passes.

A `SELECT` is not automatically repeatable. On MariaDB, `SELECT NEXTVAL(order_seq)` advances the sequence; the connection drops before the row arrives, the driver reconnects and runs it again, and the second value is the one the user sees while the first is gone. Nothing reports it: the retry looks like a connection that healed itself. `SELECT GET_LOCK(...)` re-acquires, `SELECT ... FOR UPDATE` re-locks, `SELECT ... INTO OUTFILE` re-writes the file.

The retry now goes through `mysqlStatementIsSafeToReplay`, which keeps the leading-keyword test and adds a scan for the markers that make a read non-repeatable: sequence functions, the lock functions, `INTO OUTFILE` / `INTO DUMPFILE` / `INTO @`, row-locking clauses, user-variable assignment, and the functions whose value moves on its own.

It is deliberately crude, and it only ever errs toward "do not replay". A false positive costs the user a connection error where they would have got a transparent retry, which is the safe direction. It cannot see inside a stored function, so `SELECT my_function()` that writes is still replayable; that would need the server's own read-only tracking.

## Verification

| Step | Result |
|---|---|
| `verify.sh build` | PASS |
| `verify.sh test MySQLStatementClassificationTests MySQLReplaySafetyTests` | PASS, 14 cases |
| `verify.sh lint Plugins/MySQLDriverPlugin TableProTests/Plugins` | 0 violations |

`MySQLReplaySafetyTests` covers each marker class plus the whitespace forms, since `NEXT VALUE FOR` and `FOR UPDATE` are multi-word and a line break between them must not hide them.

No UI automation for the Stop path: reproducing it needs a server that accepts a connection and then stops answering, which no deterministic fixture in the repo provides. The 5,001 ms figure above is from a compiled probe against the real library rather than through the app.

https://claude.ai/code/session_01KsqHrFwJxUW6eWozYjT8JZ
