### PR TITLE
fix(connections): settle the connections strip on whole entries and reveal the one you switch to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stale cells after fitting, hiding or reordering a data grid column on a result narrower than the window. (#2446)
 - Autocomplete keeping an earlier prefix's ordering after the typed word becomes an exact match. (#2444)
 - Whole MySQL and MariaDB result set fetched before a capped query returned its first rows. (#2427)
 - KILL sent to a different server when a MySQL or MariaDB connection's host is spelled `localhost`.
@@ -41,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Active editor tab drawn darker than its track on macOS 27, and inverting when the window lost focus.
 - Editor tab selection changing with the desktop picture behind the window.
 - Editor tab strip tests reporting four appearances while running plain Aqua and Dark Aqua twice.
+- Icon cut off the entry at the top of a scrolled connections strip. (#2452)
+- Connections strip not scrolling to the entry you switch to.
 
 ## [0.68.1] - 2026-08-26
 

--- a/TablePro/Core/Services/Infrastructure/WorkspaceRailMetrics.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspaceRailMetrics.swift
@@ -11,6 +11,14 @@ internal enum WorkspaceRailMetrics {
         internal let rowHeight: CGFloat
         internal let iconSize: CGFloat
         internal let fontSize: CGFloat
+        internal let rowSpacing: CGFloat
+
+        /// What one entry costs down the strip, and the only spacing `WorkspaceRailScrollGeometry`
+        /// works in. The table's `intercellSpacing` is set from `rowSpacing` for the same reason:
+        /// a pitch assembled from two places drifts the moment one of them changes.
+        internal var rowPitch: CGFloat {
+            rowHeight + rowSpacing
+        }
     }
 
     /// An icon above a label, the shape Finder's icon view and Reminders' smart lists use,
@@ -18,11 +26,15 @@ internal enum WorkspaceRailMetrics {
     /// spends 32pt on insets, so the rail has to be wide enough that what is left still
     /// holds a database name at a legible size. `smallSystemFontSize` is the smallest system
     /// size and stays above the 10pt macOS minimum.
-    internal static let small = Layout(width: 80, rowHeight: 52, iconSize: 20, fontSize: 10)
-    internal static let medium = Layout(
-        width: 90, rowHeight: 58, iconSize: 24, fontSize: NSFont.smallSystemFontSize
+    internal static let small = Layout(
+        width: 80, rowHeight: 52, iconSize: 20, fontSize: 10, rowSpacing: 2
     )
-    internal static let large = Layout(width: 100, rowHeight: 66, iconSize: 28, fontSize: 12)
+    internal static let medium = Layout(
+        width: 90, rowHeight: 58, iconSize: 24, fontSize: NSFont.smallSystemFontSize, rowSpacing: 2
+    )
+    internal static let large = Layout(
+        width: 100, rowHeight: 66, iconSize: 28, fontSize: 12, rowSpacing: 2
+    )
 
     /// Mirrors System Settings > Appearance > Sidebar icon size, which AppKit exposes
     /// through `NSTableView.effectiveRowSizeStyle`.

--- a/TablePro/Core/Services/Infrastructure/WorkspaceRailScrollGeometry.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspaceRailScrollGeometry.swift
@@ -1,0 +1,139 @@
+//
+//  WorkspaceRailScrollGeometry.swift
+//  TablePro
+//
+
+import AppKit
+
+/// Where the rail is allowed to come to rest.
+///
+/// Every entry is a tile whose meaning is its glyph, laid out across the top of the row, so a
+/// viewport edge that falls inside a tile does not read as a partly scrolled row the way a line of
+/// text does: it deletes the glyph and leaves the label behind with nothing above it. The rail
+/// autohides its scroller, so at rest there is no affordance saying the strip scrolls at all, and
+/// that orphaned label reads as a drawing bug. It was reported as one (#2452).
+///
+/// `NSClipView.constrainBoundsRect` allows any offset between zero and the document's end, so a
+/// mid-tile offset is a legal resting position that nothing corrects. These are the offsets the
+/// rail settles onto instead, all of them multiples of the row pitch.
+///
+/// The document's own end is the case that forces `bottomInset`. A viewport is almost never a whole
+/// number of tiles, so the last tile can be reached only from an offset that is not a multiple of
+/// the pitch; without the inset the rail either stops short of its final entry or slices the tile at
+/// the top to reach it. The inset is the empty strip that makes that final offset land on a boundary
+/// like every other one.
+internal enum WorkspaceRailScrollGeometry {
+    /// The furthest the rail may rest while still keeping the last entry whole and a tile edge at
+    /// the top of the viewport.
+    ///
+    /// Measured against the last entry's own bottom rather than by counting whole pitches. The
+    /// spacing under the final entry is not part of it, so a viewport that ends between the last
+    /// entry and the next boundary already holds every entry: counting pitches called that a scroll
+    /// of one whole row and let the first entry be hidden under a strip that fits.
+    internal static func maximumRestingOrigin(
+        rowCount: Int,
+        rowPitch: CGFloat,
+        rowHeight: CGFloat,
+        viewportHeight: CGFloat
+    ) -> CGFloat {
+        guard rowPitch > 0, rowCount > 0, viewportHeight > 0 else { return 0 }
+        let lastRowBottom = CGFloat(rowCount - 1) * rowPitch + rowHeight
+        guard lastRowBottom > viewportHeight else { return 0 }
+        return ((lastRowBottom - viewportHeight) / rowPitch).rounded(.up) * rowPitch
+    }
+
+    /// The empty strip below the last tile that brings `maximumRestingOrigin` within reach.
+    ///
+    /// `documentHeight` is asked for rather than derived, because `NSTableView` sizes its document
+    /// to fill a viewport the rows do not, and pads it past the rows when they overflow.
+    internal static func bottomInset(
+        rowCount: Int,
+        rowPitch: CGFloat,
+        rowHeight: CGFloat,
+        documentHeight: CGFloat,
+        viewportHeight: CGFloat
+    ) -> CGFloat {
+        guard rowPitch > 0, rowCount > 0, viewportHeight > 0 else { return 0 }
+        let maximum = maximumRestingOrigin(
+            rowCount: rowCount, rowPitch: rowPitch, rowHeight: rowHeight, viewportHeight: viewportHeight
+        )
+        return max(0, maximum + viewportHeight - documentHeight)
+    }
+
+    /// The boundary a settled scroll lands on.
+    internal static func settledOrigin(
+        proposed: CGFloat,
+        rowPitch: CGFloat,
+        maximumOrigin: CGFloat
+    ) -> CGFloat {
+        guard rowPitch > 0, maximumOrigin > 0 else { return 0 }
+        let snapped = (proposed / rowPitch).rounded() * rowPitch
+        return min(max(0, snapped), maximumOrigin)
+    }
+
+    /// The boundary a settled scroll lands on, without cutting an entry the highlight was already
+    /// showing whole.
+    ///
+    /// `NSTableView` reveals the row the arrow keys reach by scrolling the least it can, which stops
+    /// between boundaries; rounding that to the nearest one would cut the entry the keyboard just
+    /// moved to. Only an entry that was whole before the snap is protected, so scrolling away from
+    /// the highlighted entry on purpose still settles wherever the scroll ended.
+    internal static func settledOrigin(
+        proposed: CGFloat,
+        selectedRow: Int?,
+        rowCount: Int,
+        rowPitch: CGFloat,
+        rowHeight: CGFloat,
+        viewportHeight: CGFloat
+    ) -> CGFloat {
+        let maximum = maximumRestingOrigin(
+            rowCount: rowCount, rowPitch: rowPitch, rowHeight: rowHeight, viewportHeight: viewportHeight
+        )
+        let snapped = settledOrigin(proposed: proposed, rowPitch: rowPitch, maximumOrigin: maximum)
+        guard rowPitch > 0, viewportHeight > 0, rowCount > 0 else { return snapped }
+        guard let selectedRow, selectedRow >= 0, selectedRow < rowCount else { return snapped }
+
+        let top = CGFloat(selectedRow) * rowPitch
+        let bottom = top + rowHeight
+        func showsSelectionWhole(_ origin: CGFloat) -> Bool {
+            top >= origin - 0.5 && bottom <= origin + viewportHeight + 0.5
+        }
+        guard showsSelectionWhole(proposed), !showsSelectionWhole(snapped) else { return snapped }
+
+        let nearest = ((bottom - viewportHeight) / rowPitch).rounded(.up) * rowPitch
+        let furthest = (top / rowPitch).rounded(.down) * rowPitch
+        return min(max(min(max(snapped, nearest), furthest), 0), maximum)
+    }
+
+    /// The offset that brings `row` fully into view, or nil while it already is.
+    ///
+    /// Nil is the answer that lets every caller ask unconditionally. The rail's entries are the same
+    /// list in every window, so a change in one window reloads the rail in all of them; a reveal
+    /// that moved a rail whose entry was already on screen would drag another window's strip away
+    /// from wherever its owner had scrolled it.
+    internal static func revealOrigin(
+        row: Int,
+        rowCount: Int,
+        rowPitch: CGFloat,
+        rowHeight: CGFloat,
+        viewportHeight: CGFloat,
+        currentOrigin: CGFloat
+    ) -> CGFloat? {
+        guard rowPitch > 0, rowCount > 0, viewportHeight > 0 else { return nil }
+        guard row >= 0, row < rowCount else { return nil }
+
+        let top = CGFloat(row) * rowPitch
+        let bottom = top + rowHeight
+        guard top < currentOrigin || bottom > currentOrigin + viewportHeight else { return nil }
+
+        let maximum = maximumRestingOrigin(
+            rowCount: rowCount, rowPitch: rowPitch, rowHeight: rowHeight, viewportHeight: viewportHeight
+        )
+        let target = top < currentOrigin
+            ? top
+            : ((bottom - viewportHeight) / rowPitch).rounded(.up) * rowPitch
+        let clamped = min(max(0, target), maximum)
+        guard abs(clamped - currentOrigin) > 0.5 else { return nil }
+        return clamped
+    }
+}

--- a/TablePro/Core/Services/Infrastructure/WorkspaceRailViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspaceRailViewController.swift
@@ -64,7 +64,20 @@ internal final class WorkspaceRailViewController: NSViewController {
     private var layout: WorkspaceRailMetrics.Layout = WorkspaceRailMetrics.medium
     private var changeCancellable: AnyCancellable?
     private let activationObserver = OSAllocatedUnfairLock<(any NSObjectProtocol)?>(uncheckedState: nil)
+    private let scrollObserver = OSAllocatedUnfairLock<(any NSObjectProtocol)?>(uncheckedState: nil)
     private var contentTopConstraint: NSLayoutConstraint?
+
+    /// A scroll is settled once it has stopped changing, which is the only signal every input
+    /// device gives. `NSScrollViewWillStartLiveScroll`/`DidEndLiveScroll` would be the obvious pair,
+    /// and `NSScrollView.h` says outright that a legacy mouse is not bracketed by them, which is the
+    /// device most likely to leave the strip resting mid-tile.
+    private var scrollSettle: DispatchWorkItem?
+
+    /// A reorder scrolls the strip itself as the pointer nears an edge, so settling during one would
+    /// fight the drag it is reacting to.
+    private var isReordering = false
+
+    private var needsSelectionReveal = false
 
     /// What the rail last put on screen as selected, which after every `applySelection` is the
     /// workspace the host is really showing. A commit for that same workspace has nothing to do,
@@ -97,7 +110,7 @@ internal final class WorkspaceRailViewController: NSViewController {
         tableView.backgroundColor = .clear
         tableView.allowsMultipleSelection = false
         tableView.allowsEmptySelection = true
-        tableView.intercellSpacing = NSSize(width: 0, height: 2)
+        tableView.intercellSpacing = NSSize(width: 0, height: layout.rowSpacing)
         tableView.dataSource = self
         tableView.delegate = self
         tableView.target = self
@@ -114,6 +127,12 @@ internal final class WorkspaceRailViewController: NSViewController {
         scrollView.autohidesScrollers = true
         scrollView.hasHorizontalScroller = false
         scrollView.drawsBackground = false
+        /// The bottom inset is the rail's own, and `contentInsets` and the automatic flag are one
+        /// property: writing the inset clears the flag anyway, so it is cleared here where it can be
+        /// read. Nothing is given up, because the automatic inset reads the scroll view's own safe
+        /// area, which `pinContentBelowTitleBar` has already reduced to nothing.
+        scrollView.automaticallyAdjustsContentInsets = false
+        scrollView.contentView.postsBoundsChangedNotifications = true
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(scrollView)
 
@@ -152,8 +171,104 @@ internal final class WorkspaceRailViewController: NSViewController {
             MainActor.assumeIsolated { self?.refreshLayoutIfNeeded() }
         }
         activationObserver.withLockUnchecked { $0 = observer }
+        observeScrollPosition()
         observeRowSizePreference()
         reload()
+    }
+
+    private func observeScrollPosition() {
+        let observer = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.scheduleScrollSettle() }
+        }
+        scrollObserver.withLockUnchecked { $0 = observer }
+    }
+
+    /// Re-armed on every bounds change, so the strip settles once the scrolling stops rather than
+    /// once per frame of it. Settling itself changes the bounds, which comes back through here and
+    /// finds nothing left to do.
+    private func scheduleScrollSettle() {
+        scrollSettle?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            MainActor.assumeIsolated { self?.settleScrollPosition() }
+        }
+        scrollSettle = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.scrollSettleDelay, execute: work)
+    }
+
+    private static let scrollSettleDelay: TimeInterval = 0.12
+
+    private func settleScrollPosition() {
+        guard !isReordering else { return }
+        let clipView = scrollView.contentView
+        let settled = WorkspaceRailScrollGeometry.settledOrigin(
+            proposed: clipView.bounds.origin.y,
+            selectedRow: entries.indices.contains(tableView.selectedRow) ? tableView.selectedRow : nil,
+            rowCount: entries.count,
+            rowPitch: layout.rowPitch,
+            rowHeight: layout.rowHeight,
+            viewportHeight: clipView.bounds.height
+        )
+        guard abs(settled - clipView.bounds.origin.y) > 0.5 else { return }
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.15
+            clipView.animator().setBoundsOrigin(NSPoint(x: clipView.bounds.origin.x, y: settled))
+        } completionHandler: { [weak self] in
+            guard let self else { return }
+            self.scrollView.reflectScrolledClipView(clipView)
+        }
+    }
+
+    /// Recomputed rather than set once, because the row count, the row height and the viewport all
+    /// move: an entry opens or closes, the sidebar icon size changes, the window resizes.
+    private func applyBottomInset() {
+        let clipView = scrollView.contentView
+        let inset = WorkspaceRailScrollGeometry.bottomInset(
+            rowCount: entries.count,
+            rowPitch: layout.rowPitch,
+            rowHeight: layout.rowHeight,
+            documentHeight: tableView.frame.height,
+            viewportHeight: clipView.bounds.height
+        )
+        guard abs(scrollView.contentInsets.bottom - inset) > 0.5 else { return }
+        scrollView.contentInsets = NSEdgeInsets(top: 0, left: 0, bottom: inset, right: 0)
+    }
+
+    /// Asked for when the highlight moves, and held until the strip has a viewport to move inside.
+    ///
+    /// The rail is laid out after `viewDidLoad` has already applied the first selection, so the
+    /// clip view can still be zero high when the entry to show is below the fold. Nothing arrives
+    /// later to say so: `NSView.boundsDidChangeNotification` is not posted for a bounds change that
+    /// came from the frame resizing, and `NSTableView` does not reveal a selection it already holds.
+    private func requestSelectionReveal() {
+        needsSelectionReveal = true
+        revealSelectedRowIfNeeded()
+    }
+
+    private func revealSelectedRowIfNeeded() {
+        guard needsSelectionReveal, scrollView.contentView.bounds.height > 0 else { return }
+        needsSelectionReveal = false
+        revealSelectedRow()
+    }
+
+    /// Silent while the entry is already whole and on screen. Every rail lists every workspace, so
+    /// one window's change reloads all of them; the callers are the paths where the highlight
+    /// actually moved, so a strip whose own entry did not change stays where its window left it.
+    private func revealSelectedRow() {
+        let clipView = scrollView.contentView
+        guard let origin = WorkspaceRailScrollGeometry.revealOrigin(
+            row: tableView.selectedRow,
+            rowCount: entries.count,
+            rowPitch: layout.rowPitch,
+            rowHeight: layout.rowHeight,
+            viewportHeight: clipView.bounds.height,
+            currentOrigin: clipView.bounds.origin.y
+        ) else { return }
+        clipView.scroll(to: NSPoint(x: clipView.bounds.origin.x, y: origin))
+        scrollView.reflectScrolledClipView(clipView)
     }
 
     override func viewWillAppear() {
@@ -166,11 +281,16 @@ internal final class WorkspaceRailViewController: NSViewController {
         if let observer = activationObserver.withLockUnchecked({ $0 }) {
             NotificationCenter.default.removeObserver(observer)
         }
+        if let observer = scrollObserver.withLockUnchecked({ $0 }) {
+            NotificationCenter.default.removeObserver(observer)
+        }
     }
 
     override func viewDidLayout() {
         super.viewDidLayout()
         tableView.sizeLastColumnToFit()
+        applyBottomInset()
+        revealSelectedRowIfNeeded()
     }
 
     // MARK: - Data
@@ -185,6 +305,7 @@ internal final class WorkspaceRailViewController: NSViewController {
             """
         )
         tableView.reloadData()
+        applyBottomInset()
         applySelection()
         onEntryCountChange?(entries.count)
     }
@@ -227,8 +348,10 @@ internal final class WorkspaceRailViewController: NSViewController {
         let resolved = WorkspaceRailMetrics.layout(for: resolvedRowSizeStyle)
         guard resolved != layout else { return }
         layout = resolved
+        tableView.intercellSpacing = NSSize(width: 0, height: layout.rowSpacing)
         tableView.sizeLastColumnToFit()
         tableView.reloadData()
+        applyBottomInset()
         applySelection()
         onLayoutChange?(resolved)
     }
@@ -263,6 +386,7 @@ internal final class WorkspaceRailViewController: NSViewController {
             tableView.deselectAll(nil)
             return
         }
+        let previousSelection = appliedSelection
         appliedSelection = entries[row].workspace
         Self.logger.debug(
             """
@@ -272,6 +396,8 @@ internal final class WorkspaceRailViewController: NSViewController {
             """
         )
         tableView.selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false)
+        guard previousSelection != appliedSelection else { return }
+        requestSelectionReveal()
     }
 
     // MARK: - Activation
@@ -450,6 +576,7 @@ internal final class WorkspaceRailViewController: NSViewController {
         ) else { return }
         guard let row = entries.firstIndex(where: { $0.id == next }) else { return }
         tableView.selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false)
+        requestSelectionReveal()
         commit(row: row)
     }
 
@@ -613,6 +740,25 @@ extension WorkspaceRailViewController: NSTableViewDataSource {
         entries.count
     }
 
+    internal func tableView(
+        _ tableView: NSTableView,
+        draggingSession session: NSDraggingSession,
+        willBeginAt screenPoint: NSPoint,
+        forRowIndexes rowIndexes: IndexSet
+    ) {
+        isReordering = true
+    }
+
+    internal func tableView(
+        _ tableView: NSTableView,
+        draggingSession session: NSDraggingSession,
+        endedAt screenPoint: NSPoint,
+        operation: NSDragOperation
+    ) {
+        isReordering = false
+        scheduleScrollSettle()
+    }
+
     internal func tableView(_ tableView: NSTableView, pasteboardWriterForRow row: Int) -> NSPasteboardWriting? {
         guard entries.indices.contains(row) else { return nil }
         guard let data = try? JSONEncoder().encode(entries[row].workspace) else { return nil }
@@ -686,6 +832,10 @@ extension WorkspaceRailViewController: NSTableViewDelegate {
     internal func tableViewSelectionDidChange(_ notification: Notification) {
         let row = tableView.selectedRow
         guard entries.indices.contains(row) else { return }
+        /// The arrow keys move the highlight through `NSTableView` itself, which reveals the row it
+        /// lands on by scrolling the least it can and so stops between entries. Landing on the
+        /// boundary here keeps the strip from having to slide again once the scroll settles.
+        requestSelectionReveal()
         Self.logger.debug(
             """
             selectionDidChange rail=\(self.railName, privacy: .public) row=\(row, privacy: .public) \

--- a/TableProTests/Core/Services/WorkspaceRailScrollGeometryTests.swift
+++ b/TableProTests/Core/Services/WorkspaceRailScrollGeometryTests.swift
@@ -1,0 +1,240 @@
+//
+//  WorkspaceRailScrollGeometryTests.swift
+//  TableProTests
+//
+//  The strip used to come to rest wherever a scroll left it, which cut the glyph off the entry at
+//  the top of the viewport and was reported as a drawing bug (#2452). These pin the offsets it is
+//  allowed to rest on.
+//
+
+import AppKit
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Workspace rail scroll geometry")
+struct WorkspaceRailScrollGeometryTests {
+    private static let layouts = [
+        WorkspaceRailMetrics.small,
+        WorkspaceRailMetrics.medium,
+        WorkspaceRailMetrics.large,
+    ]
+
+    @Test("Row pitch is the row plus the spacing between rows")
+    func rowPitchCombinesHeightAndSpacing() {
+        for layout in Self.layouts {
+            #expect(layout.rowPitch == layout.rowHeight + layout.rowSpacing)
+            #expect(layout.rowPitch > layout.rowHeight)
+        }
+    }
+
+    @Test("A strip whose entries fit cannot rest anywhere but the top")
+    func fittingStripRestsAtTheTop() {
+        let maximum = WorkspaceRailScrollGeometry.maximumRestingOrigin(
+            rowCount: 6, rowPitch: 60, rowHeight: 58, viewportHeight: 448
+        )
+        #expect(maximum == 0)
+        #expect(WorkspaceRailScrollGeometry.settledOrigin(
+            proposed: 137, rowPitch: 60, maximumOrigin: maximum
+        ) == 0)
+    }
+
+    @Test("The furthest resting offset keeps the last entry whole")
+    func maximumRestingOriginKeepsTheLastEntryWhole() {
+        let maximum = WorkspaceRailScrollGeometry.maximumRestingOrigin(
+            rowCount: 12, rowPitch: 60, rowHeight: 58, viewportHeight: 448
+        )
+        #expect(maximum == 300)
+        let lastEntryBottom = 11 * CGFloat(60) + 58
+        #expect(maximum + 448 >= lastEntryBottom)
+        #expect(maximum.truncatingRemainder(dividingBy: 60) == 0)
+    }
+
+    @Test("The bottom inset is what brings the furthest offset within reach")
+    func bottomInsetMakesTheLastOffsetReachable() {
+        let documentHeight: CGFloat = 732
+        let viewportHeight: CGFloat = 448
+        let inset = WorkspaceRailScrollGeometry.bottomInset(
+            rowCount: 12, rowPitch: 60, rowHeight: 58,
+            documentHeight: documentHeight, viewportHeight: viewportHeight
+        )
+        let maximum = WorkspaceRailScrollGeometry.maximumRestingOrigin(
+            rowCount: 12, rowPitch: 60, rowHeight: 58, viewportHeight: viewportHeight
+        )
+        #expect(documentHeight - viewportHeight < maximum)
+        #expect(documentHeight - viewportHeight + inset == maximum)
+    }
+
+    @Test("A strip that needs no scrolling asks for no inset")
+    func fittingStripNeedsNoInset() {
+        #expect(WorkspaceRailScrollGeometry.bottomInset(
+            rowCount: 4, rowPitch: 60, rowHeight: 58, documentHeight: 448, viewportHeight: 448
+        ) == 0)
+    }
+
+    @Test("Every settled offset lands on an entry boundary, at every layout")
+    func everySettledOffsetLandsOnABoundary() {
+        for layout in Self.layouts {
+            let pitch = layout.rowPitch
+            for viewportHeight in stride(from: CGFloat(200), through: 900, by: 37) {
+                let maximum = WorkspaceRailScrollGeometry.maximumRestingOrigin(
+                    rowCount: 20, rowPitch: pitch, rowHeight: layout.rowHeight,
+                    viewportHeight: viewportHeight
+                )
+                for proposed in stride(from: CGFloat(-40), through: maximum + 200, by: 11) {
+                    let settled = WorkspaceRailScrollGeometry.settledOrigin(
+                        proposed: proposed, rowPitch: pitch, maximumOrigin: maximum
+                    )
+                    #expect(settled >= 0)
+                    #expect(settled <= maximum)
+                    #expect(abs(settled.truncatingRemainder(dividingBy: pitch)) < 0.001)
+                }
+            }
+        }
+    }
+
+    @Test("Settling never rounds up past the furthest offset")
+    func settlingNeverOvershootsTheMaximum() {
+        let maximum = WorkspaceRailScrollGeometry.maximumRestingOrigin(
+            rowCount: 12, rowPitch: 60, rowHeight: 58, viewportHeight: 448
+        )
+        #expect(WorkspaceRailScrollGeometry.settledOrigin(
+            proposed: maximum + 500, rowPitch: 60, maximumOrigin: maximum
+        ) == maximum)
+        #expect(WorkspaceRailScrollGeometry.settledOrigin(
+            proposed: 289, rowPitch: 60, maximumOrigin: maximum
+        ) == maximum)
+    }
+
+    @Test("An entry already whole and on screen is left alone")
+    func visibleEntryIsNotRevealed() {
+        #expect(WorkspaceRailScrollGeometry.revealOrigin(
+            row: 2, rowCount: 12, rowPitch: 60, rowHeight: 58,
+            viewportHeight: 448, currentOrigin: 0
+        ) == nil)
+    }
+
+    @Test("An entry above the viewport is revealed at its own top edge")
+    func entryAboveIsRevealedAtItsTop() {
+        let origin = WorkspaceRailScrollGeometry.revealOrigin(
+            row: 1, rowCount: 12, rowPitch: 60, rowHeight: 58,
+            viewportHeight: 448, currentOrigin: 300
+        )
+        #expect(origin == 60)
+    }
+
+    @Test("An entry below the viewport is revealed whole, on a boundary")
+    func entryBelowIsRevealedWholeOnABoundary() {
+        let viewportHeight: CGFloat = 448
+        let origin = WorkspaceRailScrollGeometry.revealOrigin(
+            row: 9, rowCount: 12, rowPitch: 60, rowHeight: 58,
+            viewportHeight: viewportHeight, currentOrigin: 0
+        ) ?? -1
+        #expect(origin >= 0)
+        #expect(origin.truncatingRemainder(dividingBy: 60) == 0)
+        #expect(origin <= 9 * CGFloat(60))
+        #expect(origin + viewportHeight >= 9 * CGFloat(60) + 58)
+    }
+
+    @Test("Revealing the last entry lands exactly on the furthest resting offset")
+    func lastEntryIsReachableWhole() {
+        for layout in Self.layouts {
+            let pitch = layout.rowPitch
+            let viewportHeight: CGFloat = 448
+            let rowCount = 20
+            let maximum = WorkspaceRailScrollGeometry.maximumRestingOrigin(
+                rowCount: rowCount, rowPitch: pitch, rowHeight: layout.rowHeight,
+                viewportHeight: viewportHeight
+            )
+            let origin = WorkspaceRailScrollGeometry.revealOrigin(
+                row: rowCount - 1, rowCount: rowCount, rowPitch: pitch, rowHeight: layout.rowHeight,
+                viewportHeight: viewportHeight, currentOrigin: 0
+            )
+            #expect(origin == maximum)
+            let lastEntryBottom = CGFloat(rowCount - 1) * pitch + layout.rowHeight
+            #expect(maximum + viewportHeight >= lastEntryBottom)
+        }
+    }
+
+    @Test("A viewport that ends inside the spacing under the last entry still holds them all")
+    func viewportEndingInTrailingSpacingCountsAsFitting() {
+        let viewportHeight = 7 * CGFloat(60) + 58
+        #expect(WorkspaceRailScrollGeometry.maximumRestingOrigin(
+            rowCount: 8, rowPitch: 60, rowHeight: 58, viewportHeight: viewportHeight
+        ) == 0)
+        #expect(WorkspaceRailScrollGeometry.bottomInset(
+            rowCount: 8, rowPitch: 60, rowHeight: 58,
+            documentHeight: viewportHeight, viewportHeight: viewportHeight
+        ) == 0)
+    }
+
+    @Test("Settling does not cut an entry the highlight was showing whole")
+    func settlingKeepsAWholeHighlightWhole() {
+        let viewportHeight: CGFloat = 469
+        let settled = WorkspaceRailScrollGeometry.settledOrigin(
+            proposed: 89, selectedRow: 8, rowCount: 12,
+            rowPitch: 60, rowHeight: 58, viewportHeight: viewportHeight
+        )
+        #expect(settled.truncatingRemainder(dividingBy: 60) == 0)
+        let entryTop = 8 * CGFloat(60)
+        #expect(settled <= entryTop)
+        #expect(settled + viewportHeight >= entryTop + 58)
+    }
+
+    @Test("Scrolling away from the highlighted entry settles where the scroll ended")
+    func settlingDoesNotTetherToAnOffScreenHighlight() {
+        let viewportHeight: CGFloat = 430
+        let settled = WorkspaceRailScrollGeometry.settledOrigin(
+            proposed: 173, selectedRow: 11, rowCount: 12,
+            rowPitch: 60, rowHeight: 58, viewportHeight: viewportHeight
+        )
+        #expect(settled == 180)
+        let entryTop = 11 * CGFloat(60)
+        #expect(settled + viewportHeight < entryTop + 58)
+    }
+
+    @Test("A highlight that stays whole through the snap does not divert it")
+    func settlingSnapsNormallyWhenTheHighlightSurvives() {
+        #expect(WorkspaceRailScrollGeometry.settledOrigin(
+            proposed: 89, selectedRow: 1, rowCount: 12,
+            rowPitch: 60, rowHeight: 58, viewportHeight: 469
+        ) == 60)
+        #expect(WorkspaceRailScrollGeometry.settledOrigin(
+            proposed: 89, selectedRow: nil, rowCount: 12,
+            rowPitch: 60, rowHeight: 58, viewportHeight: 469
+        ) == 60)
+    }
+
+    @Test("A viewport with no height yet asks for no reveal")
+    func zeroHeightViewportRevealsNothing() {
+        #expect(WorkspaceRailScrollGeometry.revealOrigin(
+            row: 15, rowCount: 20, rowPitch: 60, rowHeight: 58,
+            viewportHeight: 0, currentOrigin: 0
+        ) == nil)
+        #expect(WorkspaceRailScrollGeometry.revealOrigin(
+            row: 15, rowCount: 20, rowPitch: 60, rowHeight: 58,
+            viewportHeight: 448, currentOrigin: 0
+        ) != nil)
+    }
+
+    @Test("Degenerate geometry asks for nothing")
+    func degenerateGeometryIsInert() {
+        #expect(WorkspaceRailScrollGeometry.maximumRestingOrigin(
+            rowCount: 0, rowPitch: 60, rowHeight: 58, viewportHeight: 448
+        ) == 0)
+        #expect(WorkspaceRailScrollGeometry.maximumRestingOrigin(
+            rowCount: 12, rowPitch: 0, rowHeight: 58, viewportHeight: 448
+        ) == 0)
+        #expect(WorkspaceRailScrollGeometry.bottomInset(
+            rowCount: 12, rowPitch: 60, rowHeight: 58, documentHeight: 732, viewportHeight: 0
+        ) == 0)
+        #expect(WorkspaceRailScrollGeometry.revealOrigin(
+            row: 0, rowCount: 0, rowPitch: 60, rowHeight: 58,
+            viewportHeight: 448, currentOrigin: 0
+        ) == nil)
+        #expect(WorkspaceRailScrollGeometry.revealOrigin(
+            row: 30, rowCount: 12, rowPitch: 60, rowHeight: 58,
+            viewportHeight: 448, currentOrigin: 0
+        ) == nil)
+    }
+}

