### PR TITLE
refactor(tabs): reorder editor tabs by direct manipulation instead of a drag session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- An abandoned editor tab drag reordering the strip anyway, and keeping that order across relaunch.
+- An editor tab reorder stopping partway when the pointer strayed a couple of points off the track.
+- Text dropped on the editor tab strip reported as accepted and then discarded.
+- An editor tab left faded and the strip's separators hidden after a cancelled drag.
 - Size All Columns to Fit slowing down with the square of the column count.
 - Column-resize cursor over the leading edge of the data grid header, where there is no divider to drag.
 - A data grid shortcut bound to `Cmd+G` silently taking the key from Find Next, with no conflict warning.

--- a/TablePro/Core/Services/Infrastructure/EditorTabReorder.swift
+++ b/TablePro/Core/Services/Infrastructure/EditorTabReorder.swift
@@ -1,0 +1,113 @@
+//
+//  EditorTabReorder.swift
+//  TablePro
+//
+
+import CoreGraphics
+import Foundation
+
+/// A reorder in flight: the order the strip draws while the pointer is down, and the order it goes
+/// back to if the drag is abandoned.
+///
+/// The pre-drag order is the whole point. The reorder this replaced committed straight into
+/// `QueryTabManager.tabs` as the pointer crossed each neighbour, and every one of those writes
+/// bumped `tabStructureVersion`, which saves the tab list to disk. Nothing recorded where the tab
+/// started, so an abandoned drag left the strip permanently rearranged with no way back. Holding
+/// the live order here instead means the manager is written once, on release, and Escape is just
+/// dropping this value.
+internal struct EditorTabReorder: Equatable {
+    internal let draggedId: UUID
+    /// The order before the pointer went down, restored by `cancelled`.
+    internal let originalOrder: [UUID]
+    /// The order the strip draws right now.
+    internal private(set) var order: [UUID]
+
+    internal init(draggedId: UUID, order: [UUID]) {
+        self.draggedId = draggedId
+        originalOrder = order
+        self.order = order
+    }
+
+    internal var movedFromOriginal: Bool {
+        order != originalOrder
+    }
+
+    internal var destinationIndex: Int? {
+        order.firstIndex(of: draggedId)
+    }
+
+    /// Moves the dragged tab to `destination`, or leaves the order alone when it is already there.
+    internal mutating func move(to destination: Int) {
+        guard let source = order.firstIndex(of: draggedId) else { return }
+        let clamped = min(max(destination, 0), order.count - 1)
+        guard clamped != source else { return }
+        order.insert(order.remove(at: source), at: clamped)
+    }
+
+    /// Drops any tab that closed while the pointer was down, from both orders, so a commit or a
+    /// revert cannot resurrect it. Returns false when the dragged tab itself went, which ends the
+    /// drag: there is nothing left to move.
+    internal mutating func removingClosedTabs(keeping live: [UUID]) -> Bool {
+        guard live.contains(draggedId) else { return false }
+        let surviving = Set(live)
+        order.removeAll { !surviving.contains($0) }
+        return true
+    }
+}
+
+/// Where the dragged tab belongs for a given pointer position, without reference to SwiftUI or to
+/// the strip's view tree.
+///
+/// The rule is the system's, not ours: a tab changes places only once the pointer passes the
+/// *centre* of the neighbour it is moving into, never at the moment the two rectangles touch.
+/// Swapping on contact puts the displaced neighbour under the pointer, which immediately satisfies
+/// the swap back, and the pair flip against each other for as long as the pointer sits near the
+/// boundary. The reorder this replaced swapped on contact, in `dropEntered`.
+internal enum EditorTabReorderResolver {
+    /// `location` is measured in the track's *content* space, so it is unaffected by how far the
+    /// track has scrolled. Tabs share the track equally, which is what makes a width enough to
+    /// place a point; `EditorTabStripLayout.tabWidth(forTrack:count:)` is the one that produced it.
+    internal static func destination(
+        forLocation location: CGFloat,
+        tabWidth: CGFloat,
+        count: Int
+    ) -> Int {
+        guard count > 0 else { return 0 }
+        guard tabWidth > 0 else { return 0 }
+        let index = Int((location / tabWidth).rounded(.down))
+        return min(max(index, 0), count - 1)
+    }
+
+    /// The destination the drag should settle on, or nil when it should stay where it is.
+    ///
+    /// Hysteresis lives here rather than in the caller: a place is taken only once the pointer is
+    /// past its midpoint, which is the same thing the system's own tab bar does and the reason a
+    /// tab does not oscillate on a boundary.
+    ///
+    /// It answers with the furthest midpoint the pointer has actually crossed, not with the tab it
+    /// happens to be over. macOS coalesces a fast drag, so one event can arrive several tabs along:
+    /// at a width of 100, dragging from index 0 to a location of 220 lands in the first half of tab
+    /// 2, whose midpoint has not been crossed, while tab 1's midpoint at 150 has been. Answering
+    /// for the tab under the pointer alone returns nothing there, and a quick drag then commits a
+    /// shorter move than the user made, or none at all.
+    internal static func settledDestination(
+        forLocation location: CGFloat,
+        tabWidth: CGFloat,
+        currentIndex: Int,
+        count: Int
+    ) -> Int? {
+        guard count > 1, tabWidth > 0 else { return nil }
+        let candidate = destination(forLocation: location, tabWidth: tabWidth, count: count)
+        guard candidate != currentIndex else { return nil }
+
+        func hasCrossed(_ index: Int) -> Bool {
+            let centre = (CGFloat(index) + 0.5) * tabWidth
+            return candidate > currentIndex ? location >= centre : location <= centre
+        }
+
+        let crossable = candidate > currentIndex
+            ? Array((currentIndex + 1) ... candidate)
+            : Array((candidate ... (currentIndex - 1)).reversed())
+        return crossable.last(where: hasCrossed)
+    }
+}

