### PR TITLE
test(datagrid): hold the window across the appearance flip in the overlay colour test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Connections strip not scrolling to the entry you switch to.
 - Grid cells left at the old column positions until the next click, after a resize, an auto-fit, a reorder, hiding a column, or a row-number width change. (#2449)
 - The row-number column draggable out of first place, which walked it to the far right on the next refresh.
+- Cell overlay appearance test failing at random when its window was released before the appearance changed.
 
 ## [0.68.1] - 2026-08-26
 

--- a/TableProTests/Views/Results/CellOverlayAppearanceTests.swift
+++ b/TableProTests/Views/Results/CellOverlayAppearanceTests.swift
@@ -47,6 +47,14 @@ struct CellOverlayAppearanceTests {
     /// `NSAppearance.currentDrawing()` is still the old one, so a bare `.cgColor` resolves to the old
     /// colour. Setting `container.appearance` directly does not reproduce that and would pass even
     /// without `performAsCurrentDrawingAppearance`. The container has to be in a real window.
+    ///
+    /// The window has to be held across the flip. AppKit does not retain a window that was never
+    /// ordered front, and this one's last use is the `contentView` read below, so an autorelease pool
+    /// draining between that and the flip deallocates it. Measured: after a pool drain the window is
+    /// gone, `NSApp.windows` is empty, the container's `window` is nil, and the appearance change
+    /// produces zero `viewDidChangeEffectiveAppearance` calls, leaving `effectiveAppearance` at Aqua
+    /// and both reads at the light colour. That is the failure this suite showed once and could not
+    /// explain, and it is intermittent because where the pool drains is not the test's to decide.
     @Test("An app appearance change repaints an open overlay")
     func appAppearanceChangeRepaintsAnOpenOverlay() throws {
         let originalAppearance = NSApp.appearance
@@ -60,6 +68,7 @@ struct CellOverlayAppearanceTests {
             backing: .buffered,
             defer: false
         )
+        window.isReleasedWhenClosed = false
         let tableView = NSTableView(frame: NSRect(x: 0, y: 0, width: 400, height: 200))
         let contentView = try #require(window.contentView)
         contentView.addSubview(tableView)
@@ -67,15 +76,20 @@ struct CellOverlayAppearanceTests {
         let container = makeContainer()
         tableView.addSubview(container)
 
-        let lightBackground = try components(of: container.layer?.backgroundColor)
-        let lightBorder = try components(of: container.layer?.borderColor)
+        try withExtendedLifetime(window) {
+            let lightBackground = try components(of: container.layer?.backgroundColor)
+            let lightBorder = try components(of: container.layer?.borderColor)
 
-        NSApp.appearance = try #require(NSAppearance(named: .darkAqua))
+            NSApp.appearance = try #require(NSAppearance(named: .darkAqua))
 
-        let darkBackground = try components(of: container.layer?.backgroundColor)
-        let darkBorder = try components(of: container.layer?.borderColor)
+            #expect(container.window === window)
+            #expect(container.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua)
 
-        #expect(lightBackground.brightness > darkBackground.brightness)
-        #expect(lightBorder.brightness != darkBorder.brightness)
+            let darkBackground = try components(of: container.layer?.backgroundColor)
+            let darkBorder = try components(of: container.layer?.borderColor)
+
+            #expect(lightBackground.brightness > darkBackground.brightness)
+            #expect(lightBorder.brightness != darkBorder.brightness)
+        }
     }
 }


### PR DESCRIPTION
Found while investigating #2449, when `CellOverlayAppearanceTests/appAppearanceChangeRepaintsAnOpenOverlay` failed once in an isolated run and then passed 3/3 on re-run with identical code. It will redden CI at random.

## Root cause

The test builds an `NSWindow`, adds the overlay container to it, flips `NSApp.appearance`, and reads the container's layer colours. The window is never ordered front, and its last use is the `contentView` read that happens before the flip.

**AppKit does not retain a window that was never ordered front.** Measured with a probe that drains an autorelease pool between building the window and flipping the appearance:

```
after pool drain: window alive=false   probe.window != nil=false
callbacks after flip: 0                effectiveAppearance=NSAppearanceNameAqua
NSApp.windows count=0
```

The window is deallocated, the container is left in no window, `viewDidChangeEffectiveAppearance` never runs, and `effectiveAppearance` stays at Aqua. Both reads then return the light colour and the two comparisons fail together, which is exactly the signature seen:

```
lightBackground.brightness → 1.0    darkBackground.brightness → 1.0
lightBorder.brightness → 0.4536     darkBorder.brightness → 0.4536
```

It is intermittent because where an autorelease pool drains between two statements is not the test's to decide. A first probe that did *not* drain a pool showed the window surviving and the callback firing normally, which is why this looked unreproducible.

## The fix

Hold the window across the flip with `withExtendedLifetime(window)`, and assert the precondition the test was silently relying on: that the container is still in that window, and that its `effectiveAppearance` actually moved to darkAqua. If this ever fails again it now names its own cause instead of reporting two colours that happen to match.

The test keeps `NSApp.appearance` as its channel on purpose. Its own doc comment explains why: on that path a view's `effectiveAppearance` is already the new one while `NSAppearance.currentDrawing()` is still the old one, so a bare `.cgColor` resolves the old colour, and setting `container.appearance` directly would pass even without the `performAsCurrentDrawingAppearance` wrapper that is the thing under test. Nothing here weakens what it guards.

Also sets `isReleasedWhenClosed = false`, matching the other window-building suites.

## Verification

- `test` PASS, 13 cases across the three overlay suites, and the hardened test run 4 times in isolation, 4/4.
- `lint` 0 SwiftLint violations.

Repeats cannot prove a fix for an intermittent failure, so the argument here rests on the measurement above rather than on the reruns: the failure mode is reproduced deterministically with a pool drain, and `withExtendedLifetime` is what removes it.
