### PR TITLE
build(plugin-mysql): vendor the MariaDB headers from the version the build pins

### DIFF
--- a/Plugins/MySQLDriverPlugin/CMariaDB/include/errmsg.h
+++ b/Plugins/MySQLDriverPlugin/CMariaDB/include/errmsg.h
@@ -116,11 +116,10 @@ extern const char *mariadb_client_errors[];	/* Error messages */
 #define CR_BINLOG_SEMI_SYNC_ERROR 5023
 #define CR_INVALID_CLIENT_FLAG 5024
 #define CR_STMT_NO_RESULT 5025
-#define CR_ERR_MISSING_ERROR_INFO 5026
 
 /* Always last, if you add new error codes please update the
    value for CR_MARIADB_LAST_ERROR */
-#define CR_MARIADB_LAST_ERROR CR_ERR_MISSING_ERROR_INFO
+#define CR_MARIADB_LAST_ERROR CR_STMT_NO_RESULT
 
 #endif
 
@@ -129,6 +128,6 @@ extern const char *mariadb_client_errors[];	/* Error messages */
 
 #define ER(code) IS_MYSQL_ERROR((code)) ? client_errors[(code) - CR_MIN_ERROR] : \
                  IS_MARIADB_ERROR((code)) ?  mariadb_client_errors[(code) - CER_MIN_ERROR] : \
-                 "Unknown or undefined error code"
+                 "Unknown or undefined error code" 
 #define CER(code) ER((code))
 

--- a/Plugins/MySQLDriverPlugin/CMariaDB/include/ma_pvio.h
+++ b/Plugins/MySQLDriverPlugin/CMariaDB/include/ma_pvio.h
@@ -9,7 +9,7 @@
 #endif
 
 /* CONC-492: Allow to build plugins outside of MariaDB Connector/C
-   source tree when ma_global.h was not included. */
+   source tree wnen ma_global.h was not included. */
 #if !defined(_global_h) && !defined(MY_GLOBAL_INCLUDED)
 typedef unsigned char uchar;
 #endif

--- a/Plugins/MySQLDriverPlugin/CMariaDB/include/ma_tls.h
+++ b/Plugins/MySQLDriverPlugin/CMariaDB/include/ma_tls.h
@@ -28,7 +28,6 @@ enum enum_pvio_tls_type {
 ((m)->options.extension->tls_fp_list && (m)->options.extension->tls_fp_list[0]))
 
 extern char tls_library_version[TLS_VERSION_LENGTH];