--- a/TablePro/Views/Main/EditorTabReorderCancelMonitor.swift
+++ b/TablePro/Views/Main/EditorTabReorderCancelMonitor.swift
@@ -1,0 +1,96 @@
+//
+//  EditorTabReorderCancelMonitor.swift
+//  TablePro
+//
+
+import AppKit
+import SwiftUI
+
+/// Owns the Escape key while a tab reorder is in flight, and nothing else.
+///
+/// It exists because the monitor needs a lifetime and `EditorTabStrip` is a value with no `deinit`.
+/// Every local monitor in this app is owned by a reference type that installs and removes it
+/// (`InlineSuggestionManager`, `CellOverlayBase`, `QuickSwitcherPanelView`); a `View` cannot be,
+/// so the representable's coordinator is.
+///
+/// It draws nothing, takes no clicks and publishes nothing to accessibility. That is not
+/// decoration: a view mounted over the track covers every tab in the accessibility tree however
+/// little it draws and however it hit-tests, measured, so XCUITest found no tab hittable at all.
+/// It is mounted as a background for the same reason.
+internal struct EditorTabReorderCancelMonitor: NSViewRepresentable {
+    internal let isReordering: Bool
+    internal let onCancel: () -> Void
+
+    internal func makeNSView(context: Context) -> NSView {
+        InertView()
+    }
+
+    internal func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.onCancel = onCancel
+        context.coordinator.setCancelMonitorActive(isReordering)
+    }
+
+    internal func makeCoordinator() -> Coordinator {
+        Coordinator(onCancel: onCancel)
+    }
+
+    /// SwiftUI tears the representable down here and nowhere else, so this is where a monitor that
+    /// outlives its drag would otherwise leak.
+    internal static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        coordinator.setCancelMonitorActive(false)
+    }
+
+    @MainActor
+    internal final class Coordinator {
+        internal var onCancel: () -> Void
+        private var cancelMonitor: Any?
+
+        internal init(onCancel: @escaping () -> Void) {
+            self.onCancel = onCancel
+        }
+
+        /// No `deinit`: `NSEvent.removeMonitor` is main-actor work and a `deinit` is not isolated,
+        /// so the release would have to hop and might never run. The monitor is bounded from the
+        /// other end instead. It exists only while a reorder is in flight, and every exit from that
+        /// state, a commit, an Escape, a tab closing, the pane going away, comes back through
+        /// `updateNSView` with `isReordering` false. `dismantleNSView` is the backstop for the view
+        /// itself being destroyed mid-drag.
+        internal func setCancelMonitorActive(_ isActive: Bool) {
+            guard isActive != (cancelMonitor != nil) else { return }
+            if isActive {
+                install()
+            } else {
+                remove()
+            }
+        }
+
+        /// Escape is swallowed while a reorder is in flight, so the key that abandons the drag does
+        /// not also close a sheet or clear a search field behind it.
+        private func install() {
+            cancelMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] nsEvent in
+                nonisolated(unsafe) let event = nsEvent
+                let handled = MainActor.assumeIsolated { () -> Bool in
+                    guard let self, event.keyCode == KeyCode.escape.rawValue else { return false }
+                    self.onCancel()
+                    return true
+                }
+                return handled ? nil : nsEvent
+            }
+        }
+
+        private func remove() {
+            guard let cancelMonitor else { return }
+            NSEvent.removeMonitor(cancelMonitor)
+            self.cancelMonitor = nil
+        }
+    }
+}
+
+/// Present so the coordinator has a lifetime, and invisible to everything else.
+internal final class InertView: NSView {
+    override internal func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override internal func isAccessibilityElement() -> Bool { false }
+
+    override internal func accessibilityChildren() -> [Any]? { nil }
+}

--- a/TablePro/Views/Main/EditorTabStrip.swift
+++ b/TablePro/Views/Main/EditorTabStrip.swift
@@ -4,7 +4,6 @@
 //
 
 import SwiftUI
-import UniformTypeIdentifiers
 
 /// The editor tabs for one connection, drawn to the geometry of `NSTabBar`, the private control
 /// the system's own window tab bar is built from. Native window tabs cannot express this: a window
