### PR TITLE
perf(datagrid): capture the column layout once per Size All Columns to Fit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Stale cells after fitting, hiding or reordering a data grid column on a result narrower than the window. (#2446)
+- Size All Columns to Fit slowing down with the square of the column count.
+- Column-resize cursor over the leading edge of the data grid header, where there is no divider to drag.
 - Autocomplete keeping an earlier prefix's ordering after the typed word becomes an exact match. (#2444)
 - Whole MySQL and MariaDB result set fetched before a capped query returned its first rows. (#2427)
 - KILL sent to a different server when a MySQL or MariaDB connection's host is spelled `localhost`.
@@ -45,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Editor tab strip tests reporting four appearances while running plain Aqua and Dark Aqua twice.
 - Icon cut off the entry at the top of a scrolled connections strip. (#2452)
 - Connections strip not scrolling to the entry you switch to.
-- Grid cells left at the old column positions until the next click, after a resize, an auto-fit, a reorder, hiding a column, or a row-number width change. (#2449)
+- Grid cells left at the old column positions until the next click, after a resize, an auto-fit, a reorder, hiding a column, or a row-number width change. (#2449, #2446)
 - The row-number column draggable out of first place, which walked it to the far right on the next refresh.
 
 ## [0.68.1] - 2026-08-26

--- a/TablePro/Views/Results/Extensions/DataGridView+Sort.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Sort.swift
@@ -352,6 +352,10 @@ extension TableViewCoordinator {
         scheduleLayoutPersist()
     }
 
+    /// Every `column.width` write posts its own resize notification, and each one that reaches
+    /// `tableViewColumnDidResize` takes a fresh `captureColumnLayout()` walk across every attached
+    /// column, so fitting the table costs its column count squared. The loop claims ownership per
+    /// column already, and the repaint runs ahead of the same guard.
     @objc func sizeAllColumnsToFit(_ sender: NSMenuItem) {
         guard let tableView else { return }
 
@@ -360,6 +364,9 @@ extension TableViewCoordinator {
             guard presentsColumn(column), let index = dataColumnIndex(from: column.identifier) else { return false }
             return index < tableRows.columns.count
         }
+
+        let wasRebuildingColumns = isRebuildingColumns
+        isRebuildingColumns = true
         for column in fittedColumns {
             guard let dataColumnIndex = dataColumnIndex(from: column.identifier) else { continue }
 
@@ -371,6 +378,8 @@ extension TableViewCoordinator {
                 fittedColumnCount: fittedColumns.count
             )
         }
+        isRebuildingColumns = wasRebuildingColumns
+
         scheduleLayoutPersist()
     }
 

--- a/TablePro/Views/Results/SortableHeaderView.swift
+++ b/TablePro/Views/Results/SortableHeaderView.swift
@@ -229,11 +229,15 @@ final class SortableHeaderView: NSTableHeaderView {
         updateFunnelHover(column: nil)
     }
 
-    private func isInResizeZone(point: NSPoint) -> Bool {
-        guard let tableView else { return false }
+    /// `headerRect(ofColumn:)` gives a hidden column a zero rect, so its trailing edge is x = 0. The
+    /// pool keeps user-hidden columns and the surplus slots of a wider result attached with
+    /// `userResizingMask` set, and each one reports a divider at the header's leading edge.
+    internal func isInResizeZone(point: NSPoint) -> Bool {
+        guard let tableView, let coordinator else { return false }
         let zone = Self.resizeZoneWidth
         return tableView.tableColumns.enumerated().contains { index, column in
-            guard column.resizingMask.contains(.userResizingMask) else { return false }
+            guard column.resizingMask.contains(.userResizingMask),
+                  coordinator.presentsColumn(column) else { return false }
             let edge = headerRect(ofColumn: index).maxX
             return abs(point.x - edge) <= zone
         }

--- a/TableProTests/Views/Results/SizeAllColumnsToFitTests.swift
+++ b/TableProTests/Views/Results/SizeAllColumnsToFitTests.swift
@@ -1,0 +1,191 @@
+//
+//  SizeAllColumnsToFitTests.swift
+//  TableProTests
+//
+
+import AppKit
+import SwiftUI
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+@MainActor
+private final class CountingLayoutPersister: ColumnLayoutPersisting {
+    private(set) var saveCount = 0
+
+    func load(for key: ColumnLayoutTableKey) -> ColumnLayoutState? { nil }
+    func save(_ layout: ColumnLayoutState, for key: ColumnLayoutTableKey) { saveCount += 1 }
+    func clear(for key: ColumnLayoutTableKey) {}
+}
+
+/// `captureColumnLayout()` asks `tableRowsProvider` for the result exactly once, which is what
+/// these tests count. The walks are otherwise invisible from outside.
+@Suite("Size All Columns to Fit", .serialized)
+@MainActor
+struct SizeAllColumnsToFitTests {
+    private struct Grid {
+        let window: NSWindow
+        let coordinator: TableViewCoordinator
+        let persister: CountingLayoutPersister
+        let rowsRequested: () -> Int
+    }
+
+    private func makeGrid(columns: [String], rows: Int = 3) -> Grid {
+        let persister = CountingLayoutPersister()
+        let coordinator = TableViewCoordinator(
+            changeManager: AnyChangeManager(DataChangeManager()),
+            isEditable: true,
+            selectedRowIndices: .constant([]),
+            delegate: nil,
+            layoutPersister: persister
+        )
+        coordinator.tabType = .table
+        coordinator.connectionId = UUID()
+        coordinator.tableName = "users"
+
+        let queryRows = (0 ..< rows).map { row in columns.map { PluginCellValue.text("\($0)-\(row)") } }
+        let tableRows = TableRows.from(
+            queryRows: queryRows,
+            columns: columns,
+            columnTypes: Array(repeating: ColumnType.text(rawType: "TEXT"), count: columns.count)
+        )
+
+        let counter = RequestCounter()
+        coordinator.tableRowsProvider = {
+            counter.value += 1
+            return tableRows
+        }
+        coordinator.rebuildColumnMetadataCache(from: tableRows)
+        coordinator.updateCache()
+
+        let tableView = KeyHandlingTableView(frame: NSRect(x: 0, y: 0, width: 900, height: 200))
+        tableView.columnAutoresizingStyle = .noColumnAutoresizing
+        tableView.rowHeight = 21
+        tableView.coordinator = coordinator
+        tableView.dataSource = coordinator
+        tableView.delegate = coordinator
+        tableView.addTableColumn(DataGridView.makeRowNumberColumn())
+        coordinator.tableView = tableView
+        coordinator.columnPool.reconcile(
+            tableView: tableView,
+            schema: coordinator.identitySchema,
+            columnTypes: Array(repeating: ColumnType.text(rawType: "TEXT"), count: columns.count),
+            savedLayout: nil,
+            isEditable: true,
+            hiddenColumnNames: [],
+            widthCalculator: { _, _ in 90 }
+        )
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 900, height: 200))
+        scrollView.documentView = tableView
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 900, height: 200),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = scrollView
+        tableView.reloadData()
+        tableView.layoutSubtreeIfNeeded()
+        return Grid(
+            window: window,
+            coordinator: coordinator,
+            persister: persister,
+            rowsRequested: { counter.value }
+        )
+    }
+
+    @MainActor
+    private final class RequestCounter {
+        var value = 0
+    }
+
+    /// One read for the menu item and one for the single capture, whatever the column count.
+    @Test("Fitting every column captures the layout once")
+    func fittingEveryColumnCapturesOnce() throws {
+        let grid = makeGrid(columns: ["id", "name", "email", "city", "country"])
+        defer { grid.coordinator.layoutPersistTask?.cancel() }
+        let before = grid.rowsRequested()
+
+        grid.coordinator.sizeAllColumnsToFit(NSMenuItem())
+
+        #expect(grid.rowsRequested() - before == 2)
+    }
+
+    @Test("The capture count does not grow with the number of columns")
+    func captureCountIsIndependentOfColumnCount() throws {
+        let narrow = makeGrid(columns: ["id", "name"])
+        defer { narrow.coordinator.layoutPersistTask?.cancel() }
+        let narrowBefore = narrow.rowsRequested()
+        narrow.coordinator.sizeAllColumnsToFit(NSMenuItem())
+        let narrowCost = narrow.rowsRequested() - narrowBefore
+
+        let wide = makeGrid(columns: (0 ..< 24).map { "c\($0)" })
+        defer { wide.coordinator.layoutPersistTask?.cancel() }
+        let wideBefore = wide.rowsRequested()
+        wide.coordinator.sizeAllColumnsToFit(NSMenuItem())
+        let wideCost = wide.rowsRequested() - wideBefore
+
+        #expect(narrowCost == wideCost)
+    }
+
+    /// Without ownership the next reconcile measures every column from its content and drops the fit.
+    @Test("Every fitted column is still marked user-sized")
+    func everyFittedColumnKeepsOwnership() throws {
+        let grid = makeGrid(columns: ["id", "name", "email"])
+        defer { grid.coordinator.layoutPersistTask?.cancel() }
+
+        grid.coordinator.sizeAllColumnsToFit(NSMenuItem())
+
+        #expect(grid.coordinator.userSizedColumnNames == ["id", "name", "email"])
+    }
+
+    @Test("Every fitted column ends up in the persisted layout")
+    func everyFittedColumnIsPersisted() throws {
+        let grid = makeGrid(columns: ["id", "name", "email"])
+
+        grid.coordinator.sizeAllColumnsToFit(NSMenuItem())
+        grid.coordinator.flushPendingColumnLayoutPersistence()
+
+        #expect(grid.persister.saveCount == 1)
+    }
+
+    /// A fit inside a rebuild must leave the rebuild's own suppression intact.
+    @Test("A fit restores the rebuild flag it found")
+    func theRebuildFlagIsRestored() throws {
+        let grid = makeGrid(columns: ["id", "name"])
+        defer { grid.coordinator.layoutPersistTask?.cancel() }
+
+        grid.coordinator.sizeAllColumnsToFit(NSMenuItem())
+        #expect(!grid.coordinator.isRebuildingColumns)
+
+        grid.coordinator.isRebuildingColumns = true
+        grid.coordinator.sizeAllColumnsToFit(NSMenuItem())
+        #expect(grid.coordinator.isRebuildingColumns)
+        grid.coordinator.isRebuildingColumns = false
+    }
+
+    @Test("Fitting every column still repaints the drawn cells")
+    func fittingEveryColumnStillRepaints() throws {
+        let grid = makeGrid(columns: ["id", "name", "email"])
+        defer { grid.coordinator.layoutPersistTask?.cancel() }
+        let tableView = try #require(grid.coordinator.tableView)
+        for row in 0 ..< tableView.numberOfRows {
+            _ = tableView.rowView(atRow: row, makeIfNecessary: true)
+        }
+        tableView.display()
+
+        var contentViews: [DataGridRowContentView] = []
+        tableView.enumerateAvailableRowViews { rowView, _ in
+            guard let content = rowView.subviews.first as? DataGridRowContentView else { return }
+            contentViews.append(content)
+        }
+        #expect(!contentViews.isEmpty)
+        #expect(contentViews.allSatisfy { !$0.needsDisplay })
+
+        grid.coordinator.sizeAllColumnsToFit(NSMenuItem())
+
+        let everyRowAwaitsRepaint = contentViews.allSatisfy { $0.needsDisplay }
+        #expect(everyRowAwaitsRepaint)
+    }
+}

--- a/TableProTests/Views/Results/SortableHeaderResizeZoneTests.swift
+++ b/TableProTests/Views/Results/SortableHeaderResizeZoneTests.swift
@@ -1,0 +1,158 @@
+//
+//  SortableHeaderResizeZoneTests.swift
+//  TableProTests
+//
+
+import AppKit
+import SwiftUI
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+@MainActor
+private final class ResizeZoneLayoutPersister: ColumnLayoutPersisting {
+    func load(for key: ColumnLayoutTableKey) -> ColumnLayoutState? { nil }
+    func save(_ layout: ColumnLayoutState, for key: ColumnLayoutTableKey) {}
+    func clear(for key: ColumnLayoutTableKey) {}
+}
+
+/// A hidden column's header rect is zero, so its trailing edge is x = 0 and it reads as a divider
+/// at the header's leading edge: the resize cursor appeared over the row-number heading and the
+/// header swallowed the clicks landing there.
+@Suite("Sortable header resize zone", .serialized)
+@MainActor
+struct SortableHeaderResizeZoneTests {
+    private struct Grid {
+        let window: NSWindow
+        let coordinator: TableViewCoordinator
+        let header: SortableHeaderView
+    }
+
+    private func makeGrid(columns: [String], hidden: Set<String> = [], columnWidth: CGFloat = 120) -> Grid {
+        let coordinator = TableViewCoordinator(
+            changeManager: AnyChangeManager(DataChangeManager()),
+            isEditable: true,
+            selectedRowIndices: .constant([]),
+            delegate: nil,
+            layoutPersister: ResizeZoneLayoutPersister()
+        )
+        let queryRows = [columns.map { PluginCellValue.text($0) }]
+        let tableRows = TableRows.from(
+            queryRows: queryRows,
+            columns: columns,
+            columnTypes: Array(repeating: ColumnType.text(rawType: "TEXT"), count: columns.count)
+        )
+        coordinator.tableRowsProvider = { tableRows }
+        coordinator.rebuildColumnMetadataCache(from: tableRows)
+        coordinator.updateCache()
+
+        let tableView = KeyHandlingTableView(frame: NSRect(x: 0, y: 0, width: 900, height: 200))
+        tableView.style = .plain
+        tableView.columnAutoresizingStyle = .noColumnAutoresizing
+        tableView.rowHeight = 21
+        tableView.coordinator = coordinator
+        tableView.dataSource = coordinator
+        tableView.delegate = coordinator
+        tableView.addTableColumn(DataGridView.makeRowNumberColumn())
+        coordinator.tableView = tableView
+
+        let header = SortableHeaderView(frame: NSRect(x: 0, y: 0, width: 900, height: 28))
+        header.coordinator = coordinator
+        tableView.headerView = header
+
+        coordinator.columnPool.reconcile(
+            tableView: tableView,
+            schema: coordinator.identitySchema,
+            columnTypes: Array(repeating: ColumnType.text(rawType: "TEXT"), count: columns.count),
+            savedLayout: nil,
+            isEditable: true,
+            hiddenColumnNames: hidden,
+            widthCalculator: { _, _ in columnWidth }
+        )
+
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 900, height: 200))
+        scrollView.documentView = tableView
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 900, height: 200),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = scrollView
+        tableView.reloadData()
+        tableView.layoutSubtreeIfNeeded()
+        return Grid(window: window, coordinator: coordinator, header: header)
+    }
+
+    private func point(x: CGFloat, in grid: Grid) -> NSPoint {
+        NSPoint(x: x, y: grid.header.bounds.midY)
+    }
+
+    @Test("The header's leading edge is not a resize zone when a column is hidden")
+    func theLeadingEdgeIsNotAResizeZone() throws {
+        let grid = makeGrid(columns: ["id", "name", "email"], hidden: ["name"])
+
+        #expect(!grid.header.isInResizeZone(point: point(x: 0, in: grid)))
+        #expect(!grid.header.isInResizeZone(point: point(x: 2, in: grid)))
+    }
+
+    /// Surplus slots need no user action: a narrower result in a grid that held a wider one leaves them.
+    @Test("Slots left over from a wider result are not resize zones")
+    func surplusPoolSlotsAreNotResizeZones() throws {
+        let grid = makeGrid(columns: ["a", "b", "c", "d", "e", "f"])
+        let tableView = try #require(grid.coordinator.tableView)
+        let narrower = TableRows.from(
+            queryRows: [[.text("a"), .text("b")]],
+            columns: ["a", "b"],
+            columnTypes: [.text(rawType: "TEXT"), .text(rawType: "TEXT")]
+        )
+        grid.coordinator.tableRowsProvider = { narrower }
+        grid.coordinator.rebuildColumnMetadataCache(from: narrower)
+        grid.coordinator.columnPool.reconcile(
+            tableView: tableView,
+            schema: grid.coordinator.identitySchema,
+            columnTypes: [.text(rawType: "TEXT"), .text(rawType: "TEXT")],
+            savedLayout: nil,
+            isEditable: true,
+            hiddenColumnNames: [],
+            widthCalculator: { _, _ in 120 }
+        )
+        tableView.layoutSubtreeIfNeeded()
+
+        #expect(!grid.header.isInResizeZone(point: point(x: 0, in: grid)))
+        #expect(!grid.header.isInResizeZone(point: point(x: 2, in: grid)))
+    }
+
+    @Test("A presented column's trailing edge is still a resize zone")
+    func aPresentedColumnEdgeIsAResizeZone() throws {
+        let grid = makeGrid(columns: ["id", "name", "email"])
+        let tableView = try #require(grid.coordinator.tableView)
+        let firstData = try #require(grid.coordinator.firstPresentedColumnIndex())
+        let edge = grid.header.headerRect(ofColumn: firstData).maxX
+        #expect(edge > 0)
+
+        #expect(grid.header.isInResizeZone(point: point(x: edge, in: grid)))
+    }
+
+    /// The middle of a heading is where a click sorts.
+    @Test("The middle of a column heading is not a resize zone")
+    func theMiddleOfAHeadingIsNotAResizeZone() throws {
+        let grid = makeGrid(columns: ["id", "name", "email"])
+        let firstData = try #require(grid.coordinator.firstPresentedColumnIndex())
+        let rect = grid.header.headerRect(ofColumn: firstData)
+
+        #expect(!grid.header.isInResizeZone(point: point(x: rect.midX, in: grid)))
+    }
+
+    @Test("The row-number column's trailing edge is not a resize zone")
+    func theRowNumberColumnEdgeIsNotAResizeZone() throws {
+        let grid = makeGrid(columns: ["id", "name"])
+        let tableView = try #require(grid.coordinator.tableView)
+        let rowNumber = tableView.column(withIdentifier: ColumnIdentitySchema.rowNumberIdentifier)
+        #expect(rowNumber >= 0)
+        let edge = grid.header.headerRect(ofColumn: rowNumber).maxX
+
+        #expect(!grid.header.isInResizeZone(point: point(x: edge, in: grid)))
+    }
+}


### PR DESCRIPTION
Two data grid defects found while investigating #2446, neither of them the reported bug. #2446 itself is already fixed on `main` by #2455; this is the residue that fix did not cover.

## Size All Columns to Fit was quadratic in the column count

`sizeAllColumnsToFit` writes one width per column, and every `NSTableColumn.width` write posts its own `columnDidResizeNotification` synchronously. Each one reaches the persistence half of `tableViewColumnDidResize`, which runs `scheduleLayoutPersist()` → `captureColumnLayout()`, and that walks every attached column. So the menu item costs `columns × columns`: about 250,000 iterations on the 500-column result #2381 measured. #2455 made the constant worse by adding a full-body invalidation to the same re-entry.

The loop now runs with `isRebuildingColumns` set, so the run persists once at the end instead of once per column. Nothing is lost: the loop already calls `markColumnWidthUserSized` per column, so ownership is unaffected, and `columnGeometryDidChange()` sits ahead of that guard so the repaint #2455 added still happens. The flag is saved and restored rather than cleared, so a fit nested inside a rebuild leaves the rebuild's own suppression intact.

## The header's leading edge showed a resize cursor with no divider there

`SortableHeaderView.isInResizeZone` filtered on `resizingMask` alone and never asked whether the result presents the column. `NSTableHeaderView.headerRect(ofColumn:)` returns a zero rect for a hidden column, so its trailing edge is x = 0, and `DataGridColumnPool` keeps every user-hidden column and every surplus slot of a previously wider result attached with `userResizingMask` set. Each of those reported a divider at x = 0.

The effect: run a 10-column query and then a 3-column one in the same tab, or just hide a column, and the leftmost 4 points of the header show the column-resize cursor over the row-number heading and swallow the clicks that land there. It also cost one `headerRect(ofColumn:)` per attached column on every mouse-moved event, surplus slots included.

`presentsColumn` is the question CLAUDE.md already names for "which columns is the user looking at" (#2381), and it is now asked here too.

## CHANGELOG

`main` carried two entries for one fix: #2456 accidentally swept an uncommitted `(#2446)` line into its commit alongside #2455's own `(#2449)` entry. Merged into one, per the "two entries describing one change get merged" rule.

## Verified

- `verify.sh build`: PASS
- `verify.sh test SizeAllColumnsToFitTests SortableHeaderResizeZoneTests DataGridColumnGeometryRepaintTests TableViewCoordinatorLayoutTests SortableHeaderViewTests`: PASS, 62 executed, 62 passed
- `verify.sh lint TablePro/Views/Results TableProTests/Views/Results`: 0 violations
- Reverting only the two source changes turns exactly the 4 regression tests red (`theLeadingEdgeIsNotAResizeZone`, `surplusPoolSlotsAreNotResizeZones`, `fittingEveryColumnCapturesOnce`, `captureCountIsIndependentOfColumnCount`) and leaves the 7 guard tests green.
- Codex review and adversarial review both raised nothing against either change.

No UI automation: neither defect has a deterministic XCUITest. The cursor one is a `NSCursor` state over a 4-point strip, and CI's accessibility tree does not expose header dividers; the perf one is a call count. Both are covered by unit tests that fail without the fix.

No screenshots: neither change alters what the grid draws. The cursor fix changes which pointer appears over a 4-point strip of the header, which a screenshot does not capture.

Found while investigating #2446. That issue is fixed by #2455, not by this PR.

https://claude.ai/code/session_01MS7GCfhh6NmnPKajZ9wfpM
