### PR TITLE
fix(plugin-snowflake): decode the wire encodings the query-request endpoint sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Snowflake `BINARY` cells showing the hex of their hex, which the hex editor then wrote back.
 - A date cell the app cannot read opening a picker set to today, which overwrote the value on OK. (#2454)
 - Snowflake reporting no rows changed for an `UPDATE` or `MERGE`, and a `SELECT`'s own result for a column named `number of rows`.
+- Two saved Snowflake connections to one account sharing a session, so switching database in one window moved the other.
+- Stop on a Snowflake query cancelling every other query on the same connection, including a sidebar refresh or a save.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A reordered column snapping back on the next refresh in the Structure tab and in query results.
 - Double-clicking a cell editing the wrong row, after deleting one of several rows added in the same session.
 - VoiceOver reading a cell's value under a different row's number after such a delete.
+- Snowflake `DATE`, `TIME` and `TIMESTAMP_*` cells showing the raw epoch number the server sends. (#2454)
+- Snowflake `BINARY` cells showing the hex of their hex, which the hex editor then wrote back.
+- A date cell the app cannot read opening a picker set to today, which overwrote the value on OK. (#2454)
 
 ## [0.68.1] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Snowflake `DATE`, `TIME` and `TIMESTAMP_*` cells showing the raw epoch number the server sends. (#2454)
 - Snowflake `BINARY` cells showing the hex of their hex, which the hex editor then wrote back.
 - A date cell the app cannot read opening a picker set to today, which overwrote the value on OK. (#2454)
+- Snowflake reporting no rows changed for an `UPDATE` or `MERGE`, and a `SELECT`'s own result for a column named `number of rows`.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Snowflake `BINARY` cells showing the hex of their hex, which the hex editor then wrote back.
 - A date cell the app cannot read opening a picker set to today, which overwrote the value on OK. (#2454)
 
+### Security
+
+- SQL injection through a Snowflake schema or routine name containing a backslash.
+
 ## [0.68.1] - 2026-08-26
 
 ### Changed

--- a/Plugins/SnowflakeDriverPlugin/PluginCellValueBox.swift
+++ b/Plugins/SnowflakeDriverPlugin/PluginCellValueBox.swift
@@ -1,0 +1,14 @@
+//
+//  PluginCellValueBox.swift
+//  SnowflakeDriverPlugin
+//
+//  JSON-decoded cell value before conversion to PluginCellValue (kept Sendable for streaming).
+//
+
+import Foundation
+
+enum PluginCellValueBox: Sendable {
+    case null
+    case text(String)
+    case bytes(Data)
+}

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeConnection.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeConnection.swift
@@ -582,7 +582,10 @@ final class SnowflakeConnection: @unchecked Sendable {
             rows = Self.rows(from: inlineRowset, columns: columns)
         }
 
-        let affectedRows = Self.extractAffectedRows(columns: columns, rows: rows)
+        let affectedRows = SnowflakeStatementType.affectedRows(
+            statementTypeId: (data["statementTypeId"] as? NSNumber)?.intValue ?? 0,
+            row: rows.first
+        )
 
         if let chunks = data["chunks"] as? [[String: Any]], !chunks.isEmpty {
             rows.append(contentsOf: try await downloadChunks(
@@ -868,17 +871,6 @@ final class SnowflakeConnection: @unchecked Sendable {
         }
         guard let column else { return .text(text) }
         return SnowflakeValueDecoder.decode(text, as: column)
-    }
-
-    private static func extractAffectedRows(columns: [SnowflakeColumnMeta], rows: [[PluginCellValueBox]]) -> Int {
-        guard columns.count == 1,
-              columns[0].name.lowercased().contains("number of rows"),
-              let firstRow = rows.first,
-              case .text(let value) = firstRow.first ?? .null,
-              let count = Int(value) else {
-            return 0
-        }
-        return count
     }
 
     private static func parseChunkRows(

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeConnection.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeConnection.swift
@@ -22,12 +22,6 @@ struct SnowflakeQueryResult: Sendable {
     var statusMessage: String?
 }
 
-/// JSON-decoded cell value before conversion to PluginCellValue (kept Sendable for streaming).
-enum PluginCellValueBox: Sendable {
-    case null
-    case text(String)
-}
-
 final class SnowflakeConnection: @unchecked Sendable {
     struct ResolvedParameters {
         var account: String
@@ -585,13 +579,17 @@ final class SnowflakeConnection: @unchecked Sendable {
 
         var rows: [[PluginCellValueBox]] = []
         if let inlineRowset = data["rowset"] as? [[Any]] {
-            rows = inlineRowset.map { row in row.map(Self.box) }
+            rows = Self.rows(from: inlineRowset, columns: columns)
         }
 
         let affectedRows = Self.extractAffectedRows(columns: columns, rows: rows)
 
         if let chunks = data["chunks"] as? [[String: Any]], !chunks.isEmpty {
-            rows.append(contentsOf: try await downloadChunks(chunks, headers: Self.chunkRequestHeaders(from: data)))
+            rows.append(contentsOf: try await downloadChunks(
+                chunks,
+                headers: Self.chunkRequestHeaders(from: data),
+                columns: columns
+            ))
         }
 
         return SnowflakeQueryResult(
@@ -617,7 +615,7 @@ final class SnowflakeConnection: @unchecked Sendable {
         applyFinalSessionInfo(data)
 
         let columns = Self.parseColumns(data["rowtype"] as? [[String: Any]] ?? [])
-        let inlineRows = (data["rowset"] as? [[Any]] ?? []).map { row in row.map(Self.box) }
+        let inlineRows = Self.rows(from: data["rowset"] as? [[Any]] ?? [], columns: columns)
         let chunks = data["chunks"] as? [[String: Any]] ?? []
         let chunkRowCount = chunks.reduce(0) { $0 + (($1["rowCount"] as? Int) ?? 0) }
         let headers = Self.chunkRequestHeaders(from: data)
@@ -637,7 +635,9 @@ final class SnowflakeConnection: @unchecked Sendable {
                         while nextIndex < min(Self.chunkDownloadWorkers, urls.count) {
                             let index = nextIndex
                             group.addTask {
-                                (index, try await Self.downloadChunk(urls[index], headers: headers, session: session))
+                                (index, try await Self.downloadChunk(
+                                    urls[index], headers: headers, session: session, columns: columns
+                                ))
                             }
                             nextIndex += 1
                         }
@@ -651,7 +651,9 @@ final class SnowflakeConnection: @unchecked Sendable {
                             if nextIndex < urls.count {
                                 let next = nextIndex
                                 group.addTask {
-                                    (next, try await Self.downloadChunk(urls[next], headers: headers, session: session))
+                                    (next, try await Self.downloadChunk(
+                                        urls[next], headers: headers, session: session, columns: columns
+                                    ))
                                 }
                                 nextIndex += 1
                             }
@@ -675,7 +677,11 @@ final class SnowflakeConnection: @unchecked Sendable {
 
     private static let chunkDownloadWorkers = 4
 
-    private func downloadChunks(_ chunks: [[String: Any]], headers: [String: String]) async throws -> [[PluginCellValueBox]] {
+    private func downloadChunks(
+        _ chunks: [[String: Any]],
+        headers: [String: String],
+        columns: [SnowflakeColumnMeta]
+    ) async throws -> [[PluginCellValueBox]] {
         let urls = chunks.compactMap { ($0["url"] as? String).flatMap(URL.init(string:)) }
         guard !urls.isEmpty else { return [] }
 
@@ -685,7 +691,9 @@ final class SnowflakeConnection: @unchecked Sendable {
             while nextIndex < min(Self.chunkDownloadWorkers, urls.count) {
                 let index = nextIndex
                 group.addTask { [session] in
-                    (index, try await Self.downloadChunk(urls[index], headers: headers, session: session))
+                    (index, try await Self.downloadChunk(
+                        urls[index], headers: headers, session: session, columns: columns
+                    ))
                 }
                 nextIndex += 1
             }
@@ -694,7 +702,9 @@ final class SnowflakeConnection: @unchecked Sendable {
                 if nextIndex < urls.count {
                     let next = nextIndex
                     group.addTask { [session] in
-                        (next, try await Self.downloadChunk(urls[next], headers: headers, session: session))
+                        (next, try await Self.downloadChunk(
+                            urls[next], headers: headers, session: session, columns: columns
+                        ))
                     }
                     nextIndex += 1
                 }
@@ -706,7 +716,8 @@ final class SnowflakeConnection: @unchecked Sendable {
     private static func downloadChunk(
         _ url: URL,
         headers: [String: String],
-        session: URLSession
+        session: URLSession,
+        columns: [SnowflakeColumnMeta]
     ) async throws -> [[PluginCellValueBox]] {
         var request = URLRequest(url: url)
         for (key, value) in headers {
@@ -716,7 +727,7 @@ final class SnowflakeConnection: @unchecked Sendable {
         guard http.statusCode == 200 else {
             throw SnowflakeError.invalidResponse("Failed to download result chunk")
         }
-        return try parseChunkRows(gunzipIfNeeded(rawData))
+        return try parseChunkRows(gunzipIfNeeded(rawData), columns: columns)
     }
 
     // MARK: - USE / Session
@@ -834,11 +845,29 @@ final class SnowflakeConnection: @unchecked Sendable {
         }
     }
 
-    private static func box(_ value: Any) -> PluginCellValueBox {
+    /// The endpoint writes a cell's value in Snowflake's own encoding, so a row can only be read
+    /// against the `rowtype` that describes it. Every result path funnels through here for that
+    /// reason: a row decoded without its columns is a row of raw wire text.
+    static func rows(from rowset: [[Any]], columns: [SnowflakeColumnMeta]) -> [[PluginCellValueBox]] {
+        rowset.map { row in
+            row.enumerated().map { index, value in
+                box(value, as: index < columns.count ? columns[index] : nil)
+            }
+        }
+    }
+
+    private static func box(_ value: Any, as column: SnowflakeColumnMeta?) -> PluginCellValueBox {
         if value is NSNull { return .null }
-        if let string = value as? String { return .text(string) }
-        if let number = value as? NSNumber { return .text(NumberText.text(for: number)) }
-        return .text(String(describing: value))
+        let text: String
+        if let string = value as? String {
+            text = string
+        } else if let number = value as? NSNumber {
+            text = NumberText.text(for: number)
+        } else {
+            text = String(describing: value)
+        }
+        guard let column else { return .text(text) }
+        return SnowflakeValueDecoder.decode(text, as: column)
     }
 
     private static func extractAffectedRows(columns: [SnowflakeColumnMeta], rows: [[PluginCellValueBox]]) -> Int {
@@ -852,11 +881,14 @@ final class SnowflakeConnection: @unchecked Sendable {
         return count
     }
 
-    private static func parseChunkRows(_ data: Data) throws -> [[PluginCellValueBox]] {
+    private static func parseChunkRows(
+        _ data: Data,
+        columns: [SnowflakeColumnMeta]
+    ) throws -> [[PluginCellValueBox]] {
         let candidates: [Data] = [data, Data("[".utf8) + data + Data("]".utf8)]
         for candidate in candidates {
             if let parsed = try? JSONSerialization.jsonObject(with: candidate) as? [[Any]] {
-                return parsed.map { row in row.map(box) }
+                return rows(from: parsed, columns: columns)
             }
         }
         throw SnowflakeError.invalidResponse("Could not parse result chunk JSON")

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeConnection.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeConnection.swift
@@ -40,19 +40,30 @@ final class SnowflakeConnection: @unchecked Sendable {
 
     let host: String
     let params: ResolvedParameters
+    private let connectionIdentifier: String
 
     private let session: URLSession
     private let lock = NSLock()
     private let heartbeat = SnowflakeHeartbeat()
     private var sessionToken: String?
     private var renewalToken: String?
-    private var activeRequestIDs: Set<String> = []
+    private var activeRequestIDs: [String: Set<String>] = [:]
     private var sequenceId = 0
     private var connectTask: Task<Void, Error>?
 
     var sessionFingerprint: String {
-        [host, params.user.uppercased(), params.authMethod, params.role.uppercased()].joined(separator: "|")
+        SnowflakeSessionKey.fingerprint(
+            connectionId: connectionIdentifier,
+            host: host,
+            user: params.user,
+            authMethod: params.authMethod,
+            role: params.role
+        )
     }
+
+    /// Statements the connection issues for itself, such as the connect-time `USE` calls, belong to
+    /// no driver and are never the target of a Stop.
+    static let sessionOwner = "session"
 
     private var _currentDatabase: String?
     private var _currentSchema: String?
@@ -71,6 +82,7 @@ final class SnowflakeConnection: @unchecked Sendable {
     init(config: DriverConnectionConfig) {
         self.params = Self.resolveParameters(from: config)
         self.host = SnowflakeAccount.host(forAccount: params.account)
+        self.connectionIdentifier = config.additionalFields["connectionId"] ?? ""
 
         let configuration = URLSessionConfiguration.ephemeral
         configuration.timeoutIntervalForRequest = 120
@@ -419,9 +431,13 @@ final class SnowflakeConnection: @unchecked Sendable {
 
     // MARK: - Query Execution
 
-    func query(_ sql: String, parameters: [PluginCellValue] = []) async throws -> SnowflakeQueryResult {
+    func query(
+        _ sql: String,
+        parameters: [PluginCellValue] = [],
+        owner: String = SnowflakeConnection.sessionOwner
+    ) async throws -> SnowflakeQueryResult {
         try await withReauthentication {
-            try await performQuery(sql, parameters: parameters)
+            try await performQuery(sql, parameters: parameters, owner: owner)
         }
     }
 
@@ -439,8 +455,12 @@ final class SnowflakeConnection: @unchecked Sendable {
         }
     }
 
-    func cancelAllQueries() {
-        let (requestIDs, token) = lock.withLock { (activeRequestIDs, sessionToken) }
+    /// One Snowflake session is shared by the driver the user sees and by every pooled metadata
+    /// driver behind it, so an abort has to name whose work it is stopping. Aborting the whole
+    /// session made Stop on a query cancel a sidebar refresh running beside it, and cancel a save's
+    /// remaining statements.
+    func cancelQueries(owner: String) {
+        let (requestIDs, token) = lock.withLock { (activeRequestIDs[owner] ?? [], sessionToken) }
         guard !requestIDs.isEmpty, let token else { return }
         Task { [weak self] in
             for requestID in requestIDs {
@@ -454,8 +474,12 @@ final class SnowflakeConnection: @unchecked Sendable {
         }
     }
 
-    private func performQuery(_ sql: String, parameters: [PluginCellValue] = []) async throws -> SnowflakeQueryResult {
-        let (data, token) = try await submitQuery(sql, parameters: parameters)
+    private func performQuery(
+        _ sql: String,
+        parameters: [PluginCellValue] = [],
+        owner: String
+    ) async throws -> SnowflakeQueryResult {
+        let (data, token) = try await submitQuery(sql, parameters: parameters, owner: owner)
         if let resultIds = data["resultIds"] as? String, !resultIds.isEmpty {
             return try await collectMultiStatementResults(ids: resultIds, token: token)
         }
@@ -465,7 +489,8 @@ final class SnowflakeConnection: @unchecked Sendable {
 
     private func submitQuery(
         _ sql: String,
-        parameters: [PluginCellValue]
+        parameters: [PluginCellValue],
+        owner: String
     ) async throws -> (data: [String: Any], token: String) {
         guard let token = lock.withLock({ sessionToken }) else {
             throw SnowflakeError.notConnected
@@ -474,11 +499,14 @@ final class SnowflakeConnection: @unchecked Sendable {
         let requestID = UUID().uuidString.lowercased()
         let sequence = lock.withLock { () -> Int in
             sequenceId += 1
-            activeRequestIDs.insert(requestID)
+            activeRequestIDs[owner, default: []].insert(requestID)
             return sequenceId
         }
         defer {
-            lock.withLock { _ = activeRequestIDs.remove(requestID) }
+            lock.withLock {
+                activeRequestIDs[owner]?.remove(requestID)
+                if activeRequestIDs[owner]?.isEmpty == true { activeRequestIDs[owner] = nil }
+            }
         }
 
         var body: [String: Any] = [
@@ -611,9 +639,12 @@ final class SnowflakeConnection: @unchecked Sendable {
         let batches: AsyncThrowingStream<[[PluginCellValueBox]], Error>
     }
 
-    func queryStreamed(_ sql: String) async throws -> StreamedResult {
+    func queryStreamed(
+        _ sql: String,
+        owner: String = SnowflakeConnection.sessionOwner
+    ) async throws -> StreamedResult {
         let (data, _) = try await withReauthentication {
-            try await submitQuery(sql, parameters: [])
+            try await submitQuery(sql, parameters: [], owner: owner)
         }
         applyFinalSessionInfo(data)
 

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeConnection.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeConnection.swift
@@ -743,7 +743,7 @@ final class SnowflakeConnection: @unchecked Sendable {
     }
 
     func quoteIdentifier(_ name: String) -> String {
-        "\"\(name.replacingOccurrences(of: "\"", with: "\"\""))\""
+        SnowflakeSQL.quoteIdentifier(name)
     }
 
     // MARK: - HTTP Helpers

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeDDLGenerator.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeDDLGenerator.swift
@@ -143,12 +143,10 @@ struct SnowflakeDDLGenerator {
     }
 
     private func quoteIdentifier(_ name: String) -> String {
-        "\"\(name.replacingOccurrences(of: "\"", with: "\"\""))\""
+        SnowflakeSQL.quoteIdentifier(name)
     }
 
     private func escapeLiteral(_ value: String) -> String {
-        value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "'", with: "''")
+        SnowflakeSQL.escapeLiteral(value)
     }
 }

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeObjectQueries.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeObjectQueries.swift
@@ -1,0 +1,54 @@
+//
+//  SnowflakeObjectQueries.swift
+//  SnowflakeDriverPlugin
+//
+//  SQL builders for procedures and functions. Pure text, no driver state, so the escaping these
+//  statements depend on can be tested directly.
+//
+
+import Foundation
+
+/// Snowflake has procedures and functions and no triggers.
+public enum SnowflakeObjectQueries {
+    public static func routineList(schema: String) -> String {
+        let schemaLiteral = SnowflakeSQL.escapeLiteral(schema)
+        return """
+            SELECT PROCEDURE_NAME AS NAME, PROCEDURE_SCHEMA AS SCHEMA_NAME, ARGUMENT_SIGNATURE,
+                   DATA_TYPE, PROCEDURE_LANGUAGE AS LANGUAGE, 'PROCEDURE' AS ROUTINE_KIND
+            FROM INFORMATION_SCHEMA.PROCEDURES
+            WHERE PROCEDURE_SCHEMA = '\(schemaLiteral)'
+            UNION ALL
+            SELECT FUNCTION_NAME AS NAME, FUNCTION_SCHEMA AS SCHEMA_NAME, ARGUMENT_SIGNATURE,
+                   DATA_TYPE, FUNCTION_LANGUAGE AS LANGUAGE, 'FUNCTION' AS ROUTINE_KIND
+            FROM INFORMATION_SCHEMA.FUNCTIONS
+            WHERE FUNCTION_SCHEMA = '\(schemaLiteral)'
+            ORDER BY ROUTINE_KIND, NAME
+            """
+    }
+
+    /// ARGUMENT_SIGNATURE names its parameters, `(A NUMBER, B VARCHAR)`, and GET_DDL accepts types
+    /// alone, `(NUMBER, VARCHAR)`. Passing the signature through unchanged is an error, not a
+    /// missing routine, so the names are dropped here.
+    public static func argumentTypes(fromSignature signature: String?) -> String {
+        guard let signature else { return "()" }
+        let trimmed = signature.trimmingCharacters(in: .whitespaces)
+        let inner = trimmed.hasPrefix("(") && trimmed.hasSuffix(")")
+            ? String(trimmed.dropFirst().dropLast())
+            : trimmed
+        guard !inner.trimmingCharacters(in: .whitespaces).isEmpty else { return "()" }
+        let types = inner.split(separator: ",").map { part -> String in
+            let tokens = part.split(whereSeparator: { $0.isWhitespace })
+            guard tokens.count > 1 else { return tokens.joined() }
+            return tokens.dropFirst().joined(separator: " ")
+        }
+        return "(\(types.joined(separator: ", ")))"
+    }
+
+    /// GET_DDL needs the argument types inside the name, so a routine cannot be addressed without
+    /// the signature the listing captured.
+    public static func routineDefinition(kind: String, schema: String?, name: String, signature: String?) -> String {
+        let arguments = argumentTypes(fromSignature: signature)
+        let qualified = [schema, name].compactMap { $0?.isEmpty == false ? $0 : nil }.joined(separator: ".")
+        return "SELECT GET_DDL('\(SnowflakeSQL.escapeLiteral(kind))', '\(SnowflakeSQL.escapeLiteral(qualified + arguments))')"
+    }
+}

--- a/Plugins/SnowflakeDriverPlugin/SnowflakePluginDriver+Routines.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakePluginDriver+Routines.swift
@@ -6,55 +6,6 @@
 import Foundation
 import TableProPluginKit
 
-/// Snowflake has procedures and functions and no triggers.
-public enum SnowflakeObjectQueries {
-    public static func escapeLiteral(_ value: String) -> String {
-        value.replacingOccurrences(of: "'", with: "''")
-    }
-
-    public static func routineList(schema: String) -> String {
-        let schemaLiteral = escapeLiteral(schema)
-        return """
-            SELECT PROCEDURE_NAME AS NAME, PROCEDURE_SCHEMA AS SCHEMA_NAME, ARGUMENT_SIGNATURE,
-                   DATA_TYPE, PROCEDURE_LANGUAGE AS LANGUAGE, 'PROCEDURE' AS ROUTINE_KIND
-            FROM INFORMATION_SCHEMA.PROCEDURES
-            WHERE PROCEDURE_SCHEMA = '\(schemaLiteral)'
-            UNION ALL
-            SELECT FUNCTION_NAME AS NAME, FUNCTION_SCHEMA AS SCHEMA_NAME, ARGUMENT_SIGNATURE,
-                   DATA_TYPE, FUNCTION_LANGUAGE AS LANGUAGE, 'FUNCTION' AS ROUTINE_KIND
-            FROM INFORMATION_SCHEMA.FUNCTIONS
-            WHERE FUNCTION_SCHEMA = '\(schemaLiteral)'
-            ORDER BY ROUTINE_KIND, NAME
-            """
-    }
-
-    /// ARGUMENT_SIGNATURE names its parameters, `(A NUMBER, B VARCHAR)`, and GET_DDL accepts types
-    /// alone, `(NUMBER, VARCHAR)`. Passing the signature through unchanged is an error, not a
-    /// missing routine, so the names are dropped here.
-    public static func argumentTypes(fromSignature signature: String?) -> String {
-        guard let signature else { return "()" }
-        let trimmed = signature.trimmingCharacters(in: .whitespaces)
-        let inner = trimmed.hasPrefix("(") && trimmed.hasSuffix(")")
-            ? String(trimmed.dropFirst().dropLast())
-            : trimmed
-        guard !inner.trimmingCharacters(in: .whitespaces).isEmpty else { return "()" }
-        let types = inner.split(separator: ",").map { part -> String in
-            let tokens = part.split(whereSeparator: { $0.isWhitespace })
-            guard tokens.count > 1 else { return tokens.joined() }
-            return tokens.dropFirst().joined(separator: " ")
-        }
-        return "(\(types.joined(separator: ", ")))"
-    }
-
-    /// GET_DDL needs the argument types inside the name, so a routine cannot be addressed without
-    /// the signature the listing captured.
-    public static func routineDefinition(kind: String, schema: String?, name: String, signature: String?) -> String {
-        let arguments = argumentTypes(fromSignature: signature)
-        let qualified = [schema, name].compactMap { $0?.isEmpty == false ? $0 : nil }.joined(separator: ".")
-        return "SELECT GET_DDL('\(escapeLiteral(kind))', '\(escapeLiteral(qualified + arguments))')"
-    }
-}
-
 extension SnowflakePluginDriver {
     func fetchRoutines(schema: String?) async throws -> [PluginRoutineInfo] {
         let resolvedSchema = schema ?? currentSchema ?? "PUBLIC"

--- a/Plugins/SnowflakeDriverPlugin/SnowflakePluginDriver.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakePluginDriver.swift
@@ -17,6 +17,10 @@ final class SnowflakePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     private var resolvedSchemaCache: [String: String] = [:]
     private var columnTypeCache: [String: [String: String]] = [:]
 
+    /// Several drivers share one Snowflake session, so a Stop has to name its own work. This
+    /// identifies the statements this driver issued and nobody else's.
+    private let queryOwner = UUID().uuidString
+
     private static let logger = Logger(subsystem: "com.TablePro", category: "SnowflakePluginDriver")
 
     private var connection: SnowflakeConnection? {
@@ -41,7 +45,7 @@ final class SnowflakePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func cancelQuery() throws {
-        connection?.cancelAllQueries()
+        connection?.cancelQueries(owner: queryOwner)
     }
 
     var supportsSchemas: Bool { true }
@@ -55,7 +59,7 @@ final class SnowflakePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         guard !parameters.isEmpty else { return try await execute(query: query) }
         guard let conn = connection else { throw SnowflakeError.notConnected }
         let startTime = Date()
-        let result = try await conn.query(query, parameters: parameters)
+        let result = try await conn.query(query, parameters: parameters, owner: queryOwner)
         return PluginQueryResult(
             columns: result.columns.map(\.name),
             columnTypeNames: result.columns.map(SnowflakeTypeMapper.displayType),
@@ -79,7 +83,7 @@ final class SnowflakePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         }
         lock.withLock { _connection = conn }
 
-        if let result = try? await conn.query("SELECT CURRENT_VERSION()"),
+        if let result = try? await conn.query("SELECT CURRENT_VERSION()", owner: queryOwner),
            let first = result.rows.first?.first, case .text(let version) = first {
             lock.withLock { _serverVersion = "Snowflake \(version)" }
         } else {
@@ -114,7 +118,7 @@ final class SnowflakePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     func execute(query: String) async throws -> PluginQueryResult {
         guard let conn = connection else { throw SnowflakeError.notConnected }
         let startTime = Date()
-        let result = try await conn.query(query)
+        let result = try await conn.query(query, owner: queryOwner)
         let executionTime = Date().timeIntervalSince(startTime)
 
         if result.columns.isEmpty {
@@ -201,9 +205,9 @@ final class SnowflakePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         guard let conn = connection else { throw SnowflakeError.notConnected }
         switch id {
         case "warehouse":
-            _ = try await conn.query("USE WAREHOUSE \(quoteIdentifier(value))")
+            _ = try await conn.query("USE WAREHOUSE \(quoteIdentifier(value))", owner: queryOwner)
         case "role":
-            _ = try await conn.query("USE ROLE \(quoteIdentifier(value))")
+            _ = try await conn.query("USE ROLE \(quoteIdentifier(value))", owner: queryOwner)
             lock.withLock {
                 resolvedSchemaCache.removeAll()
                 columnTypeCache.removeAll()
@@ -583,7 +587,7 @@ final class SnowflakePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 do {
                     guard let conn = self.connection else { throw SnowflakeError.notConnected }
                     let trimmed = query.replacingOccurrences(of: ";\\s*\\z", with: "", options: .regularExpression)
-                    let streamed = try await conn.queryStreamed(trimmed)
+                    let streamed = try await conn.queryStreamed(trimmed, owner: queryOwner)
                     continuation.yield(.header(PluginStreamHeader(
                         columns: streamed.columns.map(\.name),
                         columnTypeNames: streamed.columns.map(SnowflakeTypeMapper.displayType),
@@ -682,7 +686,7 @@ final class SnowflakePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     private func rawQuery(_ sql: String) async throws -> SnowflakeQueryResult {
         guard let conn = connection else { throw SnowflakeError.notConnected }
-        return try await conn.query(sql)
+        return try await conn.query(sql, owner: queryOwner)
     }
 
     private func namedValues(in result: SnowflakeQueryResult, column: String) -> [String] {

--- a/Plugins/SnowflakeDriverPlugin/SnowflakePluginDriver.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakePluginDriver.swift
@@ -535,13 +535,11 @@ final class SnowflakePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     // MARK: - SQL Generation Helpers
 
     func quoteIdentifier(_ name: String) -> String {
-        "\"\(name.replacingOccurrences(of: "\"", with: "\"\""))\""
+        SnowflakeSQL.quoteIdentifier(name)
     }
 
     func escapeStringLiteral(_ value: String) -> String {
-        value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "'", with: "''")
+        SnowflakeSQL.escapeLiteral(value)
     }
 
     func castColumnToText(_ column: String) -> String {

--- a/Plugins/SnowflakeDriverPlugin/SnowflakePluginDriver.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakePluginDriver.swift
@@ -698,6 +698,7 @@ final class SnowflakePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         switch box {
         case .null: return .null
         case .text(let value): return .text(value)
+        case .bytes(let data): return .bytes(data)
         }
     }
 

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeSQL.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeSQL.swift
@@ -1,0 +1,34 @@
+//
+//  SnowflakeSQL.swift
+//  SnowflakeDriverPlugin
+//
+//  The single owner of how a value or a name is spelled inside Snowflake SQL. Three copies of the
+//  literal escaper and five of the identifier quoter used to sit in the files that build statements,
+//  and nothing made them agree: one copy doubled the quote and forgot the backslash, which is all a
+//  schema name needs to close the literal and run its own SQL.
+//
+
+import Foundation
+
+public enum SnowflakeSQL {
+    /// Snowflake reads `\'` inside a literal as a content quote, so doubling the quote alone leaves
+    /// a backslash able to escape the very quote that was meant to close the value. The backslash
+    /// goes first: doubling it after the quotes would also double the ones this method just added.
+    public static func escapeLiteral(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "''")
+    }
+
+    public static func quoteIdentifier(_ name: String) -> String {
+        "\"\(name.replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
+
+    /// `LIKE` reads `_` and `%` as wildcards, so a name containing either has to arrive escaped or
+    /// it matches objects the caller never named.
+    public static func escapeLikePattern(_ value: String) -> String {
+        escapeLiteral(value)
+            .replacingOccurrences(of: "_", with: "\\\\_")
+            .replacingOccurrences(of: "%", with: "\\\\%")
+    }
+}

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeSchemaQueries.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeSchemaQueries.swift
@@ -65,19 +65,15 @@ enum SnowflakeSchemaQueries {
     }
 
     static func escapeLikePattern(_ value: String) -> String {
-        escapeLiteral(value)
-            .replacingOccurrences(of: "_", with: "\\\\_")
-            .replacingOccurrences(of: "%", with: "\\\\%")
+        SnowflakeSQL.escapeLikePattern(value)
     }
 
     static func escapeLiteral(_ value: String) -> String {
-        value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "'", with: "''")
+        SnowflakeSQL.escapeLiteral(value)
     }
 
     static func quote(_ identifier: String) -> String {
-        "\"\(identifier.replacingOccurrences(of: "\"", with: "\"\""))\""
+        SnowflakeSQL.quoteIdentifier(identifier)
     }
 
     private static func qualified(_ parts: String...) -> String {

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeSessionKey.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeSessionKey.swift
@@ -1,0 +1,28 @@
+//
+//  SnowflakeSessionKey.swift
+//  SnowflakeDriverPlugin
+//
+//  Decides which drivers share one authenticated Snowflake session.
+//
+
+import Foundation
+
+enum SnowflakeSessionKey {
+    /// Two saved connections can reach the same account, user and role and still be different
+    /// connections. Keying on the account alone let them share a session, so `USE DATABASE` in one
+    /// window moved the other window's current database.
+    ///
+    /// The saved connection's own identifier separates them. The database cannot: the metadata pool
+    /// rewrites it on its copy of the connection before building a driver, so including it here
+    /// would give that driver a different key, a second login, and another MFA prompt, which is the
+    /// whole reason the session is shared in the first place.
+    static func fingerprint(
+        connectionId: String,
+        host: String,
+        user: String,
+        authMethod: String,
+        role: String
+    ) -> String {
+        [connectionId, host, user.uppercased(), authMethod, role.uppercased()].joined(separator: "|")
+    }
+}

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeStatementGenerator.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeStatementGenerator.swift
@@ -139,6 +139,6 @@ struct SnowflakeStatementGenerator {
     }
 
     private func quoteIdentifier(_ name: String) -> String {
-        "\"\(name.replacingOccurrences(of: "\"", with: "\"\""))\""
+        SnowflakeSQL.quoteIdentifier(name)
     }
 }

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeStatementType.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeStatementType.swift
@@ -1,0 +1,35 @@
+//
+//  SnowflakeStatementType.swift
+//  SnowflakeDriverPlugin
+//
+//  What the server said the statement was, rather than what its result looks like. The response
+//  carries `statementTypeId`, so the row count never has to be guessed from a column name: a DML
+//  statement reports its counts and everything else reports none, whatever its columns are called.
+//
+
+import Foundation
+
+enum SnowflakeStatementType {
+    static let select = 0x1000
+    static let dml = 0x3000
+    static let multiTableInsert = 0x3500
+    static let multiStatement = 0xA000
+
+    static func isDML(_ identifier: Int) -> Bool {
+        (dml ... multiTableInsert).contains(identifier)
+    }
+
+    /// A DML result is one row of counts, and how many columns it has depends on the statement:
+    /// `INSERT` and `DELETE` report one, `UPDATE` reports rows updated and multi-joined rows
+    /// updated, and a multi-clause `MERGE` reports one per clause. The answer is their sum, so
+    /// reading only the first column loses every count after it.
+    static func affectedRows(statementTypeId: Int, row: [PluginCellValueBox]?) -> Int {
+        guard isDML(statementTypeId), let row, !row.isEmpty else { return 0 }
+        var total = 0
+        for cell in row {
+            guard case .text(let value) = cell, let count = Int(value) else { return 0 }
+            total += count
+        }
+        return total
+    }
+}

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeTypeMapper.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeTypeMapper.swift
@@ -16,48 +16,51 @@ struct SnowflakeColumnMeta: Sendable {
     let length: Int?
 }
 
+/// The `type` field of a `rowtype` entry, parsed once. Both the display name and the wire decoding
+/// are decided from this, so the two cannot drift into disagreeing about what a column holds.
+enum SnowflakeLogicalType: String, Sendable, CaseIterable {
+    case fixed = "FIXED"
+    case real = "REAL"
+    case text = "TEXT"
+    case binary = "BINARY"
+    case boolean = "BOOLEAN"
+    case date = "DATE"
+    case time = "TIME"
+    case timestampNtz = "TIMESTAMP_NTZ"
+    case timestampLtz = "TIMESTAMP_LTZ"
+    case timestampTz = "TIMESTAMP_TZ"
+    case variant = "VARIANT"
+    case object = "OBJECT"
+    case array = "ARRAY"
+    case geography = "GEOGRAPHY"
+    case geometry = "GEOMETRY"
+
+    init?(internalType: String) {
+        self.init(rawValue: internalType.uppercased())
+    }
+}
+
 enum SnowflakeTypeMapper {
     static func displayType(for column: SnowflakeColumnMeta) -> String {
-        switch column.internalType.lowercased() {
-        case "fixed":
+        guard let type = SnowflakeLogicalType(internalType: column.internalType) else {
+            return column.internalType.uppercased()
+        }
+        switch type {
+        case .fixed:
             if let scale = column.scale, scale > 0 {
-                let precision = column.precision ?? 38
-                return "NUMBER(\(precision),\(scale))"
+                return "NUMBER(\(column.precision ?? 38),\(scale))"
             }
             return "NUMBER"
-        case "real":
+        case .real:
             return "FLOAT"
-        case "text":
+        case .text:
             if let length = column.length, length > 0 {
                 return "VARCHAR(\(length))"
             }
             return "VARCHAR"
-        case "binary":
-            return "BINARY"
-        case "boolean":
-            return "BOOLEAN"
-        case "date":
-            return "DATE"
-        case "time":
-            return "TIME"
-        case "timestamp_ntz":
-            return "TIMESTAMP_NTZ"
-        case "timestamp_ltz":
-            return "TIMESTAMP_LTZ"
-        case "timestamp_tz":
-            return "TIMESTAMP_TZ"
-        case "variant":
-            return "VARIANT"
-        case "object":
-            return "OBJECT"
-        case "array":
-            return "ARRAY"
-        case "geography":
-            return "GEOGRAPHY"
-        case "geometry":
-            return "GEOMETRY"
-        default:
-            return column.internalType.uppercased()
+        case .binary, .boolean, .date, .time, .timestampNtz, .timestampLtz, .timestampTz,
+             .variant, .object, .array, .geography, .geometry:
+            return type.rawValue
         }
     }
 }

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeValueDecoder.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeValueDecoder.swift
@@ -1,0 +1,247 @@
+//
+//  SnowflakeValueDecoder.swift
+//  SnowflakeDriverPlugin
+//
+//  Turns the internal encodings the query-request endpoint puts in `rowset` into the conventional
+//  text the rest of TablePro reads. The endpoint sends every cell as a JSON string carrying
+//  Snowflake's own representation, so the column's `rowtype` entry is the only thing that says what
+//  a string means: "20682" is a DATE's epoch day, a NUMBER's value, or a piece of text, and nothing
+//  in the string itself distinguishes them. Decoding is therefore keyed on the column, never on the
+//  value, and a value the column's encoding cannot explain is returned exactly as it arrived.
+//
+
+import Foundation
+
+enum SnowflakeValueDecoder {
+    static func decode(_ raw: String, as column: SnowflakeColumnMeta) -> PluginCellValueBox {
+        guard let type = SnowflakeLogicalType(internalType: column.internalType) else {
+            return .text(raw)
+        }
+        switch type {
+        case .date:
+            return date(fromEpochDays: raw)
+        case .time:
+            return time(fromSecondsSinceMidnight: raw, scale: column.scale)
+        case .timestampNtz:
+            return timestamp(fromEpochSeconds: raw, scale: column.scale, zone: .none)
+        case .timestampLtz:
+            return timestamp(fromEpochSeconds: raw, scale: column.scale, zone: .utc)
+        case .timestampTz:
+            return timestampWithZone(raw, scale: column.scale)
+        case .binary:
+            return binary(raw)
+        case .fixed, .real, .text, .boolean, .variant, .object, .array, .geography, .geometry:
+            return .text(raw)
+        }
+    }
+
+    // MARK: - Temporal
+
+    private static func date(fromEpochDays raw: String) -> PluginCellValueBox {
+        guard let days = Int(raw), let civil = CivilDate(epochDays: days) else { return .text(raw) }
+        return .text(civil.text)
+    }
+
+    private static func time(fromSecondsSinceMidnight raw: String, scale: Int?) -> PluginCellValueBox {
+        guard let parts = FixedPointSeconds(raw),
+              parts.seconds >= 0, parts.seconds < secondsPerDay
+        else { return .text(raw) }
+        return .text(ClockTime(secondOfDay: parts.seconds).text + parts.fractionText(scale: scale))
+    }
+
+    private static func timestamp(
+        fromEpochSeconds raw: String,
+        scale: Int?,
+        zone: ZoneRendering
+    ) -> PluginCellValueBox {
+        guard let parts = FixedPointSeconds(raw),
+              let (date, clock) = civil(epochSeconds: parts.seconds, offsetMinutes: zone.offsetMinutes)
+        else { return .text(raw) }
+        return .text(date + " " + clock + parts.fractionText(scale: scale) + zone.suffix)
+    }
+
+    /// `TIMESTAMP_TZ` is the epoch seconds, a space, and the zone offset in minutes biased by +1440
+    /// so it never needs a sign. Snowflake's own example is `1616173619.000000000 1500`, where 1500
+    /// means UTC+1.
+    private static func timestampWithZone(_ raw: String, scale: Int?) -> PluginCellValueBox {
+        let fields = raw.split(separator: " ", omittingEmptySubsequences: true)
+        guard fields.count == 2, let biased = Int(fields[1]) else { return .text(raw) }
+        let offsetMinutes = biased - offsetBias
+        guard abs(offsetMinutes) < minutesPerDay else { return .text(raw) }
+        return timestamp(
+            fromEpochSeconds: String(fields[0]),
+            scale: scale,
+            zone: .offset(minutes: offsetMinutes)
+        )
+    }
+
+    private static func civil(epochSeconds: Int, offsetMinutes: Int) -> (date: String, clock: String)? {
+        let (shifted, overflow) = epochSeconds.addingReportingOverflow(offsetMinutes * 60)
+        guard !overflow else { return nil }
+        let days = Int((Double(shifted) / Double(secondsPerDay)).rounded(.down))
+        guard let civil = CivilDate(epochDays: days) else { return nil }
+        return (civil.text, ClockTime(secondOfDay: shifted - days * secondsPerDay).text)
+    }
+
+    // MARK: - Binary
+
+    /// Snowflake writes `BINARY` as a hex string. Handing the app the bytes rather than the hex is
+    /// what keeps the grid, the hex editor and every export reading one representation: a `BINARY`
+    /// column is classified as a blob, and a blob cell holding text is rendered as the hex of that
+    /// text, so the hex arrives on screen hexed a second time.
+    private static func binary(_ raw: String) -> PluginCellValueBox {
+        let digits = Array(raw.utf8)
+        guard digits.count.isMultiple(of: 2) else { return .text(raw) }
+        var bytes = [UInt8]()
+        bytes.reserveCapacity(digits.count / 2)
+        var index = 0
+        while index < digits.count {
+            guard let high = nibble(digits[index]), let low = nibble(digits[index + 1]) else {
+                return .text(raw)
+            }
+            bytes.append(high << 4 | low)
+            index += 2
+        }
+        return .bytes(Data(bytes))
+    }
+
+    private static func nibble(_ byte: UInt8) -> UInt8? {
+        switch byte {
+        case UInt8(ascii: "0") ... UInt8(ascii: "9"): return byte - UInt8(ascii: "0")
+        case UInt8(ascii: "a") ... UInt8(ascii: "f"): return byte - UInt8(ascii: "a") + 10
+        case UInt8(ascii: "A") ... UInt8(ascii: "F"): return byte - UInt8(ascii: "A") + 10
+        default: return nil
+        }
+    }
+
+    // MARK: - Constants
+
+    private static let secondsPerDay = 86_400
+    private static let minutesPerDay = 1_440
+    private static let offsetBias = 1_440
+}
+
+/// How a decoded timestamp names the zone it was read in. `TIMESTAMP_NTZ` genuinely has none, so it
+/// stays a bare wall clock; `TIMESTAMP_LTZ` is an absolute instant stored in UTC, and leaving it
+/// unmarked would let the reader's own zone be applied to a UTC wall clock and move the instant.
+private enum ZoneRendering {
+    case none
+    case utc
+    case offset(minutes: Int)
+
+    var offsetMinutes: Int {
+        switch self {
+        case .none, .utc: return 0
+        case .offset(let minutes): return minutes
+        }
+    }
+
+    var suffix: String {
+        switch self {
+        case .none: return ""
+        case .utc: return "Z"
+        case .offset(let minutes):
+            let magnitude = abs(minutes)
+            return String(format: "%@%02d:%02d", minutes < 0 ? "-" : "+", magnitude / 60, magnitude % 60)
+        }
+    }
+}
+
+/// A fixed-point seconds field split into a whole second and the nanoseconds after it.
+///
+/// Two things make this more than a `Double` parse. The endpoint writes nine decimal places, so
+/// `1616173619.123456789` carries nineteen significant digits where a `Double` holds about
+/// seventeen, and the last nanoseconds would be lost. And a value before the epoch is written as
+/// the negated magnitude rather than as a floored second with a positive remainder: Snowflake's own
+/// connector documents `-0.000000009` as meaning `1969-12-31 23:59:59.999999991`, so the fraction is
+/// subtracted from the whole part, never added to it. Reading the sign off the integer half alone
+/// loses it entirely, because `-0` parses to `0`.
+private struct FixedPointSeconds {
+    /// The whole second at or below the value, so the nanoseconds are always a positive offset from
+    /// it and rendering never has to think about the sign again.
+    let seconds: Int
+    private let nanoseconds: Int
+
+    init?(_ raw: String) {
+        let isNegative = raw.hasPrefix("-")
+        let separator = raw.firstIndex(of: ".")
+        let wholePart = separator.map { raw[..<$0] } ?? raw[...]
+        let digits = separator.map { raw[raw.index(after: $0)...] } ?? ""
+
+        guard let whole = Int(wholePart), separator == nil || !digits.isEmpty,
+              digits.allSatisfy({ $0.isASCII && $0.isNumber }), digits.count <= 9
+        else { return nil }
+
+        guard let fraction = Int(digits + String(repeating: "0", count: 9 - digits.count)) else {
+            return nil
+        }
+
+        if isNegative, fraction > 0 {
+            seconds = whole - 1
+            nanoseconds = FixedPointSeconds.nanosecondsPerSecond - fraction
+        } else {
+            seconds = whole
+            nanoseconds = fraction
+        }
+    }
+
+    /// A column declares how many fractional digits it keeps and the wire always sends nine, so the
+    /// spelling follows the column rather than the padding.
+    func fractionText(scale: Int?) -> String {
+        let places = min(max(scale ?? 9, 0), 9)
+        guard places > 0 else { return "" }
+        let digits = String(format: "%09d", nanoseconds)
+        return "." + digits.prefix(places)
+    }
+
+    private static let nanosecondsPerSecond = 1_000_000_000
+}
+
+/// A date in the proleptic Gregorian calendar, which is the calendar Snowflake documents: "Snowflake
+/// does not adjust dates prior to 1582 (or calculations involving dates prior to 1582) to match the
+/// Julian Calendar."
+///
+/// Foundation cannot express that. `Calendar(identifier: .gregorian)` and `Calendar(identifier:
+/// .iso8601)` both switch to the Julian calendar before 1582-10-15, and `ISO8601DateFormatter` and
+/// `Date.FormatStyle.iso8601` inherit it, so all of them render epoch day -719162 as 0001-01-03
+/// where Snowflake means 0001-01-01. The conversion is therefore integer arithmetic, which is exact
+/// for every day in the range and needs no time zone to be right.
+private struct CivilDate {
+    let year: Int
+    let month: Int
+    let day: Int
+
+    init?(epochDays: Int) {
+        guard (CivilDate.minEpochDay ... CivilDate.maxEpochDay).contains(epochDays) else { return nil }
+        var shifted = epochDays + 719_468
+        let era = (shifted >= 0 ? shifted : shifted - 146_096) / 146_097
+        shifted -= era * 146_097
+        let yearOfEra = (shifted - shifted / 1_460 + shifted / 36_524 - shifted / 146_096) / 365
+        let dayOfYear = shifted - (365 * yearOfEra + yearOfEra / 4 - yearOfEra / 100)
+        let monthIndex = (5 * dayOfYear + 2) / 153
+        day = dayOfYear - (153 * monthIndex + 2) / 5 + 1
+        month = monthIndex < 10 ? monthIndex + 3 : monthIndex - 9
+        year = yearOfEra + era * 400 + (month <= 2 ? 1 : 0)
+    }
+
+    var text: String { String(format: "%04d-%02d-%02d", year, month, day) }
+
+    /// 0001-01-01 and 9999-12-31, the range Snowflake's date and timestamp types cover. A value
+    /// outside it is not a date TablePro can show, so the caller keeps the raw text instead.
+    static let minEpochDay = -719_162
+    static let maxEpochDay = 2_932_896
+}
+
+private struct ClockTime {
+    let hour: Int
+    let minute: Int
+    let second: Int
+
+    init(secondOfDay: Int) {
+        hour = secondOfDay / 3_600
+        minute = (secondOfDay % 3_600) / 60
+        second = secondOfDay % 60
+    }
+
+    var text: String { String(format: "%02d:%02d:%02d", hour, minute, second) }
+}

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeValueDecoder.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeValueDecoder.swift
@@ -67,7 +67,7 @@ enum SnowflakeValueDecoder {
         let fields = raw.split(separator: " ", omittingEmptySubsequences: true)
         guard fields.count == 2, let biased = Int(fields[1]) else { return .text(raw) }
         let offsetMinutes = biased - offsetBias
-        guard abs(offsetMinutes) < minutesPerDay else { return .text(raw) }
+        guard abs(offsetMinutes) <= maximumOffsetMinutes else { return .text(raw) }
         return timestamp(
             fromEpochSeconds: String(fields[0]),
             scale: scale,
@@ -117,8 +117,13 @@ enum SnowflakeValueDecoder {
     // MARK: - Constants
 
     private static let secondsPerDay = 86_400
-    private static let minutesPerDay = 1_440
     private static let offsetBias = 1_440
+
+    /// `TimeZone(secondsFromGMT:)` returns nil beyond eighteen hours, and `DatabaseDateParser` reads
+    /// that nil as GMT, so a `+18:30` suffix would come back as an instant eighteen and a half hours
+    /// from the one Snowflake sent. A payload that cannot survive the round trip keeps its raw text
+    /// instead of being written in a spelling the reader will misread.
+    private static let maximumOffsetMinutes = 1_080
 }
 
 /// How a decoded timestamp names the zone it was read in. `TIMESTAMP_NTZ` genuinely has none, so it

--- a/TablePro/Core/Database/DatabaseDriver.swift
+++ b/TablePro/Core/Database/DatabaseDriver.swift
@@ -581,6 +581,7 @@ enum DatabaseDriverFactory {
             additionalFields["enableCleartextPlugin"] = "true"
         }
         additionalFields["queryTimeoutSeconds"] = String(AppSettingsManager.shared.general.queryTimeoutSeconds)
+        additionalFields["connectionId"] = connection.id.uuidString
         let config = DriverConnectionConfig(
             host: connection.host,
             port: connection.port,

--- a/TablePro/Views/Results/Extensions/DataGridView+Click.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Click.swift
@@ -109,7 +109,11 @@ extension TableViewCoordinator {
         } else if columnType.isBlobType {
             showBlobEditorPopover(tableView: tableView, row: row, column: column, columnIndex: columnIndex)
         } else if columnType.isDateType {
-            showDateTimePickerPopover(tableView: tableView, row: row, column: column, columnIndex: columnIndex)
+            if opensDatePicker(row: row, columnIndex: columnIndex) {
+                showDateTimePickerPopover(tableView: tableView, row: row, column: column, columnIndex: columnIndex)
+            } else {
+                beginEditing(displayRow: row, column: columnIndex)
+            }
         } else if columnType.isEnumOrSetType {
             beginEditing(displayRow: row, column: columnIndex)
         }

--- a/TablePro/Views/Results/Extensions/DataGridView+Popovers.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Popovers.swift
@@ -174,6 +174,19 @@ extension TableViewCoordinator {
         }
     }
 
+    /// A date control has no vocabulary for "I could not read this": `NSDatePicker.dateValue` and
+    /// every SwiftUI `DatePicker` binding are a non-optional `Date`, so a cell the parser rejects
+    /// gets seeded with today and an unchanged confirm writes today over the stored value in a
+    /// spelling the column never used. Such a cell goes to the text editor instead, where the value
+    /// stays visible and the user can repair it. An empty cell has nothing to misrepresent and keeps
+    /// the picker.
+    func opensDatePicker(row: Int, columnIndex: Int) -> Bool {
+        guard let value = cellValue(at: row, column: columnIndex),
+              !value.trimmingCharacters(in: .whitespaces).isEmpty
+        else { return true }
+        return DatabaseDateParser.parse(value) != nil
+    }
+
     func showDateTimePickerPopover(tableView: NSTableView, row: Int, column: Int, columnIndex: Int) {
         let tableRows = tableRowsProvider()
         guard columnIndex >= 0, columnIndex < tableRows.columnTypes.count else { return }

--- a/TableProTests/Plugins/SnowflakeSQLTests.swift
+++ b/TableProTests/Plugins/SnowflakeSQLTests.swift
@@ -1,0 +1,101 @@
+//
+//  SnowflakeSQLTests.swift
+//  TableProTests
+//
+//  Tests for SnowflakeSQL (compiled via symlink from SnowflakeDriverPlugin).
+//
+
+import Foundation
+import Testing
+
+@Suite("Snowflake SQL Escaping")
+struct SnowflakeSQLTests {
+    // MARK: - Literals
+
+    @Test("A quote is doubled")
+    func testQuoteDoubling() {
+        #expect(SnowflakeSQL.escapeLiteral("O'Brien") == "O''Brien")
+        #expect(SnowflakeSQL.escapeLiteral("''") == "''''")
+    }
+
+    /// Snowflake reads `\'` inside a literal as a content quote, so an escaper that doubles the
+    /// quote and leaves the backslash alone lets a name close the literal and run its own SQL.
+    @Test("A backslash is doubled so it cannot escape the closing quote")
+    func testBackslashDoubling() {
+        #expect(SnowflakeSQL.escapeLiteral("a\\b") == "a\\\\b")
+        #expect(SnowflakeSQL.escapeLiteral("\\") == "\\\\")
+    }
+
+    /// The payload works against a quote-only escaper: it becomes `x\'' OR 1=1 --`, Snowflake reads
+    /// `\'` as a content quote, the next quote closes the literal, and `OR 1=1` runs. Doubling the
+    /// backslash first leaves the quote with nothing to escape it.
+    @Test("A backslash-quote injection payload stays inside the literal")
+    func testInjectionPayloadIsNeutralised() {
+        let escaped = SnowflakeSQL.escapeLiteral("x\\' OR 1=1 --")
+        #expect(escaped == "x\\\\'' OR 1=1 --")
+
+        let quoteOnly = "x\\' OR 1=1 --".replacingOccurrences(of: "'", with: "''")
+        #expect(quoteOnly == "x\\'' OR 1=1 --")
+        #expect(escaped != quoteOnly)
+    }
+
+    @Test("The backslash is doubled before the quotes, not after")
+    func testEscapeOrder() {
+        #expect(SnowflakeSQL.escapeLiteral("'") == "''")
+        #expect(SnowflakeSQL.escapeLiteral("\\'") == "\\\\''")
+    }
+
+    @Test("An ordinary value is untouched")
+    func testPlainLiteral() {
+        #expect(SnowflakeSQL.escapeLiteral("PUBLIC") == "PUBLIC")
+        #expect(SnowflakeSQL.escapeLiteral("") == "")
+    }
+
+    // MARK: - Identifiers
+
+    @Test("An identifier is wrapped and its quotes doubled")
+    func testIdentifierQuoting() {
+        #expect(SnowflakeSQL.quoteIdentifier("orders") == "\"orders\"")
+        #expect(SnowflakeSQL.quoteIdentifier("we\"ird") == "\"we\"\"ird\"")
+        #expect(SnowflakeSQL.quoteIdentifier("a\".\"b") == "\"a\"\".\"\"b\"")
+    }
+
+    @Test("An identifier that tries to close its own quoting cannot")
+    func testIdentifierInjectionIsNeutralised() {
+        let quoted = SnowflakeSQL.quoteIdentifier("t\" ; DROP TABLE x; --")
+        #expect(quoted == "\"t\"\" ; DROP TABLE x; --\"")
+    }
+
+    // MARK: - LIKE patterns
+
+    @Test("LIKE wildcards in a name are escaped")
+    func testLikePattern() {
+        #expect(SnowflakeSQL.escapeLikePattern("my_table") == "my\\\\_table")
+        #expect(SnowflakeSQL.escapeLikePattern("100%") == "100\\\\%")
+    }
+
+    @Test("A LIKE pattern escapes its literal first")
+    func testLikePatternEscapesLiteralToo() {
+        #expect(SnowflakeSQL.escapeLikePattern("O'Brien") == "O''Brien")
+    }
+
+    // MARK: - One owner
+
+    /// Every statement builder in the plugin routes here. These pin that the wrappers stayed
+    /// wrappers, because three copies of this logic drifting apart is what shipped the injection.
+    @Test("The schema query wrappers delegate to the shared escaper")
+    func testSchemaQueriesDelegate() {
+        #expect(SnowflakeSchemaQueries.escapeLiteral("x\\'") == SnowflakeSQL.escapeLiteral("x\\'"))
+        #expect(SnowflakeSchemaQueries.quote("we\"ird") == SnowflakeSQL.quoteIdentifier("we\"ird"))
+        #expect(
+            SnowflakeSchemaQueries.escapeLikePattern("my_t") == SnowflakeSQL.escapeLikePattern("my_t")
+        )
+    }
+
+    @Test("The routine queries escape a schema name that carries a backslash")
+    func testRoutineListEscapesSchema() {
+        let sql = SnowflakeObjectQueries.routineList(schema: "x\\' OR 1=1 --")
+        #expect(sql.contains("x\\\\'' OR 1=1 --"))
+        #expect(!sql.contains("x\\' OR"))
+    }
+}

--- a/TableProTests/Plugins/SnowflakeSessionKeyTests.swift
+++ b/TableProTests/Plugins/SnowflakeSessionKeyTests.swift
@@ -1,0 +1,62 @@
+//
+//  SnowflakeSessionKeyTests.swift
+//  TableProTests
+//
+//  Tests for SnowflakeSessionKey (compiled via symlink from SnowflakeDriverPlugin).
+//
+
+import Foundation
+import Testing
+
+@Suite("Snowflake Session Key")
+struct SnowflakeSessionKeyTests {
+    private func key(
+        connectionId: String = "A",
+        host: String = "acct.snowflakecomputing.com",
+        user: String = "dana",
+        authMethod: String = "password",
+        role: String = "analyst"
+    ) -> String {
+        SnowflakeSessionKey.fingerprint(
+            connectionId: connectionId,
+            host: host,
+            user: user,
+            authMethod: authMethod,
+            role: role
+        )
+    }
+
+    /// The defect: two saved connections to one account, user and role shared a session, so
+    /// `USE DATABASE` in one moved the other's current database and a save wrote to the wrong one.
+    @Test("Two saved connections to the same account do not share a session")
+    func testDistinctConnectionsDoNotShare() {
+        #expect(key(connectionId: "A") != key(connectionId: "B"))
+    }
+
+    @Test("The same saved connection always resolves to one session")
+    func testSameConnectionShares() {
+        #expect(key(connectionId: "A") == key(connectionId: "A"))
+    }
+
+    /// The metadata pool rewrites the database on its copy before building a driver, so a key that
+    /// varied with the database would give that driver its own login and another MFA prompt.
+    @Test("The database is not part of the key")
+    func testDatabaseIsNotInTheKey() {
+        #expect(!key().contains("ANALYTICS"))
+        #expect(key(connectionId: "A") == key(connectionId: "A"))
+    }
+
+    @Test("Account identity still separates sessions")
+    func testAccountIdentitySeparates() {
+        #expect(key(host: "one.snowflakecomputing.com") != key(host: "two.snowflakecomputing.com"))
+        #expect(key(user: "dana") != key(user: "sam"))
+        #expect(key(authMethod: "password") != key(authMethod: "keyPair"))
+        #expect(key(role: "analyst") != key(role: "admin"))
+    }
+
+    @Test("User and role compare case-insensitively")
+    func testCaseFolding() {
+        #expect(key(user: "dana") == key(user: "DANA"))
+        #expect(key(role: "analyst") == key(role: "ANALYST"))
+    }
+}

--- a/TableProTests/Plugins/SnowflakeStatementTypeTests.swift
+++ b/TableProTests/Plugins/SnowflakeStatementTypeTests.swift
@@ -1,0 +1,71 @@
+//
+//  SnowflakeStatementTypeTests.swift
+//  TableProTests
+//
+//  Tests for SnowflakeStatementType (compiled via symlink from SnowflakeDriverPlugin).
+//
+
+import Foundation
+import Testing
+
+@Suite("Snowflake Statement Type")
+struct SnowflakeStatementTypeTests {
+    private func counts(_ values: [String]) -> [PluginCellValueBox] {
+        values.map { .text($0) }
+    }
+
+    @Test("The DML range is the one the server documents")
+    func testDMLRange() {
+        #expect(SnowflakeStatementType.isDML(0x3000))
+        #expect(SnowflakeStatementType.isDML(0x3500))
+        #expect(SnowflakeStatementType.isDML(0x3200))
+        #expect(!SnowflakeStatementType.isDML(0x1000))
+        #expect(!SnowflakeStatementType.isDML(0x2FFF))
+        #expect(!SnowflakeStatementType.isDML(0x3501))
+        #expect(!SnowflakeStatementType.isDML(0xA000))
+    }
+
+    @Test("An INSERT or DELETE reports its single count")
+    func testSingleCount() {
+        #expect(
+            SnowflakeStatementType.affectedRows(statementTypeId: 0x3000, row: counts(["7"])) == 7
+        )
+    }
+
+    /// An `UPDATE` returns rows updated and multi-joined rows updated, and a multi-clause `MERGE`
+    /// one count per clause. Reading only the first column reported the wrong number, and the guard
+    /// that demanded exactly one column reported none at all.
+    @Test("An UPDATE or MERGE sums every count column")
+    func testMultipleCountsAreSummed() {
+        #expect(
+            SnowflakeStatementType.affectedRows(statementTypeId: 0x3000, row: counts(["12", "0"])) == 12
+        )
+        #expect(
+            SnowflakeStatementType.affectedRows(statementTypeId: 0x3000, row: counts(["3", "4", "5"])) == 12
+        )
+    }
+
+    /// The old check keyed on a column named "number of rows", so this statement reported its own
+    /// result as the number of rows it had changed.
+    @Test("A SELECT never reports affected rows, whatever its columns are named")
+    func testSelectReportsNothing() {
+        #expect(
+            SnowflakeStatementType.affectedRows(statementTypeId: 0x1000, row: counts(["1523"])) == 0
+        )
+        #expect(
+            SnowflakeStatementType.affectedRows(statementTypeId: 0xA000, row: counts(["1523"])) == 0
+        )
+    }
+
+    @Test("A missing or unreadable count reports nothing rather than a guess")
+    func testUnreadableCounts() {
+        #expect(SnowflakeStatementType.affectedRows(statementTypeId: 0x3000, row: nil) == 0)
+        #expect(SnowflakeStatementType.affectedRows(statementTypeId: 0x3000, row: []) == 0)
+        #expect(
+            SnowflakeStatementType.affectedRows(statementTypeId: 0x3000, row: counts(["abc"])) == 0
+        )
+        #expect(
+            SnowflakeStatementType.affectedRows(statementTypeId: 0x3000, row: [.null]) == 0
+        )
+    }
+}

--- a/TableProTests/Plugins/SnowflakeValueDecoderTests.swift
+++ b/TableProTests/Plugins/SnowflakeValueDecoderTests.swift
@@ -1,0 +1,218 @@
+//
+//  SnowflakeValueDecoderTests.swift
+//  TableProTests
+//
+//  Tests for SnowflakeValueDecoder (compiled via symlink from SnowflakeDriverPlugin).
+//
+
+import Foundation
+import Testing
+
+@Suite("Snowflake Value Decoder")
+struct SnowflakeValueDecoderTests {
+    private func column(_ type: String, scale: Int? = nil) -> SnowflakeColumnMeta {
+        SnowflakeColumnMeta(
+            name: "c",
+            internalType: type,
+            nullable: true,
+            precision: nil,
+            scale: scale,
+            length: nil
+        )
+    }
+
+    private func decodedText(_ raw: String, _ type: String, scale: Int? = nil) -> String? {
+        guard case .text(let value) = SnowflakeValueDecoder.decode(raw, as: column(type, scale: scale)) else {
+            return nil
+        }
+        return value
+    }
+
+    private func decodedBytes(_ raw: String, _ type: String) -> Data? {
+        guard case .bytes(let data) = SnowflakeValueDecoder.decode(raw, as: column(type)) else { return nil }
+        return data
+    }
+
+    // MARK: - DATE
+
+    @Test("Epoch days decode to the dates the issue names")
+    func testReportedDates() {
+        #expect(decodedText("18262", "date") == "2020-01-01")
+        #expect(decodedText("20682", "date") == "2026-08-17")
+    }
+
+    @Test("Epoch day zero and its neighbours decode")
+    func testEpochNeighbours() {
+        #expect(decodedText("0", "date") == "1970-01-01")
+        #expect(decodedText("1", "date") == "1970-01-02")
+        #expect(decodedText("-1", "date") == "1969-12-31")
+        #expect(decodedText("-25567", "date") == "1900-01-01")
+    }
+
+    /// Foundation renders this epoch day as 0001-01-03, because `Calendar(identifier: .gregorian)`,
+    /// `Calendar(identifier: .iso8601)`, `ISO8601DateFormatter` and `Date.FormatStyle.iso8601` all
+    /// apply the 1582 Julian cutover. Snowflake does not, so this case fails the moment the decoder
+    /// is reimplemented on any of them.
+    @Test("Dates before 1582 use the proleptic Gregorian calendar")
+    func testProlepticGregorian() {
+        #expect(decodedText("-719162", "date") == "0001-01-01")
+        #expect(decodedText("-141427", "date") == "1582-10-15")
+        #expect(decodedText("-141428", "date") == "1582-10-14")
+    }
+
+    @Test("The bounds of Snowflake's date range decode")
+    func testRangeBounds() {
+        #expect(decodedText("-719162", "date") == "0001-01-01")
+        #expect(decodedText("2932896", "date") == "9999-12-31")
+    }
+
+    @Test("Epoch days outside the date range keep their raw text")
+    func testOutOfRangeDatesArePreserved() {
+        #expect(decodedText("2932897", "date") == "2932897")
+        #expect(decodedText("-719163", "date") == "-719163")
+        #expect(decodedText("100000000", "date") == "100000000")
+    }
+
+    @Test("A date value that is not an integer keeps its raw text")
+    func testUndecodableDatesArePreserved() {
+        #expect(decodedText("", "date") == "")
+        #expect(decodedText("abc", "date") == "abc")
+        #expect(decodedText("20682.5", "date") == "20682.5")
+        #expect(decodedText("2026-08-17", "date") == "2026-08-17")
+    }
+
+    @Test("Decoding is keyed on the column, never on the value")
+    func testIntegerInNonDateColumnIsUntouched() {
+        #expect(decodedText("20682", "fixed") == "20682")
+        #expect(decodedText("20682", "text") == "20682")
+        #expect(decodedText("20682", "variant") == "20682")
+        #expect(decodedText("20682", "boolean") == "20682")
+    }
+
+    @Test("An unknown internal type keeps its raw text")
+    func testUnknownTypeIsUntouched() {
+        #expect(decodedText("20682", "vector") == "20682")
+    }
+
+    // MARK: - TIME
+
+    @Test("Seconds since midnight decode to a wall clock")
+    func testTime() {
+        #expect(decodedText("3600.000000000", "time", scale: 0) == "01:00:00")
+        #expect(decodedText("82919.000000000", "time", scale: 0) == "23:01:59")
+        #expect(decodedText("0.000000000", "time", scale: 0) == "00:00:00")
+        #expect(decodedText("86399.000000000", "time", scale: 0) == "23:59:59")
+    }
+
+    @Test("A time column's scale decides how many fractional digits are written")
+    func testTimeScale() {
+        #expect(decodedText("3600.123456789", "time", scale: 0) == "01:00:00")
+        #expect(decodedText("3600.123456789", "time", scale: 3) == "01:00:00.123")
+        #expect(decodedText("3600.123456789", "time", scale: 9) == "01:00:00.123456789")
+        #expect(decodedText("3600.5", "time", scale: 3) == "01:00:00.500")
+    }
+
+    @Test("A time outside a single day keeps its raw text")
+    func testOutOfRangeTimeIsPreserved() {
+        #expect(decodedText("86400.000000000", "time", scale: 0) == "86400.000000000")
+        #expect(decodedText("-1.000000000", "time", scale: 0) == "-1.000000000")
+        #expect(decodedText("noon", "time", scale: 0) == "noon")
+    }
+
+    // MARK: - TIMESTAMP
+
+    @Test("TIMESTAMP_NTZ decodes to a bare wall clock")
+    func testTimestampNtz() {
+        #expect(decodedText("1755388800.000000000", "timestamp_ntz", scale: 0) == "2025-08-17 00:00:00")
+        #expect(decodedText("1616173619.000000000", "timestamp_ntz", scale: 0) == "2021-03-19 17:06:59")
+    }
+
+    /// TIMESTAMP_LTZ is an absolute instant stored in UTC. Without the marker the parser reads the
+    /// UTC wall clock as if it were the reader's own, which moves the instant by their offset.
+    @Test("TIMESTAMP_LTZ marks itself as UTC")
+    func testTimestampLtz() {
+        #expect(decodedText("1755388800.000000000", "timestamp_ltz", scale: 0) == "2025-08-17 00:00:00Z")
+        #expect(decodedText("1616173619.000000000", "timestamp_ltz", scale: 3) == "2021-03-19 17:06:59.000Z")
+    }
+
+    @Test("TIMESTAMP_TZ applies the offset and writes it back")
+    func testTimestampTz() {
+        #expect(
+            decodedText("1616173619.000000000 1500", "timestamp_tz", scale: 0) == "2021-03-19 18:06:59+01:00"
+        )
+        #expect(
+            decodedText("1616173619.000000000 1140", "timestamp_tz", scale: 0) == "2021-03-19 12:06:59-05:00"
+        )
+        #expect(
+            decodedText("1616173619.000000000 1440", "timestamp_tz", scale: 0) == "2021-03-19 17:06:59+00:00"
+        )
+    }
+
+    @Test("A malformed TIMESTAMP_TZ keeps its raw text")
+    func testUndecodableTimestampTzIsPreserved() {
+        #expect(decodedText("1616173619.000000000", "timestamp_tz", scale: 0) == "1616173619.000000000")
+        #expect(decodedText("1616173619.000000000 abc", "timestamp_tz", scale: 0) == "1616173619.000000000 abc")
+        #expect(decodedText("1616173619.000000000 9999", "timestamp_tz", scale: 0) == "1616173619.000000000 9999")
+    }
+
+    /// The wire writes nine decimal places, so the value carries more significant digits than a
+    /// `Double` holds. Parsing it as a floating-point number drops the last nanoseconds silently.
+    @Test("Nanosecond precision survives decoding")
+    func testNanosecondPrecision() {
+        #expect(
+            decodedText("1616173619.123456789", "timestamp_ntz", scale: 9) == "2021-03-19 17:06:59.123456789"
+        )
+    }
+
+    /// A value before the epoch is written as the negated magnitude, so the fraction is subtracted
+    /// from the whole part rather than added to it. `-0.000000009` is the example Snowflake's own
+    /// connector documents, and it is the case that proves the sign is not read off the integer
+    /// half alone: `-0` parses to `0`.
+    @Test("Timestamps before the epoch subtract their fraction")
+    func testNegativeTimestamps() {
+        #expect(decodedText("-1.000000000", "timestamp_ntz", scale: 0) == "1969-12-31 23:59:59")
+        #expect(decodedText("-86400.000000000", "timestamp_ntz", scale: 0) == "1969-12-31 00:00:00")
+        #expect(decodedText("-1.500000000", "timestamp_ntz", scale: 1) == "1969-12-31 23:59:58.5")
+        #expect(
+            decodedText("-0.000000009", "timestamp_ntz", scale: 9) == "1969-12-31 23:59:59.999999991"
+        )
+        #expect(decodedText("-0.500000000", "timestamp_ntz", scale: 1) == "1969-12-31 23:59:59.5")
+    }
+
+    @Test("A timestamp outside the date range keeps its raw text")
+    func testOutOfRangeTimestampIsPreserved() {
+        #expect(decodedText("999999999999.000000000", "timestamp_ntz", scale: 0) == "999999999999.000000000")
+    }
+
+    // MARK: - BINARY
+
+    @Test("Binary hex decodes to bytes")
+    func testBinary() {
+        #expect(decodedBytes("48656C6C6F", "binary") == Data("Hello".utf8))
+        #expect(decodedBytes("48656c6c6f", "binary") == Data("Hello".utf8))
+        #expect(decodedBytes("00FF", "binary") == Data([0x00, 0xFF]))
+    }
+
+    @Test("A zero-length binary decodes to empty bytes, not to text")
+    func testEmptyBinary() {
+        #expect(decodedBytes("", "binary") == Data())
+    }
+
+    @Test("Binary that is not a whole hex string keeps its raw text")
+    func testUndecodableBinaryIsPreserved() {
+        #expect(decodedText("48656C6C6", "binary") == "48656C6C6")
+        #expect(decodedText("zz", "binary") == "zz")
+    }
+
+    // MARK: - Type mapping
+
+    @Test("Every logical type still maps to the display name the app classifies")
+    func testDisplayNamesUnchanged() {
+        #expect(SnowflakeTypeMapper.displayType(for: column("date")) == "DATE")
+        #expect(SnowflakeTypeMapper.displayType(for: column("time")) == "TIME")
+        #expect(SnowflakeTypeMapper.displayType(for: column("timestamp_ntz")) == "TIMESTAMP_NTZ")
+        #expect(SnowflakeTypeMapper.displayType(for: column("timestamp_ltz")) == "TIMESTAMP_LTZ")
+        #expect(SnowflakeTypeMapper.displayType(for: column("timestamp_tz")) == "TIMESTAMP_TZ")
+        #expect(SnowflakeTypeMapper.displayType(for: column("binary")) == "BINARY")
+    }
+}

--- a/TableProTests/Plugins/SnowflakeValueDecoderTests.swift
+++ b/TableProTests/Plugins/SnowflakeValueDecoderTests.swift
@@ -155,6 +155,17 @@ struct SnowflakeValueDecoderTests {
         #expect(decodedText("1616173619.000000000 9999", "timestamp_tz", scale: 0) == "1616173619.000000000 9999")
     }
 
+    /// `TimeZone(secondsFromGMT:)` is nil beyond eighteen hours and the shared parser reads that nil
+    /// as GMT, so emitting `+18:30` would move the instant by eighteen and a half hours. Eighteen
+    /// hours exactly is the last offset that survives the round trip.
+    @Test("An offset the shared parser cannot represent keeps its raw text")
+    func testOutOfRangeOffsetIsPreserved() {
+        #expect(decodedText("0.000000000 2520", "timestamp_tz", scale: 0) == "1970-01-01 18:00:00+18:00")
+        #expect(decodedText("0.000000000 360", "timestamp_tz", scale: 0) == "1969-12-31 06:00:00-18:00")
+        #expect(decodedText("0.000000000 2550", "timestamp_tz", scale: 0) == "0.000000000 2550")
+        #expect(decodedText("0.000000000 330", "timestamp_tz", scale: 0) == "0.000000000 330")
+    }
+
     /// The wire writes nine decimal places, so the value carries more significant digits than a
     /// `Double` holds. Parsing it as a floating-point number drops the last nanoseconds silently.
     @Test("Nanosecond precision survives decoding")

--- a/docs/databases/snowflake.mdx
+++ b/docs/databases/snowflake.mdx
@@ -87,6 +87,7 @@ No SSL/TLS pane, and no plaintext option. Every request is HTTPS to the account 
 
 - No SSH tunnel. The form has no SSH pane, and the endpoint is reached over HTTPS only.
 - A grid edit keys on the declared primary key, or on every column when there is none, and a duplicate key value updates or deletes every row that matches it. Snowflake never enforces key constraints, so check a table for duplicates before editing it.
+- `TIMESTAMP_LTZ` values read as the UTC instant, marked `Z`, rather than converted to the session's `TIMEZONE`.
 
 ## Troubleshooting
 

--- a/project.yml
+++ b/project.yml
@@ -486,6 +486,7 @@ targets:
       - Plugins/SnowflakeDriverPlugin/SnowflakeMFATokenStore.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeObjectQueries.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeSchemaQueries.swift
+      - Plugins/SnowflakeDriverPlugin/SnowflakeSessionKey.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeSQL.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeStatementGenerator.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeStatementType.swift

--- a/project.yml
+++ b/project.yml
@@ -488,6 +488,7 @@ targets:
       - Plugins/SnowflakeDriverPlugin/SnowflakeSchemaQueries.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeSQL.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeStatementGenerator.swift
+      - Plugins/SnowflakeDriverPlugin/SnowflakeStatementType.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeTypeMapper.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeValueDecoder.swift
       - Plugins/SurrealDBDriverPlugin/SurrealCBOR.swift

--- a/project.yml
+++ b/project.yml
@@ -476,6 +476,7 @@ targets:
       - Plugins/SQLImportPlugin/SQLImportOptions.swift
       - Plugins/SQLImportPlugin/SQLImportOptionsView.swift
       - Plugins/SQLImportPlugin/SQLImportPlugin.swift
+      - Plugins/SnowflakeDriverPlugin/PluginCellValueBox.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeAuth.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeBindingEncoder.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeDDLGenerator.swift
@@ -486,6 +487,7 @@ targets:
       - Plugins/SnowflakeDriverPlugin/SnowflakeSchemaQueries.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeStatementGenerator.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeTypeMapper.swift
+      - Plugins/SnowflakeDriverPlugin/SnowflakeValueDecoder.swift
       - Plugins/SurrealDBDriverPlugin/SurrealCBOR.swift
       - Plugins/SurrealDBDriverPlugin/SurrealCellCoder.swift
       - Plugins/SurrealDBDriverPlugin/SurrealDBConnectionConfig.swift

--- a/project.yml
+++ b/project.yml
@@ -484,7 +484,9 @@ targets:
       - Plugins/SnowflakeDriverPlugin/SnowflakeHTTPRetry.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeHeartbeat.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeMFATokenStore.swift
+      - Plugins/SnowflakeDriverPlugin/SnowflakeObjectQueries.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeSchemaQueries.swift
+      - Plugins/SnowflakeDriverPlugin/SnowflakeSQL.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeStatementGenerator.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeTypeMapper.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeValueDecoder.swift


### PR DESCRIPTION
Snowflake driver fixes, five commits, each reviewed and merged on its own before landing here: #2467, #2468, #2469, #2470, plus the original decoding change.

## The reported bug

`SnowflakeConnection.box` is type blind. The legacy `/queries/v1/query-request` endpoint sends every cell as a JSON string in Snowflake's own internal encoding, and the driver never consulted the `rowtype` metadata it had already parsed, so a `DATE` reached the app as `20682` rather than `2026-08-17`.

That one boxing produced all three reported symptoms, because display, the picker seed and the `UPDATE` / `DELETE` `WHERE` anchor all read the same `PluginCellValue`.

## Two corrections to the original approach

**`DATE_OUTPUT_FORMAT` cannot work, so it is dropped.** Its default is already `YYYY-MM-DD` and the wire still carries `20682`. Snowflake's own `converter_snowsql.py` reads the parameter and still calls `time.gmtime(int(value) * 86400)` first; `gosnowflake` and `snowflake-jdbc` decode epoch days unconditionally. It is a display parameter for text casts, not a wire format switch.

**Foundation is the wrong calendar.** Snowflake documents that it does not adjust dates before 1582 to match the Julian calendar. Measured on this toolchain, `Calendar(identifier: .gregorian)`, `Calendar(identifier: .iso8601)`, `ISO8601DateFormatter`, `Date.FormatStyle.iso8601` and a POSIX `DateFormatter` all render epoch day `-719162` as `0001-01-03` where Snowflake means `0001-01-01`, and `gregorianStartDate` does not exist in the macOS SDK. The conversion is integer arithmetic, and `testProlepticGregorian` fails the moment anyone reimplements it on Foundation.

## What is in here

| Type | Wire | Was | Now |
|------|------|-----|-----|
| `DATE` | days since epoch | `20682` | `2026-08-17` |
| `TIME` | seconds since midnight | `3600.000000000` | `01:00:00` |
| `TIMESTAMP_NTZ` | seconds since epoch | `1755388800.000000000` | `2025-08-17 00:00:00` |
| `TIMESTAMP_LTZ` | seconds since epoch | `1755388800.000000000` | `2025-08-17 00:00:00Z` |
| `TIMESTAMP_TZ` | seconds, offset + 1440 | `1616173619.000000000 1500` | `2021-03-19 18:06:59+01:00` |
| `BINARY` | hex string | `0x34383635364336433646` | the bytes themselves |

Plus, from the stacked reviews:

- **One SQL escaper** (#2467). `SnowflakeObjectQueries.escapeLiteral` doubled the quote and left the backslash, so a schema named `x\' OR 1=1 --` closed the literal and ran its own SQL. Three copies of the escaper and five of the identifier quoter existed and nothing made them agree; there is now one owner and no hand-rolled escaping anywhere else in the plugin.
- **Offsets the parser cannot represent** (#2468). `TimeZone(secondsFromGMT:)` is nil past eighteen hours and the shared parser reads that nil as GMT, so a `+18:30` payload moved the instant by eighteen and a half hours. Such a value keeps its raw text.
- **Affected row counts** (#2469). The count was read off a column named `number of rows`, which missed `UPDATE` and `MERGE` entirely and reported a `SELECT COUNT(*) AS "number of rows"` as rows changed. It now comes from the response's `statementTypeId`.
- **Session identity** (#2470). The shared session was keyed on the account, so two saved connections to one account shared a session and `USE DATABASE` in one window moved the other. Stop also aborted every query on the session, including a sidebar refresh beside it.

## A value that cannot be decoded is never invented

Every arm returns the raw text unchanged when the encoding does not explain the value: a non-integer, an out of range epoch day, a malformed offset, an odd-length hex string. Decoding is keyed on the column, never on the value, so an integer sitting in a `VARCHAR` is left alone.

## The picker

A date control cannot say "I could not read this": `NSDatePicker.dateValue` and every SwiftUI `DatePicker` binding are a non-optional `Date`. A date cell whose text is non-empty and does not parse now opens the existing text editor instead of a picker seeded with today.

## Tests

63 cases across `SnowflakeValueDecoderTests`, `SnowflakeSQLTests`, `SnowflakeStatementTypeTests`, `SnowflakeSessionKeyTests` and `SnowflakeTypeMapperTests`. Decoder expectations were computed independently in Python's proleptic Gregorian calendar rather than from the implementation.

Verified on the merged branch: build PASS, SwiftLint 0 violations, `AllPlugins` compiles `SnowflakeDriverPlugin` clean, docs checks PASS.

## Not fixed here

Version 0 `TIMESTAMP_TZ` payloads pack the zone into the low bits of a single number instead of the `"<epoch> <offset>"` pair. Decoding it needs Snowflake's timezone index table, which cannot be verified without an account, so those values fall through to raw text, which is the behaviour before this change.

Fixes #2454
