### PR TITLE
feat(sidebar): show connection identity in connections strip entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Connection-first labels with the database or schema on a second line in the connections strip. (#2550)
+
 ## [0.69.0] - 2026-08-27
 
 ### Added

--- a/TablePro/Core/Services/Infrastructure/WorkspaceRailCellView.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspaceRailCellView.swift
@@ -187,11 +187,14 @@ internal final class WorkspaceRailCellView: NSTableCellView {
         return value
     }
 
+    /// Blank is the test on both halves, not empty on one of them. A container of spaces reads as
+    /// absent and has to be treated as absent, or the row spends its second line drawing nothing and
+    /// pushes the name it exists to show off centre.
     private static func labelLines(for entry: WorkspaceRailEntry) -> [String] {
         let connection = singleLine(entry.connection.name)
         let container = singleLine(entry.container)
-        guard !connection.isBlank else { return container.isEmpty ? [] : [container] }
-        guard !container.isEmpty else { return [connection] }
+        guard !connection.isBlank else { return container.isBlank ? [] : [container] }
+        guard !container.isBlank else { return [connection] }
         return [connection, container]
     }
 

--- a/TablePro/Core/Services/Infrastructure/WorkspaceRailCellView.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspaceRailCellView.swift
@@ -6,8 +6,8 @@
 import AppKit
 import SwiftUI
 
-/// One workspace: a glyph above the container it browses, with the connection's own colour as a
-/// dot on the glyph's corner.
+/// One workspace: a glyph above its connection and container, with the connection's own colour as
+/// a dot on the glyph's corner.
 ///
 /// Three channels share this cell and each owns a different property of the same glyph. Its SHAPE
 /// is the connection's state, because a colour-only difference between failed and disconnected is
@@ -26,10 +26,9 @@ import SwiftUI
 /// is what keeps it legible against the accent fill, which seven of the eight palette colours
 /// otherwise fail 3:1 against.
 ///
-/// The label keeps its single line and its middle truncation. Wrapping to two was tried and is
-/// worse: underscore is Unicode class AL and offers no break, so `tablepro_license` breaks at the
-/// width limit into `tablepro_licens` and an orphaned `e`. The HIG's reason for middle truncation
-/// in a narrow column stands, and the full name is in the tooltip and the accessibility label.
+/// Connection and container occupy explicit lines rather than wrapping one name. Each semantic
+/// value keeps one line and its own middle truncation, and the full identity stays in the tooltip
+/// and accessibility label.
 @MainActor
 internal final class WorkspaceRailCellView: NSTableCellView {
     internal static let reuseIdentifier = NSUserInterfaceItemIdentifier("WorkspaceRailCell")
@@ -41,6 +40,7 @@ internal final class WorkspaceRailCellView: NSTableCellView {
     private var iconHeightConstraint: NSLayoutConstraint?
     private var dotWidthConstraint: NSLayoutConstraint?
     private var dotHeightConstraint: NSLayoutConstraint?
+    private var labelTopConstraint: NSLayoutConstraint?
     private var appliedTint: NSColor?
     /// Held as the palette entry rather than a resolved colour, because `systemRed` and the rest
     /// differ between light and dark: resolving at configure time would freeze the dot at the
@@ -66,8 +66,9 @@ internal final class WorkspaceRailCellView: NSTableCellView {
 
         label.translatesAutoresizingMaskIntoConstraints = false
         label.alignment = .center
+        label.usesSingleLineMode = false
         label.lineBreakMode = .byTruncatingMiddle
-        label.maximumNumberOfLines = 1
+        label.maximumNumberOfLines = 2
         label.allowsExpansionToolTips = true
         label.cell?.truncatesLastVisibleLine = true
 
@@ -91,15 +92,22 @@ internal final class WorkspaceRailCellView: NSTableCellView {
         dotWidthConstraint = dotWidth
         dotHeightConstraint = dotHeight
 
+        let labelTop = label.topAnchor.constraint(
+            equalTo: icon.bottomAnchor,
+            constant: Self.labelTopSpacing(forIcon: 24)
+        )
+        labelTopConstraint = labelTop
+
         NSLayoutConstraint.activate([
             icon.centerXAnchor.constraint(equalTo: centerXAnchor),
-            icon.topAnchor.constraint(equalTo: topAnchor, constant: 6),
+            icon.topAnchor.constraint(equalTo: topAnchor, constant: 1),
             width,
             height,
 
-            label.topAnchor.constraint(equalTo: icon.bottomAnchor, constant: 3),
+            labelTop,
             label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 2),
             label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -2),
+            label.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
 
             dotWidth,
             dotHeight,
@@ -115,6 +123,14 @@ internal final class WorkspaceRailCellView: NSTableCellView {
         (iconSize * 0.375).rounded()
     }
 
+    internal static func labelTopSpacing(forIcon iconSize: CGFloat) -> CGFloat {
+        ceil(identityDotSize(forIcon: iconSize) / 2) + 1
+    }
+
+    internal static func secondaryFontSize(for primaryFontSize: CGFloat) -> CGFloat {
+        max(10, primaryFontSize - 1)
+    }
+
     private static let identityDotRimWidth: CGFloat = 1.5
 
     internal func configure(entry: WorkspaceRailEntry, layout: WorkspaceRailMetrics.Layout) {
@@ -125,9 +141,9 @@ internal final class WorkspaceRailCellView: NSTableCellView {
         dotWidthConstraint?.constant = dotSize
         dotHeightConstraint?.constant = dotSize
         identityDot.layer?.cornerRadius = dotSize / 2
+        labelTopConstraint?.constant = Self.labelTopSpacing(forIcon: layout.iconSize)
 
-        label.font = .systemFont(ofSize: layout.fontSize)
-        label.stringValue = entry.container.isEmpty ? entry.connection.name : entry.container
+        label.attributedStringValue = Self.labelValue(for: entry, layout: layout)
 
         appliedTint = Self.glyphTint(for: entry)
         identityColor = entry.connection.identityColor
@@ -137,6 +153,50 @@ internal final class WorkspaceRailCellView: NSTableCellView {
 
         toolTip = Self.tooltipText(for: entry)
         setAccessibilityLabel(Self.voiceOverLabel(for: entry))
+    }
+
+    private static func labelValue(
+        for entry: WorkspaceRailEntry,
+        layout: WorkspaceRailMetrics.Layout
+    ) -> NSAttributedString {
+        let lines = labelLines(for: entry)
+        guard let primary = lines.first else { return NSAttributedString() }
+
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .center
+        paragraph.lineBreakMode = .byTruncatingMiddle
+
+        let value = NSMutableAttributedString(
+            string: primary,
+            attributes: [
+                .font: NSFont.systemFont(ofSize: layout.fontSize),
+                .foregroundColor: NSColor.labelColor,
+                .paragraphStyle: paragraph,
+            ]
+        )
+        guard lines.count == 2 else { return value }
+
+        value.append(NSAttributedString(
+            string: "\n\(lines[1])",
+            attributes: [
+                .font: NSFont.systemFont(ofSize: secondaryFontSize(for: layout.fontSize)),
+                .foregroundColor: NSColor.secondaryLabelColor,
+                .paragraphStyle: paragraph,
+            ]
+        ))
+        return value
+    }
+
+    private static func labelLines(for entry: WorkspaceRailEntry) -> [String] {
+        let connection = singleLine(entry.connection.name)
+        let container = singleLine(entry.container)
+        guard !connection.isBlank else { return container.isEmpty ? [] : [container] }
+        guard !container.isEmpty else { return [connection] }
+        return [connection, container]
+    }
+
+    private static func singleLine(_ value: String) -> String {
+        value.components(separatedBy: .newlines).joined(separator: " ")
     }
 
     /// On the selected row `NSTableCellView` already tints the image view for contrast, so the

--- a/TablePro/Core/Services/Infrastructure/WorkspaceRailTypeSelect.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspaceRailTypeSelect.swift
@@ -1,0 +1,57 @@
+//
+//  WorkspaceRailTypeSelect.swift
+//  TablePro
+//
+
+import Foundation
+
+/// The keyboard's own answer to "which row does this typing mean", which the rail has to give
+/// itself: a row now shows two semantic values, and AppKit's default matcher reads one string per
+/// row from the cell's text field. Left to that default, typing would match the connection name and
+/// the container only in the order they happen to be concatenated.
+///
+/// The range AppKit passes is circular: `startRow` is included, `endRow` is excluded, and the range
+/// may wrap past the last row. `startRow == endRow` therefore means one complete scan rather than an
+/// empty one, so the walk is a repeat-and-wrap that visits every row exactly once and stops.
+internal enum WorkspaceRailTypeSelect {
+    internal static let noMatch = -1
+
+    internal static func nextMatch(
+        in entries: [WorkspaceRailEntry],
+        from startRow: Int,
+        to endRow: Int,
+        search: String
+    ) -> Int {
+        guard !search.isEmpty, entries.indices.contains(startRow) else { return noMatch }
+
+        let stop = wrapped(endRow, count: entries.count)
+        var row = startRow
+        repeat {
+            if matches(entries[row], search: search) { return row }
+            row = wrapped(row + 1, count: entries.count)
+        } while row != stop
+        return noMatch
+    }
+
+    /// An out-of-range bound is a position on the same circle rather than a reason to stop
+    /// answering: an exclusive end spelled as the row count names row 0, and taking it literally
+    /// would turn every such search into "no match" and leave the strip deaf to typing.
+    private static func wrapped(_ row: Int, count: Int) -> Int {
+        let remainder = row % count
+        return remainder < 0 ? remainder + count : remainder
+    }
+
+    private static func matches(_ entry: WorkspaceRailEntry, search: String) -> Bool {
+        matchesPrefix(entry.connection.name, search: search)
+            || matchesPrefix(entry.container, search: search)
+    }
+
+    private static func matchesPrefix(_ value: String, search: String) -> Bool {
+        guard !value.isEmpty else { return false }
+        return value.range(
+            of: search,
+            options: [.anchored, .caseInsensitive, .diacriticInsensitive, .widthInsensitive],
+            locale: .current
+        ) != nil
+    }
+}

--- a/TablePro/Core/Services/Infrastructure/WorkspaceRailViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspaceRailViewController.swift
@@ -42,6 +42,41 @@ internal final class WorkspaceRailTableView: NSTableView {
 }
 
 @MainActor
+internal enum WorkspaceRailTypeSelect {
+    internal static func nextMatch(
+        in entries: [WorkspaceRailEntry],
+        from startRow: Int,
+        to endRow: Int,
+        search: String
+    ) -> Int {
+        guard !search.isEmpty,
+              entries.indices.contains(startRow),
+              entries.indices.contains(endRow) else { return -1 }
+
+        var row = startRow
+        repeat {
+            if matches(entries[row], search: search) { return row }
+            row = (row + 1) % entries.count
+        } while row != endRow
+        return -1
+    }
+
+    private static func matches(_ entry: WorkspaceRailEntry, search: String) -> Bool {
+        matchesPrefix(entry.connection.name, search: search)
+            || matchesPrefix(entry.container, search: search)
+    }
+
+    private static func matchesPrefix(_ value: String, search: String) -> Bool {
+        guard !value.isEmpty else { return false }
+        return value.range(
+            of: search,
+            options: [.anchored, .caseInsensitive, .diacriticInsensitive, .widthInsensitive],
+            locale: .current
+        ) != nil
+    }
+}
+
+@MainActor
 internal final class WorkspaceRailViewController: NSViewController {
     nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "WorkspaceRail")
     private static let reorderType = NSPasteboard.PasteboardType("com.TablePro.workspaceRailEntry")
@@ -819,6 +854,20 @@ extension WorkspaceRailViewController: NSTableViewDelegate {
 
         cell.configure(entry: entries[row], layout: layout)
         return cell
+    }
+
+    internal func tableView(
+        _ tableView: NSTableView,
+        nextTypeSelectMatchFromRow startRow: Int,
+        toRow endRow: Int,
+        for searchString: String
+    ) -> Int {
+        WorkspaceRailTypeSelect.nextMatch(
+            in: entries,
+            from: startRow,
+            to: endRow,
+            search: searchString
+        )
     }
 
     /// Selection is the highlight, not the commit.

--- a/TablePro/Core/Services/Infrastructure/WorkspaceRailViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspaceRailViewController.swift
@@ -42,41 +42,6 @@ internal final class WorkspaceRailTableView: NSTableView {
 }
 
 @MainActor
-internal enum WorkspaceRailTypeSelect {
-    internal static func nextMatch(
-        in entries: [WorkspaceRailEntry],
-        from startRow: Int,
-        to endRow: Int,
-        search: String
-    ) -> Int {
-        guard !search.isEmpty,
-              entries.indices.contains(startRow),
-              entries.indices.contains(endRow) else { return -1 }
-
-        var row = startRow
-        repeat {
-            if matches(entries[row], search: search) { return row }
-            row = (row + 1) % entries.count
-        } while row != endRow
-        return -1
-    }
-
-    private static func matches(_ entry: WorkspaceRailEntry, search: String) -> Bool {
-        matchesPrefix(entry.connection.name, search: search)
-            || matchesPrefix(entry.container, search: search)
-    }
-
-    private static func matchesPrefix(_ value: String, search: String) -> Bool {
-        guard !value.isEmpty else { return false }
-        return value.range(
-            of: search,
-            options: [.anchored, .caseInsensitive, .diacriticInsensitive, .widthInsensitive],
-            locale: .current
-        ) != nil
-    }
-}
-
-@MainActor
 internal final class WorkspaceRailViewController: NSViewController {
     nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "WorkspaceRail")
     private static let reorderType = NSPasteboard.PasteboardType("com.TablePro.workspaceRailEntry")

--- a/TableProTests/Core/Services/WorkspaceRailCellRenderingTests.swift
+++ b/TableProTests/Core/Services/WorkspaceRailCellRenderingTests.swift
@@ -18,21 +18,27 @@ import Testing
 struct WorkspaceRailCellRenderingTests {
     private static let layout = WorkspaceRailMetrics.medium
 
-    private func cell(color: ConnectionColor, status: ConnectionStatus = .connected) -> WorkspaceRailCellView {
-        var connection = TestFixtures.makeConnection(database: "app")
-        connection.name = "production"
+    private func cell(
+        name: String = "production",
+        container: String = "app",
+        color: ConnectionColor,
+        status: ConnectionStatus = .connected,
+        layout: WorkspaceRailMetrics.Layout = WorkspaceRailMetrics.medium
+    ) -> WorkspaceRailCellView {
+        var connection = TestFixtures.makeConnection(database: container)
+        connection.name = name
         connection.color = color
         let entry = WorkspaceRailEntry(
-            workspace: WorkspaceID(connectionId: connection.id, container: "app"),
+            workspace: WorkspaceID(connectionId: connection.id, container: container),
             connection: connection,
             status: status,
             containerTarget: .database
         )
 
         let view = WorkspaceRailCellView(frame: NSRect(
-            x: 0, y: 0, width: Self.layout.width, height: Self.layout.rowHeight
+            x: 0, y: 0, width: layout.width, height: layout.rowHeight
         ))
-        view.configure(entry: entry, layout: Self.layout)
+        view.configure(entry: entry, layout: layout)
         view.layoutSubtreeIfNeeded()
         view.displayIfNeeded()
         return view
@@ -47,9 +53,23 @@ struct WorkspaceRailCellRenderingTests {
     }
 
     private func pixelCount(_ rep: NSBitmapImageRep, matching predicate: (NSColor) -> Bool) -> Int {
+        pixelCount(
+            rep,
+            in: NSRect(x: 0, y: 0, width: rep.pixelsWide, height: rep.pixelsHigh),
+            matching: predicate
+        )
+    }
+
+    private func pixelCount(
+        _ rep: NSBitmapImageRep,
+        in rect: NSRect,
+        matching predicate: (NSColor) -> Bool
+    ) -> Int {
         var count = 0
-        for y in 0 ..< rep.pixelsHigh {
-            for x in 0 ..< rep.pixelsWide {
+        let xRange = max(0, Int(rect.minX)) ..< min(rep.pixelsWide, Int(ceil(rect.maxX)))
+        let yRange = max(0, Int(rect.minY)) ..< min(rep.pixelsHigh, Int(ceil(rect.maxY)))
+        for y in yRange {
+            for x in xRange {
                 guard let raw = rep.colorAt(x: x, y: y),
                       let color = raw.usingColorSpace(.sRGB),
                       color.alphaComponent > 0.5 else { continue }
@@ -59,8 +79,34 @@ struct WorkspaceRailCellRenderingTests {
         return count
     }
 
+    private func differingPixelCount(_ lhs: NSBitmapImageRep, _ rhs: NSBitmapImageRep) -> Int {
+        guard lhs.pixelsWide == rhs.pixelsWide, lhs.pixelsHigh == rhs.pixelsHigh else { return .max }
+        var count = 0
+        for y in 0 ..< lhs.pixelsHigh {
+            for x in 0 ..< lhs.pixelsWide where lhs.colorAt(x: x, y: y) != rhs.colorAt(x: x, y: y) {
+                count += 1
+            }
+        }
+        return count
+    }
+
+    private func bitmapRect(_ viewRect: NSRect, in view: NSView, rep: NSBitmapImageRep) -> NSRect {
+        let scaleX = CGFloat(rep.pixelsWide) / view.bounds.width
+        let scaleY = CGFloat(rep.pixelsHigh) / view.bounds.height
+        return NSRect(
+            x: viewRect.minX * scaleX,
+            y: (view.bounds.maxY - viewRect.maxY) * scaleY,
+            width: viewRect.width * scaleX,
+            height: viewRect.height * scaleY
+        )
+    }
+
     private func isRedish(_ color: NSColor) -> Bool {
         color.redComponent > 0.55 && color.greenComponent < 0.45 && color.blueComponent < 0.45
+    }
+
+    private func isSelectedText(_ color: NSColor) -> Bool {
+        color.redComponent > 0.75 && color.greenComponent > 0.75 && color.blueComponent > 0.75
     }
 
     /// The defect this suite exists for. The band covered the label's whole width; a dot may not
@@ -92,11 +138,69 @@ struct WorkspaceRailCellRenderingTests {
         #expect(pixelCount(rep, matching: isRedish) > 0, "identity vanished on the selected row")
     }
 
+    @Test("Both identity lines adapt to the selected-row foreground")
+    func labelLinesAdaptToSelection() throws {
+        let view = cell(color: .none)
+        view.backgroundStyle = .emphasized
+        view.layoutSubtreeIfNeeded()
+        view.displayIfNeeded()
+        let rep = try #require(render(view))
+        let label = try #require(view.textField)
+        let primaryInView = NSRect(
+            x: label.frame.minX,
+            y: label.frame.midY,
+            width: label.frame.width,
+            height: label.frame.height / 2
+        )
+        let secondaryInView = NSRect(
+            x: label.frame.minX,
+            y: label.frame.minY,
+            width: label.frame.width,
+            height: label.frame.height / 2
+        )
+        let primary = bitmapRect(primaryInView, in: view, rep: rep)
+        let secondary = bitmapRect(secondaryInView, in: view, rep: rep)
+
+        #expect(pixelCount(rep, in: primary, matching: isSelectedText) > 0)
+        #expect(pixelCount(rep, in: secondary, matching: isSelectedText) > 0)
+    }
+
     @Test("A connection with no colour paints no identity")
     func uncolouredPaintsNothing() throws {
         let view = cell(color: .none)
         let rep = try #require(render(view))
 
         #expect(pixelCount(rep, matching: isRedish) == 0)
+    }
+
+    @Test("Connections with one container keep visibly different identities")
+    func duplicateContainersKeepVisibleConnectionIdentity() throws {
+        let production = try #require(render(cell(
+            name: "podo-prod", container: "gwatop", color: .none
+        )))
+        let staging = try #require(render(cell(
+            name: "podo-stage", container: "gwatop", color: .none
+        )))
+
+        #expect(
+            differingPixelCount(production, staging) > 100,
+            "different connections rendered as the same rail entry"
+        )
+    }
+
+    @Test("Two label lines fit every rail size without touching the identity dot")
+    func labelFitsEveryLayout() throws {
+        for layout in [WorkspaceRailMetrics.small, WorkspaceRailMetrics.medium, WorkspaceRailMetrics.large] {
+            let view = cell(
+                name: "podo-stage", container: "gwatop", color: .red,
+                layout: layout
+            )
+            let label = try #require(view.textField)
+            let icon = try #require(view.imageView)
+            let dot = try #require(view.subviews.first { $0 !== label && $0 !== icon })
+
+            #expect(view.bounds.contains(label.frame), "label escaped the \(layout) row")
+            #expect(dot.frame.minY >= label.frame.maxY, "identity dot overlapped the label in \(layout)")
+        }
     }
 }

--- a/TableProTests/Core/Services/WorkspaceRailCellRenderingTests.swift
+++ b/TableProTests/Core/Services/WorkspaceRailCellRenderingTests.swift
@@ -109,6 +109,10 @@ struct WorkspaceRailCellRenderingTests {
         color.redComponent > 0.75 && color.greenComponent > 0.75 && color.blueComponent > 0.75
     }
 
+    private func isInk(_ color: NSColor) -> Bool {
+        color.brightnessComponent < 0.6
+    }
+
     /// The defect this suite exists for. The band covered the label's whole width; a dot may not
     /// cover more than a small fraction of the cell, whatever colour the user picks.
     @Test("The identity colour never covers more than a fraction of the cell")
@@ -201,6 +205,49 @@ struct WorkspaceRailCellRenderingTests {
 
             #expect(view.bounds.contains(label.frame), "label escaped the \(layout) row")
             #expect(dot.frame.minY >= label.frame.maxY, "identity dot overlapped the label in \(layout)")
+        }
+    }
+
+    /// The lowest row of the cell any text reaches. Read against the same cell carrying one line,
+    /// it is the only evidence that the second line was drawn rather than laid out and clipped.
+    ///
+    /// The alpha floor is deliberately low: the container line is `secondaryLabelColor`, which is
+    /// half-transparent by definition, so the 0.5 gate the colour counters use would read the whole
+    /// second line as empty background.
+    private func lowestInkRow(_ rep: NSBitmapImageRep) -> Int? {
+        for y in stride(from: rep.pixelsHigh - 1, through: 0, by: -1) {
+            for x in 0 ..< rep.pixelsWide {
+                guard let raw = rep.colorAt(x: x, y: y),
+                      let color = raw.usingColorSpace(.sRGB),
+                      color.alphaComponent > 0.1, isInk(color) else { continue }
+                return y
+            }
+        }
+        return nil
+    }
+
+    /// A frame inside the row proves nothing about the text inside the frame. The row height, the
+    /// icon's own offset and the two font sizes are four numbers that have to add up, and the way
+    /// they fail is the second line laying out and never being drawn, which `labelFitsEveryLayout`
+    /// reads as a pass. The one-line cell is the control: the container line has to reach below
+    /// where the connection name on its own stops.
+    @Test("The container line is painted below the connection line at every rail size")
+    func containerLinePaintsBelowConnectionLine() throws {
+        for layout in [WorkspaceRailMetrics.small, WorkspaceRailMetrics.medium, WorkspaceRailMetrics.large] {
+            let oneLine = try #require(render(cell(
+                name: "podo-stage", container: "", color: .none, layout: layout
+            )))
+            let twoLines = try #require(render(cell(
+                name: "podo-stage", container: "gwatop", color: .none, layout: layout
+            )))
+
+            let connectionOnly = try #require(lowestInkRow(oneLine))
+            let withContainer = try #require(lowestInkRow(twoLines))
+
+            #expect(
+                withContainer > connectionOnly,
+                "the container line was clipped away in the \(layout.rowHeight)pt row"
+            )
         }
     }
 }

