### PR TITLE
fix(structure): keep auto increment on the Postgres family beside the generated fields

### DIFF
--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPlugin.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPlugin.swift
@@ -92,7 +92,7 @@ final class PostgreSQLPlugin: NSObject, TableProPlugin, DriverPlugin {
     static let supportsDatabaseTriggerBrowse = true
     static let supportsTriggerEditing = true
     static let structureColumnFields: [StructureColumnField] =
-        [.name, .type, .nullable, .defaultValue, .generated, .generationExpression, .comment]
+        [.name, .type, .nullable, .defaultValue, .generated, .generationExpression, .autoIncrement, .comment]
 
     static let supportsCheckConstraints = true
     static let supportsCheckConstraintEditing = true

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+CuratedDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+CuratedDefaults.swift
@@ -392,7 +392,8 @@ extension PluginMetadataRegistry {
                     fileExtensions: [],
                     databaseGroupingStrategy: .bySchema,
                     structureColumnFields: [
-                        .name, .type, .nullable, .defaultValue, .generated, .generationExpression, .comment
+                        .name, .type, .nullable, .defaultValue, .generated, .generationExpression,
+                        .autoIncrement, .comment
                     ]
                 ),
                 editor: PluginMetadataSnapshot.EditorConfig(
@@ -525,7 +526,8 @@ extension PluginMetadataRegistry {
                     fileExtensions: [],
                     databaseGroupingStrategy: .bySchema,
                     structureColumnFields: [
-                        .name, .type, .nullable, .defaultValue, .generated, .generationExpression, .comment
+                        .name, .type, .nullable, .defaultValue, .generated, .generationExpression,
+                        .autoIncrement, .comment
                     ]
                 ),
                 editor: PluginMetadataSnapshot.EditorConfig(
@@ -589,7 +591,8 @@ extension PluginMetadataRegistry {
                     fileExtensions: [],
                     databaseGroupingStrategy: .bySchema,
                     structureColumnFields: [
-                        .name, .type, .nullable, .defaultValue, .generated, .generationExpression, .comment
+                        .name, .type, .nullable, .defaultValue, .generated, .generationExpression,
+                        .autoIncrement, .comment
                     ]
                 ),
                 editor: PluginMetadataSnapshot.EditorConfig(

--- a/TableProTests/Views/Structure/StructureColumnFieldRegistrationTests.swift
+++ b/TableProTests/Views/Structure/StructureColumnFieldRegistrationTests.swift
@@ -45,6 +45,32 @@ struct StructureColumnFieldRegistrationTests {
         }
     }
 
+    /// Adding the generated-column pair to the Postgres family replaced `.autoIncrement` instead
+    /// of joining it (#2557), so a `SERIAL` column lost its Auto Increment flag in the structure
+    /// editor while `PostgreSQLPluginDriver` went on generating the DDL for one. Redshift is in
+    /// the list as the control: it never gained the generated fields and never lost this one.
+    @Test(
+        "The Postgres family offers auto increment beside the generated fields",
+        arguments: [DatabaseType.postgresql, .cockroachdb, .pglite, .redshift]
+    )
+    func autoIncrementSurvivesTheGeneratedFields(databaseType: DatabaseType) {
+        #expect(PluginManager.shared.structureColumnFields(for: databaseType).contains(.autoIncrement))
+    }
+
+    /// The columns tab reads its dropdown options by looking each boolean field up in the ordered
+    /// list, so a field the engine stops declaring silently loses its editor rather than failing.
+    @Test(
+        "Every boolean field an engine declares resolves to a column",
+        arguments: [DatabaseType.postgresql, .mysql, .sqlite, .cockroachdb, .pglite]
+    )
+    func declaredBooleanFieldsResolve(databaseType: DatabaseType) {
+        let ordered = StructureRowProvider.orderedFields(for: databaseType)
+        let declared = Set(PluginManager.shared.structureColumnFields(for: databaseType))
+        for field in [StructureColumnField.nullable, .autoIncrement, .onUpdate] where declared.contains(field) {
+            #expect(ordered.contains(field), "\(databaseType.rawValue) declares \(field) but cannot order it")
+        }
+    }
+
     @Test("Every declared field has a display name")
     func everyFieldHasDisplayName() {
         for field in StructureColumnField.allCases {


### PR DESCRIPTION
Adding generated-column support in #2557 replaced `.autoIncrement` in the Postgres family's
`structureColumnFields` rather than joining it. MySQL, MariaDB and SQLite gained the two new fields
and kept auto increment; PostgreSQL, CockroachDB and PGlite gained them and lost it.

```
MySQL        .name .type .nullable .defaultValue .generated .generationExpression .onUpdate .autoIncrement .comment …
SQLite       .name .type .nullable .defaultValue .generated .generationExpression .autoIncrement .comment
PostgreSQL   .name .type .nullable .defaultValue .generated .generationExpression .comment      ← lost it
CockroachDB  .name .type .nullable .defaultValue .generated .generationExpression .comment      ← lost it
PGlite       .name .type .nullable .defaultValue .generated .generationExpression .comment      ← lost it
Redshift     .name .type .nullable .defaultValue .autoIncrement .comment                        ← never had them
```

`PostgreSQLPluginDriver.swift:1081` still reads `col.autoIncrement` and still generates the DDL for
it, so this removed the control rather than the capability: a `SERIAL` column had no Auto Increment
flag in the structure editor while the driver went on writing one.

The two spellings both had to move. `PostgreSQLPlugin.structureColumnFields` is what wins once the
plugin loads, and the curated entries are what answer before it does and what `registerVariant`
keeps permanently for CockroachDB and PGlite.

## How CI reported it

This is the whole of the `Unit tests` job failure on main. `StructureRowProviderBooleanOptionsTests`
walks every boolean field and records an issue for one the columns tab cannot order, and
`.autoIncrement` was the one:

```
✘ "Every boolean column supplies its own YES/NO options" 1 issue(s)
✘ Suite "StructureRowProvider boolean options" failed
```

## The guard

`autoIncrementSurvivesTheGeneratedFields` asserts the four Postgres-family engines offer the field,
with Redshift in the list as a control that never gained the generated pair and never lost this one.
`declaredBooleanFieldsResolve` covers the shape of the defect rather than this instance: the columns
tab looks each boolean field up in the ordered list and skips a miss, so an engine that stops
declaring one loses its editor silently instead of failing.

Negative-tested: with the fix reverted the guard fails on PostgreSQL, CockroachDB and PGlite and
passes on Redshift.

## No CHANGELOG entry

#2557 is unreleased, so this never reached a user. CLAUDE.md: do not add a Fixed entry for
something that is itself still unreleased.

## What this does not fix

main is also red on all three `UI tests` shards, and that is unrelated to this change. Four
`EditorTabReorderUITests` cases have failed every run since #2472 added them on Aug 26, and a
rotating pair of cases fails with "The sample database never finished opening". All four reorder
cases pass locally, including with the window pinned to the runner's 1024x768 geometry; the one
local failure I could produce came from a loaded machine and took 125s against 25s for a passing
run. Being chased separately.
