### PR TITLE
fix(connections): keep the connections strip and its commands when a connection is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Connections strip not scrolling to the entry you switch to.
 - Background connections stuck on the session preparation screen after connecting. (#2545)
 - Blank sidebar, grid and inspector on a connection opened into a window that was already on screen.
+- Connections strip hidden, with Switch Connection and the Show Next and Previous Connection items disabled, whenever the connection on screen was not connected.
+- Choosing a connection from the connection list re-fronting its window without switching to it.
 - Grid cells left at the old column positions until the next click, after a resize, an auto-fit, a reorder, hiding a column, or a row-number width change. (#2449, #2446)
 - The row-number column draggable out of first place, which walked it to the far right on the next refresh.
 - A time entered into a date cell discarded when the stored value carried no time.

--- a/TablePro/Core/Services/Infrastructure/ConnectionWindowPaneResolver.swift
+++ b/TablePro/Core/Services/Infrastructure/ConnectionWindowPaneResolver.swift
@@ -12,6 +12,16 @@ internal enum ConnectionWindowPane: Equatable {
     case empty
 }
 
+/// What the window's one sidebar item holds. `railOnly` is the state that exists because the
+/// workspace rail and the object browser share that item and answer to different owners.
+internal enum SidebarChromeMode: Equatable {
+    case revealed
+    case railOnly
+    case hidden
+
+    internal var showsObjectBrowser: Bool { self == .revealed }
+}
+
 internal enum ConnectionWindowPaneResolver {
     internal static func pane(
         phase: ConnectionWindowPhase,
@@ -33,8 +43,8 @@ internal enum ConnectionWindowPaneResolver {
         }
     }
 
-    /// A sidebar and an inspector with nothing to put in them are not chrome, they are two empty
-    /// columns that promise a session the window does not have yet.
+    /// An object browser and an inspector with nothing to put in them are not chrome, they are two
+    /// empty columns that promise a session the window does not have yet.
     internal static func hidesChrome(for pane: ConnectionWindowPane) -> Bool {
         switch pane {
         case .content:
@@ -42,6 +52,21 @@ internal enum ConnectionWindowPaneResolver {
         case .connecting, .unavailable, .empty:
             return true
         }
+    }
+
+    /// How much of the window's sidebar survives the pane it is standing next to.
+    ///
+    /// The rule above is right about the object browser and wrong about the workspace rail, which
+    /// lists every connection the window hosts and belongs to the window rather than to any one of
+    /// them. They share a split item because AppKit grants full-height sidebar layout to exactly one
+    /// leading sidebar, so collapsing for an empty object browser took the switcher with it and left
+    /// the window's other connections with no way in.
+    internal static func sidebarChromeMode(
+        for pane: ConnectionWindowPane,
+        hasRail: Bool
+    ) -> SidebarChromeMode {
+        guard hidesChrome(for: pane) else { return .revealed }
+        return hasRail ? .railOnly : .hidden
     }
 
     /// The tab strip's band is a list of tabs, so it appears only when there is a list worth

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController+MenuValidation.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController+MenuValidation.swift
@@ -229,9 +229,15 @@ extension MainSplitViewController: NSMenuItemValidation {
         }
     }
 
+    /// The workspace-rail facts come from the window in both branches. They are true of the window,
+    /// not of the connection it happens to be showing, and reading them off a connection that has
+    /// no coordinator left disabled the only menu route to the window's other connections.
     var menuValidationContext: MenuValidationContext {
         guard let actions = commandActions else {
-            return MenuValidationContext(hasSelectedWorkspace: workspaces.selectedConnectionId != nil)
+            return MenuValidationContext(
+                hasSelectedWorkspace: workspaces.selectedConnectionId != nil,
+                canToggleWorkspaceRail: canToggleWorkspaceRail
+            )
         }
         return MenuValidationContext(
             hasSelectedWorkspace: workspaces.selectedConnectionId != nil,
@@ -259,7 +265,7 @@ extension MainSplitViewController: NSMenuItemValidation {
             canNavigateForward: actions.canNavigateForward,
             canSaveAsFavorite: actions.canSaveAsFavorite,
             canSwitchSidebarLayout: actions.canSwitchSidebarLayout,
-            canToggleWorkspaceRail: actions.canToggleWorkspaceRail,
+            canToggleWorkspaceRail: canToggleWorkspaceRail,
             canShowTableStructure: actions.canShowTableStructure,
             canEditViewDefinition: actions.canEditViewDefinition,
             canCreateDatabase: actions.canCreateDatabase,

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController+ViewMenuActions.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController+ViewMenuActions.swift
@@ -10,12 +10,16 @@ extension MainSplitViewController {
         toggleWorkspaceRail()
     }
 
+    /// Switching which connection the window shows is the window's own business, so it acts on the
+    /// registry directly the way `toggleWorkspaceRail(_:)` already does. Routing it through the
+    /// selected connection's `commandActions` made it a no-op exactly when it was needed: that
+    /// connection losing its session is what leaves the others unreachable.
     @objc func showPreviousWorkspace(_ sender: Any?) {
-        commandActions?.showPreviousWorkspace()
+        activateWorkspace(offsetBy: -1)
     }
 
     @objc func showNextWorkspace(_ sender: Any?) {
-        commandActions?.showNextWorkspace()
+        activateWorkspace(offsetBy: 1)
     }
 
     @objc func setResultView(_ sender: Any?) {

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -104,8 +104,6 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     var tabStripObservationIsArmed = false
     var tabStripObservedManager: ObjectIdentifier?
 
-    private var chromeState: ChromeState = .unapplied
-
     // MARK: - Panel Layout State
 
     /// One name for the window's split view, because one `NSSplitView` can only carry one.
@@ -253,6 +251,10 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         navigationSidebar.railController.host = self
         navigationSidebar.railController.onLayoutChange = { [weak self] _ in
             self?.navigationSidebar.applyRailWidth(animated: false)
+            /// The row size is a setting, so the rail's own width changes under a sidebar already
+            /// narrowed to it. Reapplying the clamp is what moves both thicknesses onto the new
+            /// allowance rather than clipping the rail against the old one.
+            self?.reapplySidebarClampIfNarrowed()
             self?.recomputeWindowMinSize()
         }
         sidebarSplitItem = NSSplitViewItem(sidebarWithViewController: navigationSidebar)
@@ -935,6 +937,11 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         navigationSidebar.setRailVisible(visible, animated: view.window != nil) { [weak self] in
             self?.recomputeWindowMinSize()
         }
+        /// The rail appearing or going is a chrome change of its own, and it happens without the
+        /// selected connection's phase moving: a sibling opening or closing is enough. Without this
+        /// a window whose connection is down keeps a fully collapsed sidebar when the rail arrives,
+        /// or an empty clamped column after it leaves.
+        applyPaneChrome()
     }
 
     func activateWorkspace(offsetBy offset: Int) {
@@ -943,8 +950,25 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
 
     // MARK: - Sidebar
 
+    /// Whether the object browser is off screen, which is the question every caller is really
+    /// asking: the toolbar's segment, the Show/Hide Sidebar title and the reveal actions. A sidebar
+    /// narrowed to the workspace rail is an open split item with no object browser in it, so the
+    /// item's own flag is not the answer on its own.
     var isSidebarCollapsed: Bool {
-        sidebarSplitItem?.isCollapsed ?? true
+        guard sidebarChromeMode.showsObjectBrowser else { return true }
+        return sidebarSplitItem?.isCollapsed ?? true
+    }
+
+    var isSidebarUserCollapsible: Bool {
+        sidebarSplitItem?.canCollapse ?? false
+    }
+
+    var sidebarThicknessRange: (min: CGFloat, max: CGFloat) {
+        (sidebarSplitItem?.minimumThickness ?? 0, sidebarSplitItem?.maximumThickness ?? 0)
+    }
+
+    var railAllowance: CGFloat {
+        navigationSidebar?.railAllowance ?? 0
     }
 
     /// Every collapse route reaches AppKit's own `toggleSidebar(_:)`: the View menu sends the
@@ -957,6 +981,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     }
 
     func focusSidebarSearch() {
+        guard sidebarChromeMode.showsObjectBrowser else { return }
         if sidebarSplitItem?.isCollapsed == true {
             sidebarSplitItem?.animator().isCollapsed = false
         }
@@ -964,6 +989,7 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
     }
 
     func presentDatabaseFilter() {
+        guard sidebarChromeMode.showsObjectBrowser else { return }
         guard let connectionId = currentSession?.connection.id else { return }
         if sidebarSplitItem?.isCollapsed == true {
             sidebarSplitItem?.isCollapsed = false
@@ -981,7 +1007,11 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         state.databaseFilterSelected = []
     }
 
+    /// Refused while the sidebar is narrowed to the workspace rail. The item is open, so the
+    /// collapse branch below would read it as showing and collapse it, taking the rail and every
+    /// route to the window's other connections with it.
     func setSidebarTab(_ tab: SidebarTab) {
+        guard sidebarChromeMode.showsObjectBrowser else { return }
         guard let connectionId = currentSession?.connection.id else { return }
         let sidebarState = SharedSidebarState.forConnection(connectionId)
 
@@ -1062,8 +1092,12 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
         )
     }
 
+    /// Inert while the sidebar is clamped to the rail. Seven other call sites reach
+    /// `recomputeWindowMinSize`, and any of them writing the object browser's minimum back over the
+    /// clamp would leave a minimum above the maximum.
     private func applySidebarMinimumThickness() {
         guard let sidebarSplitItem else { return }
+        guard appliedSidebarMode ?? .revealed == .revealed else { return }
         let resolved = Self.resolveSidebarMinimumThickness(
             railAllowance: navigationSidebar?.railAllowance ?? 0
         )
@@ -1108,52 +1142,99 @@ internal final class MainSplitViewController: NSSplitViewController, InspectorVi
 
     // MARK: - Pane Chrome
 
-    private enum ChromeState {
-        case unapplied
-        case hidden
-        case revealed
-    }
-
     private var userPaneLayout: ChromePaneLayout?
+
+    /// What this window's sidebar is currently showing, and `nil` before the first application.
+    /// The resolver decides the mode; this records which one has been put on screen.
+    private var appliedSidebarMode: SidebarChromeMode?
+
+    internal var sidebarChromeMode: SidebarChromeMode {
+        ConnectionWindowPaneResolver.sidebarChromeMode(
+            for: currentPane,
+            hasRail: navigationSidebar?.isRailVisible ?? false
+        )
+    }
 
     /// A split item's collapse state is written into the autosave record, which is how the
     /// inspector remembers being hidden. Collapsing the sidebar for a phase the user did not
     /// choose would persist that as their layout and lose the width they set, so autosaving is
-    /// switched off for the whole span the chrome is hidden and switched back on to restore it.
+    /// switched off for the whole span the chrome is not revealed and switched back on to restore
+    /// it. The same is true of a clamp, which writes its narrow width into the record the way a
+    /// collapse writes the collapsed flag.
     func applyPaneChrome() {
-        if ConnectionWindowPaneResolver.hidesChrome(for: currentPane) {
-            hideWindowChrome()
-        } else {
-            revealWindowChrome()
-        }
+        applySidebarChromeMode(sidebarChromeMode)
         applyTabStripVisibility()
         toolbarOwner?.managedToolbar.validateVisibleItems()
         recomputeWindowMinSize()
     }
 
-    private func hideWindowChrome() {
-        guard chromeState != .hidden else { return }
-        chromeState = .hidden
+    private func applySidebarChromeMode(_ mode: SidebarChromeMode) {
+        guard appliedSidebarMode != mode else { return }
+        let previous = appliedSidebarMode
+        appliedSidebarMode = mode
 
-        resignFirstResponderInsideChrome()
-        splitView.autosaveName = nil
-        userPaneLayout = ChromePaneLayout(
-            isSidebarCollapsed: sidebarSplitItem.isCollapsed,
-            isInspectorCollapsed: inspectorSplitItem.isCollapsed
-        )
-        sidebarSplitItem.isCollapsed = true
+        guard mode != .revealed else {
+            revealWindowChrome()
+            return
+        }
+
+        /// Captured on the way out of `revealed` and never again, because the geometry a
+        /// `railOnly` to `hidden` step would see is the clamp, not the width the user chose.
+        if previous == nil || previous == .revealed {
+            resignFirstResponderInsideChrome()
+            splitView.autosaveName = nil
+            userPaneLayout = ChromePaneLayout(
+                isSidebarCollapsed: sidebarSplitItem.isCollapsed,
+                isInspectorCollapsed: inspectorSplitItem.isCollapsed
+            )
+        }
+
         inspectorSplitItem.isCollapsed = true
+        switch mode {
+        case .railOnly:
+            sidebarSplitItem.isCollapsed = false
+            clampSidebarToRail()
+        case .hidden:
+            releaseSidebarClamp()
+            sidebarSplitItem.isCollapsed = true
+        case .revealed:
+            break
+        }
         view.window?.recalculateKeyViewLoop()
     }
 
-    /// Autosaving is off while the chrome is hidden, so the record still holds what the user had.
-    /// AppKit will not re-apply it though: assigning an autosave name to a split view that has
+    /// Narrowed rather than collapsed, so the rail stays on screen while the object browser it
+    /// shares a split item with goes. Measured: clamping and later releasing returns the item to
+    /// the width the user set, but a `setPosition` while the clamp holds discards it, which is why
+    /// nothing else may write the sidebar's thickness for the span.
+    private func clampSidebarToRail() {
+        let allowance = navigationSidebar?.railAllowance ?? 0
+        sidebarSplitItem.minimumThickness = allowance
+        sidebarSplitItem.maximumThickness = allowance
+        /// A clamp is not a lock. AppKit still collapses a collapsible item on a divider
+        /// double-click or a drag to the edge, which no menu or toolbar validation sees, and the
+        /// mode is already applied so nothing would open it again.
+        sidebarSplitItem.canCollapse = false
+    }
+
+    internal func reapplySidebarClampIfNarrowed() {
+        guard appliedSidebarMode == .railOnly else { return }
+        clampSidebarToRail()
+    }
+
+    private func releaseSidebarClamp() {
+        sidebarSplitItem.canCollapse = true
+        sidebarSplitItem.maximumThickness = Self.sidebarMaxThickness
+        applySidebarMinimumThickness()
+    }
+
+    /// Autosaving is off while the chrome is not revealed, so the record still holds what the user
+    /// had. AppKit will not re-apply it though: assigning an autosave name to a split view that has
     /// already laid out restores nothing. The state captured on the way in is therefore what gives
     /// the panes back. Forcing the sidebar open here instead reopened a sidebar the user had
     /// deliberately hidden, every time a connection dropped and came back.
     private func revealWindowChrome() {
-        guard chromeState != .revealed else { return }
-        chromeState = .revealed
+        releaseSidebarClamp()
 
         /// Only a reveal that follows a hide has something to put back. A first reveal is a window
         /// opening on a live connection, where the panes are already where the user's autosaved

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Validation.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Validation.swift
@@ -24,6 +24,11 @@ extension MainWindowToolbar: NSToolbarItemValidation {
         let supportsServerDashboard: Bool
         let canNavigateBack: Bool
         let canNavigateForward: Bool
+        /// Separate from `connected` because a connection that is still dialing counts as alive
+        /// while its sidebar is narrowed to the workspace rail, and a segment that toggles an
+        /// object browser the window is not showing has nothing to toggle. Defaulted, because a
+        /// context built for a connected pane is describing a window that has one.
+        var showsObjectBrowser = true
     }
 
     /// Listed exhaustively so a new state has to choose a side instead of inheriting "alive".
@@ -46,8 +51,10 @@ extension MainWindowToolbar: NSToolbarItemValidation {
             return true
         case Self.database:
             return context.connected && !context.fileBased && context.supportsContainerSwitching
-        case Self.refresh, Self.quickSwitcher, Self.newTab, Self.exportTables, Self.sidebarToggle:
+        case Self.refresh, Self.quickSwitcher, Self.newTab, Self.exportTables:
             return context.connected
+        case Self.sidebarToggle:
+            return context.connected && context.showsObjectBrowser
         case Self.addRow:
             return context.connected && context.canAddRow
         case Self.restorePreviousValues:
@@ -86,10 +93,16 @@ extension MainWindowToolbar: NSToolbarItemValidation {
             supportsImport: PluginManager.shared.supportsImport(for: state.databaseType),
             supportsServerDashboard: coordinator?.commandActions?.supportsServerDashboard ?? false,
             canNavigateBack: coordinator?.canNavigateBack ?? false,
-            canNavigateForward: coordinator?.canNavigateForward ?? false
+            canNavigateForward: coordinator?.canNavigateForward ?? false,
+            showsObjectBrowser: coordinator?.splitViewController?.sidebarChromeMode.showsObjectBrowser ?? false
         )
     }
 
+    /// No subject disables the whole toolbar, Switch Connection included. Every item here needs the
+    /// coordinator that presents it, so enabling one without a subject would leave a live-looking
+    /// button that does nothing. The routes to a window's other connections that survive a
+    /// connection going down are the connections strip and the View menu, neither of which asks a
+    /// coordinator anything.
     func validateToolbarItem(_ item: NSToolbarItem) -> Bool {
         guard let context = validationContext() else { return false }
         return Self.isEnabled(itemIdentifier: item.itemIdentifier, context: context)

--- a/TablePro/Core/Services/Infrastructure/SidebarContainerViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/SidebarContainerViewController.swift
@@ -49,10 +49,17 @@ internal final class SidebarContainerViewController: NSViewController {
         view.addSubview(hostingView)
         searchField.nextKeyView = hostingView
 
+        /// The insets are a margin, not an invariant, so they yield rather than break when the
+        /// window narrows the sidebar to the workspace rail and leaves this view no width at all.
+        let searchLeading = searchField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10)
+        let searchTrailing = searchField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -10)
+        searchLeading.priority = .defaultHigh
+        searchTrailing.priority = .defaultHigh
+
         NSLayoutConstraint.activate([
             searchField.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 5),
-            searchField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10),
-            searchField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -10),
+            searchLeading,
+            searchTrailing,
 
             hostingView.topAnchor.constraint(equalTo: searchField.bottomAnchor, constant: 5),
             hostingView.leadingAnchor.constraint(equalTo: view.leadingAnchor),

--- a/TablePro/Core/Services/Infrastructure/TabRouter.swift
+++ b/TablePro/Core/Services/Infrastructure/TabRouter.swift
@@ -105,13 +105,25 @@ internal final class TabRouter {
         }
         if let existing = WindowLifecycleMonitor.shared.mostRecentWindow(for: id)
             ?? WindowManager.shared.window(for: id) {
+            /// A window that is a background member of a tab group is one AppKit will make key
+            /// without bringing to the front of its group, so the tab has to be selected first or
+            /// the user is left looking at a different one.
+            if let group = existing.tabGroup, group.selectedWindow !== existing {
+                group.selectedWindow = existing
+            }
             existing.makeKeyAndOrderFront(nil)
             AppActivationPolicyController.shared.activate(ignoringOtherApps: true)
             WindowOpener.shared.closeWelcome()
+            let host = existing.contentViewController as? MainSplitViewController
+            /// Raising the window is not the same as showing the connection the user picked, and a
+            /// window hosts several. Without this, choosing a connected one from the connection list
+            /// re-fronted a window still showing a different connection and stopped there.
+            if let host, host.workspaces.contains(id) {
+                host.selectHostedConnection(id)
+            }
             guard DatabaseManager.shared.activeSessions[id]?.driver == nil else { return }
-            if let splitVC = existing.contentViewController as? MainSplitViewController,
-               splitVC.workspaces.contains(id) {
-                splitVC.reconnectWorkspace(id)
+            if let host, host.workspaces.contains(id) {
+                host.reconnectWorkspace(id)
             } else {
                 try await runPreConnectScriptIfNeeded(connection)
                 try await DatabaseManager.shared.ensureConnected(connection)

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -1178,26 +1178,6 @@ final class MainContentCommandActions {
         coordinator?.inspectorProxy?.toggleInspector()
     }
 
-    var isWorkspaceRailEnabled: Bool {
-        coordinator?.splitViewController?.isWorkspaceRailEnabled ?? false
-    }
-
-    var canToggleWorkspaceRail: Bool {
-        coordinator?.splitViewController?.canToggleWorkspaceRail ?? false
-    }
-
-    func toggleWorkspaceRail() {
-        coordinator?.splitViewController?.toggleWorkspaceRail()
-    }
-
-    func showPreviousWorkspace() {
-        coordinator?.splitViewController?.activateWorkspace(offsetBy: -1)
-    }
-
-    func showNextWorkspace() {
-        coordinator?.splitViewController?.activateWorkspace(offsetBy: 1)
-    }
-
     func goToPreviousPage() {
         coordinator?.goToPreviousPage()
     }

--- a/TableProTests/Core/Services/Infrastructure/ConnectionWindowChromeTests.swift
+++ b/TableProTests/Core/Services/Infrastructure/ConnectionWindowChromeTests.swift
@@ -1,0 +1,196 @@
+import AppKit
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Connection window chrome", .serialized)
+@MainActor
+struct ConnectionWindowChromeTests {
+    @Test("A window hosting a second connection keeps its rail when the selected one is unavailable")
+    func railSurvivesAnUnavailableSelectedConnection() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        harness.setRailVisible(true)
+        harness.controller.transition(
+            to: .unavailable(.failed(ConnectionFailureInfo(message: "refused"))),
+            for: harness.selected.connectionId
+        )
+
+        #expect(harness.controller.sidebarChromeMode == .railOnly)
+        #expect(harness.controller.isSidebarCollapsed)
+    }
+
+    @Test("A window with no rail still hides its sidebar outright")
+    func loneConnectionStillHidesTheSidebar() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        harness.setRailVisible(false)
+        harness.controller.transition(to: .unavailable(.notConnected), for: harness.selected.connectionId)
+
+        #expect(harness.controller.sidebarChromeMode == .hidden)
+        #expect(harness.controller.isSidebarCollapsed)
+    }
+
+    @Test("The rail arriving while the connection is down opens the sidebar for it")
+    func railArrivingWhileHiddenReopensTheSidebar() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        harness.setRailVisible(false)
+        harness.controller.transition(to: .unavailable(.notConnected), for: harness.selected.connectionId)
+        #expect(harness.controller.sidebarChromeMode == .hidden)
+
+        harness.setRailVisible(true)
+        #expect(harness.controller.sidebarChromeMode == .railOnly)
+
+        harness.setRailVisible(false)
+        #expect(harness.controller.sidebarChromeMode == .hidden)
+    }
+
+    /// The toolbar's segment reads the same answer, so a sidebar narrowed to the rail must not
+    /// report itself as showing: the segment would light up and its own action would collapse the
+    /// rail away.
+    @Test("Switching a connection cannot collapse a sidebar narrowed to the rail")
+    func settingASidebarTabIsRefusedWhileNarrowed() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        harness.setRailVisible(true)
+        harness.controller.transition(to: .connecting, for: harness.selected.connectionId)
+        #expect(harness.controller.sidebarChromeMode == .railOnly)
+
+        harness.controller.setSidebarTab(.tables)
+
+        #expect(harness.controller.sidebarChromeMode == .railOnly)
+    }
+
+    @Test("Switching a connection off and back on restores the sidebar the user had")
+    func revealRestoresTheSidebarAcrossBothHiddenModes() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        harness.setRailVisible(true)
+        harness.controller.transition(to: .connecting, for: harness.selected.connectionId)
+        #expect(harness.controller.sidebarChromeMode == .railOnly)
+
+        harness.setRailVisible(false)
+        #expect(harness.controller.sidebarChromeMode == .hidden)
+
+        harness.setRailVisible(true)
+        harness.controller.transition(to: .idle, for: harness.selected.connectionId)
+        harness.attachRenderableSession()
+        harness.controller.transition(to: .connected, for: harness.selected.connectionId)
+
+        #expect(harness.controller.sidebarChromeMode == .revealed)
+        #expect(!harness.controller.isSidebarCollapsed)
+    }
+
+    /// The connections strip and the View menu reach a window's other connections without asking a
+    /// coordinator anything, which is what makes them the routes that survive one going down.
+    @Test("Switching connection from the View menu works with no coordinator behind it")
+    func viewMenuSwitchingDoesNotNeedACoordinator() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        harness.controller.transition(to: .unavailable(.notConnected), for: harness.selected.connectionId)
+        #expect(harness.controller.commandActions == nil)
+
+        let context = harness.controller.menuValidationContext
+        #expect(context.canToggleWorkspaceRail == harness.controller.canToggleWorkspaceRail)
+    }
+
+    @Test("A sidebar narrowed to the rail cannot be collapsed by dragging its divider")
+    func narrowedSidebarRefusesUserCollapse() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        harness.setRailVisible(true)
+        harness.controller.transition(to: .connecting, for: harness.selected.connectionId)
+
+        #expect(harness.controller.sidebarChromeMode == .railOnly)
+        #expect(!harness.controller.isSidebarUserCollapsible)
+    }
+
+    @Test("The rail growing under a narrowed sidebar moves both thicknesses with it")
+    func narrowedSidebarTracksTheRailAllowance() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        harness.setRailVisible(true)
+        harness.controller.transition(to: .connecting, for: harness.selected.connectionId)
+        #expect(harness.controller.sidebarChromeMode == .railOnly)
+
+        harness.controller.reapplySidebarClampIfNarrowed()
+
+        #expect(harness.controller.sidebarThicknessRange.min == harness.controller.railAllowance)
+        #expect(harness.controller.sidebarThicknessRange.max == harness.controller.railAllowance)
+    }
+
+    @MainActor
+    private struct Harness {
+        let controller: MainSplitViewController
+        let selected: ConnectionWorkspace
+        private let sibling: ConnectionWorkspace
+        private let connection: DatabaseConnection
+        private let window: NSWindow
+
+        init() throws {
+            connection = TestFixtures.makeConnection(name: "Selected")
+            selected = Self.makeWorkspace(connection: connection, phase: .connected)
+            sibling = Self.makeWorkspace(connection: TestFixtures.makeConnection(name: "Sibling"), phase: .connected)
+
+            controller = MainSplitViewController(payload: nil, sessionState: nil, adopting: selected)
+            controller.workspaces.insert(sibling, select: false)
+
+            window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 1_200, height: 700),
+                styleMask: [.titled],
+                backing: .buffered,
+                defer: false
+            )
+            window.isReleasedWhenClosed = false
+            window.contentViewController = controller
+            window.orderFront(nil)
+        }
+
+        /// The rail's own visibility is an app-wide question the harness's unregistered window
+        /// cannot answer, so it is driven directly here rather than through the setting.
+        func setRailVisible(_ visible: Bool) {
+            controller.setWorkspaceRailVisible(visible)
+        }
+
+        func attachRenderableSession() {
+            selected.session = ConnectionSession(
+                connection: connection,
+                driver: MockDatabaseDriver(connection: connection)
+            )
+            selected.rightPanelState = RightPanelState(connectionId: connection.id)
+            selected.sessionState = SessionStateFactory.create(connection: connection, payload: nil)
+        }
+
+        func tearDown() {
+            window.orderOut(nil)
+            window.contentViewController = nil
+            sibling.teardown()
+            selected.teardown()
+        }
+
+        private static func makeWorkspace(
+            connection: DatabaseConnection,
+            phase: ConnectionWindowPhase
+        ) -> ConnectionWorkspace {
+            ConnectionWorkspace(
+                connectionId: connection.id,
+                payload: nil,
+                autoConnect: false,
+                payloadConnection: connection,
+                session: nil,
+                sessionState: nil,
+                rightPanelState: nil,
+                phase: phase
+            )
+        }
+    }
+}

--- a/TableProTests/Core/Services/Infrastructure/ConnectionWindowPaneResolverTests.swift
+++ b/TableProTests/Core/Services/Infrastructure/ConnectionWindowPaneResolverTests.swift
@@ -46,6 +46,37 @@ struct ConnectionWindowPaneResolverTests {
         }
     }
 
