### PR TITLE
fix(datagrid): repaint the drawn body whenever column geometry changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Active editor tab drawn darker than its track on macOS 27, and inverting when the window lost focus.
 - Editor tab selection changing with the desktop picture behind the window.
 - Editor tab strip tests reporting four appearances while running plain Aqua and Dark Aqua twice.
+- Grid cells left at the old column positions until the next click, after a resize, an auto-fit, a reorder, hiding a column, or a row-number width change. (#2449)
+- The row-number column draggable out of first place, which walked it to the far right on the next refresh.
 
 ## [0.68.1] - 2026-08-26
 

--- a/TablePro/Views/Results/CellOverlayBase.swift
+++ b/TablePro/Views/Results/CellOverlayBase.swift
@@ -8,7 +8,7 @@ import AppKit
 enum CellOverlayDismissReason {
     case userAction
     case scroll
-    case columnResize
+    case columnGeometry
     case appResign
     case windowResignKey
     case outsideClick
@@ -19,7 +19,7 @@ class CellOverlayBase: NSObject {
     private var container: CellOverlayContainerView?
     private weak var hostTableView: NSTableView?
     private var scrollObserver: NSObjectProtocol?
-    private var columnResizeObserver: NSObjectProtocol?
+    private var columnGeometryObservers: [any NSObjectProtocol] = []
     private var appResignObserver: NSObjectProtocol?
     private var windowResignKeyObserver: NSObjectProtocol?
     private var outsideClickMonitor: Any?
@@ -157,13 +157,14 @@ class CellOverlayBase: NSObject {
             }
         }
 
-        columnResizeObserver = NotificationCenter.default.addObserver(
-            forName: NSTableView.columnDidResizeNotification,
-            object: hostTableView,
-            queue: .main
-        ) { [weak self] _ in
-            MainActor.assumeIsolated {
-                self?.handleDismiss(reason: .columnResize)
+        columnGeometryObservers = [
+            NSTableView.columnDidResizeNotification,
+            NSTableView.columnDidMoveNotification,
+        ].map { name in
+            NotificationCenter.default.addObserver(forName: name, object: hostTableView, queue: .main) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.handleDismiss(reason: .columnGeometry)
+                }
             }
         }
 
@@ -202,10 +203,8 @@ class CellOverlayBase: NSObject {
             NotificationCenter.default.removeObserver(observer)
             scrollObserver = nil
         }
-        if let observer = columnResizeObserver {
-            NotificationCenter.default.removeObserver(observer)
-            columnResizeObserver = nil
-        }
+        columnGeometryObservers.forEach(NotificationCenter.default.removeObserver)
+        columnGeometryObservers = []
         if let observer = appResignObserver {
             NotificationCenter.default.removeObserver(observer)
             appResignObserver = nil

--- a/TablePro/Views/Results/CellOverlayEditor.swift
+++ b/TablePro/Views/Results/CellOverlayEditor.swift
@@ -55,7 +55,7 @@ final class CellOverlayEditor: CellOverlayBase, NSTextViewDelegate {
     }
 
     override func handleDismiss(reason: CellOverlayDismissReason) {
-        dismiss(commit: reason != .columnResize)
+        dismiss(commit: reason != .columnGeometry)
     }
 
     func dismiss(commit: Bool) {

--- a/TablePro/Views/Results/DataGridColumnPool.swift
+++ b/TablePro/Views/Results/DataGridColumnPool.swift
@@ -73,6 +73,11 @@ final class DataGridColumnPool {
         attachedTableView = nil
     }
 
+    /// - Returns: whether a column's visibility changed. `NSTableColumn.isHidden` moves every column
+    ///   after it and is the one geometry change `NSTableView` announces through no notification, so
+    ///   the caller has to repaint the drawn body itself. See
+    ///   `TableViewCoordinator.columnGeometryDidChange()`.
+    @discardableResult
     func reconcile(
         tableView: NSTableView,
         schema: ColumnIdentitySchema,
@@ -82,7 +87,7 @@ final class DataGridColumnPool {
         isEditable: Bool,
         hiddenColumnNames: Set<String>,
         widthCalculator: (String, Int) -> CGFloat
-    ) {
+    ) -> Bool {
         attach(to: tableView)
         let visibleCount = schema.columnNames.count
         activeIdentifiers = Set(schema.identifiers)
@@ -93,6 +98,7 @@ final class DataGridColumnPool {
         let hiddenFromLayout = savedLayout?.hiddenColumns ?? []
         var comments: [NSUserInterfaceItemIdentifier: String] = [:]
         var showsComments = false
+        var visibilityChanged = false
 
         for slot in 0..<pooledColumns.count {
             let column = pooledColumns[slot]
@@ -116,17 +122,15 @@ final class DataGridColumnPool {
                 } else {
                     userHiddenIdentifiers.remove(column.identifier)
                 }
-                if column.isHidden != hidden {
-                    column.isHidden = hidden
-                }
+                visibilityChanged = setHidden(hidden, on: column) || visibilityChanged
                 if let comment {
                     comments[column.identifier] = comment
                     if !hidden {
                         showsComments = true
                     }
                 }
-            } else if !column.isHidden {
-                column.isHidden = true
+            } else {
+                visibilityChanged = setHidden(true, on: column) || visibilityChanged
             }
         }
         applyComments(comments, showsComments: showsComments, in: tableView)
@@ -142,6 +146,13 @@ final class DataGridColumnPool {
             visibleCount: visibleCount,
             targetOrder: targetOrder
         )
+        return visibilityChanged
+    }
+
+    private func setHidden(_ hidden: Bool, on column: NSTableColumn) -> Bool {
+        guard column.isHidden != hidden else { return false }
+        column.isHidden = hidden
+        return true
     }
 
     private func growBackingPoolIfNeeded(to count: Int) {

--- a/TablePro/Views/Results/DataGridRowView.swift
+++ b/TablePro/Views/Results/DataGridRowView.swift
@@ -50,7 +50,14 @@ class DataGridRowView: NSTableRowView {
     }
 
     func redrawCells() {
-        contentView.needsDisplay = true
+        cellsNeedDisplay = true
+    }
+
+    /// Whether the drawn cells are waiting on a repaint. The row's own `needsDisplay` answers for
+    /// the background and the selection fill, which are painted separately from the cells.
+    var cellsNeedDisplay: Bool {
+        get { contentView.needsDisplay }
+        set { contentView.needsDisplay = newValue }
     }
 
     // MARK: - Accessibility

--- a/TablePro/Views/Results/DataGridView.swift
+++ b/TablePro/Views/Results/DataGridView.swift
@@ -257,6 +257,7 @@ struct DataGridView: NSViewRepresentable {
                 if !shouldHide {
                     coordinator.resizeRowNumberColumnForCurrentRange()
                 }
+                coordinator.columnGeometryDidChange()
             }
         }
 
@@ -375,7 +376,7 @@ struct DataGridView: NSViewRepresentable {
         columnComments: [String: String],
         savedLayout: ColumnLayoutState?
     ) {
-        coordinator.columnPool.reconcile(
+        let visibilityChanged = coordinator.columnPool.reconcile(
             tableView: tableView,
             schema: coordinator.identitySchema,
             columnTypes: tableRows.columnTypes,
@@ -391,6 +392,8 @@ struct DataGridView: NSViewRepresentable {
                 )
             }
         )
+        guard visibilityChanged else { return }
+        coordinator.columnGeometryDidChange()
     }
 
     private func syncSortState(tableView: NSTableView, coordinator: TableViewCoordinator) {
@@ -421,6 +424,16 @@ struct DataGridView: NSViewRepresentable {
     }
 
     @MainActor
+    /// The column is pinned to one width, so the interval has to be opened before the width can be
+    /// assigned through it.
+    ///
+    /// Raising `minWidth` past the current width does move `width` with it, but `NSTableView` keeps
+    /// its cumulative column geometry at the old value and posts no `columnDidResizeNotification`,
+    /// and the assignment that follows then has nothing left to change, so `rect(ofColumn:)` never
+    /// catches up. Measured on macOS 27: pinning 40 to 60 reported `width == 60` while the
+    /// row-number rect stayed 47pt wide and the next column's origin stayed at 57, and neither
+    /// `tile()` nor a display pass repaired it. Assigning the width while it genuinely moves is what
+    /// makes AppKit adopt the geometry and announce it.
     static func sizeRowNumberColumn(_ column: NSTableColumn, forMaxRowNumber maxNumber: Int) {
         let display = "\(max(maxNumber, 1))"
         let font = ThemeEngine.shared.dataGridFonts.rowNumber
@@ -429,9 +442,14 @@ struct DataGridView: NSViewRepresentable {
             + 2 * DataGridMetrics.cellHorizontalInset
             + DataGridMetrics.rowNumberHeaderPadding
         let columnWidth = max(DataGridMetrics.rowNumberColumnMinWidth, measured)
+        guard column.width != columnWidth
+            || column.minWidth != columnWidth
+            || column.maxWidth != columnWidth else { return }
+        column.minWidth = min(column.minWidth, columnWidth)
+        column.maxWidth = max(column.maxWidth, columnWidth)
+        column.width = columnWidth
         column.minWidth = columnWidth
         column.maxWidth = columnWidth
-        column.width = columnWidth
     }
 
     private func installSelectionOverlay(tableView: KeyHandlingTableView, coordinator: TableViewCoordinator) {

--- a/TablePro/Views/Results/Extensions/DataGridView+ColumnGeometry.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+ColumnGeometry.swift
@@ -1,0 +1,53 @@
+//
+//  DataGridView+ColumnGeometry.swift
+//  TablePro
+//
+
+import AppKit
+
+extension TableViewCoordinator {
+    /// The one place a column width, order or visibility change reaches the drawn body.
+    ///
+    /// `NSTableView` pushes column geometry into a table body by relaying its cell views out and
+    /// redrawing them. This grid mounts no view for a data column and draws every cell itself
+    /// (#2381), so that channel is empty, and `NSTableRowView` has no geometry callback of its own.
+    /// AppKit resizes a row view only when the table's total width moves, which it does not while
+    /// the columns still fit inside the viewport, so nothing is marked dirty and the body keeps the
+    /// layout it last drew until an unrelated event invalidates a row (#2449).
+    ///
+    /// Everything that paints from live `rect(ofColumn:)` is invalidated here: each row, the table
+    /// view's own background past the last row, and the cell selection outline. A row is reached
+    /// through its drawn cells, which is enough for the whole row: `canDrawSubviewsIntoLayer` makes
+    /// the row's layer the one backing store for the row and its cells, so dirtying the cells marks
+    /// the row itself dirty and its separators and cell-range selection wash repaint with them.
+    func columnGeometryDidChange() {
+        guard let tableView else { return }
+        redrawVisibleCells()
+        tableView.setNeedsDisplay(tableView.visibleRect)
+        selectionController.overlay?.needsDisplay = true
+    }
+
+    /// Keeps the row-number column at the head of the run.
+    ///
+    /// `DataGridColumnPool` places every data column relative to it and reads its position off
+    /// `tableColumns.first`, so a row-number column dragged into the run leaves the pool ordering
+    /// from index 0 and walking it one place further right on every reconcile until it reaches the
+    /// far end, permanently. No fixed position may name a data column (#2381), and this is the
+    /// other half of that: the origin those positions are measured from has to hold still.
+    ///
+    /// A drag opens with `newColumnIndex` at -1, which asks whether the column may be reordered at
+    /// all rather than proposing a destination. Answering no there stops the drag before it starts,
+    /// so that probe is refused only for the row-number column itself.
+    func tableView(
+        _ tableView: NSTableView,
+        shouldReorderColumn columnIndex: Int,
+        toColumn newColumnIndex: Int
+    ) -> Bool {
+        guard tableView.tableColumns.indices.contains(columnIndex) else { return false }
+        guard let rowNumberIndex = tableView.tableColumns.firstIndex(where: {
+            $0.identifier == ColumnIdentitySchema.rowNumberIdentifier
+        }) else { return true }
+        guard columnIndex != rowNumberIndex else { return false }
+        return newColumnIndex < 0 || newColumnIndex > rowNumberIndex
+    }
+}

--- a/TablePro/Views/Results/Extensions/DataGridView+ColumnWidths.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+ColumnWidths.swift
@@ -76,21 +76,12 @@ extension TableViewCoordinator {
         _ changes: DataGridColumnPresentationChanges,
         tableRows: TableRows
     ) {
-        guard widenAutomaticColumns(forPresentationChanges: changes, tableRows: tableRows) else { return }
-        redrawVisibleCells()
-    }
-
-    private func widenAutomaticColumns(
-        forPresentationChanges changes: DataGridColumnPresentationChanges,
-        tableRows: TableRows
-    ) -> Bool {
-        guard let tableView, !changes.isEmpty else { return false }
+        guard let tableView, !changes.isEmpty else { return }
 
         let wasRebuildingColumns = isRebuildingColumns
         isRebuildingColumns = true
         defer { isRebuildingColumns = wasRebuildingColumns }
 
-        var didWiden = false
         for dataIndex in changes.indices {
             guard dataIndex < tableRows.columns.count else { continue }
             let columnName = tableRows.columns[dataIndex]
@@ -107,8 +98,6 @@ extension TableViewCoordinator {
             let width = automaticColumnWidth(for: columnName, columnIndex: dataIndex, tableRows: tableRows)
             guard width > column.width else { continue }
             column.width = width
-            didWiden = true
         }
-        return didWiden
     }
 }

--- a/TablePro/Views/Results/Extensions/DataGridView+Selection.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Selection.swift
@@ -7,7 +7,12 @@ import AppKit
 import SwiftUI
 
 extension TableViewCoordinator {
+    /// The repaint runs ahead of both guards below on purpose. `isRebuildingColumns` and
+    /// `markColumnWidthUserSized` decide whether the new width is the user's to keep, which is a
+    /// question about persistence; the body has to be redrawn either way, and the second guard is
+    /// false for the row-number column and for every unused pool slot.
     func tableViewColumnDidResize(_ notification: Notification) {
+        columnGeometryDidChange()
         guard !isRebuildingColumns else { return }
         guard let column = notification.userInfo?["NSTableColumn"] as? NSTableColumn else { return }
         guard markColumnWidthUserSized(column) else { return }
@@ -15,6 +20,7 @@ extension TableViewCoordinator {
     }
 
     func tableViewColumnDidMove(_ notification: Notification) {
+        columnGeometryDidChange()
         guard !isRebuildingColumns else { return }
         invalidateColumnIndexCache()
         hasUnpersistedColumnLayoutChanges = true

--- a/TablePro/Views/Results/Extensions/DataGridView+Sort.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Sort.swift
@@ -371,7 +371,6 @@ extension TableViewCoordinator {
                 fittedColumnCount: fittedColumns.count
             )
         }
-        redrawVisibleCells()
         scheduleLayoutPersist()
     }
 

--- a/TableProTests/Views/Results/DataGridColumnGeometryRepaintTests.swift
+++ b/TableProTests/Views/Results/DataGridColumnGeometryRepaintTests.swift
@@ -1,0 +1,336 @@
+//
+//  DataGridColumnGeometryRepaintTests.swift
+//  TableProTests
+//
+
+import AppKit
+import SwiftUI
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+@MainActor
+private final class NoopColumnLayoutPersister: ColumnLayoutPersisting {
+    func load(for key: ColumnLayoutTableKey) -> ColumnLayoutState? { nil }
+    func save(_ layout: ColumnLayoutState, for key: ColumnLayoutTableKey) {}
+    func clear(for key: ColumnLayoutTableKey) {}
+}
+
+/// A data cell has no view, so `NSTableView` never relays one out and never invalidates the row that
+/// drew it. AppKit resizes a row view only when the table's total width moves, which it does not
+/// while the columns still fit inside the viewport, so every column geometry change on a grid
+/// narrower than its scroll view used to leave the body painting the layout it last drew (#2449).
+@Suite("Data grid column geometry repaint")
+@MainActor
+struct DataGridColumnGeometryRepaintTests {
+    private struct Grid {
+        let window: NSWindow
+        let scrollView: NSScrollView
+        let tableView: KeyHandlingTableView
+        let coordinator: TableViewCoordinator
+        let overlay: GridSelectionOverlay
+        let dataColumns: [NSTableColumn]
+        let rowNumberColumn: NSTableColumn
+
+        var rowViews: [DataGridRowView] {
+            (0 ..< tableView.numberOfRows).compactMap {
+                tableView.rowView(atRow: $0, makeIfNecessary: false) as? DataGridRowView
+            }
+        }
+    }
+
+    private static let rows = TableRows.from(
+        queryRows: [
+            [.text("edge-01"), .text("running"), .text("2026-08-20 11:03:39")],
+            [.text("edge-02"), .text("stopped"), .text("2026-08-21 09:14:02")],
+        ],
+        columns: ["machine_id", "state", "last_seen_at"],
+        columnTypes: [.text(rawType: "TEXT"), .text(rawType: "TEXT"), .text(rawType: "TEXT")]
+    )
+
+    /// - Parameters:
+    ///   - viewportWidth: the scroll view's width. Wider than the columns is the configuration the
+    ///     bug lives in, because the table view's frame never moves and AppKit therefore never
+    ///     resizes a row view. Narrower is the configuration that hides it, where the frame grows
+    ///     and the incidental resize redraw covers for the missing invalidation.
+    private func makeGrid(viewportWidth: CGFloat, columnWidth: CGFloat) -> Grid {
+        let coordinator = TableViewCoordinator(
+            changeManager: AnyChangeManager(DataChangeManager()),
+            isEditable: true,
+            selectedRowIndices: .constant([]),
+            delegate: nil,
+            layoutPersister: NoopColumnLayoutPersister()
+        )
+        coordinator.tabType = .table
+        coordinator.connectionId = UUID()
+        coordinator.tableName = "machines"
+        coordinator.tableRowsProvider = { Self.rows }
+
+        let tableView = KeyHandlingTableView()
+        tableView.coordinator = coordinator
+        tableView.style = .plain
+        tableView.columnAutoresizingStyle = .noColumnAutoresizing
+        tableView.gridStyleMask = []
+        tableView.intercellSpacing = NSSize(width: 1, height: 0)
+        tableView.rowHeight = 24
+        tableView.usesAutomaticRowHeights = false
+        coordinator.tableView = tableView
+
+        let rowNumberColumn = NSTableColumn(identifier: ColumnIdentitySchema.rowNumberIdentifier)
+        rowNumberColumn.width = 40
+        tableView.addTableColumn(rowNumberColumn)
+
+        coordinator.rebuildColumnMetadataCache(from: Self.rows)
+        var dataColumns: [NSTableColumn] = []
+        for index in Self.rows.columns.indices {
+            let identifier = coordinator.columnIdentifier(for: index) ?? ColumnIdentitySchema.slotIdentifier(index)
+            let column = NSTableColumn(identifier: identifier)
+            column.title = Self.rows.columns[index]
+            column.minWidth = 20
+            column.maxWidth = 2000
+            column.width = columnWidth
+            tableView.addTableColumn(column)
+            dataColumns.append(column)
+        }
+        coordinator.updateColumnPresentations(from: Self.rows)
+        coordinator.updateCache()
+
+        let overlay = GridSelectionOverlay(frame: tableView.bounds)
+        overlay.tableView = tableView
+        overlay.coordinator = coordinator
+        coordinator.selectionController.overlay = overlay
+        tableView.selectionOverlay = overlay
+        tableView.addSubview(overlay)
+
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: viewportWidth, height: 200))
+        scrollView.hasHorizontalScroller = true
+        scrollView.documentView = tableView
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: viewportWidth, height: 220),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = scrollView
+
+        tableView.delegate = coordinator
+        tableView.dataSource = coordinator
+        tableView.reloadData()
+        scrollView.tile()
+        window.layoutIfNeeded()
+        for row in 0 ..< tableView.numberOfRows {
+            _ = tableView.rowView(atRow: row, makeIfNecessary: true)
+        }
+
+        return Grid(
+            window: window,
+            scrollView: scrollView,
+            tableView: tableView,
+            coordinator: coordinator,
+            overlay: overlay,
+            dataColumns: dataColumns,
+            rowNumberColumn: rowNumberColumn
+        )
+    }
+
+    private func settle(_ grid: Grid) {
+        grid.window.displayIfNeeded()
+        grid.tableView.needsDisplay = false
+        grid.overlay.needsDisplay = false
+        for rowView in grid.rowViews {
+            rowView.needsDisplay = false
+            rowView.cellsNeedDisplay = false
+        }
+    }
+
+    @Test("A width change repaints the drawn cells when the columns fit inside the viewport")
+    func widthChangeRepaintsInsideViewport() throws {
+        let grid = makeGrid(viewportWidth: 900, columnWidth: 100)
+        let rowViews = grid.rowViews
+        try #require(!rowViews.isEmpty)
+        let widthBefore = grid.tableView.frame.width
+        settle(grid)
+
+        grid.dataColumns[0].width = 260
+
+        #expect(grid.tableView.frame.width == widthBefore)
+        #expect(rowViews.filter(\.cellsNeedDisplay).count == rowViews.count)
+        #expect(grid.tableView.needsDisplay)
+        #expect(grid.overlay.needsDisplay)
+    }
+
+    @Test("A width change repaints the drawn cells when the columns overflow the viewport")
+    func widthChangeRepaintsOutsideViewport() throws {
+        let grid = makeGrid(viewportWidth: 300, columnWidth: 200)
+        let rowViews = grid.rowViews
+        try #require(!rowViews.isEmpty)
+        settle(grid)
+
+        grid.dataColumns[0].width = 380
+
+        #expect(rowViews.filter(\.cellsNeedDisplay).count == rowViews.count)
+    }
+
+    @Test("Reordering a column repaints the drawn cells")
+    func reorderRepaints() throws {
+        let grid = makeGrid(viewportWidth: 900, columnWidth: 100)
+        let rowViews = grid.rowViews
+        try #require(!rowViews.isEmpty)
+        settle(grid)
+
+        let from = grid.tableView.column(withIdentifier: grid.dataColumns[0].identifier)
+        let to = grid.tableView.column(withIdentifier: grid.dataColumns[2].identifier)
+        grid.tableView.moveColumn(from, toColumn: to)
+
+        #expect(rowViews.filter(\.cellsNeedDisplay).count == rowViews.count)
+    }
+
+    /// The row-number column is pinned, `minWidth == maxWidth == width`. Raising `minWidth` past the
+    /// current width moves `width` with it while `NSTableView` keeps the old cumulative geometry and
+    /// posts nothing, so the assertion has to be on `rect(ofColumn:)` rather than on the width
+    /// property, which reports the new value either way. Paging from row 999 to row 1000 is the
+    /// trigger.
+    @Test("Widening the row-number column moves the geometry the cells are drawn from")
+    func rowNumberWidthChangeRepaints() throws {
+        let grid = makeGrid(viewportWidth: 900, columnWidth: 100)
+        let rowViews = grid.rowViews
+        try #require(!rowViews.isEmpty)
+        let rowNumberIndex = grid.tableView.column(withIdentifier: ColumnIdentitySchema.rowNumberIdentifier)
+        let firstDataIndex = grid.tableView.column(withIdentifier: grid.dataColumns[0].identifier)
+        let rowNumberWidthBefore = grid.tableView.rect(ofColumn: rowNumberIndex).width
+        let firstDataOriginBefore = grid.tableView.rect(ofColumn: firstDataIndex).minX
+        settle(grid)
+
+        grid.coordinator.paginationOffsetProvider = { 1_000_000 }
+        grid.coordinator.resizeRowNumberColumnForCurrentRange()
+
+        #expect(grid.tableView.rect(ofColumn: rowNumberIndex).width > rowNumberWidthBefore)
+        #expect(grid.tableView.rect(ofColumn: firstDataIndex).minX > firstDataOriginBefore)
+        #expect(rowViews.filter(\.cellsNeedDisplay).count == rowViews.count)
+    }
+
+    @Test("Narrowing the row-number column moves the geometry back")
+    func rowNumberShrinkRepaints() throws {
+        let grid = makeGrid(viewportWidth: 900, columnWidth: 100)
+        grid.coordinator.paginationOffsetProvider = { 1_000_000 }
+        grid.coordinator.resizeRowNumberColumnForCurrentRange()
+        let rowViews = grid.rowViews
+        try #require(!rowViews.isEmpty)
+        let rowNumberIndex = grid.tableView.column(withIdentifier: ColumnIdentitySchema.rowNumberIdentifier)
+        let firstDataIndex = grid.tableView.column(withIdentifier: grid.dataColumns[0].identifier)
+        let widenedWidth = grid.tableView.rect(ofColumn: rowNumberIndex).width
+        let widenedOrigin = grid.tableView.rect(ofColumn: firstDataIndex).minX
+        settle(grid)
+
+        grid.coordinator.paginationOffsetProvider = { 0 }
+        grid.coordinator.resizeRowNumberColumnForCurrentRange()
+
+        #expect(grid.tableView.rect(ofColumn: rowNumberIndex).width < widenedWidth)
+        #expect(grid.tableView.rect(ofColumn: firstDataIndex).minX < widenedOrigin)
+        #expect(rowViews.filter(\.cellsNeedDisplay).count == rowViews.count)
+    }
+
+    /// The cell-range selection wash is painted by the row itself in `drawBackground`, placed from
+    /// the same live column rects the cells use. It repaints because `canDrawSubviewsIntoLayer` puts
+    /// the row and its cells in one backing store, so dirtying the cells dirties the row. This pins
+    /// that, since the wash would otherwise be left at the old column with nothing to catch it.
+    @Test("A geometry change invalidates the selection wash the row paints")
+    func geometryChangeInvalidatesTheSelectionWash() throws {
+        let grid = makeGrid(viewportWidth: 900, columnWidth: 100)
+        let rowViews = grid.rowViews
+        try #require(!rowViews.isEmpty)
+        grid.coordinator.selectionController.selectEntireColumn(0, totalRows: grid.tableView.numberOfRows)
+        settle(grid)
+
+        grid.dataColumns[0].width = 260
+
+        #expect(rowViews.filter(\.needsDisplay).count == rowViews.count)
+    }
+
+    /// `markColumnWidthUserSized` is false for the row-number column and for an unused pool slot, and
+    /// it is the second guard the resize handler returns on, so a repaint placed behind it would skip
+    /// exactly those columns.
+    @Test("A resize notification repaints a column that is never user-sized")
+    func resizeRepaintsAColumnThatIsNeverUserSized() throws {
+        let grid = makeGrid(viewportWidth: 900, columnWidth: 100)
+        let rowViews = grid.rowViews
+        try #require(!rowViews.isEmpty)
+        settle(grid)
+
+        grid.coordinator.tableViewColumnDidResize(
+            Notification(
+                name: NSTableView.columnDidResizeNotification,
+                object: grid.tableView,
+                userInfo: ["NSTableColumn": grid.rowNumberColumn, "NSOldWidth": CGFloat(40)]
+            )
+        )
+
+        #expect(grid.coordinator.userSizedColumnNames.isEmpty)
+        #expect(rowViews.filter(\.cellsNeedDisplay).count == rowViews.count)
+    }
+
+    @Test("A width change during a column rebuild still repaints")
+    func rebuildingColumnsStillRepaints() throws {
+        let grid = makeGrid(viewportWidth: 900, columnWidth: 100)
+        let rowViews = grid.rowViews
+        try #require(!rowViews.isEmpty)
+        settle(grid)
+
+        grid.coordinator.isRebuildingColumns = true
+        defer { grid.coordinator.isRebuildingColumns = false }
+        grid.dataColumns[1].width = 240
+
+        #expect(grid.coordinator.userSizedColumnNames.isEmpty)
+        #expect(rowViews.filter(\.cellsNeedDisplay).count == rowViews.count)
+    }
+
+    /// The invalidation is only half the contract. The cells have to be drawn from the geometry the
+    /// table view reports now, so the same row rasterises differently once a column has moved.
+    @Test("The redrawn cells land at the new column geometry")
+    func redrawnCellsFollowTheNewGeometry() throws {
+        let grid = makeGrid(viewportWidth: 900, columnWidth: 100)
+        let rowView = try #require(grid.rowViews.first)
+        let before = try #require(Self.rasterize(rowView))
+
+        grid.dataColumns[0].width = 300
+        grid.window.layoutIfNeeded()
+
+        let after = try #require(Self.rasterize(rowView))
+        #expect(before != after)
+    }
+
+    /// `DataGridColumnPool` places every data column relative to the row-number column and reads its
+    /// position off `tableColumns.first`, so it has to stay at the head of the run.
+    @Test("The row-number column cannot be dragged out of the first position")
+    func rowNumberColumnStaysFirst() {
+        let grid = makeGrid(viewportWidth: 900, columnWidth: 100)
+        let coordinator = grid.coordinator
+
+        #expect(!coordinator.tableView(grid.tableView, shouldReorderColumn: 0, toColumn: 2))
+        #expect(!coordinator.tableView(grid.tableView, shouldReorderColumn: 2, toColumn: 0))
+        #expect(coordinator.tableView(grid.tableView, shouldReorderColumn: 2, toColumn: 1))
+        #expect(coordinator.tableView(grid.tableView, shouldReorderColumn: 1, toColumn: 3))
+    }
+
+    /// A drag opens with a `newColumnIndex` of -1, and answering no to it disallows the column from
+    /// being reordered at all. Refusing that probe for every column would disable the whole feature
+    /// while trying to pin one column.
+    @Test("The opening reorder probe leaves data columns draggable")
+    func openingReorderProbeAllowsDataColumns() {
+        let grid = makeGrid(viewportWidth: 900, columnWidth: 100)
+        let coordinator = grid.coordinator
+
+        #expect(coordinator.tableView(grid.tableView, shouldReorderColumn: 1, toColumn: -1))
+        #expect(coordinator.tableView(grid.tableView, shouldReorderColumn: 3, toColumn: -1))
+        #expect(!coordinator.tableView(grid.tableView, shouldReorderColumn: 0, toColumn: -1))
+    }
+
+    private static func rasterize(_ rowView: DataGridRowView) -> Data? {
+        guard let representation = rowView.bitmapImageRepForCachingDisplay(in: rowView.bounds) else { return nil }
+        rowView.cacheDisplay(in: rowView.bounds, to: representation)
+        return representation.representation(using: .png, properties: [:])
+    }
+}


### PR DESCRIPTION
Fixes #2449.

## The bug

Double-clicking a column separator in the Structure tab auto-fits the column: the header divider jumps to the fitted position, but the grid body keeps painting cells at the old column geometry until an unrelated click repaints it.

## Root cause

AppKit's only channel for pushing column geometry into a table body is relaying out and redrawing the **cell views**. This grid mounts no view for a data column and draws every cell itself in `DataGridRowView` (#2381), so that channel is empty, and `NSTableRowView` has no column-geometry callback of its own.

AppKit resizes a row view only when the table's *total* width moves. With `.noColumnAutoresizing` the table's width is `max(sum of columns, clip width)`, so on a grid whose columns fit inside the viewport, which is the Structure tab's normal shape, one column growing while another shrinks leaves the frame untouched. Measured with a compiled AppKit probe:

```
columns NARROWER than the viewport   table.frame.width 900 -> 900
   row0.frame.width 900 -> 900        setFrameSize width changes: []
   row needsDisplay after mutation: [false, false, false]
   row draws [1,1,1] -> [1,1,1]        <- never repainted
columns WIDER than the viewport      table.frame.width 666 -> 816
   row draws [1,1,1] -> [2,2,2]        <- repaints only as a side effect of the frame change
```

That second line is why the bug reads as Structure-only: on a wide result the frame change repaints the rows incidentally and covers for the missing invalidation.

The codebase already half-knew this. Three sites mutate a column width and only two of them repaint by hand: `sizeAllColumnsToFit` and `applyAccessoryWidthChanges` call `redrawVisibleCells()`, while `tableView(_:sizeToFitWidthOfColumn:)`, `sizeColumnToFit`, drag-resize, reorder and the row-number visibility toggle do not. Column geometry had no owner.

## The fix

`TableViewCoordinator.columnGeometryDidChange()` is that owner. It invalidates the three things that paint from live `rect(ofColumn:)`: the rows, the table view's own background past the last row (`KeyHandlingTableView.drawBackground` continues the separators there), and the cell selection outline.

It hangs off AppKit's own two funnels, `tableViewColumnDidResize` and `tableViewColumnDidMove`, **ahead of the existing guards**. Both guards belong to persistence, not painting, and the second (`markColumnWidthUserSized`) returns `false` for the row-number column and for every unused pool slot. Measured: `NSTableColumn.width = x` posts `columnDidResizeNotification` for every source, including a bare programmatic set and AppKit's own assignment after `sizeToFitWidthOfColumn`, so all five width paths are covered by those two hooks and the two hand-rolled `redrawVisibleCells()` calls are deleted.

`NSTableColumn.isHidden` is the one geometry change AppKit announces to nobody, so `DataGridColumnPool.reconcile` reports whether it moved and its caller fires the owner.

Rejected after measuring: `tile()`, `reloadData(forRowIndexes:columnIndexes:)` and `noteHeightOfRows(withIndexesChanged:)` each produced **zero** body redraws for this grid. Only `enumerateAvailableRowViews` plus per-row invalidation works, which is what `redrawVisibleCells()` already does.

## What else this fixes

Same root cause, all covered by the one owner:

- Divider **drag** resize, and the header menu's **Size to Fit**.
- **Column reorder**: `moveColumn` posts `columnDidMove` and likewise left `needsDisplay == false`, so values kept painting under the old headers.
- **Hiding a column** whose data is still fetched (a primary key or the sorted column), where no reload follows.
- Toggling **Show row numbers**.
- **Paging across a row-number digit boundary**, which turned out to be a separate defect. `sizeRowNumberColumn` pins the column at `minWidth == maxWidth == width`, and raising `minWidth` past the current width moves `width` with it while `NSTableView` keeps its old cumulative geometry and posts nothing; the assignment that follows then has nothing left to change, so `rect(ofColumn:)` never catches up. Measured on macOS 27:

```
CURRENT (minWidth, maxWidth, width all -> 60)
  rowNum.width=60   rect(0).width=47   rect(1).minX=57   events=0
  after tile+pump:  rect(0).width=47   rect(1).minX=57   events=0   <- unrepairable
FIXED (open the pin interval, assign width, repin)
  rowNum.width=90   rect(0).width=97   rect(1).minX=107  events=1
```

  Opening the interval before assigning the width is what makes AppKit adopt the geometry, and it posts the notification too, so the owner covers it with no special case.

Two guards ship alongside, both in the reorder path this makes work for the first time:

- `tableView(_:shouldReorderColumn:toColumn:)` pins the row-number column. It could be dragged into the run, and `DataGridColumnPool`'s `baseOffset` reads its position off `tableColumns.first`, so the next reconcile walked it one place right per column until it reached the far end, permanently. The delegate allows AppKit's opening `newColumnIndex == -1` probe, which asks whether a column may be dragged at all rather than proposing a destination; refusing it would disable reordering outright.
- `CellOverlayBase` now dismisses an open editor on a column **move**, not only on a resize.

## Performance

The owner runs once per notification, and a column-pool rebase writes one width per column. Measured on a 500-column grid: 500 notifications x 32 mounted row views = 16,000 invalidations in **2.8 ms**, against the 10.7 s the `column.width` writes themselves cost. There is nothing to coalesce, and `redrawCells()` is a dirty-flag set that AppKit already collapses into one paint per display pass.

## Verification

- `build` PASS.
- `test` PASS, 183 cases, 0 failed, across the 21 suites that own the types this touches.
- `lint` 0 SwiftLint violations. (The wrapper's `agent docs` step reports one pre-existing stale symbol, `CLAUDE.md:216 AXCell`, in a file this branch does not touch.)
- New suite `DataGridColumnGeometryRepaintTests`, 11 cases, asserting invalidation in **both** viewport configurations so the test cannot ride the incidental frame-resize redraw; reorder; the row-number grow and shrink, asserting `rect(ofColumn:)` and the first data column's origin rather than the width property, which reports the new value either way; a resize on a column that is never user-sized; a resize during a column rebuild; the reorder guard including the `-1` probe; and a rasterised before/after proving the redrawn cells land at the new geometry.
- **Negative controls.** With the notification wiring removed, 6 of 8 then-existing cases fail. With the row-number ordering reverted, both row-number cases fail. The tests are not vacuous.

No UI automation: driving a synthetic double-click onto a header divider needs a coordinate offset from the `data-grid` element (every row and cell in this grid reads as obscured to XCUITest, per CLAUDE.md), and it did not run deterministically. The behaviour is pinned by the unit suite above instead.

No docs change: `docs/features/data-grid.mdx` already documents divider double-click auto-fit and per-table column order. It described the intended behaviour that was broken.