--- a/TableProTests/Core/Services/WorkspaceRailStoreTests.swift
+++ b/TableProTests/Core/Services/WorkspaceRailStoreTests.swift
@@ -503,6 +503,22 @@ struct WorkspaceRailCellTextTests {
         #expect(!label.stringValue.contains("\n"))
     }
 
+    @Test("A blank container leaves no empty second line")
+    func blankContainerLeavesNoEmptySecondLine() throws {
+        let cell = configuredCell(name: "Production", container: " \u{2028} ")
+        let label = try #require(cell.textField)
+
+        #expect(label.stringValue == "Production")
+        #expect(!label.stringValue.contains("\n"))
+    }
+
+    @Test("Two blank identities leave the label empty rather than blank-lined")
+    func twoBlankIdentitiesLeaveTheLabelEmpty() throws {
+        let cell = configuredCell(name: "  ", container: " ")
+
+        #expect(try #require(cell.textField).stringValue.isEmpty)
+    }
+
     @Test("Long labels keep AppKit's independent middle truncation contract")
     func longLabelsKeepMiddleTruncation() throws {
         let cell = configuredCell(
@@ -695,5 +711,21 @@ struct WorkspaceRailTypeSelectTests {
         #expect(WorkspaceRailTypeSelect.nextMatch(in: entries, from: 0, to: 0, search: "") == -1)
         #expect(WorkspaceRailTypeSelect.nextMatch(in: entries, from: -1, to: 1, search: "pro") == -1)
         #expect(WorkspaceRailTypeSelect.nextMatch(in: [], from: 0, to: 0, search: "pro") == -1)
+    }
+
+    /// An end bound past the last row is the same position on the circle as row 0, so it is a
+    /// search, not a reason to stop answering. Reading it as out of range turned every such call
+    /// into "no match" and left the strip deaf to typing.
+    @Test("An end bound past the last row names the row it wraps to")
+    func endBoundOutsideTheRowsWrapsOntoTheCircle() {
+        let entries = [
+            entry(name: "Production", container: "app"),
+            entry(name: "Staging", container: "analytics"),
+            entry(name: "Development", container: "warehouse"),
+        ]
+
+        #expect(WorkspaceRailTypeSelect.nextMatch(in: entries, from: 0, to: 3, search: "dev") == 2)
+        #expect(WorkspaceRailTypeSelect.nextMatch(in: entries, from: 1, to: 3, search: "pro") == -1)
+        #expect(WorkspaceRailTypeSelect.nextMatch(in: entries, from: 1, to: -1, search: "sta") == 1)
     }
 }

--- a/TableProTests/Core/Services/WorkspaceRailStoreTests.swift
+++ b/TableProTests/Core/Services/WorkspaceRailStoreTests.swift
@@ -432,6 +432,92 @@ struct WorkspaceRailCellTextTests {
         )
     }
 
