### PR TITLE
fix(ssh): release the socket, listening port and session when a tunnel ends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Leaked socket on every SSH Test Connection against a server reached without jump hosts.
+- Leaked listening port, socket and session each time an SSH tunnel died from sleep or a dropped network.
 - Selection highlight missing from part of a long selection after scrolling back up to it.
 - Editor not scrolling to follow a selection extended past the edge of the viewport.
 - Find highlight and the run band covering only the first line of a match that spans several lines.

--- a/TablePro/Core/SSH/LibSSH2Tunnel.swift
+++ b/TablePro/Core/SSH/LibSSH2Tunnel.swift
@@ -27,7 +27,7 @@ internal final class LibSSH2Tunnel: @unchecked Sendable {
 
     private var forwardingTask: Task<Void, Never>?
     private var keepAliveTask: Task<Void, Never>?
-    private let isAlive = OSAllocatedUnfairLock(initialState: true)
+    private let aliveLatch = TeardownLatch()
     private let clientTasks = OSAllocatedUnfairLock(initialState: [Task<Void, Never>]())
 
     /// Serial queue for all libssh2 calls on this tunnel's session.
@@ -96,7 +96,7 @@ internal final class LibSSH2Tunnel: @unchecked Sendable {
     }
 
     var isRunning: Bool {
-        isAlive.withLock { $0 }
+        aliveLatch.isLive
     }
 
     // MARK: - Forwarding
@@ -170,13 +170,20 @@ internal final class LibSSH2Tunnel: @unchecked Sendable {
     // MARK: - Lifecycle
 
     func close() {
-        let wasAlive = isAlive.withLock { alive -> Bool in
-            let was = alive
-            alive = false
-            return was
-        }
-        guard wasAlive else { return }
+        guard consumeAliveLatch() else { return }
+        performTeardown()
+    }
 
+    /// Takes the one-shot alive latch, returning true to exactly one caller.
+    ///
+    /// The latch decides who performs teardown, so every path that consumes it owes the teardown.
+    /// `markDead` used to consume it and only fire `onDeath`, which left `close()` a no-op for the
+    /// rest of the tunnel's life and every resource it held unreleased.
+    private func consumeAliveLatch() -> Bool {
+        aliveLatch.claim()
+    }
+
+    private func performTeardown() {
         // Cancel all tasks so relay loops see isCancelled
         forwardingTask?.cancel()
         keepAliveTask?.cancel()
@@ -234,12 +241,7 @@ internal final class LibSSH2Tunnel: @unchecked Sendable {
     /// and tear down immediately. We avoid closing socketFD or freeing the session
     /// since relay tasks may still reference them; the OS reclaims all resources.
     func closeSync() {
-        let wasAlive = isAlive.withLock { alive -> Bool in
-            let was = alive
-            alive = false
-            return was
-        }
-        guard wasAlive else { return }
+        guard consumeAliveLatch() else { return }
 
         forwardingTask?.cancel()
         keepAliveTask?.cancel()
@@ -262,14 +264,9 @@ internal final class LibSSH2Tunnel: @unchecked Sendable {
     // MARK: - Private
 
     private func markDead() {
-        let wasAlive = isAlive.withLock { alive -> Bool in
-            let was = alive
-            alive = false
-            return was
-        }
-        if wasAlive {
-            onDeath?(connectionId)
-        }
+        guard consumeAliveLatch() else { return }
+        performTeardown()
+        onDeath?(connectionId)
     }
 
     /// Accepts a client on the listening socket. The accept timestamp is taken here, not once
@@ -378,7 +375,7 @@ internal final class LibSSH2Tunnel: @unchecked Sendable {
         let shouldCancel = clientTasks.withLock { tasks -> Bool in
             tasks.removeAll { $0.isCancelled }
             tasks.append(task)
-            return !isAlive.withLock { $0 }
+            return !aliveLatch.isLive
         }
         if shouldCancel {
             task.cancel()

--- a/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
+++ b/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
@@ -117,7 +117,6 @@ internal enum LibSSH2TunnelFactory {
     private struct AuthenticatedChain {
         let session: OpaquePointer
         let socketFD: Int32
-        let initialSocketFD: Int32
         let jumpHops: [HopInfo]
 
         struct HopInfo {
@@ -269,7 +268,6 @@ internal enum LibSSH2TunnelFactory {
                 return AuthenticatedChain(
                     session: currentSession,
                     socketFD: currentSocketFD,
-                    initialSocketFD: socketFD,
                     jumpHops: jumpHops
                 )
             } catch {
@@ -309,9 +307,7 @@ internal enum LibSSH2TunnelFactory {
     private static func cleanupChain(_ chain: AuthenticatedChain, reason: String) {
         tablepro_libssh2_session_disconnect(chain.session, reason)
         libssh2_session_free(chain.session)
-        if chain.socketFD != chain.initialSocketFD {
-            Darwin.close(chain.socketFD)
-        }
+        Darwin.close(chain.socketFD)
 
         // Clean up jump hops in reverse order:
         // First pass: cancel relays and shutdown sockets to break relay loops

--- a/TablePro/Core/SSH/TeardownLatch.swift
+++ b/TablePro/Core/SSH/TeardownLatch.swift
@@ -1,0 +1,36 @@
+//
+//  TeardownLatch.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+/// Names exactly one owner for a teardown that must happen once.
+///
+/// A tunnel can stop for two reasons at once: the app closes it, and its keep-alive notices the
+/// server has gone. Both need to release the same listening socket, session and jump hops, and
+/// neither may do it twice. A bare boolean invites the shape that caused #2474's collateral leak:
+/// one path took the flag to mean "someone else will tear down" and returned, the other took it to
+/// mean "I have already torn down" and also returned, so nothing was ever released and the tunnel
+/// went permanently deaf to close.
+///
+/// `claim()` returns true to exactly one caller for the lifetime of the latch. **Whoever gets true
+/// owes the teardown.** Checking `isLive` never claims.
+struct TeardownLatch: Sendable {
+    private let live = OSAllocatedUnfairLock(initialState: true)
+
+    /// True for the first caller and false for every caller after it, including concurrent ones.
+    func claim() -> Bool {
+        live.withLock { isLive -> Bool in
+            let was = isLive
+            isLive = false
+            return was
+        }
+    }
+
+    /// Whether the thing this latch guards is still running. Observation only; never claims.
+    var isLive: Bool {
+        live.withLock { $0 }
+    }
+}

--- a/TableProTests/Core/SSH/TeardownLatchTests.swift
+++ b/TableProTests/Core/SSH/TeardownLatchTests.swift
@@ -1,0 +1,56 @@
+//
+//  TeardownLatchTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+/// The latch exists because two paths can decide a tunnel is over at the same moment, and exactly
+/// one of them has to release its listening socket, session and jump hops.
+@Suite("Teardown latch")
+struct TeardownLatchTests {
+    @Test("The first claim wins and every later one loses")
+    func onlyTheFirstClaimWins() {
+        let latch = TeardownLatch()
+        #expect(latch.claim())
+        #expect(!latch.claim())
+        #expect(!latch.claim())
+    }
+
+    @Test("A latch starts live and stops being live once claimed")
+    func claimingEndsTheLifetime() {
+        let latch = TeardownLatch()
+        #expect(latch.isLive)
+        _ = latch.claim()
+        #expect(!latch.isLive)
+    }
+
+    @Test("Observing does not claim")
+    func observingIsNotClaiming() {
+        let latch = TeardownLatch()
+        #expect(latch.isLive)
+        #expect(latch.isLive)
+        #expect(latch.claim(), "reading isLive must leave the claim available")
+    }
+
+    /// The case the tunnel actually hits: the app closes it in the same instant its keep-alive
+    /// notices the server has gone. Exactly one of them owes the teardown, whichever arrives first.
+    @Test("Exactly one of many concurrent claimants wins")
+    func concurrentClaimantsProduceOneWinner() async {
+        for _ in 0..<200 {
+            let latch = TeardownLatch()
+            let winners = await withTaskGroup(of: Bool.self) { group in
+                for _ in 0..<8 {
+                    group.addTask { latch.claim() }
+                }
+                var count = 0
+                for await didWin in group where didWin { count += 1 }
+                return count
+            }
+            #expect(winners == 1)
+        }
+    }
+}


### PR DESCRIPTION
Two resource leaks in the SSH tunnel stack, found while investigating #2474 and verified with `lsof` against a running app.

## A socket per Test Connection

`cleanupChain` released the SSH socket only when `chain.socketFD != chain.initialSocketFD`. Those differ only when the chain went through a jump host: with hops, `chain.socketFD` is the last relay's socketpair end and `initialSocketFD` is the first hop's socket, which the hop loop closes. **Without hops they are the same fd, the guard is false, and the hop loop is empty, so nothing closes it.**

The guard was the whole bug. `chain.socketFD` is only ever a hop's socket when there are no hops, which is exactly the case that needed closing, so it is now closed unconditionally and the field that existed only for that comparison is gone.

**Reproduce:** connection form > SSH Tunnel > edit a profile with no jump hosts > press **Test Connection** repeatedly, watching `lsof -p $(pgrep TablePro) | grep -c TCP`. It rises by one per press and never falls. The same leak happens on every `createTunnel` failure after authentication, including the port-collision retry loop, which re-authenticates each attempt.

## Everything, every time a tunnel dies

`markDead()` and `close()` both consumed the same `isAlive` latch, but only `close()` did any releasing. Keep-alive failure called `markDead()`, which took the latch and fired `onDeath`; `close()` then hit `guard wasAlive else { return }` and did nothing for the rest of the tunnel's life. `SSHTunnelManager.handleTunnelDeath` drops the tunnel from both dictionaries without calling `close()`, so the listening port, the socket to the server, the libssh2 session and every jump hop's session, channel and socket were never released, and `terminateAllProcessesSync` could not reclaim them because the registry entry was already gone.

**Reproduce:** connect through an SSH tunnel, note the `127.0.0.1:6xxxx` LISTEN in `lsof -p $(pgrep -x TablePro) -iTCP -P -n`, then kill that sshd session server-side. The log shows "marking tunnel dead" and "Tunnel died" and never "Tunnel closed". The port stays bound and cannot be rebound even with `SO_REUSEADDR` (measured: `errno 48`). Every sleep/wake or network drop adds another.

## The fix

The latch is the thing that was ambiguous, so it now says what it means. `TeardownLatch.claim()` returns true to exactly one caller ever, and **whoever gets true owes the teardown**; `isLive` observes without claiming. `close()`, `closeSync()` and `markDead()` each claim it and each perform the teardown, with `markDead()` additionally firing `onDeath` afterwards.

A bare boolean invited the shape that caused this: one path read it as "someone else will tear down", the other as "I already did", and neither was true.

## Tests

`TeardownLatchTests` covers the invariant directly, including 200 rounds of eight concurrent claimants each asserting exactly one winner. That is the property the tunnel needs and the one a boolean could not express.

The fd-level behaviour itself has no unit test: `LibSSH2Tunnel` needs a live `LIBSSH2_SESSION` and its teardown calls into libssh2, so constructing one in a test would need a real server and would still be measuring the OS rather than the code. Both leaks were confirmed by `lsof` against a running build instead, with the reproductions above.

## Verification

- `verify.sh build` PASS
- `verify.sh test TeardownLatchTests SSHTunnelErrorTests SSHKeepAliveResultTests` PASS, 21/21
- `swiftlint --strict` clean over the four changed files
