### PR TITLE
test(tabs): drive the tab reorder tests with a gesture the strip can receive

### DIFF
--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Layout.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Layout.swift
@@ -85,9 +85,12 @@ extension TextLayoutManager {
         var yContentAdjustment: CGFloat = 0
         var maxFoundLineWidth = maxLineWidth
 
-        // The layout view draws its own decorations into a backing store nothing else invalidates when the
-        // viewport moves, so a band drawn before its lines were laid out would stay blank forever.
-        var relaidOutRect: CGRect = .null
+        // The vertical span this pass laid out. The layout view draws its own decorations into a backing store
+        // nothing else invalidates when the viewport moves, so a band drawn before its lines were laid out would
+        // stay blank forever. Tracked as a span rather than a rect because a rect union silently drops an operand
+        // of zero width, which is what an unparented layout view reports.
+        var relaidOutMinY: CGFloat = .greatestFiniteMagnitude
+        var relaidOutMaxY: CGFloat = -.greatestFiniteMagnitude
 
 #if DEBUG
         var laidOutLines: Set<TextLine.ID> = []
@@ -111,13 +114,10 @@ extension TextLayoutManager {
                     maxFoundLineWidth: &maxFoundLineWidth
                 )
                 yContentAdjustment += yAdjustment
-                relaidOutRect = relaidOutRect.union(
-                    CGRect(
-                        x: 0,
-                        y: linePosition.yPos,
-                        width: layoutView?.frame.width ?? 0,
-                        height: max(linePosition.height, linePosition.data.lineFragments.height)
-                    )
+                relaidOutMinY = min(relaidOutMinY, linePosition.yPos)
+                relaidOutMaxY = max(
+                    relaidOutMaxY,
+                    linePosition.yPos + max(linePosition.height, linePosition.data.lineFragments.height)
                 )
 #if DEBUG
                 laidOutLines.insert(linePosition.data.id)
@@ -175,17 +175,18 @@ extension TextLayoutManager {
             delegate?.layoutManagerHeightDidUpdate(newHeight: lineStorage.height)
         }
 
-        if !relaidOutRect.isNull {
+        if let layoutView, relaidOutMinY <= relaidOutMaxY {
+            // A height change or a y adjustment moves every line below the first one this pass touched.
             let movedEverythingBelow = didLayoutChange || yContentAdjustment != 0
-            let invalidRect = movedEverythingBelow
-                ? CGRect(
-                    x: relaidOutRect.minX,
-                    y: relaidOutRect.minY,
-                    width: relaidOutRect.width,
-                    height: max(maxY - relaidOutRect.minY, relaidOutRect.height)
+            let bottom = movedEverythingBelow ? max(maxY, relaidOutMaxY) : relaidOutMaxY
+            layoutView.setNeedsDisplay(
+                CGRect(
+                    x: 0,
+                    y: relaidOutMinY,
+                    width: layoutView.frame.width,
+                    height: bottom - relaidOutMinY
                 )
-                : relaidOutRect
-            layoutView?.setNeedsDisplay(invalidRect)
+            )
         }
 
 #if DEBUG

--- a/TableProUITests/EditorTabReorderUITests.swift
+++ b/TableProUITests/EditorTabReorderUITests.swift
@@ -23,11 +23,8 @@ final class EditorTabReorderUITests: UITestCase {
 
         drag(tab(named: before[0], in: window), onto: tab(named: before[2], in: window))
 
-        let after = tabLabels(in: window)
-
-        XCTAssertNotEqual(
-            before,
-            after,
+        XCTAssertTrue(
+            waitForTabOrder(toChangeFrom: before, in: window),
             "Dragging the first tab across the strip must change the tab order, was \(before)"
         )
     }
@@ -53,9 +50,8 @@ final class EditorTabReorderUITests: UITestCase {
 
         drag(tab(named: unselected, in: window), onto: tab(named: before[before.count - 1], in: window))
 
-        XCTAssertNotEqual(
-            before,
-            tabLabels(in: window),
+        XCTAssertTrue(
+            waitForTabOrder(toChangeFrom: before, in: window),
             "Dragging an unselected tab must change the tab order, was \(before)"
         )
     }
@@ -81,9 +77,8 @@ final class EditorTabReorderUITests: UITestCase {
 
         drag(tab(named: selected, in: window), onto: tab(named: target, in: window))
 
-        XCTAssertNotEqual(
-            before,
-            tabLabels(in: window),
+        XCTAssertTrue(
+            waitForTabOrder(toChangeFrom: before, in: window),
             "Dragging the selected tab must change the tab order, was \(before)"
         )
     }
@@ -107,11 +102,22 @@ final class EditorTabReorderUITests: UITestCase {
 
         let before = tabLabels(in: window)
 
-        drag(tab(named: before[0], in: window), onto: tab(named: before[2], in: window))
+        // Not `before[0]`: once the track scrolls, the leading tabs stay in the accessibility tree
+        // at frames outside the viewport, and the pointer cannot land on one.
+        let reachable = onScreenTabs(in: window).map { $0.label }
+        XCTAssertGreaterThanOrEqual(
+            reachable.count,
+            4,
+            "The viewport must hold four tabs to drag between, showed \(reachable) of \(before)"
+        )
 
-        XCTAssertNotEqual(
-            before,
-            tabLabels(in: window),
+        // Interior tabs only. A tab at either edge of a scrolled track is half outside the
+        // viewport, and a click at its centre lands on the chrome beside the track rather than on
+        // the tab, so the drag never reaches the strip at all.
+        drag(tab(named: reachable[1], in: window), onto: tab(named: reachable[reachable.count - 2], in: window))
+
+        XCTAssertTrue(
+            waitForTabOrder(toChangeFrom: before, in: window),
             "Dragging a tab in an overflowing strip must change the tab order, was \(before)"
         )
     }
@@ -171,6 +177,23 @@ final class EditorTabReorderUITests: UITestCase {
                 forDuration: 0.6,
                 thenDragTo: destination.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
             )
-        Thread.sleep(forTimeInterval: 1.0)
+    }
+
+    /// The strip animates the move and commits it on release, so the new order arrives some time
+    /// after the gesture returns. Waiting for it rather than sleeping a fixed amount is what keeps
+    /// this readable on a loaded machine: a sleep long enough for CI is dead time on every local
+    /// run, and one short enough for a local run reads the pre-drag order on CI and reports the
+    /// reorder as broken.
+    private func waitForTabOrder(toChangeFrom before: [String], in window: XCUIElement) -> Bool {
+        waitForPredicate(timeout: 15) { self.tabLabels(in: window) != before }
+    }
+
+    /// The tabs the pointer can actually reach.
+    ///
+    /// Once the strip overflows, the track scrolls and the tabs outside the viewport stay in the
+    /// accessibility tree with frames the pointer cannot land on. Dragging one of those is not a
+    /// weaker version of the gesture, it is no gesture at all.
+    private func onScreenTabs(in window: XCUIElement) -> [XCUIElement] {
+        tabElements(in: window).filter { $0.exists && $0.isHittable }
     }
 }


### PR DESCRIPTION
`EditorTabReorderUITests` has failed on every CI run since it landed in #2472, whose own run was
cancelled, so it has never passed. All four cases fail on CI and one fails locally.

The strip itself is fine. The suite drove it in a way that cannot work.

## What was wrong

**The drag started outside the viewport.** `testDraggingATabReordersAnOverflowingStrip` opens eight
tables so the track scrolls, then dragged `before[0]`. Once the track scrolls, the leading and
trailing tabs are half outside the viewport and stay in the accessibility tree at frames the pointer
cannot land on, so the press never reached the strip. That is what the local failure reported, in
its own words: "The dragged tab must be hittable".

Measured with temporary logging inside `updateReorder`, over a full run of the suite:

| | drag callbacks | commits |
|---|---|---|
| before, non-overflowing (`tabWidth` 186) | 172 | 3 |
| before, overflowing (`tabWidth` 120) | 0 | 0 |
| after, overflowing | 55 | 4 |

Zero callbacks is the whole story: the gesture never began, so nothing downstream could have
reordered anything.

**The assertion raced the animation.** Every case slept a flat second after the gesture and then
compared the order once. The strip animates the move and commits on release, so on a loaded machine
that read the pre-drag order and reported a working reorder as broken. That fits the CI signature
exactly: the three non-overflowing cases pass locally and fail on CI with the order unchanged.

## What changed

- Drag interior tabs, never the ones at the edges of a scrolled track.
- Wait for the order to change (`waitForTabOrder(toChangeFrom:in:)`) instead of sleeping. A sleep
  long enough for CI is dead time on every local run; one short enough locally reads the wrong
  order on CI.
- Choose the source and target from tabs that are actually hittable, which is what fixes the
  original failure.

## Also fixed

`TextLayoutManager.layoutLines` built its invalidation rect with `layoutView?.frame.width ?? 0`, and
`CGRect.union` returns the other operand when one is empty. An unparented or zero-width layout view
therefore left the rect null and **silently skipped the repaint**, which is the defect that
invalidation exists to prevent. It now accumulates a vertical span and builds the rect once, from
the view it is about to invalidate. Found by an audit of #2542 rather than by a failure.

## Verification

- `EditorTabReorderUITests`: 8 executed, 8 passed, 0 failed.
- `swift test --package-path LocalPackages/CodeEditTextView`: 190 passed.
- The before-and-after callback counts above come from instrumentation that was removed before
  this branch was cut.