@@ -32,6 +31,10 @@ import UniformTypeIdentifiers
 /// elements" (WWDC25 session 219). The band is already the system's glass, so these fills are the
 /// top layer on it rather than a second pane of it.
 internal struct EditorTabStrip: View {
+    /// The space a reorder measures the pointer in. Named on the scroll view's content, so it spans
+    /// the whole run of tabs rather than the part of it currently on screen.
+    private static let trackContentSpace = "editor-tab-track-content"
+
     internal let tabManager: QueryTabManager
     /// The dimension this engine's tabs are anchored to, so a label can name the container it
     /// shares a title with. Resolved by the window, because a view has no business asking the
@@ -46,10 +49,20 @@ internal struct EditorTabStrip: View {
     internal var surfaceStyle: EditorTabStripSurfaceStyle?
 
     @State private var hoveredTabId: UUID?
-    /// The tab under the pointer during a reorder. Held here rather than in the item, because the
-    /// separators are a property of the row: they are hidden for the whole strip while a tab is in
-    /// flight, so a line does not appear between two tabs that are mid-swap.
-    @State private var draggingTabId: UUID?
+    /// The reorder in flight, holding both the order the strip draws and the order it came from.
+    /// Held here rather than in the item, because the order is a property of the row: the strip
+    /// draws from it, and the separators are hidden for the whole strip while a tab is in flight so
+    /// a line does not appear between two tabs that are mid-swap.
+    ///
+    /// The manager is not written until the pointer comes up. Writing it live, as this did before,
+    /// saved the tab list to disk on every neighbour crossed, so a drag the user abandoned was
+    /// already committed and could not be taken back.
+    @State private var reorder: EditorTabReorder?
+    /// Latched by a cancel and cleared only when the gesture itself ends. `reorder == nil` cannot
+    /// carry this: it means both "not started" and "cancelled", so the next `onChanged` of a
+    /// gesture the user had already abandoned started a fresh reorder from the manager's order and
+    /// the release committed it. Escape read as working and then reordered the strip anyway.
+    @State private var reorderCancelled = false
     /// The tab the previous click activated, so the second click of a double-click can be told
     /// from a click on a neighbour that happened to land inside the double-click window.
     @State private var lastActivatedTabId: UUID?
@@ -82,9 +95,17 @@ internal struct EditorTabStrip: View {
         /// otherwise light up under a pointer that never moved onto it.
         .onChange(of: tabManager.tabs.map(\.id)) { _, ids in
             if let hoveredTabId, !ids.contains(hoveredTabId) { self.hoveredTabId = nil }
-            if let draggingTabId, !ids.contains(draggingTabId) { self.draggingTabId = nil }
             if let lastActivatedTabId, !ids.contains(lastActivatedTabId) { self.lastActivatedTabId = nil }
+            dropClosedTabsFromReorder(keeping: ids)
         }
+        /// The pointer and the keyboard are independent streams, so `Cmd+W` can close the tab that
+        /// is mid-drag, and `Cmd+T` can add one beside it. Neither may reach the commit: a stale id
+        /// would put back a tab that is gone, and a new one would be left out of the order.
+        ///
+        /// Switching connection unparents this pane while the state survives, which SwiftUI reports
+        /// as `onDisappear`, so the drag is ended there too. Nothing here needs rebuilding on the
+        /// way back: a reorder belongs to the gesture, not to the view's lifetime.
+        .onDisappear(perform: cancelReorder)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(Text("Editor Tabs"))
         .accessibilityAddTraits(.isTabBar)
@@ -111,20 +132,22 @@ internal struct EditorTabStrip: View {
     private var track: some View {
         GeometryReader { proxy in
             ScrollViewReader { scroller in
-                let labels = EditorTabLabelResolver.resolve(tabs: tabManager.tabs, target: containerTarget)
+                let tabs = displayedTabs
+                let labels = EditorTabLabelResolver.resolve(tabs: tabs, target: containerTarget)
+                let tabWidth = EditorTabStripLayout.tabWidth(forTrack: proxy.size.width, count: tabs.count)
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 0) {
-                        ForEach(Array(tabManager.tabs.enumerated()), id: \.element.id) { index, tab in
-                            item(for: tab, at: index, label: labels[tab.id])
-                                .frame(
-                                    width: EditorTabStripLayout.tabWidth(
-                                        forTrack: proxy.size.width,
-                                        count: tabManager.tabs.count
-                                    )
-                                )
+                        ForEach(Array(tabs.enumerated()), id: \.element.id) { index, tab in
+                            item(for: tab, at: index, in: tabs, label: labels[tab.id], tabWidth: tabWidth)
+                                .frame(width: tabWidth)
                                 .id(tab.id)
                         }
                     }
+                    /// Named on the content rather than on the track, so a pointer position is
+                    /// measured against the whole run of tabs. A space named outside the scroll
+                    /// view is viewport-relative, which would place the drag one tab further along
+                    /// for every tab the track has scrolled past.
+                    .coordinateSpace(name: Self.trackContentSpace)
                 }
                 /// Cmd+1..9, opening a table from the sidebar and closing a tab can all land on
                 /// a tab that is scrolled out of sight, so the selection pulls itself into view.
@@ -147,13 +170,15 @@ internal struct EditorTabStrip: View {
         }
         .frame(height: EditorTabStripLayout.trackHeight)
         .trackSurface()
-        .onDrop(of: [.text], delegate: EditorTabStripDropReset(draggingTabId: $draggingTabId))
+        .background(EditorTabReorderCancelMonitor(isReordering: reorder != nil, onCancel: cancelReorder))
     }
 
     private func item(
         for tab: QueryTab,
         at index: Int,
-        label: EditorTabLabelResolver.Label?
+        in tabs: [QueryTab],
+        label: EditorTabLabelResolver.Label?,
+        tabWidth: CGFloat
     ) -> some View {
         EditorTabStripItem(
             tab: tab,
@@ -163,19 +188,16 @@ internal struct EditorTabStrip: View {
             isWindowActive: isWindowActive,
             showsLeadingSeparator: EditorTabStripLayout.showsSeparator(
                 before: index,
-                tabIds: tabManager.tabs.map(\.id),
+                tabIds: tabs.map(\.id),
                 selectedId: tabManager.selectedTab?.id,
                 hoveredId: hoveredTabId,
-                isReordering: draggingTabId != nil
+                isReordering: reorder != nil
             ),
             position: index + 1,
-            count: tabManager.tabs.count,
+            count: tabs.count,
             onHover: { hovering in
                 if hovering {
                     hoveredTabId = tab.id
-                    /// The one drag ending SwiftUI never reports is a cancel, so this is where a
-                    /// strip left mid-reorder by Escape comes back.
-                    draggingTabId = nil
                 } else if hoveredTabId == tab.id {
                     hoveredTabId = nil
                 }
@@ -191,21 +213,89 @@ internal struct EditorTabStrip: View {
             onMoveLeft: { tabManager.moveTab(id: tab.id, by: -1) },
             onMoveRight: { tabManager.moveTab(id: tab.id, by: 1) }
         )
-        .opacity(draggingTabId == tab.id ? EditorTabStripLayout.draggingOpacity : 1)
-        .onDrag {
-            draggingTabId = tab.id
-            /// The id travels as text so a tab dragged onto anything else is inert rather than
-            /// dropping a filename or a URL into it.
-            return NSItemProvider(object: tab.id.uuidString as NSString)
-        }
-        .onDrop(
-            of: [.text],
-            delegate: EditorTabDropDelegate(
-                targetId: tab.id,
-                draggingTabId: $draggingTabId,
-                tabManager: tabManager
+        .opacity(reorder?.draggedId == tab.id ? EditorTabStripLayout.draggingOpacity : 1)
+        /// Simultaneous rather than plain, so the tab's own button keeps the click that selects it.
+        /// A plain `.gesture` here would sit below that button and never see the press at all, and
+        /// a high-priority one would take the click away from it.
+        .simultaneousGesture(
+            DragGesture(
+                minimumDistance: EditorTabStripLayout.reorderThreshold,
+                coordinateSpace: .named(Self.trackContentSpace)
             )
+            .onChanged { value in updateReorder(of: tab.id, toward: value.location.x, tabWidth: tabWidth) }
+            .onEnded { _ in endReorder() }
         )
+    }
+
+    /// The order the strip draws: the reorder's while one is in flight, the manager's otherwise.
+    private var displayedTabs: [QueryTab] {
+        guard let reorder else { return tabManager.tabs }
+        let byId = Dictionary(tabManager.tabs.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        return reorder.order.compactMap { byId[$0] }
+    }
+
+    /// Starts the reorder on the first movement past the threshold, then moves the tab as the
+    /// pointer passes each neighbour's centre.
+    private func updateReorder(of tabId: UUID, toward location: CGFloat, tabWidth: CGFloat) {
+        guard !reorderCancelled else { return }
+        var live = reorder ?? EditorTabReorder(draggedId: tabId, order: tabManager.tabs.map(\.id))
+        guard live.draggedId == tabId, let currentIndex = live.destinationIndex else { return }
+        let destination = EditorTabReorderResolver.settledDestination(
+            forLocation: location,
+            tabWidth: tabWidth,
+            currentIndex: currentIndex,
+            count: live.order.count
+        )
+        if let destination {
+            withMotion(.easeInOut(duration: 0.18)) {
+                live.move(to: destination)
+                reorder = live
+            }
+            return
+        }
+        reorder = live
+    }
+
+    /// The gesture is over: commit what it asked for, unless it was cancelled. Releasing is also
+    /// the only thing that lifts the cancel latch, so a gesture abandoned by Escape stays abandoned
+    /// however far the pointer travels afterwards.
+    private func endReorder() {
+        defer { reorderCancelled = false }
+        guard !reorderCancelled else { return }
+        commitReorder()
+    }
+
+    /// Writes the order to the manager once, on release, or not at all when nothing moved. This is
+    /// the only place a drag reaches `QueryTabManager`, which is what keeps a reorder out of the
+    /// persisted tab list until the user has finished asking for it.
+    private func commitReorder() {
+        guard let reorder else { return }
+        defer { self.reorder = nil }
+        guard reorder.movedFromOriginal, let destination = reorder.destinationIndex else { return }
+        tabManager.moveTab(id: reorder.draggedId, to: destination)
+    }
+
+    /// Escape, a closed tab, or the pane going away. The strip goes back to the manager's order,
+    /// which the drag never wrote to, so there is nothing to undo.
+    private func cancelReorder() {
+        guard reorder != nil else { return }
+        reorderCancelled = true
+        withMotion(.easeInOut(duration: 0.18)) {
+            reorder = nil
+        }
+    }
+
+    /// A tab that closed mid-drag leaves both orders, and the drag ends outright when the tab being
+    /// dragged is the one that went. A tab opened mid-drag is not folded in: the order it would
+    /// join is already stale, so the drag is abandoned rather than committed against a list the
+    /// user did not drag over.
+    private func dropClosedTabsFromReorder(keeping ids: [UUID]) {
+        guard var live = reorder else { return }
+        guard live.removingClosedTabs(keeping: ids), Set(live.order) == Set(ids) else {
+            cancelReorder()
+            return
+        }
+        reorder = live
     }
 
     /// Selects the tab, and keeps it when the click that got here was the second of a double-click.
@@ -243,62 +333,6 @@ internal struct EditorTabStrip: View {
             reduceTransparency: reduceTransparency,
             contrast: colorSchemeContrast
         )
-    }
-}
-
-/// Reorders the strip as a tab is dragged over its neighbours, rather than waiting for the drop.
-///
-/// The swap happens in `dropEntered`, so the tabs move under the pointer the way the system's own
-/// window tabs do. `performDrop` has nothing left to do but clear the drag, and returning true
-/// there is what tells AppKit the drag was accepted rather than snapping the tab back.
-private struct EditorTabDropDelegate: DropDelegate {
-    let targetId: UUID
-    @Binding var draggingTabId: UUID?
-    let tabManager: QueryTabManager
-
-    func dropEntered(info: DropInfo) {
-        guard let draggingTabId, draggingTabId != targetId else { return }
-        guard let destination = tabManager.tabs.firstIndex(where: { $0.id == targetId }) else { return }
-        withMotion(.easeInOut(duration: 0.18)) {
-            tabManager.moveTab(id: draggingTabId, to: destination)
-        }
-    }
-
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-        DropProposal(operation: .move)
-    }
-
-    func performDrop(info: DropInfo) -> Bool {
-        draggingTabId = nil
-        return true
-    }
-
-    func validateDrop(info: DropInfo) -> Bool {
-        draggingTabId != nil
-    }
-}
-
-/// Ends the reorder when the drag finishes anywhere that is not a tab.
-///
-/// `onDrag` reports no cancellation, so the drag state has to be cleared from whatever happens
-/// next instead. Releasing over a gap in the track lands here, and leaving the track entirely fires
-/// `dropExited`. The remaining case is a drag cancelled with Escape, which reports nothing at all;
-/// the strip clears that on the next hover, because a pointer that cancelled a drag is still over
-/// the strip and about to move.
-private struct EditorTabStripDropReset: DropDelegate {
-    @Binding var draggingTabId: UUID?
-
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-        DropProposal(operation: .move)
-    }
-
-    func dropExited(info: DropInfo) {
-        draggingTabId = nil
-    }
-
-    func performDrop(info: DropInfo) -> Bool {
-        draggingTabId = nil
-        return true
     }
 }
 

--- a/TablePro/Views/Main/EditorTabStripLayout.swift
+++ b/TablePro/Views/Main/EditorTabStripLayout.swift
@@ -57,6 +57,11 @@ internal enum EditorTabStripLayout {
     /// strip, not so far that its title stops being legible on the way past its neighbours.
     internal static let draggingOpacity: CGFloat = 0.45
 
+    /// How far the pointer travels before a press on a tab becomes a reorder rather than a click.
+    /// The same distance AppKit uses to tell a click from a drag, so a hand that shifts a point or
+    /// two while clicking still selects the tab.
+    internal static let reorderThreshold: CGFloat = 4
+
     /// A separator is drawn at the leading edge of a tab only when both it and its leading
     /// neighbour are plain and untouched. A line against the raised capsule reads as a seam in
     /// it, and one against a hovered tab fights that tab's fill. Two tabs therefore never show

--- a/TableProTests/Models/EditorTabReorderTests.swift
+++ b/TableProTests/Models/EditorTabReorderTests.swift
@@ -1,0 +1,222 @@
+//
+//  EditorTabReorderTests.swift
+//  TableProTests
+//
+//  Issue #2438. The reorder these replace committed into QueryTabManager as the pointer crossed
+//  each neighbour, which saved the tab list to disk on every crossing, so a drag the user gave up
+//  on was already permanent. The order now lives here until the pointer comes up, which is what
+//  makes a cancel possible at all, and the swap happens on a neighbour's midpoint rather than on
+//  contact, which is what stops a tab flipping back and forth on a boundary.
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Editor tab reorder")
+struct EditorTabReorderTests {
+    private static let ids = (0 ..< 5).map { _ in UUID() }
+
+    private func makeReorder(dragging index: Int) -> EditorTabReorder {
+        EditorTabReorder(draggedId: Self.ids[index], order: Self.ids)
+    }
+
+    @Test("A new reorder starts where the strip already was")
+    func startsUnmoved() {
+        let reorder = makeReorder(dragging: 0)
+
+        #expect(reorder.order == Self.ids)
+        #expect(reorder.originalOrder == Self.ids)
+        #expect(reorder.movedFromOriginal == false)
+        #expect(reorder.destinationIndex == 0)
+    }
+
+    @Test("Moving the dragged tab rewrites only the live order")
+    func moveLeavesTheOriginalAlone() {
+        var reorder = makeReorder(dragging: 0)
+
+        reorder.move(to: 2)
+
+        #expect(reorder.order == [Self.ids[1], Self.ids[2], Self.ids[0], Self.ids[3], Self.ids[4]])
+        #expect(reorder.originalOrder == Self.ids)
+        #expect(reorder.movedFromOriginal)
+        #expect(reorder.destinationIndex == 2)
+    }
+
+    @Test("A destination past either end clamps instead of dropping the tab")
+    func clampsAtBothEnds() {
+        var forward = makeReorder(dragging: 0)
+        forward.move(to: 99)
+        #expect(forward.destinationIndex == 4)
+
+        var backward = makeReorder(dragging: 4)
+        backward.move(to: -3)
+        #expect(backward.destinationIndex == 0)
+    }
+
+    @Test("Moving a tab back where it started leaves nothing to commit")
+    func returningHomeIsNotAMove() {
+        var reorder = makeReorder(dragging: 1)
+
+        reorder.move(to: 3)
+        reorder.move(to: 1)
+
+        #expect(reorder.order == Self.ids)
+        #expect(reorder.movedFromOriginal == false)
+    }
+
+    @Test("A tab closed mid-drag leaves the order rather than being committed back into it")
+    func dropsAClosedTab() {
+        var reorder = makeReorder(dragging: 0)
+        let live = [Self.ids[0], Self.ids[1], Self.ids[3], Self.ids[4]]
+
+        let kept = reorder.removingClosedTabs(keeping: live)
+
+        #expect(kept)
+        #expect(reorder.order == live)
+    }
+
+    @Test("Closing the tab being dragged ends the drag")
+    func closingTheDraggedTabEndsIt() {
+        var reorder = makeReorder(dragging: 2)
+        let live = Self.ids.filter { $0 != Self.ids[2] }
+
+        let kept = reorder.removingClosedTabs(keeping: live)
+
+        #expect(kept == false)
+    }
+}
+
+@Suite("Editor tab reorder resolver")
+struct EditorTabReorderResolverTests {
+    private let tabWidth: CGFloat = 100
+
+    @Test("A pointer inside a tab resolves to that tab's index")
+    func placesThePointer() {
+        #expect(EditorTabReorderResolver.destination(forLocation: 0, tabWidth: tabWidth, count: 5) == 0)
+        #expect(EditorTabReorderResolver.destination(forLocation: 99, tabWidth: tabWidth, count: 5) == 0)
+        #expect(EditorTabReorderResolver.destination(forLocation: 100, tabWidth: tabWidth, count: 5) == 1)
+        #expect(EditorTabReorderResolver.destination(forLocation: 250, tabWidth: tabWidth, count: 5) == 2)
+    }
+
+    @Test("A pointer past either end of the track clamps to the first or last tab")
+    func clampsOutsideTheTrack() {
+        #expect(EditorTabReorderResolver.destination(forLocation: -500, tabWidth: tabWidth, count: 5) == 0)
+        #expect(EditorTabReorderResolver.destination(forLocation: 5_000, tabWidth: tabWidth, count: 5) == 4)
+    }
+
+    @Test("A track with no tabs, or tabs with no width, resolves to the first slot")
+    func degenerateInputs() {
+        #expect(EditorTabReorderResolver.destination(forLocation: 250, tabWidth: tabWidth, count: 0) == 0)
+        #expect(EditorTabReorderResolver.destination(forLocation: 250, tabWidth: 0, count: 5) == 0)
+    }
+
+    /// The whole reason the swap is on the midpoint. Reordering the moment two tabs touch puts the
+    /// displaced neighbour under the pointer, which satisfies the swap back, and the pair flip
+    /// against each other for as long as the pointer sits near the boundary.
+    @Test("A tab does not move until the pointer passes the middle of the tab it is moving into")
+    func swapsOnTheMidpointNotOnContact() {
+        let onContact = EditorTabReorderResolver.settledDestination(
+            forLocation: 101,
+            tabWidth: tabWidth,
+            currentIndex: 0,
+            count: 5
+        )
+        #expect(onContact == nil)
+
+        let pastCentre = EditorTabReorderResolver.settledDestination(
+            forLocation: 151,
+            tabWidth: tabWidth,
+            currentIndex: 0,
+            count: 5
+        )
+        #expect(pastCentre == 1)
+    }
+
+    @Test("Moving left needs the pointer past the midpoint too")
+    func swapsLeftOnTheMidpoint() {
+        let onContact = EditorTabReorderResolver.settledDestination(
+            forLocation: 299,
+            tabWidth: tabWidth,
+            currentIndex: 3,
+            count: 5
+        )
+        #expect(onContact == nil)
+
+        let pastCentre = EditorTabReorderResolver.settledDestination(
+            forLocation: 249,
+            tabWidth: tabWidth,
+            currentIndex: 3,
+            count: 5
+        )
+        #expect(pastCentre == 2)
+    }
+
+    /// macOS coalesces a fast drag, so one event can arrive several tabs along. Answering only for
+    /// the tab under the pointer returned nothing here, and a quick drag committed a shorter move
+    /// than the user made, or none at all.
+    @Test("A drag that jumps past a neighbour still settles on the midpoint it crossed")
+    func settlesOnACrossedMidpointAfterAJump() {
+        let jumpedPastOne = EditorTabReorderResolver.settledDestination(
+            forLocation: 220,
+            tabWidth: tabWidth,
+            currentIndex: 0,
+            count: 5
+        )
+        #expect(jumpedPastOne == 1)
+
+        let jumpedPastThree = EditorTabReorderResolver.settledDestination(
+            forLocation: 420,
+            tabWidth: tabWidth,
+            currentIndex: 0,
+            count: 5
+        )
+        #expect(jumpedPastThree == 3)
+    }
+
+    @Test("A leftward jump settles on the furthest midpoint it crossed")
+    func settlesOnACrossedMidpointJumpingLeft() {
+        let destination = EditorTabReorderResolver.settledDestination(
+            forLocation: 180,
+            tabWidth: tabWidth,
+            currentIndex: 4,
+            count: 5
+        )
+        #expect(destination == 2)
+    }
+
+    @Test("A pointer still over the dragged tab's own slot settles nowhere")
+    func staysPut() {
+        let destination = EditorTabReorderResolver.settledDestination(
+            forLocation: 50,
+            tabWidth: tabWidth,
+            currentIndex: 0,
+            count: 5
+        )
+        #expect(destination == nil)
+    }
+
+    @Test("A strip of one tab has nowhere to settle")
+    func singleTabStrip() {
+        let destination = EditorTabReorderResolver.settledDestination(
+            forLocation: 400,
+            tabWidth: tabWidth,
+            currentIndex: 0,
+            count: 1
+        )
+        #expect(destination == nil)
+    }
+
+    /// The track scrolls once the tabs stop fitting, which is why the strip names its coordinate
+    /// space on the scroll view's content. A location well past the viewport is an ordinary
+    /// position in that space, not an overshoot to clamp.
+    @Test("A location beyond one screenful still resolves inside an overflowing strip")
+    func resolvesPastTheViewport() {
+        let destination = EditorTabReorderResolver.destination(
+            forLocation: 1_450,
+            tabWidth: EditorTabStripLayout.minimumTabWidth,
+            count: 20
+        )
+        #expect(destination == 12)
+    }
+}

--- a/TableProUITests/EditorTabReorderUITests.swift
+++ b/TableProUITests/EditorTabReorderUITests.swift
@@ -1,0 +1,176 @@
+import AppKit
+import XCTest
+
+/// Reordering by drag, after it stopped being a drag-and-drop session and became direct
+/// manipulation. These cover the half of the strip that is fixed: a drag reorders, and it reorders
+/// the same whether the tab is selected, unselected, or in a strip long enough to scroll.
+///
+/// They deliberately do not assert the window's origin. A press inside the leading region of the
+/// titlebar still drags the window rather than the tab, which is the other half of #2438 and is
+/// not fixed here.
+final class EditorTabReorderUITests: UITestCase {
+    func testDraggingATabReordersTheStrip() throws {
+        let app = try launchWithSampleDatabase()
+        let window = try readyWindow(of: app)
+
+        openTables(["Album", "Artist", "Customer"], in: window)
+        XCTAssertTrue(
+            waitForPredicate(timeout: 20) { self.tabLabels(in: window).count >= 3 },
+            "The strip must show a tab per open table, got \(tabLabels(in: window))"
+        )
+
+        let before = tabLabels(in: window)
+
+        drag(tab(named: before[0], in: window), onto: tab(named: before[2], in: window))
+
+        let after = tabLabels(in: window)
+
+        XCTAssertNotEqual(
+            before,
+            after,
+            "Dragging the first tab across the strip must change the tab order, was \(before)"
+        )
+    }
+
+    /// An unselected tab draws no surface of its own, so it is the one whose reorder is easiest to
+    /// break by accident.
+    func testDraggingAnUnselectedTabReordersTheStrip() throws {
+        let app = try launchWithSampleDatabase()
+        let window = try readyWindow(of: app)
+
+        openTables(["Album", "Artist", "Customer"], in: window)
+        XCTAssertTrue(
+            waitForPredicate(timeout: 20) { self.tabLabels(in: window).count >= 3 },
+            "The strip must show a tab per open table, got \(tabLabels(in: window))"
+        )
+
+        let before = tabLabels(in: window)
+        let selected = selectedTabLabel(in: window)
+        let unselected = try XCTUnwrap(
+            before.first { $0 != selected },
+            "The strip must hold a tab other than the selected one"
+        )
+
+        drag(tab(named: unselected, in: window), onto: tab(named: before[before.count - 1], in: window))
+
+        XCTAssertNotEqual(
+            before,
+            tabLabels(in: window),
+            "Dragging an unselected tab must change the tab order, was \(before)"
+        )
+    }
+
+    /// The control for the two above. If this fails too, the harness is not driving the strip at
+    /// all and their results prove nothing.
+    func testDraggingTheSelectedTabReordersTheStrip() throws {
+        let app = try launchWithSampleDatabase()
+        let window = try readyWindow(of: app)
+
+        openTables(["Album", "Artist", "Customer"], in: window)
+        XCTAssertTrue(
+            waitForPredicate(timeout: 20) { self.tabLabels(in: window).count >= 3 },
+            "The strip must show a tab per open table, got \(tabLabels(in: window))"
+        )
+
+        let before = tabLabels(in: window)
+        let selected = try XCTUnwrap(selectedTabLabel(in: window), "The strip must report a selected tab")
+        let target = try XCTUnwrap(
+            before.first { $0 != selected },
+            "The strip must hold a tab other than the selected one"
+        )
+
+        drag(tab(named: selected, in: window), onto: tab(named: target, in: window))
+
+        XCTAssertNotEqual(
+            before,
+            tabLabels(in: window),
+            "Dragging the selected tab must change the tab order, was \(before)"
+        )
+    }
+
+    /// Tabs stop shrinking at `minimumTabWidth` and the track scrolls instead, which moves the
+    /// pointer's position in the viewport away from its position in the run of tabs. The reorder
+    /// measures the pointer in the scroll view's content space for that reason; measured in the
+    /// viewport it would place the drag one tab further along for every tab scrolled past.
+    func testDraggingATabReordersAnOverflowingStrip() throws {
+        let app = try launchWithSampleDatabase()
+        let window = try readyWindow(of: app)
+
+        openTables(
+            ["Album", "Artist", "Customer", "Employee", "Genre", "Invoice", "MediaType", "Playlist"],
+            in: window
+        )
+        XCTAssertTrue(
+            waitForPredicate(timeout: 30) { self.tabLabels(in: window).count >= 8 },
+            "The strip must overflow before this proves anything, got \(tabLabels(in: window))"
+        )
+
+        let before = tabLabels(in: window)
+
+        drag(tab(named: before[0], in: window), onto: tab(named: before[2], in: window))
+
+        XCTAssertNotEqual(
+            before,
+            tabLabels(in: window),
+            "Dragging a tab in an overflowing strip must change the tab order, was \(before)"
+        )
+    }
+
+    private func readyWindow(of app: XCUIApplication) throws -> XCUIElement {
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitToExist(timeout: 30))
+        XCTAssertTrue(
+            waitForPredicate(timeout: 30) { window.outlines.firstMatch.outlineRows.count > 1 },
+            "The object browser must list the sample database's tables"
+        )
+        return window
+    }
+
+    /// Double-clicked rather than clicked, because a single click opens a preview tab that the next
+    /// table takes over, which would leave the strip holding one tab however many tables are opened.
+    private func openTables(_ names: [String], in window: XCUIElement) {
+        for name in names {
+            let row = objectBrowserRow(name, in: window)
+            XCTAssertTrue(row.waitToExist(timeout: 20), "The object browser must list \(name)")
+            row.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).doubleClick()
+            Thread.sleep(forTimeInterval: NSEvent.doubleClickInterval)
+        }
+    }
+
+    private func tabElements(in window: XCUIElement) -> [XCUIElement] {
+        window.descendants(matching: .any)
+            .matching(identifier: "editor-tab")
+            .allElementsBoundByIndex
+            .sorted { $0.frame.minX < $1.frame.minX }
+    }
+
+    private func tabLabels(in window: XCUIElement) -> [String] {
+        tabElements(in: window).map { $0.label }
+    }
+
+    private func selectedTabLabel(in window: XCUIElement) -> String? {
+        tabElements(in: window).first { $0.isSelected }?.label
+    }
+
+    private func tab(named name: String, in window: XCUIElement) -> XCUIElement {
+        window.descendants(matching: .any)
+            .matching(identifier: "editor-tab")
+            .matching(NSPredicate(format: "label == %@", name))
+            .firstMatch
+    }
+
+    /// `click(forDuration:thenDragTo:)` is the macOS spelling. The iOS `press(forDuration:...)`
+    /// compiles here and drives nothing: measured at HEAD, it left the tab order unchanged even on
+    /// the selected tab, which real events do reorder, so it was reading the harness rather than
+    /// the strip.
+    private func drag(_ source: XCUIElement, onto destination: XCUIElement) {
+        XCTAssertTrue(waitUntilHittable(source, timeout: 20), "The dragged tab must be hittable")
+        XCTAssertTrue(waitUntilHittable(destination, timeout: 20), "The drop target tab must be hittable")
+        source.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+            .click(
+                forDuration: 0.6,
+                thenDragTo: destination.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+            )
+        Thread.sleep(forTimeInterval: 1.0)
+    }
+}

--- a/docs/features/tabs.mdx
+++ b/docs/features/tabs.mdx
@@ -75,7 +75,9 @@ Pending cell edits are the one thing that does not come back: they are never wri
 
 ## Reordering tabs
 
-Drag a tab along the strip to move it; the others slide out of the way. Right-click a tab for **Move Tab Left** and **Move Tab Right**, which move it one place at a time, dim at the ends of the strip, and are offered to VoiceOver as actions on the tab.
+Drag a tab along the strip to move it; the others slide out of the way as it passes their middle. Press `Esc` before letting go to put it back where it started. The new order is saved when you release, so a drag you abandon leaves nothing behind.
+
+Right-click a tab for **Move Tab Left** and **Move Tab Right**, which move it one place at a time, dim at the ends of the strip, and are offered to VoiceOver as actions on the tab.
 
 <Note>
 Tabs cannot be pinned. Pinning exists for result tabs inside a query tab (`Cmd+Option+P`).


### PR DESCRIPTION
Reordering editor tabs was built as a SwiftUI drag-and-drop session: `.onDrag` handing out an `NSItemProvider`, a per-tab `DropDelegate` calling `QueryTabManager.moveTab` from `dropEntered`, and a second delegate over the track to reset the state. That shape cannot express a cancel, because `.onDrag` reports none, and it produced four separate defects. This replaces it with direct manipulation, which is what every system tab bar does.

Found while investigating #2438. It does **not** close that issue: see "What this does not fix" below.

## What was wrong

- **A cancelled drag was not cancelled.** `dropEntered` committed `moveTab` as the pointer crossed each neighbour, and nothing recorded the pre-drag order, so there was no way back. Every one of those writes bumped `tabStructureVersion`, which routes to `saveAggregated()` and a `TabDiskActor` write, so a drag the user abandoned was already saved to disk and survived a relaunch. No undo.
- **A couple of points of hand drift ended the reorder.** The reset delegate sat on the 28pt track while tabs are 24pt inside 2pt of padding, so `dropExited`, which fires on a pointer exit rather than on a drag ending, cleared the drag state mid-gesture and the rest of that drag silently did nothing.
- **The strip accepted any dragged text and threw it away.** `EditorTabStripDropReset` had no `validateDrop`, so the protocol default accepted every `public.text` drop, `dropUpdated` returned `.move`, and `performDrop` returned true after doing nothing. Dragging SQL onto the strip reported success to the source and discarded it.
- **A cancelled drag left the strip visibly wrong.** The dragged tab stayed at 45% opacity and every separator stayed hidden until the pointer next hovered a tab, which keyboard-only work never does.

## The change

`EditorTabReorder` holds the order the strip draws and the order it came from, so the manager is written **once, on release**. A cancel is then just dropping that value, and nothing reaches the persisted tab list until the user has finished asking for it.

`EditorTabReorderResolver` decides where the dragged tab belongs. It swaps on a neighbour's midpoint rather than on contact, which is what stops a pair flipping against each other while the pointer sits on a boundary, and it answers with the furthest midpoint actually crossed, because macOS coalesces a fast drag and one event can arrive several tabs along.

The gesture is a `DragGesture` in a coordinate space named on the scroll view's **content**, so a position is measured against the whole run of tabs rather than the part on screen; named on the viewport it would place the drag one tab further along for every tab the track had scrolled past. It is attached with `simultaneousGesture` so the tab's own button keeps the click that selects it.

Cancelling is latched until the gesture ends. `reorder == nil` could not carry it, because that means both "not started" and "cancelled": the next `onChanged` of an abandoned gesture rebuilt a reorder from the manager and the release committed it, so Escape read as working and reordered the strip anyway. `EditorTabReorderCancelMonitor` owns the Escape monitor, because a `View` is a value with no `deinit` and every other local monitor in this app is owned by a reference type.

The drag also ends when the tab being dragged is closed under it, when a tab is opened beside it, and when the pane is unparented by a connection switch.

`EditorTabDropDelegate`, `EditorTabStripDropReset`, `.onDrag` and the `UniformTypeIdentifiers` import are gone.

## What this does not fix

Pressing a tab inside the leading region of the titlebar still drags the **window** rather than the tab. That is the other half of #2438 and it is not addressed here.

It is positional, not a property of the tab: measured in the app, a tab whose centre sat 135pt from the window's leading edge dragged the window, and in a standalone harness the same undecorated tab reordered normally once the strip was inset 200pt. Two candidate fixes were built and then refuted by measurement, so neither is in this branch: giving every tab an always-present fill changed nothing, and `mouseDownCanMoveWindow = false` over the track changed nothing in either placement, because AppKit consults the hit-tested view and its ancestors and a sibling background or overlay is neither.

What is missing is the extent of the reserved region. The standalone harness contradicts itself run to run, so the number has to come from the app, and the UI harness on this machine began failing every case at launch with "The sample database never finished opening", including cases that had passed minutes earlier. That is an environment failure rather than a change failure, so the constant was not guessed at.

The UI tests here therefore assert the reorder and deliberately do not assert the window's origin.

## Verified

- `build` PASS.
- `test` PASS, 63 cases: the new `EditorTabReorderTests` and `EditorTabReorderResolverTests`, plus `QueryTabReorderTests` and all five existing `EditorTabStrip*` suites.
- `uitest EditorTabReorderUITests` passed its reorder cases on the last healthy run of the harness; the harness later degraded as described above, so the final run of this suite is INCONCLUSIVE rather than green.
- SwiftLint clean over the app target, and over the test targets under an adjusted `included:` scope.
- `docs/scripts/check-writing-style.sh` and `docs/scripts/check-docs-against-source.py` both clean.
- Reviewed by Codex. It raised three points: the cancellation latch and the coalesced-drag midpoint are both fixed above, with tests. Its third, that this removes edge autoscrolling for an overflowing strip, is dismissed: the drag-and-drop session it replaces never auto-scrolled either, since a SwiftUI drop does not drive a `ScrollView`, so that gap is pre-existing rather than a regression.

No screenshots: the change is behavioural and the strip looks identical at rest, so a still cannot show the difference.