--- a/docs/features/workspace-rail.mdx
+++ b/docs/features/workspace-rail.mdx
@@ -46,6 +46,8 @@ Between two connections, the window switches connection and returns you to the t
 
 The strip takes the keyboard too. Click into it, then arrow keys move the highlight, typing jumps to a name, and `Return` opens the entry you land on.
 
+More entries than fit the window means the strip scrolls, and it settles on whole entries rather than halfway through one. Switching to an entry that is off screen brings it into view.
+
 ## Windows
 
 One window hosts every connection you have open, and the tab strip below the toolbar lists only the current connection's tabs. Opening a table or query on a connection already open adds a tab there rather than opening a second window.


### PR DESCRIPTION
Fixes #2452.

## What was wrong

The connections strip is a scrollable list of fixed-height tiles with no owner for its scroll position. Two separate defects follow from that, and the issue reports both.

A tile's meaning is its glyph, drawn across the top 6pt to 30pt of the cell. `NSClipView.constrainBoundsRect` accepts any offset between zero and the document's end, so an ordinary scroll comes to rest mid-tile and the top entry loses its glyph, leaving the label behind with nothing above it. The strip autohides its scroller, so at rest nothing says it scrolls at all, and that orphan reads as a drawing bug.

Separately, `scrollRowToVisible` appeared nowhere in `WorkspaceRail*.swift`. Both places that moved the highlight called `selectRowIndexes` and stopped, so the entry the window was actually showing could sit half-cut or entirely off screen, and **View > Show Next Connection** moved the highlight out of sight with no visible response.