+    private func configuredCell(
+        name: String = "staging",
+        container: String = "app",
+        containerTarget: ContainerSwitchTarget? = .database
+    ) -> WorkspaceRailCellView {
+        let cell = WorkspaceRailCellView(frame: NSRect(
+            x: 0,
+            y: 0,
+            width: WorkspaceRailMetrics.medium.width,
+            height: WorkspaceRailMetrics.medium.rowHeight
+        ))
+        cell.configure(
+            entry: makeEntry(name: name, container: container, containerTarget: containerTarget),
+            layout: WorkspaceRailMetrics.medium
+        )
+        cell.layoutSubtreeIfNeeded()
+        return cell
+    }
+
+    @Test("Connection and database occupy stable connection-first lines")
+    func connectionAndDatabaseUseSeparateLines() throws {
+        let production = configuredCell(name: "Production", container: "app")
+        let staging = configuredCell(name: "Staging", container: "app")
+
+        #expect(try #require(production.textField).stringValue == "Production\napp")
+        #expect(try #require(staging.textField).stringValue == "Staging\napp")
+        #expect(production.textField?.stringValue != staging.textField?.stringValue)
+    }
+
+    @Test("One connection keeps distinct second lines for its containers")
+    func oneConnectionKeepsDistinctContainers() throws {
+        let app = configuredCell(name: "Production", container: "app")
+        let analytics = configuredCell(name: "Production", container: "analytics")
+
+        #expect(try #require(app.textField).stringValue == "Production\napp")
+        #expect(try #require(analytics.textField).stringValue == "Production\nanalytics")
+    }
+
+    @Test("A schema uses the same connection-first hierarchy")
+    func schemaUsesConnectionFirstHierarchy() throws {
+        let cell = configuredCell(name: "Warehouse", container: "reporting", containerTarget: .schema)
+
+        #expect(try #require(cell.textField).stringValue == "Warehouse\nreporting")
+    }
+
+    @Test("An unnamed container leaves the connection on one line")
+    func emptyContainerUsesConnectionOnly() throws {
+        let cell = configuredCell(name: "Local SQLite", container: "", containerTarget: nil)
+        let label = try #require(cell.textField)
+
+        #expect(label.stringValue == "Local SQLite")
+        #expect(!label.stringValue.contains("\n"))
+    }
+
+    @Test("Embedded line separators cannot add visual rows")
+    func embeddedLineSeparatorsAreFlattened() throws {
+        let cell = configuredCell(name: "Pro\nduction", container: "app\u{2028}archive")
+
+        #expect(try #require(cell.textField).stringValue == "Pro duction\napp archive")
+        #expect(cell.textField?.stringValue.components(separatedBy: "\n").count == 2)
+    }
+
+    @Test("A blank connection name falls back without an empty first line")
+    func blankConnectionFallsBackToContainer() throws {
+        let cell = configuredCell(name: " \n ", container: "app")
+        let label = try #require(cell.textField)
+
+        #expect(label.stringValue == "app")
+        #expect(!label.stringValue.contains("\n"))
+    }
+
+    @Test("Long labels keep AppKit's independent middle truncation contract")
+    func longLabelsKeepMiddleTruncation() throws {
+        let cell = configuredCell(
+            name: "a-very-long-production-connection",
+            container: "a_very_long_database_name"
+        )
+        let label = try #require(cell.textField)
+
+        #expect(label.stringValue == "a-very-long-production-connection\na_very_long_database_name")
+        #expect(label.lineBreakMode == .byTruncatingMiddle)
+        #expect(label.maximumNumberOfLines == 2)
+        #expect(!label.usesSingleLineMode)
+        #expect(label.allowsExpansionToolTips)
+    }
+
     /// The regression this exists to stop: the glyph used to take the engine's brand colour in
     /// every state, so a failed PostgreSQL connection's warning triangle rendered PostgreSQL blue.
     @Test("A failed connection's glyph is not the engine's brand colour")
