### PR TITLE
fix(datagrid): keep a column order whose columns have not changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Connections strip not scrolling to the entry you switch to.
 - Grid cells left at the old column positions until the next click, after a resize, an auto-fit, a reorder, hiding a column, or a row-number width change. (#2449)
 - The row-number column draggable out of first place, which walked it to the far right on the next refresh.
+- A reordered column snapping back on the next refresh in the Structure tab and in query results.
 
 ## [0.68.1] - 2026-08-26
 

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -262,11 +262,26 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         tabType = configuration.tabType
     }
 
+    /// A grid with no table behind it keeps a saved column order only while its columns are still
+    /// the ones that order was saved for.
+    ///
+    /// A query result's columns are authored by the SELECT list and their order is meaningful, so an
+    /// order saved for a different set must not be replayed over it: `computeTargetOrder` appends
+    /// every column the saved order does not name, which landed a newly written column at the far
+    /// right instead of where it was typed (#1565). Dropping the order outright was the first answer
+    /// to that, and it also threw away an order the columns had not moved under, so a reorder was
+    /// captured and persisted and then silently undone on the next update. Comparing the sets keeps
+    /// #1565 fixed, lets a reorder survive a re-run of the same query, and is what lets the Structure
+    /// grid, whose columns never change, hold one at all.
     func savedColumnLayout(binding: ColumnLayoutState) -> ColumnLayoutState? {
         guard tabType == .table else {
-            guard !binding.columnWidths.isEmpty || binding.columnContentWidths?.isEmpty == false else { return nil }
             var layout = binding
-            layout.columnOrder = nil
+            if let order = layout.columnOrder, Set(order) != Set(identitySchema.columnNames) {
+                layout.columnOrder = nil
+            }
+            guard !layout.columnWidths.isEmpty
+                || layout.columnContentWidths?.isEmpty == false
+                || layout.columnOrder?.isEmpty == false else { return nil }
             return layout
         }
 

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -262,21 +262,19 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         tabType = configuration.tabType
     }
 
-    /// A grid with no table behind it keeps a saved column order only while its columns are still
-    /// the ones that order was saved for.
+    /// A grid with no table behind it keeps a saved column order only while its columns are still the
+    /// ones that order was saved for.
     ///
     /// A query result's columns are authored by the SELECT list and their order is meaningful, so an
     /// order saved for a different set must not be replayed over it: `computeTargetOrder` appends
     /// every column the saved order does not name, which landed a newly written column at the far