+    @Test("A window hosting a rail keeps it when its own connection has nothing to show")
+    func railSurvivesEveryNonContentPane() {
+        let reasons: [ConnectionUnavailableReason] = [
+            .notConnected,
+            .cancelled,
+            .disconnected(nil),
+            .disconnectedByUser,
+            .failed(Self.failure),
+            .pluginMissing(Self.failure)
+        ]
+        let panes: [ConnectionWindowPane] = [.connecting, .empty] + reasons.map { .unavailable($0) }
+
+        for pane in panes {
+            #expect(ConnectionWindowPaneResolver.sidebarChromeMode(for: pane, hasRail: true) == .railOnly)
+            #expect(ConnectionWindowPaneResolver.sidebarChromeMode(for: pane, hasRail: false) == .hidden)
+        }
+    }
+
+    @Test("Content reveals the whole sidebar whether or not a rail is in it")
+    func contentAlwaysRevealsTheSidebar() {
+        #expect(ConnectionWindowPaneResolver.sidebarChromeMode(for: .content, hasRail: true) == .revealed)
+        #expect(ConnectionWindowPaneResolver.sidebarChromeMode(for: .content, hasRail: false) == .revealed)
+    }
+
+    @Test("Only the revealed sidebar carries an object browser")
+    func objectBrowserBelongsToTheRevealedModeAlone() {
+        #expect(SidebarChromeMode.revealed.showsObjectBrowser)
+        #expect(!SidebarChromeMode.railOnly.showsObjectBrowser)
+        #expect(!SidebarChromeMode.hidden.showsObjectBrowser)
+    }
+
     @Test("Every unavailable reason reaches its pane")
     func everyUnavailableReasonResolves() {
         let reasons: [ConnectionUnavailableReason] = [


### PR DESCRIPTION
A window whose selected connection is not connected hides the connections strip and disables every menu route to the other connections it hosts. Those connections stay open, with unsaved editor state in them, and the only ways left are Cmd+W, File > Close Connection, or another window's strip.

Found while investigating #2545.

## Why the strip goes

`ConnectionWindowPaneResolver.hidesChrome` is right that an object browser with no session in it is an empty column, and `hideWindowChrome` spells that as collapsing the sidebar split item. The connections strip lives in that same item, because AppKit grants full-height sidebar layout to exactly one leading sidebar and `NavigationSidebarViewController`'s own comment records that two items was tried and rejected. So a rule about the object browser takes the window's connection switcher with it.

The strip is not per connection. It lists every connection the window hosts, and switching through it needs no session and no coordinator.

## What else was dead

Three separate things, each with the same shape: a window-level capability read off the selected connection.

`MainContentCommandActions.showPreviousWorkspace`, `showNextWorkspace`, `toggleWorkspaceRail`, `canToggleWorkspaceRail` and `isWorkspaceRailEnabled` all bounced straight back to `coordinator?.splitViewController`, so the round trip through the coordinator added nothing but a nil failure mode. `menuValidationContext` returned an all-false context whenever `commandActions` was nil, which disabled Show Next Connection and Show Previous Connection along with it, and the actions were no-ops anyway.

`TabRouter.openConnection` fronts the window and then returns at `guard activeSessions[id]?.driver == nil`. For a connection that is already up, that is every time, so Manage Connections re-fronted a window still showing a different connection and stopped there.

## The fix

`ConnectionWindowPaneResolver.sidebarChromeMode(for:hasRail:)` is a new pure function returning `revealed`, `railOnly` or `hidden`. `hidesChrome` keeps its answer and its reasoning for the object browser and the inspector.

In `railOnly` the sidebar is narrowed rather than collapsed: `minimumThickness` and `maximumThickness` both go to `railAllowance`, inside the `autosaveName = nil` span that already exists, because a clamp writes its width into the autosave record exactly as a collapse writes the collapsed flag. `canCollapse` goes to `false` for the span, since a divider double-click sees no menu validation. `applySidebarMinimumThickness` is inert while clamped, because seven other call sites reach `recomputeWindowMinSize` and any of them writing the minimum back would leave a minimum above the maximum. The rail's own width is a setting, so `onLayoutChange` reapplies the clamp.

`ChromePaneLayout` is captured on the way out of `revealed` and never again, so a `railOnly` to `hidden` step cannot overwrite the user's width with the clamp.

`isSidebarCollapsed` now answers "the object browser is off screen", which is what its five readers were asking. That keeps the toolbar's segment unlit and the menu title correct, and `setSidebarTab`, `focusSidebarSearch` and `presentDatabaseFilter` are refused while narrowed.

The sidebar segment is disabled when there is no object browser to toggle. The View menu's switching commands act on the registry directly. `TabRouter` selects the native tab, then the hosted connection.

`SidebarContainerViewController`'s search-field insets drop to `.defaultHigh`: they are a margin, and at width 0 a required pair is unsatisfiable.

## Measured

AppKit is not documented on this, so it was probed with `swiftc` against the macOS 14 target (Xcode 27.0 / 27A5237l):

- Clamping `minimumThickness == maximumThickness == 52` and later releasing returns the item to its user width, 420, with or without an autosave name.
- With the name set the clamp writes 52 into the record, exactly as a collapse writes its flag. Hence the existing `autosaveName = nil` span.
- A `setPosition` during the clamped span discards the width: 420 becomes 280. Nothing here calls it.
- At width 52 the item keeps `behavior = 1`, `allowsFullHeightLayout = true`, its `NSGlassEffectView` and `safeAreaTop = 66`, so sidebar material and full-height layout survive the clamp.

## Not done

Switch Connection in the toolbar stays disabled without a coordinator. Its popover is presented by the coordinator's `ToolbarSwitcherPresenter`, so enabling it would give a live-looking button that does nothing. The connections strip and the View menu are the routes that survive, and both work now.

Rail visibility still comes from the app-wide `WorkspaceRailStore.entries.count`. Narrowing it to this window's own workspace count is a different quantity, not a smaller one: two windows each hosting one connection would lose their strips. That is a real question and it is left alone here.

## Tests

`ConnectionWindowChromeTests` is new and builds a real `MainSplitViewController` in an `NSWindow` with two workspaces, the harness #2545 established. `ConnectionWindowPaneResolverTests` gains the pure cases.

Covered: the strip survives an unavailable selected connection; a lone connection still hides its sidebar outright; the strip arriving and leaving while the connection is down moves the mode both ways; a narrowed sidebar refuses `setSidebarTab` and refuses user collapse; the clamp tracks the rail allowance; reveal restores the user's sidebar across both hidden modes; and the View menu's switching validates with no coordinator.

Making `sidebarChromeMode` ignore `hasRail` fails 5 of them. 110 cases pass across the chrome, resolver, three toolbar-validation, pane-synchronization, workspace-registry, phase-machine, detail-width and split-pane suites. macOS Debug build passes; SwiftLint reports 0 violations on the 11 changed files.

No `TableProUITests` coverage: no suite opens two connections into one window today, and nothing drives a connection down deterministically. That gap is why the new suite drives the controller directly instead.

## Review

A Codex review of the branch found five issues, all fixed here: an existing toolbar-validation test broken by the new context field; Switch Connection enabled without a working action, which is why it stays disabled above; `makeKeyAndOrderFront` not selecting a background native tab; `canCollapse` left true in `railOnly`; and the clamp not tracking a rail row-size change.

## Before / After

No screenshots. The state needs a window hosting two connections with the selected one down, which is what the new suite constructs; a still frame of a narrowed sidebar does not show that the strip is reachable, which is the whole claim.