@@ -525,7 +611,89 @@ struct WorkspaceRailCellTextTests {
         let label = WorkspaceRailCellView.voiceOverLabel(
             for: makeEntry(container: "public", containerTarget: .schema)
         )
-        #expect(label.contains("schema public"))
-        #expect(!label.contains("database"))
+        let schema = String(format: String(localized: "schema %@"), "public")
+        let database = String(format: String(localized: "database %@"), "public")
+
+        #expect(label.contains(schema))
+        #expect(!label.contains(database))
+    }
+}
+
+@Suite("Workspace rail type select")
+@MainActor
+struct WorkspaceRailTypeSelectTests {
+    private func entry(name: String, container: String) -> WorkspaceRailEntry {
+        var connection = TestFixtures.makeConnection(database: container)
+        connection.name = name
+        return WorkspaceRailEntry(
+            workspace: WorkspaceID(connectionId: connection.id, container: container),
+            connection: connection,
+            status: .connected,
+            containerTarget: .database
+        )
+    }
+
+    @Test("Connection and container prefixes both match")
+    func bothIdentityPartsMatch() {
+        let entries = [
+            entry(name: "Production", container: "app"),
+            entry(name: "Staging", container: "app"),
+            entry(name: "Development", container: "analytics"),
+        ]
+
+        #expect(WorkspaceRailTypeSelect.nextMatch(in: entries, from: 1, to: 0, search: "sta") == 1)
+        #expect(WorkspaceRailTypeSelect.nextMatch(in: entries, from: 0, to: 0, search: "app") == 0)
+    }
+
+    @Test("A wrapped search visits the tail before the head")
+    func wrappedSearchKeepsAppKitOrder() {
+        let entries = [
+            entry(name: "Production", container: "app"),
+            entry(name: "Staging", container: "app"),
+            entry(name: "Development", container: "analytics"),
+        ]
+
+        #expect(WorkspaceRailTypeSelect.nextMatch(in: entries, from: 2, to: 1, search: "pro") == 0)
+        #expect(WorkspaceRailTypeSelect.nextMatch(in: entries, from: 1, to: 0, search: "dev") == 2)
+    }
+
+    @Test("The end row is excluded from the search range")
+    func endRowIsExcluded() {
+        let entries = [
+            entry(name: "Production", container: "app"),
+            entry(name: "Staging", container: "analytics"),
+        ]
+
+        #expect(WorkspaceRailTypeSelect.nextMatch(in: entries, from: 0, to: 1, search: "sta") == -1)
+    }
+
+    @Test("Prefix matching ignores case, diacritics, and character width")
+    func prefixComparisonFollowsLocalizedTyping() {
+        let entries = [entry(name: "Résumé", container: "Ａnalytics")]
+
+        #expect(WorkspaceRailTypeSelect.nextMatch(in: entries, from: 0, to: 0, search: "res") == 0)
+        #expect(WorkspaceRailTypeSelect.nextMatch(in: entries, from: 0, to: 0, search: "ana") == 0)
+    }
+
+    @Test("Equal bounds scan every row once")
+    func equalBoundsMeanAFullCircularSearch() {
+        let entries = [
+            entry(name: "Production", container: "app"),
+            entry(name: "Staging", container: "analytics"),
+            entry(name: "Development", container: "warehouse"),
+        ]
+
+        #expect(WorkspaceRailTypeSelect.nextMatch(in: entries, from: 0, to: 0, search: "dev") == 2)
+        #expect(WorkspaceRailTypeSelect.nextMatch(in: entries, from: 1, to: 1, search: "pro") == 0)
+    }
+
+    @Test("Empty, missing, and invalid searches return no match")
+    func invalidSearchReturnsNoMatch() {
+        let entries = [entry(name: "Production", container: "app")]
+
+        #expect(WorkspaceRailTypeSelect.nextMatch(in: entries, from: 0, to: 0, search: "missing") == -1)
+        #expect(WorkspaceRailTypeSelect.nextMatch(in: entries, from: 0, to: 0, search: "") == -1)
+        #expect(WorkspaceRailTypeSelect.nextMatch(in: entries, from: -1, to: 1, search: "pro") == -1)
+        #expect(WorkspaceRailTypeSelect.nextMatch(in: [], from: 0, to: 0, search: "pro") == -1)
     }
 }

