### PR TITLE
fix(plugin-snowflake): give every statement builder one SQL escaper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Snowflake `BINARY` cells showing the hex of their hex, which the hex editor then wrote back.
 - A date cell the app cannot read opening a picker set to today, which overwrote the value on OK. (#2454)
 
+### Security
+
+- SQL injection through a Snowflake schema or routine name containing a backslash.
+
 ## [0.68.1] - 2026-08-26
 
 ### Changed

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeConnection.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeConnection.swift
@@ -743,7 +743,7 @@ final class SnowflakeConnection: @unchecked Sendable {
     }
 
     func quoteIdentifier(_ name: String) -> String {
-        "\"\(name.replacingOccurrences(of: "\"", with: "\"\""))\""
+        SnowflakeSQL.quoteIdentifier(name)
     }
 
     // MARK: - HTTP Helpers

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeDDLGenerator.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeDDLGenerator.swift
@@ -143,12 +143,10 @@ struct SnowflakeDDLGenerator {
     }
 
     private func quoteIdentifier(_ name: String) -> String {
-        "\"\(name.replacingOccurrences(of: "\"", with: "\"\""))\""
+        SnowflakeSQL.quoteIdentifier(name)
     }
 
     private func escapeLiteral(_ value: String) -> String {
-        value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "'", with: "''")
+        SnowflakeSQL.escapeLiteral(value)
     }
 }

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeObjectQueries.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeObjectQueries.swift
@@ -1,0 +1,54 @@
+//
+//  SnowflakeObjectQueries.swift
+//  SnowflakeDriverPlugin
+//
+//  SQL builders for procedures and functions. Pure text, no driver state, so the escaping these
+//  statements depend on can be tested directly.
+//
+
+import Foundation
+
+/// Snowflake has procedures and functions and no triggers.
+public enum SnowflakeObjectQueries {
+    public static func routineList(schema: String) -> String {
+        let schemaLiteral = SnowflakeSQL.escapeLiteral(schema)
+        return """
+            SELECT PROCEDURE_NAME AS NAME, PROCEDURE_SCHEMA AS SCHEMA_NAME, ARGUMENT_SIGNATURE,
+                   DATA_TYPE, PROCEDURE_LANGUAGE AS LANGUAGE, 'PROCEDURE' AS ROUTINE_KIND
+            FROM INFORMATION_SCHEMA.PROCEDURES
+            WHERE PROCEDURE_SCHEMA = '\(schemaLiteral)'
+            UNION ALL
+            SELECT FUNCTION_NAME AS NAME, FUNCTION_SCHEMA AS SCHEMA_NAME, ARGUMENT_SIGNATURE,
+                   DATA_TYPE, FUNCTION_LANGUAGE AS LANGUAGE, 'FUNCTION' AS ROUTINE_KIND
+            FROM INFORMATION_SCHEMA.FUNCTIONS
+            WHERE FUNCTION_SCHEMA = '\(schemaLiteral)'
+            ORDER BY ROUTINE_KIND, NAME
+            """
+    }
+
+    /// ARGUMENT_SIGNATURE names its parameters, `(A NUMBER, B VARCHAR)`, and GET_DDL accepts types
+    /// alone, `(NUMBER, VARCHAR)`. Passing the signature through unchanged is an error, not a
+    /// missing routine, so the names are dropped here.
+    public static func argumentTypes(fromSignature signature: String?) -> String {
+        guard let signature else { return "()" }
+        let trimmed = signature.trimmingCharacters(in: .whitespaces)
+        let inner = trimmed.hasPrefix("(") && trimmed.hasSuffix(")")
+            ? String(trimmed.dropFirst().dropLast())
+            : trimmed
+        guard !inner.trimmingCharacters(in: .whitespaces).isEmpty else { return "()" }
+        let types = inner.split(separator: ",").map { part -> String in
+            let tokens = part.split(whereSeparator: { $0.isWhitespace })
+            guard tokens.count > 1 else { return tokens.joined() }
+            return tokens.dropFirst().joined(separator: " ")
+        }
+        return "(\(types.joined(separator: ", ")))"
+    }
+
+    /// GET_DDL needs the argument types inside the name, so a routine cannot be addressed without
+    /// the signature the listing captured.
+    public static func routineDefinition(kind: String, schema: String?, name: String, signature: String?) -> String {
+        let arguments = argumentTypes(fromSignature: signature)
+        let qualified = [schema, name].compactMap { $0?.isEmpty == false ? $0 : nil }.joined(separator: ".")
+        return "SELECT GET_DDL('\(SnowflakeSQL.escapeLiteral(kind))', '\(SnowflakeSQL.escapeLiteral(qualified + arguments))')"
+    }
+}