-extern my_bool ma_is_ip_address(const char *s);
 
 typedef struct st_ma_pvio_tls {
   void *data;

--- a/Plugins/MySQLDriverPlugin/CMariaDB/include/mariadb_com.h
+++ b/Plugins/MySQLDriverPlugin/CMariaDB/include/mariadb_com.h
@@ -170,7 +170,7 @@ enum enum_server_command
 #define CLIENT_SSL_VERIFY_SERVER_CERT_OBSOLETE CLIENT_SSL_VERIFY_SERVER_CERT
 #define CLIENT_REMEMBER_OPTIONS  (1UL << 31)
 
-/* MariaDB-specific capabilities */
+/* MariaDB specific capabilities */
 #define MARIADB_CLIENT_FLAGS 0xFFFFFFFF00000000ULL
 #define MARIADB_CLIENT_PROGRESS (1ULL << 32)
 #define MARIADB_CLIENT_RESERVED_1 (1ULL << 33) /* Former COM_MULTI, don't use */
@@ -419,7 +419,6 @@ void	ma_net_end(NET *net);
 void	ma_net_clear(NET *net);
 int	ma_net_flush(NET *net);
 int	ma_net_write(NET *net,const unsigned char *packet, size_t len);
-int ma_net_write_buff(NET *net, const char *packet, size_t len);
 int	ma_net_write_command(NET *net,unsigned char command,const char *packet,
 			  size_t len, my_bool disable_flush);
 int	ma_net_real_write(NET *net,const char *packet, size_t len);
@@ -429,28 +428,6 @@ struct rand_struct {
   unsigned long seed1,seed2,max_value;
   double max_value_dbl;
 };
-
-  /* The following is for user defined functions */
-
-typedef struct st_udf_args
-{
-  unsigned int arg_count;		/* Number of arguments */
-  enum Item_result *arg_type;		/* Pointer to item_results */
-  char **args;				/* Pointer to argument */
-  unsigned long *lengths;		/* Length of string arguments */
-  char *maybe_null;			/* Set to 1 for all maybe_null args */
-} UDF_ARGS;
-
-  /* This holds information about the result */
-
-typedef struct st_udf_init
-{
-  my_bool maybe_null;			/* 1 if function can return NULL */
-  unsigned int decimals;		/* for real functions */
-  unsigned int max_length;		/* For string functions */
-  char	  *ptr;				/* free pointer for function data */
-  my_bool const_item;			/* 0 if result is independent of arguments */
-} UDF_INIT;
 
 /* Connection types */
 #define MARIADB_CONNECTION_UNIXSOCKET   0

--- a/Plugins/MySQLDriverPlugin/CMariaDB/include/mariadb_version.h
+++ b/Plugins/MySQLDriverPlugin/CMariaDB/include/mariadb_version.h
@@ -26,11 +26,11 @@
 #define MYSQL_VERSION_ID                100808
 #define MYSQL_SERVER_VERSION            "10.8.8-MariaDB"
 
-#define MARIADB_PACKAGE_VERSION "3.4.8"
-#define MARIADB_PACKAGE_VERSION_ID 30408
+#define MARIADB_PACKAGE_VERSION "3.4.4"
+#define MARIADB_PACKAGE_VERSION_ID 30404
 #define MARIADB_SYSTEM_TYPE "Darwin"
 #define MARIADB_MACHINE_TYPE "arm64"
-#define MARIADB_PLUGINDIR "/opt/homebrew/Cellar/mariadb-connector-c/3.4.8_1/lib/mariadb/plugin"
+#define MARIADB_PLUGINDIR "/usr/local/lib/mariadb/plugin"
 
 /* mysqld compile time options */
 #ifndef MYSQL_CHARSET

--- a/Plugins/MySQLDriverPlugin/CMariaDB/include/mysql.h
+++ b/Plugins/MySQLDriverPlugin/CMariaDB/include/mysql.h
@@ -226,7 +226,7 @@ extern const char *SQLSTATE_UNKNOWN;
     MYSQL_OPT_TLS_VERSION,
     MYSQL_OPT_ZSTD_COMPRESSION_LEVEL,
 
-    /* MariaDB-specific */
+    /* MariaDB specific */
     MYSQL_PROGRESS_CALLBACK=5999,
     MYSQL_OPT_NONBLOCK,
     /* MariaDB Connector/C specific */

--- a/scripts/check-mariadb-headers.sh
+++ b/scripts/check-mariadb-headers.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Check the vendored MariaDB Connector/C headers against the version build-mariadb.sh pins.
+#
+# The headers under Plugins/MySQLDriverPlugin/CMariaDB/include describe the library the plugin
+# compiles against, and Libs/libmariadb*.a is what it links. Nothing keeps the two together, and
+# they came apart: the headers were copied out of a Homebrew mariadb-connector-c 3.4.8 keg, still
+# carrying that keg's plugin directory, while build-mariadb.sh pins and builds 3.4.4. That skew is
+# quiet by construction. A declaration the binary does not export fails at link time, which is loud,
+# but a macro or a struct that changed between the two versions compiles and then misbehaves.
+#
+# Usage:
+#   scripts/check-mariadb-headers.sh
+#
+# Downloads the pinned source to a temporary directory, renders mariadb_version.h the way the build
+# does, and diffs every vendored header against it. Needs curl and cmake. Exits non-zero on a
+# difference; the fix is to copy the upstream headers over the vendored ones.
+
+set -uo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_SCRIPT="$PROJECT_DIR/scripts/build-mariadb.sh"
+VENDORED="$PROJECT_DIR/Plugins/MySQLDriverPlugin/CMariaDB/include"
+
+for tool in curl cmake; do
+    command -v "$tool" > /dev/null || {
+        echo "$tool not found" >&2
+        exit 2
+    }
+done
+
+VERSION="$(sed -n 's/^MARIADB_VERSION="\(.*\)"$/\1/p' "$BUILD_SCRIPT")"
+[ -n "$VERSION" ] || {
+    echo "could not read MARIADB_VERSION from $BUILD_SCRIPT" >&2
+    exit 2
+}
+echo "build-mariadb.sh pins Connector/C $VERSION"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+curl -fsSL "https://archive.mariadb.org/connector-c-$VERSION/mariadb-connector-c-$VERSION-src.tar.gz" \
+    -o "$WORK/src.tgz" || {
+    echo "could not download Connector/C $VERSION" >&2
+    exit 2
+}
+tar xzf "$WORK/src.tgz" -C "$WORK" || exit 2
+SRC="$WORK/mariadb-connector-c-$VERSION-src"
+[ -d "$SRC/include" ] || {
+    echo "unexpected archive layout under $SRC" >&2
+    exit 2
+}
+
+# mariadb_version.h is generated, so it has to be rendered rather than copied. The install prefix is
+# the only input that reaches it, through MARIADB_PLUGINDIR.
+cmake -S "$SRC" -B "$WORK/cfg" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+    -DCMAKE_INSTALL_PREFIX=/usr/local > /dev/null 2>&1
+[ -f "$WORK/cfg/include/mariadb_version.h" ] || {
+    echo "cmake did not generate mariadb_version.h" >&2
+    exit 2
+}
+
+differences=0
+while IFS= read -r relative; do
+    upstream="$SRC/include/$relative"
+    [ "$relative" = "mariadb_version.h" ] && upstream="$WORK/cfg/include/mariadb_version.h"
+    if [ ! -f "$upstream" ]; then
+        printf '  EXTRA     %s  (not in Connector/C %s)\n' "$relative" "$VERSION"
+        differences=$((differences + 1))
+        continue
+    fi
+    if diff -q "$VENDORED/$relative" "$upstream" > /dev/null 2>&1; then
+        printf '  ok        %s\n' "$relative"
+    else
+        printf '  DIFFERS   %s  (%s changed line(s))\n' \
+            "$relative" "$(diff "$VENDORED/$relative" "$upstream" | grep -c '^[<>]')"
+        differences=$((differences + 1))
+    fi
+done < <(cd "$VENDORED" && find . -name '*.h' | sed 's|^\./||' | sort)
+
+if [ "$differences" -ne 0 ]; then
+    echo
+    echo "$differences vendored header(s) do not match Connector/C $VERSION." >&2
+    echo "Copy them from the upstream include/ directory, and render mariadb_version.h" >&2
+    echo "from a cmake configure of the same source rather than from a package manager." >&2
+    exit 1
+fi
+
+echo
+echo "every vendored header matches Connector/C $VERSION"


### PR DESCRIPTION
The vendored MariaDB Connector/C headers and the static library we ship are different versions, and nothing keeps them together.

- `Plugins/MySQLDriverPlugin/CMariaDB/include/mariadb_version.h` declares `MARIADB_PACKAGE_VERSION "3.4.8"`.
- `Libs/libmariadb_arm64.a` answers `mysql_get_client_info()` with `3.4.4`, measured by a probe compiled against it.
- `scripts/build-mariadb.sh` pins `MARIADB_VERSION="3.4.4"` and builds exactly that.

So the binary is right and the headers are the wrong artifact. Their own provenance says where they came from: the vendored file carries `MARIADB_PLUGINDIR "/opt/homebrew/Cellar/mariadb-connector-c/3.4.8_1/lib/mariadb/plugin"`. They were copied out of a Homebrew keg rather than out of the source the build script downloads.

## What the skew actually contains

Diffed every vendored header against the pinned 3.4.4 source. Five differ, and two of those carry declarations the shipped binary does not export:

| Header | Difference |
|---|---|
| `errmsg.h` | adds `CR_ERR_MISSING_ERROR_INFO 5026` and moves `CR_MARIADB_LAST_ERROR` onto it, so the client-error boundary sits one past what the linked library can produce |
| `mariadb_com.h` | declares `ma_net_write_buff` and the `UDF_ARGS` / `UDF_INIT` structs |
| `ma_tls.h` | declares `ma_is_ip_address` |
| `mariadb_version.h` | the version macros and the Homebrew plugin directory |
| `ma_pvio.h`, `mysql.h` | a typo fix and two comment edits |

Checked the whole surface rather than just those: of 236 function declarations across the headers, exactly two are absent from `libmariadb_arm64.a`, `mariadb_dyncol_prepare_decimal` and `mariadb_load_defaults`. Neither is referenced anywhere in the repo, and nor is anything else in the table above.

That makes this latent rather than active. A call to a declaration the binary lacks fails at link time, which is loud. The quiet half is a macro or a struct that changed between the two versions: it compiles, and then it is wrong.

## The change

The headers now come from the 3.4.4 source that `build-mariadb.sh` pins. `mariadb_version.h` is generated by CMake rather than shipped, so it is rendered from a configure run of that same source instead of copied, which is also what drops the Homebrew path.

`scripts/check-mariadb-headers.sh` reads the pinned version out of `build-mariadb.sh`, downloads that source, renders the generated header the same way, and diffs all fifteen. It is the shape `check-duckdb-value-api.sh` and `check-pluginkit-abi.sh` already use: a fact the tree hard-codes gets a script that re-checks it, rather than a comment asking the next person to remember.

## Verification

| Step | Result |
|---|---|
| `verify.sh build` | PASS |
| `MySQLDriver` scheme | BUILD SUCCEEDED |
| `scripts/check-mariadb-headers.sh` | every vendored header matches Connector/C 3.4.4 |
| `shellcheck --severity=warning` | clean |

No library rebuild and no republish: the binary already is the pinned version, so `Libs/` and its checksums are untouched.

Found while investigating #2427.

https://claude.ai/code/session_01KsqHrFwJxUW6eWozYjT8JZ