--- a/docs/features/workspace-rail.mdx
+++ b/docs/features/workspace-rail.mdx
@@ -16,9 +16,9 @@ A hidden strip comes back on its own while the connection you are on has nothing
 
 ## What an entry shows
 
-The icon is the database engine's symbol, tinted with the connection's color, so staging and production are distinguishable without hovering. Under it is the database that entry browses, shortened in the middle when long. Hovering gives the full connection name, host, and database; VoiceOver reads that plus the connection's state. The entry you are in is highlighted, in each window separately.
+The icon shape and color identify the connection state and database engine. A colored dot marks the connection color. The first line under the icon names the connection, and the second names its database or schema. Each line shortens in the middle when long. Hovering gives the full connection name, host, and database or schema; VoiceOver reads those plus the connection state. The entry you are in is highlighted, in each window separately.
 
-On servers that group objects by schema, an entry stands for a schema. On a single-file or single-database engine, such as SQLite, DuckDB, or BigQuery, a connection has one entry, under the connection's name.
+On an engine that switches neither databases nor schemas, an entry has one line with the connection name.
 
 ## Icon states
 
@@ -46,7 +46,7 @@ Closing an entry's last tab leaves the entry where it is: tabs and entries close
 
 Between two connections, the window switches connection and returns you to the tab you last used there; between two databases of one connection, the sidebar moves and the tabs stay. An entry with nothing open moves the sidebar only, and clicking the entry you are in does nothing. No tab is ever closed or retargeted by a switch: each one keeps querying the database it was opened against.
 