## What this changes

`WorkspaceRailScrollGeometry` is a new pure type holding the three offsets the strip is allowed to rest on, so the arithmetic is testable on its own:

- **Settle on a boundary.** After scrolling stops, the strip animates to the nearest whole-entry offset. Debounced off the clip view's `boundsDidChangeNotification`, which is the one signal every input device produces: `NSScrollView.h:172` says outright that a legacy mouse is not bracketed by the `willStart`/`didEnd` live-scroll pair, and that is the device most likely to leave a tile sliced. `CLAUDE.md` already records this notification as the only one that also reports programmatic scrolling, for the data grid's accessibility remount.
- **A bottom content inset of the viewport remainder.** A viewport is almost never a whole number of tiles, so without it the final entry is reachable only from an offset that is not a boundary: the strip either stops short of its last entry or slices the top one to reach it. The inset is what makes that last offset land on a boundary like every other.
- **Reveal the entry you switch to**, when the highlight actually moves, held until the strip has a viewport to move inside.
- `rowSpacing` moves onto `WorkspaceRailMetrics.Layout` so the table's `intercellSpacing` and the scroll arithmetic read one pitch.

## What this deliberately does not change

The safe-area pin and `automaticallyAdjustsContentInsets` are both correct and inert, measured through the accessibility tree of the running app at 1600x900, 720x480 and full screen, with the editor tab-strip band shown and hidden, at 6 and 12 entries. In every state the strip's scroll area top, its safe-area top and the sidebar separator's top are the same value, row 0 is flush, and `contentInsets` is zero. There is no structural displacement and no double inset, so nothing here touches that pinning.

