### PR TITLE
fix(datagrid): resolve a row view's index from the table instead of a stale copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Connections strip not scrolling to the entry you switch to.
 - Grid cells left at the old column positions until the next click, after a resize, an auto-fit, a reorder, hiding a column, or a row-number width change. (#2449)
 - The row-number column draggable out of first place, which walked it to the far right on the next refresh.
+- Double-clicking a cell editing the wrong row, after deleting one of several rows added in the same session.
+- VoiceOver reading a cell's value under a different row's number after such a delete.
 
 ## [0.68.1] - 2026-08-26
 

--- a/TablePro/Views/Results/Cells/DataGridCellAccessibilityView.swift
+++ b/TablePro/Views/Results/Cells/DataGridCellAccessibilityView.swift
@@ -44,15 +44,30 @@ internal final class DataGridCellAccessibilityView: NSView {
     internal static let reuseIdentifier = NSUserInterfaceItemIdentifier("DataGridCellAccessibilityView")
 
     private weak var coordinator: TableViewCoordinator?
-    private var row = 0
+    private var seededRow = 0
     private var dataColumn = 0
+
+    /// The row this cell is showing now, asked of the table rather than remembered, for the reason
+    /// `DataGridRowView.rowIndex` is: an incremental insert or remove moves a mounted cell view to
+    /// its new slot without asking for it again, so a stored index outlives the row it named and the
+    /// cell then speaks a different row's value under the old row's number.
+    private var row: Int {
+        guard let tableView = coordinator?.tableView else { return seededRow }
+        let resolved = tableView.row(for: self)
+        return resolved >= 0 ? resolved : seededRow
+    }
 
     internal func configure(coordinator: TableViewCoordinator, row: Int, dataColumn: Int) {
         self.coordinator = coordinator
-        self.row = row
+        seededRow = row
         self.dataColumn = dataColumn
-        setAccessibilityRowIndexRange(NSRange(location: row, length: 1))
         setAccessibilityColumnIndexRange(NSRange(location: dataColumn, length: 1))
+    }
+
+    /// Answered live for the same reason, rather than stamped in `configure`, so a client reading the
+    /// tree after a row moved is told where the cell is rather than where it was built.
+    override internal func accessibilityRowIndexRange() -> NSRange {
+        NSRange(location: row, length: 1)
     }
 
     override internal func hitTest(_ point: NSPoint) -> NSView? { nil }

--- a/TablePro/Views/Results/DataGridRowView.swift
+++ b/TablePro/Views/Results/DataGridRowView.swift
@@ -15,7 +15,27 @@ class DataGridRowView: NSTableRowView {
     }
 
     weak var coordinator: TableViewCoordinator?
-    var rowIndex: Int = 0
+
+    /// The row this view is showing now, asked of the table rather than remembered.
+    ///
+    /// `insertRows(at:)` and `removeRows(at:)` move an already-built row view to its new slot
+    /// without calling `tableView(_:rowViewForRow:)` for it again, so an index captured at mount
+    /// goes stale the moment a row is inserted or removed above this one, and every read of it then
+    /// names a different row. Measured: after `removeRows(at: [1])` the view at display row 1 still
+    /// carried 2, the one at 2 carried 3, and an insert left two views both claiming 0, while
+    /// `row(for:)` answered correctly throughout at 26ns a call. AppKit keeps that mapping itself,
+    /// so it is asked for it. The seed answers only for a row view that is in no table, which is how
+    /// the copy tests build one.
+    var rowIndex: Int {
+        get {
+            guard let tableView = coordinator?.tableView else { return seededRowIndex }
+            let resolved = tableView.row(for: self)
+            return resolved >= 0 ? resolved : seededRowIndex
+        }
+        set { seededRowIndex = newValue }
+    }
+
+    private var seededRowIndex: Int = 0
 
     private(set) var visualState: RowVisualState = .empty
     private var rowTint: NSColor?
@@ -132,13 +152,14 @@ class DataGridRowView: NSTableRowView {
         guard let coordinator, let tableView = coordinator.tableView else { return }
         let inTableView = view.convert(dirtyRect, to: tableView)
         let onEmphasizedSelection = isSelected && isEmphasized
+        let row = rowIndex
 
         for tableColumnIndex in tableView.columnIndexes(in: inTableView) {
             guard tableColumnIndex < tableView.tableColumns.count else { continue }
             let identifier = tableView.tableColumns[tableColumnIndex].identifier
             guard let dataColumn = coordinator.dataColumnIndex(from: identifier) else { continue }
             guard let appearance = coordinator.cellAppearance(
-                row: rowIndex,
+                row: row,
                 columnIndex: dataColumn,
                 onEmphasizedSelection: onEmphasizedSelection
             ) else { continue }

--- a/TableProTests/Views/Results/DataGridRowIdentityTests.swift
+++ b/TableProTests/Views/Results/DataGridRowIdentityTests.swift
@@ -1,0 +1,173 @@
+//
+//  DataGridRowIdentityTests.swift
+//  TableProTests
+//
+
+import AppKit
+import SwiftUI
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+@MainActor
+private final class NoopRowIdentityPersister: ColumnLayoutPersisting {
+    func load(for key: ColumnLayoutTableKey) -> ColumnLayoutState? { nil }
+    func save(_ layout: ColumnLayoutState, for key: ColumnLayoutTableKey) {}
+    func clear(for key: ColumnLayoutTableKey) {}
+}
+
+/// `insertRows(at:)` and `removeRows(at:)` move an already-built row view to its new slot without
+/// asking the delegate for it again, so an index captured when the view was mounted names a
+/// different row from then on. Measured: after `removeRows(at: [1])` the view at display row 1 still
+/// carried 2 and an insert left two views both claiming 0, which sent a double-click to the wrong
+/// row and had an accessibility cell speak one row's value under another row's number.
+@Suite("Data grid row identity", .serialized)
+@MainActor
+struct DataGridRowIdentityTests {
+    private struct Grid {
+        let window: NSWindow
+        let tableView: KeyHandlingTableView
+        let coordinator: TableViewCoordinator
+        let rowCount: Box
+
+        var rowViews: [DataGridRowView] {
+            (0 ..< tableView.numberOfRows).compactMap {
+                tableView.rowView(atRow: $0, makeIfNecessary: false) as? DataGridRowView
+            }
+        }
+    }
+
+    /// The provider is read on every access, so the row count has to live somewhere the test can
+    /// move before it tells the table view about the mutation, exactly as the coordinator does.
+    private final class Box {
+        var value: Int
+        init(_ value: Int) { self.value = value }
+    }
+
+    private static func rows(count: Int) -> TableRows {
+        TableRows.from(
+            queryRows: (0 ..< count).map { [.text("id-\($0)"), .text("name-\($0)")] },
+            columns: ["id", "name"],
+            columnTypes: [.text(rawType: "TEXT"), .text(rawType: "TEXT")]
+        )
+    }
+
+    private func makeGrid(rowCount: Int = 5) -> Grid {
+        let box = Box(rowCount)
+        let coordinator = TableViewCoordinator(
+            changeManager: AnyChangeManager(DataChangeManager()),
+            isEditable: true,
+            selectedRowIndices: .constant([]),
+            delegate: nil,
+            layoutPersister: NoopRowIdentityPersister()
+        )
+        coordinator.tableRowsProvider = { Self.rows(count: box.value) }
+        coordinator.rebuildColumnMetadataCache(from: Self.rows(count: box.value))
+        coordinator.updateCache()
+
+        let tableView = KeyHandlingTableView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
+        tableView.columnAutoresizingStyle = .noColumnAutoresizing
+        tableView.rowHeight = 21
+        tableView.coordinator = coordinator
+        tableView.dataSource = coordinator
+        tableView.delegate = coordinator
+        tableView.addTableColumn(DataGridView.makeRowNumberColumn())
+        coordinator.tableView = tableView
+        coordinator.columnPool.reconcile(
+            tableView: tableView,
+            schema: coordinator.identitySchema,
+            columnTypes: [.text(rawType: "TEXT"), .text(rawType: "TEXT")],
+            savedLayout: nil,
+            isEditable: true,
+            hiddenColumnNames: [],
+            widthCalculator: { _, _ in 120 }
+        )
+
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
+        scrollView.documentView = tableView
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = scrollView
+        tableView.reloadData()
+        window.layoutIfNeeded()
+        for row in 0 ..< tableView.numberOfRows {
+            _ = tableView.rowView(atRow: row, makeIfNecessary: true)
+        }
+        return Grid(window: window, tableView: tableView, coordinator: coordinator, rowCount: box)
+    }
+
+    @Test("Every mounted row reports its own display row before any mutation")
+    func rowsStartCorrect() {
+        let grid = makeGrid()
+        #expect(grid.rowViews.map(\.rowIndex) == Array(0 ..< 5))
+    }
+
+    @Test("Removing a row above a mounted one moves its index down")
+    func removeShiftsTheRowsBelow() throws {
+        let grid = makeGrid()
+        let third = try #require(grid.tableView.rowView(atRow: 2, makeIfNecessary: false) as? DataGridRowView)
+        #expect(third.rowIndex == 2)
+
+        grid.rowCount.value = 4
+        grid.coordinator.updateCache()
+        grid.tableView.removeRows(at: IndexSet(integer: 1), withAnimation: [])
+
+        #expect(third.rowIndex == 1)
+        #expect(grid.rowViews.map(\.rowIndex) == Array(0 ..< 4))
+    }
+
+    @Test("Inserting a row above a mounted one moves its index up")
+    func insertShiftsTheRowsBelow() throws {
+        let grid = makeGrid()
+        let first = try #require(grid.tableView.rowView(atRow: 0, makeIfNecessary: false) as? DataGridRowView)
+        #expect(first.rowIndex == 0)
+
+        grid.rowCount.value = 6
+        grid.coordinator.updateCache()
+        grid.tableView.insertRows(at: IndexSet(integer: 0), withAnimation: [])
+
+        #expect(first.rowIndex == 1)
+        #expect(grid.rowViews.map(\.rowIndex) == Array(0 ..< 6))
+    }
+
+    /// A row view outside any table keeps the index it was handed, which is the shape the copy tests
+    /// build and the only case the stored seed still answers for.
+    @Test("A row view in no table falls back to the index it was given")
+    func detachedRowKeepsItsSeededIndex() {
+        let rowView = DataGridRowView()
+        rowView.rowIndex = 7
+        #expect(rowView.rowIndex == 7)
+    }
+
+    /// The accessibility cell is a real mounted view, so an incremental mutation moves it the same
+    /// way and it used to keep speaking the row it was built for.
+    @Test("An accessibility cell moved by a removal speaks its new row")
+    func accessibilityCellFollowsTheRemoval() throws {
+        DataGridAccessibility.isActive = true
+        defer { DataGridAccessibility.isActive = false }
+        let grid = makeGrid()
+        grid.tableView.reloadData()
+        grid.window.layoutIfNeeded()
+
+        let dataColumn = try #require(grid.coordinator.tableColumnIndex(for: 0))
+        let cell = try #require(
+            grid.tableView.view(atColumn: dataColumn, row: 2, makeIfNecessary: true)
+                as? DataGridCellAccessibilityView
+        )
+        #expect(cell.accessibilityValue() as? String == "id-2")
+        #expect(cell.accessibilityRowIndexRange().location == 2)
+
+        grid.rowCount.value = 4
+        grid.coordinator.updateCache()
+        grid.tableView.removeRows(at: IndexSet(integer: 1), withAnimation: [])
+
+        #expect(cell.accessibilityRowIndexRange().location == 1)
+        #expect(cell.accessibilityValue() as? String == "id-1")
+    }
+}


### PR DESCRIPTION
Found while investigating #2449, and independent of the fix that shipped there (#2455).

## The bug

Delete one of several rows added in the same session, then double-click a cell: the editor opens on a **different row**, or on a row past the end where nothing happens. With VoiceOver attached, cells below the deletion read one row's value under another row's number.

## Root cause

`DataGridRowView.rowIndex` and `DataGridCellAccessibilityView.row` are copies of a display-row index taken once, when AppKit first builds the view in `tableView(_:rowViewForRow:)` / `tableView(_:viewFor:row:)`.

`NSTableView.insertRows(at:)` and `removeRows(at:)` move an already-built view to its new slot **without asking the delegate for it again**, so the copy goes stale the moment a row is inserted or removed above it. `reloadData(forRowIndexes:columnIndexes:)` does not heal it either; only a full `reloadData()` does, and `applyRemovedRows` calls `updateCache()` first, so `updateNSView` sees `structureChanged == false` and skips it.

Measured, with the stored index beside AppKit's own answer:

```
after removeRows(at: [1])   rowViewForRow: calls = 0
  display row 1: stored rowIndex=2   row(for:)=1     cell.storedRow=2  row(for: cell)=1
  display row 2: stored rowIndex=3   row(for:)=2     cell.storedRow=3  row(for: cell)=2
after insertRows(at: [0])   rowViewForRow: calls = 1   (the new row only)
  display row 0: stored rowIndex=0   row(for:)=0
  display row 1: stored rowIndex=0   row(for:)=1     <- two views both claiming 0
```

Every read of the stale copy then names the wrong row, and there are about thirty of them in `DataGridRowView` alone: the double-click handler, the cell drawing, the selection wash, the whole context menu and its actions, copy-as-INSERT/UPDATE/JSON/CSV, set-NULL/empty/default, and foreign-key navigation.

## The fix

AppKit already tracks the mapping, so it is asked for it rather than mirrored. `rowIndex` becomes a computed property over `NSTableView.row(for:)`, keeping the assigned value as a seed that answers only for a row view that is in no table, which is the shape `DataGridRowViewCopyTests` builds. Every existing read site is correct with no further change, and `StructureRowViewWithMenu` inherits it.

`DataGridCellAccessibilityView` gets the same treatment, and publishes its row index through `accessibilityRowIndexRange()` rather than stamping it into `setAccessibilityRowIndexRange` at build time, so a client reading the tree after a row moved is told where the cell is rather than where it was built.

Rejected: rewriting the stored indices from `applyInsertedRows` / `applyRemovedRows`. It duplicates bookkeeping AppKit already does, reaches only the *available* row views, and needs a matching accessibility remount call of its own. Also rejected: forcing a full `reloadData()` on every incremental mutation, which throws away the view reuse those calls exist for.

## The row number, found by review

Codex's review of the first commit caught the half this left behind. The row-number column is the one column that still mounts a real cell view, and `makeRowNumberCell` stamps its text, its colour and its accessibility label once. AppKit slides that cell to its new slot without asking the delegate to configure it again, so after removing row 1 the row now at 1 kept reading "3" and announcing "Row 3" while the drawn values beside it had already moved on. Making the data correct without this would have left the number and the values in open disagreement, which is worse than both being wrong together.

That cell is now a `DataGridRowNumberCellView` that owns its own presentation, and `applyInsertedRows` / `applyRemovedRows` renumber the viewport after the mutation. Only the viewport is walked, because only the viewport holds a cell.

## Performance

`row(for:)` is documented as O(visible rows), and it lands on a draw path. Measured on a 5,000-row table with 28 mounted row views: **26 ns per call**, 13.2 ms for 500,000 calls. `drawCells` still hoists it into one local before its per-column loop, next to the `onEmphasizedSelection` local that is already hoisted there, so a 500-column row resolves it once rather than 500 times.

## Verification

- `test` PASS, 57 cases, 0 failed, across the 7 suites that own these types (84 across 11 on the first commit).
- `lint` 0 SwiftLint violations. (The wrapper's `agent docs` step reports one pre-existing stale symbol, `CLAUDE.md:216 AXCell`, in a file this branch does not touch.)
- New suite `DataGridRowIdentityTests`, 6 cases: every mounted row reports its own display row; a removal above a mounted row moves its index down; an insert above it moves it up; a detached row view still answers with its seed; an accessibility cell moved by a removal reports the new row's index *and* speaks the new row's value; and the row number follows a removal, in its text and in its spoken label.
- **Negative controls**, run separately for each half: with `rowIndex` and `row` returning the stored copy again, 3 of the 5 then-existing cases fail, and the other 2 are correct in both worlds by design, one of them deliberately so since it pins the detached-view fallback. With the renumbering removed, `rowNumberFollowsTheRemoval` fails on its own.

No UI automation: reproducing this needs an editable connection, three added rows and a delete, which does not run deterministically in `TableProUITests`. The unit suite drives the same AppKit calls the coordinator makes.
