### PR TITLE
fix(plugin-snowflake): take the affected row count from the statement type, not a column name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Snowflake `DATE`, `TIME` and `TIMESTAMP_*` cells showing the raw epoch number the server sends. (#2454)
 - Snowflake `BINARY` cells showing the hex of their hex, which the hex editor then wrote back.
 - A date cell the app cannot read opening a picker set to today, which overwrote the value on OK. (#2454)
+- Snowflake reporting no rows changed for an `UPDATE` or `MERGE`, and a `SELECT`'s own result for a column named `number of rows`.
 
 ### Security
 

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeConnection.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeConnection.swift
@@ -582,7 +582,10 @@ final class SnowflakeConnection: @unchecked Sendable {
             rows = Self.rows(from: inlineRowset, columns: columns)
         }
 
-        let affectedRows = Self.extractAffectedRows(columns: columns, rows: rows)
+        let affectedRows = SnowflakeStatementType.affectedRows(
+            statementTypeId: (data["statementTypeId"] as? NSNumber)?.intValue ?? 0,
+            row: rows.first
+        )
 
         if let chunks = data["chunks"] as? [[String: Any]], !chunks.isEmpty {
             rows.append(contentsOf: try await downloadChunks(
@@ -868,17 +871,6 @@ final class SnowflakeConnection: @unchecked Sendable {
         }
         guard let column else { return .text(text) }
         return SnowflakeValueDecoder.decode(text, as: column)
-    }
-
-    private static func extractAffectedRows(columns: [SnowflakeColumnMeta], rows: [[PluginCellValueBox]]) -> Int {
-        guard columns.count == 1,
-              columns[0].name.lowercased().contains("number of rows"),
-              let firstRow = rows.first,
-              case .text(let value) = firstRow.first ?? .null,
-              let count = Int(value) else {
-            return 0
-        }
-        return count
     }
 
     private static func parseChunkRows(

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeStatementType.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeStatementType.swift
@@ -1,0 +1,35 @@
+//
+//  SnowflakeStatementType.swift
+//  SnowflakeDriverPlugin
+//
+//  What the server said the statement was, rather than what its result looks like. The response
+//  carries `statementTypeId`, so the row count never has to be guessed from a column name: a DML
+//  statement reports its counts and everything else reports none, whatever its columns are called.
+//
+
+import Foundation
+
+enum SnowflakeStatementType {
+    static let select = 0x1000
+    static let dml = 0x3000
+    static let multiTableInsert = 0x3500
+    static let multiStatement = 0xA000
+
+    static func isDML(_ identifier: Int) -> Bool {
+        (dml ... multiTableInsert).contains(identifier)
+    }
+
+    /// A DML result is one row of counts, and how many columns it has depends on the statement:
+    /// `INSERT` and `DELETE` report one, `UPDATE` reports rows updated and multi-joined rows
+    /// updated, and a multi-clause `MERGE` reports one per clause. The answer is their sum, so
+    /// reading only the first column loses every count after it.
+    static func affectedRows(statementTypeId: Int, row: [PluginCellValueBox]?) -> Int {
+        guard isDML(statementTypeId), let row, !row.isEmpty else { return 0 }
+        var total = 0
+        for cell in row {
+            guard case .text(let value) = cell, let count = Int(value) else { return 0 }
+            total += count
+        }
+        return total
+    }
+}

--- a/TableProTests/Plugins/SnowflakeStatementTypeTests.swift
+++ b/TableProTests/Plugins/SnowflakeStatementTypeTests.swift
@@ -1,0 +1,71 @@
+//
+//  SnowflakeStatementTypeTests.swift
+//  TableProTests
+//
+//  Tests for SnowflakeStatementType (compiled via symlink from SnowflakeDriverPlugin).
+//
+
+import Foundation
+import Testing
+
+@Suite("Snowflake Statement Type")
+struct SnowflakeStatementTypeTests {
+    private func counts(_ values: [String]) -> [PluginCellValueBox] {
+        values.map { .text($0) }
+    }
+
+    @Test("The DML range is the one the server documents")
+    func testDMLRange() {
+        #expect(SnowflakeStatementType.isDML(0x3000))
+        #expect(SnowflakeStatementType.isDML(0x3500))
+        #expect(SnowflakeStatementType.isDML(0x3200))
+        #expect(!SnowflakeStatementType.isDML(0x1000))
+        #expect(!SnowflakeStatementType.isDML(0x2FFF))
+        #expect(!SnowflakeStatementType.isDML(0x3501))
+        #expect(!SnowflakeStatementType.isDML(0xA000))
+    }
+
+    @Test("An INSERT or DELETE reports its single count")
+    func testSingleCount() {
+        #expect(
+            SnowflakeStatementType.affectedRows(statementTypeId: 0x3000, row: counts(["7"])) == 7
+        )
+    }
+
+    /// An `UPDATE` returns rows updated and multi-joined rows updated, and a multi-clause `MERGE`
+    /// one count per clause. Reading only the first column reported the wrong number, and the guard
+    /// that demanded exactly one column reported none at all.
+    @Test("An UPDATE or MERGE sums every count column")
+    func testMultipleCountsAreSummed() {
+        #expect(
+            SnowflakeStatementType.affectedRows(statementTypeId: 0x3000, row: counts(["12", "0"])) == 12
+        )
+        #expect(
+            SnowflakeStatementType.affectedRows(statementTypeId: 0x3000, row: counts(["3", "4", "5"])) == 12
+        )
+    }
+
+    /// The old check keyed on a column named "number of rows", so this statement reported its own
+    /// result as the number of rows it had changed.
+    @Test("A SELECT never reports affected rows, whatever its columns are named")
+    func testSelectReportsNothing() {
+        #expect(
+            SnowflakeStatementType.affectedRows(statementTypeId: 0x1000, row: counts(["1523"])) == 0
+        )
+        #expect(
+            SnowflakeStatementType.affectedRows(statementTypeId: 0xA000, row: counts(["1523"])) == 0
+        )
+    }
+
+    @Test("A missing or unreadable count reports nothing rather than a guess")
+    func testUnreadableCounts() {
+        #expect(SnowflakeStatementType.affectedRows(statementTypeId: 0x3000, row: nil) == 0)
+        #expect(SnowflakeStatementType.affectedRows(statementTypeId: 0x3000, row: []) == 0)
+        #expect(
+            SnowflakeStatementType.affectedRows(statementTypeId: 0x3000, row: counts(["abc"])) == 0
+        )
+        #expect(
+            SnowflakeStatementType.affectedRows(statementTypeId: 0x3000, row: [.null]) == 0
+        )
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -488,6 +488,7 @@ targets:
       - Plugins/SnowflakeDriverPlugin/SnowflakeSchemaQueries.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeSQL.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeStatementGenerator.swift