-The strip takes the keyboard too. Click into it, then arrow keys move the highlight, typing jumps to a name, and `Return` opens the entry you land on.
+The strip takes the keyboard too. Click into it, then use the arrow keys to move the highlight. Type the start of a connection, database, or schema name to jump to it, and press `Return` to open the entry.
 
 More entries than fit the window means the strip scrolls, and it settles on whole entries rather than halfway through one. Switching to an entry that is off screen brings it into view.
 

--- a/docs/features/workspace-rail.mdx
+++ b/docs/features/workspace-rail.mdx
@@ -16,9 +16,9 @@ A hidden strip comes back on its own while the connection you are on has nothing
 
 ## What an entry shows
 
-The icon shape and color identify the connection state and database engine. A colored dot marks the connection color. The first line under the icon names the connection, and the second names its database or schema. Each line shortens in the middle when long. Hovering gives the full connection name, host, and database or schema; VoiceOver reads those plus the connection state. The entry you are in is highlighted, in each window separately.
+The icon is the database engine's symbol, and its shape changes with the connection's state. A connection you gave a color shows it as a dot in the icon's corner. The first line under the icon names the connection, the second names the database or schema it browses, and each line shortens in the middle when long. Hovering gives the full connection name, host, and database or schema; VoiceOver reads those plus the connection state. The entry you are in is highlighted, in each window separately.
 
