### PR TITLE
fix(ios): six collateral defects found while fixing #2543 and #2544

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Snowflake reporting no rows changed for an `UPDATE` or `MERGE`, and a `SELECT`'s own result for a column named `number of rows`.
 - Two saved Snowflake connections to one account sharing a session, so switching database in one window moved the other.
 - Stop on a Snowflake query cancelling every other query on the same connection, including a sidebar refresh or a save.
+- `tablepro://` deep links ignored on iPhone and iPad, from the widget, a Live Activity and the Open Connection shortcut.
+- iOS PostgreSQL and Redshift reading another schema's table of the same name in the columns, indexes and foreign keys it showed.
+- iOS SQL Server reading and writing the login's default schema rather than the one the toolbar showed, Truncate Table and Drop Table included.
+- Computed SQL Server columns offered as editable and written into the `INSERT`, on both Mac and iOS.
+- A CSV export writing a real NULL and the text `NULL` identically.
+- A JSON export emitting a leading-zero string such as `01234` as an unquoted number, which no JSON parser accepts.
+- A SQL `INSERT` export quoting identifiers for ANSI on every engine, which MySQL and MariaDB reject outright.
 - Insert Row on iPhone and iPad writing every column, so a `NOT NULL` column with a default could not be inserted. (#2543)
 - NULL offered on a `NOT NULL` column in Insert Row and the row editor on iPhone and iPad.
 - Insert Row on iPhone and iPad writing a generated column, which every engine refuses.
@@ -99,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - SQL injection through a Snowflake schema or routine name containing a backslash.
+- Safe Mode on iPhone and iPad no longer lets a write run when it follows a comment or a CTE; an unrecognized statement is treated as a write.
 
 ## [0.68.1] - 2026-08-26
 

--- a/Packages/TableProCore/Sources/TableProMSSQLCore/MSSQLSchemaQueries.swift
+++ b/Packages/TableProCore/Sources/TableProMSSQLCore/MSSQLSchemaQueries.swift
@@ -92,7 +92,8 @@ public enum MSSQLSchemaQueries {
                 c.IS_NULLABLE,
                 c.COLUMN_DEFAULT,
                 COLUMNPROPERTY(OBJECT_ID(c.TABLE_SCHEMA + '.' + c.TABLE_NAME), c.COLUMN_NAME, 'IsIdentity') AS IS_IDENTITY,
-                CASE WHEN pk.COLUMN_NAME IS NOT NULL THEN 1 ELSE 0 END AS IS_PK
+                CASE WHEN pk.COLUMN_NAME IS NOT NULL THEN 1 ELSE 0 END AS IS_PK,
+                COLUMNPROPERTY(OBJECT_ID(c.TABLE_SCHEMA + '.' + c.TABLE_NAME), c.COLUMN_NAME, 'IsComputed') AS IS_COMPUTED
             FROM INFORMATION_SCHEMA.COLUMNS c
             LEFT JOIN (
                 SELECT kcu.COLUMN_NAME
@@ -171,6 +172,7 @@ public struct MSSQLColumnRow: Sendable, Equatable {
     public let defaultValue: String?
     public let isIdentity: Bool
     public let isPrimaryKey: Bool
+    public let isComputed: Bool
 
     public init(
         name: String,
@@ -181,7 +183,8 @@ public struct MSSQLColumnRow: Sendable, Equatable {
         isNullable: Bool,
         defaultValue: String?,
         isIdentity: Bool,
-        isPrimaryKey: Bool
+        isPrimaryKey: Bool,
+        isComputed: Bool = false
     ) {
         self.name = name
         self.dataType = dataType
@@ -192,6 +195,7 @@ public struct MSSQLColumnRow: Sendable, Equatable {
         self.defaultValue = defaultValue
         self.isIdentity = isIdentity
         self.isPrimaryKey = isPrimaryKey
+        self.isComputed = isComputed
     }
 
     public var displayType: String {
@@ -270,7 +274,8 @@ public extension MSSQLSchemaQueries {
             isNullable: (row[safe: 5] ?? nil) == "YES",
             defaultValue: row[safe: 6] ?? nil,
             isIdentity: (row[safe: 7] ?? nil) == "1",
-            isPrimaryKey: (row[safe: 8] ?? nil) == "1"
+            isPrimaryKey: (row[safe: 8] ?? nil) == "1",
+            isComputed: (row[safe: 9] ?? nil) == "1"
         )
     }
 

--- a/Packages/TableProCore/Sources/TableProQuery/SQLWriteClassifier.swift
+++ b/Packages/TableProCore/Sources/TableProQuery/SQLWriteClassifier.swift
@@ -1,0 +1,232 @@
+import Foundation
+import TableProModels
+
+/// Decides whether a statement batch writes, so Safe Mode can block or confirm it.
+///
+/// The rule is fail-closed: a statement counts as a read only when its leading keyword is one of a
+/// short, closed set of read verbs. Everything else writes, including a keyword this classifier has
+/// never heard of. A write-keyword allowlist cannot be safe, because anything it has not been
+/// taught, or anything hidden behind a leading comment, runs unguarded.
+public enum SQLWriteClassifier {
+    /// `EXPLAIN` and `PRAGMA` are deliberately absent: `EXPLAIN ANALYZE DELETE …` runs the delete on
+    /// PostgreSQL, and `PRAGMA journal_mode = WAL` writes on SQLite and DuckDB.
+    private static let readKeywords: Set<String> = ["SHOW", "DESCRIBE", "DESC"]
+
+    /// A `SELECT` reads unless it materialises a table, which `SELECT … INTO` does on SQL Server and
+    /// `SELECT … INTO OUTFILE` does on MySQL. Mirrors QueryClassifier.swift:288-291.
+    private static let readUnlessIntoKeywords: Set<String> = ["SELECT", "TABLE", "VALUES"]
+
+    /// Statement verbs only. `REPLACE`, `INTO` and `COPY` are left out because they collide with
+    /// ordinary function and column names, and a CTE that merely calls `replace()` is a read.
+    /// Matches QueryClassifier.swift:304-312.
+    private static let writeKeywordsInsideCTE: [String] = [
+        "INSERT", "UPDATE", "DELETE", "MERGE", "UPSERT", "DROP", "TRUNCATE", "ALTER", "CREATE", "INTO"
+    ]
+
+    public static func isWriteQuery(_ sql: String, databaseType: DatabaseType) -> Bool {
+        if databaseType == .redis { return redisWrites(sql) }
+        let statements = splitStatements(sql)
+        guard !statements.isEmpty else { return false }
+        return statements.contains(where: statementWrites)
+    }
+
+    private static func statementWrites(_ statement: String) -> Bool {
+        let body = strippingLeadingTrivia(statement)
+        // Content this cannot name is content it cannot vouch for.
+        guard let keyword = leadingKeyword(of: body) else { return true }
+        if keyword == "WITH" { return commonTableExpressionWrites(body) }
+        if readUnlessIntoKeywords.contains(keyword) {
+            return containsWord("INTO", in: maskingLiteralsAndComments(body).uppercased())
+        }
+        return !readKeywords.contains(keyword)
+    }
+
+    /// Redis speaks commands, not SQL, so the SQL path would call every `GET` a write. The read set
+    /// is the one QueryClassifier.swift:436-451 already curates for the Mac.
+    private static func redisWrites(_ command: String) -> Bool {
+        let verb = strippingLeadingTrivia(command)
+            .prefix { !$0.isWhitespace }
+            .uppercased()
+        guard !verb.isEmpty else { return false }
+        if verb == "CONFIG" {
+            let rest = strippingLeadingTrivia(command)
+                .dropFirst(verb.count)
+                .trimmingCharacters(in: .whitespaces)
+                .uppercased()
+            return !rest.hasPrefix("GET")
+        }
+        return !redisReadCommands.contains(verb)
+    }
+
+    private static let redisReadCommands: Set<String> = [
+        "GET", "MGET", "STRLEN", "GETRANGE", "SUBSTR", "EXISTS", "TYPE", "TTL", "PTTL",
+        "EXPIRETIME", "PEXPIRETIME", "KEYS", "SCAN", "RANDOMKEY", "DBSIZE", "DUMP",
+        "HGET", "HMGET", "HGETALL", "HKEYS", "HVALS", "HLEN", "HEXISTS", "HRANDFIELD",
+        "HSCAN", "HSTRLEN", "LRANGE", "LLEN", "LINDEX", "LPOS",
+        "SMEMBERS", "SISMEMBER", "SMISMEMBER", "SCARD", "SRANDMEMBER", "SSCAN",
+        "SDIFF", "SINTER", "SUNION", "SINTERCARD",
+        "ZRANGE", "ZRANGEBYSCORE", "ZRANGEBYLEX", "ZREVRANGE", "ZREVRANGEBYSCORE",
+        "ZREVRANGEBYLEX", "ZRANK", "ZREVRANK", "ZSCORE", "ZMSCORE", "ZCARD", "ZCOUNT",
+        "ZLEXCOUNT", "ZSCAN", "ZRANDMEMBER", "ZDIFF", "ZINTER", "ZUNION", "ZINTERCARD",
+        "XRANGE", "XREVRANGE", "XLEN", "XREAD", "XINFO", "XPENDING", "XAUTOCLAIM",
+        "PFCOUNT", "BITCOUNT", "BITPOS", "GETBIT", "BITFIELD_RO",
+        "GEOPOS", "GEODIST", "GEOHASH", "GEOSEARCH", "GEORADIUS_RO", "GEORADIUSBYMEMBER_RO",
+        "SORT_RO", "OBJECT", "COMMAND", "INFO", "TIME", "LASTSAVE", "PING", "ECHO", "LOLWUT",
+        "JSON.GET", "JSON.MGET", "JSON.TYPE", "JSON.OBJKEYS", "JSON.ARRLEN", "JSON.STRLEN",
+        "TS.RANGE", "TS.REVRANGE", "TS.GET", "TS.MGET", "TS.INFO", "FT.SEARCH", "FT.INFO"
+    ]
+
+    /// A CTE's leading keyword says nothing about what the statement finally does, so the body is
+    /// searched for a write verb with its literals and comments blanked out first.
+    private static func commonTableExpressionWrites(_ statement: String) -> Bool {
+        let masked = maskingLiteralsAndComments(statement).uppercased()
+        return writeKeywordsInsideCTE.contains { keyword in
+            containsWord(keyword, in: masked)
+        }
+    }
+
+    private static func containsWord(_ word: String, in haystack: String) -> Bool {
+        let characters = Array(haystack)
+        let needle = Array(word)
+        guard characters.count >= needle.count else { return false }
+        for start in 0...(characters.count - needle.count) {
+            guard Array(characters[start ..< start + needle.count]) == needle else { continue }
+            let before = start > 0 ? characters[start - 1] : " "
+            let afterIndex = start + needle.count
+            let after = afterIndex < characters.count ? characters[afterIndex] : " "
+            if !isIdentifierCharacter(before) && !isIdentifierCharacter(after) { return true }
+        }
+        return false
+    }
+
+    private static func isIdentifierCharacter(_ character: Character) -> Bool {
+        character.isLetter || character.isNumber || character == "_" || character == "$"
+    }
+
+    private static func leadingKeyword(of statement: String) -> String? {
+        var keyword = ""
+        for character in statement {
+            if isIdentifierCharacter(character) {
+                keyword.append(character)
+            } else {
+                break
+            }
+        }
+        return keyword.isEmpty ? nil : keyword.uppercased()
+    }
+
+    private static func strippingLeadingTrivia(_ statement: String) -> String {
+        var rest = Substring(statement)
+        while true {
+            let beforeTrim = rest
+            rest = rest.drop(while: { $0.isWhitespace })
+            if rest.hasPrefix("--") {
+                rest = rest.drop(while: { !$0.isNewline })
+            } else if rest.hasPrefix("/*") {
+                rest = rest.dropFirst(2)
+                while !rest.isEmpty, !rest.hasPrefix("*/") { rest = rest.dropFirst() }
+                rest = rest.hasPrefix("*/") ? rest.dropFirst(2) : rest
+            }
+            if rest == beforeTrim { break }
+        }
+        return String(rest)
+    }
+
+    /// Splits on semicolons that are not inside a string, an identifier quote, or a comment.
+    private static func splitStatements(_ sql: String) -> [String] {
+        let characters = Array(sql)
+        let quoted = quotedOrCommentMask(characters)
+        var statements: [String] = []
+        var current = ""
+
+        for (index, character) in characters.enumerated() {
+            if character == ";", !quoted[index] {
+                appendIfMeaningful(current, to: &statements)
+                current = ""
+                continue
+            }
+            current.append(character)
+        }
+        appendIfMeaningful(current, to: &statements)
+        return statements
+    }
+
+    private static func appendIfMeaningful(_ statement: String, to statements: inout [String]) {
+        let body = strippingLeadingTrivia(statement).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !body.isEmpty else { return }
+        statements.append(statement)
+    }
+
+    private static func maskingLiteralsAndComments(_ sql: String) -> String {
+        let characters = Array(sql)
+        let quoted = quotedOrCommentMask(characters)
+        return String(characters.enumerated().map { quoted[$0.offset] ? " " : $0.element })
+    }
+
+    /// One pass marking every position that sits inside a string literal, a quoted identifier, or a
+    /// comment. Doubled and backslash-escaped quotes do not end a literal. Splitting and blanking
+    /// both read this rather than re-deriving the state, so neither can drift from the other.
+    private static func quotedOrCommentMask(_ characters: [Character]) -> [Bool] {
+        var mask = [Bool](repeating: false, count: characters.count)
+        var index = 0
+        var quote: Character?
+
+        while index < characters.count {
+            let character = characters[index]
+            let following = index + 1 < characters.count ? characters[index + 1] : nil
+
+            if let open = quote {
+                mask[index] = true
+                // A backslash is not an escape under PostgreSQL's standard_conforming_strings, which
+                // PostgreSQLDriver sets on. Treating it as one would swallow the terminating quote
+                // and hide the rest of the batch, so it is left alone: ending a literal early splits
+                // more statements, and more statements can only classify toward write.
+                if character == open {
+                    if following == open {
+                        mask[index + 1] = true
+                        index += 2
+                        continue
+                    }
+                    quote = nil
+                }
+                index += 1
+                continue
+            }
+
+            if character == "-", following == "-" {
+                while index < characters.count, !characters[index].isNewline {
+                    mask[index] = true
+                    index += 1
+                }
+                continue
+            }
+
+            if character == "/", following == "*" {
+                mask[index] = true
+                mask[index + 1] = true
+                index += 2
+                while index < characters.count {
+                    if characters[index] == "*", index + 1 < characters.count, characters[index + 1] == "/" {
+                        mask[index] = true
+                        mask[index + 1] = true
+                        index += 2
+                        break
+                    }
+                    mask[index] = true
+                    index += 1
+                }
+                continue
+            }
+
+            if character == "'" || character == "\"" || character == "`" {
+                quote = character
+                mask[index] = true
+                index += 1
+                continue
+            }
+
+            index += 1
+        }
+        return mask
+    }
+}

--- a/Packages/TableProCore/Tests/TableProQueryTests/SQLWriteClassifierTests.swift
+++ b/Packages/TableProCore/Tests/TableProQueryTests/SQLWriteClassifierTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import TableProModels
+import Testing
+@testable import TableProQuery
+
+@Suite("SQLWriteClassifier")
+struct SQLWriteClassifierTests {
+    private func isWrite(_ sql: String, _ type: DatabaseType = .postgresql) -> Bool {
+        SQLWriteClassifier.isWriteQuery(sql, databaseType: type)
+    }
+
+    // MARK: - The reported bypasses
+
+    @Test("a leading line comment does not hide a write")
+    func lineCommentBypass() {
+        #expect(isWrite("-- cleanup\nDELETE FROM users"))
+        #expect(isWrite("--cleanup\r\nTRUNCATE TABLE users"))
+    }
+
+    @Test("a leading block comment does not hide a write")
+    func blockCommentBypass() {
+        #expect(isWrite("/* nightly */ DELETE FROM users"))
+        #expect(isWrite("/* one */ /* two */\n UPDATE users SET a = 1"))
+    }
+
+    @Test("a CTE that ends in a write is a write")
+    func cteBypass() {
+        #expect(isWrite("WITH d AS (SELECT id FROM users) DELETE FROM users WHERE id IN (SELECT id FROM d)"))
+        #expect(isWrite("WITH t AS (SELECT 1) INSERT INTO log SELECT * FROM t"))
+    }
+
+    @Test("a CTE that only reads is a read")
+    func readOnlyCTE() {
+        #expect(!isWrite("WITH d AS (SELECT id FROM users) SELECT * FROM d"))
+    }
+
+    @Test("a CTE ending in SELECT INTO materialises a table, so it is a write")
+    func cteSelectIntoIsWrite() {
+        #expect(isWrite("WITH x AS (SELECT 1 AS a) SELECT * INTO backup FROM x", .mssql))
+    }
+
+    @Test("a column whose name merely starts with a verb does not make a CTE a write")
+    func cteIdentifierPrefixIsNotAVerb() {
+        #expect(!isWrite("WITH x AS (SELECT into_count FROM users) SELECT * FROM x"))
+    }
+
+    @Test("a CTE calling a function whose name matches a statement verb is still a read")
+    func cteFunctionNameIsNotAVerb() {
+        #expect(!isWrite("WITH x AS (SELECT replace(name, 'a', 'b') FROM users) SELECT * FROM x"))
+        #expect(!isWrite("WITH x AS (SELECT copy_count FROM users) SELECT * FROM x"))
+    }
+
+    @Test("a write verb appearing only inside a string literal does not make a CTE a write")
+    func cteWriteWordInsideLiteral() {
+        #expect(!isWrite("WITH d AS (SELECT 'DELETE FROM users' AS note) SELECT * FROM d"))
+    }
+
+    // MARK: - Keywords the old allowlist never had
+
+    @Test("statements the old keyword list omitted are writes")
+    func unlistedWriteKeywords() {
+        #expect(isWrite("MERGE INTO target USING source ON target.id = source.id WHEN MATCHED THEN UPDATE SET a = 1"))
+        #expect(isWrite("GRANT SELECT ON users TO analyst"))
+        #expect(isWrite("REVOKE SELECT ON users FROM analyst"))
+        #expect(isWrite("SET search_path TO app"))
+        #expect(isWrite("COPY users FROM '/tmp/users.csv'"))
+        #expect(isWrite("CALL rebuild_indexes()"))
+        #expect(isWrite("EXEC sp_who"))
+    }
+
+    @Test("an unrecognised keyword fails closed")
+    func unknownKeywordIsWrite() {
+        #expect(isWrite("FROBNICATE the_widgets"))
+        #expect(isWrite("\u{FFFD}\u{FFFD}"))
+    }
+
+    // MARK: - Reads
+
+    @Test("plain reads are reads")
+    func reads() {
+        #expect(!isWrite("SELECT * FROM users"))
+        #expect(!isWrite("  select 1  "))
+        #expect(!isWrite("SHOW TABLES", .mysql))
+        #expect(!isWrite("DESCRIBE users", .mysql))
+        #expect(!isWrite("-- just a note\nSELECT 1"))
+        #expect(!isWrite("SELECT count(*) FROM users"))
+    }
+
+    @Test("a statement that runs its plan or writes a pragma is a write")
+    func explainAndPragmaAreWrites() {
+        #expect(isWrite("EXPLAIN ANALYZE DELETE FROM users"))
+        #expect(isWrite("EXPLAIN SELECT * FROM users"))
+        #expect(isWrite("PRAGMA journal_mode = WAL", .sqlite))
+    }
+
+    @Test("SELECT INTO materialises a table, so it is a write")
+    func selectIntoIsWrite() {
+        #expect(isWrite("SELECT * INTO backup FROM users", .mssql))
+        #expect(isWrite("SELECT * FROM users INTO OUTFILE '/tmp/u.csv'", .mysql))
+        #expect(!isWrite("SELECT 'INTO' FROM users"))
+    }
+
+    @Test("a backslash does not swallow the quote that ends a literal")
+    func backslashDoesNotHideABatch() {
+        #expect(isWrite(#"SELECT 'a\' ; DELETE FROM users"#))
+    }
+
+    @Test("Redis reads are reads and Redis writes are writes")
+    func redisCommands() {
+        #expect(!isWrite("GET user:1", .redis))
+        #expect(!isWrite("HGETALL user:1", .redis))
+        #expect(!isWrite("SCAN 0", .redis))
+        #expect(!isWrite("TTL user:1", .redis))
+        #expect(!isWrite("CONFIG GET maxmemory", .redis))
+        #expect(isWrite("SET user:1 bob", .redis))
+        #expect(isWrite("DEL user:1", .redis))
+        #expect(isWrite("FLUSHALL", .redis))
+        #expect(isWrite("CONFIG SET maxmemory 0", .redis))
+        #expect(isWrite("SOMETHINGNEW key", .redis))
+    }
+
+    @Test("empty and comment-only input is not a write")
+    func emptyInput() {
+        #expect(!isWrite(""))
+        #expect(!isWrite("   \n  "))
+        #expect(!isWrite("-- nothing here"))
+        #expect(!isWrite("/* nothing */"))
+        #expect(!isWrite(";;;"))
+    }
+
+    // MARK: - Batches
+
+    @Test("any write in a batch makes the batch a write")
+    func batchWithWrite() {
+        #expect(isWrite("SELECT 1; DELETE FROM users"))
+        #expect(isWrite("SELECT 1;\n-- cleanup\nDELETE FROM users"))
+        #expect(!isWrite("SELECT 1; SELECT 2"))
+    }
+
+    @Test("a semicolon inside a literal does not split a statement")
+    func semicolonInsideLiteral() {
+        #expect(!isWrite("SELECT 'a;b' FROM users"))
+        #expect(isWrite("SELECT 'a;b' FROM users; UPDATE users SET a = 1"))
+    }
+
+    @Test("a semicolon inside a quoted identifier does not split a statement")
+    func semicolonInsideIdentifier() {
+        #expect(!isWrite(#"SELECT "odd;name" FROM users"#))
+    }
+
+    @Test("a doubled quote does not end a literal")
+    func doubledQuote() {
+        #expect(!isWrite("SELECT 'it''s; fine' FROM users"))
+    }
+
+    @Test("a semicolon inside a comment does not split a statement")
+    func semicolonInsideComment() {
+        #expect(!isWrite("SELECT 1 -- ; DELETE FROM users"))
+        #expect(!isWrite("SELECT 1 /* ; DELETE FROM users */"))
+    }
+}

--- a/Plugins/MSSQLDriverPlugin/MSSQLPlugin.swift
+++ b/Plugins/MSSQLDriverPlugin/MSSQLPlugin.swift
@@ -214,6 +214,11 @@ final class MSSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     /// rejects explicit values for IDENTITY columns unless IDENTITY_INSERT is ON,
     /// and the value the user typed is server-allocated anyway.
     var identityColumnsByTable: [String: Set<String>] = [:]
+
+    /// Computed columns observed during a column fetch, keyed by table name. SQL Server rejects an
+    /// explicit value for one the same way it does for IDENTITY: "The column cannot be modified
+    /// because it is either a computed column or is the result of a UNION operator."
+    var computedColumnsByTable: [String: Set<String>] = [:]
     let identityCacheLock = NSLock()
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "MSSQLPluginDriver")
@@ -492,6 +497,7 @@ final class MSSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         var nonDefaultColumns: [String] = []
         var parameters: [PluginCellValue] = []
         let identityColumns = cachedIdentityColumns(for: table)
+        let computedColumns = cachedComputedColumns(for: table)
 
         for (index, value) in values.enumerated() {
             if value.asText == "__DEFAULT__" { continue }
@@ -501,6 +507,7 @@ final class MSSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             // an explicit value fail unless `SET IDENTITY_INSERT <table> ON` was issued,
             // so always omit them and let the server assign the next value.
             if identityColumns.contains(columnName) { continue }
+            if computedColumns.contains(columnName) { continue }
             nonDefaultColumns.append("[\(columnName.replacingOccurrences(of: "]", with: "]]"))]")
             parameters.append(value)
         }

--- a/Plugins/MSSQLDriverPlugin/MSSQLPluginDriver+Schema.swift
+++ b/Plugins/MSSQLDriverPlugin/MSSQLPluginDriver+Schema.swift
@@ -43,7 +43,8 @@ extension MSSQLPluginDriver {
                 c.IS_NULLABLE,
                 c.COLUMN_DEFAULT,
                 COLUMNPROPERTY(OBJECT_ID(c.TABLE_SCHEMA + '.' + c.TABLE_NAME), c.COLUMN_NAME, 'IsIdentity') AS IS_IDENTITY,
-                CASE WHEN pk.COLUMN_NAME IS NOT NULL THEN 1 ELSE 0 END AS IS_PK
+                CASE WHEN pk.COLUMN_NAME IS NOT NULL THEN 1 ELSE 0 END AS IS_PK,
+                COLUMNPROPERTY(OBJECT_ID(c.TABLE_SCHEMA + '.' + c.TABLE_NAME), c.COLUMN_NAME, 'IsComputed') AS IS_COMPUTED
             FROM INFORMATION_SCHEMA.COLUMNS c
             LEFT JOIN (
                 SELECT kcu.COLUMN_NAME
@@ -61,6 +62,7 @@ extension MSSQLPluginDriver {
             """
         let result = try await execute(query: sql)
         var identityColumns: Set<String> = []
+        var computedColumns: Set<String> = []
         let columns: [PluginColumnInfo] = result.rows.compactMap { row -> PluginColumnInfo? in
             guard let name = row[safe: 0]?.asText else { return nil }
             let dataType = row[safe: 1]?.asText
@@ -70,10 +72,14 @@ extension MSSQLPluginDriver {
             let isNullable = (row[safe: 5]?.asText) == "YES"
             let defaultValue = row[safe: 6]?.asText
             let isIdentity = (row[safe: 7]?.asText) == "1"
+            let isComputed = (row[safe: 9]?.asText) == "1"
             let isPk = (row[safe: 8]?.asText) == "1"
 
             if isIdentity {
                 identityColumns.insert(name)
+            }
+            if isComputed {
+                computedColumns.insert(name)
             }
 
             let baseType = (dataType ?? "nvarchar").lowercased()
@@ -102,10 +108,14 @@ extension MSSQLPluginDriver {
                 isNullable: isNullable,
                 isPrimaryKey: isPk,
                 defaultValue: defaultValue,
-                extra: isIdentity ? "IDENTITY" : nil
+                extra: isIdentity ? "IDENTITY" : nil,
+                isGenerated: isComputed
             )
         }
-        identityCacheLock.withLock { identityColumnsByTable[table] = identityColumns }
+        identityCacheLock.withLock {
+            identityColumnsByTable[table] = identityColumns
+            computedColumnsByTable[table] = computedColumns
+        }
         return columns
     }
 
@@ -118,11 +128,24 @@ extension MSSQLPluginDriver {
         return identityColumnsByTable[table] ?? []
     }
 
+    /// Snapshot of computed columns observed by the most recent column fetch for the table.
+    internal func cachedComputedColumns(for table: String) -> Set<String> {
+        identityCacheLock.lock()
+        defer { identityCacheLock.unlock() }
+        return computedColumnsByTable[table] ?? []
+    }
+
     /// Test seam: pre-populate the cache so generateMssqlInsert can be exercised
     /// without going through a live `fetchColumns` round-trip.
     internal func setIdentityColumnsForTesting(_ columns: Set<String>, table: String) {
         identityCacheLock.lock()
         identityColumnsByTable[table] = columns
+        identityCacheLock.unlock()
+    }
+
+    internal func setComputedColumnsForTesting(_ columns: Set<String>, table: String) {
+        identityCacheLock.lock()
+        computedColumnsByTable[table] = columns
         identityCacheLock.unlock()
     }
 
@@ -230,7 +253,8 @@ extension MSSQLPluginDriver {
                 c.IS_NULLABLE,
                 c.COLUMN_DEFAULT,
                 COLUMNPROPERTY(OBJECT_ID(c.TABLE_SCHEMA + '.' + c.TABLE_NAME), c.COLUMN_NAME, 'IsIdentity') AS IS_IDENTITY,
-                CASE WHEN pk.COLUMN_NAME IS NOT NULL THEN 1 ELSE 0 END AS IS_PK
+                CASE WHEN pk.COLUMN_NAME IS NOT NULL THEN 1 ELSE 0 END AS IS_PK,
+                COLUMNPROPERTY(OBJECT_ID(c.TABLE_SCHEMA + '.' + c.TABLE_NAME), c.COLUMN_NAME, 'IsComputed') AS IS_COMPUTED
             FROM INFORMATION_SCHEMA.COLUMNS c
             LEFT JOIN (
                 SELECT kcu.TABLE_NAME, kcu.COLUMN_NAME
@@ -246,6 +270,8 @@ extension MSSQLPluginDriver {
             """
         let result = try await execute(query: sql)
         var columnsByTable: [String: [PluginColumnInfo]] = [:]
+        var identityByTable: [String: Set<String>] = [:]
+        var computedByTable: [String: Set<String>] = [:]
         for row in result.rows {
             guard let tableName = row[safe: 0]?.asText,
                   let name = row[safe: 1]?.asText else { continue }
@@ -256,6 +282,7 @@ extension MSSQLPluginDriver {
             let isNullable = (row[safe: 6]?.asText) == "YES"
             let defaultValue = row[safe: 7]?.asText
             let isIdentity = (row[safe: 8]?.asText) == "1"
+            let isComputed = (row[safe: 10]?.asText) == "1"
             let isPk = (row[safe: 9]?.asText) == "1"
 
             let baseType = (dataType ?? "nvarchar").lowercased()
@@ -284,9 +311,18 @@ extension MSSQLPluginDriver {
                 isNullable: isNullable,
                 isPrimaryKey: isPk,
                 defaultValue: defaultValue,
-                extra: isIdentity ? "IDENTITY" : nil
+                extra: isIdentity ? "IDENTITY" : nil,
+                isGenerated: isComputed
             )
             columnsByTable[tableName, default: []].append(col)
+            if isIdentity { identityByTable[tableName, default: []].insert(name) }
+            if isComputed { computedByTable[tableName, default: []].insert(name) }
+        }
+        identityCacheLock.withLock {
+            for table in columnsByTable.keys {
+                identityColumnsByTable[table] = identityByTable[table] ?? []
+                computedColumnsByTable[table] = computedByTable[table] ?? []
+            }
         }
         return columnsByTable
     }

--- a/TableProMobile/TableProMobile/Drivers/MSSQLDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/MSSQLDriver.swift
@@ -251,7 +251,8 @@ nonisolated final class MSSQLDriver: DatabaseDriver, @unchecked Sendable {
                     defaultValue: parsed.defaultValue,
                     characterMaxLength: parsed.characterMaxLength,
                     ordinalPosition: idx,
-                    isAutoIncrement: parsed.isIdentity
+                    isAutoIncrement: parsed.isIdentity,
+                    isGenerated: parsed.isComputed
                 )
             }
         }

--- a/TableProMobile/TableProMobile/Drivers/PostgreSQLDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/PostgreSQLDriver.swift
@@ -19,10 +19,9 @@ nonisolated final class PostgreSQLDriver: DatabaseDriver, @unchecked Sendable {
     nonisolated(unsafe) private(set) var currentSchema: String? = "public"
     nonisolated(unsafe) private(set) var serverVersion: String?
 
-    /// Nil until the first column fetch answers it. Redshift shares this driver and its
-    /// `information_schema` predates `is_identity`, so the answer is remembered rather than
-    /// re-probed for every table.
     nonisolated(unsafe) private var reportsIdentityColumns: Bool?
+
+    private var effectiveSchema: String { currentSchema ?? "public" }
 
     init(host: String, port: Int, user: String, password: String, database: String, ssl: DriverSSLConfiguration = .disabled) {
         self.host = host
@@ -40,6 +39,13 @@ nonisolated final class PostgreSQLDriver: DatabaseDriver, @unchecked Sendable {
         try await actor.connect(host: host, port: port, user: user, password: password, database: database, ssl: ssl)
         _ = try? await actor.execute("SET standard_conforming_strings = on")
         serverVersion = await actor.serverVersion()
+        await adoptServerSchema()
+    }
+
+    private func adoptServerSchema() async {
+        guard let schema = try? await actor.execute("SELECT current_schema()").rows.first?.first ?? nil,
+              !schema.isEmpty else { return }
+        currentSchema = schema
     }
 
     func disconnect() async throws {
@@ -132,7 +138,7 @@ nonisolated final class PostgreSQLDriver: DatabaseDriver, @unchecked Sendable {
     // MARK: - Schema
 
     func fetchTables(schema: String?) async throws -> [TableInfo] {
-        let schemaName = schema ?? "public"
+        let schemaName = schema ?? effectiveSchema
         let safe = schemaName.replacingOccurrences(of: "'", with: "''")
         let raw = try await actor.execute("""
             SELECT table_name, table_type
@@ -155,7 +161,7 @@ nonisolated final class PostgreSQLDriver: DatabaseDriver, @unchecked Sendable {
     }
 
     func fetchColumns(table: String, schema: String?) async throws -> [ColumnInfo] {
-        let schemaName = schema ?? "public"
+        let schemaName = schema ?? effectiveSchema
         let safeTbl = table.replacingOccurrences(of: "'", with: "''")
         let safeSchema = schemaName.replacingOccurrences(of: "'", with: "''")
 
@@ -196,8 +202,6 @@ nonisolated final class PostgreSQLDriver: DatabaseDriver, @unchecked Sendable {
         }
     }
 
-    /// The plain form drops `is_identity` (PostgreSQL 10) and `is_generated` (PostgreSQL 12) for a
-    /// server that has neither. A serial default still reports auto-increment through `nextval`.
     private func columnsQuery(schema: String, table: String, identity: Bool) -> String {
         let identityColumns = identity ? ",\n                c.is_identity,\n                c.is_generated" : ""
         return """
@@ -225,7 +229,7 @@ nonisolated final class PostgreSQLDriver: DatabaseDriver, @unchecked Sendable {
     }
 
     func fetchIndexes(table: String, schema: String?) async throws -> [IndexInfo] {
-        let schemaName = schema ?? "public"
+        let schemaName = schema ?? effectiveSchema
         let safeTbl = table.replacingOccurrences(of: "'", with: "''")
         let safeSchema = schemaName.replacingOccurrences(of: "'", with: "''")
 
@@ -273,7 +277,7 @@ nonisolated final class PostgreSQLDriver: DatabaseDriver, @unchecked Sendable {
     }
 
     func fetchForeignKeys(table: String, schema: String?) async throws -> [ForeignKeyInfo] {
-        let schemaName = schema ?? "public"
+        let schemaName = schema ?? effectiveSchema
         let safeTbl = table.replacingOccurrences(of: "'", with: "''")
         let safeSchema = schemaName.replacingOccurrences(of: "'", with: "''")
 

--- a/TableProMobile/TableProMobile/Helpers/ClipboardExporter.swift
+++ b/TableProMobile/TableProMobile/Helpers/ClipboardExporter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TableProDatabase
 import TableProModels
 import UIKit
 import UniformTypeIdentifiers
@@ -11,18 +12,35 @@ nonisolated enum ExportFormat: String, CaseIterable, Identifiable {
 }
 
 nonisolated enum ClipboardExporter {
-    static func exportRow(columns: [ColumnInfo], row: [String?], format: ExportFormat, tableName: String? = nil) -> String {
+    static func exportRow(
+        columns: [ColumnInfo],
+        row: [String?],
+        format: ExportFormat,
+        tableName: String? = nil,
+        databaseType: DatabaseType,
+        driver: (any DatabaseDriver)?
+    ) -> String {
         switch format {
         case .json:
             return rowToJson(columns: columns, row: row)
         case .csv:
             return rowToCsv(columns: columns, row: row, includeHeader: true)
         case .sqlInsert:
-            return rowToInsert(columns: columns, row: row, tableName: tableName ?? "table")
+            return rowToInsert(
+                columns: columns, row: row, tableName: tableName ?? "table",
+                databaseType: databaseType, driver: driver
+            )
         }
     }
 
-    static func exportRows(columns: [ColumnInfo], rows: [[String?]], format: ExportFormat, tableName: String? = nil) -> String {
+    static func exportRows(
+        columns: [ColumnInfo],
+        rows: [[String?]],
+        format: ExportFormat,
+        tableName: String? = nil,
+        databaseType: DatabaseType,
+        driver: (any DatabaseDriver)?
+    ) -> String {
         switch format {
         case .json:
             let objects = rows.map { rowToJson(columns: columns, row: $0) }
@@ -31,13 +49,18 @@ nonisolated enum ClipboardExporter {
             let header = columns.map { escapeCsvField($0.name) }.joined(separator: ",")
             let dataLines = rows.map { row in
                 columns.indices.map { i in
-                    escapeCsvField(i < row.count ? row[i] ?? "NULL" : "NULL")
+                    csvField(i < row.count ? row[i] : nil)
                 }.joined(separator: ",")
             }
             return ([header] + dataLines).joined(separator: "\n")
         case .sqlInsert:
             let name = tableName ?? "table"
-            return rows.map { rowToInsert(columns: columns, row: $0, tableName: name) }.joined(separator: "\n")
+            return rows.map {
+                rowToInsert(
+                    columns: columns, row: $0, tableName: name,
+                    databaseType: databaseType, driver: driver
+                )
+            }.joined(separator: "\n")
         }
     }
 
@@ -66,9 +89,7 @@ nonisolated enum ClipboardExporter {
             let value = i < row.count ? row[i] : nil
             let key = "  \"\(escapeJsonString(col.name))\""
             if let value {
-                if Int64(value) != nil {
-                    pairs.append("\(key): \(value)")
-                } else if let parsed = Double(value), parsed.isFinite {
+                if isJsonNumber(value) {
                     pairs.append("\(key): \(value)")
                 } else if value == "true" || value == "false" {
                     pairs.append("\(key): \(value)")
@@ -88,20 +109,97 @@ nonisolated enum ClipboardExporter {
             lines.append(columns.map { escapeCsvField($0.name) }.joined(separator: ","))
         }
         let dataLine = columns.indices.map { i in
-            escapeCsvField(i < row.count ? row[i] ?? "NULL" : "NULL")
+            csvField(i < row.count ? row[i] : nil)
         }.joined(separator: ",")
         lines.append(dataLine)
         return lines.joined(separator: "\n")
     }
 
-    private static func rowToInsert(columns: [ColumnInfo], row: [String?], tableName: String) -> String {
-        let cols = columns.map { "\"\($0.name)\"" }.joined(separator: ", ")
+    private static func rowToInsert(
+        columns: [ColumnInfo],
+        row: [String?],
+        tableName: String,
+        databaseType: DatabaseType,
+        driver: (any DatabaseDriver)?
+    ) -> String {
+        let quotedTable = SQLBuilder.quoteIdentifier(tableName, for: databaseType)
+        let cols = columns
+            .map { SQLBuilder.quoteIdentifier($0.name, for: databaseType) }
+            .joined(separator: ", ")
         let vals = columns.indices.map { i in
             let value = i < row.count ? row[i] : nil
             guard let value else { return "NULL" }
-            return "'\(value.replacingOccurrences(of: "'", with: "''"))'"
+            return "'\(escapeLiteral(value, databaseType: databaseType, driver: driver))'"
         }.joined(separator: ", ")
-        return "INSERT INTO \"\(tableName)\" (\(cols)) VALUES (\(vals));"
+        return "INSERT INTO \(quotedTable) (\(cols)) VALUES (\(vals));"
+    }
+
+    private static func escapeLiteral(
+        _ value: String,
+        databaseType: DatabaseType,
+        driver: (any DatabaseDriver)?
+    ) -> String {
+        if let driver { return driver.escapeStringLiteral(value) }
+        switch databaseType {
+        case .mysql, .mariadb:
+            return SQLEscaping.backslashStringLiteral(value)
+        default:
+            return SQLEscaping.ansiStringLiteral(value)
+        }
+    }
+
+    private static func csvField(_ value: String?) -> String {
+        guard let value else { return "" }
+        if value.isEmpty || value == "NULL" { return "\"\(value)\"" }
+        return escapeCsvField(value)
+    }
+
+    /// The JSON number grammar over ASCII digits only, so a VARCHAR like "01234", "+5", "0x10" or
+    /// "\u{0661}\u{0662}\u{0663}" stays a quoted string rather than a token no JSON parser accepts.
+    private static func isJsonNumber(_ value: String) -> Bool {
+        var characters = Substring(value)
+        if characters.first == "-" { characters = characters.dropFirst() }
+        guard let first = characters.first, isAsciiDigit(first) else { return false }
+        if first == "0", characters.count > 1, characters.dropFirst().first.map(isAsciiDigit) == true {
+            return false
+        }
+
+        var sawDigit = false
+        var index = characters.startIndex
+        while index < characters.endIndex, isAsciiDigit(characters[index]) {
+            sawDigit = true
+            index = characters.index(after: index)
+        }
+        guard sawDigit else { return false }
+
+        if index < characters.endIndex, characters[index] == "." {
+            index = characters.index(after: index)
+            var sawFraction = false
+            while index < characters.endIndex, isAsciiDigit(characters[index]) {
+                sawFraction = true
+                index = characters.index(after: index)
+            }
+            guard sawFraction else { return false }
+        }
+
+        if index < characters.endIndex, characters[index] == "e" || characters[index] == "E" {
+            index = characters.index(after: index)
+            if index < characters.endIndex, characters[index] == "+" || characters[index] == "-" {
+                index = characters.index(after: index)
+            }
+            var sawExponent = false
+            while index < characters.endIndex, isAsciiDigit(characters[index]) {
+                sawExponent = true
+                index = characters.index(after: index)
+            }
+            guard sawExponent else { return false }
+        }
+
+        return index == characters.endIndex
+    }
+
+    private static func isAsciiDigit(_ character: Character) -> Bool {
+        character.isASCII && character.isNumber
     }
 
     private static func escapeCsvField(_ field: String) -> String {

--- a/TableProMobile/TableProMobile/Helpers/SQLBuilder.swift
+++ b/TableProMobile/TableProMobile/Helpers/SQLBuilder.swift
@@ -32,24 +32,25 @@ nonisolated enum SQLBuilder {
         }
     }
 
-    static func buildCount(table: String, type: DatabaseType) -> String {
-        let quoted = quoteIdentifier(table, for: type)
+    static func buildCount(table: String, schema: String?, type: DatabaseType) -> String {
+        let quoted = qualifiedIdentifier(table: table, schema: schema, for: type)
         return "SELECT COUNT(*) FROM \(quoted)"
     }
 
-    static func buildSelect(table: String, type: DatabaseType, limit: Int, offset: Int) -> String {
-        let quoted = quoteIdentifier(table, for: type)
+    static func buildSelect(table: String, schema: String?, type: DatabaseType, limit: Int, offset: Int) -> String {
+        let quoted = qualifiedIdentifier(table: table, schema: schema, for: type)
         let pagination = paginationClause(orderBy: "", limit: limit, offset: offset, for: type)
         return "SELECT * FROM \(quoted) \(pagination)"
     }
 
     static func buildDelete(
         table: String,
+        schema: String?,
         type: DatabaseType,
         driver: any DatabaseDriver,
         primaryKeys: [(column: String, value: String)]
     ) -> String {
-        let quotedTable = quoteIdentifier(table, for: type)
+        let quotedTable = qualifiedIdentifier(table: table, schema: schema, for: type)
         let predicate = primaryKeys.map {
             "\(quoteIdentifier($0.column, for: type)) = '\(driver.escapeStringLiteral($0.value))'"
         }.joined(separator: " AND ")
@@ -58,12 +59,13 @@ nonisolated enum SQLBuilder {
 
     static func buildUpdate(
         table: String,
+        schema: String?,
         type: DatabaseType,
         driver: any DatabaseDriver,
         changes: [(column: String, value: String?)],
         primaryKeys: [(column: String, value: String)]
     ) -> String {
-        let quotedTable = quoteIdentifier(table, for: type)
+        let quotedTable = qualifiedIdentifier(table: table, schema: schema, for: type)
         let assignments = changes.map { col, val in
             let qcol = quoteIdentifier(col, for: type)
             if let val { return "\(qcol) = '\(driver.escapeStringLiteral(val))'" }
@@ -120,25 +122,25 @@ nonisolated enum SQLBuilder {
     }
 
     static func buildSelect(
-        table: String, type: DatabaseType,
+        table: String, schema: String?, type: DatabaseType,
         sortState: SortState,
         limit: Int, offset: Int
     ) -> String {
-        let quoted = quoteIdentifier(table, for: type)
+        let quoted = qualifiedIdentifier(table: table, schema: schema, for: type)
         let orderBy = buildOrderByClause(sortState, for: type)
         let pagination = paginationClause(orderBy: orderBy, limit: limit, offset: offset, for: type)
         return "SELECT * FROM \(quoted) \(pagination)"
     }
 
     static func buildFilteredSelect(
-        table: String, type: DatabaseType,
+        table: String, schema: String?, type: DatabaseType,
         filters: [TableFilter], logicMode: FilterLogicMode,
         limit: Int, offset: Int
     ) -> String {
         let dialect = dialectDescriptor(for: type)
         let generator = FilterSQLGenerator(dialect: dialect)
         let whereClause = generator.generateWhereClause(from: filters, logicMode: logicMode)
-        let quoted = quoteIdentifier(table, for: type)
+        let quoted = qualifiedIdentifier(table: table, schema: schema, for: type)
         let pagination = paginationClause(orderBy: "", limit: limit, offset: offset, for: type)
         var sql = "SELECT * FROM \(quoted)"
         if !whereClause.isEmpty { sql += " \(whereClause)" }
@@ -147,7 +149,7 @@ nonisolated enum SQLBuilder {
     }
 
     static func buildFilteredSelect(
-        table: String, type: DatabaseType,
+        table: String, schema: String?, type: DatabaseType,
         filters: [TableFilter], logicMode: FilterLogicMode,
         sortState: SortState,
         limit: Int, offset: Int
@@ -156,7 +158,7 @@ nonisolated enum SQLBuilder {
         let generator = FilterSQLGenerator(dialect: dialect)
         let whereClause = generator.generateWhereClause(from: filters, logicMode: logicMode)
         let orderBy = buildOrderByClause(sortState, for: type)
-        let quoted = quoteIdentifier(table, for: type)
+        let quoted = qualifiedIdentifier(table: table, schema: schema, for: type)
         let pagination = paginationClause(orderBy: orderBy, limit: limit, offset: offset, for: type)
         var sql = "SELECT * FROM \(quoted)"
         if !whereClause.isEmpty { sql += " \(whereClause)" }
@@ -165,13 +167,13 @@ nonisolated enum SQLBuilder {
     }
 
     static func buildFilteredCount(
-        table: String, type: DatabaseType,
+        table: String, schema: String?, type: DatabaseType,
         filters: [TableFilter], logicMode: FilterLogicMode
     ) -> String {
         let dialect = dialectDescriptor(for: type)
         let generator = FilterSQLGenerator(dialect: dialect)
         let whereClause = generator.generateWhereClause(from: filters, logicMode: logicMode)
-        let quoted = quoteIdentifier(table, for: type)
+        let quoted = qualifiedIdentifier(table: table, schema: schema, for: type)
         if whereClause.isEmpty {
             return "SELECT COUNT(*) FROM \(quoted)"
         }
@@ -181,13 +183,13 @@ nonisolated enum SQLBuilder {
     // MARK: - Search
 
     static func buildSearchSelect(
-        table: String, type: DatabaseType,
+        table: String, schema: String?, type: DatabaseType,
         searchText: String, searchColumns: [ColumnInfo],
         filters: [TableFilter] = [], logicMode: FilterLogicMode = .and,
         sortState: SortState = SortState(),
         limit: Int, offset: Int
     ) -> String {
-        let quoted = quoteIdentifier(table, for: type)
+        let quoted = qualifiedIdentifier(table: table, schema: schema, for: type)
         let whereClause = buildSearchWhereClause(
             searchText: searchText, searchColumns: searchColumns,
             filters: filters, logicMode: logicMode, type: type
@@ -201,11 +203,11 @@ nonisolated enum SQLBuilder {
     }
 
     static func buildSearchCount(
-        table: String, type: DatabaseType,
+        table: String, schema: String?, type: DatabaseType,
         searchText: String, searchColumns: [ColumnInfo],
         filters: [TableFilter] = [], logicMode: FilterLogicMode = .and
     ) -> String {
-        let quoted = quoteIdentifier(table, for: type)
+        let quoted = qualifiedIdentifier(table: table, schema: schema, for: type)
         let whereClause = buildSearchWhereClause(
             searchText: searchText, searchColumns: searchColumns,
             filters: filters, logicMode: logicMode, type: type

--- a/TableProMobile/TableProMobile/Info.plist
+++ b/TableProMobile/TableProMobile/Info.plist
@@ -29,6 +29,19 @@
 		<string>com.TablePro.viewConnection</string>
 		<string>com.TablePro.viewTable</string>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.TablePro.deeplink</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>tablepro</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+		</dict>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/TableProMobile/TableProMobile/ViewModels/DataBrowserViewModel.swift
+++ b/TableProMobile/TableProMobile/ViewModels/DataBrowserViewModel.swift
@@ -44,6 +44,10 @@ final class DataBrowserViewModel {
     @ObservationIgnored private var session: ConnectionSession?
     @ObservationIgnored private var table: TableInfo?
     @ObservationIgnored private var databaseType: DatabaseType = .mysql
+    /// The schema the rows on screen were fetched with. Every statement the browser and its
+    /// children issue reads this one value, so an edit cannot target a schema the visible rows did
+    /// not come from.
+    private(set) var schema: String?
     @ObservationIgnored private var host: String = ""
     @ObservationIgnored private var fetchTask: Task<Void, Never>?
     @ObservationIgnored private var searchTask: Task<Void, Never>?
@@ -72,11 +76,18 @@ final class DataBrowserViewModel {
 
     // MARK: - Attach
 
-    func attach(session: ConnectionSession?, table: TableInfo, databaseType: DatabaseType, host: String) {
+    func attach(
+        session: ConnectionSession?,
+        table: TableInfo,
+        databaseType: DatabaseType,
+        host: String,
+        schema: String? = nil
+    ) {
         self.session = session
         self.table = table
         self.databaseType = databaseType
         self.host = host
+        self.schema = schema
     }
 
     // MARK: - Load
@@ -157,7 +168,7 @@ final class DataBrowserViewModel {
         let activeSort = effectiveSortState()
         if hasActiveSearch {
             return SQLBuilder.buildSearchSelect(
-                table: table.name, type: databaseType,
+                table: table.name, schema: schema, type: databaseType,
                 searchText: activeSearchText, searchColumns: searchableColumns(),
                 filters: filters, logicMode: filterLogicMode,
                 sortState: activeSort,
@@ -166,7 +177,7 @@ final class DataBrowserViewModel {
         }
         if hasActiveFilters {
             return SQLBuilder.buildFilteredSelect(
-                table: table.name, type: databaseType,
+                table: table.name, schema: schema, type: databaseType,
                 filters: filters, logicMode: filterLogicMode,
                 sortState: activeSort,
                 limit: pagination.pageSize, offset: pagination.currentOffset
@@ -174,13 +185,13 @@ final class DataBrowserViewModel {
         }
         if activeSort.isSorting {
             return SQLBuilder.buildSelect(
-                table: table.name, type: databaseType,
+                table: table.name, schema: schema, type: databaseType,
                 sortState: activeSort,
                 limit: pagination.pageSize, offset: pagination.currentOffset
             )
         }
         return SQLBuilder.buildSelect(
-            table: table.name, type: databaseType,
+            table: table.name, schema: schema, type: databaseType,
             limit: pagination.pageSize, offset: pagination.currentOffset
         )
     }
@@ -209,17 +220,17 @@ final class DataBrowserViewModel {
             let countQuery: String
             if hasActiveSearch {
                 countQuery = SQLBuilder.buildSearchCount(
-                    table: table.name, type: databaseType,
+                    table: table.name, schema: schema, type: databaseType,
                     searchText: activeSearchText, searchColumns: searchableColumns(),
                     filters: filters, logicMode: filterLogicMode
                 )
             } else if hasActiveFilters {
                 countQuery = SQLBuilder.buildFilteredCount(
-                    table: table.name, type: databaseType,
+                    table: table.name, schema: schema, type: databaseType,
                     filters: filters, logicMode: filterLogicMode
                 )
             } else {
-                countQuery = SQLBuilder.buildCount(table: table.name, type: databaseType)
+                countQuery = SQLBuilder.buildCount(table: table.name, schema: schema, type: databaseType)
             }
             let countResult = try await session.driver.execute(query: countQuery)
             if let firstRow = countResult.rows.first, let firstCol = firstRow.first {
@@ -323,6 +334,7 @@ final class DataBrowserViewModel {
             _ = try await session.driver.execute(
                 query: SQLBuilder.buildDelete(
                     table: table.name,
+                    schema: schema,
                     type: databaseType,
                     driver: session.driver,
                     primaryKeys: pkValues

--- a/TableProMobile/TableProMobile/ViewModels/RowDetailViewModel.swift
+++ b/TableProMobile/TableProMobile/ViewModels/RowDetailViewModel.swift
@@ -14,6 +14,7 @@ final class RowDetailViewModel {
     let table: TableInfo?
     let session: ConnectionSession?
     let databaseType: DatabaseType
+    let schema: String?
     let safeModeLevel: SafeModeLevel
 
     private(set) var rows: [Row]
@@ -41,6 +42,7 @@ final class RowDetailViewModel {
         session: ConnectionSession? = nil,
         columnDetails: [ColumnInfo] = [],
         databaseType: DatabaseType = .sqlite,
+        schema: String? = nil,
         safeModeLevel: SafeModeLevel = .off,
         foreignKeys: [ForeignKeyInfo] = [],
         onSaved: (() -> Void)? = nil,
@@ -53,6 +55,7 @@ final class RowDetailViewModel {
         self.session = session
         self.columnDetails = columnDetails
         self.databaseType = databaseType
+        self.schema = schema
         self.safeModeLevel = safeModeLevel
         self.foreignKeys = foreignKeys
         self.onSaved = onSaved
@@ -189,6 +192,7 @@ final class RowDetailViewModel {
 
         let sql = SQLBuilder.buildUpdate(
             table: table.name,
+            schema: schema,
             type: databaseType,
             driver: session.driver,
             changes: changes,

--- a/TableProMobile/TableProMobile/Views/Components/FKPreviewView.swift
+++ b/TableProMobile/TableProMobile/Views/Components/FKPreviewView.swift
@@ -74,7 +74,9 @@ struct FKPreviewView: View {
         }
 
         do {
-            let quoted = SQLBuilder.quoteIdentifier(fk.referencedTable, for: databaseType)
+            let quoted = SQLBuilder.qualifiedIdentifier(
+                table: fk.referencedTable, schema: fk.referencedSchema, for: databaseType
+            )
             let quotedCol = SQLBuilder.quoteIdentifier(fk.referencedColumn, for: databaseType)
             let escapedValue = value.replacingOccurrences(of: "'", with: "''")
             /// SQL Server and Oracle reject `LIMIT`, so the clause comes from the shared builder

--- a/TableProMobile/TableProMobile/Views/DataBrowserView.swift
+++ b/TableProMobile/TableProMobile/Views/DataBrowserView.swift
@@ -28,6 +28,10 @@ struct DataBrowserView: View {
     @State private var hapticSuccess = false
     @State private var hapticError = false
 
+    private var activeSchema: String? {
+        coordinator.supportsSchemas ? coordinator.activeSchema : nil
+    }
+
     private var isView: Bool { table.type == .view || table.type == .materializedView }
     private var isRedis: Bool { connection.type == .redis }
 
@@ -81,8 +85,18 @@ struct DataBrowserView: View {
             .toolbar(rows.isEmpty && !viewModel.hasActiveSearch && !viewModel.hasActiveFilters && !viewModel.isPageLoading ? .hidden : .visible, for: .bottomBar)
             .toolbar { paginationToolbar }
             .task {
-                viewModel.attach(session: session, table: table, databaseType: connection.type, host: connection.host)
+                viewModel.attach(
+                    session: session, table: table, databaseType: connection.type,
+                    host: connection.host, schema: activeSchema
+                )
                 await viewModel.load(isInitial: true)
+            }
+            .onChange(of: activeSchema) { _, newSchema in
+                viewModel.attach(
+                    session: session, table: table, databaseType: connection.type,
+                    host: connection.host, schema: newSchema
+                )
+                Task { await viewModel.load(isInitial: true) }
             }
             .onDisappear { viewModel.cancel() }
             .sheet(isPresented: $showInsertSheet) { insertSheet }
@@ -256,6 +270,7 @@ struct DataBrowserView: View {
                 session: session,
                 columnDetails: viewModel.columnDetails,
                 databaseType: connection.type,
+                schema: viewModel.schema,
                 safeModeLevel: connection.safeModeLevel,
                 foreignKeys: viewModel.foreignKeys,
                 onSaved: { Task { await viewModel.load() } },
@@ -294,7 +309,8 @@ struct DataBrowserView: View {
                 Button(format.rawValue) {
                     shareText = ClipboardExporter.exportRow(
                         columns: columns, row: row,
-                        format: format, tableName: table.name
+                        format: format, tableName: table.name,
+                        databaseType: connection.type, driver: session?.driver
                     )
                     showShareSheet = true
                 }
@@ -305,7 +321,8 @@ struct DataBrowserView: View {
                 Button(format.rawValue) {
                     let text = ClipboardExporter.exportRow(
                         columns: columns, row: row,
-                        format: format, tableName: table.name
+                        format: format, tableName: table.name,
+                        databaseType: connection.type, driver: session?.driver
                     )
                     ClipboardExporter.copyToClipboard(text)
                 }
@@ -380,7 +397,8 @@ struct DataBrowserView: View {
                         Button {
                             let text = ClipboardExporter.exportRows(
                                 columns: columns, rows: rows,
-                                format: format, tableName: table.name
+                                format: format, tableName: table.name,
+                                databaseType: connection.type, driver: session?.driver
                             )
                             ClipboardExporter.copyToClipboard(text)
                         } label: {
@@ -458,6 +476,7 @@ struct DataBrowserView: View {
             columnDetails: viewModel.columnDetails,
             session: session,
             databaseType: connection.type,
+            schema: viewModel.schema,
             safeModeLevel: connection.safeModeLevel,
             onInserted: { Task { await viewModel.load() } }
         )

--- a/TableProMobile/TableProMobile/Views/InsertRowView.swift
+++ b/TableProMobile/TableProMobile/Views/InsertRowView.swift
@@ -7,6 +7,7 @@ struct InsertRowView: View {
     let columnDetails: [ColumnInfo]
     let session: ConnectionSession?
     let databaseType: DatabaseType
+    let schema: String?
     let safeModeLevel: SafeModeLevel
     var onInserted: (() -> Void)?
 
@@ -269,7 +270,7 @@ struct InsertRowView: View {
     private func buildInsertSQL(driver: any DatabaseDriver) -> String? {
         try? RowInsertPlanner.statements(
             table: table.name,
-            schema: nil,
+            schema: schema,
             type: databaseType,
             driver: driver,
             columns: columnDetails,

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -3,6 +3,7 @@ import os
 import SwiftUI
 import TableProDatabase
 import TableProModels
+import TableProQuery
 
 struct QueryEditorView: View {
     @Environment(ConnectionCoordinator.self) private var coordinator
@@ -315,7 +316,8 @@ struct QueryEditorView: View {
                 Button(format.rawValue) {
                     let text = ClipboardExporter.exportRow(
                         columns: columns, row: row,
-                        format: format
+                        format: format,
+                        databaseType: databaseType, driver: coordinator.session?.driver
                     )
                     ClipboardExporter.copyToClipboard(text)
                 }
@@ -352,7 +354,8 @@ struct QueryEditorView: View {
                         Button {
                             shareText = ClipboardExporter.exportRows(
                                 columns: viewModel.columns, rows: viewModel.legacyRows,
-                                format: format
+                                format: format,
+                                databaseType: databaseType, driver: coordinator.session?.driver
                             )
                             showShareSheet = true
                         } label: {
@@ -365,7 +368,8 @@ struct QueryEditorView: View {
                         Button {
                             let text = ClipboardExporter.exportRows(
                                 columns: viewModel.columns, rows: viewModel.legacyRows,
-                                format: format
+                                format: format,
+                                databaseType: databaseType, driver: coordinator.session?.driver
                             )
                             ClipboardExporter.copyToClipboard(text)
                         } label: {
@@ -391,17 +395,11 @@ struct QueryEditorView: View {
 
     // MARK: - Execution
 
-    private func isWriteQuery(_ sql: String) -> Bool {
-        let trimmed = sql.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
-        let writeKeywords = ["INSERT", "UPDATE", "DELETE", "DROP", "ALTER", "CREATE", "TRUNCATE", "REPLACE"]
-        return writeKeywords.contains(where: { trimmed.hasPrefix($0) })
-    }
-
     private func executeQuery() async {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
 
-        if isWriteQuery(trimmed) {
+        if SQLWriteClassifier.isWriteQuery(trimmed, databaseType: databaseType) {
             switch safeModeLevel.writePermission {
             case .blocked:
                 showWriteBlockedAlert = true

--- a/TableProMobile/TableProMobile/Views/RowDetailView.swift
+++ b/TableProMobile/TableProMobile/Views/RowDetailView.swift
@@ -20,6 +20,7 @@ struct RowDetailView: View {
         session: ConnectionSession? = nil,
         columnDetails: [ColumnInfo] = [],
         databaseType: DatabaseType = .sqlite,
+        schema: String? = nil,
         safeModeLevel: SafeModeLevel = .off,
         foreignKeys: [ForeignKeyInfo] = [],
         onSaved: (() -> Void)? = nil,
@@ -33,6 +34,7 @@ struct RowDetailView: View {
             session: session,
             columnDetails: columnDetails,
             databaseType: databaseType,
+            schema: schema,
             safeModeLevel: safeModeLevel,
             foreignKeys: foreignKeys,
             onSaved: onSaved,
@@ -175,7 +177,8 @@ struct RowDetailView: View {
                 Button {
                     shareText = ClipboardExporter.exportRow(
                         columns: viewModel.columns, row: viewModel.currentRow,
-                        format: format, tableName: viewModel.table?.name
+                        format: format, tableName: viewModel.table?.name,
+                        databaseType: viewModel.databaseType, driver: viewModel.session?.driver
                     )
                     showShareSheet = true
                 } label: {
@@ -188,7 +191,8 @@ struct RowDetailView: View {
                 Button {
                     let text = ClipboardExporter.exportRow(
                         columns: viewModel.columns, row: viewModel.currentRow,
-                        format: format, tableName: viewModel.table?.name
+                        format: format, tableName: viewModel.table?.name,
+                        databaseType: viewModel.databaseType, driver: viewModel.session?.driver
                     )
                     ClipboardExporter.copyToClipboard(text)
                 } label: {

--- a/TableProMobile/TableProMobile/Views/TableListView.swift
+++ b/TableProMobile/TableProMobile/Views/TableListView.swift
@@ -9,6 +9,10 @@ struct TableListView: View {
     private var tables: [TableInfo] { coordinator.tables }
     private var session: ConnectionSession? { coordinator.session }
 
+    private var activeSchema: String? {
+        coordinator.supportsSchemas ? coordinator.activeSchema : nil
+    }
+
     /// Scoped to the connection: one shared key leaves a filter from another connection applied
     /// to a list that never shows it.
     @SceneStorage private var searchText: String
@@ -139,7 +143,9 @@ struct TableListView: View {
                 if let table = tableToTruncate {
                     Task {
                         do {
-                            let quoted = SQLBuilder.quoteIdentifier(table.name, for: connection.type)
+                            let quoted = SQLBuilder.qualifiedIdentifier(
+                                table: table.name, schema: activeSchema, for: connection.type
+                            )
                             _ = try await session?.driver.execute(query: "TRUNCATE TABLE \(quoted)")
                             await coordinator.refreshTables()
                         } catch {
@@ -163,7 +169,9 @@ struct TableListView: View {
                 if let table = tableToDrop {
                     Task {
                         do {
-                            let quoted = SQLBuilder.quoteIdentifier(table.name, for: connection.type)
+                            let quoted = SQLBuilder.qualifiedIdentifier(
+                                table: table.name, schema: activeSchema, for: connection.type
+                            )
                             _ = try await session?.driver.execute(query: "DROP TABLE \(quoted)")
                             await coordinator.refreshTables()
                         } catch {

--- a/TableProMobile/TableProMobileTests/Helpers/ClipboardExporterFidelityTests.swift
+++ b/TableProMobile/TableProMobileTests/Helpers/ClipboardExporterFidelityTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import TableProModels
+import Testing
+@testable import TableProMobile
+
+@Suite("ClipboardExporter round-trip fidelity")
+struct ClipboardExporterFidelityTests {
+    private let columns = [
+        ColumnInfo(name: "id", typeName: "INT", ordinalPosition: 0),
+        ColumnInfo(name: "zip", typeName: "VARCHAR(10)", ordinalPosition: 1),
+        ColumnInfo(name: "note", typeName: "TEXT", ordinalPosition: 2)
+    ]
+
+    private func csv(_ row: [String?]) -> String {
+        ClipboardExporter.exportRows(
+            columns: columns, rows: [row], format: .csv,
+            tableName: "t", databaseType: .postgresql, driver: nil
+        )
+    }
+
+    private func json(_ row: [String?]) -> String {
+        ClipboardExporter.exportRow(
+            columns: columns, row: row, format: .json,
+            tableName: "t", databaseType: .postgresql, driver: nil
+        )
+    }
+
+    private func insert(_ row: [String?], _ type: DatabaseType) -> String {
+        ClipboardExporter.exportRow(
+            columns: columns, row: row, format: .sqlInsert,
+            tableName: "t", databaseType: type, driver: nil
+        )
+    }
+
+    // MARK: - CSV
+
+    @Test("a NULL and the text NULL do not export the same way")
+    func nullIsDistinguishable() {
+        let withNull = csv(["1", nil, "x"])
+        let withText = csv(["1", "NULL", "x"])
+        #expect(withNull != withText)
+        #expect(withNull.hasSuffix("1,,x"))
+        #expect(withText.hasSuffix("1,\"NULL\",x"))
+    }
+
+    @Test("an empty string is quoted so it does not read as NULL")
+    func emptyStringIsQuoted() {
+        #expect(csv(["1", "", "x"]).hasSuffix("1,\"\",x"))
+    }
+
+    @Test("a field with a comma, quote or newline still escapes")
+    func csvEscaping() {
+        #expect(csv(["1", "a,b", "x"]).hasSuffix("1,\"a,b\",x"))
+        #expect(csv(["1", "a\"b", "x"]).hasSuffix("1,\"a\"\"b\",x"))
+    }
+
+    // MARK: - JSON
+
+    @Test("a leading-zero string stays a string, so the JSON parses")
+    func leadingZeroStaysAString() throws {
+        let text = json(["1", "01234", "x"])
+        #expect(text.contains("\"zip\": \"01234\""))
+        let data = try #require(text.data(using: .utf8))
+        _ = try JSONSerialization.jsonObject(with: data)
+    }
+
+    @Test("values a JSON parser would reject unquoted stay quoted")
+    func nonJsonNumbersStayStrings() throws {
+        for value in ["+5", "0x10", "1.", ".5", "1e", "Infinity", "NaN", " 1", "\u{0661}\u{0662}\u{0663}"] {
+            let text = json(["1", value, "x"])
+            let data = try #require(text.data(using: .utf8))
+            _ = try JSONSerialization.jsonObject(with: data)
+            #expect(text.contains("\"zip\": \"\(value)\""), "\(value) should stay quoted")
+        }
+    }
+
+    @Test("real numbers are still emitted unquoted")
+    func realNumbersStayNumbers() {
+        #expect(json(["1", "0", "x"]).contains("\"zip\": 0"))
+        #expect(json(["1", "-12", "x"]).contains("\"zip\": -12"))
+        #expect(json(["1", "1.5", "x"]).contains("\"zip\": 1.5"))
+        #expect(json(["1", "1e10", "x"]).contains("\"zip\": 1e10"))
+    }
+
+    @Test("a NULL is emitted as JSON null")
+    func jsonNull() {
+        #expect(json(["1", nil, "x"]).contains("\"zip\": null"))
+    }
+
+    // MARK: - SQL INSERT
+
+    @Test("identifiers are quoted for the dialect, not always ANSI")
+    func identifierQuoting() {
+        #expect(insert(["1", "a", "b"], .mysql).hasPrefix("INSERT INTO `t` (`id`, `zip`, `note`)"))
+        #expect(insert(["1", "a", "b"], .postgresql).hasPrefix("INSERT INTO \"t\" (\"id\", \"zip\", \"note\")"))
+        #expect(insert(["1", "a", "b"], .mssql).hasPrefix("INSERT INTO [t] ([id], [zip], [note])"))
+    }
+
+    @Test("MySQL escapes a backslash, ANSI dialects do not")
+    func literalEscaping() {
+        #expect(insert(["1", #"a\b"#, "c"], .mysql).contains(#"'a\\b'"#))
+        #expect(insert(["1", #"a\b"#, "c"], .postgresql).contains(#"'a\b'"#))
+        #expect(insert(["1", "it's", "c"], .postgresql).contains("'it''s'"))
+    }
+
+    @Test("a NULL stays the NULL keyword rather than a quoted string")
+    func insertNull() {
+        #expect(insert(["1", nil, "c"], .postgresql).contains(", NULL, "))
+    }
+}

--- a/TableProMobile/TableProMobileTests/Helpers/SQLBuilderSchemaQualificationTests.swift
+++ b/TableProMobile/TableProMobileTests/Helpers/SQLBuilderSchemaQualificationTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import TableProModels
+import TableProQuery
+import Testing
+@testable import TableProMobile
+
+/// SQL Server has no session-level schema to set, so every data statement has to name the schema
+/// the toolbar shows. An unqualified one resolves against the login's default schema, which is a
+/// different table of the same name.
+@Suite("SQLBuilder schema qualification")
+struct SQLBuilderSchemaQualificationTests {
+    private func driver() -> MockDatabaseDriver { MockDatabaseDriver() }
+
+    @Test("a select names the schema it was given")
+    func selectIsQualified() {
+        #expect(SQLBuilder.buildSelect(table: "orders", schema: "sales", type: .mssql, limit: 10, offset: 0)
+            .hasPrefix("SELECT * FROM [sales].[orders]"))
+        #expect(SQLBuilder.buildCount(table: "orders", schema: "sales", type: .mssql)
+            == "SELECT COUNT(*) FROM [sales].[orders]")
+    }
+
+    @Test("a delete names the schema, so it cannot remove the default schema's rows")
+    func deleteIsQualified() {
+        let sql = SQLBuilder.buildDelete(
+            table: "orders", schema: "sales", type: .mssql, driver: driver(),
+            primaryKeys: [(column: "id", value: "1")]
+        )
+        #expect(sql.hasPrefix("DELETE FROM [sales].[orders] WHERE"))
+    }
+
+    @Test("an update names the schema")
+    func updateIsQualified() {
+        let sql = SQLBuilder.buildUpdate(
+            table: "orders", schema: "sales", type: .mssql, driver: driver(),
+            changes: [(column: "note", value: "x")],
+            primaryKeys: [(column: "id", value: "1")]
+        )
+        #expect(sql.hasPrefix("UPDATE [sales].[orders] SET"))
+    }
+
+    @Test("a filtered select and count name the schema")
+    func filteredIsQualified() {
+        #expect(SQLBuilder.buildFilteredSelect(
+            table: "orders", schema: "sales", type: .mssql,
+            filters: [], logicMode: .and, limit: 10, offset: 0
+        ).hasPrefix("SELECT * FROM [sales].[orders]"))
+        #expect(SQLBuilder.buildFilteredCount(
+            table: "orders", schema: "sales", type: .mssql, filters: [], logicMode: .and
+        ).hasPrefix("SELECT COUNT(*) FROM [sales].[orders]"))
+    }
+
+    @Test("a search select and count name the schema")
+    func searchIsQualified() {
+        let columns = [ColumnInfo(name: "note", typeName: "nvarchar", ordinalPosition: 0)]
+        #expect(SQLBuilder.buildSearchSelect(
+            table: "orders", schema: "sales", type: .mssql,
+            searchText: "a", searchColumns: columns, limit: 10, offset: 0
+        ).hasPrefix("SELECT * FROM [sales].[orders]"))
+        #expect(SQLBuilder.buildSearchCount(
+            table: "orders", schema: "sales", type: .mssql,
+            searchText: "a", searchColumns: columns
+        ).hasPrefix("SELECT COUNT(*) FROM [sales].[orders]"))
+    }
+
+    @Test("a nil schema leaves the identifier unqualified, for engines that have none")
+    func nilSchemaStaysBare() {
+        #expect(SQLBuilder.buildCount(table: "orders", schema: nil, type: .mysql)
+            == "SELECT COUNT(*) FROM `orders`")
+        #expect(SQLBuilder.buildCount(table: "orders", schema: "", type: .mysql)
+            == "SELECT COUNT(*) FROM `orders`")
+    }
+
+    @Test("the qualifier follows each dialect's own quoting")
+    func dialectQuoting() {
+        #expect(SQLBuilder.qualifiedIdentifier(table: "orders", schema: "sales", for: .postgresql)
+            == "\"sales\".\"orders\"")
+        #expect(SQLBuilder.qualifiedIdentifier(table: "orders", schema: "sales", for: .mssql)
+            == "[sales].[orders]")
+        #expect(SQLBuilder.qualifiedIdentifier(table: "orders", schema: "sales", for: .mysql)
+            == "`sales`.`orders`")
+    }
+}


### PR DESCRIPTION
The six defects the investigation behind #2548 found and reported rather than fixed. One commit each.

## Safe Mode let a write run when it followed a comment or a CTE

`QueryEditorView.isWriteQuery` classified by `hasPrefix` over eight uppercased keywords, so recognition required the write verb to be the literal first characters. Anything else fell through the `safeModeLevel.writePermission` gate and ran unconfirmed. On a Read-Only connection:

```sql
-- cleanup
DELETE FROM users
```

A write-keyword allowlist cannot be made safe, because whatever it has not been taught runs unguarded. `SQLWriteClassifier` in `TableProQuery` inverts it: a statement is a read only when its leading keyword is one of a short closed set, and everything else writes, including a keyword it has never seen. It strips leading line and block comments, splits a batch on semicolons that are not inside a literal, an identifier quote or a comment, and treats any write in the batch as a write.

Five holes were found by compiling and running an earlier draft, and each has a test:

| Input | Was | Why it matters |
| --- | --- | --- |
| `EXPLAIN ANALYZE DELETE FROM users` | read | PostgreSQL executes the delete |
| `PRAGMA journal_mode = WAL` | read | writes on SQLite and DuckDB |
| `SELECT * INTO backup FROM users` | read | creates a table on SQL Server |
| `SELECT 'a\' ; DELETE FROM users` | one statement | PostgreSQL sets `standard_conforming_strings = on`, so the backslash is not an escape and this is two statements |
| `WITH x AS (…) SELECT * INTO backup FROM x` | read | same as row three, through the CTE path |

Redis needed its own arm. It speaks commands rather than SQL, so the SQL path called every `GET` a write, and Read-Only would have refused every read on a supported engine whose Query tab is always shown. The read-command set is the one `QueryClassifier.swift:436-451` already curates for the Mac.

The classifier lives in `TableProQuery`, which only TableProMobile and TableProCore's own tests link, so this compiles nothing the macOS app builds. macOS keeps its own `QueryClassifier`; sharing one would mean generalising ~1,300 lines over two different `DatabaseType`s and was out of scope here.

## Deep links could never work on iOS

`TableProMobileApp.onOpenURL` parses `tablepro://connect/<uuid>`, the Open Connection intent opens that URL, both widget views and the Live Activity build it, and `docs/ios/index.mdx` says deep links work as on the Mac. `CFBundleURLTypes` was absent from the iOS `Info.plist`, so the app claimed no scheme and the OS had nothing to route to. Measured: `PlistBuddy` reported the key does not exist on the built app, and `simctl openurl` failed with `LSApplicationWorkspaceErrorDomain error 115` until the plist was patched by hand.

The entry mirrors the Mac's first one exactly. The Mac's second entry, the `postgresql`/`mysql` schemes, is deliberately not copied: nothing on iOS parses an external database URL, and an unused claim is how this drifted in the first place.

## PostgreSQL and Redshift read the wrong schema

`fetchTables`, `fetchColumns`, `fetchIndexes` and `fetchForeignKeys` each resolved a nil schema to the literal `"public"` and never read `currentSchema`, which `switchSchema` keeps in step with `search_path`. Measured against PostgreSQL 17: with an `app.orders` of three columns and a `public.orders` of two, the driver returned **two** columns, so the app showed and edited metadata belonging to a different table rather than simply finding nothing.

`effectiveSchema` alone would have been inert. `connect()` never probed, so `currentSchema` stayed the seeded `"public"` and the fallback returned the literal it replaced on every fresh connection; the fix would only have bitten after the user switched schema by hand. `adoptServerSchema` runs `SELECT current_schema()` at connect, the way `MSSQLDriver` and `OracleDriver` already do. Measured: returns `app` for a role carrying `ALTER ROLE … SET search_path TO app`, and `public` otherwise.

## SQL Server read and wrote the login's default schema

T-SQL has no session-level schema to set, so `MSSQLDriver.switchSchema` correctly only records the choice, and metadata already followed it. The data statements did not: every `SELECT`, `COUNT`, `UPDATE` and `DELETE` named a bare table, which resolves against the login's default schema rather than the one in the toolbar.

Two paths were worse than the report described, and neither was in it:

- `TableListView` ran **`TRUNCATE TABLE` and `DROP TABLE` unqualified**. With a `sales.orders` and a `dbo.orders`, the destructive statement could hit the wrong one while the UI named the other.
- `FKPreviewView` built an unqualified `SELECT` reachable from the row context menu.

`schema` is now a **required** parameter on all ten `SQLBuilder` data builders, so no call site can silently stay unqualified, and it flows from `coordinator.activeSchema` through the view model. The foreign-key preview uses `ForeignKeyInfo.referencedSchema` rather than the browsing schema, because a key may point into another schema; no iOS driver populates that field yet, so it stays unqualified exactly as before and becomes correct the moment one does.

The browser keeps **one** schema snapshot. An earlier version recomputed it per child, so a schema switch with a table open left the view model on the old schema for the rows and deletes while the row editor and insert form used the new one, and an edit could reach a different table than the rows on screen. Every statement now reads `viewModel.schema`, and a switch re-attaches and reloads.

This reaches five engines, not one: `supportsSchemas` covers PostgreSQL, Redshift, SQL Server, DuckDB and Oracle.

## Computed SQL Server columns were offered as editable

`MSSQLColumnRow` carried no computed flag, so `ColumnInfo.isGenerated` stayed false and a computed column rendered as an ordinary field. Measured on SQL Server 2022: `COLUMNPROPERTY(…, 'IsComputed')` returns 1 for it, writing to it gives `Msg 271 … cannot be modified because it is either a computed column or is the result of a UNION operator`, and omitting it computes correctly.

The macOS plugin had the same bug independently, and `PluginColumnInfo.isGenerated` predates #2548 and was simply never populated. Because the plugin owns its own DML generation, populating the field was not enough on its own: computed columns now join the identity cache that `generateMssqlInsert` already filters, and `fetchAllColumns` populates both caches, having previously populated neither.

## Exports corrupted data on a round trip

Three separate defects in `ClipboardExporter`:

- **CSV** wrote `row[i] ?? "NULL"` unquoted, so a real NULL and a cell holding the text `NULL` were identical. NULL is now an unquoted empty field and the text is quoted.
- **JSON** decided numeric-versus-string by parsing the cell's own text, so `Int64("01234")` succeeded and the export emitted `01234` unquoted, which no JSON parser accepts. It now tests the JSON number grammar over ASCII digits, which also keeps `+5`, `0x10` and `١٢٣` quoted. Gating on the column type was rejected: `columns` is the result set, MySQL reports `NEWDECIMAL`, and SQLite reports `""` for every expression, so `SELECT COUNT(*)` would have regressed to a quoted string.
- **SQL INSERT** hard-coded ANSI double-quoted identifiers, which **MySQL and MariaDB reject as a syntax error** whatever the escaping, and applied ANSI literal escaping everywhere. Identifiers now go through `SQLBuilder.quoteIdentifier` and literals through the driver, matching how `SQLBuilder` already works. This also closes an unescaped embedded quote in an identifier.

`parseCSV` is deliberately unchanged. Pairing CSV `NULL → ""` with `parseCSV "" → .null` would turn every empty string into NULL on re-import, which is the same indistinguishability being fixed.

## Verification

- iOS: **267 tests pass, 0 fail**
- `TableProQuery`: **21 classifier tests pass**
- macOS app: builds clean
- `MSSQLDriver` plugin target: builds clean, which PR CI never does because MSSQL is registry-only
- SwiftLint: 0 violations across `TableProMobile`, `Packages/TableProCore/Sources` and `Plugins/MSSQLDriverPlugin`; docs checks pass

Behaviour was measured against a real PostgreSQL 17, a real SQL Server 2022, `sqlite3` and the `duckdb` CLI rather than read off documentation. Both patched MSSQL queries were run against the live server to confirm `IS_COMPUTED` lands at the index the parser reads.

Two reviewers read the diff. A `code-review` pass produced six findings, five fixed here. A Codex pass produced five more, all addressed, including the schema-snapshot desync above and a CTE that called `replace()` classifying as a write, which would have made Read-Only block an ordinary read. A self-directed security pass then found one more, fixed here: narrowing the CTE scan to remove that false positive had reopened `SELECT INTO` through the CTE path.

## Two things to know before this ships

**MSSQL is registry-only.** The plugin half of the computed-column fix reaches users through a `plugin-mssql-v*` tag rather than the next app release. No plugin has been published.

**`isGenerated` now also blocks grid edits on macOS** for computed columns, via `DataGridView+Editing.swift`. That is correct, since SQL Server refuses the write, but it is a visible change to existing behaviour.

## Not covered

`TableProMobile` has no UI test target, so none of this could get XCUITest coverage. Oracle and DuckDB still report neither identity nor generated columns, and SQL Server reports no generated flag on iOS beyond the computed one added here; their metadata queries live in packages the macOS app also links. A column left on **DEFAULT** is omitted on every engine regardless, so the user-facing behaviour is correct everywhere; what those engines lose is the extra refusal when a value is typed in.
