### PR TITLE
fix(settings): say why a shortcut with only Option or Shift is refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A data grid shortcut bound to `Cmd+G` silently taking the key from Find Next, with no conflict warning.
 - Stale cells after fitting, hiding or reordering a data grid column on a result narrower than the window. (#2446)
+- A shortcut recorded with only Option or Shift beeping with no reason given, against docs that said it would work.
 - Autocomplete keeping an earlier prefix's ordering after the typed word becomes an exact match. (#2444)
 - Whole MySQL and MariaDB result set fetched before a capped query returned its first rows. (#2427)
 - KILL sent to a different server when a MySQL or MariaDB connection's host is spelled `localhost`.

--- a/TablePro/Views/Settings/KeyboardSettingsView.swift
+++ b/TablePro/Views/Settings/KeyboardSettingsView.swift
@@ -132,7 +132,7 @@ struct KeyboardSettingsView: View {
                 needsModifierAlert = nil
             }
         } message: {
-            Text(String(localized: "This action needs a modifier key like ⌘ or ⌥. A plain key won't reach the menu reliably."))
+            Text(String(localized: "This action needs ⌘ or ⌃. Option and Shift can join them, but cannot hold a shortcut on their own."))
         }
         .onAppear {
             SystemHotkeyChecker.shared.reload()
@@ -169,6 +169,9 @@ struct KeyboardSettingsView: View {
                 },
                 onClear: {
                     settings.clearShortcut(for: action)
+                },
+                onUnusableModifiers: {
+                    needsModifierAlert = action
                 }
             )
             .frame(width: 160, height: 24)

--- a/TablePro/Views/Settings/ShortcutRecorderView.swift
+++ b/TablePro/Views/Settings/ShortcutRecorderView.swift
@@ -19,6 +19,10 @@ final class ShortcutRecorderNSView: NSView {
     /// Callback when the shortcut is cleared (Delete key while recording)
     var onClear: (() -> Void)?
 
+    /// Callback when the captured combo carries no modifier the menu can use, so the
+    /// caller can say why instead of leaving the recorder to beep with no explanation.
+    var onUnusableModifiers: (() -> Void)?
+
     /// The currently displayed key combo
     var currentCombo: BoundKey? {
         didSet {
@@ -149,7 +153,8 @@ final class ShortcutRecorderNSView: NSView {
             return nil
         }
         guard let combo = BoundKey(from: event) else {
-            NSSound.beep()
+            endRecording()
+            onUnusableModifiers?()
             return nil
         }
         onRecord?(combo)
@@ -290,6 +295,9 @@ struct ShortcutRecorderView: NSViewRepresentable {
     /// Called when the shortcut is cleared
     var onClear: (() -> Void)?
 
+    /// Called when the pressed combo carries no modifier a menu key equivalent can use.
+    var onUnusableModifiers: (() -> Void)?
+
     func makeNSView(context: Context) -> ShortcutRecorderNSView {
         let view = ShortcutRecorderNSView()
         view.currentCombo = combo
@@ -299,6 +307,9 @@ struct ShortcutRecorderView: NSViewRepresentable {
         view.onClear = {
             onClear?()
         }
+        view.onUnusableModifiers = {
+            onUnusableModifiers?()
+        }
         return view
     }
 
@@ -306,5 +317,6 @@ struct ShortcutRecorderView: NSViewRepresentable {
         nsView.currentCombo = combo
         nsView.onRecord = { [onRecord] newCombo in onRecord?(newCombo) }
         nsView.onClear = { [onClear] in onClear?() }
+        nsView.onUnusableModifiers = { [onUnusableModifiers] in onUnusableModifiers?() }
     }
 }

--- a/TableProTests/Models/KeyboardShortcutTests.swift
+++ b/TableProTests/Models/KeyboardShortcutTests.swift
@@ -7,6 +7,7 @@
 //  and migration from the legacy character-string storage.
 //
 
+import AppKit
 import Foundation
 @testable import TablePro
 import Testing
@@ -179,6 +180,35 @@ struct BareKeyValidationTests {
     func menuActionsRejectBareKeys() {
         #expect(!ShortcutAction.toggleInspector.allowsBareKey)
         #expect(!ShortcutAction.executeQuery.allowsBareKey)
+    }
+
+    /// The recorder tells the user a shortcut needs Command or Control, so the capture rule has
+    /// to be exactly that. Option and Shift only ever qualify a combo, they never carry one, and
+    /// a letter key held with either alone is a text-input keystroke rather than a shortcut.
+    @Test("Option and Shift cannot hold a shortcut without Command or Control")
+    func optionAndShiftAloneAreNotRecordable() {
+        func capture(_ flags: NSEvent.ModifierFlags) -> BoundKey? {
+            let event = NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: flags,
+                timestamp: 0,
+                windowNumber: 0,
+                context: nil,
+                characters: "e",
+                charactersIgnoringModifiers: "e",
+                isARepeat: false,
+                keyCode: 14
+            )
+            return event.flatMap(BoundKey.init(from:))
+        }
+
+        #expect(capture(.option) == nil)
+        #expect(capture(.shift) == nil)
+        #expect(capture([.option, .shift]) == nil)
+        #expect(capture(.command) != nil)
+        #expect(capture(.control) != nil)
+        #expect(capture([.command, .option]) != nil)
     }
 
     @Test("hasModifier reflects the combo")

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -270,7 +270,7 @@ Open **Settings > Keyboard** (`Cmd+,`). Each action has a recorder field: click 
 
 A combination already taken by another action in the same context raises a dialog naming it: **Cancel** keeps the existing assignment, **Reassign** moves the shortcut and clears it from the other action. Editor and grid actions can share a key without conflict.
 
-Menu actions need a modifier (`Cmd`, `Option`, `Ctrl`, or `Shift`); function keys `F1` through `F12` work bare, as do grid actions that read the key directly, like Preview FK Reference (`Space`).
+Menu actions need `Cmd` or `Ctrl`, with `Option` and `Shift` available alongside them but not on their own; function keys `F1` through `F12` work bare, as do grid actions that read the key directly, like Preview FK Reference (`Space`).
 
 <Info>
 Some shortcuts cannot be reassigned: editor built-ins such as `Cmd+/`, tab selection (`Cmd+1` through `Cmd+9`), text size (`Cmd+=`, `Cmd+-`), and macOS system shortcuts, which are read live from System Settings. The recorder warns if you try.


### PR DESCRIPTION
Found while investigating #2453.

## The defect

`BoundKey.init?(from:)` requires Command or Control (or one of the four bare-recordable keys), so `⌥E`, `⇧F` and `⌥⇧E` all return nil. `handleRecordingEvent` answered nil with a bare `NSSound.beep()` and nothing else: no alert, no message, and the field still showing the old combo. The user is left guessing whether the app registered the keystroke at all.

Worse, the app was telling them it should have worked. The recorder's own alert said:

> This action needs a modifier key like ⌘ or **⌥**. A plain key won't reach the menu reliably.

and `docs/features/keyboard-shortcuts.mdx:273` said menu actions need "`Cmd`, `Option`, `Ctrl`, or `Shift`". Both name Option as sufficient. Neither is true.

## The change

The capture rule is right and stays: Option and Shift qualify a combo, they never carry one, and a letter held with either alone is a text-input keystroke, not a shortcut. `⌥E` is a dead key for accents. What was wrong is that the app promised otherwise and then refused in silence.

- The recorder gained `onUnusableModifiers`, so a combo it cannot capture raises the existing **Modifier Key Required** alert instead of beeping.
- The alert now says what actually works: "This action needs ⌘ or ⌃. Option and Shift can join them, but cannot hold a shortcut on their own."
- The docs sentence is corrected to match.
- `optionAndShiftAloneAreNotRecordable` pins the rule the alert now states, driving real `NSEvent`s through `BoundKey.init(from:)` across six modifier combinations.

## Verification

| Step | Result |
|---|---|
| `verify.sh build` | PASS |
| `verify.sh test` (8 keyboard + menu suites) | PASS, 48 executed, 48 passed |
| `verify.sh lint TablePro TableProTests` | 0 violations |
| `verify.sh docs` | PASS |

## Not fixed here, and why

The collateral hunt also flagged **Clear Selection's recorder row**. `.clearSelection` defaults to bare `Escape`, but `menuKeyEquivalent(for:)` rejects bare keys, so the Edit menu item never carries it, and `KeyHandlingTableView.cancelOperation` clears the selection whatever the binding says. Clearing the row does not stop Escape.

The obvious fix does not work. Gating `cancelOperation` on the binding breaks the menu path, because `MainSplitViewController.clearSelection` drives that same selector, so a non-Escape binding would fire the menu item into a gate that refuses it. Making Escape itself configurable means intercepting a key AppKit routes through `interpretKeyEvents`, in an area that has already shipped a regression (#1490). The remaining option, removing the row, is a product decision rather than a defect fix.

Reported rather than guessed at.