-On an engine that switches neither databases nor schemas, an entry has one line with the connection name.
+On servers that group objects by schema, an entry stands for a schema. On an engine that switches neither databases nor schemas, such as SQLite or Redis, a connection has one entry and one line, the connection name.
 
 ## Icon states
 


### PR DESCRIPTION
## Purpose

Fixes #2550.

A connections-strip entry represents a workspace identified by both a connection and the database or schema it is browsing. The visible label only showed the container, so two different connections could render as identical entries.

For example:

| Connection | Database | Visible label before |
|---|---|---|
| Production | app | `app` |
| Staging | app | `app` |

When both connections use the same engine and have no custom connection color, identifying the environment requires hovering over each entry or switching to it first.

### What was wrong

`WorkspaceRailEntry` already carries the full `DatabaseConnection` and a `WorkspaceID` keyed by `connectionId + container`. The identity and navigation models were not losing data. The visible label discarded the connection name whenever a container existed.

Switching, selection, ordering, closing, dragging, and persistence continue to use `WorkspaceID`, so the fix belongs in the cell presentation rather than in the workspace or connection model.

### Why two lines

The obvious version was a single combined label:

```text
Production · app
Staging · app
```

That still becomes ambiguous in a narrow rail. With middle truncation, connection names that share a prefix and a common container can lose the part that distinguishes them:

```text
podo-prod · gwatop  → pod…atop
podo-stage · gwatop → pod…atop
```

The connection and container now occupy explicit semantic lines, and each line truncates independently:

```text
podo-prod
gwatop

podo-stage
gwatop
```

This keeps the connection identity visible without widening the strip or making the label depend on which other workspaces happen to be open.

## Changes and intent

### Connection-first labels

`WorkspaceRailCellView` keeps its existing `NSTableCellView.textField` and renders one attributed value with an explicit semantic line break:

- first line: connection name
- second line: database or schema name
- one line only when the engine has no switchable container
- primary text at the current sidebar font size
- secondary text one point smaller, with a minimum size of 10 pt
- independent middle truncation on both lines

Keeping one native text field preserves AppKit selected-row foreground colors, drag images, expansion tooltips, cell reuse, accessibility ownership, and source-list behavior.

