### PR TITLE
fix(datagrid): make the grid, the date picker and the write-back agree on a value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Connections strip not scrolling to the entry you switch to.
 - Grid cells left at the old column positions until the next click, after a resize, an auto-fit, a reorder, hiding a column, or a row-number width change. (#2449, #2446)
 - The row-number column draggable out of first place, which walked it to the far right on the next refresh.
+- A time entered into a date cell discarded when the stored value carried no time.
+- A timestamp with an offset showing one day in the grid and another in its date picker.
+- Opening a date picker and confirming without changing anything rewriting the cell.
 - Cell overlay appearance test failing at random when its window was released before the appearance changed.
 - A reordered column snapping back on the next refresh in the Structure tab and in query results.
 - Double-clicking a cell editing the wrong row, after deleting one of several rows added in the same session.

--- a/TablePro/Core/Services/Formatting/DateEditingService.swift
+++ b/TablePro/Core/Services/Formatting/DateEditingService.swift
@@ -16,7 +16,16 @@ enum TemporalComponents: Equatable {
 }
 
 enum DateEditingService {
-    static func string(from date: Date, like parsed: ParsedTemporalValue) -> String {
+    /// `offered` is the set of fields the editor actually showed, which comes from the column type
+    /// rather than from the text. They disagree whenever a column typed `DATETIME` holds a date-only
+    /// value, which SQLite allows and which MySQL produces for a zero time. Writing back only what
+    /// the old text spelled then dropped the time the user had just entered, and because the result
+    /// equalled the stored value the commit was discarded as a no-op: no error, no dirty marker.
+    static func string(
+        from date: Date,
+        like parsed: ParsedTemporalValue,
+        offered: TemporalComponents? = nil
+    ) -> String {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = parsed.timeZone
         let components = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
@@ -25,13 +34,15 @@ enum DateEditingService {
         let datePart = dateString(from: components)
         let timePart = timeString(from: components) + (layout.fractionalSeconds ?? "")
 
+        let writesDate = layout.hasDate || offered == .dateOnly || offered == .dateAndTime
+        let writesTime = layout.hasTime || offered == .timeOnly || offered == .dateAndTime
+
+        let separator = layout.dateTimeSeparator.isEmpty ? " " : layout.dateTimeSeparator
         var result: String
-        if layout.hasDate && layout.hasTime {
-            result = datePart + layout.dateTimeSeparator + timePart
-        } else if layout.hasDate {
-            result = datePart
-        } else {
-            result = timePart
+        switch (writesDate, writesTime) {
+        case (true, true): result = datePart + separator + timePart
+        case (true, false): result = datePart
+        default: result = timePart
         }
         if let suffix = layout.timeZoneSuffix {
             result += suffix

--- a/TablePro/Core/Services/Formatting/DateFormattingService.swift
+++ b/TablePro/Core/Services/Formatting/DateFormattingService.swift
@@ -54,10 +54,19 @@ final class DateFormattingService {
     /// - Parameter date: The date to format
     /// - Returns: Formatted date string
     func format(_ date: Date) -> String {
-        formatter.string(from: date)
+        formatter.timeZone = .current
+        return formatter.string(from: date)
     }
 
-    /// Format a string date value (parse then format)
+    /// Format a string date value (parse then format).
+    ///
+    /// The value is rendered in the zone it was written in, not the reader's. A value carrying an
+    /// offset names an instant in that offset, and the cell editor opens it there, so formatting it
+    /// somewhere else made the grid and the picker disagree about which day the row held. A value
+    /// with no offset is naive and parses in the reader's own zone, so this is the same zone it
+    /// always used.
+    ///
+    /// The cache key needs no zone: the zone is read off the value, so the string determines it.
     /// - Parameter dateString: Date string from database (ISO 8601, MySQL timestamp, etc.)
     /// - Parameter columnType: Column type, used to pick date-only / time-only / datetime variant
     /// - Returns: Formatted date string, or nil if unparseable
@@ -68,11 +77,12 @@ final class DateFormattingService {
             return cached.length == 0 ? nil : cached as String
         }
 
-        guard let date = DatabaseDateParser.date(from: dateString) else {
+        guard let parsed = DatabaseDateParser.parse(dateString) else {
             formatCache.setObject("" as NSString, forKey: cacheKey)
             return nil
         }
-        let result = targetFormatter.string(from: date)
+        targetFormatter.timeZone = parsed.timeZone
+        let result = targetFormatter.string(from: parsed.date)
         formatCache.setObject(result as NSString, forKey: cacheKey)
         return result
     }

--- a/TablePro/Views/Results/Extensions/DataGridView+Popovers.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Popovers.swift
@@ -196,7 +196,9 @@ extension TableViewCoordinator {
                 components: components,
                 timeZone: timeZone,
                 onCommit: { picked in
-                    let newValue = parsed.map { DateEditingService.string(from: picked, like: $0) }
+                    guard picked != initialDate else { return }
+                    let newValue = parsed
+                        .map { DateEditingService.string(from: picked, like: $0, offered: components) }
                         ?? DateEditingService.defaultString(from: picked, columnType: columnType)
                     self?.commitPopoverEdit(row: row, columnIndex: columnIndex, newValue: newValue)
                 },

--- a/TableProTests/Core/Services/TemporalEditingConsistencyTests.swift
+++ b/TableProTests/Core/Services/TemporalEditingConsistencyTests.swift
@@ -1,0 +1,105 @@
+//
+//  TemporalEditingConsistencyTests.swift
+//  TableProTests
+//
+//  The grid, the cell editor and the write-back have to agree about a temporal value: which instant
+//  it names, which zone it is read in, and which fields it spells.
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("Temporal Editing Consistency")
+struct TemporalEditingConsistencyTests {
+    // MARK: - The editor's fields decide what is written
+
+    /// A `DATETIME` column holding date-only text showed hour, minute and second steppers, but the
+    /// write-back copied the old text's shape and dropped the time. The result equalled the stored
+    /// value, so the commit was discarded with no error and no dirty marker.
+    @Test("A time entered into a date-only value is written, not dropped")
+    func testEnteredTimeSurvives() throws {
+        let parsed = try #require(DatabaseDateParser.parse("2024-03-15"))
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = parsed.timeZone
+        let picked = try #require(
+            calendar.date(from: DateComponents(year: 2024, month: 3, day: 15, hour: 14, minute: 30, second: 0))
+        )
+
+        let written = DateEditingService.string(from: picked, like: parsed, offered: .dateAndTime)
+        #expect(written == "2024-03-15 14:30:00")
+        #expect(written != "2024-03-15")
+    }
+
+    @Test("Without an offered set the value keeps the shape it arrived in")
+    func testLayoutStillDrivesTheDefault() throws {
+        let parsed = try #require(DatabaseDateParser.parse("2024-03-15"))
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = parsed.timeZone
+        let picked = try #require(
+            calendar.date(from: DateComponents(year: 2024, month: 3, day: 15, hour: 14, minute: 30, second: 0))
+        )
+        #expect(DateEditingService.string(from: picked, like: parsed) == "2024-03-15")
+    }
+
+    @Test("A date-only editor on a value carrying time keeps the time")
+    func testDateOnlyEditorDoesNotTruncate() throws {
+        let parsed = try #require(DatabaseDateParser.parse("2024-03-15 09:00:00"))
+        let written = DateEditingService.string(from: parsed.date, like: parsed, offered: .dateOnly)
+        #expect(written == "2024-03-15 09:00:00")
+    }
+
+    @Test("An offset suffix survives the write-back")
+    func testOffsetSuffixPreserved() throws {
+        let parsed = try #require(DatabaseDateParser.parse("2024-03-15 01:00:00+05:30"))
+        let written = DateEditingService.string(from: parsed.date, like: parsed, offered: .dateAndTime)
+        #expect(written == "2024-03-15 01:00:00+05:30")
+    }
+
+    // MARK: - The grid reads a value in the zone the editor opens it in
+
+    /// The grid formatted every value in the reader's zone while the picker opened it in the value's
+    /// own, so one cell showed 14 March in the grid and 15 March in the calendar.
+    @Test("An offset-bearing value formats in its own zone")
+    @MainActor
+    func testGridUsesTheValuesOwnZone() throws {
+        let service = DateFormattingService.shared
+        service.updateFormat(.iso8601)
+
+        let text = "2024-03-15 01:00:00+05:30"
+        let formatted = try #require(service.format(dateString: text, columnType: .timestamp(rawType: "TIMESTAMPTZ")))
+        let parsed = try #require(DatabaseDateParser.parse(text))
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = parsed.timeZone
+        let day = calendar.component(.day, from: parsed.date)
+
+        #expect(day == 15)
+        #expect(formatted.contains("2024-03-15"))
+    }
+
+    @Test("A naive value still reads in the reader's own zone")
+    @MainActor
+    func testNaiveValueUnchanged() throws {
+        let service = DateFormattingService.shared
+        service.updateFormat(.iso8601)
+        let formatted = try #require(
+            service.format(dateString: "2024-06-01 09:30:00", columnType: .timestamp(rawType: "DATETIME"))
+        )
+        #expect(formatted.contains("2024-06-01"))
+        #expect(formatted.contains("09:30"))
+    }
+
+    @Test("Formatting one value does not change how the next one reads")
+    @MainActor
+    func testFormatterZoneDoesNotLeak() throws {
+        let service = DateFormattingService.shared
+        service.updateFormat(.iso8601)
+        let offsetType = ColumnType.timestamp(rawType: "TIMESTAMPTZ")
+
+        _ = service.format(dateString: "2024-03-15 01:00:00+05:30", columnType: offsetType)
+        let naive = try #require(service.format(dateString: "2024-06-01 09:30:00", columnType: offsetType))
+        #expect(naive.contains("09:30"))
+    }
+}


### PR DESCRIPTION
Found while investigating #2454. Unlike the Snowflake work that issue produced, these are app-side and affect every driver, so this is based on `main` rather than stacked.

Three defects with one shape: the grid, the cell editor and the write-back each decided for themselves what a temporal value meant, and they disagreed.

## A time you typed was thrown away

The picker chooses its fields from the column type, but `DateEditingService.string(from:like:)` chose what to write from the shape of the stored text:

```swift
if layout.hasDate && layout.hasTime { ... } else if layout.hasDate { result = datePart }
```

A SQLite column declared `DATETIME` holding `2024-03-15` showed hour, minute and second steppers, because `DATETIME` maps to `.dateAndTime`. Setting 14:30:00 and pressing OK wrote `2024-03-15`, identical to the stored value, so the commit was discarded as a no-op. No error, no dirty marker, no redraw. The time simply vanished.

The write-back now takes the fields the editor actually offered as well as the shape the value arrived in, so a field the user was allowed to fill is a field that gets written.

## The grid and the picker showed different days

`DateFormattingService` set its formatter's zone once, at creation:

```swift
formatter.timeZone = TimeZone.current
```

while the picker opened the value in the zone the value itself carried. A PostgreSQL `timestamptz` rendered by the server as `2024-03-15 01:00:00+05:30`, viewed on a Mac in Europe/London, read `2024-03-14 19:30:00` in the cell and opened on 15 March in the calendar. The same row, two days, and no way to tell which one the database held.

The value is now formatted in the zone it was written in. That is what `DatabaseDateParser` already documents as the intent: the zone travels with the value so the grid, the chart's axis and the picker all show it as written. A value with no offset is naive and still resolves in the reader's own zone, so nothing changes for `DATETIME` and friends.

The cache key needs no zone, because the zone is read off the value and the string therefore determines it.

## Opening a picker and pressing OK rewrote the cell

`onCommit` always synthesized a string and committed it, so merely opening the editor and confirming could replace the stored value. The clearest case is a wall clock inside the reader's spring-forward gap: `2024-03-10 02:30:00` in a MySQL `DATETIME` is legal and common when the data was written elsewhere, but `Calendar` rolls it to 03:30, and confirming unchanged committed `2024-03-10 03:30:00`, moving the row an hour.

Confirming without changing the value now writes nothing, which is the rule #2454 asked for.

## Tests

`TemporalEditingConsistencyTests`, 7 cases: an entered time survives on a date-only value, the arrival shape still drives the default when no field set is offered, a date-only editor does not truncate a value carrying time, an offset suffix survives the round trip, an offset-bearing value formats on its own day, a naive value still reads in the reader's zone, and formatting one value does not change how the next reads (the shared formatter's zone does not leak).

Verified: build PASS, 108/108 across every suite that touches `DateFormattingService`, `CellDisplayFormatter`, `ResultChartProjector`, `DateEditingService` and `DatabaseDateParser`, SwiftLint 0 violations.

No UI automation. The flows need a cell whose stored text disagrees with its column type and a Mac in a specific time zone, neither of which the UI test harness can set deterministically. The behaviour is pinned at the three services instead.

## Two related things deliberately left alone

**The DST-gap display.** `DatabaseDateParser.keepsItsDay` compares only year, month and day, so a wall clock rolled forward by an hour still passes and the grid shows 03:30 for a stored 02:30. The comment above it defends that on purpose: such a value is still the day it says it is. Rejecting it would make those cells fall back to raw text. The damaging half, the silent rewrite, is fixed above; changing what the grid displays is a product decision.

**The 1582 calendar.** `DatabaseDateParser` builds a Foundation `.gregorian` calendar, which applies the Julian cutover, so a date from `1582-10-05` to `1582-10-14` does not parse and an older one resolves to a different absolute day. Snowflake, and ISO 8601, use the proleptic calendar. Making the shared parser proleptic changes behaviour for every driver at once and deserves its own change.