--- a/Plugins/SnowflakeDriverPlugin/SnowflakePluginDriver+Routines.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakePluginDriver+Routines.swift
@@ -6,55 +6,6 @@
 import Foundation
 import TableProPluginKit
 
-/// Snowflake has procedures and functions and no triggers.
-public enum SnowflakeObjectQueries {
-    public static func escapeLiteral(_ value: String) -> String {
-        value.replacingOccurrences(of: "'", with: "''")
-    }
-
-    public static func routineList(schema: String) -> String {
-        let schemaLiteral = escapeLiteral(schema)
-        return """
-            SELECT PROCEDURE_NAME AS NAME, PROCEDURE_SCHEMA AS SCHEMA_NAME, ARGUMENT_SIGNATURE,
-                   DATA_TYPE, PROCEDURE_LANGUAGE AS LANGUAGE, 'PROCEDURE' AS ROUTINE_KIND
-            FROM INFORMATION_SCHEMA.PROCEDURES
-            WHERE PROCEDURE_SCHEMA = '\(schemaLiteral)'
-            UNION ALL
-            SELECT FUNCTION_NAME AS NAME, FUNCTION_SCHEMA AS SCHEMA_NAME, ARGUMENT_SIGNATURE,
-                   DATA_TYPE, FUNCTION_LANGUAGE AS LANGUAGE, 'FUNCTION' AS ROUTINE_KIND
-            FROM INFORMATION_SCHEMA.FUNCTIONS
-            WHERE FUNCTION_SCHEMA = '\(schemaLiteral)'
-            ORDER BY ROUTINE_KIND, NAME
-            """
-    }
-
-    /// ARGUMENT_SIGNATURE names its parameters, `(A NUMBER, B VARCHAR)`, and GET_DDL accepts types
-    /// alone, `(NUMBER, VARCHAR)`. Passing the signature through unchanged is an error, not a
-    /// missing routine, so the names are dropped here.
-    public static func argumentTypes(fromSignature signature: String?) -> String {
-        guard let signature else { return "()" }
-        let trimmed = signature.trimmingCharacters(in: .whitespaces)
-        let inner = trimmed.hasPrefix("(") && trimmed.hasSuffix(")")
-            ? String(trimmed.dropFirst().dropLast())
-            : trimmed
-        guard !inner.trimmingCharacters(in: .whitespaces).isEmpty else { return "()" }
-        let types = inner.split(separator: ",").map { part -> String in
-            let tokens = part.split(whereSeparator: { $0.isWhitespace })
-            guard tokens.count > 1 else { return tokens.joined() }
-            return tokens.dropFirst().joined(separator: " ")
-        }
-        return "(\(types.joined(separator: ", ")))"
-    }
-
-    /// GET_DDL needs the argument types inside the name, so a routine cannot be addressed without
-    /// the signature the listing captured.
-    public static func routineDefinition(kind: String, schema: String?, name: String, signature: String?) -> String {
-        let arguments = argumentTypes(fromSignature: signature)
-        let qualified = [schema, name].compactMap { $0?.isEmpty == false ? $0 : nil }.joined(separator: ".")
-        return "SELECT GET_DDL('\(escapeLiteral(kind))', '\(escapeLiteral(qualified + arguments))')"
-    }
-}
-
 extension SnowflakePluginDriver {
     func fetchRoutines(schema: String?) async throws -> [PluginRoutineInfo] {
         let resolvedSchema = schema ?? currentSchema ?? "PUBLIC"

--- a/Plugins/SnowflakeDriverPlugin/SnowflakePluginDriver.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakePluginDriver.swift
@@ -535,13 +535,11 @@ final class SnowflakePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     // MARK: - SQL Generation Helpers
 
     func quoteIdentifier(_ name: String) -> String {
-        "\"\(name.replacingOccurrences(of: "\"", with: "\"\""))\""
+        SnowflakeSQL.quoteIdentifier(name)
     }
 
     func escapeStringLiteral(_ value: String) -> String {
-        value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "'", with: "''")
+        SnowflakeSQL.escapeLiteral(value)
     }
 
     func castColumnToText(_ column: String) -> String {

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeSQL.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeSQL.swift
@@ -1,0 +1,34 @@
+//
+//  SnowflakeSQL.swift
+//  SnowflakeDriverPlugin
+//
+//  The single owner of how a value or a name is spelled inside Snowflake SQL. Three copies of the
+//  literal escaper and five of the identifier quoter used to sit in the files that build statements,
+//  and nothing made them agree: one copy doubled the quote and forgot the backslash, which is all a
+//  schema name needs to close the literal and run its own SQL.
+//
+
+import Foundation
+
+public enum SnowflakeSQL {
+    /// Snowflake reads `\'` inside a literal as a content quote, so doubling the quote alone leaves
+    /// a backslash able to escape the very quote that was meant to close the value. The backslash
+    /// goes first: doubling it after the quotes would also double the ones this method just added.
+    public static func escapeLiteral(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "''")
+    }
+
+    public static func quoteIdentifier(_ name: String) -> String {
+        "\"\(name.replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
+
+    /// `LIKE` reads `_` and `%` as wildcards, so a name containing either has to arrive escaped or
+    /// it matches objects the caller never named.
+    public static func escapeLikePattern(_ value: String) -> String {
+        escapeLiteral(value)
+            .replacingOccurrences(of: "_", with: "\\\\_")
+            .replacingOccurrences(of: "%", with: "\\\\%")
+    }
+}

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeSchemaQueries.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeSchemaQueries.swift
@@ -65,19 +65,15 @@ enum SnowflakeSchemaQueries {
     }
 
     static func escapeLikePattern(_ value: String) -> String {
-        escapeLiteral(value)
-            .replacingOccurrences(of: "_", with: "\\\\_")
-            .replacingOccurrences(of: "%", with: "\\\\%")
+        SnowflakeSQL.escapeLikePattern(value)
     }
 
     static func escapeLiteral(_ value: String) -> String {
-        value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "'", with: "''")
+        SnowflakeSQL.escapeLiteral(value)
     }
 
     static func quote(_ identifier: String) -> String {
-        "\"\(identifier.replacingOccurrences(of: "\"", with: "\"\""))\""
+        SnowflakeSQL.quoteIdentifier(identifier)
     }
 
     private static func qualified(_ parts: String...) -> String {

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeStatementGenerator.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeStatementGenerator.swift
@@ -139,6 +139,6 @@ struct SnowflakeStatementGenerator {
     }
 
     private func quoteIdentifier(_ name: String) -> String {
-        "\"\(name.replacingOccurrences(of: "\"", with: "\"\""))\""
+        SnowflakeSQL.quoteIdentifier(name)
     }
 }