-    /// right instead of where it was typed (#1565). Dropping the order outright was the first answer
-    /// to that, and it also threw away an order the columns had not moved under, so a reorder was
-    /// captured and persisted and then silently undone on the next update. Comparing the sets keeps
-    /// #1565 fixed, lets a reorder survive a re-run of the same query, and is what lets the Structure
-    /// grid, whose columns never change, hold one at all.
+    /// right instead of where it was typed (#1565). Dropping the order outright answered that and
+    /// also threw away orders the columns had never moved under, so a reorder was captured, persisted
+    /// and then silently undone on the next update.
     func savedColumnLayout(binding: ColumnLayoutState) -> ColumnLayoutState? {
         guard tabType == .table else {
             var layout = binding
-            if let order = layout.columnOrder, Set(order) != Set(identitySchema.columnNames) {
+            if let order = layout.columnOrder, !canRestoreColumnOrder(order) {
                 layout.columnOrder = nil
             }
             guard !layout.columnWidths.isEmpty
@@ -294,6 +292,15 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
             return nil
         }
         return binding
+    }
+
+    /// A saved order is a list of names, and a name identifies a column only while the names are
+    /// unique. `SELECT a.id, b.id` gives two columns called `id`, and `ColumnIdentitySchema` resolves
+    /// a duplicate name to its last slot, so replaying such an order swaps the two columns.
+    private func canRestoreColumnOrder(_ order: [String]) -> Bool {
+        let columns = identitySchema.columnNames
+        let names = Set(columns)
+        return names.count == columns.count && Set(order) == names
     }
 
     /// A saved width is the width the column had, accessory or not. Nothing here re-derives it from

--- a/TableProTests/Views/Results/TableViewCoordinatorLayoutTests.swift
+++ b/TableProTests/Views/Results/TableViewCoordinatorLayoutTests.swift
@@ -168,6 +168,33 @@ struct TableViewCoordinatorLayoutTests {
         #expect(coordinator.savedColumnLayout(binding: binding) == binding)
     }
 
+    /// A saved order names its columns, and `SELECT a.id, b.id` gives two of them the same name.
+    /// `ColumnIdentitySchema` resolves a duplicate to its last slot, so replaying such an order
+    /// silently swaps the pair.
+    @Test("Query tab drops a column order when two columns share a name")
+    func queryTabDropsColumnOrderForDuplicateNames() {
+        let coordinator = makeCoordinator(
+            tabType: .query,
+            connectionId: nil,
+            tableName: nil,
+            persister: FakeColumnLayoutPersister()
+        )
+        let rows = TableRows.from(
+            queryRows: [[.text("1"), .text("2")]],
+            columns: ["id", "id"],
+            columnTypes: Array(repeating: ColumnType.text(rawType: "TEXT"), count: 2)
+        )
+        coordinator.rebuildColumnMetadataCache(from: rows)
+        var binding = ColumnLayoutState()
+        binding.columnWidths = ["id": 60]
+        binding.columnOrder = ["id", "id"]
+
+        var expected = ColumnLayoutState()
+        expected.columnWidths = ["id": 60]
+
+        #expect(coordinator.savedColumnLayout(binding: binding) == expected)
+    }
+
     /// A reorder with no width change is the whole layout, and it used to fall through the
     /// emptiness guard and come back as nil.
     @Test("Query tab keeps an order-only layout")

--- a/TableProTests/Views/Results/TableViewCoordinatorLayoutTests.swift
+++ b/TableProTests/Views/Results/TableViewCoordinatorLayoutTests.swift
@@ -128,6 +128,12 @@ struct TableViewCoordinatorLayoutTests {
             tableName: nil,
             persister: FakeColumnLayoutPersister()
         )
+        let rows = TableRows.from(
+            queryRows: [[.text("1"), .text("direct"), .text("EU")]],
+            columns: ["id", "business_model", "region"],
+            columnTypes: Array(repeating: ColumnType.text(rawType: "TEXT"), count: 3)
+        )
+        coordinator.rebuildColumnMetadataCache(from: rows)
         var binding = ColumnLayoutState()
         binding.columnWidths = ["id": 60, "business_model": 120]
         binding.columnOrder = ["id", "business_model"]
@@ -136,6 +142,52 @@ struct TableViewCoordinatorLayoutTests {
         expected.columnWidths = ["id": 60, "business_model": 120]
 
         #expect(coordinator.savedColumnLayout(binding: binding) == expected)
+    }
+
+    /// The order is dropped because the columns moved under it, not because the grid has no table.
+    /// A re-run of the same query, and every update of the Structure grid, arrives with the same
+    /// column set, and the reorder the user made has to survive it.
+    @Test("Query tab keeps a column order saved for the same columns")
+    func queryTabKeepsMatchingColumnOrder() {
+        let coordinator = makeCoordinator(
+            tabType: .query,
+            connectionId: nil,
+            tableName: nil,
+            persister: FakeColumnLayoutPersister()
+        )
+        let rows = TableRows.from(
+            queryRows: [[.text("1"), .text("direct")]],
+            columns: ["id", "business_model"],
+            columnTypes: Array(repeating: ColumnType.text(rawType: "TEXT"), count: 2)
+        )
+        coordinator.rebuildColumnMetadataCache(from: rows)
+        var binding = ColumnLayoutState()
+        binding.columnWidths = ["id": 60, "business_model": 120]
+        binding.columnOrder = ["business_model", "id"]
+
+        #expect(coordinator.savedColumnLayout(binding: binding) == binding)
+    }
+
+    /// A reorder with no width change is the whole layout, and it used to fall through the
+    /// emptiness guard and come back as nil.
+    @Test("Query tab keeps an order-only layout")
+    func queryTabKeepsAnOrderOnlyLayout() {
+        let coordinator = makeCoordinator(
+            tabType: .query,
+            connectionId: nil,
+            tableName: nil,
+            persister: FakeColumnLayoutPersister()
+        )
+        let rows = TableRows.from(
+            queryRows: [[.text("1"), .text("direct")]],
+            columns: ["id", "business_model"],
+            columnTypes: Array(repeating: ColumnType.text(rawType: "TEXT"), count: 2)
+        )
+        coordinator.rebuildColumnMetadataCache(from: rows)
+        var binding = ColumnLayoutState()
+        binding.columnOrder = ["business_model", "id"]
+
+        #expect(coordinator.savedColumnLayout(binding: binding) == binding)
     }
 
     @Test("Query tab keeps remembered widths when there is no saved order")


### PR DESCRIPTION
Found while investigating #2449, and made visible by the fix that shipped there (#2455): reordering a column in the Structure tab now repaints correctly, and then silently snaps back.

## The bug

Drag a column header in the Structure tab, or in a query result. The move lands and is written to the session's column layouts. On the next update, a keystroke in the Structure filter, a cell edit, a refresh, a re-run of the same query, the columns jump back to their original order with no explanation.

## Root cause

`savedColumnLayout(binding:)` drops the order outright for every grid whose `tabType != .table`:

```swift
guard tabType == .table else {
    ...
    layout.columnOrder = nil
    return layout
}
```

`TableStructureView` builds its `DataGridConfiguration` with no `tabType`, so the Structure grid takes that branch. Meanwhile `captureColumnLayout()` records `columnOrder` for **every** grid and `tableViewColumnDidMove` persists it, so the reorder is written and then thrown away on the way back in. `DataGridColumnPool.computeTargetOrder` receives `nil` and returns the natural slot order, and `attachAndOrderColumns` moves the columns back.

That nil-ing is not arbitrary. It came from #1565 via e582a8bbe: in a SQL tab, going from `select id, business_model from orders` to `select id, state, business_model from orders` put the new `state` column at the **far right** rather than between the other two, because `computeTargetOrder` appends every schema slot the saved order does not name. Dropping the order fixed that, and also threw away orders the columns had never moved under.

## The fix

The order is unsafe when the columns moved under it, not when the grid has no table behind it. So the sets are compared instead:

```swift
if let order = layout.columnOrder, Set(order) != Set(identitySchema.columnNames) {
    layout.columnOrder = nil
}
```

`identitySchema` is rebuilt from the current rows immediately before both production call sites, so it is the live column set.

- Adding or removing a column in the SELECT list changes the set, the saved order is dropped, and the columns arrive in SELECT order. #1565 stays fixed, and its regression test still passes unchanged in substance.
- Re-running the same query, and every update of the Structure grid whose columns never change, keeps the set, so a reorder survives.

The emptiness guard moved below that check, because a reorder with no width change is the entire layout and used to fall through it and come back as `nil`.

`.table` tabs are untouched: they read from the persister, keyed per table, and keep today's behaviour.

## Duplicate column names, found by review

Codex caught a hole in the first version of that rule. A set comparison accepts `SELECT a.id, b.id`, whose captured order is `["id", "id"]`, but `ColumnIdentitySchema.slotByColumnName` keeps the **last** occurrence of a duplicate name, so `computeTargetOrder` resolves both entries to slot 1, dedupes them, then appends slot 0: the two columns silently swap on the next update.

A saved order is a list of names, and a name identifies a column only while the names are unique, so the order is now dropped unless the current column names are unique as well as matching.

## Scope

Deliberately not changed: `.table` grids still replay a saved order across a schema change, appending a newly added column at the end rather than discarding a layout the user built on purpose. That is the same trade-off #1565 names, decided the other way, and it is the right one where the order is persisted per table and deliberate.

## Verification

- `test` PASS, 86 cases across the four suites that own column layout and identity, and 161 across ten on the first commit. 0 failed.
- `lint` 0 SwiftLint violations. (The wrapper's `agent docs` step reports one pre-existing stale symbol, `CLAUDE.md:216 AXCell`, in a file this branch does not touch.)
- `queryTabDropsStaleColumnOrder` now rebuilds a three-column schema so it exercises a genuinely stale order rather than an empty one, which is what its name always claimed.
- Three new cases: a query tab keeps an order saved for the same columns, keeps an order-only layout with no widths in it, and drops an order when two columns share a name.
- **Negative controls**, one per rule: with the unconditional nil-ing restored, both preservation cases fail and `queryTabDropsStaleColumnOrder` still passes, so the tests separate the two behaviours rather than just pinning the new one. With the uniqueness half of the check removed, the duplicate-name case fails on its own.

No UI automation: the flow needs a live connection and a header drag, which does not run deterministically in `TableProUITests`.
