### PR TITLE
feat(settings): make Find a rebindable shortcut so Cmd+F can open the filter bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restore Previous Values in the Edit menu, taking back a save that already committed. Starter license. (#2107)
 - Data Rewind settings in Settings > Data & Results, with an off switch and Clear Saved Changes.
 - Restore Previous Values in the toolbar's Table Actions group.
+- Rebindable Find shortcut in Settings > Keyboard, for giving `Cmd+F` to the filter bar instead.
 
 ### Changed
 

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+Lifecycle.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+Lifecycle.swift
@@ -259,10 +259,6 @@ extension TextViewController {
         case (commandKey, "]"):
             handleIndent()
             return nil
-        case (commandKey, "f"):
-            _ = self.textView.resignFirstResponder()
-            self.findViewController?.showFindPanel()
-            return nil
         case ([commandKey, .shift], "D"):
             duplicateLine()
             return nil

--- a/TablePro/Core/Menu/EditMenuBuilder.swift
+++ b/TablePro/Core/Menu/EditMenuBuilder.swift
@@ -119,8 +119,8 @@ enum EditMenuBuilder {
             MenuItemFactory.item(
                 String(localized: "Find…"),
                 action: #selector(MainSplitViewController.performFind(_:)),
-                keyEquivalent: "f",
-                modifiers: .command
+                shortcut: .find,
+                keyboard: keyboard
             ),
             MenuItemFactory.item(
                 String(localized: "Find Next"),

--- a/TablePro/Models/UI/KeyboardShortcutModels.swift
+++ b/TablePro/Models/UI/KeyboardShortcutModels.swift
@@ -82,6 +82,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case nextStatement
     case runStatementAndAdvance
     case previewSQL
+    case find
     case findNext
     case findPrevious
     case aiExplainQuery
@@ -149,7 +150,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
              .executeQueryWithoutLimit, .cancelQuery, .explainQuery, .formatQuery,
              .foldAll, .unfoldAll, .toggleFold,
              .previousStatement, .nextStatement, .runStatementAndAdvance,
-             .previewSQL, .findNext, .findPrevious, .aiExplainQuery, .aiOptimizeQuery:
+             .previewSQL, .find, .findNext, .findPrevious, .aiExplainQuery, .aiOptimizeQuery:
             return .editor
         case .undo, .redo, .cut, .copy, .copyRowsExplicit, .copyWithHeaders, .copyAsJson,
              .paste, .delete, .selectAll, .clearSelection, .addRow, .duplicateRow,
@@ -167,8 +168,13 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         }
     }
 
+    /// `find` is deliberately `.global` rather than `.editor`: it dispatches to whichever
+    /// surface holds focus, and only a global context overlaps `.dataGrid`, which is what
+    /// lets it yield `Cmd+F` to a user who binds the filter bar there instead.
     var context: ShortcutContext {
         switch self {
+        case .find:
+            return .global
         case .executeQuery, .executeAllStatements, .executeQueryWithoutLimit,
              .cancelQuery, .explainQuery, .formatQuery, .foldAll, .unfoldAll,
              .toggleFold, .previousStatement, .nextStatement, .runStatementAndAdvance,
@@ -224,6 +230,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .previousStatement: return String(localized: "Previous Statement")
         case .nextStatement: return String(localized: "Next Statement")
         case .runStatementAndAdvance: return String(localized: "Run Statement and Advance")
+        case .find: return String(localized: "Find")
         case .findNext: return String(localized: "Find Next")
         case .findPrevious: return String(localized: "Find Previous")
         case .export: return String(localized: "Export")
@@ -281,7 +288,6 @@ extension ShortcutAction {
         (.character("/", command: true), String(localized: "Toggle Comment")),
         (.character("[", command: true), String(localized: "Indent")),
         (.character("]", command: true), String(localized: "Outdent")),
-        (.character("f", command: true), String(localized: "Find")),
         (.character("d", command: true, shift: true), String(localized: "Duplicate Line")),
         (.character("k", command: true, shift: true), String(localized: "Delete Line")),
         (.special(.space, control: true), String(localized: "Show Completions")),
@@ -315,8 +321,7 @@ extension ShortcutAction {
     static let reservedAppShortcuts: [(key: BoundKey, name: String)] = {
         var shortcuts: [(key: BoundKey, name: String)] = [
             (.character("=", command: true), String(localized: "Zoom In")),
-            (.character("-", command: true), String(localized: "Zoom Out")),
-            (.character("f", command: true), String(localized: "Find"))
+            (.character("-", command: true), String(localized: "Zoom Out"))
         ]
         for number in 1...9 {
             shortcuts.append((
@@ -517,6 +522,7 @@ struct KeyboardSettings: Codable, Equatable {
         .unfoldAll: .special(.rightArrow, command: true, shift: true, option: true),
         .toggleFold: .special(.leftArrow, command: true, option: true),
         .previewSQL: .character("p", command: true, shift: true),
+        .find: .character("f", command: true),
         .findNext: .character("g", command: true),
         .findPrevious: .character("g", command: true, shift: true),
         .aiExplainQuery: .character("l", command: true),

--- a/TablePro/Views/Settings/KeyboardSettingsView.swift
+++ b/TablePro/Views/Settings/KeyboardSettingsView.swift
@@ -69,7 +69,9 @@ struct KeyboardSettingsView: View {
             }
             Button(String(localized: "Reassign")) {
                 if let state = conflictAlert {
-                    settings.clearShortcut(for: state.conflictingAction)
+                    if settings.isCustomized(state.conflictingAction) {
+                        settings.clearShortcut(for: state.conflictingAction)
+                    }
                     settings.setShortcut(state.combo, for: state.action)
                 }
                 conflictAlert = nil

--- a/TableProTests/Core/Menu/MainMenuBuilderTests.swift
+++ b/TableProTests/Core/Menu/MainMenuBuilderTests.swift
@@ -122,14 +122,72 @@ struct MainMenuShortcutCoverageTests {
         #expect(item?.keyEquivalentModifierMask == [.command, .shift])
     }
 
-    @Test("Find keeps Cmd+F and the filter bar no longer competes for it")
-    func findOwnsCommandF() {
+    @Test("Find ships on Cmd+F and the filter bar keeps Cmd+Option+F")
+    func findAndFilterDefaultsHold() {
+        #expect(KeyboardSettings.defaultShortcuts[.find] == .character("f", command: true))
         #expect(KeyboardSettings.defaultShortcuts[.toggleFilters] == .character("f", command: true, option: true))
         #expect(
             KeyboardSettings.defaultShortcuts[.focusSidebarSearch]
                 == .character("f", command: true, option: true, control: true)
         )
-        #expect(ShortcutAction.reservedAppShortcuts.contains { $0.key == .character("f", command: true) })
+    }
+
+    @Test("Cmd+F is customizable rather than reserved")
+    func commandFIsNoLongerReserved() {
+        let commandF = BoundKey.character("f", command: true)
+        #expect(!ShortcutAction.reservedAppShortcuts.contains { $0.key == commandF })
+        #expect(!ShortcutAction.editorBuiltIns.contains { $0.key == commandF })
+        #expect(ShortcutAction.reservedConflict(for: commandF, context: .dataGrid) == nil)
+        #expect(ShortcutAction.reservedConflict(for: commandF, context: .editor) == nil)
+    }
+
+    @Test("Cmd+F for the filter bar is no longer refused outright, only reported against Find")
+    func recorderReportsFindRatherThanRefusingCommandF() {
+        let commandF = BoundKey.character("f", command: true)
+        #expect(ShortcutAction.reservedConflict(for: commandF, context: ShortcutAction.toggleFilters.context) == nil)
+        #expect(KeyboardSettings.default.findConflict(for: commandF, excluding: .toggleFilters) == .find)
+    }
+
+    @Test("Reassigning Cmd+F leaves Find on its default so it recovers when the filter bar moves back")
+    func reassigningCommandFDoesNotStrandFind() {
+        var keyboard = KeyboardSettings()
+        #expect(!keyboard.isCustomized(.find))
+
+        keyboard.setShortcut(.character("f", command: true), for: .toggleFilters)
+        #expect(keyboard.shortcut(for: .find) == nil)
+        #expect(!keyboard.isCustomized(.find))
+
+        keyboard.setShortcut(.character("f", command: true, option: true), for: .toggleFilters)
+        #expect(keyboard.shortcut(for: .find) == .character("f", command: true))
+    }
+
+    @Test("Find yields Cmd+F to a user-bound filter bar instead of sharing it")
+    func findYieldsCommandFToFilterBar() {
+        var keyboard = KeyboardSettings()
+        keyboard.setShortcut(.character("f", command: true), for: .toggleFilters)
+
+        #expect(keyboard.shortcut(for: .find) == nil)
+        #expect(keyboard.shortcut(for: .toggleFilters) == .character("f", command: true))
+
+        let menu = buildMenu()
+        MainMenuKeyEquivalentSync.apply(keyboard: keyboard, to: menu)
+        let claimants = flatten(menu).filter {
+            $0.keyEquivalent == "f" && $0.keyEquivalentModifierMask == [.command]
+        }
+        #expect(claimants.count == 1)
+        #expect(claimants.first?.identifier == MenuItemFactory.identifier(for: .toggleFilters))
+    }
+
+    @Test("Find… carries no hardcoded key equivalent")
+    func findMenuItemFollowsKeyboardSettings() {
+        var keyboard = KeyboardSettings()
+        keyboard.setShortcut(.character("f", command: true, shift: true), for: .find)
+
+        let menu = buildMenu()
+        MainMenuKeyEquivalentSync.apply(keyboard: keyboard, to: menu)
+        let item = flatten(menu).first { $0.identifier == MenuItemFactory.identifier(for: .find) }
+        #expect(item?.keyEquivalent == "f")
+        #expect(item?.keyEquivalentModifierMask == [.command, .shift])
     }
 }
 

--- a/TableProTests/Models/KeyboardShortcutTests.swift
+++ b/TableProTests/Models/KeyboardShortcutTests.swift
@@ -223,10 +223,21 @@ struct ShortcutConflictTests {
         #expect(conflict == .refresh)
     }
 
-    @Test("Editor action does not conflict with the data-grid Cmd+F filter")
-    func crossContextDoesNotConflict() {
+    @Test("Cmd+F is held by the global Find action, so an editor binding collides with it")
+    func commandFConflictsWithFind() {
         let settings = KeyboardSettings.default
         let conflict = settings.findConflict(for: .character("f", command: true), excluding: .executeQuery)
+        #expect(conflict == .find)
+    }
+
+    @Test("A data-grid binding does not conflict with an editor-only default")
+    func crossContextDoesNotConflict() {
+        let settings = KeyboardSettings.default
+        #expect(KeyboardSettings.defaultShortcuts[.formatQuery] == .character("l", command: true, shift: true))
+        let conflict = settings.findConflict(
+            for: .character("l", command: true, shift: true),
+            excluding: .previousPage
+        )
         #expect(conflict == nil)
     }
 }

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -78,7 +78,7 @@ The grid meanings come back the moment you click into the grid, and `Delete` on 
 | Find next | `Cmd+G` |
 | Find previous | `Cmd+Shift+G` |
 
-Every row except Find Next and Find Previous is built into the editor and cannot be rebound. Standard macOS text navigation and clipboard keys also apply.
+Every row except Find, Find Next and Find Previous is built into the editor and cannot be rebound. Standard macOS text navigation and clipboard keys also apply.
 
 ## Data Grid
 
@@ -273,7 +273,7 @@ A combination already taken by another action in the same context raises a dialo
 Menu actions need a modifier (`Cmd`, `Option`, `Ctrl`, or `Shift`); function keys `F1` through `F12` work bare, as do grid actions that read the key directly, like Preview FK Reference (`Space`).
 
 <Info>
-Some shortcuts cannot be reassigned: editor built-ins such as `Cmd+/`, tab selection (`Cmd+1` through `Cmd+9`), text size (`Cmd+=`, `Cmd+-`), Find (`Cmd+F`), and macOS system shortcuts, which are read live from System Settings. The recorder warns if you try.
+Some shortcuts cannot be reassigned: editor built-ins such as `Cmd+/`, tab selection (`Cmd+1` through `Cmd+9`), text size (`Cmd+=`, `Cmd+-`), and macOS system shortcuts, which are read live from System Settings. The recorder warns if you try.
 </Info>
 
 ## Outside the app

--- a/docs/switching.mdx
+++ b/docs/switching.mdx
@@ -81,7 +81,9 @@ Set these up on your first day:
 | Explain the query | `Cmd+Option+E` |
 | Save the query as a favorite | `Cmd+D` |
 
-A few cannot be reassigned, so learn them rather than fight them: editor built-ins such as `Cmd+/` for comment, `Cmd+[` and `Cmd+]` for indent, tab selection `Cmd+1` through `Cmd+9`, text size `Cmd+=` and `Cmd+-`, and `Cmd+F` for find. The recorder tells you when you hit one.
+A few cannot be reassigned, so learn them rather than fight them: editor built-ins such as `Cmd+/` for comment, `Cmd+[` and `Cmd+]` for indent, tab selection `Cmd+1` through `Cmd+9`, and text size `Cmd+=` and `Cmd+-`. The recorder tells you when you hit one.
+
+Coming from TablePlus, where `Cmd+F` opens the row filter? Rebind **Toggle Filters** to `Cmd+F` in **Settings > Keyboard** and choose **Reassign** when it asks. Find gives up `Cmd+F` while the filter bar holds it, and takes it back if you move the filter bar off again.
 
 If you use Vim bindings, turn on [Vim Mode](/features/vim-mode) in **Settings > Editor** and most of this section stops mattering.
 


### PR DESCRIPTION
A user asked to use `Cmd+F` for the filter drawer instead of Find. This makes that possible without changing anyone's defaults.

## Root cause

Not a wrong default, a missing capability. `Find…` was the only command wired outside the shortcut-customization system:

- `EditMenuBuilder.swift:118-124` hardcoded `keyEquivalent: "f", modifiers: .command` and passed no `shortcut:` / `keyboard:`, unlike its siblings Find Next and Find Previous.
- `Cmd+F` sat in `ShortcutAction.reservedAppShortcuts`, and `reservedConflict(for:context:)` returns that for **every** context, so `ShortcutConflictResolver` refused to bind `Cmd+F` to anything at all.

So the request was blocked by a hard gate, not declined as a preference.

## Why the defaults do not move

Apple's HIG lists `Command-F / Open a Find window` as a standard shortcut and says "In general, don't repurpose standard keyboard shortcuts for custom actions". Measured on macOS, Mail and Xcode both give **filter** a non-F key (`Cmd+L`, `Cmd+Option+J`).

TablePlus binds `Cmd+F` to Open Row Filter and ships no grid find at all, which is where the request comes from. But TablePlus users are themselves asking for the opposite (TablePlus #2279, still open), Postico 2 ships `Cmd+Option+F` for the filter bar exactly as we do, and DataGrip, the only surveyed tool that has both a grid find and a filter, gives `Cmd+F` to Find.

This shortcut has already flip-flopped three times (`CHANGELOG.md:2164` → `:1538` → `:658`/`:213`), and the current arrangement is what the grid find bar with Search All Rows and the #2244 JSON-mode work were built for. A preference split between two camps is settled by rebinding, not by a fourth reversal.

## The change

- `ShortcutAction.find`, context `.global`, default `Cmd+F`. `.global` is explicit and commented, because only a global context overlaps `.dataGrid`, and that overlap is the entire reason the yield works.
- `Cmd+F` removed from `reservedAppShortcuts` and from `editorBuiltIns`.
- `Find…` now routes through `KeyboardSettings` like every other customizable command.
- The vendored `CodeEditSourceEditor` local key monitor drops its `case (commandKey, "f")`.

That last one is required, not cosmetic. The monitor runs before NSMenu key-equivalent matching and ignores `KeyboardSettings`, so without it Settings would show Find on another key while the editor still opened Find on `Cmd+F`. It is safe because `TextViewController+FindActions.swift` already declares `performFind` on the same controller, so the nil-targeted menu item reaches the identical `showFindPanel()` through the responder chain. Commit `f5afbe221` already added `Cmd+Shift+D` and `Cmd+Shift+K` to that same switch, so editing it is established practice here.

**One edit for the user.** `shortcut(for:)` already yields an action's default when another action's override claims that key in an overlapping context, so binding Toggle Filters to `Cmd+F` stands Find down on its own. Two menu items can never both hold `Cmd+F`, which is the AppKit-blanks-the-loser trap in `CLAUDE.md`.

## Fixed while here

Review caught that the recorder's **Reassign** button called `clearShortcut` unconditionally, persisting the cleared sentinel even when the losing action was still on its default. `KeyboardShortcutModels.swift:390-392` says explicitly that storing the stand-down is wrong: it makes it permanent, shows the action as customized, and its Reset arrow appears to work until the next launch re-applies the clear. In this feature's headline flow that meant a user who later moved the filter bar back to `Cmd+Option+F` would find Find permanently unbound. Reassign now clears only a loser that has an explicit override; one on its default is left to yield and recovers on its own.

## Verification

| Step | Result |
|---|---|
| `verify.sh build` | PASS |
| `verify.sh test` (14 menu + keyboard suites) | PASS, 92 executed, 92 passed |
| `verify.sh lint TablePro TableProTests LocalPackages/CodeEditSourceEditor` | 0 violations |
| `verify.sh docs` | PASS |

The `category` switch is exhaustive with no `default:`, so the new case had to be handled at every site to compile at all. `MainMenuShortcutCoverageTests.everyShortcutActionIsReachable` pins that `.find` reaches exactly one menu item.

Tests added: defaults still pin `.find` == `Cmd+F` and `.toggleFilters` == `Cmd+Option+F` (a guard against reversal four); `Cmd+F` is no longer reserved in any context; Find yields and exactly one menu item ends up holding `Cmd+F`; `Find…` carries no hardcoded key equivalent; and Reassign leaves Find recoverable.

No UI automation: the flow is Settings > Keyboard recorder input, and `ShortcutConflictResolver` consults `SystemHotkeyChecker`, which reads live System Settings through `CopySymbolicHotKeys`. Asserting on it would make the test depend on the machine, so the coverage sits on the deterministic app-owned layer instead.

## Notes for the reviewer

- `docs/features/keyboard-shortcuts.mdx:266` pictures the Settings > Keyboard list, which now has a Find row. The screenshot needs re-capturing; I did not fabricate one.
- Keyboard settings sync (`SyncCoordinator.swift:880`). A user running this build and an older one with sync on, who rebinds `Cmd+F`, gets a duplicate key equivalent on the **old** build, which still hardcodes `Cmd+F` for Find. `sanitized()` only drops bare keys, so it does not filter this. Not fixable from this side and it heals when the other build updates.