--- a/TableProTests/Plugins/SnowflakeSQLTests.swift
+++ b/TableProTests/Plugins/SnowflakeSQLTests.swift
@@ -1,0 +1,101 @@
+//
+//  SnowflakeSQLTests.swift
+//  TableProTests
+//
+//  Tests for SnowflakeSQL (compiled via symlink from SnowflakeDriverPlugin).
+//
+
+import Foundation
+import Testing
+
+@Suite("Snowflake SQL Escaping")
+struct SnowflakeSQLTests {
+    // MARK: - Literals
+
+    @Test("A quote is doubled")
+    func testQuoteDoubling() {
+        #expect(SnowflakeSQL.escapeLiteral("O'Brien") == "O''Brien")
+        #expect(SnowflakeSQL.escapeLiteral("''") == "''''")
+    }
+
+    /// Snowflake reads `\'` inside a literal as a content quote, so an escaper that doubles the
+    /// quote and leaves the backslash alone lets a name close the literal and run its own SQL.
+    @Test("A backslash is doubled so it cannot escape the closing quote")
+    func testBackslashDoubling() {
+        #expect(SnowflakeSQL.escapeLiteral("a\\b") == "a\\\\b")
+        #expect(SnowflakeSQL.escapeLiteral("\\") == "\\\\")
+    }
+
+    /// The payload works against a quote-only escaper: it becomes `x\'' OR 1=1 --`, Snowflake reads
+    /// `\'` as a content quote, the next quote closes the literal, and `OR 1=1` runs. Doubling the
+    /// backslash first leaves the quote with nothing to escape it.
+    @Test("A backslash-quote injection payload stays inside the literal")
+    func testInjectionPayloadIsNeutralised() {
+        let escaped = SnowflakeSQL.escapeLiteral("x\\' OR 1=1 --")
+        #expect(escaped == "x\\\\'' OR 1=1 --")
+
+        let quoteOnly = "x\\' OR 1=1 --".replacingOccurrences(of: "'", with: "''")
+        #expect(quoteOnly == "x\\'' OR 1=1 --")
+        #expect(escaped != quoteOnly)
+    }
+
+    @Test("The backslash is doubled before the quotes, not after")
+    func testEscapeOrder() {
+        #expect(SnowflakeSQL.escapeLiteral("'") == "''")
+        #expect(SnowflakeSQL.escapeLiteral("\\'") == "\\\\''")
+    }
+
+    @Test("An ordinary value is untouched")
+    func testPlainLiteral() {
+        #expect(SnowflakeSQL.escapeLiteral("PUBLIC") == "PUBLIC")
+        #expect(SnowflakeSQL.escapeLiteral("") == "")
+    }
+
+    // MARK: - Identifiers
+
+    @Test("An identifier is wrapped and its quotes doubled")
+    func testIdentifierQuoting() {
+        #expect(SnowflakeSQL.quoteIdentifier("orders") == "\"orders\"")
+        #expect(SnowflakeSQL.quoteIdentifier("we\"ird") == "\"we\"\"ird\"")
+        #expect(SnowflakeSQL.quoteIdentifier("a\".\"b") == "\"a\"\".\"\"b\"")
+    }
+
+    @Test("An identifier that tries to close its own quoting cannot")
+    func testIdentifierInjectionIsNeutralised() {
+        let quoted = SnowflakeSQL.quoteIdentifier("t\" ; DROP TABLE x; --")
+        #expect(quoted == "\"t\"\" ; DROP TABLE x; --\"")
+    }
+
+    // MARK: - LIKE patterns
+
+    @Test("LIKE wildcards in a name are escaped")
+    func testLikePattern() {
+        #expect(SnowflakeSQL.escapeLikePattern("my_table") == "my\\\\_table")
+        #expect(SnowflakeSQL.escapeLikePattern("100%") == "100\\\\%")
+    }
+
+    @Test("A LIKE pattern escapes its literal first")
+    func testLikePatternEscapesLiteralToo() {
+        #expect(SnowflakeSQL.escapeLikePattern("O'Brien") == "O''Brien")
+    }
+
+    // MARK: - One owner
+
+    /// Every statement builder in the plugin routes here. These pin that the wrappers stayed
+    /// wrappers, because three copies of this logic drifting apart is what shipped the injection.
+    @Test("The schema query wrappers delegate to the shared escaper")
+    func testSchemaQueriesDelegate() {
+        #expect(SnowflakeSchemaQueries.escapeLiteral("x\\'") == SnowflakeSQL.escapeLiteral("x\\'"))
+        #expect(SnowflakeSchemaQueries.quote("we\"ird") == SnowflakeSQL.quoteIdentifier("we\"ird"))
+        #expect(
+            SnowflakeSchemaQueries.escapeLikePattern("my_t") == SnowflakeSQL.escapeLikePattern("my_t")
+        )
+    }
+
+    @Test("The routine queries escape a schema name that carries a backslash")
+    func testRoutineListEscapesSchema() {
+        let sql = SnowflakeObjectQueries.routineList(schema: "x\\' OR 1=1 --")
+        #expect(sql.contains("x\\\\'' OR 1=1 --"))
+        #expect(!sql.contains("x\\' OR"))
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -484,7 +484,9 @@ targets:
       - Plugins/SnowflakeDriverPlugin/SnowflakeHTTPRetry.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeHeartbeat.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeMFATokenStore.swift
+      - Plugins/SnowflakeDriverPlugin/SnowflakeObjectQueries.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeSchemaQueries.swift
+      - Plugins/SnowflakeDriverPlugin/SnowflakeSQL.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeStatementGenerator.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeTypeMapper.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeValueDecoder.swift


### PR DESCRIPTION
> Stacked on #2466. Base is `fix/snowflake-temporal-decoding`, a pointer at that PR's commit, because #2466's head lives on a fork and a base branch has to live in this repo. Retarget to `main` once #2466 merges.

Found while investigating #2454.

## The defect

`SnowflakeObjectQueries.escapeLiteral` doubled the quote and left the backslash alone:

```swift
value.replacingOccurrences(of: "'", with: "''")
```

Snowflake reads `\'` inside a literal as a content quote, and the driver says so itself: `requiresBackslashEscapingInLiterals` is `true`. So a schema named

```
x\' OR 1=1 --
```

escaped to `x\'' OR 1=1 --`. The `\'` is content, the next `'` closes the literal, `OR 1=1` becomes live SQL and `--` comments the tail. The routine listing then returns every schema's routines. `routineDefinition` feeds the same escaper into `GET_DDL`.

Schema and routine names arrive from `fetchSchemas` unsanitized, so anyone able to create an object in the account controls the string.

## Why one escaper instead of one fix

Three copies of the literal escaper existed and only one was wrong. Five copies of the identifier quoter existed, all byte identical. Nothing made any of them agree, which is how the wrong one survived.

Writing a fourth correct copy leaves that intact, so `SnowflakeSQL` is now the single owner of `escapeLiteral`, `quoteIdentifier` and `escapeLikePattern`, and every statement builder calls it:

| File | Was |
|------|-----|
| `SnowflakeObjectQueries` | quote only, the defect |
| `SnowflakeSchemaQueries` | own copy of all three |
| `SnowflakeDDLGenerator` | own literal escaper and quoter |
| `SnowflakeStatementGenerator` | own quoter |
| `SnowflakeConnection` | own quoter |
| `SnowflakePluginDriver` | own quoter and `escapeStringLiteral` |

There is now no hand-rolled quote or backslash doubling anywhere else in the plugin.

`SnowflakeObjectQueries` moved out of `SnowflakePluginDriver+Routines.swift` into its own file. It is a pure SQL builder that was sharing a file with a driver extension, which is what kept it out of the test target and therefore untested.

## Order matters

The backslash is doubled before the quotes. Doubling it afterwards would also double the backslashes in the quotes that step just added.

## Tests

`SnowflakeSQLTests`, 11 cases: quote doubling, backslash doubling, escape order, the injection payload above (asserted against what a quote-only escaper produces, so the test states the difference rather than restating the implementation), identifier quoting and an identifier that tries to close its own quoting, `LIKE` wildcard escaping, and delegation checks pinning that the per-file wrappers stayed wrappers.

Verified: build PASS, 56/56 across the escaping suite and every statement-builder suite, `AllPlugins` compiles `SnowflakeDriverPlugin` clean, SwiftLint 0 violations.