Embedded line separators are flattened for display before the semantic line break is inserted, so imported or legacy values cannot create additional visual rows. A blank connection name falls back to the container without leaving an empty first line. Stored connection and workspace identities are not modified.

### Existing rail density

The strip keeps its existing size contracts:

| Sidebar size | Rail width | Row height | Icon size |
|---|---:|---:|---:|
| Small | 80 pt | 52 pt | 20 pt |
| Medium | 90 pt | 58 pt | 24 pt |
| Large | 100 pt | 66 pt | 28 pt |

The icon moves upward within the existing row. The gap before the label is derived from the identity-dot radius, which keeps the dot and text from overlapping at every sidebar size.

The row height, row pitch, scroll snapping, and window minimum width are unchanged.

### Type select

Changing the visible text to begin with the connection name would have removed the existing database/schema prefix search if the table continued relying on AppKit default text-field matching.

The rail now matches prefixes of both the connection name and the database or schema name. Matching ignores case, diacritic, and full-width versus half-width differences.

The matcher follows the circular range passed by AppKit:

- `startRow` is included
- `endRow` is excluded
- the range can wrap from the last row to the first
- `startRow == endRow` means one complete circular scan
- no match returns `-1`

A local AppKit probe measured the equal-bound behavior for tables with one and multiple rows. The implementation uses a repeat-and-wrap scan so every candidate is visited exactly once.

### Existing behavior preserved

The following continue to use `WorkspaceID(connectionId, container)` and were not re-keyed by the new presentation:

- connection and container switching
- selected-row tracking
- previous and next workspace commands
- drag reordering and order persistence
- middle-click and `Cmd+W` closing
- Close Database, Close Schema, and Close Connection
- disconnect and reconnect
- scroll snapping and selected-row reveal
- status glyphs, engine colors, and custom connection-color dots

The tooltip still contains the full connection, host, and container identity. The VoiceOver label still names the connection, typed database or schema, connection state, and optional color.

### Documentation

The connections-strip documentation now describes the connection name on the first line, the database or schema on the second line, and prefix type select across both values.

Two stale claims in the section were also corrected:

- the connection color appears on the identity dot rather than tinting the engine glyph
- DuckDB is not an unconditional single-entry example because it supports database and schema switching

The change is recorded under `[Unreleased] > Changed`.

### Before / After

Before, two connections that browse the same database show the same visible label:

```text
[MySQL]
app

[MySQL]
app
```

After, the connection is the primary line and the database or schema is the secondary line:

```text
[MySQL]
Production
app

[MySQL]
Staging
app
```

Sanitized light and dark screenshots using generic fixtures will be attached before the PR is marked ready for review. No private hosts, accounts, or environment names will be included.

## Success criteria

### Cell text, type select, and rendering

The following suites cover the presentation and keyboard contracts:

- `WorkspaceRailCellTextTests`
- `WorkspaceRailTypeSelectTests`
- `WorkspaceRailCellRenderingTests`

Covered cases include different connections with one database, one connection with multiple databases, schema workspaces, engines with no container, blank-name fallback, embedded line separators, independent middle truncation, connection and container prefix matching, ordinary and wrapped ranges, excluded end rows, equal-bound circular searches, localized comparisons, empty searches, empty lists, and invalid ranges.

Result after the AppKit circular-range correction:

```text
55 executed
55 passed
0 failed
```

`WorkspaceRailCellRenderingTests` builds and rasterizes the real `WorkspaceRailCellView`. It verifies that the reported production/staging class of entries produces visibly different rows, the label stays within all three row sizes, the identity dot never overlaps the label, and both label lines use the selected-row foreground.

Final rendering result:

```text
12 executed
12 passed
0 failed
```

### Neighboring rail behavior

The following suites cover the unchanged workspace model and neighboring behavior:

- `WorkspaceRailStoreTests`
- `WorkspaceRailOrderingTests`
- `WorkspaceRailMetricsTests`
- `WorkspaceRailScrollGeometryTests`

Result:

```text
137 executed
137 passed
0 failed
```

### Build, documentation, and lint

After rebasing onto the latest `main` and regenerating the Xcode project:

```text
verify.sh generate: PASS
verify.sh build: PASS
verify.sh docs: PASS
swiftlint lint --strict: 0 violations
git diff --check: PASS
```

`verify.sh lint` still reports two pre-existing agent-document references outside this change: `CLAUDE.md` references the missing `AXCell` symbol, and `verification.md` references the unavailable `/Applications/Xcode-beta.app`. The changed Swift files themselves have zero lint violations.

### Review

A fresh independent review initially raised concerns about selected-row attributed-text contrast and arbitrary ultra-long near-duplicate names.

The selected-row concern was tested against the actual product cell. Both label lines render with the selected-row foreground, and a pixel-level regression test now pins that behavior.

The ultra-long near-duplicate case remains a fixed-width truncation limitation equivalent to exact duplicate user-assigned connection names. The full connection, host, and container remain available in the tooltip, and the reported production/staging class of issue is covered by the product-cell raster test.

After reviewing the corrected matcher and selected-row raster evidence, the final verdict was:

```text
SHIP
```

### Not verified

No full `TableProUITests` flow was added. The current isolated UI fixture opens one sample SQLite connection, while the connections strip appears only after a second workspace exists. A new UI test would otherwise depend on the user connection store or a live database, neither of which is deterministic or safe.

The following remain manual proof layers:

- a running app window with two isolated workspace fixtures
- VoiceOver speech in the full app
- Accessibility Inspector inspection of the complete window tree
- sanitized full-window light and dark screenshots

The deterministic behavior changed by this PR is covered through AppKit cell configuration, layout, raster, semantic-label, keyboard matcher, neighboring workspace-model tests, and a Debug build.

<!--
## 목적
## 내용(의도 포함)
## 성공기준
-->