## Verification

Build, lint (0 violations) and the docs checks pass. 68 unit cases across `WorkspaceRailScrollGeometryTests`, `WorkspaceRailMetricsTests`, `WorkspaceRailCellRenderingTests`, `WorkspaceRailStoreTests` and `MainSplitViewControllerDetailWidthTests`.

Measured against a Debug build driven with 12 SQLite connections in a 720x480 window, so the strip overflows its 430pt viewport:

| Check | Result |
|---|---|
| Rest offsets over five scroll gestures | 240, 240, 180, 240, 300, every one a multiple of the 60pt pitch |
| Nine arrow-downs | origin 300, rows 5 through 11 all whole, none clipped at either edge |
| Last entry at full scroll | whole, 652 to 712 inside a viewport ending at 722 |
| Source-list row phase, hard against the top | `clip.top 292.0, row0.top 292.0, phase 0.0` |

## Before / after

Same build, same 13-entry strip, same scroll position. Before: the top tile is an orphaned label with its glyph sliced off above. After: glyph then label, whole.

Screenshots are on the author's machine and need dragging in; `gh` cannot upload them.

## No UI test

`.claude/rules/ui-lifecycle.md:19` requires `TableProUITests` coverage for a flow that runs deterministically, and this one does not. Reproducing it needs eight or more live connections to make the strip overflow, and `CLAUDE.md` records that CI's accessibility tree reports grid and rail rows differently from a local run and that XCUITest refuses to click them. The scroll arithmetic is covered by the pure suite instead, and the AppKit behaviour was verified by driving the built app.
