### PR TITLE
fix(sidebar): let the object selection follow the database being browsed again

### DIFF
--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator.swift
@@ -368,9 +368,15 @@ final class DatabaseTreeOutlineCoordinator: NSObject {
         publishedTables = selectedTables
         publishedSelectionDatabase = selectionDatabase
 
+        /// Matched on the object and scoped to the database on screen, in that order, rather than
+        /// on the whole reference. The model holds the row the user picked, database included, but
+        /// browsing elsewhere is meant to move the highlight onto that database's copy of the same
+        /// object; comparing references pins it to the database it was picked in and leaves the
+        /// tree with nothing selected the moment the browse cursor moves.
+        let selectedObjects = Set(selectedTables.map(\.table))
         var nodes: [DatabaseTreeNode] = []
         for node in nodeCache.values {
-            guard case .table(let ref) = node.kind, selectedTables.contains(ref) else { continue }
+            guard case .table(let ref) = node.kind, selectedObjects.contains(ref.table) else { continue }
             guard selectionDatabase == nil || ref.database == selectionDatabase else { continue }
             nodes.append(node)
         }
@@ -378,7 +384,7 @@ final class DatabaseTreeOutlineCoordinator: NSObject {
         lastSelection = Set(DatabaseTreeSelection.tableRefs(of: nodes))
         /// Still pending while a selected table has no row in the database being browsed: the row is
         /// usually one that has not been built yet, and the next sync adopts it.
-        isModelSelectionAdoptionPending = Set(lastSelection) != selectedTables
+        isModelSelectionAdoptionPending = Set(lastSelection.map(\.table)) != selectedObjects
     }
 
     private var modelSelectionDatabase: String? {


### PR DESCRIPTION
`main` is red. The three failing cases in `DatabaseTreeObjectGroupHierarchyTests` came in with #2556 and are failing on every run since, including [33057688123](https://github.com/TableProApp/TablePro/actions/runs/33057688123) on `main`'s own head:

```
Expectation failed: await selectionSettles(in: outlineView, on: activeView)
Expectation failed: (selected.count → 1) == 2
Expectation failed: selected.contains { $0 === shopReport }
```

## Cause

Sidebar selection adoption matched in two steps: by table object, then scoped to the database on screen. #2556 moved `WindowSidebarState.selectedTables` to carry `DatabaseTreeTableRef` so the staged Truncate and Drop queue could stop keying on a bare name, and the first step became a whole-reference comparison. A reference pins the database it was picked in, so browsing elsewhere left the tree with nothing selected, and a multi-selection stopped adopting the active database's rows.

## Fix

Match on the object, keep the database scope that already sits on the next line. `selectedTables` still carries full references, which is what the queue needs; only the adoption comparison changes.

Both behaviours are already pinned by the suite that has been failing: "Selection adoption distinguishes identical objects across databases" and "A multi-selection adopts only rows in the active database".

## Verified

`verify.sh test DatabaseTreeObjectGroupHierarchyTests SidebarOutlineScaffoldTests SidebarHostingCellTests`: 15 executed, 15 passed.

The three UI test jobs fail on `main` as well, on the tab-drag reorder and "The sample database never finished opening". Those are not this.

The same commit is on #2559, which is where the fix was written; this PR carries it alone so `main` does not have to wait for that feature.