+      - Plugins/SnowflakeDriverPlugin/SnowflakeStatementType.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeTypeMapper.swift
       - Plugins/SnowflakeDriverPlugin/SnowflakeValueDecoder.swift
       - Plugins/SurrealDBDriverPlugin/SurrealCBOR.swift


### PR DESCRIPTION
> Stacked on the Snowflake decoding work. Base is `fix/snowflake-temporal-decoding`, which carries #2466's commit plus the merged #2467 and #2468. Retarget to `main` when that branch lands.

Found while investigating #2454.

## The defect

`extractAffectedRows` decided what a result meant by reading its column names:

```swift
guard columns.count == 1,
      columns[0].name.lowercased().contains("number of rows"),
```

It is wrong in both directions.

**It misses real counts.** An `UPDATE` returns two columns, `number of rows updated` and `number of multi-joined rows updated`, and a multi-clause `MERGE` returns one per clause. `columns.count == 1` rejects them, so a save that changed rows reported none: the completion message dropped the count and query history recorded `0`.

**It invents counts that never happened.** `SELECT COUNT(*) AS "number of rows" FROM orders` is one column with that name holding `1523`, so a plain read was reported as having changed 1523 rows.

## The fix

The server already says what the statement was. The response carries `statementTypeId`, which the driver never read, so the count now comes from that and the sum of the count row:

```swift
static func isDML(_ identifier: Int) -> Bool {
    (dml ... multiTableInsert).contains(identifier)
}
```

The range and the summing both follow the official Go driver, which gates on `isDml(data.Data.StatementTypeID)` and whose `updateRows` sums every column of the first row rather than reading one:

- `statementTypeIDSelect = 0x1000`
- `statementTypeIDDml = 0x3000`
- `statementTypeIDMultiTableInsert = statementTypeIDDml + 0x500`
- `statementTypeIDMultistatement = 0xA000`

A `SELECT` is no longer DML whatever its columns are called, and a DML statement reports the sum of its counts however many it has.

This is the same rule the ClickHouse driver already follows: classify a result from the server's answer, never from its shape.

## Tests

`SnowflakeStatementTypeTests`, 5 cases: the DML range and its boundaries at `0x2FFF` and `0x3501`, a single count, an `UPDATE` and a three-clause `MERGE` summed, a `SELECT` holding `1523` in a column named `number of rows` reporting nothing, and an unreadable or missing count reporting nothing rather than a guess.

Verified: build PASS, 43/43 across this and the neighbouring Snowflake suites, SwiftLint 0 violations.
