### PR TITLE
fix(editor): rebuild text selection around an anchor and the rect being drawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Selection highlight missing from part of a long selection after scrolling back up to it.
+- Editor not scrolling to follow a selection extended past the edge of the viewport.
+- Find highlight and the run band covering only the first line of a match that spans several lines.
+- Nothing selected when double-clicking `=`, `<`, `>` or any other SQL operator.
+- Shift+Arrow extending the wrong end of a selection made by dragging.
+- Selection starting a few characters away from the press point on a quick drag.
+- A pause before the pointer responds when pressing inside selected text.
+- Shift+double-click and Shift+triple-click doing nothing.
+- Drag-select scrolling faster on a mouse than on a trackpad, and stalling mid-drag.
+- Statement selection with `Option+Shift+Down` leaving the highlight behind.
+- No arrow-key movement or Shift+Arrow selection in the JSON, DDL and SQL preview editors.
+- Explain with AI acting on the previous selection after a right-click somewhere else.
+- Selection painted in the accent colour in a window that is not the active one.
+- Selection bounds reported to VoiceOver covering only the first line, and no announcement when the selection moved.
 - An abandoned editor tab drag reordering the strip anyway, and keeping that order across relaunch.
 - An editor tab reorder stopping partway when the pointer strayed a couple of points off the track.
 - Text dropped on the editor tab strip reported as accepted and then discarded.

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Minimap/MinimapView+TextSelectionManagerDelegate.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Minimap/MinimapView+TextSelectionManagerDelegate.swift
@@ -10,13 +10,7 @@ import CodeEditTextView
 
 extension MinimapView: TextSelectionManagerDelegate {
     public var visibleTextRange: NSRange? {
-        let minY = max(visibleRect.minY, 0)
-        let maxY = min(visibleRect.maxY, layoutManager?.estimatedHeight() ?? 3.0)
-        guard let minYLine = layoutManager?.textLineForPosition(minY),
-              let maxYLine = layoutManager?.textLineForPosition(maxY) else {
-            return nil
-        }
-        return NSRange(start: minYLine.range.location, end: maxYLine.range.max)
+        layoutManager?.textRange(covering: visibleRect)
     }
 
     public func setNeedsDisplay() {

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/Extensions/CGRectArray+BoundingRect.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/Extensions/CGRectArray+BoundingRect.swift
@@ -12,12 +12,7 @@ extension Array where Element == CGRect {
     /// Returns `.zero` if the array is empty.
     /// - Returns: The minimum rectangle that contains all rectangles in this array.
     func boundingRect() -> CGRect {
-        guard !self.isEmpty else { return .zero }
-        let minX = self.min(by: { $0.origin.x < $1.origin.x })?.origin.x ?? 0
-        let minY = self.min(by: { $0.origin.y < $1.origin.y })?.origin.y ?? 0
-        let max = self.max(by: { $0.maxY < $1.maxY }) ?? .zero
-        let origin = CGPoint(x: minX, y: minY)
-        let size = CGSize(width: max.maxX - minX, height: max.maxY - minY)
-        return CGRect(origin: origin, size: size)
+        guard let first = self.first else { return .zero }
+        return self.dropFirst().reduce(first) { $0.union($1) }
     }
 }

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Layout.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Layout.swift
@@ -85,6 +85,10 @@ extension TextLayoutManager {
         var yContentAdjustment: CGFloat = 0
         var maxFoundLineWidth = maxLineWidth
 
+        // The layout view draws its own decorations into a backing store nothing else invalidates when the
+        // viewport moves, so a band drawn before its lines were laid out would stay blank forever.
+        var relaidOutRect: CGRect = .null
+
 #if DEBUG
         var laidOutLines: Set<TextLine.ID> = []
 #endif
@@ -107,6 +111,14 @@ extension TextLayoutManager {
                     maxFoundLineWidth: &maxFoundLineWidth
                 )
                 yContentAdjustment += yAdjustment
+                relaidOutRect = relaidOutRect.union(
+                    CGRect(
+                        x: 0,
+                        y: linePosition.yPos,
+                        width: layoutView?.frame.width ?? 0,
+                        height: max(linePosition.height, linePosition.data.lineFragments.height)
+                    )
+                )
 #if DEBUG
                 laidOutLines.insert(linePosition.data.id)
 #endif
@@ -161,6 +173,19 @@ extension TextLayoutManager {
 
         if originalHeight != lineStorage.height || layoutView?.frame.size.height != lineStorage.height {
             delegate?.layoutManagerHeightDidUpdate(newHeight: lineStorage.height)
+        }
+
+        if !relaidOutRect.isNull {
+            let movedEverythingBelow = didLayoutChange || yContentAdjustment != 0
+            let invalidRect = movedEverythingBelow
+                ? CGRect(
+                    x: relaidOutRect.minX,
+                    y: relaidOutRect.minY,
+                    width: relaidOutRect.width,
+                    height: max(maxY - relaidOutRect.minY, relaidOutRect.height)
+                )
+                : relaidOutRect
+            layoutView?.setNeedsDisplay(invalidRect)
         }
 
 #if DEBUG

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Public.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Public.swift
@@ -50,6 +50,26 @@ extension TextLayoutManager {
         }
     }
 
+    /// The range of text laid out inside a rect.
+    ///
+    /// This is the geometric question every rect-driven consumer has to ask: given a rect the view has been asked
+    /// to draw, hit test or measure, which text does it cover? Callers that answer it from the *viewport* instead
+    /// are wrong: AppKit calls `draw(_:)` with rects outside the visible area under responsive scrolling and caches
+    /// the result, so a viewport-derived answer bakes the scroll position into the drawing.
+    ///
+    /// - Parameter rect: The rect to find text for, in the text view's coordinate space.
+    /// - Returns: The range the rect covers, or `nil` when the rect lies past the end of the document.
+    public func textRange(covering rect: CGRect) -> NSRange? {
+        let minY = max(rect.minY, 0)
+        let maxY = min(rect.maxY, estimatedHeight())
+        guard maxY >= minY,
+              let firstLine = textLineForPosition(minY),
+              let lastLine = textLineForPosition(maxY) else {
+            return nil
+        }
+        return NSRange(start: firstLine.range.location, end: lastLine.range.max)
+    }
+
     /// Finds text line and returns it if found.
     /// Lines are 0 indexed.
     /// - Parameter index: The line to find.
@@ -232,10 +252,16 @@ extension TextLayoutManager {
         let realRangeStart = textStorage.rangeOfComposedCharacterSequence(at: range.lowerBound)
         let realRangeEnd = textStorage.rangeOfComposedCharacterSequence(at: range.upperBound - 1)
 
+        // Clamp to this line before rebasing. The requested range is document-absolute, so on every line after
+        // the first, subtracting the line's own location from it produces a negative start and the fragment
+        // lookup below matches nothing. That silently reduced any multi-line range to its first line.
+        let characterAlignedRange = NSRange(start: realRangeStart.lowerBound, end: realRangeEnd.upperBound)
+        guard let lineIntersection = characterAlignedRange.intersection(line.range) else { return [] }
+
         // Fragments are relative to the line
         let relativeRange = NSRange(
-            start: realRangeStart.lowerBound - line.range.location,
-            end: realRangeEnd.upperBound - line.range.location
+            start: lineIntersection.location - line.range.location,
+            end: lineIntersection.max - line.range.location
         )
 
         var rects: [CGRect] = []

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+Draw.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+Draw.swift
@@ -75,16 +75,16 @@ extension TextSelectionManager {
     private func drawSelectedRange(in rect: NSRect, for textSelection: TextSelection, context: CGContext) {
         context.saveGState()
 
-        let fillColor = (textView?.isFirstResponder ?? false)
+        // `unemphasizedSelectedTextBackgroundColor` is documented for a window that is not key OR a view without
+        // key focus, so both conditions gate the accent colour.
+        let isEmphasized = (textView?.isFirstResponder ?? false) && (textView?.window?.isKeyWindow ?? false)
+        let fillColor = isEmphasized
         ? selectionBackgroundColor.safeCGColor
-        : selectionBackgroundColor.grayscale.safeCGColor
+        : NSColor.unemphasizedSelectedTextBackgroundColor.safeCGColor
 
         context.setFillColor(fillColor)
 
-        let fillRects = getFillRects(in: rect, for: textSelection)
-        textSelection.boundingRect = fillRects.boundingRect()
-
-        context.fill(fillRects)
+        context.fill(getFillRects(in: rect, for: textSelection))
         context.restoreGState()
     }
 

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+FillRects.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+FillRects.swift
@@ -17,8 +17,11 @@ extension TextSelectionManager {
     ///   - textSelection: The selection to use.
     /// - Returns: An array of rects that the selection overlaps.
     func getFillRects(in rect: NSRect, for textSelection: TextSelection) -> [CGRect] {
+        // Bound the work by the rect we were asked to fill, never by the viewport: under responsive scrolling
+        // `draw(_:)` is called with rects outside the visible area and the result is cached.
         guard let layoutManager,
-              let range = textSelection.range.intersection(delegate?.visibleTextRange ?? .zero) else {
+              let drawnRange = layoutManager.textRange(covering: rect),
+              let range = textSelection.range.intersection(drawnRange) else {
             return []
         }
 
@@ -43,8 +46,11 @@ extension TextSelectionManager {
             )
         }
 
-        // Pixel align these to avoid aliasing on the edges of each rect that should be a solid box.
-        return fillRects.map { $0.intersection(validTextDrawingRect).pixelAligned }
+        // Pixel align these to avoid aliasing on the edges of each rect that should be a solid box. A fragment
+        // that misses the drawing rect intersects to `CGRect.null`, whose origin is infinite.
+        return fillRects
+            .map { $0.intersection(validTextDrawingRect).pixelAligned }
+            .filter { !$0.isNull && !$0.isEmpty }
     }
 
     /// Find fill rects for a specific line position.

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+Move.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+Move.swift
@@ -31,7 +31,7 @@ extension TextSelectionManager {
         }
         updateSelectionViews()
         delegate?.setNeedsDisplay()
-        NotificationCenter.default.post(Notification(name: Self.selectionChangedNotification, object: self))
+        notifySelectionChanged()
     }
 
     /// Moves a single selection determined by the direction and destination provided.

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+Update.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager+Update.swift
@@ -15,6 +15,10 @@ extension TextSelectionManager {
         // multi-cursor IME path replaces each marked range char-for-char).
         let delta = replacementLength - range.length
         for textSelection in self.textSelections {
+            // A pivot that survives the edit points at an offset that no longer means what it did, and the
+            // modifying motions subtract against it until the range length goes negative.
+            textSelection.pivot = nil
+            textSelection.suggestedXPos = nil
             if textSelection.range.location > range.max {
                 textSelection.range.location = max(0, textSelection.range.location + delta)
                 textSelection.range.length = 0
@@ -45,6 +49,6 @@ extension TextSelectionManager {
 
     public func notifyAfterEdit(force: Bool = false) {
         updateSelectionViews(force: force)
-        NotificationCenter.default.post(Notification(name: Self.selectionChangedNotification, object: self))
+        notifySelectionChanged()
     }
 }

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextSelectionManager/TextSelectionManager.swift
@@ -80,7 +80,8 @@ public class TextSelectionManager: NSObject {
         selection.suggestedXPos = layoutManager?.rectForOffset(range.location)?.minX
         textSelections = [selection]
         updateSelectionViews()
-        NotificationCenter.default.post(Notification(name: Self.selectionChangedNotification, object: self))
+        delegate?.setNeedsDisplay()
+        notifySelectionChanged()
     }
 
     /// Set the selected ranges to new ranges. Overrides any existing selections.
@@ -105,7 +106,7 @@ public class TextSelectionManager: NSObject {
         delegate?.setNeedsDisplay()
 
         if oldRanges != textSelections.map(\.range) {
-            NotificationCenter.default.post(Notification(name: Self.selectionChangedNotification, object: self))
+            notifySelectionChanged()
         }
     }
 
@@ -132,8 +133,18 @@ public class TextSelectionManager: NSObject {
         }
 
         updateSelectionViews()
-        NotificationCenter.default.post(Notification(name: Self.selectionChangedNotification, object: self))
+        notifySelectionChanged()
         delegate?.setNeedsDisplay()
+    }
+
+    /// The single place a selection change is announced, to observers and to assistive clients alike.
+    func notifySelectionChanged() {
+        NotificationCenter.default.post(Notification(name: Self.selectionChangedNotification, object: self))
+        // Only the manager the text view answers to speaks for it. The minimap builds a second manager over the
+        // same text view and mirrors every selection into it, which would announce each move twice.
+        if let textView, textView.selectionManager === self {
+            NSAccessibility.post(element: textView, notification: .selectedTextChanged)
+        }
     }
 
     // MARK: - Selection Views

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+Delete.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+Delete.swift
@@ -49,6 +49,10 @@ extension TextView {
         destination: TextSelectionManager.Destination,
         decomposeCharacters: Bool = false
     ) {
+        // A selectable read-only view still routes key equivalents here. `replaceCharacters` refuses the edit, but
+        // only after this method has already widened the selection and filled the kill ring.
+        guard isEditable else { return }
+
         /// Extend each selection by a distance specified by `destination`, then update both storage and the selection.
         for textSelection in selectionManager.textSelections {
             guard textSelection.range.isEmpty else { continue }

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+Drag.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+Drag.swift
@@ -20,9 +20,10 @@ extension TextView: NSDraggingSource {
                 return
             }
 
+            // A click is visible by definition, and the frame is the whole document.
             let clickPoint = view.convert(event.locationInWindow, from: nil)
             let selectionRects = view.selectionManager.textSelections.filter({ !$0.range.isEmpty }).flatMap {
-                view.selectionManager.getFillRects(in: view.frame, for: $0)
+                view.selectionManager.getFillRects(in: view.visibleRect, for: $0)
             }
             if !selectionRects.contains(where: { $0.contains(clickPoint) }) {
                 state = .failed
@@ -37,6 +38,11 @@ extension TextView: NSDraggingSource {
     func setUpDragGesture() {
         let dragGesture = DragSelectionGesture(target: self, action: #selector(dragGestureHandler(_:)))
         dragGesture.minimumPressDuration = NSEvent.doubleClickInterval / 3
+        // `NSPressGestureRecognizer` turns this on for itself, which withheld every primary mouse-down inside a
+        // selection for the press duration: measured at 167ms of a completely dead pointer. The view no longer
+        // needs the delay, because a press inside a selection defers its caret to mouse up rather than collapsing
+        // the selection immediately, so there is nothing for the gesture to protect the selection from.
+        dragGesture.delaysPrimaryMouseButtonEvents = false
         dragGesture.isEnabled = isSelectable
         addGestureRecognizer(dragGesture)
     }
@@ -118,6 +124,7 @@ extension TextView: NSDraggingSource {
             self.draggingCursorView = nil
         }
         isDragging = true
+        pendingCaretOffset = nil
         setUpMouseAutoscrollTimer()
     }
 

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+KeyDown.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+KeyDown.swift
@@ -10,7 +10,10 @@ import Carbon.HIToolbox
 
 extension TextView {
     override public func keyDown(with event: NSEvent) {
-        guard isEditable else {
+        // A selectable but non-editable view still moves its insertion point and extends its selection from the
+        // keyboard, the same as `NSTextView` with `isEditable = false` and `isSelectable = true`. Bailing on
+        // `isEditable` alone left the read-only editors with no arrow keys and no Shift+Arrow at all.
+        guard isEditable || isSelectable else {
             super.keyDown(with: event)
             return
         }

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+Layout.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+Layout.swift
@@ -49,16 +49,7 @@ extension TextView {
     }
 
     public var visibleTextRange: NSRange? {
-        let minY = max(visibleRect.minY, 0)
-        let maxY = min(visibleRect.maxY, layoutManager.estimatedHeight())
-        guard let minYLine = layoutManager.textLineForPosition(minY),
-              let maxYLine = layoutManager.textLineForPosition(maxY) else {
-            return nil
-        }
-        return NSRange(
-            location: minYLine.range.location,
-            length: (maxYLine.range.location - minYLine.range.location) + maxYLine.range.length
-        )
+        layoutManager.textRange(covering: visibleRect)
     }
 
     public func updatedViewport(_ newRect: CGRect) {

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+Menu.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+Menu.swift
@@ -14,6 +14,8 @@ extension TextView {
     override public func menu(for event: NSEvent) -> NSMenu? {
         guard event.type == .rightMouseDown else { return nil }
 
+        moveSelectionForContextClick(event)
+
         if let assignedMenu = super.menu(for: event) {
             return assignedMenu
         }
@@ -26,5 +28,22 @@ extension TextView {
         ]
 
         return menu
+    }
+
+    /// Moves the selection to the right-clicked text before the menu opens, the way `NSTextView` does.
+    ///
+    /// A right click inside the selection leaves it alone, so "Copy" still copies what the user can see is
+    /// selected. Anywhere else it selects the word under the pointer, so a menu item that reads the selection acts
+    /// on what was clicked rather than on whatever was selected beforehand.
+    private func moveSelectionForContextClick(_ event: NSEvent) {
+        guard isSelectable,
+              let offset = layoutManager.textOffsetAtPoint(self.convert(event.locationInWindow, from: nil)) else {
+            return
+        }
+        guard !selectionManager.textSelections.contains(where: { $0.range.contains(offset) }) else { return }
+
+        let wordRange = findWordBoundary(at: offset)
+        selectionManager.setSelectedRange(wordRange)
+        selectionManager.textSelections.first?.pivot = wordRange.location
     }
 }

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+Mouse.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+Mouse.swift
@@ -23,6 +23,8 @@ extension TextView {
             return
         }
 
+        mouseDragAnchor = self.convert(event.locationInWindow, from: nil)
+
         switch event.clickCount {
         case 1:
             handleSingleClick(event: event, offset: offset)
@@ -33,8 +35,18 @@ extension TextView {
         default:
             break
         }
+    }
 
-        setUpMouseAutoscrollTimer()
+    /// The range a gesture at this offset anchors on, for the current selection granularity.
+    func selectionRange(at offset: Int, for mode: CursorSelectionMode) -> NSRange {
+        switch mode {
+        case .character:
+            return NSRange(location: offset, length: 0)
+        case .word:
+            return findWordBoundary(at: offset)
+        case .line:
+            return findLineBoundary(at: offset)
+        }
     }
 
     /// Single click, if control-shift we add a cursor
@@ -42,6 +54,7 @@ extension TextView {
     /// else we set the cursor
     fileprivate func handleSingleClick(event: NSEvent, offset: Int) {
         cursorSelectionMode = .character
+        pendingCaretOffset = nil
 
         let eventFlags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         if eventFlags == [.control, .shift] {
@@ -51,13 +64,20 @@ extension TextView {
             }
             unmarkText()
             selectionManager.addSelectedRange(NSRange(location: offset, length: 0))
+            selectionDragAnchor = NSRange(location: offset, length: 0)
         } else if eventFlags.contains(.shift) {
             if isEditable {
                 unmarkText()
             }
             shiftClickExtendSelection(to: offset)
+        } else if selectionManager.textSelections.contains(where: { $0.range.contains(offset) }) {
+            // Pressing inside the selection may be the start of a drag of that text, so leave the selection alone
+            // and place the caret on mouse up if no drag follows.
+            pendingCaretOffset = offset
         } else {
             selectionManager.setSelectedRange(NSRange(location: offset, length: 0))
+            selectionDragAnchor = NSRange(location: offset, length: 0)
+            selectionManager.textSelections.first?.pivot = offset
             if isEditable {
                 unmarkTextIfNeeded()
             }
@@ -72,29 +92,35 @@ extension TextView {
     /// falls inside an existing selection, and a document swap can leave the view with no selection
     /// at all.
     fileprivate func handleDoubleClick(event: NSEvent, offset: Int) {
-        guard !event.modifierFlags.contains(.shift) else {
-            super.mouseDown(with: event)
+        if event.modifierFlags.contains(.shift) {
+            extendSelection(to: offset, granularity: .word)
             return
         }
         if isEditable {
             unmarkText()
         }
-        selectionManager.setSelectedRange(findWordBoundary(at: offset))
         cursorSelectionMode = .word
-        needsDisplay = true
+        pendingCaretOffset = nil
+        let wordRange = findWordBoundary(at: offset)
+        selectionManager.setSelectedRange(wordRange)
+        selectionDragAnchor = wordRange
+        selectionManager.textSelections.first?.pivot = wordRange.location
     }
 
     fileprivate func handleTripleClick(event: NSEvent, offset: Int) {
-        guard !event.modifierFlags.contains(.shift) else {
-            super.mouseDown(with: event)
+        if event.modifierFlags.contains(.shift) {
+            extendSelection(to: offset, granularity: .line)
             return
         }
         if isEditable {
             unmarkText()
         }
-        selectionManager.setSelectedRange(findLineBoundary(at: offset))
         cursorSelectionMode = .line
-        needsDisplay = true
+        pendingCaretOffset = nil
+        let lineRange = findLineBoundary(at: offset)
+        selectionManager.setSelectedRange(lineRange)
+        selectionDragAnchor = lineRange
+        selectionManager.textSelections.first?.pivot = lineRange.location
     }
 
     fileprivate func handleAttachmentClick(event: NSEvent, offset: Int, attachment: AnyTextAttachment) {
@@ -126,7 +152,16 @@ extension TextView {
     }
 
     override public func mouseUp(with event: NSEvent) {
+        if let pendingCaretOffset {
+            selectionManager.setSelectedRange(NSRange(location: pendingCaretOffset, length: 0))
+            selectionManager.textSelections.first?.pivot = pendingCaretOffset
+            if isEditable {
+                unmarkTextIfNeeded()
+            }
+        }
+        pendingCaretOffset = nil
         mouseDragAnchor = nil
+        selectionDragAnchor = nil
         disableMouseAutoscrollTimer()
         super.mouseUp(with: event)
     }
@@ -136,33 +171,34 @@ extension TextView {
             return
         }
 
+        if let pendingCaretOffset {
+            selectionDragAnchor = NSRange(location: pendingCaretOffset, length: 0)
+            selectionManager.setSelectedRange(NSRange(location: pendingCaretOffset, length: 0))
+            selectionManager.textSelections.first?.pivot = pendingCaretOffset
+            self.pendingCaretOffset = nil
+        }
+
         // We receive global events because our view received the drag event, but we need to clamp the potentially
         // out-of-bounds positions to a position our layout manager can deal with.
-        let locationInWindow = convert(event.locationInWindow, from: nil)
-        let locationInView = CGPoint(
-            x: max(0.0, min(locationInWindow.x, frame.width)),
-            y: max(0.0, min(locationInWindow.y, frame.height))
+        let locationInView = convert(event.locationInWindow, from: nil)
+        let clampedLocation = CGPoint(
+            x: max(0.0, min(locationInView.x, frame.width)),
+            y: max(0.0, min(locationInView.y, frame.height))
         )
 
-        if mouseDragAnchor == nil {
-            mouseDragAnchor = locationInView
-            super.mouseDragged(with: event)
+        guard let mouseDragAnchor,
+              let anchorRange = selectionDragAnchor,
+              let endPosition = layoutManager.textOffsetAtPoint(clampedLocation) else {
+            return
+        }
+
+        setUpMouseAutoscrollTimer()
+
+        let modifierFlags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        if modifierFlags.contains(.option) {
+            dragColumnSelection(mouseDragAnchor: mouseDragAnchor, locationInView: clampedLocation)
         } else {
-            guard let mouseDragAnchor,
-                  let startPosition = layoutManager.textOffsetAtPoint(mouseDragAnchor),
-                  let endPosition = layoutManager.textOffsetAtPoint(locationInView) else {
-                return
-            }
-
-            let modifierFlags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            if modifierFlags.contains(.option) {
-                dragColumnSelection(mouseDragAnchor: mouseDragAnchor, locationInView: locationInView)
-            } else {
-                dragSelection(startPosition: startPosition, endPosition: endPosition, mouseDragAnchor: mouseDragAnchor)
-            }
-
-            setNeedsDisplay()
-            self.autoscroll(with: event)
+            dragSelection(from: anchorRange, to: endPosition)
         }
     }
 
@@ -175,22 +211,33 @@ extension TextView {
     /// - Parameter offset: The offset clicked on.
     fileprivate func shiftClickExtendSelection(to offset: Int) {
         // Use the last added selection, this is behavior copied from Xcode.
-        guard var selectedRange = selectionManager.textSelections.last?.range else { return }
-        if selectedRange.contains(offset) {
-            if offset - selectedRange.location <= selectedRange.max - offset {
-                selectedRange.length -= offset - selectedRange.location
-                selectedRange.location = offset
-            } else {
-                selectedRange.length -= selectedRange.max - offset
-            }
-        } else {
-            selectedRange.formUnion(NSRange(
-                start: min(offset, selectedRange.location),
-                end: max(offset, selectedRange.max)
-            ))
+        guard let selection = selectionManager.textSelections.last else { return }
+        // Move the free end and keep the anchor fixed, which is what `NSTextView` does and what makes a shift-click
+        // that crosses the anchor reverse the selection instead of trimming the near edge. Fall back to the far end
+        // for a selection whose anchor was never recorded.
+        let anchor = selection.pivot ?? (offset > selection.range.location ? selection.range.location
+                                                                           : selection.range.max)
+        let extended = NSRange(start: min(anchor, offset), end: max(anchor, offset))
+        selectionManager.setSelectedRange(extended)
+        selectionManager.textSelections.first?.pivot = anchor
+        selectionDragAnchor = NSRange(location: anchor, length: 0)
+    }
+
+    /// Extends the current selection to the offset, rounding both ends out to the given granularity.
+    ///
+    /// This is Shift+double-click and Shift+triple-click, which `NSTextView` answers by extending to whole words
+    /// and whole paragraphs. Both used to fall through to `super.mouseDown`, so neither did anything.
+    fileprivate func extendSelection(to offset: Int, granularity: CursorSelectionMode) {
+        guard let selection = selectionManager.textSelections.last else { return }
+        if isEditable {
+            unmarkText()
         }
-        selectionManager.setSelectedRange(selectedRange)
-        setNeedsDisplay()
+        cursorSelectionMode = granularity
+        let anchorOffset = selection.pivot ?? (offset > selection.range.location ? selection.range.location
+                                                                                : selection.range.max)
+        let anchorRange = selectionRange(at: anchorOffset, for: granularity)
+        selectionDragAnchor = anchorRange
+        dragSelection(from: anchorRange, to: offset)
     }
 
     // MARK: - Mouse Autoscroll
@@ -198,14 +245,20 @@ extension TextView {
     /// Sets up a timer that fires at a predetermined period to autoscroll the text view.
     /// Ensure the timer is disabled using ``disableMouseAutoscrollTimer``.
     func setUpMouseAutoscrollTimer() {
-        mouseDragTimer?.invalidate()
+        guard mouseDragTimer == nil else { return }
+        // The timer is the single autoscroll driver. `mouseDragged` deliberately does not scroll: the pointer
+        // delivers drag events at whatever rate the input device runs at, so scrolling from there made the speed
+        // track the device rather than the clock, and the timer used to scroll a second time for the same event.
+        //
+        // Scheduled in `.common` so it keeps firing inside the event tracking loop a drag runs in.
         // https://cocoadev.github.io/AutoScrolling/ (fired at ~45Hz)
-        mouseDragTimer = Timer.scheduledTimer(withTimeInterval: 0.022, repeats: true) { [weak self] _ in
-            if let event = self?.window?.currentEvent, event.type == .leftMouseDragged {
-                self?.mouseDragged(with: event)
-                self?.autoscroll(with: event)
-            }
+        let timer = Timer(timeInterval: 0.022, repeats: true) { [weak self] _ in
+            guard let self, let event = self.window?.currentEvent, event.type == .leftMouseDragged else { return }
+            self.mouseDragged(with: event)
+            self.autoscroll(with: event)
         }
+        RunLoop.current.add(timer, forMode: .common)
+        mouseDragTimer = timer
     }
 
     /// Disables the mouse drag timer started by ``setUpMouseAutoscrollTimer``
@@ -216,42 +269,24 @@ extension TextView {
 
     // MARK: - Drag Selection
 
-    private func dragSelection(startPosition: Int, endPosition: Int, mouseDragAnchor: CGPoint) {
-        switch cursorSelectionMode {
-        case .character:
-            selectionManager.setSelectedRange(
-                NSRange(
-                    location: min(startPosition, endPosition),
-                    length: max(startPosition, endPosition) - min(startPosition, endPosition)
-                )
-            )
-
-        case .word:
-            let startWordRange = findWordBoundary(at: startPosition)
-            let endWordRange = findWordBoundary(at: endPosition)
-
-            selectionManager.setSelectedRange(
-                NSRange(
-                    location: min(startWordRange.location, endWordRange.location),
-                    length: max(startWordRange.location + startWordRange.length,
-                                endWordRange.location + endWordRange.length) -
-                    min(startWordRange.location, endWordRange.location)
-                )
-            )
-
-        case .line:
-            let startLineRange = findLineBoundary(at: startPosition)
-            let endLineRange = findLineBoundary(at: endPosition)
-
-            selectionManager.setSelectedRange(
-                NSRange(
-                    location: min(startLineRange.location, endLineRange.location),
-                    length: max(startLineRange.location + startLineRange.length,
-                                endLineRange.location + endLineRange.length) -
-                    min(startLineRange.location, endLineRange.location)
-                )
-            )
-        }
+    /// Extends a drag selection from its anchor range to the offset under the pointer.
+    ///
+    /// The anchor range and the range under the pointer are unioned, which rounds both ends of the selection
+    /// outward to the current granularity. That single rule is what `NSTextView` does, and it is why dragging back
+    /// past the anchor keeps the anchor's whole word or line selected instead of splitting it.
+    ///
+    /// The anchor also becomes the selection's pivot, so a following Shift+Arrow moves the free end rather than
+    /// guessing which end is live from the arrow's direction.
+    private func dragSelection(from anchorRange: NSRange, to endPosition: Int) {
+        let headRange = selectionRange(at: endPosition, for: cursorSelectionMode)
+        let selectedRange = NSRange(
+            start: min(anchorRange.location, headRange.location),
+            end: max(anchorRange.max, headRange.max)
+        )
+        selectionManager.setSelectedRange(selectedRange)
+        selectionManager.textSelections.first?.pivot = endPosition >= anchorRange.max
+            ? anchorRange.location
+            : anchorRange.max
     }
 
     private func dragColumnSelection(mouseDragAnchor: CGPoint, locationInView: CGPoint) {

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+ReplaceCharacters.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+ReplaceCharacters.swift
@@ -53,9 +53,11 @@ extension TextView {
         }
         NotificationCenter.default.post(name: Self.textDidChangeNotification, object: self)
 
-        // `scrollSelectionToVisible` is a little expensive to call every time. Instead we just check if the first
-        // selection is entirely visible. `.contains` checks that all points in the rect are inside. 
-        if let selection = selectionManager.textSelections.first, !visibleRect.contains(selection.boundingRect) {
+        // `scrollSelectionToVisible` is a little expensive to call every time. Instead we just check if the caret
+        // the edit left behind is visible. `.contains` checks that all points in the rect are inside.
+        if let selection = selectionManager.textSelections.first,
+           let caretRect = layoutManager.rectForOffset(selection.range.max),
+           !visibleRect.contains(caretRect) {
             scrollSelectionToVisible()
         }
     }

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+ScrollToVisible.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+ScrollToVisible.swift
@@ -12,28 +12,30 @@ extension TextView {
     fileprivate typealias Direction = TextSelectionManager.Direction
     fileprivate typealias TextSelection = TextSelectionManager.TextSelection
 
-    /// Scrolls the upmost selection to the visible rect if `scrollView` is not `nil`.
+    /// Scrolls the moving end of the upmost selection into view, if `scrollView` is not `nil`.
+    ///
+    /// Follows the end that moved, never the selection's whole bounding rect. `scrollToVisible` only scrolls far
+    /// enough to bring a rect into view, so once a selection grows past the height of the viewport its bounding
+    /// rect already spans the visible area and the scroll becomes a no-op: extending further stops following.
+    /// `NSTextView` scrolls to the moving end for the same reason.
     public func scrollSelectionToVisible() {
-        guard let scrollView else {
+        guard let scrollView, let selection = getSelection() else {
             return
         }
 
-        // There's a bit of a chicken-and-the-egg issue going on here. We need to know the rect to scroll to, but we
-        // can't know the exact rect to make visible without laying out the text. Then, once text is laid out the
-        // selection rect may be different again. To solve this, we loop until the frame doesn't change after a layout
-        // pass and scroll to that rect.
-
+        // Laying out changes line heights, which moves the offset we are scrolling to, so converge instead of
+        // scrolling to the first estimate. `rectForOffset` answers a not-yet-laid-out line from the line storage's
+        // estimated heights, which can be off by whole screens in a wrapped document.
+        let offset = offsetNotPivot(selection)
         var lastFrame: CGRect = .zero
-        while let boundingRect = getSelection()?.boundingRect, lastFrame != boundingRect {
-            lastFrame = boundingRect
+        let deadline = Date().addingTimeInterval(0.5)
+
+        while let rect = layoutManager.rectForOffset(offset), lastFrame != rect, Date() < deadline {
+            lastFrame = rect
             layoutManager.layoutLines()
             selectionManager.updateSelectionViews()
-            selectionManager.drawSelections(in: visibleRect)
-
-            if lastFrame != .zero {
-                scrollView.contentView.scrollToVisible(lastFrame)
-                scrollView.reflectScrolledClipView(scrollView.contentView)
-            }
+            scrollView.contentView.scrollToVisible(rect)
+            scrollView.reflectScrolledClipView(scrollView.contentView)
         }
     }
 
@@ -82,7 +84,6 @@ extension TextView {
             lastFrame = newRect
             layoutManager.layoutLines()
             selectionManager.updateSelectionViews()
-            selectionManager.drawSelections(in: visibleRect)
         }
 
         // Scroll to make the range appear at the desired position

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+Select.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+Select.swift
@@ -11,8 +11,8 @@ import TextStory
 extension TextView {
     override public func selectAll(_ sender: Any?) {
         selectionManager.setSelectedRange(documentRange)
+        selectionManager.textSelections.first?.pivot = documentRange.location
         unmarkTextIfNeeded()
-        needsDisplay = true
     }
 
     override public func selectLine(_ sender: Any?) {
@@ -24,7 +24,6 @@ extension TextView {
         }
         selectionManager.setSelectedRanges(newSelections)
         unmarkTextIfNeeded()
-        needsDisplay = true
     }
 
     override public func selectWord(_ sender: Any?) {
@@ -33,7 +32,6 @@ extension TextView {
         }
         selectionManager.setSelectedRanges(newSelections)
         unmarkTextIfNeeded()
-        needsDisplay = true
     }
 
     /// Given a position, find the range of the word that exists at that position.
@@ -56,6 +54,11 @@ extension TextView {
             characterSet = .newlines
         } else if CharacterSet.punctuationCharacters.isSuperset(of: charSet) {
             characterSet = .punctuationCharacters
+        } else if CharacterSet.symbols.isSuperset(of: charSet) {
+            // Operators are Unicode symbols, not punctuation: `= < > + | ~ ^ $` are all in Sm or Sk. Without this
+            // branch every one of them fell through to the zero-length return, so double-clicking an operator in a
+            // SQL statement selected nothing.
+            characterSet = .symbols
         } else {
             return NSRange(location: position, length: 0)
         }

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+TextSelectionManagerDelegate.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+TextSelectionManagerDelegate.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension TextView: TextSelectionManagerDelegate {
     public func setNeedsDisplay() {
-        self.setNeedsDisplay(frame)
+        self.setNeedsDisplay(bounds)
     }
 
     public func estimatedLineHeight() -> CGFloat {

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView.swift
@@ -264,6 +264,20 @@ open class TextView: NSView, NSTextContent {
     var mouseDragTimer: Timer?
     var cursorSelectionMode: CursorSelectionMode = .character
 
+    /// The range a drag selection grows from, in document offsets, at the granularity the gesture started with.
+    ///
+    /// Captured on mouse *down* rather than on the first drag event: the pointer has already travelled by the time
+    /// the first drag arrives, so anchoring there starts the selection several characters from where the user
+    /// pressed. Holding a whole word or line here is also what keeps the anchor word intact when the pointer moves
+    /// back past it, matching `NSTextView`.
+    var selectionDragAnchor: NSRange?
+
+    /// A click inside an existing selection whose caret placement is waiting for mouse up.
+    ///
+    /// `NSTextView` does not collapse a selection the moment you press inside it, because that press may be the
+    /// start of a drag of the selected text. The caret lands on mouse up instead, and only if no drag happened.
+    var pendingCaretOffset: Int?
+
     /// When we receive a drag operation we add a temporary cursor view not managed by the selection manager.
     /// This is the reference to that view, it is cleaned up when a drag ends.
     var draggingCursorView: NSView?

--- a/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/SelectionBehaviourTests.swift
+++ b/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/SelectionBehaviourTests.swift
@@ -1,0 +1,226 @@
+import AppKit
+@testable import CodeEditTextView
+import Testing
+
+private final class InvalidationSpy: TextSelectionManagerDelegate {
+    var visibleTextRange: NSRange?
+    private(set) var setNeedsDisplayCount = 0
+
+    func setNeedsDisplay() { setNeedsDisplayCount += 1 }
+    func estimatedLineHeight() -> CGFloat { 14.0 }
+}
+
+@Suite
+@MainActor
+struct SelectionBehaviourTests {
+    private func makeLaidOutTextView(_ text: String) -> TextView {
+        let textView = TextView(string: text)
+        textView.font = .monospacedSystemFont(ofSize: 14, weight: .regular)
+        textView.wrapLines = false
+        textView.frame = NSRect(x: 0, y: 0, width: 900, height: 2_000)
+        textView.updateFrameIfNeeded()
+        textView.frame.size.width = 900
+        textView.layoutManager.invalidateLayoutForRange(textView.documentRange)
+        textView.layoutManager.layoutLines(in: NSRect(x: 0, y: 0, width: 900, height: 2_000))
+        return textView
+    }
+
+    // MARK: - Anchor
+
+    /// Measured from a live `NSTextView`: the anchor is sticky and survives the selection crossing it.
+    /// Caret at N, Shift+Right x3 gives (N, 3); Shift+Left x6 gives (N-3, 3); Shift+Right x6 returns to (N, 3).
+    @Test("An anchored selection shrinks back through its anchor instead of growing both ways")
+    func anchorSurvivesCrossingItself() throws {
+        let textView = makeLaidOutTextView("alpha beta gamma delta epsilon zeta eta theta")
+        let manager: TextSelectionManager = textView.selectionManager
+        let anchor = 20
+
+        manager.setSelectedRange(NSRange(location: anchor, length: 0))
+        let selection = try #require(manager.textSelections.first)
+        selection.pivot = anchor
+
+        for _ in 0..<3 {
+            manager.moveSelections(direction: .forward, destination: .character, modifySelection: true)
+        }
+        #expect(textView.selectedRange() == NSRange(location: anchor, length: 3))
+
+        for _ in 0..<6 {
+            manager.moveSelections(direction: .backward, destination: .character, modifySelection: true)
+        }
+        #expect(textView.selectedRange() == NSRange(location: anchor - 3, length: 3))
+
+        for _ in 0..<6 {
+            manager.moveSelections(direction: .forward, destination: .character, modifySelection: true)
+        }
+        #expect(textView.selectedRange() == NSRange(location: anchor, length: 3))
+    }
+
+    @Test("A selection never takes a negative length after the text under it is replaced")
+    func editedSelectionKeepsAUsableLength() throws {
+        let textView = makeLaidOutTextView("alpha beta gamma delta epsilon zeta eta theta")
+        let manager: TextSelectionManager = textView.selectionManager
+
+        manager.setSelectedRange(NSRange(location: 20, length: 0))
+        let selection = try #require(manager.textSelections.first)
+        selection.pivot = 20
+        manager.moveSelections(direction: .backward, destination: .character, modifySelection: true)
+
+        textView.replaceCharacters(in: NSRange(location: 0, length: 6), with: "")
+        manager.moveSelections(direction: .forward, destination: .character, modifySelection: true)
+
+        for selection in manager.textSelections {
+            #expect(selection.range.length >= 0)
+            #expect(selection.range.location >= 0)
+        }
+    }
+
+    @Test("Replacing text clears the anchor and the preferred column it was built from")
+    func editClearsStaleSelectionState() throws {
+        let textView = makeLaidOutTextView("alpha beta gamma\ndelta epsilon zeta")
+        let manager: TextSelectionManager = textView.selectionManager
+
+        manager.setSelectedRange(NSRange(location: 12, length: 0))
+        let selection = try #require(manager.textSelections.first)
+        selection.pivot = 12
+        selection.suggestedXPos = 400
+
+        textView.replaceCharacters(in: NSRange(location: 0, length: 5), with: "")
+
+        for selection in manager.textSelections {
+            #expect(selection.pivot == nil)
+            #expect(selection.suggestedXPos == nil)
+        }
+    }
+
+    // MARK: - Word boundaries
+
+    @Test(
+        "Double-clicking a SQL operator selects the operator",
+        arguments: ["=", "<", ">", "+", "|", "~", "^", "$"]
+    )
+    func operatorsAreSelectable(_ operatorText: String) {
+        let text = "WHERE id \(operatorText) 1"
+        let textView = makeLaidOutTextView(text)
+        let offset = (text as NSString).range(of: operatorText).location
+
+        let range = textView.findWordBoundary(at: offset)
+
+        #expect(range.length > 0)
+        #expect(NSRange(location: offset, length: 1).intersection(range) != nil)
+    }
+
+    @Test("A run of operator characters selects as one unit")
+    func operatorRunsSelectTogether() {
+        let text = "WHERE a <= b"
+        let textView = makeLaidOutTextView(text)
+        let offset = (text as NSString).range(of: "<=").location
+
+        let range = textView.findWordBoundary(at: offset)
+
+        #expect(range == NSRange(location: offset, length: 2))
+    }
+
+    @Test("Identifiers still select as whole words")
+    func identifiersStillSelectAsWords() {
+        let text = "SELECT some_column FROM t"
+        let textView = makeLaidOutTextView(text)
+        let offset = (text as NSString).range(of: "some_column").location
+
+        #expect(textView.findWordBoundary(at: offset + 2) == NSRange(location: offset, length: 11))
+    }
+
+    // MARK: - Read-only editors
+
+    @Test("A read-only editor moves and extends its selection from the keyboard")
+    func readOnlyEditorSelectsFromTheKeyboard() throws {
+        let textView = makeLaidOutTextView("alpha beta gamma delta")
+        textView.isEditable = false
+        textView.isSelectable = true
+        let manager: TextSelectionManager = textView.selectionManager
+
+        manager.setSelectedRange(NSRange(location: 6, length: 0))
+        let selection = try #require(manager.textSelections.first)
+        selection.pivot = 6
+        manager.moveSelections(direction: .forward, destination: .word, modifySelection: true)
+
+        #expect(textView.selectedRange().length > 0)
+    }
+
+    @Test("Delete does not touch the selection or the kill ring in a read-only editor")
+    func readOnlyEditorIgnoresDelete() {
+        let text = "alpha beta gamma delta"
+        let textView = makeLaidOutTextView(text)
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.selectionManager.setSelectedRange(NSRange(location: 6, length: 0))
+
+        textView.deleteBackward(nil)
+        textView.deleteWordForward(nil)
+
+        #expect(textView.string == text)
+        #expect(textView.selectedRange() == NSRange(location: 6, length: 0))
+    }
+
+    // MARK: - Invalidation
+
+    @Test("Every range setter invalidates the view for a real change")
+    func everySetterInvalidates() {
+        let textView = makeLaidOutTextView("alpha beta gamma delta")
+        let spy = InvalidationSpy()
+        let manager = TextSelectionManager(
+            layoutManager: textView.layoutManager,
+            textStorage: textView.textStorage,
+            textView: textView,
+            delegate: spy
+        )
+
+        manager.setSelectedRange(NSRange(location: 0, length: 5))
+        #expect(spy.setNeedsDisplayCount >= 1)
+
+        let afterFirst = spy.setNeedsDisplayCount
+        manager.setSelectedRange(NSRange(location: 6, length: 4))
+        #expect(spy.setNeedsDisplayCount > afterFirst, "A ranged selection change must repaint")
+
+        let afterSecond = spy.setNeedsDisplayCount
+        manager.setSelectedRanges([NSRange(location: 0, length: 3)])
+        #expect(spy.setNeedsDisplayCount > afterSecond)
+
+        let afterThird = spy.setNeedsDisplayCount
+        manager.addSelectedRange(NSRange(location: 10, length: 2))
+        #expect(spy.setNeedsDisplayCount > afterThird)
+    }
+
+    @Test("Laying out a band that was never laid out invalidates the view that draws over it")
+    func layoutInvalidatesTheLayoutView() {
+        let text = (0..<400).map { "SELECT column_\($0) FROM some_table;" }.joined(separator: "\n")
+        let textView = RecordingTextView(string: text)
+        textView.font = .monospacedSystemFont(ofSize: 14, weight: .regular)
+        textView.wrapLines = false
+        textView.frame = NSRect(x: 0, y: 0, width: 900, height: 6_000)
+        textView.updateFrameIfNeeded()
+        textView.layoutManager.invalidateLayoutForRange(textView.documentRange)
+
+        // Lay out only the top of the document, then ask for a band far below it.
+        textView.layoutManager.layoutLines(in: NSRect(x: 0, y: 0, width: 900, height: 300))
+        textView.invalidatedRects.removeAll()
+
+        let band = NSRect(x: 0, y: 2_000, width: 900, height: 300)
+        textView.layoutManager.layoutLines(in: band)
+
+        // The view draws the selection and the caret line highlight into its own backing store, and only a layout
+        // pass knows the text under them just moved.
+        #expect(textView.invalidatedRects.contains { $0.intersects(band) })
+    }
+}
+
+/// A text view that records what it was asked to redraw.
+///
+/// `needsDisplay` only latches for a view inside a window, so a headless test has to observe the call itself.
+private final class RecordingTextView: TextView {
+    var invalidatedRects: [NSRect] = []
+
+    override func setNeedsDisplay(_ invalidRect: NSRect) {
+        invalidatedRects.append(invalidRect)
+        super.setNeedsDisplay(invalidRect)
+    }
+}

--- a/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/SelectionGeometryTests.swift
+++ b/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/SelectionGeometryTests.swift
@@ -1,0 +1,206 @@
+import AppKit
+@testable import CodeEditTextView
+import Testing
+
+/// A delegate that reports a viewport unrelated to the rect being drawn.
+///
+/// Selection geometry must not consult it. AppKit calls `draw(_:)` with rects outside the visible area under
+/// responsive scrolling and caches the result, so a viewport-derived answer paints a band blank and leaves it that
+/// way when the user scrolls back to it.
+private final class FixedViewportDelegate: TextSelectionManagerDelegate {
+    var visibleTextRange: NSRange?
+    private(set) var setNeedsDisplayCount = 0
+
+    func setNeedsDisplay() { setNeedsDisplayCount += 1 }
+    func estimatedLineHeight() -> CGFloat { 14.0 }
+}
+
+@Suite
+@MainActor
+struct SelectionGeometryTests {
+    private static let lineCount = 200
+
+    private func makeLaidOutTextView() -> TextView {
+        let text = (0..<Self.lineCount)
+            .map { "SELECT column_\($0) FROM some_table WHERE id = \($0);" }
+            .joined(separator: "\n")
+        let textView = TextView(string: text)
+        textView.font = .monospacedSystemFont(ofSize: 14, weight: .regular)
+        textView.wrapLines = false
+        textView.frame = NSRect(x: 0, y: 0, width: 900, height: 6_000)
+        textView.updateFrameIfNeeded()
+        textView.frame.size.width = 900
+        textView.layoutManager.invalidateLayoutForRange(textView.documentRange)
+        textView.layoutManager.layoutLines(in: NSRect(x: 0, y: 0, width: 900, height: 6_000))
+        return textView
+    }
+
+    private func selectAll(in textView: TextView, delegate: TextSelectionManagerDelegate) -> (
+        TextSelectionManager, TextSelectionManager.TextSelection
+    ) {
+        let manager = TextSelectionManager(
+            layoutManager: textView.layoutManager,
+            textStorage: textView.textStorage,
+            textView: textView,
+            delegate: delegate
+        )
+        manager.setSelectedRange(textView.documentRange)
+        // swiftlint:disable:next force_unwrapping
+        return (manager, manager.textSelections.first!)
+    }
+
+    // MARK: - Fill rects follow the drawn rect, not the viewport
+
+    @Test("Fill rects cover a band the viewport is nowhere near")
+    func fillRectsCoverAnOffViewportBand() throws {
+        let textView = makeLaidOutTextView()
+        let delegate = FixedViewportDelegate()
+        let (manager, selection) = selectAll(in: textView, delegate: delegate)
+
+        // The viewport is at the very top of the document; AppKit asks us to draw a band far below it.
+        delegate.visibleTextRange = try #require(textView.layoutManager.textRange(
+            covering: NSRect(x: 0, y: 0, width: 900, height: 300)
+        ))
+        let band = NSRect(x: 0, y: 2_000, width: 900, height: 300)
+
+        let rects = manager.getFillRects(in: band, for: selection)
+
+        #expect(!rects.isEmpty, "The selection covers this band, so it must produce fill rects for it")
+        for rect in rects {
+            #expect(band.intersects(rect), "Every fill rect must land inside the band we were asked to draw")
+        }
+    }
+
+    @Test("Fill rects for a band do not change when the viewport moves")
+    func fillRectsAreIndependentOfTheViewport() throws {
+        let textView = makeLaidOutTextView()
+        let delegate = FixedViewportDelegate()
+        let (manager, selection) = selectAll(in: textView, delegate: delegate)
+        let band = NSRect(x: 0, y: 1_200, width: 900, height: 400)
+
+        delegate.visibleTextRange = NSRange(location: 0, length: 10)
+        let withViewportAtTop = manager.getFillRects(in: band, for: selection)
+
+        delegate.visibleTextRange = textView.layoutManager.textRange(covering: band)
+        let withViewportOnBand = manager.getFillRects(in: band, for: selection)
+
+        delegate.visibleTextRange = nil
+        let withNoViewportAtAll = manager.getFillRects(in: band, for: selection)
+
+        #expect(withViewportAtTop == withViewportOnBand)
+        #expect(withViewportAtTop == withNoViewportAtAll)
+        #expect(!withViewportAtTop.isEmpty)
+    }
+
+    @Test("Fill rects stay bounded by the rect being drawn")
+    func fillRectsStayInsideTheDrawnRect() throws {
+        let textView = makeLaidOutTextView()
+        let delegate = FixedViewportDelegate()
+        let (manager, selection) = selectAll(in: textView, delegate: delegate)
+        delegate.visibleTextRange = textView.documentRange
+
+        let band = NSRect(x: 0, y: 900, width: 900, height: 200)
+        let rects = manager.getFillRects(in: band, for: selection)
+        let documentRects = manager.getFillRects(
+            in: NSRect(x: 0, y: 0, width: 900, height: textView.layoutManager.estimatedHeight()),
+            for: selection
+        )
+
+        #expect(!rects.isEmpty)
+        #expect(rects.count < documentRects.count, "A 200pt band must cost less than the whole document")
+        for rect in rects {
+            #expect(rect.minY >= band.minY - 1 && rect.maxY <= band.maxY + 1)
+        }
+    }
+
+    @Test("Fill rects never contain a null or empty rect")
+    func fillRectsAreAllRealRects() throws {
+        let textView = makeLaidOutTextView()
+        let delegate = FixedViewportDelegate()
+        let (manager, selection) = selectAll(in: textView, delegate: delegate)
+        delegate.visibleTextRange = textView.documentRange
+
+        let rects = manager.getFillRects(
+            in: NSRect(x: 0, y: 0, width: 900, height: textView.layoutManager.estimatedHeight()),
+            for: selection
+        )
+
+        #expect(!rects.isEmpty)
+        for rect in rects {
+            #expect(!rect.isNull)
+            #expect(!rect.isInfinite)
+            #expect(rect.height > 0)
+        }
+        // A null rect poisons any union taken over the result.
+        #expect(!rects.boundingRect().isInfinite)
+    }
+
+    // MARK: - textRange(covering:)
+
+    @Test("textRange(covering:) spans exactly the lines the rect touches")
+    func textRangeCoveringMatchesTheLinesInTheRect() throws {
+        let textView = makeLaidOutTextView()
+        let layoutManager: TextLayoutManager = textView.layoutManager
+        let firstLine = try #require(layoutManager.textLineForIndex(10))
+        let lastLine = try #require(layoutManager.textLineForIndex(14))
+
+        let rect = NSRect(
+            x: 0,
+            y: firstLine.yPos + 1,
+            width: 900,
+            height: (lastLine.yPos + lastLine.height) - firstLine.yPos - 2
+        )
+        let range = try #require(layoutManager.textRange(covering: rect))
+
+        #expect(range.location == firstLine.range.location)
+        #expect(range.max == lastLine.range.max)
+    }
+
+    @Test("textRange(covering:) matches the text view's visible range")
+    func textRangeCoveringMatchesVisibleTextRange() throws {
+        let textView = makeLaidOutTextView()
+        let expected = textView.layoutManager.textRange(covering: textView.visibleRect)
+        #expect(textView.visibleTextRange == expected)
+    }
+
+    // MARK: - Multi-line range rects
+
+    @Test("rectsFor(range:) returns a rect for every line the range covers")
+    func rectsForRangeCoversEveryLine() throws {
+        let textView = makeLaidOutTextView()
+        let layoutManager: TextLayoutManager = textView.layoutManager
+
+        let firstLine = try #require(layoutManager.textLineForIndex(0))
+        let thirdLine = try #require(layoutManager.textLineForIndex(2))
+        let threeLines = NSRange(start: firstLine.range.location, end: thirdLine.range.max)
+
+        let rects = layoutManager.rectsFor(range: threeLines)
+
+        #expect(rects.count >= 3)
+        let distinctRows = Set(rects.map { Int($0.minY.rounded()) })
+        #expect(distinctRows.count >= 3)
+    }
+
+    @Test("A rounded path for a multi-line range spans every line")
+    func roundedPathSpansEveryLine() throws {
+        let textView = makeLaidOutTextView()
+        let layoutManager: TextLayoutManager = textView.layoutManager
+
+        let firstLine = try #require(layoutManager.textLineForIndex(0))
+        let thirdLine = try #require(layoutManager.textLineForIndex(2))
+        let threeLines = NSRange(start: firstLine.range.location, end: thirdLine.range.max)
+
+        let path = try #require(layoutManager.roundedPathForRange(threeLines))
+        #expect(path.bounds.maxY >= thirdLine.yPos, "The path must reach the last line of the range")
+    }
+
+    // MARK: - Bounding rect
+
+    @Test("boundingRect() is the union of every rect, not just the lowest one")
+    func boundingRectUnionsEveryRect() {
+        let wide = CGRect(x: 10, y: 0, width: 600, height: 20)
+        let narrow = CGRect(x: 10, y: 20, width: 90, height: 20)
+        #expect([wide, narrow].boundingRect() == CGRect(x: 10, y: 0, width: 600, height: 40))
+        #expect([CGRect]().boundingRect() == .zero)
+    }
+}

--- a/TablePro/Core/Vim/VimTextBufferAdapter.swift
+++ b/TablePro/Core/Vim/VimTextBufferAdapter.swift
@@ -253,11 +253,6 @@ final class VimTextBufferAdapter: VimTextBuffer {
         guard clampedRange != currentRange else { return }
 
         textView.selectionManager.setSelectedRange(clampedRange)
-        // CodeEditTextView's setSelectedRange (singular) doesn't call setNeedsDisplay,
-        // so selection highlights (drawn in draw(_:)) won't render without this.
-        if clampedRange.length > 0 {
-            textView.needsDisplay = true
-        }
         textView.scrollToRange(clampedRange)
     }
 

--- a/TablePro/Views/Editor/SQLEditorCoordinator.swift
+++ b/TablePro/Views/Editor/SQLEditorCoordinator.swift
@@ -247,10 +247,10 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
         vimCursorManager?.updatePosition()
         statementRunController.refreshHighlight(in: controller)
 
-        // When the find panel navigates to a match, it changes the selection
-        // but the editor is not first responder. Scroll to the match manually
-        // because CodeEditTextView's scrollSelectionToVisible() fails for
-        // off-screen matches (TextSelection.boundingRect is .zero until drawn).
+        // A find match is centred rather than nudged just far enough into view, so the next and previous matches
+        // land in the same place instead of hugging whichever edge they came from. The editor's own
+        // `scrollSelectionToVisible` deliberately scrolls the minimum distance, which is right when the user is
+        // extending a selection and wrong when they are stepping through matches.
         guard !isEditorFirstResponder else { return }
         guard let range = newPositions.first?.range, range.location != NSNotFound else { return }
 

--- a/docs/features/sql-editor.mdx
+++ b/docs/features/sql-editor.mdx
@@ -68,6 +68,26 @@ Turn either marker off in **Settings > Editor** with **Highlight current stateme
 
 A statement hidden inside a [collapsed fold](/features/code-folding) unfolds when the cursor lands on it. All three commands are in the Query menu and rebindable in **Settings > Keyboard**.
 
+## Selecting text
+
+Double-click takes a word, triple-click takes a line, and holding the button after either keeps
+extending at that size: a double-click drag moves whole words, a triple-click drag moves whole
+lines. Drag back past where the gesture started and that first word or line stays whole.
+
+`Shift`-click moves the far end of the selection and leaves the end you started from where it is, so
+a `Shift`-click on the other side of the anchor turns the selection around instead of trimming it.
+`Shift`-double-click and `Shift`-triple-click do the same to whole words and whole lines.
+
+Operators select as one unit. Double-click the `=` in `WHERE id = 1` and the operator comes back;
+`<=` and `||` come back whole.
+
+Drag past the top or bottom edge and the editor scrolls to follow at a steady speed. Extending with
+`Shift`+arrow follows the end that is moving, so the moving edge stays on screen no matter how far
+the selection already runs.
+
+The JSON viewer, a table's DDL and an import preview are read-only, and take the same arrow-key
+movement and `Shift`+arrow selection as the editor here.
+
 ## Inline diagnostics
 
 A structural mistake is underlined in red 500ms after you stop typing, and the underline clears as soon as you fix it. Only two things are reported, both of them problems more typing cannot fix:


### PR DESCRIPTION
Selecting a long stretch of text downward past the viewport and then scrolling back up left a band
near the top with no highlight. Executing still ran the whole selection, so the model was right and
only the drawing was wrong.

Tracing that turned up a subsystem with three separate structural problems, so this rebuilds it
rather than patching the symptom.

## Root cause

Selection was modelled as a bare `NSRange` with no anchor and no granularity, its geometry was
produced as a side effect of drawing, and its drawing read the scroll position. So the model could
not say which end was live, the view could not scroll to it, and the paint went stale.

**The reported bug.** `getFillRects` clipped the selection to the current viewport instead of to the
rect `draw(_:)` was handed. The text view opts into responsive scrolling and is layer-backed, and
AppKit documents that `draw(_:)`'s `dirtyRect` "can also represent a nonvisible portion of the view
that AppKit wants to cache". Forcing that exact case with `cacheDisplay(in:to:)`:

| `dirtyRect` | `visibleRect` | selection painted into the band |
|---|---|---|
| y 1000..1300 | y 3000..3600 | nothing |
| y 1000..1300 | y 1000..1600 | y 1000..1300, 44 rects |

Same rect, same selection, same layout; only the scroll position differs. The blank band is then
cached, and nothing on the scroll path repainted the text view, because `layoutLines` marked only
the `LineFragmentView` subviews. The text came back on the way up and the highlight could not.

That line is verbatim upstream CodeEditTextView, not a TablePro modification, and upstream has not
fixed it.

## What else this fixes

Measured in a real key window, the editor never scrolled to follow a *ranged* selection, only a
caret, because it scrolled to the selection's whole bounding rect and `scrollToVisible` stops once
that rect is already on screen:

| | before | after |
|---|---|---|
| Caret, Down x60 | 462 | 462 |
| Shift+Down x60 | 0 | 462 |
| Range near the end of the document | 0 | 8037 |
| Caret at that same offset | 8037 | 8037 |

- `rectsFor(range:)` rebased a document-absolute range against each line, so the offset went negative
  on every line after the first and the fragment lookup matched nothing. A three-line range returned
  one rect. That truncated multi-line find highlights, the statement run band and VoiceOver bounds.
- `setSelectedRange` was the only range setter that never invalidated. Five call sites patched around
  it; `Option+Shift+Down` statement extension and accessibility-set selections did not, and changed
  the selection without repainting.
- Mouse gestures never recorded an anchor, so `Shift`+arrow after a drag guessed the live end from
  the arrow direction and moved the wrong one.
- The drag anchor was taken from the first delivered drag event rather than the press, so a quick
  sweep started the selection several characters from where the pointer went down.
- `NSPressGestureRecognizer` turns on `delaysPrimaryMouseButtonEvents` for itself, which withheld
  every primary mouse-down inside a selection for the press duration. Measured on the live
  recogniser: 167ms of dead pointer. A press inside a selection now defers its caret to mouse up the
  way `NSTextView` does, so the delay is no longer needed.
- Autoscroll ran from two places, `mouseDragged` and the timer, plus once per real drag event, so its
  speed tracked the input device's event rate. It was also scheduled in `.default`, which stops
  firing inside the tracking loop a drag runs in.
- Double-clicking `=`, `<`, `>`, `+`, `|`, `~`, `^` or `$` selected nothing: they are Unicode symbols,
  not punctuation, and fell through to the zero-length return. In a SQL editor.
- `keyDown` bailed on `isEditable`, so the read-only JSON, DDL and preview editors had no arrow keys
  and no `Shift`+arrow at all.
- A right-click never moved the insertion point, so Explain with AI acted on the previous selection.
- The inactive selection was keyed on first responder alone and used a luma collapse of the accent
  colour rather than `unemphasizedSelectedTextBackgroundColor`.
- Nothing posted `selectedTextChanged`, so assistive clients never heard the selection move.
- A pivot surviving an edit could drive an `NSRange` to length -1.

## Shape of the change

- **Geometry** is a pure function of layout and selection. New
  `TextLayoutManager.textRange(covering:)` answers "what text is in this rect"; `getFillRects` clips
  to that, and the two hand-copied `visibleTextRange` computations collapse onto it. Drawing no longer
  publishes `boundingRect`.
- **The model** carries an anchor, written by every path that establishes a selection, and one sink
  announces a change to both the internal notification and accessibility.
- **Input** anchors at mouse down as offsets, unions the anchor range with the range under the pointer
  so both ends round out to the current granularity, and drives autoscroll from one source at one call
  per tick.

## Verification

- `swift test --package-path LocalPackages/CodeEditTextView`: 188 passed, 17 of them new. The new
  guards were checked against the unfixed source and fail there.
- `TableProTests`: 76 cases across the Vim and editor-coordinator suites, all passing.
- App target builds; SwiftLint reports 0 violations; `verify.sh docs` passes.
- Fill-rect cost on the draw path is unchanged: 0.183ms before and 0.184ms after at 1,000 lines,
  0.203ms and 0.209ms at 20,000, flat in document size either way.

UI automation is not included: the behaviours here are pointer gestures, autoscroll timing and
painted pixels, none of which XCUITest drives deterministically. They are covered by unit tests
against the layout and selection managers instead.
