### PR TITLE
feat(plugin-mongodb): run queries as JavaScript through an embedded mongosh shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- JavaScript shell for MongoDB queries, with mongosh's `db` API, cursors, variables, functions and `print`.
+- Per-connection MongoDB shell state, so a variable or function survives from one statement to the next.
+- Cursor method autocomplete after `find()` and `aggregate()`.
+
+### Changed
+
+- MongoDB statements split as JavaScript rather than at every semicolon.
+- MongoDB editor diagnostics report JavaScript syntax errors rather than unsupported method names.
+
+### Fixed
+
+- Parse error on any MongoDB filter written in shell syntax, such as `db.orders.find({status: 1})`.
+- MongoDB `.sort()` and `.projection()` silently ignored when written with unquoted keys.
+
 ## [0.69.0] - 2026-08-27
 
 ### Added

--- a/Plugins/MongoDBDriverPlugin/MongoDBConnection+ScriptHelpers.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBConnection+ScriptHelpers.swift
@@ -1,0 +1,240 @@
+import Foundation
+import TableProPluginKit
+
+/// One page of documents, kept as canonical Extended JSON.
+///
+/// The script runtime has two consumers for the same documents and they want different shapes: the
+/// result grid wants Swift values, and the JavaScript side wants Extended JSON it can revive into
+/// `ObjectId`, `Date` and the rest. Keeping the canonical text is the only representation both can
+/// be derived from without losing a type on the way, so a document that is never read from
+/// JavaScript costs one conversion rather than two.
+struct MongoScriptDocumentBatch: Sendable {
+    var json: [String]
+    var isTruncated: Bool
+
+    static let empty = MongoScriptDocumentBatch(json: [], isTruncated: false)
+
+    var jsonArray: String { "[\(json.joined(separator: ","))]" }
+
+    var dictionaries: [[String: Any]] {
+        json.compactMap { document in
+            guard let data = document.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data),
+                  let dictionary = object as? [String: Any] else { return nil }
+            return MongoDBConnection.unwrapExtendedJson(dictionary) as? [String: Any] ?? dictionary
+        }
+    }
+}
+
+#if canImport(CLibMongoc)
+import CLibMongoc
+
+extension MongoDBConnection {
+    func scriptRunCommand(client: OpaquePointer, command: String, database: String?) throws -> String {
+        try checkCancelled()
+
+        guard let bsonCommand = jsonToBson(command) else {
+            throw MongoDBError(code: 0, message: MongoScriptText.invalidDocument(command))
+        }
+        defer { bson_destroy(bsonCommand) }
+
+        let timeoutMS = queryTimeoutMS
+        if timeoutMS > 0, !bson_has_field(bsonCommand, "maxTimeMS") {
+            bson_append_int32(bsonCommand, "maxTimeMS", -1, timeoutMS)
+        }
+
+        let reply = bson_new()
+        defer { bson_destroy(reply) }
+        var error = bson_error_t()
+
+        let resolved = (database ?? self.database).isEmpty ? "admin" : (database ?? self.database)
+        let ok = resolved.withCString {
+            mongoc_client_command_simple(client, $0, bsonCommand, nil, reply, &error)
+        }
+
+        try checkCancelled()
+        guard ok else { throw makeError(error) }
+        return bsonToJson(reply) ?? "{}"
+    }
+
+    func scriptFind(
+        client: OpaquePointer,
+        database: String,
+        collection: String,
+        filter: String,
+        options: MongoScriptCursorOptions,
+        limit: Int
+    ) throws -> MongoScriptDocumentBatch {
+        try checkCancelled()
+
+        guard let filterBson = jsonToBson(filter) else {
+            throw MongoDBError(code: 0, message: MongoScriptText.invalidFilter(filter))
+        }
+        defer { bson_destroy(filterBson) }
+
+        let optionsJson = options.findOptionsJson(limit: limit, timeoutMS: queryTimeoutMS)
+        guard let optsBson = jsonToBson(optionsJson) else {
+            throw MongoDBError(code: 0, message: MongoScriptText.invalidDocument(optionsJson))
+        }
+        defer { bson_destroy(optsBson) }
+
+        let session = attachCancellableSession(client: client, opts: optsBson)
+        defer {
+            if let session {
+                releaseSessionLsid()
+                mongoc_client_session_destroy(session)
+            }
+        }
+
+        let handle = try getCollection(client, database: database, collection: collection)
+        defer { mongoc_collection_destroy(handle) }
+
+        try checkCancelled()
+
+        guard let cursor = mongoc_collection_find_with_opts(handle, filterBson, optsBson, nil) else {
+            throw MongoDBError(code: 0, message: MongoScriptText.cursorFailed)
+        }
+        defer { mongoc_cursor_destroy(cursor) }
+
+        return try iterateCursorJson(cursor, cap: limit)
+    }
+
+    func scriptAggregate(
+        client: OpaquePointer,
+        database: String,
+        collection: String,
+        pipeline: String,
+        options: MongoScriptCursorOptions,
+        limit: Int
+    ) throws -> MongoScriptDocumentBatch {
+        try checkCancelled()
+
+        guard let pipelineBson = jsonToBson(options.decoratedPipeline(pipeline)) else {
+            throw MongoDBError(code: 0, message: MongoScriptText.invalidPipeline(pipeline))
+        }
+        defer { bson_destroy(pipelineBson) }
+
+        let optionsJson = options.aggregateOptionsJson(timeoutMS: queryTimeoutMS)
+        let optsBson = optionsJson.map { jsonToBson($0) } ?? nil
+        defer { if let optsBson { bson_destroy(optsBson) } }
+
+        let handle = try getCollection(client, database: database, collection: collection)
+        defer { mongoc_collection_destroy(handle) }
+
+        try checkCancelled()
+
+        guard let cursor = mongoc_collection_aggregate(
+            handle, MONGOC_QUERY_NONE, pipelineBson, optsBson, nil
+        ) else {
+            throw MongoDBError(code: 0, message: MongoScriptText.cursorFailed)
+        }
+        defer { mongoc_cursor_destroy(cursor) }
+
+        return try iterateCursorJson(cursor, cap: limit)
+    }
+
+    /// Inserts documents, returning each `_id` as Extended JSON.
+    ///
+    /// A document with no `_id` gets one prepended through libbson rather than through a Swift
+    /// dictionary, so the rest of its fields keep the order the script wrote them in and `_id`
+    /// lands first, where the server puts it.
+    func scriptInsert(
+        client: OpaquePointer,
+        database: String,
+        collection: String,
+        documents: [String]
+    ) throws -> [String] {
+        try checkCancelled()
+        guard !documents.isEmpty else { return [] }
+
+        let handle = try getCollection(client, database: database, collection: collection)
+        defer { mongoc_collection_destroy(handle) }
+
+        var identifiers: [String] = []
+        var prepared: [OpaquePointer] = []
+        defer { prepared.forEach { bson_destroy($0) } }
+
+        for document in documents {
+            guard let parsed = jsonToBson(document) else {
+                throw MongoDBError(code: 0, message: MongoScriptText.invalidDocument(document))
+            }
+            if bson_has_field(parsed, "_id") {
+                prepared.append(parsed)
+                identifiers.append(identifierJson(in: parsed))
+                continue
+            }
+            defer { bson_destroy(parsed) }
+            let hex = MongoScriptObjectId.generate()
+            guard let withId = jsonToBson("{\"_id\": {\"$oid\": \"\(hex)\"}}"),
+                  bson_concat(withId, parsed) else {
+                throw MongoDBError(code: 0, message: MongoScriptText.invalidDocument(document))
+            }
+            prepared.append(withId)
+            identifiers.append("{\"$oid\": \"\(hex)\"}")
+        }
+
+        try checkCancelled()
+
+        var pointers: [OpaquePointer?] = prepared.map { Optional($0) }
+        let reply = bson_new()
+        defer { bson_destroy(reply) }
+        var error = bson_error_t()
+
+        let ok = pointers.withUnsafeMutableBufferPointer { buffer -> Bool in
+            guard let base = buffer.baseAddress else { return false }
+            return mongoc_collection_insert_many(handle, base, buffer.count, nil, reply, &error)
+        }
+        guard ok else { throw makeError(error) }
+        return identifiers
+    }
+
+    func listIndexesJsonSync(
+        client: OpaquePointer, database: String, collection: String
+    ) throws -> [String] {
+        try checkCancelled()
+
+        let handle = try getCollection(client, database: database, collection: collection)
+        defer { mongoc_collection_destroy(handle) }
+
+        guard let cursor = mongoc_collection_find_indexes_with_opts(handle, nil) else {
+            throw MongoDBError(code: 0, message: MongoScriptText.cursorFailed)
+        }
+        defer { mongoc_cursor_destroy(cursor) }
+
+        return try iterateCursorJson(cursor, cap: 0).json
+    }
+
+    private func identifierJson(in document: OpaquePointer) -> String {
+        guard let json = bsonToJson(document),
+              let identifier = MongoScriptJson.member(of: json, key: "_id") else { return "null" }
+        return identifier
+    }
+
+    private func iterateCursorJson(_ cursor: OpaquePointer, cap: Int) throws -> MongoScriptDocumentBatch {
+        try checkCancelled()
+
+        let ceiling = cap > 0 ? min(cap, PluginRowLimits.emergencyMax) : PluginRowLimits.emergencyMax
+        var documents: [String] = []
+        var pointer: OpaquePointer?
+        var truncated = false
+
+        while mongoc_cursor_next(cursor, &pointer) {
+            try checkCancelled()
+            if let document = pointer, let json = bsonToJson(document) {
+                documents.append(json)
+            }
+            if documents.count >= ceiling {
+                truncated = true
+                logger.warning("MongoDB script result truncated at \(ceiling) documents")
+                break
+            }
+        }
+
+        var error = bson_error_t()
+        if mongoc_cursor_error(cursor, &error) {
+            throw makeError(error)
+        }
+        return MongoScriptDocumentBatch(json: documents, isTruncated: truncated)
+    }
+}
+#endif

--- a/Plugins/MongoDBDriverPlugin/MongoDBConnection.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBConnection.swift
@@ -166,6 +166,31 @@ final class MongoDBConnection: @unchecked Sendable {
         DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self)
     }
 
+    /// Runs a libmongoc call on the connection's own queue and waits for it.
+    ///
+    /// The script runtime evaluates JavaScript on a thread of its own and has to block there while
+    /// a host call reaches the driver, because a `JSContext` cannot suspend. Going through the
+    /// async entry points would mean blocking a cooperative-pool thread on a continuation, so the
+    /// script path takes the queue directly. Re-entry is safe: an on-queue caller runs the body
+    /// inline rather than deadlocking on `dispatch_sync`.
+    #if canImport(CLibMongoc)
+    func withClientSync<T>(_ body: (OpaquePointer) throws -> T) throws -> T {
+        if isOnQueue {
+            guard !isShuttingDown, let client else { throw MongoDBError.notConnected }
+            return try body(client)
+        }
+        return try queue.sync {
+            guard !isShuttingDown, let client else { throw MongoDBError.notConnected }
+            return try body(client)
+        }
+    }
+    #endif
+
+    /// Clears a stale cancellation flag so a new script run starts clean.
+    func beginScriptRun() {
+        resetCancellation()
+    }
+
     deinit {
         #if canImport(CLibMongoc)
         // Capture the handle and queue to clean up asynchronously.
@@ -728,14 +753,16 @@ final class MongoDBConnection: @unchecked Sendable {
     }
     // MARK: - Streaming Queries
 
+    /// Streams a find whose options are given as the document the caller already built.
+    ///
+    /// Taking the text rather than rebuilding it from pieces is what keeps an export reading the
+    /// same rows the grid showed: `hint`, `collation` and `allowDiskUse` change which documents come
+    /// back, and a signature that only carries sort, projection, skip and limit drops them.
     func streamFind(
         database: String,
         collection: String,
         filter: String,
-        sort: String?,
-        projection: String?,
-        skip: Int = 0,
-        limit: Int? = nil
+        optionsJson: String
     ) -> AsyncThrowingStream<PluginStreamElement, Error> {
         #if canImport(CLibMongoc)
         let queue = self.queue
@@ -770,33 +797,7 @@ final class MongoDBConnection: @unchecked Sendable {
                     }
                     defer { bson_destroy(filterBson) }
 
-                    var optsJson: [String: Any] = [:]
-                    if let sort = sort, let data = sort.data(using: .utf8),
-                       let obj = try? JSONSerialization.jsonObject(with: data) {
-                        optsJson["sort"] = obj
-                    }
-                    if let projection = projection, let data = projection.data(using: .utf8),
-                       let obj = try? JSONSerialization.jsonObject(with: data) {
-                        optsJson["projection"] = obj
-                    }
-                    if skip > 0 {
-                        optsJson["skip"] = skip
-                    }
-                    if let limit, limit > 0 {
-                        optsJson["limit"] = limit
-                    }
-                    let timeoutMS = queryTimeoutMS
-                    if timeoutMS > 0 {
-                        optsJson["maxTimeMS"] = timeoutMS
-                    }
-
-                    var optsBson: OpaquePointer?
-                    if !optsJson.isEmpty {
-                        let optsData = try JSONSerialization.data(withJSONObject: optsJson)
-                        if let optsStr = String(data: optsData, encoding: .utf8) {
-                            optsBson = jsonToBson(optsStr)
-                        }
-                    }
+                    let optsBson = jsonToBson(optionsJson)
                     defer { if let opts = optsBson { bson_destroy(opts) } }
 
                     let col = try getCollection(client, database: database, collection: collection)
@@ -824,7 +825,8 @@ final class MongoDBConnection: @unchecked Sendable {
     func streamAggregate(
         database: String,
         collection: String,
-        pipeline: String
+        pipeline: String,
+        optionsJson: String? = nil
     ) -> AsyncThrowingStream<PluginStreamElement, Error> {
         #if canImport(CLibMongoc)
         let queue = self.queue
@@ -861,10 +863,14 @@ final class MongoDBConnection: @unchecked Sendable {
 
                     let col = try getCollection(client, database: database, collection: collection)
 
-                    let timeoutMS = queryTimeoutMS
                     var optsBson: OpaquePointer?
-                    if timeoutMS > 0 {
-                        optsBson = jsonToBson("{\"maxTimeMS\": \(timeoutMS)}")
+                    if let optionsJson {
+                        optsBson = jsonToBson(optionsJson)
+                    } else {
+                        let timeoutMS = queryTimeoutMS
+                        if timeoutMS > 0 {
+                            optsBson = jsonToBson("{\"maxTimeMS\": \(timeoutMS)}")
+                        }
                     }
                     defer { if let opts = optsBson { bson_destroy(opts) } }
 

--- a/Plugins/MongoDBDriverPlugin/MongoDBPluginDriver.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBPluginDriver.swift
@@ -11,6 +11,7 @@ import TableProPluginKit
 final class MongoDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     private let config: DriverConnectionConfig
     private var mongoConnection: MongoDBConnection?
+    private var scriptRuntime: MongoScriptRuntime?
     private var currentDb: String
     private let columnKindLock = NSLock()
     private var columnKindsByCollection: [String: [String: BsonValueKind]] = [:]
@@ -101,9 +102,12 @@ final class MongoDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         }
 
         mongoConnection = conn
+        scriptRuntime = MongoScriptRuntime(connection: conn)
     }
 
     func disconnect() {
+        scriptRuntime?.reset()
+        scriptRuntime = nil
         mongoConnection?.disconnect()
         mongoConnection = nil
     }
@@ -135,8 +139,7 @@ final class MongoDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             )
         }
 
-        let operation = try MongoShellParser.parse(trimmed)
-        return try await executeOperation(operation, connection: conn, startTime: startTime)
+        return try await runScript(trimmed, rowCap: nil, startTime: startTime)
     }
 
     func executeParameterized(query: String, parameters: [PluginCellValue]) async throws -> PluginQueryResult {
@@ -150,25 +153,46 @@ final class MongoDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     ) async throws -> PluginQueryResult {
         let startTime = Date()
 
-        guard let conn = mongoConnection else {
+        guard mongoConnection != nil else {
             throw MongoDBPluginError.notConnected
         }
 
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.lowercased() != "select 1",
-              case .find(let collection, let filter, var options) = try MongoShellParser.parse(trimmed) else {
-            return try await capToRowCap(execute(query: query), rowCap: rowCap)
+        guard trimmed.lowercased() != "select 1" else {
+            return try await execute(query: query)
         }
+        return try await runScript(trimmed, rowCap: rowCap, startTime: startTime)
+    }
 
-        options.limit = MongoDBFindLimitPolicy.fetchLimit(parsedLimit: options.limit, rowCap: rowCap)
+    /// Runs one statement of the connection's shell and turns what it evaluated to into a result.
+    private func runScript(
+        _ statement: String,
+        rowCap: Int?,
+        startTime: Date
+    ) async throws -> PluginQueryResult {
+        guard let runtime = scriptRuntime else { throw MongoDBPluginError.notConnected }
 
+        let ceiling = MongoDBFindLimitPolicy.fetchLimit(parsedLimit: nil, rowCap: rowCap)
         do {
-            let result = try await executeOperation(
-                .find(collection: collection, filter: filter, options: options),
-                connection: conn,
-                startTime: startTime
+            let outcome = try await runtime.evaluate(
+                statement: MongoShellCommandLine.rewrite(statement),
+                database: currentDb,
+                valueCeiling: ceiling
             )
-            return capToRowCap(result, rowCap: rowCap)
+            if let switched = outcome.databaseSwitch { currentDb = switched }
+            return capToRowCap(
+                MongoScriptResultBuilder.result(
+                    for: outcome,
+                    startTime: startTime,
+                    documents: { documents, collection, isTruncated in
+                        self.buildPluginResult(
+                            from: documents, startTime: startTime,
+                            isTruncated: isTruncated, collection: collection
+                        )
+                    }
+                ),
+                rowCap: rowCap
+            )
         } catch {
             throw mapExecutionError(error)
         }
@@ -204,7 +228,7 @@ final class MongoDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     // MARK: - Query Cancellation
 
     func cancelQuery() throws {
-        mongoConnection?.cancelCurrentQuery()
+        scriptRuntime?.cancel()
     }
 
     // MARK: - Schema Operations
@@ -219,47 +243,6 @@ final class MongoDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             .map { PluginTableInfo(name: $0, type: "table", rowCount: nil) }
     }
 
-    private func executeWrite(
-        kind: MongoWriteKind,
-        collection: String,
-        filter: String,
-        document: String,
-        options: MongoWriteOptions,
-        conn: MongoDBConnection,
-        db: String,
-        startTime: Date
-    ) async throws -> PluginQueryResult {
-        var fields: [String] = []
-        if options.upsert { fields.append("\"upsert\": true") }
-        if let arrayFilters = options.arrayFilters { fields.append("\"arrayFilters\": \(arrayFilters)") }
-        if let hint = options.hint { fields.append("\"hint\": \(hint)") }
-        let extras = fields.isEmpty ? "" : ", " + fields.joined(separator: ", ")
-
-        if kind == .findOneAndUpdate {
-            let command = """
-                {"findAndModify": "\(escapeJsonString(collection))", "query": \(filter), \
-                "update": \(document), "new": true\(extras)}
-                """
-            let docs = try await conn.runCommand(command, database: db)
-            return buildPluginResult(from: docs.isEmpty ? [] : [docs[0]], startTime: startTime)
-        }
-
-        let command = """
-            {"update": "\(escapeJsonString(collection))", \
-            "updates": [{"q": \(filter), "u": \(document), "multi": \(kind == .updateMany)\(extras)}]}
-            """
-        let result = try await conn.runCommand(command, database: db)
-        let modified = (result.first?["nModified"] as? Int64)
-            ?? (result.first?["nModified"] as? Int).map(Int64.init) ?? 0
-        let upserted = (result.first?["upserted"] as? [Any])?.count ?? 0
-        let affected = Int(modified) + upserted
-
-        return PluginQueryResult(
-            columns: ["modifiedCount", "upsertedCount"], columnTypeNames: ["Int64", "Int64"],
-            rows: [[.text(String(modified)), .text(String(upserted))]], rowsAffected: affected,
-            executionTime: Date().timeIntervalSince(startTime)
-        )
-    }
 
     func sampleFieldPaths(table: String, schema: String?, limit: Int) async throws -> [PluginFieldPath] {
         guard let conn = mongoConnection else {
@@ -662,78 +645,14 @@ final class MongoDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     // MARK: - Database Switching
 
     func switchDatabase(to database: String) async throws {
+        // Every scoped execution re-pins the driver to its tab's database, so this is called with
+        // the same name over and over. Only a real change moves the shell, or a `use` inside a
+        // script would be undone before the next statement ran.
+        guard database != currentDb else { return }
         currentDb = database
+        scriptRuntime?.rebindDatabase(database)
     }
 
-    // MARK: - EXPLAIN
-
-    func buildExplainQuery(_ sql: String) -> String? {
-        guard let operation = try? MongoShellParser.parse(sql) else {
-            return "db.runCommand({\"explain\": \"\(escapeJsonString(sql))\", \"verbosity\": \"executionStats\"})"
-        }
-
-        switch operation {
-        case .find(let collection, let filter, let options):
-            var findDoc = "\"find\": \"\(escapeJsonString(collection))\", \"filter\": \(filter)"
-            if let sort = options.sort {
-                findDoc += ", \"sort\": \(sort)"
-            }
-            if let skip = options.skip {
-                findDoc += ", \"skip\": \(skip)"
-            }
-            if let limit = options.limit {
-                findDoc += ", \"limit\": \(limit)"
-            }
-            if let projection = options.projection {
-                findDoc += ", \"projection\": \(projection)"
-            }
-            return "db.runCommand({\"explain\": {\(findDoc)}, \"verbosity\": \"executionStats\"})"
-
-        case .findOne(let collection, let filter):
-            return "db.runCommand({\"explain\": {\"find\": \"\(escapeJsonString(collection))\", \"filter\": \(filter), \"limit\": 1}, \"verbosity\": \"executionStats\"})"
-
-        case .aggregate(let collection, let pipeline):
-            return "db.runCommand({\"explain\": {\"aggregate\": \"\(escapeJsonString(collection))\", \"pipeline\": \(pipeline), \"cursor\": {}}, \"verbosity\": \"executionStats\"})"
-
-        case .countDocuments(let collection, let filter):
-            return "db.runCommand({\"explain\": {\"count\": \"\(escapeJsonString(collection))\", \"query\": \(filter)}, \"verbosity\": \"executionStats\"})"
-
-        case .deleteOne(let collection, let filter):
-            return "db.runCommand({\"explain\": {\"delete\": \"\(escapeJsonString(collection))\", \"deletes\": [{\"q\": \(filter), \"limit\": 1}]}, \"verbosity\": \"executionStats\"})"
-
-        case .deleteMany(let collection, let filter):
-            return "db.runCommand({\"explain\": {\"delete\": \"\(escapeJsonString(collection))\", \"deletes\": [{\"q\": \(filter), \"limit\": 0}]}, \"verbosity\": \"executionStats\"})"
-
-        case .updateOne(let collection, let filter, let update):
-            return "db.runCommand({\"explain\": {\"update\": \"\(escapeJsonString(collection))\", \"updates\": [{\"q\": \(filter), \"u\": \(update), \"multi\": false}]}, \"verbosity\": \"executionStats\"})"
-
-        case .updateMany(let collection, let filter, let update):
-            return "db.runCommand({\"explain\": {\"update\": \"\(escapeJsonString(collection))\", \"updates\": [{\"q\": \(filter), \"u\": \(update), \"multi\": true}]}, \"verbosity\": \"executionStats\"})"
-
-        case .findOneAndUpdate(let collection, let filter, let update):
-            let cmd = "\"findAndModify\": \"\(escapeJsonString(collection))\", \"query\": \(filter), \"update\": \(update)"
-            return "db.runCommand({\"explain\": {\(cmd)}, \"verbosity\": \"executionStats\"})"
-
-        case .write(let kind, let collection, let filter, let document, _):
-            let multi = kind == .updateMany
-            if kind == .findOneAndUpdate {
-                let cmd = "\"findAndModify\": \"\(escapeJsonString(collection))\", \"query\": \(filter), \"update\": \(document)"
-                return "db.runCommand({\"explain\": {\(cmd)}, \"verbosity\": \"executionStats\"})"
-            }
-            return "db.runCommand({\"explain\": {\"update\": \"\(escapeJsonString(collection))\", \"updates\": [{\"q\": \(filter), \"u\": \(document), \"multi\": \(multi)}]}, \"verbosity\": \"executionStats\"})"
-
-        case .findOneAndReplace(let collection, let filter, let replacement):
-            let cmd = "\"findAndModify\": \"\(escapeJsonString(collection))\", \"query\": \(filter), \"update\": \(replacement)"
-            return "db.runCommand({\"explain\": {\(cmd)}, \"verbosity\": \"executionStats\"})"
-
-        case .findOneAndDelete(let collection, let filter):
-            let cmd = "\"findAndModify\": \"\(escapeJsonString(collection))\", \"query\": \(filter), \"remove\": true"
-            return "db.runCommand({\"explain\": {\(cmd)}, \"verbosity\": \"executionStats\"})"
-
-        default:
-            return "db.runCommand({\"explain\": \"\(escapeJsonString(sql))\", \"verbosity\": \"executionStats\"})"
-        }
-    }
 
     // MARK: - View Templates
 
@@ -818,266 +737,76 @@ final class MongoDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             return AsyncThrowingStream { $0.finish(throwing: MongoDBPluginError.notConnected) }
         }
 
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = MongoShellCommandLine.rewrite(
+            query.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
         let db = currentDb
 
-        let operation: MongoOperation
-        do {
-            operation = try MongoShellParser.parse(trimmed)
-        } catch {
-            return AsyncThrowingStream { $0.finish(throwing: error) }
+        guard let runtime = scriptRuntime else {
+            return AsyncThrowingStream { $0.finish(throwing: MongoDBPluginError.notConnected) }
         }
+        let timeout = conn.queryTimeoutMS
 
-        switch operation {
-        case .find(let collection, let filter, let options):
-            return conn.streamFind(
-                database: db, collection: collection, filter: filter,
-                sort: options.sort, projection: options.projection,
-                skip: options.skip ?? 0, limit: options.limit
-            )
-        case .aggregate(let collection, let pipeline):
-            return conn.streamAggregate(
-                database: db, collection: collection, pipeline: pipeline
-            )
-        default:
-            return AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
-                Task {
-                    do {
-                        let result = try await self.execute(query: query)
-                        if !result.columns.isEmpty {
-                            continuation.yield(.header(PluginStreamHeader(
-                                columns: result.columns,
-                                columnTypeNames: result.columnTypeNames
-                            )))
+        return AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
+            let work = Task {
+                do {
+                    switch try await runtime.exportPlan(for: trimmed, database: db) {
+                    case .cursor(let plan):
+                        let inner = plan.isFind
+                            ? conn.streamFind(
+                                database: plan.database, collection: plan.collection,
+                                filter: plan.filter,
+                                optionsJson: plan.options.findOptionsJson(
+                                    limit: PluginRowLimits.emergencyMax, timeoutMS: timeout
+                                )
+                            )
+                            : conn.streamAggregate(
+                                database: plan.database, collection: plan.collection,
+                                pipeline: plan.pipeline,
+                                optionsJson: plan.options.aggregateOptionsJson(timeoutMS: timeout)
+                            )
+                        for try await element in inner {
+                            try Task.checkCancellation()
+                            continuation.yield(element)
                         }
-                        if !result.rows.isEmpty {
-                            continuation.yield(.rows(result.rows))
-                        }
-                        continuation.finish()
-                    } catch {
-                        continuation.finish(throwing: error)
+                    case .result(let outcome):
+                        self.yieldMaterialised(outcome, into: continuation)
                     }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
                 }
             }
+            // A consumer that stops reading has to stop the cursor too, or it keeps draining the
+            // whole query and holds the leased driver busy.
+            continuation.onTermination = { @Sendable _ in work.cancel() }
         }
     }
 
-    // MARK: - Operation Dispatch
-
-    private func executeOperation(
-        _ operation: MongoOperation,
-        connection conn: MongoDBConnection,
-        startTime: Date
-    ) async throws -> PluginQueryResult {
-        let db = currentDb
-
-        switch operation {
-        case .find(let collection, let filter, let options):
-            let result = try await conn.find(
-                database: db, collection: collection, filter: filter,
-                sort: options.sort, projection: options.projection,
-                skip: options.skip ?? 0, limit: options.limit ?? PluginRowLimits.emergencyMax
-            )
-            if result.docs.isEmpty {
-                return PluginQueryResult(
-                    columns: ["_id"], columnTypeNames: ["ObjectId"],
-                    rows: [], rowsAffected: 0, executionTime: Date().timeIntervalSince(startTime)
+    /// Hands over a statement that had already run by the time the export asked, rather than
+    /// running it a second time.
+    private func yieldMaterialised(
+        _ outcome: MongoScriptStatementResult,
+        into continuation: AsyncThrowingStream<PluginStreamElement, Error>.Continuation
+    ) {
+        let result = MongoScriptResultBuilder.result(
+            for: outcome,
+            startTime: Date(),
+            documents: { documents, collection, isTruncated in
+                self.buildPluginResult(
+                    from: documents, startTime: Date(),
+                    isTruncated: isTruncated, collection: collection
                 )
             }
-            return buildPluginResult(
-                from: result.docs, startTime: startTime, isTruncated: result.isTruncated, collection: collection
-            )
-
-        case .findOne(let collection, let filter):
-            let result = try await conn.find(
-                database: db, collection: collection, filter: filter,
-                sort: nil, projection: nil, skip: 0, limit: 1
-            )
-            return buildPluginResult(from: result.docs, startTime: startTime, collection: collection)
-
-        case .aggregate(let collection, let pipeline):
-            let result = try await conn.aggregate(database: db, collection: collection, pipeline: pipeline)
-            return buildPluginResult(
-                from: result.docs, startTime: startTime, isTruncated: result.isTruncated, collection: collection
-            )
-
-        case .countDocuments(let collection, let filter):
-            let count = try await conn.countDocuments(
-                database: db, collection: collection, filter: filter, background: false
-            )
-            return PluginQueryResult(
-                columns: ["count"], columnTypeNames: ["Int64"],
-                rows: [[.text(String(count))]], rowsAffected: 0,
-                executionTime: Date().timeIntervalSince(startTime)
-            )
-
-        case .insertOne(let collection, let document):
-            let insertedId = try await conn.insertOne(database: db, collection: collection, document: document)
-            return PluginQueryResult(
-                columns: ["insertedId"], columnTypeNames: ["ObjectId"],
-                rows: [[.text(insertedId ?? "null")]], rowsAffected: 1,
-                executionTime: Date().timeIntervalSince(startTime)
-            )
-
-        case .insertMany(let collection, let documents):
-            let cmd = "{\"insert\": \"\(escapeJsonString(collection))\", \"documents\": \(documents)}"
-            let result = try await conn.runCommand(cmd, database: db)
-            let inserted = (result.first?["n"] as? Int) ?? 0
-            return PluginQueryResult(
-                columns: ["insertedCount"], columnTypeNames: ["Int32"],
-                rows: [[.text(String(inserted))]], rowsAffected: inserted,
-                executionTime: Date().timeIntervalSince(startTime)
-            )
-
-        case .updateOne(let collection, let filter, let update):
-            let modified = try await conn.updateOne(database: db, collection: collection, filter: filter, update: update)
-            return PluginQueryResult(
-                columns: ["modifiedCount"], columnTypeNames: ["Int64"],
-                rows: [[.text(String(modified))]], rowsAffected: Int(modified),
-                executionTime: Date().timeIntervalSince(startTime)
-            )
-
-        case .updateMany(let collection, let filter, let update):
-            let cmd = """
-                {"update": "\(escapeJsonString(collection))", \
-                "updates": [{"q": \(filter), "u": \(update), "multi": true}]}
-                """
-            let result = try await conn.runCommand(cmd, database: db)
-            let modified = (result.first?["nModified"] as? Int64)
-                ?? (result.first?["nModified"] as? Int).map(Int64.init) ?? 0
-            return PluginQueryResult(
-                columns: ["modifiedCount"], columnTypeNames: ["Int64"],
-                rows: [[.text(String(modified))]], rowsAffected: Int(modified),
-                executionTime: Date().timeIntervalSince(startTime)
-            )
-
-        case .replaceOne(let collection, let filter, let replacement):
-            let cmd = """
-                {"update": "\(escapeJsonString(collection))", \
-                "updates": [{"q": \(filter), "u": \(replacement), "multi": false}]}
-                """
-            let result = try await conn.runCommand(cmd, database: db)
-            let modified = (result.first?["nModified"] as? Int64)
-                ?? (result.first?["nModified"] as? Int).map(Int64.init) ?? 0
-            return PluginQueryResult(
-                columns: ["modifiedCount"], columnTypeNames: ["Int64"],
-                rows: [[.text(String(modified))]], rowsAffected: Int(modified),
-                executionTime: Date().timeIntervalSince(startTime)
-            )
-
-        case .deleteOne(let collection, let filter):
-            let deleted = try await conn.deleteOne(database: db, collection: collection, filter: filter)
-            return PluginQueryResult(
-                columns: ["deletedCount"], columnTypeNames: ["Int64"],
-                rows: [[.text(String(deleted))]], rowsAffected: Int(deleted),
-                executionTime: Date().timeIntervalSince(startTime)
-            )
-
-        case .deleteMany(let collection, let filter):
-            let cmd = """
-                {"delete": "\(escapeJsonString(collection))", \
-                "deletes": [{"q": \(filter), "limit": 0}]}
-                """
-            let result = try await conn.runCommand(cmd, database: db)
-            let deleted = (result.first?["n"] as? Int64)
-                ?? (result.first?["n"] as? Int).map(Int64.init) ?? 0
-            return PluginQueryResult(
-                columns: ["deletedCount"], columnTypeNames: ["Int64"],
-                rows: [[.text(String(deleted))]], rowsAffected: Int(deleted),
-                executionTime: Date().timeIntervalSince(startTime)
-            )
-
-        default:
-            return try await executeCommandOperation(operation, connection: conn, startTime: startTime)
+        )
+        if !result.columns.isEmpty {
+            continuation.yield(.header(PluginStreamHeader(
+                columns: result.columns,
+                columnTypeNames: result.columnTypeNames
+            )))
         }
-    }
-
-    private func executeCommandOperation(
-        _ operation: MongoOperation,
-        connection conn: MongoDBConnection,
-        startTime: Date
-    ) async throws -> PluginQueryResult {
-        let db = currentDb
-
-        switch operation {
-        case .createIndex(let collection, let keys, let options):
-            var indexDoc = "{\"key\": \(keys)"
-            if let opts = options {
-                indexDoc += ", " + String(opts.dropFirst())
-            } else {
-                indexDoc += "}"
-            }
-            let cmd = """
-                {"createIndexes": "\(escapeJsonString(collection))", \
-                "indexes": [\(indexDoc)]}
-                """
-            let result = try await conn.runCommand(cmd, database: db)
-            return buildPluginResult(from: result, startTime: startTime)
-
-        case .dropIndex(let collection, let indexName):
-            let cmd = """
-                {"dropIndexes": "\(escapeJsonString(collection))", \
-                "index": "\(escapeJsonString(indexName))"}
-                """
-            let result = try await conn.runCommand(cmd, database: db)
-            return buildPluginResult(from: result, startTime: startTime)
-
-        case .findOneAndUpdate(let collection, let filter, let update):
-            let cmd = "{\"findAndModify\": \"\(escapeJsonString(collection))\", \"query\": \(filter), \"update\": \(update), \"new\": true}"
-            let docs = try await conn.runCommand(cmd, database: db)
-            return buildPluginResult(from: docs.isEmpty ? [] : [docs[0]], startTime: startTime)
-
-        case .write(let kind, let collection, let filter, let document, let options):
-            return try await executeWrite(
-                kind: kind, collection: collection, filter: filter, document: document,
-                options: options, conn: conn, db: db, startTime: startTime
-            )
-
-        case .findOneAndReplace(let collection, let filter, let replacement):
-            let cmd = "{\"findAndModify\": \"\(escapeJsonString(collection))\", \"query\": \(filter), \"update\": \(replacement), \"new\": true}"
-            let docs = try await conn.runCommand(cmd, database: db)
-            return buildPluginResult(from: docs.isEmpty ? [] : [docs[0]], startTime: startTime)
-
-        case .findOneAndDelete(let collection, let filter):
-            let cmd = "{\"findAndModify\": \"\(escapeJsonString(collection))\", \"query\": \(filter), \"remove\": true}"
-            let docs = try await conn.runCommand(cmd, database: db)
-            return buildPluginResult(from: docs.isEmpty ? [] : [docs[0]], startTime: startTime)
-
-        case .drop(let collection):
-            let cmd = "{\"drop\": \"\(escapeJsonString(collection))\"}"
-            let result = try await conn.runCommand(cmd, database: db)
-            return buildPluginResult(from: result, startTime: startTime)
-
-        case .runCommand(let command):
-            let result = try await conn.runCommand(command, database: db)
-            return buildPluginResult(from: result, startTime: startTime)
-
-        case .listCollections:
-            let collections = try await conn.listCollections(database: db)
-            return PluginQueryResult(
-                columns: ["collection"], columnTypeNames: ["String"],
-                rows: collections.map { [.text($0)] }, rowsAffected: 0,
-                executionTime: Date().timeIntervalSince(startTime)
-            )
-
-        case .listDatabases:
-            let databases = try await conn.listDatabases()
-            return PluginQueryResult(
-                columns: ["database"], columnTypeNames: ["String"],
-                rows: databases.map { [.text($0)] }, rowsAffected: 0,
-                executionTime: Date().timeIntervalSince(startTime)
-            )
-
-        case .ping:
-            _ = try await conn.ping()
-            return PluginQueryResult(
-                columns: ["ok"], columnTypeNames: ["Int32"],
-                rows: [["1"]], rowsAffected: 0,
-                executionTime: Date().timeIntervalSince(startTime)
-            )
-
-        default:
-            throw MongoDBPluginError.unsupportedOperation
+        if !result.rows.isEmpty {
+            continuation.yield(.rows(result.rows))
         }
     }
 

--- a/Plugins/MongoDBDriverPlugin/MongoScriptCommandBuilder.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoScriptCommandBuilder.swift
@@ -1,0 +1,211 @@
+import Foundation
+
+/// Builds the database commands a script's collection methods stand for.
+///
+/// Writes go out as commands rather than through the collection convenience calls so the whole
+/// server reply is available: `n`, `nModified` and `upserted` are what a mongosh result object is
+/// made of, and the convenience calls report only one of them.
+enum MongoScriptCommandBuilder {
+    enum BulkKind {
+        case insert
+        case update
+        case delete
+    }
+
+    struct BulkStatement {
+        let kind: BulkKind
+        let document: String
+    }
+
+    static func update(
+        collection: String,
+        filter: String,
+        update: String,
+        multi: Bool,
+        options: [String: Any]
+    ) -> String {
+        var fields = [
+            "\"q\": \(filter)",
+            "\"u\": \(update)",
+            "\"multi\": \(multi)",
+            "\"upsert\": \(options["upsert"] as? Bool ?? false)"
+        ]
+        appendPassThrough(&fields, options: options, keys: ["arrayFilters", "hint", "collation"])
+        return """
+            {"update": \(MongoScriptJson.jsonString(collection)), "updates": [{\(fields.joined(separator: ", "))}]}
+            """
+    }
+
+    static func delete(collection: String, filter: String, multi: Bool, options: [String: Any]) -> String {
+        var fields = ["\"q\": \(filter)", "\"limit\": \(multi ? 0 : 1)"]
+        appendPassThrough(&fields, options: options, keys: ["hint", "collation"])
+        return """
+            {"delete": \(MongoScriptJson.jsonString(collection)), "deletes": [{\(fields.joined(separator: ", "))}]}
+            """
+    }
+
+    static func findAndModify(
+        collection: String,
+        filter: String,
+        update: String?,
+        remove: Bool,
+        options: [String: Any]
+    ) -> String {
+        var fields = [
+            "\"findAndModify\": \(MongoScriptJson.jsonString(collection))",
+            "\"query\": \(filter)"
+        ]
+        if remove {
+            fields.append("\"remove\": true")
+        } else if let update {
+            fields.append("\"update\": \(update)")
+            fields.append("\"new\": \(returnsUpdatedDocument(options))")
+            fields.append("\"upsert\": \(options["upsert"] as? Bool ?? false)")
+        }
+        appendPassThrough(&fields, options: options, keys: ["sort", "arrayFilters", "hint", "collation"])
+        if let projection = jsonText(options["projection"]) {
+            fields.append("\"fields\": \(projection)")
+        }
+        return "{\(fields.joined(separator: ", "))}"
+    }
+
+    static func createIndex(collection: String, keys: String, options: [String: Any]) -> String {
+        var fields = ["\"key\": \(keys)", "\"name\": \(MongoScriptJson.jsonString(indexName(keys: keys, options: options)))"]
+        appendPassThrough(
+            &fields,
+            options: options,
+            keys: [
+                "unique", "sparse", "expireAfterSeconds", "partialFilterExpression",
+                "collation", "background", "hidden", "weights", "default_language"
+            ]
+        )
+        return """
+            {"createIndexes": \(MongoScriptJson.jsonString(collection)), \
+            "indexes": [{\(fields.joined(separator: ", "))}]}
+            """
+    }
+
+    static func find(
+        collection: String,
+        filter: String,
+        options: MongoScriptCursorOptions,
+        ceiling: Int
+    ) -> String {
+        var fields = [
+            "\"find\": \(MongoScriptJson.jsonString(collection))",
+            "\"filter\": \(filter)",
+            "\"limit\": \(options.effectiveLimit(ceiling: ceiling))"
+        ]
+        if let sort = options.sort { fields.append("\"sort\": \(sort)") }
+        if let projection = options.projection { fields.append("\"projection\": \(projection)") }
+        if let skip = options.skip, skip > 0 { fields.append("\"skip\": \(skip)") }
+        if let hint = options.hint { fields.append("\"hint\": \(hint)") }
+        if let collation = options.collation { fields.append("\"collation\": \(collation)") }
+        if let batchSize = options.batchSize { fields.append("\"batchSize\": \(batchSize)") }
+        if let maxTimeMS = options.maxTimeMS { fields.append("\"maxTimeMS\": \(maxTimeMS)") }
+        if options.allowDiskUse { fields.append("\"allowDiskUse\": true") }
+        return "{\(fields.joined(separator: ", "))}"
+    }
+
+    static func aggregate(collection: String, pipeline: String, options: MongoScriptCursorOptions) -> String {
+        var fields = [
+            "\"aggregate\": \(MongoScriptJson.jsonString(collection))",
+            "\"pipeline\": \(options.decoratedPipeline(pipeline))",
+            "\"cursor\": {}"
+        ]
+        if let hint = options.hint { fields.append("\"hint\": \(hint)") }
+        if let collation = options.collation { fields.append("\"collation\": \(collation)") }
+        if options.allowDiskUse { fields.append("\"allowDiskUse\": true") }
+        if let maxTimeMS = options.maxTimeMS { fields.append("\"maxTimeMS\": \(maxTimeMS)") }
+        return "{\(fields.joined(separator: ", "))}"
+    }
+
+    static func bulkOperation(_ operation: String, collection: String) throws -> BulkStatement {
+        if let document = MongoScriptJson.member(of: operation, key: "insertOne") {
+            let payload = MongoScriptJson.member(of: document, key: "document") ?? "{}"
+            return BulkStatement(
+                kind: .insert,
+                document: """
+                    {"insert": \(MongoScriptJson.jsonString(collection)), "documents": [\(payload)]}
+                    """
+            )
+        }
+        for name in ["updateOne", "updateMany", "replaceOne"] {
+            guard let body = MongoScriptJson.member(of: operation, key: name) else { continue }
+            let filter = MongoScriptJson.member(of: body, key: "filter") ?? "{}"
+            let change = MongoScriptJson.member(of: body, key: name == "replaceOne" ? "replacement" : "update")
+            return BulkStatement(
+                kind: .update,
+                document: update(
+                    collection: collection,
+                    filter: filter,
+                    update: change ?? "{}",
+                    multi: name == "updateMany",
+                    options: MongoScriptJson.options(body)
+                )
+            )
+        }
+        for name in ["deleteOne", "deleteMany"] {
+            guard let body = MongoScriptJson.member(of: operation, key: name) else { continue }
+            return BulkStatement(
+                kind: .delete,
+                document: delete(
+                    collection: collection,
+                    filter: MongoScriptJson.member(of: body, key: "filter") ?? "{}",
+                    multi: name == "deleteMany",
+                    options: [:]
+                )
+            )
+        }
+        throw MongoScriptError(MongoScriptText.unsupportedBulkOperation(operation))
+    }
+
+    // MARK: - Helpers
+
+    /// The name MongoDB gives an index the script did not name, which is the key names and their
+    /// directions joined with underscores, in the order the key document declares them.
+    static func indexName(keys: String, options: [String: Any]) -> String {
+        if let named = options["name"] as? String, !named.isEmpty { return named }
+        let parts = MongoScriptJson.members(of: keys).map { member -> String in
+            "\(member.key)_\(direction(of: member.value))"
+        }
+        return parts.isEmpty ? "index" : parts.joined(separator: "_")
+    }
+
+    private static func direction(of valueJson: String) -> String {
+        let trimmed = valueJson.trimmingCharacters(in: .whitespaces)
+        if let literal = Int(trimmed) { return String(literal) }
+        if trimmed.hasPrefix("\""), trimmed.hasSuffix("\""), trimmed.count >= 2 {
+            return String(trimmed.dropFirst().dropLast())
+        }
+        guard let data = trimmed.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]),
+              let number = MongoScriptJson.numeric(parsed) else { return "1" }
+        return String(number)
+    }
+
+    private static func returnsUpdatedDocument(_ options: [String: Any]) -> Bool {
+        if let flag = options["returnNewDocument"] as? Bool { return flag }
+        if let document = options["returnDocument"] as? String { return document.lowercased() == "after" }
+        if let flag = options["new"] as? Bool { return flag }
+        return false
+    }
+
+    private static func appendPassThrough(_ fields: inout [String], options: [String: Any], keys: [String]) {
+        for key in keys {
+            guard let text = jsonText(options[key]) else { continue }
+            fields.append("\"\(key)\": \(text)")
+        }
+    }
+
+    private static func jsonText(_ value: Any?) -> String? {
+        guard let value, !(value is NSNull) else { return nil }
+        if let flag = value as? Bool { return flag ? "true" : "false" }
+        if let number = value as? NSNumber { return number.stringValue }
+        if let text = value as? String { return MongoScriptJson.jsonString(text) }
+        guard JSONSerialization.isValidJSONObject(value),
+              let data = try? JSONSerialization.data(withJSONObject: value),
+              let text = String(data: data, encoding: .utf8) else { return nil }
+        return text
+    }
+}

--- a/Plugins/MongoDBDriverPlugin/MongoScriptCursor.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoScriptCursor.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+/// A cursor the script holds but the server has not been asked about yet.
+///
+/// `find()` in mongosh returns without touching the server, and the modifiers chained onto it are
+/// part of the query rather than post-processing. Keeping the cursor lazy is what makes
+/// `.sort().limit()` reach MongoDB as one query, and it is also what lets a statement whose value
+/// is a cursor skip JavaScript entirely: nothing has been marshalled yet, so the driver can drain
+/// it straight into the result grid.
+final class MongoScriptCursor {
+    enum Kind {
+        case find(filter: String)
+        case aggregate(pipeline: String)
+    }
+
+    let handle: Int
+    let kind: Kind
+    let database: String
+    let collection: String
+    private(set) var options: MongoScriptCursorOptions
+    private(set) var isStarted = false
+    private(set) var isClosed = false
+
+    private var materialised: MongoScriptDocumentBatch?
+    private var position = 0
+
+    init(
+        handle: Int,
+        kind: Kind,
+        database: String,
+        collection: String,
+        options: MongoScriptCursorOptions = .none
+    ) {
+        self.handle = handle
+        self.kind = kind
+        self.database = database
+        self.collection = collection
+        self.options = options
+    }
+
+    var isFind: Bool {
+        if case .find = kind { return true }
+        return false
+    }
+
+    var filterJson: String {
+        if case .find(let filter) = kind { return filter }
+        return "{}"
+    }
+
+    var pipelineJson: String {
+        if case .aggregate(let pipeline) = kind { return pipeline }
+        return "[]"
+    }
+
+    func configure(key: String, value: String) throws {
+        guard !isStarted else {
+            throw MongoScriptError(MongoScriptText.cursorAlreadyStarted(key))
+        }
+        try options.apply(key: key, value: value)
+    }
+
+    /// Documents the script has not consumed yet, materialising on the first ask.
+    func remaining(loader: (MongoScriptCursor) throws -> MongoScriptDocumentBatch) throws -> MongoScriptDocumentBatch {
+        let batch = try materialise(loader: loader)
+        guard position < batch.json.count else {
+            return MongoScriptDocumentBatch(json: [], isTruncated: batch.isTruncated)
+        }
+        let rest = Array(batch.json[position...])
+        position = batch.json.count
+        return MongoScriptDocumentBatch(json: rest, isTruncated: batch.isTruncated)
+    }
+
+    func page(
+        size: Int,
+        loader: (MongoScriptCursor) throws -> MongoScriptDocumentBatch
+    ) throws -> (batch: MongoScriptDocumentBatch, done: Bool) {
+        let batch = try materialise(loader: loader)
+        guard position < batch.json.count else {
+            return (MongoScriptDocumentBatch(json: [], isTruncated: batch.isTruncated), true)
+        }
+        let end = min(position + max(size, 1), batch.json.count)
+        let slice = Array(batch.json[position ..< end])
+        position = end
+        return (
+            MongoScriptDocumentBatch(json: slice, isTruncated: batch.isTruncated),
+            position >= batch.json.count
+        )
+    }
+
+    func close() {
+        isClosed = true
+        materialised = nil
+    }
+
+    private func materialise(
+        loader: (MongoScriptCursor) throws -> MongoScriptDocumentBatch
+    ) throws -> MongoScriptDocumentBatch {
+        if let materialised { return materialised }
+        isStarted = true
+        let batch = try loader(self)
+        materialised = batch
+        return batch
+    }
+}
+
+/// The cursors one script run has open, keyed by the handle JavaScript holds.
+final class MongoScriptCursorRegistry {
+    private var cursors: [Int: MongoScriptCursor] = [:]
+    private var nextHandle = 1
+
+    func open(
+        kind: MongoScriptCursor.Kind,
+        database: String,
+        collection: String,
+        options: MongoScriptCursorOptions = .none
+    ) -> MongoScriptCursor {
+        let cursor = MongoScriptCursor(
+            handle: nextHandle, kind: kind, database: database, collection: collection, options: options
+        )
+        cursors[nextHandle] = cursor
+        nextHandle += 1
+        return cursor
+    }
+
+    func cursor(for handle: Int) throws -> MongoScriptCursor {
+        guard let cursor = cursors[handle], !cursor.isClosed else {
+            throw MongoScriptError(MongoScriptText.unknownCursor)
+        }
+        return cursor
+    }
+
+    func close(handle: Int) {
+        cursors[handle]?.close()
+        cursors[handle] = nil
+    }
+
+    /// Drops all but the most recent cursors.
+    ///
+    /// A cursor outlives the statement that opened it, because a shell lets you keep one in a
+    /// variable and read it in the next statement. Without a ceiling that would hold every
+    /// materialised page for the life of the connection, so the oldest go first.
+    func prune(keeping limit: Int) {
+        guard cursors.count > limit else { return }
+        for handle in cursors.keys.sorted().dropLast(limit) {
+            cursors[handle]?.close()
+            cursors[handle] = nil
+        }
+    }
+
+    func removeAll() {
+        for cursor in cursors.values { cursor.close() }
+        cursors.removeAll()
+    }
+}

--- a/Plugins/MongoDBDriverPlugin/MongoScriptCursorOptions.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoScriptCursorOptions.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// The cursor modifiers a script chains onto `find()` or `aggregate()`.
+///
+/// Every value arrives from JavaScript as canonical Extended JSON, so it is carried as text and
+/// spliced into the options document verbatim. The previous path pushed `sort` and `projection`
+/// through `JSONSerialization`, which cannot read Extended JSON and reported failure by returning
+/// nil, so a sort the parser had accepted was dropped and the query ran unsorted while reporting
+/// success.
+struct MongoScriptCursorOptions: Equatable, Sendable {
+    var sort: String?
+    var projection: String?
+    var skip: Int?
+    var limit: Int?
+    var batchSize: Int?
+    var hint: String?
+    var collation: String?
+    var maxTimeMS: Int?
+    var allowDiskUse = false
+
+    static let none = MongoScriptCursorOptions()
+
+    var isMutated: Bool { self != .none }
+
+    mutating func apply(key: String, value: String) throws {
+        switch key {
+        case "sort": sort = value
+        case "projection": projection = value
+        case "hint": hint = value
+        case "collation": collation = value
+        case "limit": limit = try Self.wholeNumber(value, key: key)
+        case "skip": skip = try Self.wholeNumber(value, key: key)
+        case "batchSize": batchSize = try Self.wholeNumber(value, key: key)
+        case "maxTimeMS": maxTimeMS = try Self.wholeNumber(value, key: key)
+        case "allowDiskUse": allowDiskUse = true
+        default: throw MongoScriptError(MongoScriptText.unsupportedCursorOption(key))
+        }
+    }
+
+    /// The `find` options document, as text libbson parses directly.
+    ///
+    /// `limit` is the smaller of what the script asked for and the ceiling the caller imposes, so a
+    /// script that asks for more than the row cap still stops at the cap and a script that asks for
+    /// fewer is not silently raised to it.
+    func findOptionsJson(limit ceiling: Int, timeoutMS: Int32) -> String {
+        var fields: [String] = ["\"skip\": \(skip ?? 0)", "\"limit\": \(effectiveLimit(ceiling: ceiling))"]
+        appendDocument(&fields, key: "sort", value: sort)
+        appendDocument(&fields, key: "projection", value: projection)
+        appendDocument(&fields, key: "hint", value: hint)
+        appendDocument(&fields, key: "collation", value: collation)
+        if let batchSize { fields.append("\"batchSize\": \(batchSize)") }
+        if allowDiskUse { fields.append("\"allowDiskUse\": true") }
+        if let resolved = resolvedMaxTimeMS(timeoutMS) { fields.append("\"maxTimeMS\": \(resolved)") }
+        return "{\(fields.joined(separator: ", "))}"
+    }
+
+    func aggregateOptionsJson(timeoutMS: Int32) -> String? {
+        var fields: [String] = []
+        appendDocument(&fields, key: "hint", value: hint)
+        appendDocument(&fields, key: "collation", value: collation)
+        if let batchSize { fields.append("\"batchSize\": \(batchSize)") }
+        if allowDiskUse { fields.append("\"allowDiskUse\": true") }
+        if let resolved = resolvedMaxTimeMS(timeoutMS) { fields.append("\"maxTimeMS\": \(resolved)") }
+        guard !fields.isEmpty else { return nil }
+        return "{\(fields.joined(separator: ", "))}"
+    }
+
+    /// An aggregation takes its ordering and paging as pipeline stages, not as cursor options, so a
+    /// `.sort()` chained onto `aggregate()` has to become a `$sort` stage appended after the
+    /// script's own stages. Appending rather than prepending is what mongosh does and what the
+    /// chaining reads as: the modifier applies to the pipeline's output.
+    func decoratedPipeline(_ pipeline: String) -> String {
+        var stages: [String] = []
+        if let sort { stages.append("{\"$sort\": \(sort)}") }
+        if let skip, skip > 0 { stages.append("{\"$skip\": \(skip)}") }
+        if let limit, limit > 0 { stages.append("{\"$limit\": \(limit)}") }
+        guard !stages.isEmpty else { return pipeline }
+
+        let trimmed = pipeline.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("["), trimmed.hasSuffix("]") else { return pipeline }
+        let inner = String(trimmed.dropFirst().dropLast()).trimmingCharacters(in: .whitespacesAndNewlines)
+        let appended = stages.joined(separator: ",")
+        return inner.isEmpty ? "[\(appended)]" : "[\(inner),\(appended)]"
+    }
+
+    func effectiveLimit(ceiling: Int) -> Int {
+        guard let limit, limit > 0 else { return ceiling }
+        return ceiling > 0 ? min(limit, ceiling) : limit
+    }
+
+    private func resolvedMaxTimeMS(_ timeoutMS: Int32) -> Int? {
+        if let maxTimeMS, maxTimeMS > 0 { return maxTimeMS }
+        return timeoutMS > 0 ? Int(timeoutMS) : nil
+    }
+
+    private func appendDocument(_ fields: inout [String], key: String, value: String?) {
+        guard let value, !value.isEmpty, value != "null" else { return }
+        fields.append("\"\(key)\": \(value)")
+    }
+
+    /// A cursor modifier's numeric argument.
+    ///
+    /// Refused rather than converted when it is not a whole number: JavaScript reaches NaN and
+    /// infinity through ordinary arithmetic, `Double("NaN")` parses, and `Int(Double.nan)` traps.
+    private static func wholeNumber(_ value: String, key: String) throws -> Int {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let direct = Int(trimmed) { return direct }
+        guard let data = trimmed.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]),
+              let parsed = MongoScriptJson.numeric(object),
+              let narrowed = Int(exactly: parsed) else {
+            throw MongoScriptError(MongoScriptText.wholeNumberExpected(key))
+        }
+        return narrowed
+    }
+}

--- a/Plugins/MongoDBDriverPlugin/MongoScriptCursorPlan.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoScriptCursorPlan.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// The query a lazy cursor stands for, read off it without running it.
+///
+/// A streaming export wants the shape rather than the documents, so it can hand the query to the
+/// driver's own cursor stream and page through a collection larger than memory.
+struct MongoScriptCursorPlan: Sendable {
+    let database: String
+    let collection: String
+    let isFind: Bool
+    let filter: String
+    let pipeline: String
+    let options: MongoScriptCursorOptions
+
+    var sort: String? { options.sort }
+    var projection: String? { options.projection }
+    var skip: Int { options.skip ?? 0 }
+    var limit: Int? { options.limit }
+}

--- a/Plugins/MongoDBDriverPlugin/MongoScriptError.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoScriptError.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// What the script layer throws.
+///
+/// Separate from `MongoDBError` so the parts that build commands and read cursor options depend on
+/// nothing but Foundation: the layer that talks to libmongoc maps this at its boundary, and
+/// everything above it can be tested without a database.
+struct MongoScriptError: Error, LocalizedError, Equatable {
+    let message: String
+
+    var errorDescription: String? { message }
+
+    init(_ message: String) {
+        self.message = message
+    }
+}

--- a/Plugins/MongoDBDriverPlugin/MongoScriptExport.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoScriptExport.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// What a streaming export found when it evaluated its statement.
+///
+/// The distinction exists so a statement is never evaluated twice. A cursor has not touched the
+/// server yet, so the export can page through it; anything else has already run, and running it
+/// again to fill the stream would repeat its write.
+enum MongoScriptExport: Sendable {
+    case cursor(MongoScriptCursorPlan)
+    case result(MongoScriptStatementResult)
+}

--- a/Plugins/MongoDBDriverPlugin/MongoScriptHost.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoScriptHost.swift
@@ -1,0 +1,571 @@
+import Foundation
+import TableProPluginKit
+import os
+
+/// The one entry point JavaScript has into the driver.
+///
+/// Every call from the prelude arrives here as a JSON request and leaves as a JSON response, so the
+/// bridge is a single function rather than a bridged object graph. Values cross as Extended JSON in
+/// both directions and are spliced into command documents as text, never rebuilt through
+/// `JSONSerialization`, because a document round-tripped through a Swift dictionary comes back with
+/// its fields in another order and BSON field order is part of the document.
+final class MongoScriptHost {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "MongoScriptHost")
+    private static let pageSize = 1_000
+    private static let retainedCursors = 64
+
+    private let connection: MongoDBConnection
+    private let cursors = MongoScriptCursorRegistry()
+    private let activityLock = NSLock()
+    private var activity = Date()
+    private var cancelled = false
+    private(set) var database: String
+    private(set) var printedLines: [String] = []
+    private(set) var databaseSwitch: String?
+
+    /// How many documents a cursor may materialise when it *is* the statement's value, which is the
+    /// row cap the result grid will show plus the one document that says there are more.
+    private(set) var valueCeiling: Int
+
+    /// How many a cursor may materialise when the script reads it itself. A `forEach` over a
+    /// collection is not bounded by what a grid can display, so the row cap must not reach it.
+    private let iterationCeiling = PluginRowLimits.emergencyMax
+
+    init(connection: MongoDBConnection, database: String, valueCeiling: Int) {
+        self.connection = connection
+        self.database = database
+        self.valueCeiling = valueCeiling
+    }
+
+    /// When the script last reached the host.
+    ///
+    /// The runtime's watchdog reads this rather than a start time, so a script that is working
+    /// through a large collection is never mistaken for one that has stopped responding.
+    var lastActivity: Date {
+        activityLock.lock()
+        defer { activityLock.unlock() }
+        return activity
+    }
+
+    func touch() {
+        activityLock.lock()
+        activity = Date()
+        activityLock.unlock()
+    }
+
+    /// Refuses every further host call for the rest of this statement.
+    ///
+    /// The driver's own flag is consumed by the first `checkCancelled` that sees it, so a script
+    /// that wraps its work in `try`/`catch` would swallow the cancellation and carry on querying.
+    /// This latch is what makes `Cmd+.` stick: it is cleared only when the next statement starts.
+    func markCancelled() {
+        activityLock.lock()
+        cancelled = true
+        activityLock.unlock()
+    }
+
+    var isCancelled: Bool {
+        activityLock.lock()
+        defer { activityLock.unlock() }
+        return cancelled
+    }
+
+    /// Clears what belonged to the previous statement.
+    ///
+    /// Cursors are pruned rather than dropped: a shell lets you keep one in a variable and read it
+    /// in the next statement, so only the oldest go, and only past the ceiling.
+    func beginStatement() {
+        cursors.prune(keeping: Self.retainedCursors)
+        printedLines.removeAll()
+        databaseSwitch = nil
+        activityLock.lock()
+        cancelled = false
+        activityLock.unlock()
+        touch()
+    }
+
+    func prepare(valueCeiling: Int) {
+        self.valueCeiling = valueCeiling
+    }
+
+    func reset(database: String, valueCeiling: Int) {
+        cursors.removeAll()
+        printedLines.removeAll()
+        databaseSwitch = nil
+        touch()
+        self.database = database
+        self.valueCeiling = valueCeiling
+    }
+
+    /// Records a printed line, or refuses once the statement has been cancelled.
+    ///
+    /// `print` is the one bridge that is not a `handle` call, so without this a `while (true)
+    /// print("x")` would neither see the cancel latch nor ever fall silent, and the watchdog that
+    /// exists for exactly that script would never fire. Printing therefore does not count as
+    /// activity: only a call that reached the database does.
+    func record(printed line: String) -> Bool {
+        guard !isCancelled else { return false }
+        guard printedLines.count < PluginRowLimits.emergencyMax else { return true }
+        printedLines.append(line)
+        return true
+    }
+
+    // MARK: - Dispatch
+
+    func handle(_ requestJson: String) -> String {
+        touch()
+        defer { touch() }
+        guard !isCancelled else {
+            return MongoScriptJson.failure(message: MongoScriptText.cancelled, code: 0)
+        }
+        do {
+            guard let data = requestJson.data(using: .utf8),
+                  let request = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let op = request["op"] as? String else {
+                throw MongoScriptError(MongoScriptText.unknownOperation(requestJson))
+            }
+            return MongoScriptJson.success(try perform(op: op, request: request))
+        } catch is CancellationError {
+            markCancelled()
+            return MongoScriptJson.failure(message: MongoScriptText.cancelled, code: 0)
+        } catch let error as MongoDBError {
+            return MongoScriptJson.failure(message: error.message, code: error.code)
+        } catch let error as MongoScriptError {
+            return MongoScriptJson.failure(message: error.message, code: 0)
+        } catch {
+            return MongoScriptJson.failure(message: error.localizedDescription, code: 0)
+        }
+    }
+
+    private func perform(op: String, request: [String: Any]) throws -> String {
+        switch op {
+        case "currentDatabase": return MongoScriptJson.jsonString(database)
+        case "useDatabase": return try useDatabase(request)
+        case "listCollections": return try listCollections(request)
+        case "openCursor": return try openCursor(request)
+        case "cursorConfigure": return try configureCursor(request)
+        case "cursorFetch": return try fetchCursor(request)
+        case "cursorCount": return try countCursor(request)
+        case "cursorExplain": return try explainCursor(request)
+        case "cursorClose": return closeCursor(request)
+        case "command": return try runCommand(request)
+        case "countDocuments": return try countDocuments(request)
+        case "estimatedDocumentCount": return try estimatedCount(request)
+        case "distinct": return try distinct(request)
+        case "insertOne", "insertMany": return try insert(request, many: op == "insertMany")
+        case "update", "replace": return try update(request, isReplace: op == "replace")
+        case "delete": return try delete(request)
+        case "findAndModify": return try findAndModify(request)
+        case "bulkWrite": return try bulkWrite(request)
+        case "createIndex": return try createIndex(request)
+        case "dropIndex": return try dropIndex(request)
+        case "listIndexes": return try listIndexes(request)
+        case "dropCollection": return try command("{\"drop\": \(MongoScriptJson.jsonString(collectionName(request)))}", request)
+        case "renameCollection": return try renameCollection(request)
+        case "collectionStats":
+            return try command("{\"collStats\": \(MongoScriptJson.jsonString(collectionName(request)))}", request)
+        case "newObjectId": return MongoScriptJson.jsonString(MongoScriptObjectId.generate())
+        case "hexToBase64": return try hexToBase64(request)
+        case "encodeUuid": return try encodeUuid(request)
+        case "sleep": return try sleep(request)
+        default: throw MongoScriptError(MongoScriptText.unknownOperation(op))
+        }
+    }
+
+    // MARK: - Cursors
+
+    /// Drains a cursor the script left as the statement's value.
+    ///
+    /// Nothing has crossed into JavaScript at this point in the common case, so the documents go
+    /// straight to the grid without being marshalled twice.
+    func drain(handle: Int) throws -> MongoScriptDocumentBatch {
+        let cursor = try cursors.cursor(for: handle)
+        return try cursor.remaining { try load($0, ceiling: valueCeiling) }
+    }
+
+    func cursorDescription(handle: Int) -> (collection: String, isFind: Bool)? {
+        guard let cursor = try? cursors.cursor(for: handle) else { return nil }
+        return (cursor.collection, cursor.isFind)
+    }
+
+    /// The query a cursor stands for, without running it.
+    ///
+    /// Streaming exports need the shape of the query rather than its documents, and a cursor that
+    /// nothing has read has not touched the server yet, so asking costs nothing.
+    func cursorPlan(handle: Int) -> MongoScriptCursorPlan? {
+        guard let cursor = try? cursors.cursor(for: handle), !cursor.isStarted else { return nil }
+        return MongoScriptCursorPlan(
+            database: cursor.database,
+            collection: cursor.collection,
+            isFind: cursor.isFind,
+            filter: cursor.filterJson,
+            pipeline: cursor.options.decoratedPipeline(cursor.pipelineJson),
+            options: cursor.options
+        )
+    }
+
+    private func openCursor(_ request: [String: Any]) throws -> String {
+        let collection = collectionName(request)
+        var options = MongoScriptCursorOptions.none
+
+        let kind: MongoScriptCursor.Kind
+        if (request["kind"] as? String) == "aggregate" {
+            kind = .aggregate(pipeline: MongoScriptJson.rawJson(request["pipeline"]) ?? "[]")
+            if let raw = MongoScriptJson.rawJson(request["options"]), raw != "null" {
+                try applyAggregateOptions(raw, to: &options)
+            }
+        } else {
+            kind = .find(filter: MongoScriptJson.rawJson(request["filter"]) ?? "{}")
+            if let projection = MongoScriptJson.rawJson(request["projection"]), projection != "null" {
+                options.projection = projection
+            }
+        }
+
+        let cursor = cursors.open(
+            kind: kind, database: databaseName(request), collection: collection, options: options
+        )
+        return String(cursor.handle)
+    }
+
+    private func configureCursor(_ request: [String: Any]) throws -> String {
+        guard let handle = request["handle"] as? Int, let key = request["key"] as? String else {
+            throw MongoScriptError(MongoScriptText.unknownCursor)
+        }
+        try cursors.cursor(for: handle).configure(key: key, value: MongoScriptJson.rawJson(request["value"]) ?? "null")
+        return "null"
+    }
+
+    private func fetchCursor(_ request: [String: Any]) throws -> String {
+        guard let handle = request["handle"] as? Int else {
+            throw MongoScriptError(MongoScriptText.unknownCursor)
+        }
+        let page = try cursors.cursor(for: handle).page(size: Self.pageSize) {
+            try load($0, ceiling: iterationCeiling)
+        }
+        return "{\"docs\": \(page.batch.jsonArray), \"done\": \(page.done)}"
+    }
+
+    private func countCursor(_ request: [String: Any]) throws -> String {
+        guard let handle = request["handle"] as? Int else {
+            throw MongoScriptError(MongoScriptText.unknownCursor)
+        }
+        let cursor = try cursors.cursor(for: handle)
+        guard cursor.isFind else {
+            let drained = try cursor.remaining { try load($0, ceiling: iterationCeiling) }
+            return String(drained.json.count)
+        }
+        let reply = try withClient {
+            try connection.scriptRunCommand(
+                client: $0,
+                command: """
+                    {"count": \(MongoScriptJson.jsonString(cursor.collection)), "query": \(cursor.filterJson)}
+                    """,
+                database: cursor.database
+            )
+        }
+        return String(MongoScriptJson.number(in: reply, key: "n") ?? 0)
+    }
+
+    private func explainCursor(_ request: [String: Any]) throws -> String {
+        guard let handle = request["handle"] as? Int else {
+            throw MongoScriptError(MongoScriptText.unknownCursor)
+        }
+        let cursor = try cursors.cursor(for: handle)
+        let verbosity = (request["verbosity"] as? String) ?? "queryPlanner"
+        let inner = cursor.isFind
+            ? MongoScriptCommandBuilder.find(
+                collection: cursor.collection, filter: cursor.filterJson,
+                options: cursor.options, ceiling: valueCeiling
+            )
+            : MongoScriptCommandBuilder.aggregate(
+                collection: cursor.collection, pipeline: cursor.pipelineJson, options: cursor.options
+            )
+        return try withClient {
+            try connection.scriptRunCommand(
+                client: $0,
+                command: "{\"explain\": \(inner), \"verbosity\": \(MongoScriptJson.jsonString(verbosity))}",
+                database: cursor.database
+            )
+        }
+    }
+
+    private func closeCursor(_ request: [String: Any]) -> String {
+        if let handle = request["handle"] as? Int { cursors.close(handle: handle) }
+        return "null"
+    }
+
+    /// The options document `aggregate()` takes as its second argument, which carries the same
+    /// modifiers a cursor takes through chaining.
+    private func applyAggregateOptions(_ raw: String, to options: inout MongoScriptCursorOptions) throws {
+        for member in MongoScriptJson.members(of: raw) {
+            switch member.key {
+            case "hint", "collation", "batchSize", "maxTimeMS", "allowDiskUse":
+                try options.apply(key: member.key, value: member.value)
+            default:
+                continue
+            }
+        }
+    }
+
+    private func load(_ cursor: MongoScriptCursor, ceiling: Int) throws -> MongoScriptDocumentBatch {
+        try withClient { client in
+            if cursor.isFind {
+                return try connection.scriptFind(
+                    client: client,
+                    database: cursor.database,
+                    collection: cursor.collection,
+                    filter: cursor.filterJson,
+                    options: cursor.options,
+                    limit: ceiling
+                )
+            }
+            return try connection.scriptAggregate(
+                client: client,
+                database: cursor.database,
+                collection: cursor.collection,
+                pipeline: cursor.pipelineJson,
+                options: cursor.options,
+                limit: ceiling
+            )
+        }
+    }
+
+    // MARK: - Commands
+
+    private func useDatabase(_ request: [String: Any]) throws -> String {
+        guard let name = request["db"] as? String, !name.isEmpty else {
+            throw MongoScriptError(MongoScriptText.unknownOperation("use"))
+        }
+        database = name
+        databaseSwitch = name
+        return "null"
+    }
+
+    private func listCollections(_ request: [String: Any]) throws -> String {
+        let names = try withClient {
+            try connection.listCollectionsSync(client: $0, database: databaseName(request))
+        }
+        return "[\(names.map { MongoScriptJson.jsonString($0) }.joined(separator: ","))]"
+    }
+
+    private func runCommand(_ request: [String: Any]) throws -> String {
+        try command(MongoScriptJson.rawJson(request["command"]) ?? "{}", request)
+    }
+
+    private func command(_ document: String, _ request: [String: Any]) throws -> String {
+        try withClient {
+            try connection.scriptRunCommand(client: $0, command: document, database: databaseName(request))
+        }
+    }
+
+    private func countDocuments(_ request: [String: Any]) throws -> String {
+        let count = try withClient {
+            try connection.countDocumentsSync(
+                client: $0,
+                database: databaseName(request),
+                collection: collectionName(request),
+                filter: MongoScriptJson.rawJson(request["filter"]) ?? "{}",
+                background: false
+            )
+        }
+        return String(count)
+    }
+
+    private func estimatedCount(_ request: [String: Any]) throws -> String {
+        let reply = try command(
+            "{\"count\": \(MongoScriptJson.jsonString(collectionName(request)))}", request
+        )
+        return String(MongoScriptJson.number(in: reply, key: "n") ?? 0)
+    }
+
+    private func distinct(_ request: [String: Any]) throws -> String {
+        let field = (request["field"] as? String) ?? ""
+        let reply = try command(
+            """
+            {"distinct": \(MongoScriptJson.jsonString(collectionName(request))), \
+            "key": \(MongoScriptJson.jsonString(field)), \
+            "query": \(MongoScriptJson.rawJson(request["filter"]) ?? "{}")}
+            """,
+            request
+        )
+        return MongoScriptJson.member(of: reply, key: "values") ?? "[]"
+    }
+
+    private func insert(_ request: [String: Any], many: Bool) throws -> String {
+        let documents: [String]
+        if many {
+            documents = MongoScriptJson.topLevelElements(MongoScriptJson.rawJson(request["documents"]) ?? "[]")
+        } else {
+            documents = [MongoScriptJson.rawJson(request["document"]) ?? "{}"]
+        }
+        let inserted = try withClient {
+            try connection.scriptInsert(
+                client: $0,
+                database: databaseName(request),
+                collection: collectionName(request),
+                documents: documents
+            )
+        }
+        let ids = inserted.map { $0 }.joined(separator: ",")
+        return "{\"insertedIds\": [\(ids)], \"insertedCount\": \(inserted.count)}"
+    }
+
+    private func update(_ request: [String: Any], isReplace: Bool) throws -> String {
+        let options = MongoScriptJson.options(request["options"])
+        let statement = MongoScriptCommandBuilder.update(
+            collection: collectionName(request),
+            filter: MongoScriptJson.rawJson(request["filter"]) ?? "{}",
+            update: MongoScriptJson.rawJson(request["update"]) ?? "{}",
+            multi: !isReplace && (request["multi"] as? Bool ?? false),
+            options: options
+        )
+        return try command(statement, request)
+    }
+
+    private func delete(_ request: [String: Any]) throws -> String {
+        let statement = MongoScriptCommandBuilder.delete(
+            collection: collectionName(request),
+            filter: MongoScriptJson.rawJson(request["filter"]) ?? "{}",
+            multi: request["multi"] as? Bool ?? false,
+            options: MongoScriptJson.options(request["options"])
+        )
+        return try command(statement, request)
+    }
+
+    private func findAndModify(_ request: [String: Any]) throws -> String {
+        let statement = MongoScriptCommandBuilder.findAndModify(
+            collection: collectionName(request),
+            filter: MongoScriptJson.rawJson(request["filter"]) ?? "{}",
+            update: MongoScriptJson.rawJson(request["update"]),
+            remove: request["remove"] as? Bool ?? false,
+            options: MongoScriptJson.options(request["options"])
+        )
+        return try command(statement, request)
+    }
+
+    private func bulkWrite(_ request: [String: Any]) throws -> String {
+        let operations = MongoScriptJson.topLevelElements(MongoScriptJson.rawJson(request["operations"]) ?? "[]")
+        var inserted = 0
+        var matched = 0
+        var modified = 0
+        var deleted = 0
+        var upserted = 0
+
+        for operation in operations {
+            let statement = try MongoScriptCommandBuilder.bulkOperation(
+                operation, collection: collectionName(request)
+            )
+            let reply = try command(statement.document, request)
+            switch statement.kind {
+            case .insert: inserted += Int(MongoScriptJson.number(in: reply, key: "n") ?? 0)
+            case .update:
+                matched += Int(MongoScriptJson.number(in: reply, key: "n") ?? 0)
+                modified += Int(MongoScriptJson.number(in: reply, key: "nModified") ?? 0)
+                upserted += MongoScriptJson.member(of: reply, key: "upserted") == nil ? 0 : 1
+            case .delete: deleted += Int(MongoScriptJson.number(in: reply, key: "n") ?? 0)
+            }
+        }
+
+        return """
+            {"insertedCount": \(inserted), "matchedCount": \(matched), "modifiedCount": \(modified), \
+            "deletedCount": \(deleted), "upsertedCount": \(upserted)}
+            """
+    }
+
+    private func createIndex(_ request: [String: Any]) throws -> String {
+        let statement = MongoScriptCommandBuilder.createIndex(
+            collection: collectionName(request),
+            keys: MongoScriptJson.rawJson(request["keys"]) ?? "{}",
+            options: MongoScriptJson.options(request["options"])
+        )
+        return try command(statement, request)
+    }
+
+    private func dropIndex(_ request: [String: Any]) throws -> String {
+        try command(
+            """
+            {"dropIndexes": \(MongoScriptJson.jsonString(collectionName(request))), \
+            "index": \(MongoScriptJson.rawJson(request["index"]) ?? "\"*\"")}
+            """,
+            request
+        )
+    }
+
+    private func listIndexes(_ request: [String: Any]) throws -> String {
+        let indexes = try withClient {
+            try connection.listIndexesJsonSync(
+                client: $0, database: databaseName(request), collection: collectionName(request)
+            )
+        }
+        return "[\(indexes.joined(separator: ","))]"
+    }
+
+    private func renameCollection(_ request: [String: Any]) throws -> String {
+        let source = "\(databaseName(request)).\(collectionName(request))"
+        let target = "\(databaseName(request)).\((request["target"] as? String) ?? "")"
+        return try withClient {
+            try connection.scriptRunCommand(
+                client: $0,
+                command: """
+                    {"renameCollection": \(MongoScriptJson.jsonString(source)), "to": \(MongoScriptJson.jsonString(target)), \
+                    "dropTarget": \(request["dropTarget"] as? Bool ?? false)}
+                    """,
+                database: "admin"
+            )
+        }
+    }
+
+    // MARK: - Value Helpers
+
+    private func hexToBase64(_ request: [String: Any]) throws -> String {
+        guard let hex = request["hex"] as? String, let data = MongoScriptObjectId.data(fromHex: hex) else {
+            throw MongoScriptError(MongoScriptText.invalidDocument("HexData"))
+        }
+        return MongoScriptJson.jsonString(data.base64EncodedString())
+    }
+
+    /// The constructor's own tag decides the subtype and the byte order, so it reaches the codec
+    /// rather than being normalised to `UUID`.
+    private func encodeUuid(_ request: [String: Any]) throws -> String {
+        let text = (request["value"] as? String) ?? UUID().uuidString
+        let tag = (request["tag"] as? String) ?? "UUID"
+        guard let binary = MongoDBUuidCodec.parseWrapper("\(tag)(\"\(text)\")") else {
+            throw MongoScriptError(MongoScriptText.invalidDocument("\(tag)(\(text))"))
+        }
+        return """
+            {"base64": \(MongoScriptJson.jsonString(binary.data.base64EncodedString())), \
+            "subtype": \(binary.subtype), "text": \(MongoScriptJson.jsonString(text.lowercased()))}
+            """
+    }
+
+    private func sleep(_ request: [String: Any]) throws -> String {
+        let milliseconds = (request["ms"] as? NSNumber)?.doubleValue ?? 0
+        guard milliseconds.isFinite, milliseconds > 0 else { return "null" }
+        let deadline = Date().addingTimeInterval(min(milliseconds, 60_000) / 1_000)
+        while Date() < deadline {
+            try connection.checkCancelled()
+            touch()
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+        return "null"
+    }
+
+    // MARK: - Plumbing
+
+    private func withClient<T>(_ body: (OpaquePointer) throws -> T) throws -> T {
+        #if canImport(CLibMongoc)
+        return try connection.withClientSync(body)
+        #else
+        throw MongoDBError.libmongocUnavailable
+        #endif
+    }
+
+    private func databaseName(_ request: [String: Any]) -> String {
+        let named = (request["db"] as? String) ?? ""
+        return named.isEmpty ? database : named
+    }
+
+    private func collectionName(_ request: [String: Any]) -> String {
+        (request["collection"] as? String) ?? ""
+    }
+}

--- a/Plugins/MongoDBDriverPlugin/MongoScriptJson.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoScriptJson.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+/// Reading and writing the bridge's JSON without going through `JSONSerialization` for anything
+/// whose field order matters.
+///
+/// Documents cross the bridge as JSON *strings* rather than as nested JSON values, so parsing the
+/// request leaves them untouched as text. A document rebuilt from a Swift dictionary comes back
+/// with its fields reordered, and BSON field order decides how an embedded document compares, what
+/// a compound index matches and where `_id` sits.
+enum MongoScriptJson {
+    static func success(_ value: String) -> String {
+        "{\"ok\":true,\"v\":\(value)}"
+    }
+
+    static func failure(message: String, code: UInt32) -> String {
+        "{\"ok\":false,\"e\":{\"m\":\(jsonString(message)),\"c\":\(code)}}"
+    }
+
+    static func jsonString(_ value: String) -> String {
+        var escaped = ""
+        escaped.reserveCapacity(value.count + 2)
+        escaped.append("\"")
+        for character in value.unicodeScalars {
+            switch character {
+            case "\"": escaped.append("\\\"")
+            case "\\": escaped.append("\\\\")
+            case "\n": escaped.append("\\n")
+            case "\r": escaped.append("\\r")
+            case "\t": escaped.append("\\t")
+            default:
+                if character.value < 0x20 {
+                    escaped.append(String(format: "\\u%04x", character.value))
+                } else {
+                    escaped.unicodeScalars.append(character)
+                }
+            }
+        }
+        escaped.append("\"")
+        return escaped
+    }
+
+    /// Whether this object is an Extended JSON wrapper around a single BSON value.
+    ///
+    /// `db.users.distinct("_id")` answers with ObjectIds, whose Extended JSON is `{"$oid": …}`.
+    /// Reading that as a document renders a `$oid` column instead of one value per row.
+    static func isScalarWrapper(_ objectJson: String) -> Bool {
+        let members = members(of: objectJson)
+        guard let first = members.first, first.key.hasPrefix("$") else { return false }
+        if members.count == 1 { return true }
+        return members.count == 2 && first.key == "$code" && members[1].key == "$scope"
+    }
+
+    /// A document the prelude sent as text, kept verbatim.
+    static func rawJson(_ value: Any?) -> String? {
+        guard let text = value as? String else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func options(_ value: Any?) -> [String: Any] {
+        guard let text = rawJson(value), text != "null",
+              let data = text.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return [:]
+        }
+        return parsed
+    }
+
+    /// A numeric field of a command reply, whichever Extended JSON wrapper the server used.
+    static func number(in replyJson: String, key: String) -> Int64? {
+        guard let data = replyJson.data(using: .utf8),
+              let reply = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return numeric(reply[key])
+    }
+
+    static func numeric(_ value: Any?) -> Int64? {
+        if let number = value as? NSNumber { return whole(number.doubleValue) }
+        guard let wrapper = value as? [String: Any] else { return nil }
+        // An integer wrapper is parsed as an integer. Going through `Double` first would round
+        // `9223372036854775807` up to 2^63, which is past what `Int64` can hold.
+        for key in ["$numberInt", "$numberLong"] {
+            if let text = wrapper[key] as? String { return Int64(text) }
+        }
+        if let text = wrapper["$numberDouble"] as? String, let parsed = Double(text) {
+            return whole(parsed)
+        }
+        return nil
+    }
+
+    /// A double as a whole number, or nil when it is not exactly one.
+    ///
+    /// `Int64(Double.nan)` traps, and so does a value past `Int64`'s range, where the obvious bound
+    /// check does not help: `Double(Int64.max)` rounds *up* to 2^63, so an inclusive comparison
+    /// against it still admits a value that traps. `Int64(exactly:)` is the check that holds, and it
+    /// also refuses `1.5` rather than silently truncating a whole-number argument.
+    static func whole(_ value: Double) -> Int64? {
+        guard value.isFinite else { return nil }
+        return Int64(exactly: value.rounded(.towardZero)) == Int64(exactly: value)
+            ? Int64(exactly: value)
+            : nil
+    }
+
+    /// One member of a JSON object, returned as the text it occupies rather than as a rebuilt value.
+    static func member(of objectJson: String, key: String) -> String? {
+        members(of: objectJson).first { $0.key == key }?.value
+    }
+
+    /// Every member of a JSON object, in the order the document carries them, each value as text.
+    static func members(of objectJson: String) -> [(key: String, value: String)] {
+        let characters = Array(objectJson)
+        guard let start = characters.firstIndex(of: "{") else { return [] }
+        var index = start + 1
+        var pairs: [(key: String, value: String)] = []
+
+        while index < characters.count {
+            skipWhitespace(characters, &index)
+            guard index < characters.count, characters[index] == "\"" else { return pairs }
+            guard let name = readString(characters, &index) else { return pairs }
+            skipWhitespace(characters, &index)
+            guard index < characters.count, characters[index] == ":" else { return pairs }
+            index += 1
+            skipWhitespace(characters, &index)
+            let valueStart = index
+            skipValue(characters, &index)
+            pairs.append((name, String(characters[valueStart ..< index]).trimmingCharacters(in: .whitespaces)))
+            skipWhitespace(characters, &index)
+            guard index < characters.count, characters[index] == "," else { return pairs }
+            index += 1
+        }
+        return pairs
+    }
+
+    /// The elements of a JSON array, each as its own text.
+    static func topLevelElements(_ arrayJson: String) -> [String] {
+        let characters = Array(arrayJson)
+        guard let start = characters.firstIndex(of: "[") else { return [] }
+        var index = start + 1
+        var elements: [String] = []
+
+        while index < characters.count {
+            skipWhitespace(characters, &index)
+            guard index < characters.count, characters[index] != "]" else { break }
+            let elementStart = index
+            skipValue(characters, &index)
+            elements.append(String(characters[elementStart ..< index]).trimmingCharacters(in: .whitespaces))
+            skipWhitespace(characters, &index)
+            guard index < characters.count, characters[index] == "," else { break }
+            index += 1
+        }
+        return elements
+    }
+
+    // MARK: - Scanning
+
+    private static func skipWhitespace(_ characters: [Character], _ index: inout Int) {
+        while index < characters.count, characters[index].isWhitespace { index += 1 }
+    }
+
+    private static func readString(_ characters: [Character], _ index: inout Int) -> String? {
+        guard index < characters.count, characters[index] == "\"" else { return nil }
+        index += 1
+        var value = ""
+        while index < characters.count {
+            let character = characters[index]
+            if character == "\\" {
+                index += 2
+                continue
+            }
+            index += 1
+            if character == "\"" { return value }
+            value.append(character)
+        }
+        return nil
+    }
+
+    private static func skipValue(_ characters: [Character], _ index: inout Int) {
+        var depth = 0
+        var inString = false
+        var escaped = false
+
+        while index < characters.count {
+            let character = characters[index]
+            if escaped {
+                escaped = false
+                index += 1
+                continue
+            }
+            if inString {
+                if character == "\\" { escaped = true }
+                if character == "\"" { inString = false }
+                index += 1
+                continue
+            }
+            switch character {
+            case "\"":
+                inString = true
+            case "{", "[":
+                depth += 1
+            case "}", "]":
+                if depth == 0 { return }
+                depth -= 1
+            case ",":
+                if depth == 0 { return }
+            default:
+                break
+            }
+            index += 1
+            if depth == 0, character == "}" || character == "]" { return }
+        }
+    }
+}

--- a/Plugins/MongoDBDriverPlugin/MongoScriptObjectId.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoScriptObjectId.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Client-side ObjectId generation, in the layout the MongoDB specification defines: 4 bytes of
+/// seconds since the epoch, 5 random bytes fixed per process, then a 3 byte counter.
+///
+/// Generated here rather than left to the server so an insert can report the `insertedId` the way
+/// mongosh does. libmongoc adds the field to the document it sends without writing it back into the
+/// caller's, so reading it afterwards reports `null` for every document that did not carry one.
+enum MongoScriptObjectId {
+    private final class Sequence: @unchecked Sendable {
+        private let lock = NSLock()
+        private var counter = UInt32.random(in: 0 ... 0xFF_FFFF)
+
+        func next() -> UInt32 {
+            lock.lock()
+            defer { lock.unlock() }
+            counter = (counter &+ 1) & 0xFF_FFFF
+            return counter
+        }
+    }
+
+    private static let processRandom: [UInt8] = (0 ..< 5).map { _ in UInt8.random(in: 0 ... 255) }
+    private static let sequence = Sequence()
+
+    static func generate() -> String {
+        let seconds = UInt32(Date().timeIntervalSince1970)
+        let sequence = Self.sequence.next()
+
+        var bytes: [UInt8] = [
+            UInt8((seconds >> 24) & 0xFF), UInt8((seconds >> 16) & 0xFF),
+            UInt8((seconds >> 8) & 0xFF), UInt8(seconds & 0xFF)
+        ]
+        bytes.append(contentsOf: processRandom)
+        bytes.append(UInt8((sequence >> 16) & 0xFF))
+        bytes.append(UInt8((sequence >> 8) & 0xFF))
+        bytes.append(UInt8(sequence & 0xFF))
+        return bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func data(fromHex hex: String) -> Data? {
+        let characters = Array(hex)
+        guard !characters.isEmpty, characters.count.isMultiple(of: 2) else { return nil }
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(characters.count / 2)
+        var index = 0
+        while index < characters.count {
+            guard let byte = UInt8(String(characters[index ... index + 1]), radix: 16) else { return nil }
+            bytes.append(byte)
+            index += 2
+        }
+        return Data(bytes)
+    }
+}

--- a/Plugins/MongoDBDriverPlugin/MongoScriptPrelude.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoScriptPrelude.swift
@@ -1,0 +1,729 @@
+import Foundation
+
+/// The mongosh-shaped API the script runtime installs into every `JSContext`.
+///
+/// Written in JavaScript rather than bridged through `JSExport` because the surface is a
+/// vocabulary, not an object graph: `db.<anything>.<anything>()` has to resolve without the host
+/// knowing the collection names, which is what `Proxy` gives and a bridged class cannot. Everything
+/// funnels into two host functions, so the Swift side stays one dispatcher.
+///
+/// Documents cross the bridge as JSON *text*, never as nested JSON values, because the host parses
+/// a request with `JSONSerialization` and a document rebuilt from a Swift dictionary comes back
+/// with its fields reordered. BSON field order decides how an embedded document compares and where
+/// `_id` sits, so `__ejson` is used for every payload that carries one.
+enum MongoScriptPrelude {
+    static let source = [
+        core, values, cursor, collection, database, serialization, output
+    ].joined(separator: "\n")
+
+    private static let core = """
+    var __tp = (function () {
+        function call(request) {
+            var response = JSON.parse(__tp_exec(JSON.stringify(request)));
+            if (!response.ok) {
+                var failure = new Error(response.e.m);
+                failure.code = response.e.c;
+                failure.isMongoError = true;
+                throw failure;
+            }
+            return response.v;
+        }
+        return { call: call };
+    })();
+
+    function __ejson(value) { return JSON.stringify(EJSON.serialize(value)); }
+    """
+
+    private static let values = """
+    function ObjectId(hex) {
+        if (!(this instanceof ObjectId)) { return new ObjectId(hex); }
+        if (hex === undefined || hex === null) {
+            this.__id = __tp.call({ op: "newObjectId" });
+        } else {
+            if (typeof hex !== "string" || !/^[0-9a-fA-F]{24}$/.test(hex)) {
+                throw new Error("ObjectId takes a 24 character hex string");
+            }
+            this.__id = hex.toLowerCase();
+        }
+        this.str = this.__id;
+    }
+    ObjectId.prototype.toString = function () { return this.__id; };
+    ObjectId.prototype.valueOf = function () { return this.__id; };
+    ObjectId.prototype.equals = function (other) { return String(other) === this.__id; };
+    ObjectId.prototype.getTimestamp = function () {
+        return new Date(parseInt(this.__id.substring(0, 8), 16) * 1000);
+    };
+    ObjectId.prototype.toEJSON = function () { return { "$oid": this.__id }; };
+
+    function __wholeText(value, name) {
+        var text = value === undefined ? "0" : String(value);
+        if (!/^[+-]?[0-9]+$/.test(text)) { throw new Error(name + " takes a whole number"); }
+        return text;
+    }
+
+    function NumberLong(value) {
+        if (!(this instanceof NumberLong)) { return new NumberLong(value); }
+        this.__value = __wholeText(value, "NumberLong");
+    }
+    NumberLong.prototype.toString = function () { return this.__value; };
+    NumberLong.prototype.valueOf = function () { return Number(this.__value); };
+    NumberLong.prototype.toNumber = function () { return Number(this.__value); };
+    NumberLong.prototype.toEJSON = function () { return { "$numberLong": this.__value }; };
+
+    function NumberInt(value) {
+        if (!(this instanceof NumberInt)) { return new NumberInt(value); }
+        this.__value = __wholeText(value === undefined ? 0 : parseInt(value, 10), "NumberInt");
+    }
+    NumberInt.prototype.toString = function () { return this.__value; };
+    NumberInt.prototype.valueOf = function () { return Number(this.__value); };
+    NumberInt.prototype.toEJSON = function () { return { "$numberInt": this.__value }; };
+
+    function NumberDecimal(value) {
+        if (!(this instanceof NumberDecimal)) { return new NumberDecimal(value); }
+        var text = value === undefined ? "0" : String(value);
+        if (!/^[+-]?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)([eE][+-]?[0-9]+)?$/.test(text)) {
+            throw new Error("NumberDecimal takes a number");
+        }
+        this.__value = text;
+    }
+    NumberDecimal.prototype.toString = function () { return this.__value; };
+    NumberDecimal.prototype.toEJSON = function () { return { "$numberDecimal": this.__value }; };
+
+    function Timestamp(t, i) {
+        if (!(this instanceof Timestamp)) { return new Timestamp(t, i); }
+        this.t = t === undefined ? 0 : t;
+        this.i = i === undefined ? 0 : i;
+    }
+    Timestamp.prototype.toString = function () { return "Timestamp(" + this.t + ", " + this.i + ")"; };
+    Timestamp.prototype.toEJSON = function () { return { "$timestamp": { t: this.t, i: this.i } }; };
+
+    function __subTypeHex(subtype) {
+        var hex = subtype.toString(16);
+        return hex.length === 1 ? "0" + hex : hex;
+    }
+
+    function BinData(subtype, base64) {
+        if (!(this instanceof BinData)) { return new BinData(subtype, base64); }
+        this.__subtype = subtype;
+        this.__base64 = base64;
+    }
+    BinData.prototype.toString = function () {
+        return "BinData(" + this.__subtype + ", \\"" + this.__base64 + "\\")";
+    };
+    BinData.prototype.base64 = function () { return this.__base64; };
+    BinData.prototype.toEJSON = function () {
+        return { "$binary": { base64: this.__base64, subType: __subTypeHex(this.__subtype) } };
+    };
+
+    function HexData(subtype, hex) {
+        return new BinData(subtype, __tp.call({ op: "hexToBase64", hex: String(hex) }));
+    }
+
+    // Every legacy spelling keeps its own tag. The Java, C# and Python drivers each wrote subtype 3
+    // with a different byte order and nothing in the stored bytes says which, so collapsing them
+    // onto `UUID` emits subtype 4 in identity order: the filter matches nothing and a write stores
+    // different bytes.
+    function UUID(value, tag) {
+        if (!(this instanceof UUID)) { return new UUID(value, tag); }
+        this.__tag = tag === undefined ? "UUID" : tag;
+        var encoded = __tp.call({
+            op: "encodeUuid",
+            tag: this.__tag,
+            value: value === undefined ? null : String(value)
+        });
+        this.__base64 = encoded.base64;
+        this.__subtype = encoded.subtype;
+        this.__text = encoded.text;
+    }
+    UUID.prototype.toString = function () { return this.__tag + "(\\"" + this.__text + "\\")"; };
+    UUID.prototype.hex = function () { return this.__text.replace(/-/g, ""); };
+    UUID.prototype.toEJSON = function () {
+        return { "$binary": { base64: this.__base64, subType: __subTypeHex(this.__subtype) } };
+    };
+
+    // Callable as well as bare, because the translator this replaces accepted `MinKey()` too and a
+    // saved query may use either form. A function carrying `toEJSON` is what makes both work; the
+    // serializer asks for `toEJSON` before it asks whether something is a function, so this does
+    // not serialize as `Code`.
+    function __boundaryKey(name, wrapper) {
+        var key = function () { return key; };
+        key.toString = function () { return name; };
+        key.toEJSON = function () { return wrapper; };
+        return key;
+    }
+    var MinKey = __boundaryKey("MinKey", { "$minKey": 1 });
+    var MaxKey = __boundaryKey("MaxKey", { "$maxKey": 1 });
+
+    function Code(code, scope) {
+        if (!(this instanceof Code)) { return new Code(code, scope); }
+        this.code = String(code);
+        this.scope = scope;
+    }
+    Code.prototype.toString = function () { return this.code; };
+    Code.prototype.toEJSON = function () {
+        return this.scope === undefined
+            ? { "$code": this.code }
+            : { "$code": this.code, "$scope": EJSON.serialize(this.scope) };
+    };
+
+    function DBRef(collection, id, database) {
+        if (!(this instanceof DBRef)) { return new DBRef(collection, id, database); }
+        this.$ref = collection;
+        this.$id = id;
+        if (database !== undefined) { this.$db = database; }
+    }
+
+    function ISODate(value) {
+        if (value === undefined) { return new Date(); }
+        var parsed = new Date(value);
+        if (isNaN(parsed.getTime())) { throw new Error("ISODate could not read \\"" + value + "\\""); }
+        return parsed;
+    }
+
+    // `Date("2020-01-01")` without `new` is a string in JavaScript, built from *today*, so a saved
+    // filter written that way would silently stop matching. A Proxy with only an `apply` trap
+    // forwards construction to the native Date, so `new Date(...)` and `instanceof Date` are
+    // untouched and a bare call returns the date it names.
+    var __NativeDate = Date;
+    Date = new Proxy(__NativeDate, {
+        apply: function (target, thisArg, args) {
+            return args.length === 0 ? new target() : new target(args[0]);
+        }
+    });
+
+    function LegacyJavaUUID(value) { return new UUID(value, "LegacyJavaUUID"); }
+    function LegacyCSharpUUID(value) { return new UUID(value, "LegacyCSharpUUID"); }
+    function LegacyPythonUUID(value) { return new UUID(value, "LegacyPythonUUID"); }
+    function JUUID(value) { return new UUID(value, "JUUID"); }
+    function CSUUID(value) { return new UUID(value, "CSUUID"); }
+    function NUUID(value) { return new UUID(value, "NUUID"); }
+    function PYUUID(value) { return new UUID(value, "PYUUID"); }
+    function LUUID(value) { return new UUID(value, "LUUID"); }
+    """
+
+    private static let cursor = """
+    function Cursor(handle, describe) {
+        this.__handle = handle;
+        this.__describe = describe;
+        this.__batch = null;
+        this.__index = 0;
+        this.__exhausted = false;
+        this.__started = false;
+    }
+    Cursor.prototype.__configure = function (name, value) {
+        if (this.__started) { throw new Error("." + name + "() cannot be set once the cursor has started"); }
+        __tp.call({ op: "cursorConfigure", handle: this.__handle, key: name, value: __ejson(value) });
+        return this;
+    };
+    Cursor.prototype.sort = function (spec) { return this.__configure("sort", spec); };
+    Cursor.prototype.projection = function (spec) {
+        // An aggregation projects with a `$project` stage, and a cursor projection would be
+        // accepted and then ignored, so it is refused rather than silently dropped.
+        if (this.__describe.indexOf(".aggregate(") !== -1) {
+            throw new Error("Use a $project stage rather than .projection() on an aggregation");
+        }
+        return this.__configure("projection", spec);
+    };
+    Cursor.prototype.limit = function (value) { return this.__configure("limit", value); };
+    Cursor.prototype.skip = function (value) { return this.__configure("skip", value); };
+    Cursor.prototype.batchSize = function (value) { return this.__configure("batchSize", value); };
+    Cursor.prototype.hint = function (spec) { return this.__configure("hint", spec); };
+    Cursor.prototype.collation = function (spec) { return this.__configure("collation", spec); };
+    Cursor.prototype.maxTimeMS = function (value) { return this.__configure("maxTimeMS", value); };
+    Cursor.prototype.allowDiskUse = function () { return this.__configure("allowDiskUse", true); };
+    Cursor.prototype.__fill = function () {
+        if (this.__batch !== null && this.__index < this.__batch.length) { return true; }
+        if (this.__exhausted) { return false; }
+        this.__started = true;
+        var page = __tp.call({ op: "cursorFetch", handle: this.__handle });
+        this.__batch = EJSON.deserialize(page.docs);
+        this.__index = 0;
+        this.__exhausted = page.done;
+        return this.__batch.length > 0;
+    };
+    Cursor.prototype.hasNext = function () { return this.__fill(); };
+    Cursor.prototype.next = function () {
+        if (!this.__fill()) { throw new Error("The cursor has no more documents"); }
+        return this.__batch[this.__index++];
+    };
+    Cursor.prototype.tryNext = function () { return this.__fill() ? this.__batch[this.__index++] : null; };
+    Cursor.prototype.toArray = function () {
+        var all = [];
+        while (this.__fill()) { all.push(this.__batch[this.__index++]); }
+        return all;
+    };
+    Cursor.prototype.forEach = function (body) {
+        var index = 0;
+        while (this.__fill()) { body(this.__batch[this.__index++], index++); }
+        return undefined;
+    };
+    Cursor.prototype.map = function (body) {
+        var mapped = [];
+        while (this.__fill()) { mapped.push(body(this.__batch[this.__index++])); }
+        return mapped;
+    };
+    Cursor.prototype.itcount = function () {
+        var seen = 0;
+        while (this.__fill()) { this.__index++; seen++; }
+        return seen;
+    };
+    Cursor.prototype.size = function () { return this.itcount(); };
+    Cursor.prototype.count = function () { return __tp.call({ op: "cursorCount", handle: this.__handle }); };
+    Cursor.prototype.explain = function (verbosity) {
+        return EJSON.deserialize(__tp.call({
+            op: "cursorExplain",
+            handle: this.__handle,
+            verbosity: verbosity === undefined ? "queryPlanner" : String(verbosity)
+        }));
+    };
+    Cursor.prototype.pretty = function () { return this; };
+    Cursor.prototype.close = function () {
+        __tp.call({ op: "cursorClose", handle: this.__handle });
+        this.__exhausted = true;
+        return undefined;
+    };
+    Cursor.prototype.isExhausted = function () { return !this.__fill(); };
+    Cursor.prototype.objsLeftInBatch = function () {
+        return this.__batch === null ? 0 : this.__batch.length - this.__index;
+    };
+    Cursor.prototype.toString = function () { return this.__describe; };
+    """
+
+    private static let collection = """
+    function DBCollection(databaseName, name) {
+        this.__db = databaseName;
+        this.__name = name;
+    }
+    DBCollection.prototype.getName = function () { return this.__name; };
+    DBCollection.prototype.getFullName = function () { return this.__db + "." + this.__name; };
+    DBCollection.prototype.toString = function () { return this.getFullName(); };
+    DBCollection.prototype.__call = function (op, payload) {
+        payload = payload || {};
+        payload.op = op;
+        payload.db = this.__db;
+        payload.collection = this.__name;
+        return __tp.call(payload);
+    };
+    DBCollection.prototype.__reply = function (op, payload) {
+        return EJSON.deserialize(this.__call(op, payload));
+    };
+    DBCollection.prototype.find = function (filter, projection) {
+        var handle = this.__call("openCursor", {
+            kind: "find",
+            filter: __ejson(filter === undefined ? {} : filter),
+            projection: projection === undefined ? null : __ejson(projection)
+        });
+        return new Cursor(handle, this.getFullName() + ".find()");
+    };
+    DBCollection.prototype.findOne = function (filter, projection) {
+        var found = this.find(filter, projection).limit(1);
+        return found.hasNext() ? found.next() : null;
+    };
+    DBCollection.prototype.aggregate = function (pipeline, options) {
+        var stages = pipeline === undefined ? [] : pipeline;
+        if (!Array.isArray(stages)) {
+            stages = Array.prototype.slice.call(arguments);
+            options = undefined;
+        }
+        var handle = this.__call("openCursor", {
+            kind: "aggregate",
+            pipeline: __ejson(stages),
+            options: options === undefined ? null : __ejson(options)
+        });
+        return new Cursor(handle, this.getFullName() + ".aggregate()");
+    };
+    DBCollection.prototype.countDocuments = function (filter) {
+        return this.__call("countDocuments", { filter: __ejson(filter === undefined ? {} : filter) });
+    };
+    DBCollection.prototype.count = function (filter) { return this.countDocuments(filter); };
+    DBCollection.prototype.estimatedDocumentCount = function () {
+        return this.__call("estimatedDocumentCount", {});
+    };
+    DBCollection.prototype.distinct = function (field, filter) {
+        return this.__reply("distinct", {
+            field: String(field),
+            filter: __ejson(filter === undefined ? {} : filter)
+        });
+    };
+    DBCollection.prototype.insertOne = function (document) {
+        if (document === undefined || document === null) { throw new Error("insertOne needs a document"); }
+        var reply = this.__reply("insertOne", { document: __ejson(document) });
+        return { acknowledged: true, insertedId: reply.insertedIds[0] };
+    };
+    DBCollection.prototype.insertMany = function (documents) {
+        var reply = this.__reply("insertMany", { documents: __ejson(documents) });
+        return {
+            acknowledged: true,
+            insertedIds: reply.insertedIds,
+            insertedCount: reply.insertedCount
+        };
+    };
+    DBCollection.prototype.insert = function (documentOrArray) {
+        return Array.isArray(documentOrArray)
+            ? this.insertMany(documentOrArray)
+            : this.insertOne(documentOrArray);
+    };
+    function __updateResult(reply) {
+        // An upsert replies with n = 1 and an `upserted` entry even though nothing matched, so the
+        // upserted rows come out of `n` to give mongosh's matchedCount.
+        var upserted = reply.upserted || [];
+        return {
+            acknowledged: true,
+            matchedCount: Math.max((reply.n || 0) - upserted.length, 0),
+            modifiedCount: reply.nModified || 0,
+            upsertedCount: upserted.length,
+            upsertedId: upserted.length ? upserted[0]._id : null
+        };
+    }
+    DBCollection.prototype.__write = function (op, filter, change, options, multi) {
+        if (change === undefined || change === null) {
+            throw new Error(op === "replace"
+                ? "replaceOne needs a replacement document"
+                : "update needs an update document or pipeline");
+        }
+        return __updateResult(this.__reply(op, {
+            filter: __ejson(filter === undefined ? {} : filter),
+            update: __ejson(change),
+            options: options === undefined ? null : __ejson(options),
+            multi: multi === true
+        }));
+    };
+    DBCollection.prototype.updateOne = function (filter, update, options) {
+        return this.__write("update", filter, update, options, false);
+    };
+    DBCollection.prototype.updateMany = function (filter, update, options) {
+        return this.__write("update", filter, update, options, true);
+    };
+    DBCollection.prototype.update = function (filter, update, options) {
+        return this.__write("update", filter, update, options, !!(options && options.multi));
+    };
+    DBCollection.prototype.replaceOne = function (filter, replacement, options) {
+        return this.__write("replace", filter, replacement, options, false);
+    };
+    DBCollection.prototype.save = function (document) {
+        if (document && document._id !== undefined) {
+            return this.replaceOne({ _id: document._id }, document, { upsert: true });
+        }
+        return this.insertOne(document);
+    };
+    DBCollection.prototype.__delete = function (filter, options, multi) {
+        var reply = this.__reply("delete", {
+            filter: __ejson(filter === undefined ? {} : filter),
+            options: options === undefined ? null : __ejson(options),
+            multi: multi
+        });
+        return { acknowledged: true, deletedCount: reply.n || 0 };
+    };
+    DBCollection.prototype.deleteOne = function (filter, options) {
+        return this.__delete(filter, options, false);
+    };
+    DBCollection.prototype.deleteMany = function (filter, options) {
+        return this.__delete(filter, options, true);
+    };
+    DBCollection.prototype.remove = function (filter, justOne) {
+        return justOne === true ? this.deleteOne(filter) : this.deleteMany(filter);
+    };
+    DBCollection.prototype.__findAndModify = function (filter, change, options, remove) {
+        if (!remove && (change === undefined || change === null)) {
+            throw new Error("findOneAndUpdate needs an update document or pipeline");
+        }
+        var reply = this.__reply("findAndModify", {
+            filter: __ejson(filter === undefined ? {} : filter),
+            update: change === undefined ? null : __ejson(change),
+            options: options === undefined ? null : __ejson(options),
+            remove: remove
+        });
+        return reply.value === undefined ? null : reply.value;
+    };
+    DBCollection.prototype.findOneAndUpdate = function (filter, update, options) {
+        return this.__findAndModify(filter, update, options, false);
+    };
+    DBCollection.prototype.findOneAndReplace = function (filter, replacement, options) {
+        return this.__findAndModify(filter, replacement, options, false);
+    };
+    DBCollection.prototype.findOneAndDelete = function (filter, options) {
+        return this.__findAndModify(filter, undefined, options, true);
+    };
+    DBCollection.prototype.bulkWrite = function (operations) {
+        var reply = this.__reply("bulkWrite", { operations: __ejson(operations) });
+        reply.acknowledged = true;
+        return reply;
+    };
+    DBCollection.prototype.createIndex = function (keys, options) {
+        this.__reply("createIndex", {
+            keys: __ejson(keys),
+            options: options === undefined ? null : __ejson(options)
+        });
+        return __indexName(keys, options);
+    };
+    DBCollection.prototype.createIndexes = function (specs, options) {
+        var made = [];
+        for (var i = 0; i < specs.length; i++) { made.push(this.createIndex(specs[i], options)); }
+        return made;
+    };
+    DBCollection.prototype.dropIndex = function (name) {
+        return this.__reply("dropIndex", { index: __ejson(name) });
+    };
+    DBCollection.prototype.dropIndexes = function () {
+        return this.__reply("dropIndex", { index: __ejson("*") });
+    };
+    DBCollection.prototype.getIndexes = function () { return this.__reply("listIndexes", {}); };
+    DBCollection.prototype.getIndices = DBCollection.prototype.getIndexes;
+    DBCollection.prototype.drop = function () { return this.__reply("dropCollection", {}); };
+    DBCollection.prototype.renameCollection = function (name, dropTarget) {
+        return this.__reply("renameCollection", { target: String(name), dropTarget: dropTarget === true });
+    };
+    DBCollection.prototype.stats = function () { return this.__reply("collectionStats", {}); };
+    DBCollection.prototype.dataSize = function () { return this.stats().size; };
+    DBCollection.prototype.storageSize = function () { return this.stats().storageSize; };
+    DBCollection.prototype.totalIndexSize = function () { return this.stats().totalIndexSize; };
+    DBCollection.prototype.totalSize = function () {
+        var stats = this.stats();
+        return stats.storageSize + stats.totalIndexSize;
+    };
+    DBCollection.prototype.isCapped = function () { return this.stats().capped === true; };
+    DBCollection.prototype.validate = function (full) {
+        return this.__reply("command", {
+            command: __ejson({ validate: this.__name, full: full === true })
+        });
+    };
+    DBCollection.prototype.hideIndex = function (index) { return this.__hideIndex(index, true); };
+    DBCollection.prototype.unhideIndex = function (index) { return this.__hideIndex(index, false); };
+    DBCollection.prototype.__hideIndex = function (index, hidden) {
+        var key = typeof index === "string" ? { name: index } : { keyPattern: index };
+        key.hidden = hidden;
+        return this.__reply("command", {
+            command: __ejson({ collMod: this.__name, index: key })
+        });
+    };
+    DBCollection.prototype.explain = function (verbosity) {
+        var target = this;
+        var level = verbosity === undefined ? "queryPlanner" : String(verbosity);
+        return {
+            find: function (filter, projection) { return target.find(filter, projection).explain(level); },
+            aggregate: function (pipeline) { return target.aggregate(pipeline).explain(level); },
+            count: function (filter) { return target.find(filter).explain(level); }
+        };
+    };
+
+    function __indexName(keys, options) {
+        if (options && options.name) { return String(options.name); }
+        var parts = [];
+        for (var key in keys) {
+            if (Object.prototype.hasOwnProperty.call(keys, key)) { parts.push(key + "_" + keys[key]); }
+        }
+        return parts.length ? parts.join("_") : "index";
+    }
+    """
+
+    private static let database = """
+    function DB(name) {
+        this.__name = name;
+        var owner = this;
+        return new Proxy(this, {
+            get: function (target, key) {
+                if (typeof key !== "string") { return target[key]; }
+                if (key in target) { return target[key]; }
+                if (key.indexOf("__") === 0) { return undefined; }
+                return new DBCollection(owner.__name, key);
+            }
+        });
+    }
+    DB.prototype.getName = function () { return this.__name; };
+    DB.prototype.toString = function () { return this.__name; };
+    DB.prototype.getCollection = function (name) { return new DBCollection(this.__name, String(name)); };
+    DB.prototype.getSiblingDB = function (name) { return new DB(String(name)); };
+    DB.prototype.getMongo = function () {
+        return { getDB: function (name) { return new DB(String(name)); } };
+    };
+    DB.prototype.runCommand = function (command) {
+        return EJSON.deserialize(__tp.call({ op: "command", db: this.__name, command: __ejson(command) }));
+    };
+    DB.prototype.adminCommand = function (command) {
+        return EJSON.deserialize(__tp.call({ op: "command", db: "admin", command: __ejson(command) }));
+    };
+    DB.prototype.getCollectionNames = function () {
+        return __tp.call({ op: "listCollections", db: this.__name });
+    };
+    DB.prototype.getCollectionInfos = function () {
+        return this.runCommand({ listCollections: 1 }).cursor.firstBatch;
+    };
+    DB.prototype.createCollection = function (name, options) {
+        var command = { create: String(name) };
+        if (options) {
+            for (var key in options) {
+                if (Object.prototype.hasOwnProperty.call(options, key)) { command[key] = options[key]; }
+            }
+        }
+        return this.runCommand(command);
+    };
+    DB.prototype.dropDatabase = function () { return this.runCommand({ dropDatabase: 1 }); };
+    DB.prototype.stats = function () { return this.runCommand({ dbStats: 1 }); };
+    DB.prototype.version = function () { return this.runCommand({ buildInfo: 1 }).version; };
+    DB.prototype.serverStatus = function () { return this.adminCommand({ serverStatus: 1 }); };
+    DB.prototype.hostInfo = function () { return this.adminCommand({ hostInfo: 1 }); };
+    DB.prototype.currentOp = function () { return this.adminCommand({ currentOp: 1 }); };
+    DB.prototype.killOp = function (id) { return this.adminCommand({ killOp: 1, op: id }); };
+    DB.prototype.getCollectionNames = DB.prototype.getCollectionNames;
+
+    var db = new DB(__tp.call({ op: "currentDatabase" }));
+
+    function use(name) {
+        db = new DB(String(name));
+        __tp.call({ op: "useDatabase", db: String(name) });
+        return "switched to db " + String(name);
+    }
+
+    function show(what) {
+        var topic = String(what);
+        if (topic === "dbs" || topic === "databases") {
+            return db.adminCommand({ listDatabases: 1 }).databases;
+        }
+        if (topic === "collections" || topic === "tables") { return db.getCollectionNames(); }
+        throw new Error("show " + topic + " is not something TablePro knows");
+    }
+    """
+
+    private static let serialization = """
+    var EJSON = (function () {
+        function serialize(value) {
+            if (value === null || value === undefined) { return null; }
+            if (typeof value === "boolean" || typeof value === "string") { return value; }
+            if (typeof value === "number") { return serializeNumber(value); }
+            if (typeof value.toEJSON === "function") { return value.toEJSON(); }
+            if (typeof value === "function") { return { "$code": String(value) }; }
+            if (Array.isArray(value)) {
+                var list = [];
+                for (var i = 0; i < value.length; i++) { list.push(serialize(value[i])); }
+                return list;
+            }
+            if (value instanceof Date) { return { "$date": { "$numberLong": String(value.getTime()) } }; }
+            if (value instanceof RegExp) {
+                return { "$regularExpression": { pattern: value.source, options: value.flags } };
+            }
+            var document = {};
+            for (var key in value) {
+                if (Object.prototype.hasOwnProperty.call(value, key)) { document[key] = serialize(value[key]); }
+            }
+            return document;
+        }
+
+        function serializeNumber(value) {
+            if (!isFinite(value)) { return { "$numberDouble": String(value) }; }
+            if (Math.floor(value) !== value) { return { "$numberDouble": String(value) }; }
+            return value >= -2147483648 && value <= 2147483647
+                ? { "$numberInt": String(value) }
+                : { "$numberLong": String(value) };
+        }
+
+        function deserialize(value) {
+            if (value === null || typeof value !== "object") { return value; }
+            if (Array.isArray(value)) {
+                var list = [];
+                for (var i = 0; i < value.length; i++) { list.push(deserialize(value[i])); }
+                return list;
+            }
+            var keys = Object.keys(value);
+            if (keys.length === 1 || (keys.length === 2 && keys[0] === "$code")) {
+                var revived = revive(value, keys[0]);
+                if (revived !== undefined) { return revived; }
+            }
+            var document = {};
+            for (var key in value) {
+                if (Object.prototype.hasOwnProperty.call(value, key)) { document[key] = deserialize(value[key]); }
+            }
+            return document;
+        }
+
+        function revive(value, key) {
+            switch (key) {
+            case "$oid": return new ObjectId(value.$oid);
+            case "$numberInt": return parseInt(value.$numberInt, 10);
+            case "$numberDouble": return Number(value.$numberDouble);
+            case "$numberLong": return new NumberLong(value.$numberLong);
+            case "$numberDecimal": return new NumberDecimal(value.$numberDecimal);
+            case "$date":
+                return new Date(typeof value.$date === "object" ? Number(value.$date.$numberLong) : value.$date);
+            case "$regularExpression":
+                return new RegExp(value.$regularExpression.pattern, value.$regularExpression.options);
+            case "$binary": return new BinData(parseInt(value.$binary.subType, 16), value.$binary.base64);
+            case "$timestamp": return new Timestamp(value.$timestamp.t, value.$timestamp.i);
+            case "$minKey": return MinKey;
+            case "$maxKey": return MaxKey;
+            case "$code": return new Code(value.$code, value.$scope);
+            case "$symbol": return String(value.$symbol);
+            default: return undefined;
+            }
+        }
+
+        return {
+            serialize: serialize,
+            deserialize: deserialize,
+            stringify: function (value, indent) {
+                return JSON.stringify(serialize(value), null, indent === undefined ? 0 : indent);
+            },
+            parse: function (text) {
+                return deserialize(typeof text === "string" ? JSON.parse(text) : text);
+            }
+        };
+    })();
+    """
+
+    private static let output = """
+    function tojson(value, indent) {
+        if (value === undefined) { return "undefined"; }
+        if (value === null) { return "null"; }
+        if (typeof value === "string") { return value; }
+        if (typeof value.toEJSON === "function") { return value.toString(); }
+        if (typeof value !== "object") { return String(value); }
+        if (value instanceof Cursor) { return value.toString(); }
+        return JSON.stringify(EJSON.serialize(value), null, indent === undefined ? 2 : indent);
+    }
+
+    function __emit(text) {
+        if (__tp_print(text) === false) {
+            var stopped = new Error("The script was cancelled.");
+            stopped.isMongoError = true;
+            stopped.code = 0;
+            throw stopped;
+        }
+    }
+
+    function print() {
+        var parts = [];
+        for (var i = 0; i < arguments.length; i++) { parts.push(tojson(arguments[i], 0)); }
+        __emit(parts.join(" "));
+    }
+
+    function printjson(value) { __emit(tojson(value, 2)); }
+
+    var console = {
+        log: function () { print.apply(null, arguments); },
+        info: function () { print.apply(null, arguments); },
+        warn: function () { print.apply(null, arguments); },
+        error: function () { print.apply(null, arguments); },
+        debug: function () { print.apply(null, arguments); }
+    };
+
+    function sleep(milliseconds) { __tp.call({ op: "sleep", ms: Number(milliseconds) }); }
+
+    /// Tells the host what a statement evaluated to, so a cursor nothing has read can be drained
+    /// straight into the result grid without its documents crossing into JavaScript at all.
+    function __tp_classify(value) {
+        if (value === undefined || value === null) { return JSON.stringify({ kind: "none" }); }
+        if (value instanceof Cursor) {
+            return JSON.stringify({ kind: "cursor", handle: value.__handle });
+        }
+        if (Array.isArray(value)) {
+            var texts = [];
+            for (var i = 0; i < value.length; i++) { texts.push(tojson(value[i], 0)); }
+            return JSON.stringify({ kind: "array", json: __ejson(value), texts: texts });
+        }
+        return JSON.stringify({
+            kind: typeof value === "object" && typeof value.toEJSON !== "function" ? "document" : "scalar",
+            json: __ejson(value),
+            text: tojson(value, 0)
+        });
+    }
+    """
+}

--- a/Plugins/MongoDBDriverPlugin/MongoScriptResultBuilder.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoScriptResultBuilder.swift
@@ -1,0 +1,98 @@
+import Foundation
+import TableProPluginKit
+
+/// Turns what a statement evaluated to into the result the grid shows.
+///
+/// mongosh prints whatever the statement produced, so the rule here is the same one: documents
+/// become a grid, anything a script printed becomes a grid of its own when the statement produced
+/// no documents, and a bare value becomes one cell.
+enum MongoScriptResultBuilder {
+    static func result(
+        for outcome: MongoScriptStatementResult,
+        startTime: Date,
+        documents build: ([[String: Any]], String, Bool) -> PluginQueryResult
+    ) -> PluginQueryResult {
+        if outcome.producedDocuments, outcome.documents.json.isEmpty {
+            // Zero columns reads as write-success in the result pane, so a query that matched
+            // nothing has to keep its row-producing shape.
+            return PluginQueryResult(
+                columns: ["_id"], columnTypeNames: ["ObjectId"], rows: [], rowsAffected: 0,
+                executionTime: Date().timeIntervalSince(startTime)
+            )
+        }
+
+        if outcome.producedDocuments {
+            let grid = build(
+                outcome.documents.dictionaries,
+                outcome.collection ?? "",
+                outcome.documents.isTruncated
+            ).withRowsAffected(outcome.rowsAffected)
+            guard !outcome.printedLines.isEmpty else { return grid }
+            return grid.withStatus(printedSummary(outcome.printedLines))
+        }
+
+        if !outcome.printedLines.isEmpty {
+            return values(outcome.printedLines, column: MongoScriptText.outputColumn, startTime: startTime)
+        }
+
+        if let switched = outcome.databaseSwitch {
+            return note(MongoScriptText.switchedDatabase(switched), startTime: startTime)
+        }
+
+        guard let rows = outcome.scalarRows, !rows.isEmpty else {
+            return PluginQueryResult(
+                columns: [], columnTypeNames: [], rows: [], rowsAffected: 0,
+                executionTime: Date().timeIntervalSince(startTime)
+            )
+        }
+        return values(rows, column: MongoScriptText.resultColumn, startTime: startTime)
+    }
+
+    /// One row per value, which is what `print` output and an array of plain values both are.
+    private static func values(_ rows: [String], column: String, startTime: Date) -> PluginQueryResult {
+        PluginQueryResult(
+            columns: [column],
+            columnTypeNames: ["String"],
+            rows: rows.map { [.text($0)] },
+            rowsAffected: 0,
+            executionTime: Date().timeIntervalSince(startTime)
+        )
+    }
+
+    private static func note(_ text: String, startTime: Date) -> PluginQueryResult {
+        values([text], column: MongoScriptText.outputColumn, startTime: startTime)
+    }
+
+    private static func printedSummary(_ lines: [String]) -> String {
+        let joined = lines.joined(separator: " · ")
+        guard joined.count > 400 else { return joined }
+        return String(joined.prefix(400)) + "…"
+    }
+}
+
+private extension PluginQueryResult {
+    func withRowsAffected(_ count: Int) -> PluginQueryResult {
+        guard count != rowsAffected else { return self }
+        return PluginQueryResult(
+            columns: columns,
+            columnTypeNames: columnTypeNames,
+            rows: rows,
+            rowsAffected: count,
+            executionTime: executionTime,
+            isTruncated: isTruncated,
+            statusMessage: statusMessage
+        )
+    }
+
+    func withStatus(_ message: String) -> PluginQueryResult {
+        PluginQueryResult(
+            columns: columns,
+            columnTypeNames: columnTypeNames,
+            rows: rows,
+            rowsAffected: rowsAffected,
+            executionTime: executionTime,
+            isTruncated: isTruncated,
+            statusMessage: message
+        )
+    }
+}

--- a/Plugins/MongoDBDriverPlugin/MongoScriptRuntime.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoScriptRuntime.swift
@@ -1,0 +1,388 @@
+import Foundation
+import JavaScriptCore
+import TableProPluginKit
+import os
+
+/// What one statement of a script evaluated to.
+struct MongoScriptStatementResult: Sendable {
+    var documents = MongoScriptDocumentBatch.empty
+    var collection: String?
+    var scalarRows: [String]?
+    var printedLines: [String] = []
+    var databaseSwitch: String?
+    var producedDocuments = false
+    var rowsAffected = 0
+}
+
+/// Runs mongosh-shaped JavaScript against the connection.
+///
+/// One runtime per connection, which is what a shell is: `var`, functions and `use` survive from
+/// one statement to the next exactly as they do in mongosh, and the app hands statements over one
+/// at a time so each gets its own result. The context lives on a queue of its own because a
+/// `JSContext` cannot suspend, so a host call has to block where it stands while the driver runs.
+///
+/// JavaScriptCore's public API has no way to interrupt a running script: the execution time limit
+/// is private and absent from the SDK headers, measured. Cancellation therefore happens at host
+/// call granularity, which covers every script that touches the database, and a script that spins
+/// without one is abandoned along with its queue rather than left able to block the next run.
+final class MongoScriptRuntime: @unchecked Sendable {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "MongoScriptRuntime")
+
+    /// How long a script may go without reaching the host before it is abandoned.
+    static let silenceLimit: TimeInterval = 120
+    private static let silenceCheckInterval: TimeInterval = 5
+
+    private final class Engine {
+        let queue: DispatchQueue
+        let context: JSContext
+        let host: MongoScriptHost
+        var isPoisoned = false
+
+        init(queue: DispatchQueue, context: JSContext, host: MongoScriptHost) {
+            self.queue = queue
+            self.context = context
+            self.host = host
+        }
+    }
+
+    private let connection: MongoDBConnection
+    private let lock = NSLock()
+    private var engine: Engine?
+    private var generation = 0
+
+    init(connection: MongoDBConnection) {
+        self.connection = connection
+    }
+
+    // MARK: - Evaluation
+
+    func evaluate(
+        statement: String,
+        database: String,
+        valueCeiling: Int
+    ) async throws -> MongoScriptStatementResult {
+        let engine = try engine(startingAt: database, valueCeiling: valueCeiling)
+        connection.beginScriptRun()
+
+        let gate = MongoScriptResumeGate()
+        return try await withCheckedThrowingContinuation { continuation in
+            gate.attach(continuation)
+            // Captured strongly: a gate that is never finished leaves the caller waiting, and the
+            // work is one statement long.
+            engine.queue.async {
+                gate.finish(with: Result { try self.run(statement, on: engine) })
+            }
+            watchForSilence(engine: engine, gate: gate)
+        }
+    }
+
+    /// Gives up on a script that has stopped talking to the host.
+    ///
+    /// The deadline is measured from the last host call rather than from the start, so a script
+    /// working through a large collection is never cut off: only one that is spinning without
+    /// touching the database, printing or sleeping reaches it. There is no way to interrupt such a
+    /// script through the public JavaScriptCore API, so its queue is abandoned and the next
+    /// statement gets a new one.
+    private func watchForSilence(engine: Engine, gate: MongoScriptResumeGate) {
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + Self.silenceCheckInterval) {
+            [weak self] in
+            guard let self, !gate.isFinished else { return }
+            guard Date().timeIntervalSince(engine.host.lastActivity) >= Self.silenceLimit else {
+                watchForSilence(engine: engine, gate: gate)
+                return
+            }
+            guard gate.finish(with: .failure(MongoDBError(
+                code: 0, message: MongoScriptText.timedOut(Self.silenceLimit)
+            ))) else { return }
+            poison(engine)
+        }
+    }
+
+    func cancel() {
+        lock.lock()
+        let running = engine
+        lock.unlock()
+        running?.host.markCancelled()
+        connection.cancelCurrentQuery()
+    }
+
+    /// Drops the shell, so the next statement starts from a clean global scope.
+    ///
+    /// Only disconnecting does this. A database switch reassigns the global `db` instead and keeps
+    /// everything the user has defined, which is what `use` does in mongosh; a collection already
+    /// captured in a variable keeps pointing at the database it came from, there too.
+    func reset() {
+        lock.lock()
+        let current = engine
+        engine = nil
+        lock.unlock()
+        current?.queue.async { current?.host.reset(database: "", valueCeiling: 0) }
+    }
+
+    /// What an export should read, having evaluated the statement exactly once.
+    ///
+    /// `find()` and `aggregate()` build a lazy cursor and touch nothing, so the export can take the
+    /// plan and page through the collection. Anything else has already run by the time we know
+    /// that, and running it a second time would repeat a write, so its result is handed back
+    /// instead of re-executed.
+    func exportPlan(for statement: String, database: String) async throws -> MongoScriptExport {
+        let engine = try engine(startingAt: database, valueCeiling: PluginRowLimits.emergencyMax)
+        connection.beginScriptRun()
+        return try await withCheckedThrowingContinuation { continuation in
+            engine.queue.async {
+                continuation.resume(with: Result { try self.runForExport(statement, on: engine) })
+            }
+        }
+    }
+
+    private func runForExport(_ statement: String, on engine: Engine) throws -> MongoScriptExport {
+        engine.host.beginStatement()
+        engine.context.exception = nil
+
+        let value = engine.context.evaluateScript(statement)
+        if let failure = engine.context.exception {
+            engine.context.exception = nil
+            if engine.host.isCancelled { throw CancellationError() }
+            throw scriptError(failure, host: engine.host)
+        }
+        if engine.host.isCancelled { throw CancellationError() }
+
+        if let value,
+           let handle = value.objectForKeyedSubscript("__handle"), handle.isNumber,
+           let plan = engine.host.cursorPlan(handle: Int(handle.toInt32())) {
+            return .cursor(plan)
+        }
+
+        var result = MongoScriptStatementResult()
+        result.printedLines = engine.host.printedLines
+        result.databaseSwitch = engine.host.databaseSwitch
+        if let value, !value.isUndefined {
+            try classify(value, on: engine, into: &result)
+        }
+        return .result(result)
+    }
+
+    // MARK: - Engine
+
+    /// The shell for this connection, built on first use and reused after that.
+    ///
+    /// The database is a starting point, not a per-statement input. Every scoped execution re-pins
+    /// the driver to the tab's database, so re-deriving the shell's `db` here would undo a `use`
+    /// the moment the next statement ran: the shell would report the switch and then query the old
+    /// database. `rebindDatabase` is the only thing that moves it.
+    ///
+    /// Everything that touches the host or the `JSContext` runs on the engine's own queue, this
+    /// included. Both are single-threaded by construction: the cursor registry is a plain
+    /// dictionary and a `JSContext` may only be entered from one thread at a time, so preparing an
+    /// engine from the caller's thread would race the statement running on it.
+    private func engine(startingAt database: String, valueCeiling: Int) throws -> Engine {
+        lock.lock()
+        let existing = engine.flatMap { $0.isPoisoned ? nil : $0 }
+        if existing == nil {
+            generation += 1
+        }
+        let requestedGeneration = generation
+        lock.unlock()
+
+        if let existing {
+            existing.queue.sync { existing.host.prepare(valueCeiling: valueCeiling) }
+            return existing
+        }
+
+        let built = try makeEngine(
+            database: database, valueCeiling: valueCeiling, generation: requestedGeneration
+        )
+        lock.lock()
+        engine = built
+        lock.unlock()
+        return built
+    }
+
+    /// Moves the shell onto a database the user switched to in the app.
+    ///
+    /// Only an actual change reaches here, so the re-pinning every execution performs leaves a
+    /// `use` alone.
+    func rebindDatabase(_ database: String) {
+        lock.lock()
+        let current = engine.flatMap { $0.isPoisoned ? nil : $0 }
+        lock.unlock()
+        guard let current else { return }
+        current.queue.sync {
+            guard current.host.database != database else { return }
+            current.host.reset(database: database, valueCeiling: current.host.valueCeiling)
+            current.context.evaluateScript("db = new DB(\(MongoScriptJson.jsonString(database)));")
+        }
+    }
+
+    private func makeEngine(database: String, valueCeiling: Int, generation: Int) throws -> Engine {
+        guard let context = JSContext(virtualMachine: JSVirtualMachine()) else {
+            throw MongoDBError(code: 0, message: MongoScriptText.scriptEngineUnavailable)
+        }
+        let host = MongoScriptHost(
+            connection: connection, database: database, valueCeiling: valueCeiling
+        )
+        let queue = DispatchQueue(
+            label: "com.TablePro.mongodb.script.\(generation)", qos: .userInitiated
+        )
+
+        let execute: @convention(block) (String) -> String = { request in host.handle(request) }
+        let emit: @convention(block) (String) -> Bool = { line in host.record(printed: line) }
+        context.setObject(execute, forKeyedSubscript: "__tp_exec" as NSString)
+        context.setObject(emit, forKeyedSubscript: "__tp_print" as NSString)
+        context.exceptionHandler = { _, exception in
+            Self.logger.debug("Script exception: \(exception?.toString() ?? "unknown", privacy: .public)")
+        }
+
+        context.evaluateScript(MongoScriptPrelude.source)
+        if let failure = context.exception {
+            throw MongoDBError(code: 0, message: failure.toString() ?? MongoScriptText.scriptEngineUnavailable)
+        }
+        return Engine(queue: queue, context: context, host: host)
+    }
+
+    /// Abandons an engine whose script stopped responding.
+    ///
+    /// The host is marked cancelled as well as detached. Without that, a script that computed
+    /// silently past the deadline and *then* reached a host call would still perform its write,
+    /// long after the caller had been told it timed out.
+    private func poison(_ engine: Engine) {
+        lock.lock()
+        engine.isPoisoned = true
+        if self.engine === engine { self.engine = nil }
+        lock.unlock()
+        engine.host.markCancelled()
+        Self.logger.warning("Abandoned a MongoDB script that did not stop; its queue stays blocked")
+    }
+
+    // MARK: - One Statement
+
+    private func run(_ statement: String, on engine: Engine) throws -> MongoScriptStatementResult {
+        engine.host.beginStatement()
+        engine.context.exception = nil
+
+        let value = engine.context.evaluateScript(statement)
+        if let failure = engine.context.exception {
+            engine.context.exception = nil
+            if engine.host.isCancelled { throw CancellationError() }
+            throw scriptError(failure, host: engine.host)
+        }
+        if engine.host.isCancelled { throw CancellationError() }
+
+        var result = MongoScriptStatementResult()
+        result.printedLines = engine.host.printedLines
+        result.databaseSwitch = engine.host.databaseSwitch
+
+        guard let value, !value.isUndefined else { return result }
+        try classify(value, on: engine, into: &result)
+        return result
+    }
+
+    private func classify(
+        _ value: JSValue,
+        on engine: Engine,
+        into result: inout MongoScriptStatementResult
+    ) throws {
+        guard let classifier = engine.context.objectForKeyedSubscript("__tp_classify"),
+              let described = classifier.call(withArguments: [value])?.toString(),
+              let data = described.data(using: .utf8),
+              let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let kind = payload["kind"] as? String else {
+            return
+        }
+
+        if let failure = engine.context.exception {
+            engine.context.exception = nil
+            throw scriptError(failure, host: engine.host)
+        }
+
+        switch kind {
+        case "cursor":
+            guard let handle = payload["handle"] as? Int else { return }
+            result.documents = try engine.host.drain(handle: handle)
+            result.collection = engine.host.cursorDescription(handle: handle)?.collection
+            result.producedDocuments = true
+        case "array":
+            guard let json = payload["json"] as? String else { return }
+            let elements = MongoScriptJson.topLevelElements(json)
+            if !elements.isEmpty, elements.allSatisfy({ $0.hasPrefix("{") }),
+               !elements.contains(where: MongoScriptJson.isScalarWrapper) {
+                result.documents = MongoScriptDocumentBatch(json: elements, isTruncated: false)
+                result.producedDocuments = true
+            } else {
+                // `distinct` and friends answer with an array of plain values, which reads as one
+                // row each rather than as one cell holding a JSON array.
+                result.scalarRows = payload["texts"] as? [String] ?? []
+            }
+        case "document":
+            guard let json = payload["json"] as? String else { return }
+            result.documents = MongoScriptDocumentBatch(json: [json], isTruncated: false)
+            result.producedDocuments = true
+            result.rowsAffected = Self.rowsAffected(in: json)
+        default:
+            let text = (payload["text"] as? String) ?? (payload["json"] as? String)
+            result.scalarRows = text.map { [$0] }
+        }
+    }
+
+    /// How many documents a write reply says it changed.
+    ///
+    /// The shell answers a write with the object mongosh answers with, so the count the result bar
+    /// reports has to be read back out of it rather than counted from the grid's one row.
+    private static func rowsAffected(in json: String) -> Int {
+        // Summed, not first-wins: a `bulkWrite` that mixes an insert with a delete carries two
+        // positive counters and affected both rows.
+        let total = ["modifiedCount", "deletedCount", "insertedCount", "upsertedCount"]
+            .compactMap { MongoScriptJson.number(in: json, key: $0) }
+            .filter { $0 > 0 }
+            .reduce(0, +)
+        if total > 0 { return Int(total) }
+        return MongoScriptJson.member(of: json, key: "insertedId") == nil ? 0 : 1
+    }
+
+    private func scriptError(_ exception: JSValue, host: MongoScriptHost) -> Error {
+        if exception.objectForKeyedSubscript("isMongoError")?.toBool() == true {
+            let message = exception.objectForKeyedSubscript("message")?.toString() ?? ""
+            if message == MongoScriptText.cancelled { return CancellationError() }
+            let code = UInt32(max(0, exception.objectForKeyedSubscript("code")?.toInt32() ?? 0))
+            return MongoDBError(code: code, message: message)
+        }
+        _ = host
+        return MongoDBError(
+            code: 0,
+            message: exception.toString() ?? MongoScriptText.scriptEngineUnavailable
+        )
+    }
+}
+
+/// Resumes a continuation exactly once, whichever of the script and the deadline gets there first.
+private final class MongoScriptResumeGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<MongoScriptStatementResult, Error>?
+    private var finished = false
+
+    var isFinished: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return finished
+    }
+
+    func attach(_ continuation: CheckedContinuation<MongoScriptStatementResult, Error>) {
+        lock.lock()
+        self.continuation = continuation
+        lock.unlock()
+    }
+
+    @discardableResult
+    func finish(with outcome: Result<MongoScriptStatementResult, Error>) -> Bool {
+        lock.lock()
+        guard !finished, let continuation else {
+            lock.unlock()
+            return false
+        }
+        finished = true
+        self.continuation = nil
+        lock.unlock()
+        continuation.resume(with: outcome)
+        return true
+    }
+}

--- a/Plugins/MongoDBDriverPlugin/MongoScriptText.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoScriptText.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// The messages the script runtime shows a user.
+///
+/// Gathered here rather than spelled at each throw site because the same wording has to reach the
+/// result pane, the diagnostics gutter and the log, and because a message built by interpolating
+/// into `String(localized:)` produces a key that never matches the catalog.
+enum MongoScriptText {
+    static func invalidDocument(_ text: String) -> String {
+        String(format: String(localized: "This is not a document MongoDB can read: %@"), text)
+    }
+
+    static func invalidFilter(_ text: String) -> String {
+        String(format: String(localized: "This filter is not a document MongoDB can read: %@"), text)
+    }
+
+    static func invalidPipeline(_ text: String) -> String {
+        String(format: String(localized: "This pipeline is not something MongoDB can read: %@"), text)
+    }
+
+    static var cursorFailed: String {
+        String(localized: "MongoDB did not return a cursor for this query.")
+    }
+
+    static func unsupportedCursorOption(_ key: String) -> String {
+        String(format: String(localized: "A cursor has no .%@() modifier."), key)
+    }
+
+    static func wholeNumberExpected(_ key: String) -> String {
+        String(format: String(localized: ".%@() takes a whole number."), key)
+    }
+
+    static func unsupportedBulkOperation(_ text: String) -> String {
+        String(format: String(localized: "bulkWrite does not know this operation: %@"), text)
+    }
+
+    static var cancelled: String {
+        String(localized: "The script was cancelled.")
+    }
+
+    static func unknownOperation(_ name: String) -> String {
+        String(format: String(localized: "Unsupported script operation: %@"), name)
+    }
+
+    static var unknownCursor: String {
+        String(localized: "This cursor has already been closed.")
+    }
+
+    static func cursorAlreadyStarted(_ key: String) -> String {
+        String(format: String(localized: ".%@() cannot be set once the cursor has started."), key)
+    }
+
+    static var scriptEngineUnavailable: String {
+        String(localized: "The MongoDB script engine could not start.")
+    }
+
+    static func timedOut(_ seconds: TimeInterval) -> String {
+        String(
+            format: String(localized: "The script did not finish within %d seconds and was abandoned."),
+            Int(seconds.rounded())
+        )
+    }
+
+    static func printedLines(_ count: Int) -> String {
+        String(format: String(localized: "%d line(s) printed"), count)
+    }
+
+    static var outputColumn: String {
+        String(localized: "output")
+    }
+
+    static var resultColumn: String {
+        String(localized: "result")
+    }
+
+    static func switchedDatabase(_ name: String) -> String {
+        String(format: String(localized: "Switched to %@"), name)
+    }
+}

--- a/Plugins/MongoDBDriverPlugin/MongoShellCommandLine.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoShellCommandLine.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Rewrites the two mongosh lines that are not JavaScript.
+///
+/// Kept in the plugin rather than shared through TableProPluginKit: a new public symbol there would
+/// be missing from every already-shipped app, so the plugin would stop loading on the version most
+/// users are running. The editor's own diagnostics recognise the same two lines through
+/// `MongoShellCommandRecognizer`, which only has to know when *not* to report a syntax error.
+///
+/// `use orders` and `show collections` are shell syntax: mongosh reads them before the engine ever
+/// sees them, and so does this. Everything else is left exactly as typed, so a statement that only
+/// happens to start with the word `use` as an identifier is untouched.
+enum MongoShellCommandLine {
+    private static let shownTopics: Set<String> = [
+        "dbs", "databases", "collections", "tables"
+    ]
+
+    static func rewrite(_ statement: String) -> String {
+        let trimmed = statement.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let rewritten = useCommand(trimmed) ?? showCommand(trimmed) else { return statement }
+        return rewritten
+    }
+
+    private static func useCommand(_ statement: String) -> String? {
+        guard let name = argument(of: "use", in: statement), !name.isEmpty else { return nil }
+        return "use(\(quoted(name)))"
+    }
+
+    private static func showCommand(_ statement: String) -> String? {
+        guard let topic = argument(of: "show", in: statement)?.lowercased(),
+              shownTopics.contains(topic) else { return nil }
+        return "show(\(quoted(topic)))"
+    }
+
+    /// The single bare word after a leading keyword, or nil when the line is ordinary JavaScript.
+    private static func argument(of keyword: String, in statement: String) -> String? {
+        guard statement.lowercased().hasPrefix(keyword + " ") else { return nil }
+        let remainder = statement.dropFirst(keyword.count).trimmingCharacters(in: .whitespaces)
+        let word = remainder.hasSuffix(";") ? String(remainder.dropLast()) : remainder
+        guard !word.isEmpty, !word.contains(where: { $0.isWhitespace }) else { return nil }
+        guard !word.contains("("), !word.contains("="), !word.contains(".") else { return nil }
+        return word.trimmingCharacters(in: CharacterSet(charactersIn: "\"'`"))
+    }
+
+    private static func quoted(_ value: String) -> String {
+        "\"\(value.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\""))\""
+    }
+}

--- a/TablePro/Core/Autocomplete/Mongo/MongoCompletionService.swift
+++ b/TablePro/Core/Autocomplete/Mongo/MongoCompletionService.swift
@@ -82,7 +82,7 @@ final class MongoCompletionService: QueryCompletionService {
 
     private func opensBrowsableList(_ position: MongoCompletionPosition) -> Bool {
         switch position {
-        case .databaseMember, .collectionMethod, .pipelineStage, .updatePipelineStage:
+        case .databaseMember, .collectionMethod, .cursorMethod, .pipelineStage, .updatePipelineStage:
             return true
         default:
             return false
@@ -99,6 +99,8 @@ final class MongoCompletionService: QueryCompletionService {
             return await collectionItems() + methodItems(MongoVocabulary.databaseMethods)
         case .collectionMethod:
             return methodItems(MongoVocabulary.collectionMethods)
+        case .cursorMethod:
+            return methodItems(MongoVocabulary.cursorMethods)
         case .filterDocument(let collection):
             return await fieldItems(for: collection) + operatorItems(MongoVocabulary.queryOperators)
         case .projectionDocument(let collection):

--- a/TablePro/Core/Autocomplete/Mongo/MongoContextAnalyzer.swift
+++ b/TablePro/Core/Autocomplete/Mongo/MongoContextAnalyzer.swift
@@ -4,6 +4,7 @@ enum MongoCompletionPosition: Equatable {
     case statementStart
     case databaseMember
     case collectionMethod(collection: String)
+    case cursorMethod
     case filterDocument(collection: String?)
     case projectionDocument(collection: String?)
     case updateDocument
@@ -269,6 +270,13 @@ enum MongoContextAnalyzer {
     private static func topLevelPosition(text: NSString, tokenStart: Int) -> MongoCompletionPosition {
         guard tokenStart > 0, text.character(at: tokenStart - 1) == dot else {
             return .statementStart
+        }
+
+        // `db.orders.find({}).` continues a cursor, not a collection: what comes next is a cursor
+        // modifier or an iterator, and offering `insertOne` there is offering something that does
+        // not exist on the value in hand.
+        if tokenStart >= 2, text.character(at: tokenStart - 2) == closeParen {
+            return .cursorMethod
         }
 
         var end = tokenStart - 1

--- a/TablePro/Core/Autocomplete/Mongo/MongoVocabulary.swift
+++ b/TablePro/Core/Autocomplete/Mongo/MongoVocabulary.swift
@@ -65,9 +65,34 @@ enum MongoVocabulary {
         ("totalSize", "Storage size plus total index size"),
         ("isCapped", "True if the collection is capped"),
         ("validate", "Validate collection and index integrity"),
+        ("explain", "Return the query plan instead of results")
+    ]
+
+    /// What a cursor answers to, which is what `find()` and `aggregate()` return.
+    static let cursorMethods: [(name: String, detail: String)] = [
+        ("sort", "Order the results by one or more fields"),
+        ("limit", "Return at most this many documents"),
+        ("skip", "Skip this many documents first"),
+        ("projection", "Choose which fields come back"),
+        ("hint", "Name the index to use"),
+        ("collation", "Language rules for string comparison"),
+        ("maxTimeMS", "Give up after this many milliseconds"),
+        ("batchSize", "Documents per round trip"),
+        ("allowDiskUse", "Let a large sort spill to disk"),
+        ("forEach", "Call a function for every document"),
+        ("map", "Build an array from every document"),
+        ("toArray", "Read every document into an array"),
+        ("hasNext", "True while documents remain"),
+        ("next", "Read the next document"),
+        ("tryNext", "Read the next document, or null"),
+        ("count", "Number of documents matching the query"),
+        ("itcount", "Count by reading the cursor to its end"),
+        ("size", "Documents remaining, after skip and limit"),
         ("explain", "Return the query plan instead of results"),
-        ("watch", "Open a change stream on the collection"),
-        ("getShardDistribution", "Chunk and data distribution for a sharded collection")
+        ("pretty", "Format the documents for reading"),
+        ("close", "Release the cursor"),
+        ("isExhausted", "True once nothing remains"),
+        ("objsLeftInBatch", "Documents left in the current batch")
     ]
 
     static let deprecatedCollectionMethods: Set<String> = [

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator.swift
@@ -23,10 +23,12 @@ final class QueryExecutionCoordinator {
         let fullQuery = tab.content.query
         guard !fullQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
 
-        let statements = SQLStatementScanner.executableStatements(in: fullQuery, dialect: parent.sqlDialect)
+        let statements = QueryStatementScanner.executableStatements(
+            in: fullQuery, model: parent.statementModel, dialect: parent.sqlDialect
+        )
         guard !statements.isEmpty else { return }
 
-        if AppSettingsManager.shared.editor.queryParametersEnabled {
+        if AppSettingsManager.shared.editor.queryParametersEnabled, parent.statementModel == .sql {
             let combinedSQL = statements.map(\.sql).joined(separator: "; ")
             let detectedNames = SQLParameterExtractor.extractParameters(from: combinedSQL)
 

--- a/TablePro/Core/Diagnostics/MongoDiagnosticsProducer.swift
+++ b/TablePro/Core/Diagnostics/MongoDiagnosticsProducer.swift
@@ -1,6 +1,11 @@
 import Foundation
 import TableProPluginKit
 
+/// Underlines what MongoDB will refuse to run.
+///
+/// The query language is JavaScript, so the check is a JavaScript parse rather than a match against
+/// a list of method names. Checking against a list said `forEach` was an unsupported method and
+/// underlined every script that iterated a cursor, while saying nothing about a missing brace.
 struct MongoDiagnosticsProducer: QueryDiagnosticsProducing {
     private static let maximumLength = 100_000
 
@@ -8,48 +13,61 @@ struct MongoDiagnosticsProducer: QueryDiagnosticsProducing {
         let source = text as NSString
         guard source.length > 0, source.length <= Self.maximumLength else { return [] }
 
-        let structure = QueryBracketScanner.scan(source, allowsLineComments: false)
+        // The bracket scanner has no regex state, so `db.c.find({x:/[)]/})` reads as an unmatched
+        // closer. The syntax checker below knows JavaScript properly, so the structural pass is
+        // only there to stay quiet while a query is still being typed.
+        let structure = QueryBracketScanner.scan(source, comments: .javaScript)
+        let hasRegexLiteral = source.range(of: "/", options: .literal).location != NSNotFound
 
-        if let range = structure.unmatchedClose {
+        if let range = structure.unmatchedClose, !hasRegexLiteral {
             return [QueryDiagnostic(range: range, message: String(localized: "No matching opening bracket"))]
         }
         if let range = structure.unterminatedComment {
             return [QueryDiagnostic(range: range, message: String(localized: "Unterminated comment"))]
         }
 
-        guard !structure.hasUnclosedOpener, !structure.hasUnterminatedString else { return [] }
+        guard !structure.hasUnterminatedString else { return [] }
+        guard !structure.hasUnclosedOpener || hasRegexLiteral else { return [] }
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return [] }
 
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return [] }
-
-        do {
-            _ = try MongoShellParser.parse(trimmed)
-            return []
-        } catch let error as MongoShellParseError {
-            guard let message = error.errorDescription else { return [] }
-            return [QueryDiagnostic(range: range(for: error, in: source), message: message)]
-        } catch {
+        guard let failure = JavaScriptSyntaxChecker.firstFailure(in: blankingShellCommands(source)) else {
             return []
         }
+        return [QueryDiagnostic(range: range(ofLine: failure.line, in: source), message: failure.message)]
     }
 
-    private func range(for error: MongoShellParseError, in source: NSString) -> NSRange {
-        if case .unsupportedMethod(let method) = error {
-            let name = method.trimmingCharacters(in: CharacterSet(charactersIn: ".()"))
-            let found = source.range(of: name)
-            if found.location != NSNotFound { return found }
+    /// The document with every `use orders` and `show collections` line blanked out.
+    ///
+    /// Blanked rather than rewritten, and with its newlines kept, so the parser never sees shell
+    /// syntax and a syntax error it does report still lands on the line the reader typed.
+    private func blankingShellCommands(_ source: NSString) -> String {
+        let statements = JavaScriptStatementScanner.executableStatements(in: source as String)
+        var checked = source as String
+        for statement in statements.reversed() where MongoShellCommandRecognizer.isShellCommand(statement.trimmed) {
+            let blank = statement.text.map { $0.isNewline ? $0 : " " }
+            checked = (checked as NSString).replacingCharacters(
+                in: statement.range, with: String(blank)
+            )
         }
-        return firstStatementLine(in: source)
+        return checked
     }
 
-    private func firstStatementLine(in source: NSString) -> NSRange {
-        let full = NSRange(location: 0, length: source.length)
-        let line = source.lineRange(for: NSRange(location: 0, length: 0))
-        let trimmedLength = source.substring(with: line)
+    private func range(ofLine line: Int, in source: NSString) -> NSRange {
+        var current = 1
+        var location = 0
+        while current < line, location < source.length {
+            location = NSMaxRange(source.lineRange(for: NSRange(location: location, length: 0)))
+            current += 1
+        }
+        guard location < source.length else {
+            return NSRange(location: max(0, source.length - 1), length: min(1, source.length))
+        }
+        let lineRange = source.lineRange(for: NSRange(location: location, length: 0))
+        let trimmedLength = source.substring(with: lineRange)
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .utf16
             .count
-        guard trimmedLength > 0 else { return full }
-        return NSRange(location: line.location, length: min(trimmedLength, source.length - line.location))
+        guard trimmedLength > 0 else { return lineRange }
+        return NSRange(location: lineRange.location, length: min(trimmedLength, source.length - lineRange.location))
     }
 }

--- a/TablePro/Core/Diagnostics/QueryBracketScanner.swift
+++ b/TablePro/Core/Diagnostics/QueryBracketScanner.swift
@@ -26,7 +26,19 @@ enum QueryBracketScanner {
     private static let doubleQuote = UInt16(UnicodeScalar("\"").value)
     private static let backtick = UInt16(UnicodeScalar("`").value)
 
-    static func scan(_ text: NSString, allowsLineComments: Bool) -> Result {
+    /// Which line-comment spelling the language uses.
+    ///
+    /// The two are mutually exclusive and taking both is wrong in both directions: `--` is the
+    /// decrement operator in JavaScript, so reading it as a comment swallows the rest of the line
+    /// and hides everything the scan was called to check.
+    enum CommentStyle {
+        /// `--` opens a line comment, and `//` does not.
+        case sql
+        /// `//` opens a line comment, and `--` is an operator.
+        case javaScript
+    }
+
+    static func scan(_ text: NSString, comments: CommentStyle) -> Result {
         var stack: [UInt16] = []
         var unmatchedClose: NSRange?
         var commentStart: Int?
@@ -73,14 +85,15 @@ enum QueryBracketScanner {
                     index += 2
                     continue
                 }
-                if next == slash, allowsLineComments {
+                if next == slash, comments == .javaScript {
                     isInLineComment = true
                     index += 2
                     continue
                 }
             }
 
-            if character == dash, index + 1 < text.length, text.character(at: index + 1) == dash {
+            if comments == .sql, character == dash, index + 1 < text.length,
+               text.character(at: index + 1) == dash {
                 isInLineComment = true
                 index += 2
                 continue

--- a/TablePro/Core/Diagnostics/SQLDiagnosticsProducer.swift
+++ b/TablePro/Core/Diagnostics/SQLDiagnosticsProducer.swift
@@ -9,7 +9,7 @@ struct SQLDiagnosticsProducer: QueryDiagnosticsProducing {
         let source = text as NSString
         guard source.length > 0, source.length <= Self.maximumLength else { return [] }
 
-        let structure = QueryBracketScanner.scan(source, allowsLineComments: false)
+        let structure = QueryBracketScanner.scan(source, comments: .sql)
         var results: [QueryDiagnostic] = []
 
         if let range = structure.unmatchedClose {

--- a/TablePro/Core/Services/Formatting/MongoShellFormatter.swift
+++ b/TablePro/Core/Services/Formatting/MongoShellFormatter.swift
@@ -47,6 +47,28 @@ struct MongoShellFormatter: QueryFormatting {
                 continue
             }
 
+            // A comment and a regular expression are single tokens. Letting the switch below see
+            // inside one turns `/a{2,3}/` into `/a{2, 3}/`, which is a different pattern, and
+            // breaks a `//` line across the reflow.
+            if scalar == "/", index + 1 < source.length {
+                let next = Character(UnicodeScalar(source.character(at: index + 1)) ?? " ")
+                if next == "/" || next == "*" {
+                    flushPending()
+                    let comment = readComment(source, from: index, isBlock: next == "*")
+                    tokens.append(.string(comment.value))
+                    index = comment.end
+                    continue
+                }
+            }
+
+            if scalar == "/", startsRegularExpression(before: tokens, pending: pending) {
+                flushPending()
+                let literal = readRegularExpression(source, from: index)
+                tokens.append(.string(literal.value))
+                index = literal.end
+                continue
+            }
+
             switch scalar {
             case "{", "[":
                 flushPending()
@@ -69,6 +91,62 @@ struct MongoShellFormatter: QueryFormatting {
 
         flushPending()
         return tokens
+    }
+
+    /// Whether a `/` here opens a regular expression rather than dividing.
+    ///
+    /// Division follows something that can end an expression, so a slash after an identifier, a
+    /// number or a closing bracket is an operator.
+    private func startsRegularExpression(before tokens: [Token], pending: String) -> Bool {
+        if let last = pending.last(where: { !$0.isWhitespace }) {
+            return !(last.isLetter || last.isNumber || last == "_" || last == ")" || last == "]")
+        }
+        guard let token = tokens.last else { return true }
+        switch token {
+        case .open, .comma, .colon: return true
+        case .text, .string, .close: return false
+        }
+    }
+
+    private func readRegularExpression(_ source: NSString, from start: Int) -> (value: String, end: Int) {
+        var index = start + 1
+        var inClass = false
+        while index < source.length {
+            let scalar = Character(UnicodeScalar(source.character(at: index)) ?? " ")
+            if scalar == "\\" {
+                index += 2
+                continue
+            }
+            if scalar.isNewline { break }
+            if scalar == "[" { inClass = true }
+            if scalar == "]" { inClass = false }
+            if scalar == "/", !inClass {
+                index += 1
+                while index < source.length {
+                    let flag = Character(UnicodeScalar(source.character(at: index)) ?? " ")
+                    guard flag.isLetter else { break }
+                    index += 1
+                }
+                return (source.substring(with: NSRange(location: start, length: index - start)), index)
+            }
+            index += 1
+        }
+        return (source.substring(with: NSRange(location: start, length: index - start)), index)
+    }
+
+    private func readComment(_ source: NSString, from start: Int, isBlock: Bool) -> (value: String, end: Int) {
+        var index = start + 2
+        while index < source.length {
+            let scalar = Character(UnicodeScalar(source.character(at: index)) ?? " ")
+            if isBlock, scalar == "*", index + 1 < source.length,
+               Character(UnicodeScalar(source.character(at: index + 1)) ?? " ") == "/" {
+                index += 2
+                break
+            }
+            if !isBlock, scalar.isNewline { break }
+            index += 1
+        }
+        return (source.substring(with: NSRange(location: start, length: index - start)), index)
     }
 
     private func readStringLiteral(

--- a/TablePro/Core/Utilities/JavaScript/JavaScriptStatementScanner.swift
+++ b/TablePro/Core/Utilities/JavaScript/JavaScriptStatementScanner.swift
@@ -1,0 +1,405 @@
+//
+//  JavaScriptStatementScanner.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Finds the top-level statements of a JavaScript program.
+///
+/// The SQL scanner splits on semicolons, which is right for SQL and wrong for JavaScript: the
+/// semicolons inside a function body, a `for` header or an object literal are not statement
+/// boundaries, so a mongosh script ran as several disconnected programs and lost its variables
+/// between them.
+///
+/// The bias here is deliberately coarse. Merging two statements still runs correct code and only
+/// costs a separate result; splitting one in half produces a syntax error. So a boundary is taken
+/// only where the language guarantees one:
+///
+/// - a `;` at bracket depth zero,
+/// - a `}` at depth zero that closes a statement opened by a statement keyword, unless what follows
+///   continues it (`else`, `catch`, `finally`, `while`),
+/// - a newline at depth zero where the next token cannot continue the expression, which is the
+///   offending-token half of automatic semicolon insertion.
+enum JavaScriptStatementScanner {
+    struct Statement {
+        let text: String
+        let range: NSRange
+
+        var trimmed: String { text.trimmingCharacters(in: .whitespacesAndNewlines) }
+
+        /// Whether the span holds anything to run. A trailing `// note` after a semicolon is a
+        /// statement to the scanner and nothing at all to the engine, so counting it adds an empty
+        /// result and a gutter control that runs nothing.
+        var hasContent: Bool {
+            !JavaScriptStatementScanner.strippingComments(text)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .isEmpty
+        }
+    }
+
+    /// Keywords that open a statement whose closing brace ends it.
+    private static let blockKeywords: Set<String> = [
+        "if", "for", "while", "do", "switch", "try", "function", "class", "with", "label"
+    ]
+
+    /// Keywords that continue the statement the previous brace closed.
+    private static let continuationKeywords: Set<String> = ["else", "catch", "finally", "while"]
+
+    /// Comment text never runs, so a span holding only comments is not a statement to execute.
+    static func strippingComments(_ text: String) -> String {
+        let source = text as NSString
+        var stripped = ""
+        var index = 0
+        while index < source.length {
+            let character = Character(UnicodeScalar(source.character(at: index)) ?? " ")
+            if character == "/", index + 1 < source.length {
+                let next = Character(UnicodeScalar(source.character(at: index + 1)) ?? " ")
+                if next == "/" {
+                    index = endOfLineComment(source, from: index)
+                    continue
+                }
+                if next == "*" {
+                    index = endOfBlockComment(source, from: index)
+                    continue
+                }
+            }
+            stripped.append(character)
+            index += 1
+        }
+        return stripped
+    }
+
+    /// Characters that can only continue the expression on the line before them, so a newline in
+    /// front of one inserts no semicolon.
+    private static let continuationStarters: Set<Character> = [
+        ".", ",", ")", "]", "}", "+", "-", "*", "/", "%", "?", ":", "=", "<", ">", "!", "&", "|",
+        "^", "~", "(", "["
+    ]
+
+    private static let continuationWords: Set<String> = ["in", "instanceof", "of"]
+
+    /// Words that continue the construct on the line before them, so a newline in front of one
+    /// inserts no semicolon. Allman-style JavaScript puts `{`, `else` and `catch` on their own
+    /// lines, and splitting there produces two fragments that are each a syntax error.
+    private static let openingWords: Set<String> = ["else", "catch", "finally", "while"]
+
+    // MARK: - Public API
+
+    /// Every statement in the document, including the empty and comment-only stretches, in order.
+    static func locatedStatements(in source: String) -> [Statement] {
+        scan(source)
+    }
+
+    /// The statements a run can execute, in order, with their spans.
+    static func executableStatements(in source: String) -> [Statement] {
+        scan(source).filter(\.hasContent)
+    }
+
+    /// The statement the caret sits in, or the last one when the caret is past the end.
+    static func statementAtCursor(in source: String, cursorPosition: Int) -> Statement? {
+        let statements = scan(source).filter(\.hasContent)
+        guard !statements.isEmpty else { return nil }
+        for statement in statements where cursorPosition <= statement.range.upperBound
+            && cursorPosition >= statement.range.location {
+            return statement
+        }
+        return statements.last { $0.range.location <= cursorPosition } ?? statements.first
+    }
+
+    // MARK: - Scanning
+
+    private static func scan(_ source: String) -> [Statement] {
+        let text = source as NSString
+        guard text.length > 0 else { return [] }
+
+        var statements: [Statement] = []
+        var start = 0
+        var index = 0
+        var depth = 0
+        var openedWithKeyword: [Bool] = []
+        var lastMeaningful: Character?
+        var lastWord = ""
+        // The statement's own first word, which is what decides whether a brace closes it. The word
+        // right before the brace cannot: `var f = function () {` and `function f() {` both read
+        // `function` there, and only the second one ends at its `}`.
+        var firstWord = ""
+        var sawNewlineSinceMeaningful = false
+
+        func closeStatement(endingAt end: Int) {
+            let range = NSRange(location: start, length: end - start)
+            guard range.length > 0 else { return }
+            statements.append(Statement(text: text.substring(with: range), range: range))
+            start = end
+            lastMeaningful = nil
+            lastWord = ""
+            firstWord = ""
+            sawNewlineSinceMeaningful = false
+        }
+
+        while index < text.length {
+            let character = Character(UnicodeScalar(text.character(at: index)) ?? " ")
+
+            if character == "/", index + 1 < text.length {
+                let next = Character(UnicodeScalar(text.character(at: index + 1)) ?? " ")
+                if next == "/" {
+                    index = endOfLineComment(text, from: index)
+                    continue
+                }
+                if next == "*" {
+                    index = endOfBlockComment(text, from: index)
+                    continue
+                }
+            }
+
+            if character == "/", startsRegularExpression(after: lastMeaningful, word: lastWord) {
+                index = endOfRegularExpression(text, from: index)
+                lastMeaningful = "/"
+                lastWord = ""
+                sawNewlineSinceMeaningful = false
+                continue
+            }
+
+            if character == "\"" || character == "'" {
+                index = endOfString(text, from: index, quote: character)
+                lastMeaningful = "\""
+                lastWord = ""
+                sawNewlineSinceMeaningful = false
+                continue
+            }
+
+            if character == "`" {
+                index = endOfTemplate(text, from: index)
+                lastMeaningful = "`"
+                lastWord = ""
+                sawNewlineSinceMeaningful = false
+                continue
+            }
+
+            if character.isNewline {
+                sawNewlineSinceMeaningful = true
+                index += 1
+                continue
+            }
+
+            if character.isWhitespace {
+                index += 1
+                continue
+            }
+
+            if depth == 0, sawNewlineSinceMeaningful, insertsSemicolon(before: character, after: lastMeaningful) {
+                let word = readWord(text, from: index)
+                if !continuationWords.contains(word), !openingWords.contains(word),
+                   !opensBlockOfCurrentStatement(character, firstWord: firstWord) {
+                    closeStatement(endingAt: index)
+                    depth = 0
+                    openedWithKeyword.removeAll()
+                }
+            }
+
+            switch character {
+            case "(", "[":
+                depth += 1
+            case ")", "]":
+                depth = max(0, depth - 1)
+            case "{":
+                openedWithKeyword.append(depth == 0 && blockKeywords.contains(firstWord))
+                depth += 1
+            case "}":
+                depth = max(0, depth - 1)
+                let closedBlock = openedWithKeyword.popLast() ?? false
+                if depth == 0, closedBlock, !continuesAfterBrace(text, from: index + 1) {
+                    lastMeaningful = "}"
+                    lastWord = ""
+                    closeStatement(endingAt: index + 1)
+                    index += 1
+                    continue
+                }
+            case ";":
+                if depth == 0 {
+                    closeStatement(endingAt: index + 1)
+                    index += 1
+                    continue
+                }
+            default:
+                break
+            }
+
+            if isWordCharacter(character) {
+                let word = readWord(text, from: index)
+                if firstWord.isEmpty, depth == 0 { firstWord = word }
+                lastWord = word
+                lastMeaningful = character
+                sawNewlineSinceMeaningful = false
+                index += max(word.utf16.count, 1)
+                continue
+            }
+
+            lastWord = ""
+            lastMeaningful = character
+            sawNewlineSinceMeaningful = false
+            index += 1
+        }
+
+        closeStatement(endingAt: text.length)
+        return statements
+    }
+
+    // MARK: - Boundary Rules
+
+    /// Whether this `{` opens the body of the control statement already under way, as Allman
+    /// bracing puts it on its own line.
+    private static func opensBlockOfCurrentStatement(_ character: Character, firstWord: String) -> Bool {
+        character == "{" && blockKeywords.contains(firstWord)
+    }
+
+    private static func insertsSemicolon(before next: Character, after previous: Character?) -> Bool {
+        guard let previous else { return false }
+        guard isExpressionEnd(previous) else { return false }
+        return !continuationStarters.contains(next)
+    }
+
+    private static func isExpressionEnd(_ character: Character) -> Bool {
+        character == ")" || character == "]" || character == "}" || character == "\""
+            || character == "`" || character == "/" || isWordCharacter(character)
+    }
+
+    private static func continuesAfterBrace(_ text: NSString, from index: Int) -> Bool {
+        var cursor = index
+        while cursor < text.length {
+            let character = Character(UnicodeScalar(text.character(at: cursor)) ?? " ")
+            if character.isWhitespace {
+                cursor += 1
+                continue
+            }
+            if character == "/", cursor + 1 < text.length {
+                let next = Character(UnicodeScalar(text.character(at: cursor + 1)) ?? " ")
+                if next == "/" {
+                    cursor = endOfLineComment(text, from: cursor)
+                    continue
+                }
+                if next == "*" {
+                    cursor = endOfBlockComment(text, from: cursor)
+                    continue
+                }
+            }
+            if continuationStarters.contains(character) { return true }
+            return continuationKeywords.contains(readWord(text, from: cursor))
+        }
+        return false
+    }
+
+    /// Whether a `/` here opens a regular expression rather than dividing.
+    ///
+    /// The standard rule: a slash after something that can end an expression is division. `)` is
+    /// treated as an expression end, which reads `if (x) /re/.test(y)` as division, exactly as
+    /// every editor heuristic does; it costs nothing here because a mis-read regex only merges
+    /// statements.
+    private static func startsRegularExpression(after previous: Character?, word: String) -> Bool {
+        guard let previous else { return true }
+        if !word.isEmpty { return continuationWords.contains(word) || word == "return" || word == "typeof" }
+        return !isExpressionEnd(previous)
+    }
+
+    // MARK: - Token Skipping
+
+    private static func endOfLineComment(_ text: NSString, from index: Int) -> Int {
+        var cursor = index
+        while cursor < text.length, !Character(UnicodeScalar(text.character(at: cursor)) ?? " ").isNewline {
+            cursor += 1
+        }
+        return cursor
+    }
+
+    private static func endOfBlockComment(_ text: NSString, from index: Int) -> Int {
+        var cursor = index + 2
+        while cursor + 1 < text.length {
+            if text.character(at: cursor) == 0x2A, text.character(at: cursor + 1) == 0x2F {
+                return cursor + 2
+            }
+            cursor += 1
+        }
+        return text.length
+    }
+
+    private static func endOfString(_ text: NSString, from index: Int, quote: Character) -> Int {
+        var cursor = index + 1
+        while cursor < text.length {
+            let character = Character(UnicodeScalar(text.character(at: cursor)) ?? " ")
+            if character == "\\" {
+                cursor += 2
+                continue
+            }
+            if character == quote { return cursor + 1 }
+            if character.isNewline { return cursor }
+            cursor += 1
+        }
+        return text.length
+    }
+
+    private static func endOfTemplate(_ text: NSString, from index: Int) -> Int {
+        var cursor = index + 1
+        var interpolation = 0
+        while cursor < text.length {
+            let character = Character(UnicodeScalar(text.character(at: cursor)) ?? " ")
+            if character == "\\" {
+                cursor += 2
+                continue
+            }
+            if character == "$", cursor + 1 < text.length, text.character(at: cursor + 1) == 0x7B {
+                interpolation += 1
+                cursor += 2
+                continue
+            }
+            if character == "}", interpolation > 0 {
+                interpolation -= 1
+                cursor += 1
+                continue
+            }
+            if character == "`", interpolation == 0 { return cursor + 1 }
+            cursor += 1
+        }
+        return text.length
+    }
+
+    private static func endOfRegularExpression(_ text: NSString, from index: Int) -> Int {
+        var cursor = index + 1
+        var inClass = false
+        while cursor < text.length {
+            let character = Character(UnicodeScalar(text.character(at: cursor)) ?? " ")
+            if character == "\\" {
+                cursor += 2
+                continue
+            }
+            if character.isNewline { return cursor }
+            if character == "[" { inClass = true }
+            if character == "]" { inClass = false }
+            if character == "/", !inClass {
+                cursor += 1
+                while cursor < text.length,
+                      isWordCharacter(Character(UnicodeScalar(text.character(at: cursor)) ?? " ")) {
+                    cursor += 1
+                }
+                return cursor
+            }
+            cursor += 1
+        }
+        return text.length
+    }
+
+    private static func readWord(_ text: NSString, from index: Int) -> String {
+        var cursor = index
+        var word = ""
+        while cursor < text.length {
+            let character = Character(UnicodeScalar(text.character(at: cursor)) ?? " ")
+            guard isWordCharacter(character) else { break }
+            word.append(character)
+            cursor += 1
+        }
+        return word
+    }
+
+    private static func isWordCharacter(_ character: Character) -> Bool {
+        character.isLetter || character.isNumber || character == "_" || character == "$"
+    }
+}

--- a/TablePro/Core/Utilities/JavaScript/JavaScriptSyntaxChecker.swift
+++ b/TablePro/Core/Utilities/JavaScript/JavaScriptSyntaxChecker.swift
@@ -1,0 +1,38 @@
+//
+//  JavaScriptSyntaxChecker.swift
+//  TablePro
+//
+
+import Foundation
+import JavaScriptCore
+
+/// Reports the syntax errors in a JavaScript document, using the engine that will run it.
+///
+/// `JSCheckScriptSyntax` parses without evaluating, so an editor can underline a mistake with the
+/// same verdict the runtime would give and without touching the database. Reimplementing a
+/// JavaScript parser to do this would disagree with the engine sooner or later; this cannot.
+enum JavaScriptSyntaxChecker {
+    struct Failure {
+        let message: String
+        /// 1-based, as JavaScriptCore reports it.
+        let line: Int
+    }
+
+    /// The first syntax error, or nil when the document parses.
+    static func firstFailure(in source: String) -> Failure? {
+        guard let context = JSContext() else { return nil }
+        let script = JSStringCreateWithCFString(source as CFString)
+        defer { JSStringRelease(script) }
+
+        var exception: JSValueRef?
+        let parsed = JSCheckScriptSyntax(context.jsGlobalContextRef, script, nil, 1, &exception)
+        guard !parsed, let exception else { return nil }
+
+        let value = JSValue(jsValueRef: exception, in: context)
+        let line = value?.objectForKeyedSubscript("line")?.toInt32() ?? 0
+        let message = value?.objectForKeyedSubscript("message")?.toString()
+            ?? value?.toString()
+            ?? String(localized: "This is not valid JavaScript.")
+        return Failure(message: message, line: max(1, Int(line)))
+    }
+}

--- a/TablePro/Core/Utilities/JavaScript/MongoShellCommandRecognizer.swift
+++ b/TablePro/Core/Utilities/JavaScript/MongoShellCommandRecognizer.swift
@@ -1,0 +1,37 @@
+//
+//  MongoShellCommandRecognizer.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Recognises the two mongosh lines that are not JavaScript.
+///
+/// `use orders` and `show collections` are shell syntax, so a JavaScript parser rejects them and
+/// the editor would underline a statement that runs perfectly well. The driver rewrites them into
+/// the calls they stand for; nothing here needs to, because all the editor has to decide is whether
+/// to look for a syntax error.
+///
+/// Deliberately not shared with the driver through TableProPluginKit. A new public symbol there is
+/// missing from every already-shipped app, so a plugin built against it stops loading on the
+/// version most people are running, and the MongoDB plugin ships from the registry ahead of the app.
+enum MongoShellCommandRecognizer {
+    private static let shownTopics: Set<String> = ["dbs", "databases", "collections", "tables"]
+
+    static func isShellCommand(_ statement: String) -> Bool {
+        let trimmed = statement.trimmingCharacters(in: .whitespacesAndNewlines)
+        if argument(after: "use", in: trimmed) != nil { return true }
+        guard let topic = argument(after: "show", in: trimmed)?.lowercased() else { return false }
+        return shownTopics.contains(topic)
+    }
+
+    /// The single bare word after a leading keyword, or nil when the line is ordinary JavaScript.
+    private static func argument(after keyword: String, in statement: String) -> String? {
+        guard statement.lowercased().hasPrefix(keyword + " ") else { return nil }
+        let remainder = statement.dropFirst(keyword.count).trimmingCharacters(in: .whitespaces)
+        let word = remainder.hasSuffix(";") ? String(remainder.dropLast()) : remainder
+        guard !word.isEmpty, !word.contains(where: { $0.isWhitespace }) else { return nil }
+        guard !word.contains("("), !word.contains("="), !word.contains(".") else { return nil }
+        return word.trimmingCharacters(in: CharacterSet(charactersIn: "\"'`"))
+    }
+}

--- a/TablePro/Core/Utilities/JavaScript/QueryStatementModel.swift
+++ b/TablePro/Core/Utilities/JavaScript/QueryStatementModel.swift
@@ -1,0 +1,165 @@
+//
+//  QueryStatementModel.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+/// How a query language divides a document into statements.
+///
+/// Curated per database type rather than read from `DriverPlugin`, for the reason
+/// `PluginMetadataRegistry.buildMetadataSnapshot` records: a static read off a plugin built before
+/// that static existed crashes with `EXC_BAD_INSTRUCTION` on a missing witness table entry. Keeping
+/// it app-side also means an already-installed MongoDB plugin gets the right splitting with no
+/// re-release.
+///
+/// `editorLanguage` cannot answer this question. Elasticsearch also highlights as JavaScript, but
+/// its Query DSL is a verb line followed by a JSON body and is not JavaScript at all.
+enum QueryStatementModel {
+    /// Statements end at a semicolon, and a semicolon inside a string or a comment does not count.
+    case sql
+
+    /// Statements are the top-level statements of a JavaScript program.
+    case javascript
+
+    static func forDatabaseType(_ type: DatabaseType) -> QueryStatementModel {
+        switch type {
+        case .mongodb: return .javascript
+        default: return .sql
+        }
+    }
+}
+
+/// Splits a query document the way its language does.
+///
+/// One entry point for both models so no caller has to branch, returning the same statement types
+/// the SQL scanner has always returned.
+enum QueryStatementScanner {
+    static func locatedStatements(
+        in text: String,
+        model: QueryStatementModel,
+        dialect: SqlDialect = .generic
+    ) -> [SQLStatementScanner.LocatedStatement] {
+        switch model {
+        case .sql:
+            return SQLStatementScanner.locatedStatements(in: text, dialect: dialect)
+        case .javascript:
+            return JavaScriptStatementScanner.locatedStatements(in: text).map(located)
+        }
+    }
+
+    static func navigableStatements(
+        in text: String,
+        model: QueryStatementModel,
+        dialect: SqlDialect = .generic
+    ) -> [SQLStatementScanner.LocatedStatement] {
+        switch model {
+        case .sql:
+            return SQLStatementScanner.navigableStatements(in: text, dialect: dialect)
+        case .javascript:
+            return JavaScriptStatementScanner.executableStatements(in: text)
+                .map(located)
+                .filter { $0.contentRange.length > 0 }
+        }
+    }
+
+    static func executableStatements(
+        in text: String,
+        model: QueryStatementModel,
+        dialect: SqlDialect = .generic
+    ) -> [SQLStatementScanner.ExecutableStatement] {
+        switch model {
+        case .sql:
+            return SQLStatementScanner.executableStatements(in: text, dialect: dialect)
+        case .javascript:
+            return JavaScriptStatementScanner.executableStatements(in: text).compactMap { statement in
+                let located = located(statement)
+                guard located.contentRange.length > 0 else { return nil }
+                return SQLStatementScanner.ExecutableStatement(
+                    sql: (text as NSString).substring(with: located.contentRange),
+                    range: located.contentRange
+                )
+            }
+        }
+    }
+
+    static func locatedStatementAtCursor(
+        in text: String,
+        cursorPosition: Int,
+        model: QueryStatementModel,
+        dialect: SqlDialect = .generic
+    ) -> SQLStatementScanner.LocatedStatement {
+        switch model {
+        case .sql:
+            return SQLStatementScanner.locatedStatementAtCursor(
+                in: text, cursorPosition: cursorPosition, dialect: dialect
+            )
+        case .javascript:
+            guard let statement = JavaScriptStatementScanner.statementAtCursor(
+                in: text, cursorPosition: cursorPosition
+            ) else {
+                return SQLStatementScanner.LocatedStatement(sql: "", offset: 0, hasContent: false)
+            }
+            return located(statement)
+        }
+    }
+
+    static func statementStart(
+        after offset: Int,
+        in text: String,
+        model: QueryStatementModel,
+        dialect: SqlDialect = .generic
+    ) -> Int? {
+        switch model {
+        case .sql:
+            return SQLStatementScanner.statementStart(after: offset, in: text, dialect: dialect)
+        case .javascript:
+            return navigableStatements(in: text, model: model)
+                .first { $0.contentRange.location > offset }?
+                .contentRange.location
+        }
+    }
+
+    static func statementStart(
+        before offset: Int,
+        in text: String,
+        model: QueryStatementModel,
+        dialect: SqlDialect = .generic
+    ) -> Int? {
+        switch model {
+        case .sql:
+            return SQLStatementScanner.statementStart(before: offset, in: text, dialect: dialect)
+        case .javascript:
+            return navigableStatements(in: text, model: model)
+                .last { $0.contentRange.location < offset }?
+                .contentRange.location
+        }
+    }
+
+    static func statementSelectionEnd(
+        after offset: Int,
+        in text: String,
+        model: QueryStatementModel,
+        dialect: SqlDialect = .generic
+    ) -> Int? {
+        switch model {
+        case .sql:
+            return SQLStatementScanner.statementSelectionEnd(after: offset, in: text, dialect: dialect)
+        case .javascript:
+            if let next = statementStart(after: offset, in: text, model: model) { return next }
+            let end = navigableStatements(in: text, model: model).last?.contentRange.upperBound
+            return end.flatMap { $0 > offset ? $0 : nil }
+        }
+    }
+
+    private static func located(
+        _ statement: JavaScriptStatementScanner.Statement
+    ) -> SQLStatementScanner.LocatedStatement {
+        SQLStatementScanner.LocatedStatement(
+            sql: statement.text,
+            offset: statement.range.location,
+            hasContent: statement.hasContent
+        )
+    }
+}

--- a/TablePro/Core/Utilities/SQL/QueryClassifier.swift
+++ b/TablePro/Core/Utilities/SQL/QueryClassifier.swift
@@ -70,8 +70,9 @@ enum QueryClassifier {
     }
 
     static func isMultiStatement(_ sql: String, databaseType: DatabaseType) -> Bool {
-        SQLStatementScanner.allStatements(
+        QueryStatementScanner.executableStatements(
             in: sql,
+            model: QueryStatementModel.forDatabaseType(databaseType),
             dialect: SqlDialect.from(databaseTypeId: databaseType.rawValue)
         ).count > 1
     }
@@ -546,7 +547,17 @@ private extension QueryClassifier {
         return QueryClassification(tier: .safe, reachesFilesystemOrExecutesCode: touchesUnsafeSurface)
     }
 
+    /// Every method a MongoDB statement invokes, by either spelling.
+    ///
+    /// The query language is JavaScript, so `db.users.deleteMany({})` and
+    /// `db.users["deleteMany"]({})` are the same call. Reading only the dotted form let the bracket
+    /// form past the destructive gate, which is what decides whether an external or assistant
+    /// client has to confirm before it runs.
     static func invokedMethodNames(in lowered: String) -> [String] {
+        dottedMethodNames(in: lowered) + bracketedMethodNames(in: lowered)
+    }
+
+    private static func dottedMethodNames(in lowered: String) -> [String] {
         var names: [String] = []
         var current = ""
         var sawDot = false
@@ -567,6 +578,36 @@ private extension QueryClassifier {
                 sawDot = false
             }
             current = ""
+        }
+        return names
+    }
+
+    /// Names taken through bracket access, whether or not they are called on the spot.
+    ///
+    /// A name is counted even without a following `(`, because `var drop = db.c["drop"]; drop()`
+    /// reaches the same command and no scan of the text can follow the binding.
+    private static func bracketedMethodNames(in lowered: String) -> [String] {
+        var names: [String] = []
+        var index = lowered.startIndex
+
+        while let open = lowered[index...].firstIndex(of: "[") {
+            var cursor = lowered.index(after: open)
+            while cursor < lowered.endIndex, lowered[cursor].isWhitespace {
+                cursor = lowered.index(after: cursor)
+            }
+            guard cursor < lowered.endIndex, lowered[cursor] == "\"" || lowered[cursor] == "'" else {
+                index = lowered.index(after: open)
+                continue
+            }
+            let quote = lowered[cursor]
+            var name = ""
+            cursor = lowered.index(after: cursor)
+            while cursor < lowered.endIndex, lowered[cursor] != quote {
+                name.append(lowered[cursor])
+                cursor = lowered.index(after: cursor)
+            }
+            if !name.isEmpty { names.append(name) }
+            index = cursor < lowered.endIndex ? lowered.index(after: cursor) : lowered.endIndex
         }
         return names
     }

--- a/TablePro/Models/Query/StatementAnchor.swift
+++ b/TablePro/Models/Query/StatementAnchor.swift
@@ -87,8 +87,14 @@ struct StatementAnchor: Equatable {
     /// Resolution is against a fresh scan rather than a search through the raw text: the scan is what decides where
     /// statements begin in the first place, and matching whole statements keeps a fingerprint from landing inside a
     /// string literal or a comment that happens to start the same way.
-    func resolve(in query: String, dialect: SqlDialect = .generic) -> NSRange? {
-        let statements = SQLStatementScanner.executableStatements(in: query, dialect: dialect)
+    func resolve(
+        in query: String,
+        model: QueryStatementModel = .sql,
+        dialect: SqlDialect = .generic
+    ) -> NSRange? {
+        let statements = QueryStatementScanner.executableStatements(
+            in: query, model: model, dialect: dialect
+        )
 
         if let exact = statements.first(where: { $0.range == range && matches($0) }) {
             return exact.range

--- a/TablePro/Views/Editor/SQLEditorCoordinator.swift
+++ b/TablePro/Views/Editor/SQLEditorCoordinator.swift
@@ -314,6 +314,7 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
 
     private func installStatementRunControls(controller: TextViewController) {
         statementRunController.dialect = SqlDialect.from(databaseTypeId: (databaseType ?? .mysql).rawValue)
+        statementRunController.statementModel = QueryStatementModel.forDatabaseType(databaseType ?? .mysql)
         statementRunController.isHighlightEnabled = AppSettingsManager.shared.editor.highlightCurrentStatement
         statementRunController.onRun = { [weak self] sql, offset in
             self?.onRunStatement?(sql, offset) ?? false
@@ -349,7 +350,11 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
     @discardableResult
     func jumpToStatement(_ anchor: StatementAnchor) -> Bool {
         guard let controller, let textView = controller.textView else { return false }
-        guard let range = anchor.resolve(in: textView.string, dialect: statementRunController.dialect) else {
+        guard let range = anchor.resolve(
+            in: textView.string,
+            model: statementRunController.statementModel,
+            dialect: statementRunController.dialect
+        ) else {
             return false
         }
         controller.moveCursor(to: range.location)

--- a/TablePro/Views/Editor/StatementRunController.swift
+++ b/TablePro/Views/Editor/StatementRunController.swift
@@ -45,6 +45,10 @@ final class StatementRunController {
     var sizeLimit = StatementRunController.defaultSizeLimit
     var dialect: SqlDialect = .generic
 
+    /// How the document divides into statements. JavaScript engines do not end a statement at every
+    /// semicolon, so the gutter controls and the caret band have to ask the same splitter execution does.
+    var statementModel: QueryStatementModel = .sql
+
     /// Called with the SQL the pressed control stands for, read from the document at the moment of the press, and
     /// where that SQL starts in the document.
     ///
@@ -126,8 +130,8 @@ final class StatementRunController {
             return
         }
 
-        controller.runnableStatements = SQLStatementScanner
-            .navigableStatements(in: text, dialect: dialect)
+        controller.runnableStatements = QueryStatementScanner
+            .navigableStatements(in: text, model: statementModel, dialect: dialect)
             .map { StatementRun(range: $0.contentRange) }
     }
 
@@ -154,9 +158,11 @@ final class StatementRunController {
         let text = textView.string
         guard (text as NSString).length <= sizeLimit else { return nil }
         guard forward else {
-            return SQLStatementScanner.statementStart(before: offset, in: text, dialect: dialect)
+            return QueryStatementScanner.statementStart(before: offset, in: text, model: statementModel, dialect: dialect)
         }
-        return SQLStatementScanner.statementSelectionEnd(after: offset, in: text, dialect: dialect)
+        return QueryStatementScanner.statementSelectionEnd(
+            after: offset, in: text, model: statementModel, dialect: dialect
+        )
     }
 
     /// The statement the caret is in and where it starts, or `nil` when there is nothing to run there.
@@ -168,9 +174,10 @@ final class StatementRunController {
         guard (text as NSString).length <= sizeLimit else { return nil }
         guard let selection = controller.cursorPositions.first, selection.range.length == 0 else { return nil }
 
-        let statement = SQLStatementScanner.locatedStatementAtCursor(
+        let statement = QueryStatementScanner.locatedStatementAtCursor(
             in: text,
             cursorPosition: selection.range.location,
+            model: statementModel,
             dialect: dialect
         )
         guard statement.hasContent, statement.contentRange.length > 0 else { return nil }
@@ -183,9 +190,9 @@ final class StatementRunController {
     private func statementStart(_ direction: StatementNavigationDirection, from offset: Int, in text: String) -> Int? {
         switch direction {
         case .previous:
-            return SQLStatementScanner.statementStart(before: offset, in: text, dialect: dialect)
+            return QueryStatementScanner.statementStart(before: offset, in: text, model: statementModel, dialect: dialect)
         case .next:
-            return SQLStatementScanner.statementStart(after: offset, in: text, dialect: dialect)
+            return QueryStatementScanner.statementStart(after: offset, in: text, model: statementModel, dialect: dialect)
         }
     }
 
@@ -221,9 +228,10 @@ final class StatementRunController {
             return
         }
 
-        let resolved = SQLStatementScanner.locatedStatementAtCursor(
+        let resolved = QueryStatementScanner.locatedStatementAtCursor(
             in: text,
             cursorPosition: statement.range.location,
+            model: statementModel,
             dialect: dialect
         )
         guard resolved.hasContent, resolved.contentRange == statement.range else {
@@ -253,9 +261,10 @@ final class StatementRunController {
         let text = textView.string
         guard (text as NSString).length <= sizeLimit else { return nil }
 
-        let statement = SQLStatementScanner.locatedStatementAtCursor(
+        let statement = QueryStatementScanner.locatedStatementAtCursor(
             in: text,
             cursorPosition: selection.range.location,
+            model: statementModel,
             dialect: dialect
         )
         guard statement.hasContent, statement.contentRange.length > 0 else { return nil }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Explain.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Explain.swift
@@ -75,17 +75,18 @@ extension MainContentCoordinator {
             sql = nsQuery.substring(with: clampedRange)
             sourceOffset = clampedRange.location
         } else {
-            let statement = SQLStatementScanner.locatedStatementAtCursor(
+            let statement = QueryStatementScanner.locatedStatementAtCursor(
                 in: fullQuery,
                 cursorPosition: cursorPositions.first?.range.location ?? 0,
+                model: statementModel,
                 dialect: sqlDialect
             )
             sql = statement.sql
             sourceOffset = statement.offset
         }
 
-        return SQLStatementScanner
-            .executableStatements(in: sql, dialect: sqlDialect)
+        return QueryStatementScanner
+            .executableStatements(in: sql, model: statementModel, dialect: sqlDialect)
             .first?
             .offset(by: sourceOffset)
     }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -97,6 +97,7 @@ final class MainContentCoordinator {
     let connection: DatabaseConnection
     var connectionId: UUID { connection.id }
     var sqlDialect: SqlDialect { SqlDialect.from(databaseTypeId: connection.type.rawValue) }
+    var statementModel: QueryStatementModel { QueryStatementModel.forDatabaseType(connection.type) }
     var browseDatabaseName: String {
         services.databaseManager.browseDatabaseName(for: connection)
     }
@@ -1016,9 +1017,10 @@ final class MainContentCoordinator {
             sql = nsQuery.substring(with: clampedRange)
             sourceOffset = clampedRange.location
         } else {
-            let statement = SQLStatementScanner.locatedStatementAtCursor(
+            let statement = QueryStatementScanner.locatedStatementAtCursor(
                 in: fullQuery,
                 cursorPosition: cursorPositions.first?.range.location ?? 0,
+                model: statementModel,
                 dialect: sqlDialect
             )
             sql = statement.sql
@@ -1070,8 +1072,13 @@ final class MainContentCoordinator {
             return statements.map { $0.offset(by: sourceOffset) }
         }
 
-        if services.appSettings.editor.queryParametersEnabled {
-            let paramStatements = anchored(SQLStatementScanner.executableStatements(in: sql, dialect: sqlDialect))
+        // `:active` is a bind placeholder in SQL and an ordinary object key in JavaScript, so a
+        // script would open the parameter panel and then be rewritten into something the driver
+        // cannot run.
+        if services.appSettings.editor.queryParametersEnabled, statementModel == .sql {
+            let paramStatements = anchored(
+                QueryStatementScanner.executableStatements(in: sql, model: statementModel, dialect: sqlDialect)
+            )
             guard !paramStatements.isEmpty else { return false }
             let combinedSQL = paramStatements.map(\.sql).joined(separator: "; ")
             let detectedNames = SQLParameterExtractor.extractParameters(from: combinedSQL)
@@ -1099,7 +1106,9 @@ final class MainContentCoordinator {
             }
         }
 
-        let statements = anchored(SQLStatementScanner.executableStatements(in: sql, dialect: sqlDialect))
+        let statements = anchored(
+            QueryStatementScanner.executableStatements(in: sql, model: statementModel, dialect: sqlDialect)
+        )
         guard !statements.isEmpty else { return false }
 
         tabManager.tabStructureVersion += 1

--- a/TableProTests/Core/Diagnostics/MongoDiagnosticsProducerTests.swift
+++ b/TableProTests/Core/Diagnostics/MongoDiagnosticsProducerTests.swift
@@ -1,0 +1,125 @@
+//
+//  MongoDiagnosticsProducerTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("MongoDiagnosticsProducer")
+struct MongoDiagnosticsProducerTests {
+    private let producer = MongoDiagnosticsProducer()
+
+    @Test("A query with conditions is not flagged")
+    func conditionsAreValid() {
+        #expect(producer.diagnostics(for: "db.dt_DispatchRule.find({status: 1})").isEmpty)
+    }
+
+    @Test("A script that iterates a cursor is not flagged")
+    func scriptIsValid() {
+        let script = """
+            var seen = 0;
+            db.orders.find({status: "new"}).forEach(function (o) { seen += o.total; });
+            print(seen);
+            """
+        #expect(producer.diagnostics(for: script).isEmpty)
+    }
+
+    @Test("A shell command is not flagged as a syntax error")
+    func shellCommandIsValid() {
+        #expect(producer.diagnostics(for: "use reporting").isEmpty)
+        #expect(producer.diagnostics(for: "show collections").isEmpty)
+    }
+
+    @Test("A shell command followed by a query is not flagged")
+    func shellCommandInScript() {
+        #expect(producer.diagnostics(for: "use reporting\ndb.orders.find({})").isEmpty)
+    }
+
+    @Test("A real syntax error is reported")
+    func syntaxErrorIsReported() {
+        let diagnostics = producer.diagnostics(for: "db.orders.find({status: })")
+        #expect(diagnostics.count == 1)
+        #expect(diagnostics.first?.message.isEmpty == false)
+    }
+
+    @Test("An unmatched closing bracket is named as such")
+    func unmatchedClose() {
+        let diagnostics = producer.diagnostics(for: "db.orders.find({}))")
+        #expect(diagnostics.first?.message.contains("matching") == true)
+    }
+
+    @Test("A decrement is an operator, not the start of a comment")
+    func decrementIsNotAComment() {
+        #expect(producer.diagnostics(for: "var i = 3; while (i-- > 0) { print(i); }").isEmpty)
+        // The rest of the line has to still be scanned, or a real mistake after one goes unreported.
+        #expect(!producer.diagnostics(for: "var i = 3; i--; db.orders.find({status: })").isEmpty)
+    }
+
+    @Test("A regular expression holding a bracket is not reported as unmatched")
+    func regexBracketsAreNotStructure() {
+        #expect(producer.diagnostics(for: "db.c.find({x: /[)]/})").isEmpty)
+        #expect(producer.diagnostics(for: "db.c.find({x: /a{2,3}/})").isEmpty)
+        #expect(producer.diagnostics(for: "db.c.find({name: /^ab/i})").isEmpty)
+    }
+
+    @Test("An empty document produces nothing")
+    func emptyDocument() {
+        #expect(producer.diagnostics(for: "").isEmpty)
+        #expect(producer.diagnostics(for: "   \n ").isEmpty)
+    }
+
+    @Test("A half-typed query is left alone rather than underlined while typing")
+    func incompleteQueryIsNotFlagged() {
+        #expect(producer.diagnostics(for: "db.orders.find({status: ").isEmpty)
+    }
+}
+
+@Suite("MongoShellCommandRecognizer")
+struct MongoShellCommandRecognizerTests {
+    @Test("The two shell lines are recognised")
+    func shellLines() {
+        #expect(MongoShellCommandRecognizer.isShellCommand("use orders"))
+        #expect(MongoShellCommandRecognizer.isShellCommand("use orders;"))
+        #expect(MongoShellCommandRecognizer.isShellCommand("SHOW TABLES"))
+        #expect(MongoShellCommandRecognizer.isShellCommand("show collections"))
+        #expect(MongoShellCommandRecognizer.isShellCommand("show dbs"))
+    }
+
+    @Test("JavaScript that starts with the same word is not one")
+    func javaScriptIsNotShell() {
+        #expect(!MongoShellCommandRecognizer.isShellCommand("use = 1"))
+        #expect(!MongoShellCommandRecognizer.isShellCommand("use(\"orders\")"))
+        #expect(!MongoShellCommandRecognizer.isShellCommand("show.me()"))
+        #expect(!MongoShellCommandRecognizer.isShellCommand("db.orders.find({})"))
+        #expect(!MongoShellCommandRecognizer.isShellCommand("show profile"))
+    }
+}
+
+@Suite("JavaScriptSyntaxChecker")
+struct JavaScriptSyntaxCheckerTests {
+    @Test("Valid JavaScript reports nothing")
+    func valid() {
+        #expect(JavaScriptSyntaxChecker.firstFailure(in: "var a = 1; function f() { return a; }") == nil)
+    }
+
+    @Test("A syntax error reports a message and a line")
+    func invalid() throws {
+        let failure = try #require(JavaScriptSyntaxChecker.firstFailure(in: "var a = ;"))
+        #expect(!failure.message.isEmpty)
+        #expect(failure.line >= 1)
+    }
+
+    @Test("The reported line is the line the mistake is on")
+    func lineNumber() throws {
+        let failure = try #require(JavaScriptSyntaxChecker.firstFailure(in: "var a = 1;\nvar b = ;\n"))
+        #expect(failure.line == 2)
+    }
+
+    @Test("A reference to something undefined is not a syntax error")
+    func runtimeErrorsAreNotSyntaxErrors() {
+        #expect(JavaScriptSyntaxChecker.firstFailure(in: "db.orders.find({})") == nil)
+    }
+}

--- a/TableProTests/Core/Diagnostics/QueryDiagnosticsTests.swift
+++ b/TableProTests/Core/Diagnostics/QueryDiagnosticsTests.swift
@@ -69,14 +69,10 @@ struct QueryDiagnosticsTests {
         #expect(results.first?.message == "Unterminated comment")
     }
 
-    @Test("an unsupported MQL method is reported on the method name")
-    func testUnsupportedMethodRange() {
-        let query = "db.users.frobnicate({})"
-        let results = mql.diagnostics(for: query)
-        #expect(results.count == 1)
-
-        guard let range = results.first?.range else { return }
-        #expect((query as NSString).substring(with: range) == "frobnicate")
+    @Test("a method name the app does not know is left alone, because the shell is JavaScript")
+    func testUnknownMethodIsNotASyntaxError() {
+        #expect(mql.diagnostics(for: "db.users.frobnicate({})").isEmpty)
+        #expect(mql.diagnostics(for: "db.users.find({}).forEach(function (d) { print(d); })").isEmpty)
     }
 
     @Test("a query that does not start with db is reported")
@@ -103,8 +99,9 @@ struct QueryDiagnosticsTests {
         #expect(sql.diagnostics(for: "SELECT 1 // )").count == 1)
     }
 
-    @Test("MQL has no comment syntax, so a double slash is not a comment")
-    func testMqlHasNoLineComments() {
-        #expect(!mql.diagnostics(for: "db.users.find({}) // )").isEmpty)
+    @Test("a double slash starts a comment in a MongoDB query")
+    func testMqlHasLineComments() {
+        #expect(mql.diagnostics(for: "db.users.find({}) // )").isEmpty)
+        #expect(mql.diagnostics(for: "db.users.find({}) /* ) */").isEmpty)
     }
 }

--- a/TableProTests/Core/MongoDB/MongoScriptCommandTests.swift
+++ b/TableProTests/Core/MongoDB/MongoScriptCommandTests.swift
@@ -1,0 +1,352 @@
+//
+//  MongoScriptCommandTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@Suite("MongoScriptJson")
+struct MongoScriptJsonTests {
+    @Test("Members come back in the order the document carries them, as text")
+    func membersKeepOrder() {
+        let members = MongoScriptJson.members(of: "{\"zeta\": 1, \"alpha\": {\"x\": [1, 2]}, \"last\": \"a, b\"}")
+        #expect(members.map(\.key) == ["zeta", "alpha", "last"])
+        #expect(members.map(\.value) == ["1", "{\"x\": [1, 2]}", "\"a, b\""])
+    }
+
+    @Test("A member's value is the text it occupies, not a rebuilt value")
+    func memberIsVerbatim() {
+        let json = "{\"filter\": {\"b\": 1, \"a\": 2}}"
+        #expect(MongoScriptJson.member(of: json, key: "filter") == "{\"b\": 1, \"a\": 2}")
+    }
+
+    @Test("A missing member is nil rather than an empty document")
+    func missingMember() {
+        #expect(MongoScriptJson.member(of: "{\"a\": 1}", key: "b") == nil)
+    }
+
+    @Test("Array elements split at the top level only")
+    func topLevelElements() {
+        let elements = MongoScriptJson.topLevelElements("[{\"a\": [1, 2]}, {\"b\": \"x, y\"}, 3]")
+        #expect(elements == ["{\"a\": [1, 2]}", "{\"b\": \"x, y\"}", "3"])
+    }
+
+    @Test("An empty array yields no elements")
+    func emptyArray() {
+        #expect(MongoScriptJson.topLevelElements("[]").isEmpty)
+    }
+
+    @Test("Control characters and quotes are escaped")
+    func stringEscaping() {
+        #expect(MongoScriptJson.jsonString("a\"b\\c\nd") == "\"a\\\"b\\\\c\\nd\"")
+    }
+
+    @Test("A non-finite reply value reads as absent rather than trapping")
+    func nonFiniteReplyValues() {
+        #expect(MongoScriptJson.number(in: "{\"n\": {\"$numberDouble\": \"NaN\"}}", key: "n") == nil)
+        #expect(MongoScriptJson.number(in: "{\"n\": {\"$numberDouble\": \"Infinity\"}}", key: "n") == nil)
+        #expect(MongoScriptJson.whole(3.0) == 3)
+        #expect(MongoScriptJson.whole(.nan) == nil)
+        #expect(MongoScriptJson.whole(.infinity) == nil)
+    }
+
+    @Test("A numeric reply field is read through whichever wrapper the server used")
+    func numericWrappers() {
+        #expect(MongoScriptJson.number(in: "{\"n\": 3}", key: "n") == 3)
+        #expect(MongoScriptJson.number(in: "{\"n\": {\"$numberInt\": \"4\"}}", key: "n") == 4)
+        #expect(MongoScriptJson.number(in: "{\"n\": {\"$numberLong\": \"5\"}}", key: "n") == 5)
+        #expect(MongoScriptJson.number(in: "{\"n\": {\"$numberDouble\": \"6\"}}", key: "n") == 6)
+    }
+}
+
+@Suite("MongoScriptCursorOptions")
+struct MongoScriptCursorOptionsTests {
+    @Test("A sort written in shell syntax reaches the find options instead of being dropped")
+    func sortSurvives() throws {
+        var options = MongoScriptCursorOptions.none
+        try options.apply(key: "sort", value: "{\"createdAt\":{\"$numberInt\":\"-1\"}}")
+        let json = options.findOptionsJson(limit: 100, timeoutMS: 0)
+        #expect(json.contains("\"sort\": {\"createdAt\":{\"$numberInt\":\"-1\"}}"))
+    }
+
+    @Test("A projection reaches the find options")
+    func projectionSurvives() throws {
+        var options = MongoScriptCursorOptions.none
+        try options.apply(key: "projection", value: "{\"name\":{\"$numberInt\":\"1\"}}")
+        #expect(options.findOptionsJson(limit: 10, timeoutMS: 0).contains("\"projection\":"))
+    }
+
+    @Test("A whole number arrives wrapped and is read back as a number")
+    func wrappedNumbers() throws {
+        var options = MongoScriptCursorOptions.none
+        try options.apply(key: "limit", value: "{\"$numberInt\":\"25\"}")
+        try options.apply(key: "skip", value: "{\"$numberLong\":\"5\"}")
+        #expect(options.limit == 25)
+        #expect(options.skip == 5)
+    }
+
+    @Test("A limit larger than the ceiling is capped, a smaller one is kept")
+    func limitRespectsCeiling() {
+        var options = MongoScriptCursorOptions.none
+        options.limit = 500
+        #expect(options.effectiveLimit(ceiling: 201) == 201)
+        options.limit = 10
+        #expect(options.effectiveLimit(ceiling: 201) == 10)
+    }
+
+    @Test("No limit falls back to the ceiling")
+    func noLimitUsesCeiling() {
+        #expect(MongoScriptCursorOptions.none.effectiveLimit(ceiling: 201) == 201)
+    }
+
+    @Test("NaN and infinity are refused rather than crashing the conversion")
+    func nonFiniteNumbersAreRefused() {
+        var options = MongoScriptCursorOptions.none
+        for value in ["{\"$numberDouble\":\"NaN\"}", "{\"$numberDouble\":\"Infinity\"}",
+                      "{\"$numberDouble\":\"-Infinity\"}", "{\"$numberDouble\":\"1e30\"}"] {
+            #expect(throws: MongoScriptError.self) {
+                try options.apply(key: "limit", value: value)
+            }
+        }
+    }
+
+    @Test("An unsupported modifier is refused by name")
+    func unsupportedModifier() {
+        var options = MongoScriptCursorOptions.none
+        #expect(throws: MongoScriptError.self) {
+            try options.apply(key: "readConcern", value: "{}")
+        }
+    }
+
+    @Test("A modifier that wants a number refuses text")
+    func nonNumericModifier() {
+        var options = MongoScriptCursorOptions.none
+        #expect(throws: MongoScriptError.self) {
+            try options.apply(key: "limit", value: "\"ten\"")
+        }
+    }
+
+    @Test("Aggregation takes ordering and paging as appended pipeline stages")
+    func aggregateStages() throws {
+        var options = MongoScriptCursorOptions.none
+        try options.apply(key: "sort", value: "{\"a\":1}")
+        try options.apply(key: "limit", value: "5")
+        let pipeline = options.decoratedPipeline("[{\"$match\":{}}]")
+        #expect(pipeline == "[{\"$match\":{}},{\"$sort\": {\"a\":1}},{\"$limit\": 5}]")
+    }
+
+    @Test("An empty pipeline still takes its stages")
+    func emptyPipeline() throws {
+        var options = MongoScriptCursorOptions.none
+        try options.apply(key: "limit", value: "2")
+        #expect(options.decoratedPipeline("[]") == "[{\"$limit\": 2}]")
+    }
+
+    @Test("The connection's query timeout becomes maxTimeMS when the script names none")
+    func timeoutFallback() {
+        let json = MongoScriptCursorOptions.none.findOptionsJson(limit: 10, timeoutMS: 3_000)
+        #expect(json.contains("\"maxTimeMS\": 3000"))
+    }
+
+    @Test("allowDiskUse reaches a find as well as an aggregation")
+    func allowDiskUseOnFind() throws {
+        var options = MongoScriptCursorOptions.none
+        try options.apply(key: "allowDiskUse", value: "true")
+        #expect(options.findOptionsJson(limit: 10, timeoutMS: 0).contains("\"allowDiskUse\": true"))
+        #expect(options.aggregateOptionsJson(timeoutMS: 0)?.contains("\"allowDiskUse\": true") == true)
+    }
+
+    @Test("A maxTimeMS the script set wins over the connection's")
+    func explicitTimeoutWins() throws {
+        var options = MongoScriptCursorOptions.none
+        try options.apply(key: "maxTimeMS", value: "500")
+        #expect(options.findOptionsJson(limit: 10, timeoutMS: 3_000).contains("\"maxTimeMS\": 500"))
+    }
+}
+
+@Suite("MongoScriptCommandBuilder")
+struct MongoScriptCommandBuilderTests {
+    @Test("updateMany becomes an update command with multi set")
+    func updateMany() {
+        let command = MongoScriptCommandBuilder.update(
+            collection: "orders", filter: "{\"a\":1}", update: "{\"$set\":{\"b\":2}}",
+            multi: true, options: [:]
+        )
+        #expect(command.contains("\"update\": \"orders\""))
+        #expect(command.contains("\"q\": {\"a\":1}"))
+        #expect(command.contains("\"u\": {\"$set\":{\"b\":2}}"))
+        #expect(command.contains("\"multi\": true"))
+        #expect(command.contains("\"upsert\": false"))
+    }
+
+    @Test("upsert and arrayFilters ride along")
+    func updateOptions() {
+        let command = MongoScriptCommandBuilder.update(
+            collection: "orders", filter: "{}", update: "{}", multi: false,
+            options: ["upsert": true, "arrayFilters": [["x.y": 1]]]
+        )
+        #expect(command.contains("\"upsert\": true"))
+        #expect(command.contains("\"arrayFilters\":"))
+    }
+
+    @Test("deleteOne limits to one document and deleteMany to none")
+    func deleteLimits() {
+        #expect(
+            MongoScriptCommandBuilder
+                .delete(collection: "orders", filter: "{}", multi: false, options: [:])
+                .contains("\"limit\": 1")
+        )
+        #expect(
+            MongoScriptCommandBuilder
+                .delete(collection: "orders", filter: "{}", multi: true, options: [:])
+                .contains("\"limit\": 0")
+        )
+    }
+
+    @Test("findOneAndDelete asks the server to remove rather than update")
+    func findAndModifyRemove() {
+        let command = MongoScriptCommandBuilder.findAndModify(
+            collection: "orders", filter: "{\"a\":1}", update: nil, remove: true, options: [:]
+        )
+        #expect(command.contains("\"remove\": true"))
+        #expect(!command.contains("\"update\""))
+    }
+
+    @Test("returnDocument after asks for the updated document")
+    func findAndModifyReturnsNew() {
+        let command = MongoScriptCommandBuilder.findAndModify(
+            collection: "orders", filter: "{}", update: "{\"$set\":{}}", remove: false,
+            options: ["returnDocument": "after"]
+        )
+        #expect(command.contains("\"new\": true"))
+    }
+
+    @Test("An unnamed index takes the name MongoDB gives it")
+    func indexNaming() {
+        #expect(
+            MongoScriptCommandBuilder.indexName(keys: "{\"a\":1,\"b\":-1}", options: [:]) == "a_1_b_-1"
+        )
+        #expect(
+            MongoScriptCommandBuilder.indexName(keys: "{\"loc\":\"2dsphere\"}", options: [:]) == "loc_2dsphere"
+        )
+        #expect(MongoScriptCommandBuilder.indexName(keys: "{\"a\":1}", options: ["name": "custom"]) == "custom")
+    }
+
+    @Test("createIndex passes the options MongoDB accepts")
+    func createIndexOptions() {
+        let command = MongoScriptCommandBuilder.createIndex(
+            collection: "orders", keys: "{\"a\":1}", options: ["unique": true, "expireAfterSeconds": 60]
+        )
+        #expect(command.contains("\"createIndexes\": \"orders\""))
+        #expect(command.contains("\"unique\": true"))
+        #expect(command.contains("\"expireAfterSeconds\": 60"))
+    }
+
+    @Test("A find for EXPLAIN carries the cursor's own modifiers")
+    func explainFind() throws {
+        var options = MongoScriptCursorOptions.none
+        try options.apply(key: "sort", value: "{\"a\":1}")
+        try options.apply(key: "skip", value: "3")
+        let command = MongoScriptCommandBuilder.find(
+            collection: "orders", filter: "{\"b\":2}", options: options, ceiling: 100
+        )
+        #expect(command.contains("\"find\": \"orders\""))
+        #expect(command.contains("\"filter\": {\"b\":2}"))
+        #expect(command.contains("\"sort\": {\"a\":1}"))
+        #expect(command.contains("\"skip\": 3"))
+    }
+
+    @Test("bulkWrite maps each operation to its own command")
+    func bulkOperations() throws {
+        let insert = try MongoScriptCommandBuilder.bulkOperation(
+            "{\"insertOne\": {\"document\": {\"a\": 1}}}", collection: "orders"
+        )
+        #expect(insert.kind == .insert)
+        #expect(insert.document.contains("\"documents\": [{\"a\": 1}]"))
+
+        let update = try MongoScriptCommandBuilder.bulkOperation(
+            "{\"updateMany\": {\"filter\": {\"a\": 1}, \"update\": {\"$set\": {\"b\": 2}}}}",
+            collection: "orders"
+        )
+        #expect(update.kind == .update)
+        #expect(update.document.contains("\"multi\": true"))
+
+        let delete = try MongoScriptCommandBuilder.bulkOperation(
+            "{\"deleteOne\": {\"filter\": {\"a\": 1}}}", collection: "orders"
+        )
+        #expect(delete.kind == .delete)
+        #expect(delete.document.contains("\"limit\": 1"))
+    }
+
+    @Test("An unknown bulk operation is refused rather than silently skipped")
+    func unknownBulkOperation() {
+        #expect(throws: MongoScriptError.self) {
+            try MongoScriptCommandBuilder.bulkOperation("{\"upsertAll\": {}}", collection: "orders")
+        }
+    }
+}
+
+@Suite("MongoScriptObjectId")
+struct MongoScriptObjectIdTests {
+    @Test("A generated id is 24 lowercase hex characters")
+    func shape() {
+        let hex = MongoScriptObjectId.generate()
+        #expect(hex.count == 24)
+        #expect(hex.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+    }
+
+    @Test("Two generated ids differ")
+    func uniqueness() {
+        #expect(MongoScriptObjectId.generate() != MongoScriptObjectId.generate())
+    }
+
+    @Test("The leading four bytes are the current time")
+    func timestampPrefix() throws {
+        let hex = MongoScriptObjectId.generate()
+        let seconds = try #require(UInt32(hex.prefix(8), radix: 16))
+        #expect(abs(Double(seconds) - Date().timeIntervalSince1970) < 5)
+    }
+
+    @Test("Hex payloads decode, and odd-length ones are refused")
+    func hexDecoding() {
+        #expect(MongoScriptObjectId.data(fromHex: "00ff10")?.count == 3)
+        #expect(MongoScriptObjectId.data(fromHex: "abc") == nil)
+        #expect(MongoScriptObjectId.data(fromHex: "zz") == nil)
+    }
+}
+
+@Suite("MongoShellCommandLine")
+struct MongoShellCommandLineTests {
+    @Test("use becomes a call")
+    func useBecomesCall() {
+        #expect(MongoShellCommandLine.rewrite("use orders") == "use(\"orders\")")
+        #expect(MongoShellCommandLine.rewrite("use orders;") == "use(\"orders\")")
+        #expect(MongoShellCommandLine.rewrite("  use  orders  ") == "use(\"orders\")")
+    }
+
+    @Test("show becomes a call for the topics MongoDB has")
+    func showBecomesCall() {
+        #expect(MongoShellCommandLine.rewrite("show dbs") == "show(\"dbs\")")
+        #expect(MongoShellCommandLine.rewrite("show collections") == "show(\"collections\")")
+        #expect(MongoShellCommandLine.rewrite("SHOW TABLES") == "show(\"tables\")")
+    }
+
+    @Test("An unknown show topic is left alone")
+    func unknownTopic() {
+        #expect(MongoShellCommandLine.rewrite("show profile") == "show profile")
+    }
+
+    @Test("JavaScript that merely starts with the word is left alone")
+    func javaScriptIsNotRewritten() {
+        #expect(MongoShellCommandLine.rewrite("use = 1") == "use = 1")
+        #expect(MongoShellCommandLine.rewrite("use(\"orders\")") == "use(\"orders\")")
+        #expect(MongoShellCommandLine.rewrite("show.me()") == "show.me()")
+        #expect(MongoShellCommandLine.rewrite("db.orders.find({})") == "db.orders.find({})")
+    }
+
+    @Test("A quoted database name loses its quotes rather than gaining a second pair")
+    func quotedName() {
+        #expect(MongoShellCommandLine.rewrite("use \"orders\"") == "use(\"orders\")")
+    }
+}

--- a/TableProTests/Core/MongoDB/MongoScriptPreludeTests.swift
+++ b/TableProTests/Core/MongoDB/MongoScriptPreludeTests.swift
@@ -1,0 +1,367 @@
+//
+//  MongoScriptPreludeTests.swift
+//  TableProTests
+//
+
+import Foundation
+import JavaScriptCore
+import Testing
+
+/// Drives the real prelude in a real `JSContext` against a recording host.
+///
+/// This is where the reported bug is pinned: `db.dt_DispatchRule.find()` worked and
+/// `db.dt_DispatchRule.find({status: 1})` did not, because the condition was a JavaScript object
+/// literal and the old path handed its text straight to libbson's strict JSON parser.
+@Suite("MongoScriptPrelude")
+struct MongoScriptPreludeTests {
+    /// A stand-in for the driver: records every request and answers from a script of replies.
+    final class RecordingHost {
+        private(set) var requests: [[String: Any]] = []
+        private(set) var printed: [String] = []
+        var replies: [String] = []
+        var database = "shop"
+
+        func handle(_ requestJson: String) -> String {
+            guard let data = requestJson.data(using: .utf8),
+                  let request = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return "{\"ok\":false,\"e\":{\"m\":\"bad request\",\"c\":0}}"
+            }
+            requests.append(request)
+
+            switch request["op"] as? String {
+            case "currentDatabase":
+                return "{\"ok\":true,\"v\":\"\(database)\"}"
+            case "newObjectId":
+                return "{\"ok\":true,\"v\":\"507f1f77bcf86cd799439011\"}"
+            // Bookkeeping calls answer without drawing on the scripted replies, so a `.limit(1)`
+            // between opening a cursor and reading it does not shift what the read gets back.
+            case "cursorConfigure", "cursorClose", "useDatabase", "sleep":
+                return "{\"ok\":true,\"v\":null}"
+            default:
+                let reply = replies.isEmpty ? "null" : replies.removeFirst()
+                return "{\"ok\":true,\"v\":\(reply)}"
+            }
+        }
+
+        func record(printed line: String) {
+            printed.append(line)
+        }
+
+        func requests(op: String) -> [[String: Any]] {
+            requests.filter { ($0["op"] as? String) == op }
+        }
+    }
+
+    private func makeContext(_ host: RecordingHost) throws -> JSContext {
+        let context = try #require(JSContext())
+        let execute: @convention(block) (String) -> String = { host.handle($0) }
+        let emit: @convention(block) (String) -> Void = { host.record(printed: $0) }
+        context.setObject(execute, forKeyedSubscript: "__tp_exec" as NSString)
+        context.setObject(emit, forKeyedSubscript: "__tp_print" as NSString)
+        context.evaluateScript(MongoScriptPrelude.source)
+        let failure = context.exception?.toString()
+        #expect(failure == nil)
+        return context
+    }
+
+    @Test("The prelude loads without a syntax error")
+    func preludeLoads() throws {
+        let host = RecordingHost()
+        let context = try makeContext(host)
+        #expect(context.objectForKeyedSubscript("db")?.isUndefined == false)
+    }
+
+    @Test("A find with an unquoted condition reaches the driver as valid Extended JSON")
+    func findWithCondition() throws {
+        let host = RecordingHost()
+        let context = try makeContext(host)
+
+        context.evaluateScript("db.dt_DispatchRule.find({status: 1})")
+        #expect(context.exception == nil)
+
+        let opened = try #require(host.requests(op: "openCursor").first)
+        #expect(opened["collection"] as? String == "dt_DispatchRule")
+        let filter = try #require(opened["filter"] as? String)
+        #expect(filter == "{\"status\":{\"$numberInt\":\"1\"}}")
+
+        let parsed = try JSONSerialization.jsonObject(with: #require(filter.data(using: .utf8)))
+        #expect(parsed is [String: Any])
+    }
+
+    @Test("Operators, regular expressions and nested documents survive the crossing")
+    func richFilter() throws {
+        let host = RecordingHost()
+        let context = try makeContext(host)
+
+        context.evaluateScript("""
+            db.orders.find({ total: {$gt: 10.5}, name: /ab.c/i, tags: ["a", "b"], meta: {seen: true} })
+            """)
+        #expect(context.exception == nil)
+
+        let filter = try #require(host.requests(op: "openCursor").first?["filter"] as? String)
+        #expect(filter.contains("\"$gt\":{\"$numberDouble\":\"10.5\"}"))
+        #expect(filter.contains("\"$regularExpression\":{\"pattern\":\"ab.c\",\"options\":\"i\"}"))
+        #expect(filter.contains("\"tags\":[\"a\",\"b\"]"))
+        #expect(filter.contains("\"meta\":{\"seen\":true}"))
+    }
+
+    @Test("Single quotes, which libbson rejects outright, are accepted")
+    func singleQuotedValues() throws {
+        let host = RecordingHost()
+        let context = try makeContext(host)
+
+        context.evaluateScript("db.orders.find({status: 'new'})")
+        #expect(context.exception == nil)
+
+        let filter = try #require(host.requests(op: "openCursor").first?["filter"] as? String)
+        #expect(filter == "{\"status\":\"new\"}")
+    }
+
+    @Test("Value constructors serialise to their Extended JSON wrappers")
+    func valueConstructors() throws {
+        let host = RecordingHost()
+        let context = try makeContext(host)
+
+        context.evaluateScript("""
+            db.orders.find({
+                _id: ObjectId("507f1f77bcf86cd799439011"),
+                at: ISODate("2020-01-02T03:04:05Z"),
+                big: NumberLong("9007199254740993"),
+                small: NumberInt(7),
+                exact: NumberDecimal("1.25"),
+                low: MinKey,
+                high: MaxKey
+            })
+            """)
+        #expect(context.exception == nil)
+
+        let filter = try #require(host.requests(op: "openCursor").first?["filter"] as? String)
+        #expect(filter.contains("\"_id\":{\"$oid\":\"507f1f77bcf86cd799439011\"}"))
+        #expect(filter.contains("\"at\":{\"$date\":{\"$numberLong\":\"1577934245000\"}}"))
+        #expect(filter.contains("\"big\":{\"$numberLong\":\"9007199254740993\"}"))
+        #expect(filter.contains("\"small\":{\"$numberInt\":\"7\"}"))
+        #expect(filter.contains("\"exact\":{\"$numberDecimal\":\"1.25\"}"))
+        #expect(filter.contains("\"low\":{\"$minKey\":1}"))
+        #expect(filter.contains("\"high\":{\"$maxKey\":1}"))
+    }
+
+    @Test("A bare Date(value) is the date it names, not today as a string")
+    func bareDateKeepsWorking() throws {
+        let host = RecordingHost()
+        let context = try makeContext(host)
+
+        context.evaluateScript("db.orders.find({at: Date(\"2020-01-02T03:04:05Z\")})")
+        #expect(context.exception == nil)
+
+        let filter = try #require(host.requests(op: "openCursor").first?["filter"] as? String)
+        #expect(filter == "{\"at\":{\"$date\":{\"$numberLong\":\"1577934245000\"}}}")
+    }
+
+    @Test("new Date and instanceof still reach the native Date")
+    func nativeDateIsIntact() throws {
+        let host = RecordingHost()
+        let context = try makeContext(host)
+
+        let value = context.evaluateScript(
+            "(new Date(0) instanceof Date) + \",\" + (Date(0) instanceof Date) + \",\" + new Date(0).getTime()"
+        )
+        #expect(context.exception == nil)
+        #expect(value?.toString() == "true,true,0")
+    }
+
+    @Test("A number constructor refuses what it cannot represent")
+    func numberConstructorsValidate() throws {
+        let host = RecordingHost()
+        let context = try makeContext(host)
+
+        for statement in ["NumberLong(\"abc\")", "NumberInt(\"abc\")", "NumberDecimal(\"abc\")"] {
+            context.exception = nil
+            context.evaluateScript(statement)
+            #expect(context.exception != nil, "\(statement) should have thrown")
+        }
+    }
+
+    @Test("Chained cursor modifiers reach the driver instead of being dropped")
+    func chainedModifiers() throws {
+        let host = RecordingHost()
+        let context = try makeContext(host)
+
+        context.evaluateScript("db.orders.find({}).sort({createdAt: -1}).skip(20).limit(10)")
+        #expect(context.exception == nil)
+
+        var applied: [String: String] = [:]
+        for request in host.requests(op: "cursorConfigure") {
+            guard let key = request["key"] as? String, let value = request["value"] as? String else { continue }
+            applied[key] = value
+        }
+        #expect(applied["sort"] == "{\"createdAt\":{\"$numberInt\":\"-1\"}}")
+        #expect(applied["skip"] == "{\"$numberInt\":\"20\"}")
+        #expect(applied["limit"] == "{\"$numberInt\":\"10\"}")
+    }
+
+    @Test("forEach walks the cursor and print collects the lines")
+    func cursorIterationAndPrinting() throws {
+        let host = RecordingHost()
+        host.replies = [
+            "1",
+            """
+            {"docs": [{"_id": {"$oid": "507f1f77bcf86cd799439011"}, "name": "first"}, \
+            {"_id": {"$oid": "507f1f77bcf86cd799439012"}, "name": "second"}], "done": true}
+            """
+        ]
+        let context = try makeContext(host)
+
+        context.evaluateScript("db.orders.find({}).forEach(function (order) { print(order.name); })")
+        #expect(context.exception == nil)
+        #expect(host.printed == ["first", "second"])
+    }
+
+    @Test("A document read back carries an ObjectId, not a wrapper object")
+    func documentsRevive() throws {
+        let host = RecordingHost()
+        host.replies = [
+            "1",
+            "{\"docs\": [{\"_id\": {\"$oid\": \"507f1f77bcf86cd799439011\"}}], \"done\": true}"
+        ]
+        let context = try makeContext(host)
+
+        let value = context.evaluateScript("db.orders.findOne({})._id.toString()")
+        #expect(context.exception == nil)
+        #expect(value?.toString() == "507f1f77bcf86cd799439011")
+    }
+
+    @Test("Variables and functions survive from one evaluated statement to the next")
+    func shellStateSurvives() throws {
+        let host = RecordingHost()
+        let context = try makeContext(host)
+
+        context.evaluateScript("var total = 0; function add(n) { total += n; }")
+        context.evaluateScript("add(4); add(6);")
+        let value = context.evaluateScript("total")
+        #expect(context.exception == nil)
+        #expect(value?.toInt32() == 10)
+    }
+
+    @Test("An update reports the counts mongosh reports")
+    func updateResultShape() throws {
+        let host = RecordingHost()
+        host.replies = ["{\"n\": 3, \"nModified\": 2}"]
+        let context = try makeContext(host)
+
+        let value = context.evaluateScript(
+            "var r = db.orders.updateMany({a: 1}, {$set: {b: 2}}); r.matchedCount + \"/\" + r.modifiedCount"
+        )
+        #expect(context.exception == nil)
+        #expect(value?.toString() == "3/2")
+
+        let request = try #require(host.requests(op: "update").first)
+        #expect(request["multi"] as? Bool == true)
+        #expect(request["update"] as? String == "{\"$set\":{\"b\":{\"$numberInt\":\"2\"}}}")
+    }
+
+    @Test("An insert keeps the document's field order")
+    func insertPreservesFieldOrder() throws {
+        let host = RecordingHost()
+        host.replies = ["{\"insertedIds\": [{\"$oid\": \"507f1f77bcf86cd799439011\"}], \"insertedCount\": 1}"]
+        let context = try makeContext(host)
+
+        context.evaluateScript("db.orders.insertOne({zeta: 1, alpha: 2, middle: 3})")
+        #expect(context.exception == nil)
+
+        let document = try #require(host.requests(op: "insertOne").first?["document"] as? String)
+        #expect(document == "{\"zeta\":{\"$numberInt\":\"1\"},\"alpha\":{\"$numberInt\":\"2\"},\"middle\":{\"$numberInt\":\"3\"}}")
+    }
+
+    @Test("A cursor cannot be re-sorted once it has started")
+    func modifiersLockAfterStart() throws {
+        let host = RecordingHost()
+        host.replies = ["1", "{\"docs\": [], \"done\": true}"]
+        let context = try makeContext(host)
+
+        context.evaluateScript("var c = db.orders.find({}); c.hasNext(); c.sort({a: 1});")
+        #expect(context.exception != nil)
+    }
+
+    @Test("A driver error surfaces as a JavaScript error carrying its code")
+    func driverErrorsPropagate() throws {
+        final class FailingHost {
+            func handle(_ requestJson: String) -> String {
+                requestJson.contains("currentDatabase")
+                    ? "{\"ok\":true,\"v\":\"shop\"}"
+                    : "{\"ok\":false,\"e\":{\"m\":\"ns not found\",\"c\":26}}"
+            }
+        }
+        let failing = FailingHost()
+        let context = try #require(JSContext())
+        let execute: @convention(block) (String) -> String = { failing.handle($0) }
+        let emit: @convention(block) (String) -> Void = { _ in }
+        context.setObject(execute, forKeyedSubscript: "__tp_exec" as NSString)
+        context.setObject(emit, forKeyedSubscript: "__tp_print" as NSString)
+        context.evaluateScript(MongoScriptPrelude.source)
+
+        let value = context.evaluateScript("""
+            (function () {
+                try { db.missing.find({}).hasNext(); } catch (e) { return e.message + "/" + e.code; }
+                return "no error";
+            })()
+            """)
+        #expect(value?.toString() == "ns not found/26")
+    }
+
+    @Test("use switches the database the shell writes to")
+    func useSwitchesDatabase() throws {
+        let host = RecordingHost()
+        let context = try makeContext(host)
+
+        context.evaluateScript("use(\"reporting\"); db.orders.find({});")
+        #expect(context.exception == nil)
+
+        let switched = try #require(host.requests(op: "useDatabase").first)
+        #expect(switched["db"] as? String == "reporting")
+        #expect(host.requests(op: "openCursor").first?["db"] as? String == "reporting")
+    }
+
+    @Test("EJSON.parse reads a string, the way mongosh's does")
+    func ejsonParseTakesText() throws {
+        let host = RecordingHost()
+        let context = try makeContext(host)
+
+        let value = context.evaluateScript(
+            "EJSON.parse('{\"_id\": {\"$oid\": \"507f1f77bcf86cd799439011\"}}')._id.toString()"
+        )
+        #expect(context.exception == nil)
+        #expect(value?.toString() == "507f1f77bcf86cd799439011")
+    }
+
+    @Test("A write with no document is refused rather than sent as null")
+    func writesNeedADocument() throws {
+        let host = RecordingHost()
+        let context = try makeContext(host)
+
+        for statement in [
+            "db.orders.updateOne({a: 1})",
+            "db.orders.replaceOne({a: 1})",
+            "db.orders.findOneAndUpdate({a: 1})",
+            "db.orders.insertOne()"
+        ] {
+            context.exception = nil
+            context.evaluateScript(statement)
+            #expect(context.exception != nil, "\(statement) should have thrown")
+        }
+        #expect(host.requests(op: "update").isEmpty)
+        #expect(host.requests(op: "insertOne").isEmpty)
+    }
+
+    @Test("An aggregation pipeline crosses as an array of stages")
+    func aggregatePipeline() throws {
+        let host = RecordingHost()
+        let context = try makeContext(host)
+
+        context.evaluateScript("db.orders.aggregate([{$match: {status: 'new'}}, {$count: 'n'}])")
+        #expect(context.exception == nil)
+
+        let request = try #require(host.requests(op: "openCursor").first)
+        #expect(request["kind"] as? String == "aggregate")
+        #expect(request["pipeline"] as? String == "[{\"$match\":{\"status\":\"new\"}},{\"$count\":\"n\"}]")
+    }
+}

--- a/TableProTests/Core/Services/Formatting/MongoShellFormatterTests.swift
+++ b/TableProTests/Core/Services/Formatting/MongoShellFormatterTests.swift
@@ -1,0 +1,51 @@
+//
+//  MongoShellFormatterTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("MongoShellFormatter")
+struct MongoShellFormatterTests {
+    private func formatted(_ text: String) throws -> String {
+        try MongoShellFormatter().format(text, cursorOffset: nil).text
+    }
+
+    @Test("A regular expression is left exactly as written")
+    func regexIsAtomic() throws {
+        // `{2,3}` is a quantifier. Reflowing it to `{2, 3}` is a different pattern.
+        #expect(try formatted("db.c.find({x: /a{2,3}/})").contains("/a{2,3}/"))
+        #expect(try formatted("db.c.find({x: /[,{}]/i})").contains("/[,{}]/i"))
+    }
+
+    @Test("Division is still formatted as an operator")
+    func divisionIsNotRegex() throws {
+        let output = try formatted("db.c.find({x: total / 2})")
+        #expect(output.contains("total / 2"))
+    }
+
+    @Test("A line comment survives with its text intact")
+    func lineCommentIsAtomic() throws {
+        #expect(try formatted("db.c.find({}) // one, two").contains("// one, two"))
+    }
+
+    @Test("A block comment survives with its text intact")
+    func blockCommentIsAtomic() throws {
+        #expect(try formatted("db.c.find(/* one, two */ {})").contains("/* one, two */"))
+    }
+
+    @Test("A brace inside a string is not structure")
+    func stringsAreAtomic() throws {
+        #expect(try formatted("db.c.find({note: \"a, b\"})").contains("\"a, b\""))
+    }
+
+    @Test("An ordinary query still reflows")
+    func plainQueryFormats() throws {
+        let output = try formatted("db.c.find({a:1,b:2})")
+        #expect(output.contains("a"))
+        #expect(output.contains("b"))
+    }
+}

--- a/TableProTests/Core/Utilities/JavaScriptStatementScannerTests.swift
+++ b/TableProTests/Core/Utilities/JavaScriptStatementScannerTests.swift
@@ -1,0 +1,190 @@
+//
+//  JavaScriptStatementScannerTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("JavaScriptStatementScanner")
+struct JavaScriptStatementScannerTests {
+    private func texts(_ source: String) -> [String] {
+        JavaScriptStatementScanner.executableStatements(in: source).map(\.trimmed)
+    }
+
+    @Test("Semicolons at the top level divide statements")
+    func topLevelSemicolons() {
+        #expect(texts("db.a.find(); db.b.find();") == ["db.a.find();", "db.b.find();"])
+    }
+
+    @Test("A semicolon inside a function body is not a boundary")
+    func semicolonInsideFunction() {
+        let source = "db.a.find().forEach(function (d) { var x = d.n; print(x); });"
+        #expect(texts(source) == [source])
+    }
+
+    @Test("A for header's semicolons are not boundaries")
+    func forHeader() {
+        let source = "for (var i = 0; i < 3; i++) { print(i); }"
+        #expect(texts(source) == [source])
+    }
+
+    @Test("A function declaration ends at its closing brace")
+    func functionDeclaration() {
+        let source = """
+            function add(a, b) { return a + b; }
+            db.orders.find({})
+            """
+        #expect(texts(source) == ["function add(a, b) { return a + b; }", "db.orders.find({})"])
+    }
+
+    @Test("else keeps an if statement together")
+    func ifElseStaysOneStatement() {
+        let source = "if (a) { print(1); } else { print(2); }"
+        #expect(texts(source) == [source])
+    }
+
+    @Test("try/catch/finally stays one statement")
+    func tryCatchStaysOneStatement() {
+        let source = "try { db.a.drop(); } catch (e) { print(e); } finally { print(\"done\"); }"
+        #expect(texts(source) == [source])
+    }
+
+    @Test("A newline splits when the next token cannot continue the expression")
+    func newlineAsSemicolon() {
+        #expect(texts("db.a.find()\ndb.b.find()") == ["db.a.find()", "db.b.find()"])
+    }
+
+    @Test("A newline before a leading dot does not split")
+    func newlineBeforeDotDoesNotSplit() {
+        let source = "db.orders.find({})\n    .sort({a: 1})\n    .limit(5)"
+        #expect(texts(source) == [source])
+    }
+
+    @Test("A newline after a trailing operator does not split")
+    func newlineAfterOperatorDoesNotSplit() {
+        let source = "var total = 1 +\n2"
+        #expect(texts(source) == [source])
+    }
+
+    @Test("A semicolon in a string literal is not a boundary")
+    func semicolonInString() {
+        let source = "db.a.find({note: \"one; two\"});"
+        #expect(texts(source) == [source])
+    }
+
+    @Test("A semicolon in a template literal is not a boundary")
+    func semicolonInTemplate() {
+        let source = "var q = `one; ${a + 1}; two`;"
+        #expect(texts(source) == [source])
+    }
+
+    @Test("A semicolon in a line comment is not a boundary")
+    func semicolonInLineComment() {
+        let source = """
+            db.a.find({}) // one; two
+            db.b.find({})
+            """
+        #expect(texts(source) == ["db.a.find({}) // one; two", "db.b.find({})"])
+    }
+
+    @Test("A semicolon in a block comment is not a boundary")
+    func semicolonInBlockComment() {
+        #expect(texts("db.a.find(/* one; two */ {});") == ["db.a.find(/* one; two */ {});"])
+    }
+
+    @Test("A regular expression containing a semicolon is not a boundary")
+    func semicolonInRegularExpression() {
+        let source = "db.a.find({name: /one;two/i});"
+        #expect(texts(source) == [source])
+    }
+
+    @Test("Division is not read as the start of a regular expression")
+    func divisionIsNotRegex() {
+        let source = """
+            var half = total / 2;
+            db.a.find({})
+            """
+        #expect(texts(source) == ["var half = total / 2;", "db.a.find({})"])
+    }
+
+    @Test("A function declaration ends at its brace even with the next statement on the same line")
+    func functionDeclarationOnOneLine() {
+        let source = "function add(a, b) { return a + b; } db.orders.find({})"
+        #expect(texts(source) == ["function add(a, b) { return a + b; }", "db.orders.find({})"])
+    }
+
+    @Test("A brace that closes a function expression does not end the assignment")
+    func braceInsideAssignmentDoesNotSplit() {
+        let source = "var f = function () { return 1; } + 1;"
+        #expect(texts(source) == [source])
+    }
+
+    @Test("A function expression assigned to a variable stays with its assignment")
+    func functionExpressionStaysWithAssignment() {
+        let source = """
+            var f = function () { return 1; }
+            db.a.find({})
+            """
+        #expect(texts(source) == ["var f = function () { return 1; }", "db.a.find({})"])
+    }
+
+    @Test("Allman bracing stays one statement")
+    func allmanBracing() {
+        let source = "if (ready)\n{\n  print(1);\n}\nelse\n{\n  print(2);\n}"
+        #expect(texts(source) == [source])
+    }
+
+    @Test("An Allman for loop stays one statement")
+    func allmanLoop() {
+        let source = "for (var i = 0; i < 3; i++)\n{\n  print(i);\n}"
+        #expect(texts(source) == [source])
+    }
+
+    @Test("An Allman try/catch stays one statement")
+    func allmanTryCatch() {
+        let source = "try\n{\n  db.a.drop();\n}\ncatch (e)\n{\n  print(e);\n}"
+        #expect(texts(source) == [source])
+    }
+
+    @Test("A trailing comment is not an executable statement")
+    func trailingCommentIsNotAStatement() {
+        #expect(texts("db.a.find(); // note") == ["db.a.find();"])
+        #expect(texts("db.a.find();\n/* just a note */") == ["db.a.find();"])
+        #expect(texts("// only a comment").isEmpty)
+    }
+
+    @Test("Ranges point back at the text the statement came from")
+    func rangesAreAccurate() throws {
+        let source = "db.a.find();\n  db.b.find();"
+        let statements = JavaScriptStatementScanner.executableStatements(in: source)
+        #expect(statements.count == 2)
+        let text = source as NSString
+        for statement in statements {
+            #expect(text.substring(with: statement.range) == statement.text)
+        }
+    }
+
+    @Test("The caret resolves to the statement it sits in")
+    func statementAtCursor() throws {
+        let source = "db.a.find();\ndb.b.find();"
+        let first = try #require(JavaScriptStatementScanner.statementAtCursor(in: source, cursorPosition: 3))
+        #expect(first.trimmed == "db.a.find();")
+        let second = try #require(JavaScriptStatementScanner.statementAtCursor(in: source, cursorPosition: 18))
+        #expect(second.trimmed == "db.b.find();")
+    }
+
+    @Test("An empty document yields nothing")
+    func emptyDocument() {
+        #expect(texts("").isEmpty)
+        #expect(texts("   \n  ").isEmpty)
+    }
+
+    @Test("An unterminated brace keeps the rest as one statement rather than splitting it")
+    func unterminatedBrace() {
+        let source = "db.a.find({status: 1"
+        #expect(texts(source) == [source])
+    }
+}

--- a/TableProTests/Core/Utilities/QueryStatementModelTests.swift
+++ b/TableProTests/Core/Utilities/QueryStatementModelTests.swift
@@ -1,0 +1,75 @@
+//
+//  QueryStatementModelTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("QueryStatementModel")
+struct QueryStatementModelTests {
+    @Test("MongoDB splits as JavaScript, everything else as SQL")
+    func modelPerType() {
+        #expect(QueryStatementModel.forDatabaseType(.mongodb) == .javascript)
+        #expect(QueryStatementModel.forDatabaseType(.postgresql) == .sql)
+        #expect(QueryStatementModel.forDatabaseType(.mysql) == .sql)
+        #expect(QueryStatementModel.forDatabaseType(DatabaseType(rawValue: "SomeFuturePlugin")) == .sql)
+    }
+
+    @Test("A mongosh script stays one statement per top-level statement")
+    func javaScriptSplitting() {
+        let script = """
+            var seen = 0;
+            db.orders.find({status: "new"}).forEach(function (o) { seen += o.total; });
+            print(seen);
+            """
+        let statements = QueryStatementScanner.executableStatements(in: script, model: .javascript)
+        #expect(statements.count == 3)
+        #expect(statements[1].sql.contains("forEach"))
+    }
+
+    @Test("The same script under the SQL model breaks at every semicolon")
+    func sqlSplittingIsWrongForJavaScript() {
+        let script = "db.orders.find({}).forEach(function (o) { var x = o.n; print(x); });"
+        #expect(QueryStatementScanner.executableStatements(in: script, model: .sql).count > 1)
+        #expect(QueryStatementScanner.executableStatements(in: script, model: .javascript).count == 1)
+    }
+
+    @Test("A statement's range points back at the text it came from")
+    func rangesResolve() {
+        let script = "db.a.find();\ndb.b.find();"
+        let statements = QueryStatementScanner.executableStatements(in: script, model: .javascript)
+        let text = script as NSString
+        for statement in statements {
+            #expect(text.substring(with: statement.range) == statement.sql)
+        }
+    }
+
+    @Test("The caret resolves to its own statement under both models")
+    func cursorResolution() {
+        let script = "db.a.find();\ndb.b.find();"
+        let located = QueryStatementScanner.locatedStatementAtCursor(
+            in: script, cursorPosition: 16, model: .javascript
+        )
+        #expect(located.sql.contains("db.b.find()"))
+    }
+
+    @Test("Statement navigation moves between statements under the JavaScript model")
+    func navigation() {
+        let script = "db.a.find();\ndb.b.find();"
+        #expect(QueryStatementScanner.statementStart(after: 0, in: script, model: .javascript) == 13)
+        // A caret past its own statement's start goes to that start first, as it does under SQL.
+        #expect(QueryStatementScanner.statementStart(before: 16, in: script, model: .javascript) == 13)
+        #expect(QueryStatementScanner.statementStart(before: 13, in: script, model: .javascript) == 0)
+        #expect(QueryStatementScanner.statementStart(after: 20, in: script, model: .javascript) == nil)
+    }
+
+    @Test("Selection past the last statement reaches its far edge")
+    func selectionEnd() {
+        let script = "db.a.find();\ndb.b.find();"
+        let end = QueryStatementScanner.statementSelectionEnd(after: 14, in: script, model: .javascript)
+        #expect(end == (script as NSString).length)
+    }
+}

--- a/docs/databases/mongodb.mdx
+++ b/docs/databases/mongodb.mdx
@@ -1,11 +1,11 @@
 ---
 title: MongoDB
-description: Connect to MongoDB with MQL shell queries, collection browsing, and automatic Atlas SRV setup
+description: Connect to MongoDB and run mongosh JavaScript, browse collections, and set up Atlas SRV automatically
 ---
 
 import RegistryPlugin from "/snippets/registry-plugin.mdx";
 
-Filters and pipelines are parsed as JSON and Extended JSON, never as JavaScript, so every key needs quoting, operators included: `{age: {$gte: 18}}` fails with a parse error. Collections appear as tables in the sidebar, with top-level fields as columns and nested objects as formatted JSON.
+The query tab is a JavaScript shell. Write `db.orders.find({status: "new"})` the way mongosh takes it, unquoted keys and all, and keep going into variables, loops and `forEach`. Collections appear as tables in the sidebar, with top-level fields as columns and nested objects as formatted JSON.
 
 <RegistryPlugin name="MongoDB" plugin="MongoDB Driver" />
 
@@ -85,43 +85,90 @@ A binary subtype 4 field renders as `UUID("8cd003eb-4a25-4324-9332-88fce2da0d1a"
 
 Once set, the value renders as `LegacyJavaUUID("…")` and reads that way everywhere, filters and MQL export included. Nothing stored is rewritten, `uuidRepresentation=javaLegacy` in a pasted URL sets the same option, and a change takes effect on the next connect.
 
-## Writing MQL
+## Writing queries
 
-Every key is quoted, and the editor has no comment syntax, so a `//` line becomes part of the statement. Value constructors are translated, so a value copied out of the grid pastes straight into a filter: `ObjectId`, `ISODate`, `Date`, `NumberInt`, `NumberLong`, `NumberDecimal`, `Timestamp`, `BinData`, `HexData`, `MinKey`, `MaxKey`, `UUID`, and the legacy UUID names. Anything else JavaScript, including `new Date()`, arithmetic, and regex literals such as `/abc/i`, is not evaluated.
+Queries run through JavaScriptCore, so a statement is JavaScript and the whole language is
+available: object literals with unquoted keys, single-quoted strings, regex literals such as
+`/abc/i`, `new Date()`, arithmetic, `//` and `/* */` comments.
+
+`Date("2020-01-01")` without `new` gives a date rather than the string plain JavaScript would
+return, so a filter written that way keeps matching. `new Date` and `instanceof Date` are the
+native ones.
 
 ```javascript
-db.orders.find(
-  {"status": "completed"},
-  {"customerId": 1, "total": 1}
-).sort({"date": -1}).limit(20)
+db.orders.find({status: "completed"}, {customerId: 1, total: 1})
+  .sort({date: -1})
+  .limit(20)
 
 db.sales.aggregate([
-  {"$match": {"date": {"$gte": {"$date": "2025-01-01T00:00:00Z"}}}},
-  {"$group": {"_id": "$product", "totalSales": {"$sum": "$amount"}}}
+  {$match: {date: {$gte: ISODate("2025-01-01")}}},
+  {$group: {_id: "$product", totalSales: {$sum: "$amount"}}}
 ])
 ```
 
+### Scripts
+
+The shell is per connection, so a variable or function defined in one statement is there for the
+next, in any tab on that connection, until you disconnect.
+
+```javascript
+var stale = [];
+db.orders.find({status: "pending"}).forEach(function (order) {
+  if (order.updatedAt < ISODate("2025-01-01")) { stale.push(order._id); }
+});
+print("stale orders: " + stale.length);
+```
+
+`print` and `printjson` write to the result grid, one row per line, whenever the statement itself
+returns no documents. A statement that returns documents shows those instead, with the printed
+lines on the status line under the grid.
+
 ### Collection references
 
-`db.users`, `db["users"]`, or `db.getCollection("users")`. The last two take the name exactly as written, so use them for names with dots or spaces, names starting with a digit, and names that collide with a database method such as `stats`.
+`db.users`, `db["users"]`, or `db.getCollection("users")`. Use `getCollection` for names with dots
+or spaces, names starting with a digit, and names that collide with a database method: `db.stats`
+and `db["stats"]` both reach the method, because the shell cannot tell which you meant.
 
-### Chained methods
+### Cursors
 
-`.sort()`, `.limit()` and `.skip()` chain onto `find` and onto `aggregate`, where they become `$sort`, `$skip` and `$limit` stages appended in that order. Chaining onto something that returns no cursor, such as `insertOne`, is an error, as is a method the parser does not know.
+`find()` and `aggregate()` return a cursor and touch nothing until something reads it. Chain
+`sort`, `skip`, `limit`, `projection`, `hint`, `collation`, `maxTimeMS`, `batchSize` and
+`allowDiskUse` onto it, then read it with `forEach`, `map`, `toArray`, `hasNext`/`next`, `itcount`,
+`count` or `explain`. On an aggregation, `sort`, `skip` and `limit` become `$sort`, `$skip` and
+`$limit` stages appended to the pipeline.
+
+A modifier after the cursor has started throws, the same as mongosh. Split it into two statements,
+or set the modifier before the first read.
 
 ### Write options
 
-`updateOne`, `updateMany`, `replaceOne` and `findOneAndUpdate` take a third options document, and `upsert`, `arrayFilters` and `hint` reach the server. The result reports `modifiedCount` and `upsertedCount`.
+`updateOne`, `updateMany`, `replaceOne`, `findOneAndUpdate` and the delete calls take an options
+document, and `upsert`, `arrayFilters`, `hint`, `collation` and `returnDocument` reach the server. A
+write returns the object mongosh returns: `matchedCount`, `modifiedCount`, `upsertedCount` and
+`upsertedId` for an update, `deletedCount` for a delete, `insertedId` for an insert.
 
 ```javascript
-db.users.updateOne({_id: 1}, {"$set": {"active": true}}, {"upsert": true})
+db.users.updateOne({_id: 1}, {$set: {active: true}}, {upsert: true})
 ```
 
-### Supported methods
+### Methods
 
-Collection-level `find`, `findOne`, `aggregate`, `countDocuments`/`count`, `insertOne`/`insertMany`, `updateOne`/`updateMany`, `replaceOne`, `deleteOne`/`deleteMany`, `findOneAndUpdate`/`findOneAndReplace`/`findOneAndDelete`, `createIndex`, `dropIndex`, `drop`; database-level `getCollectionNames`/`listCollections`, `createCollection`, `dropDatabase`, `version`, `stats`. Anything else goes through `db.runCommand({…})` or `db.adminCommand({…})`. An unlisted shell method such as `distinct` or `getUsers` returns an unsupported-method error.
+Collection: `find`, `findOne`, `aggregate`, `countDocuments`/`count`, `estimatedDocumentCount`,
+`distinct`, `insertOne`/`insertMany`/`insert`, `updateOne`/`updateMany`/`update`, `replaceOne`,
+`save`, `deleteOne`/`deleteMany`/`remove`, `findOneAndUpdate`/`findOneAndReplace`/`findOneAndDelete`,
+`bulkWrite`, `createIndex`/`createIndexes`, `dropIndex`/`dropIndexes`, `getIndexes`,
+`hideIndex`/`unhideIndex`, `drop`, `renameCollection`, `stats`, `dataSize`, `storageSize`,
+`totalIndexSize`, `totalSize`, `isCapped`, `validate`, `explain`.
 
-`Cmd+Option+E` explains a statement, converting `find`, `aggregate`, `countDocuments`, update, delete, and `findOneAnd*` calls into `db.runCommand({"explain": …, "verbosity": "executionStats"})`. `Cmd+Shift+F` reformats by nesting depth. Autocomplete offers collections, methods, nested field paths such as `address.city`, and the `$` operators valid at the cursor; see [Autocomplete](/features/autocomplete#mongodb).
+Database: `getCollection`, `getSiblingDB`, `getCollectionNames`, `getCollectionInfos`,
+`createCollection`, `dropDatabase`, `stats`, `version`, `serverStatus`, `hostInfo`, `currentOp`,
+`killOp`, `runCommand`, `adminCommand`. `use <name>`, `show dbs` and `show collections` work as
+typed. Anything with no method of its own goes through `db.runCommand({…})`.
+
+`Cmd+Shift+F` reformats by nesting depth. Autocomplete offers collections, collection methods,
+cursor methods after `find()`, nested field paths such as `address.city`, and the `$` operators
+valid at the cursor; see [Autocomplete](/features/autocomplete#mongodb). For a query plan, chain
+`.explain("executionStats")` onto the cursor.
 
 ## SSL/TLS
 
@@ -135,7 +182,8 @@ New connections default to **Disabled**, and the driver has no TLS fallback: **P
 - Nested paths filter but do not sort. Sorting works on the grid's own columns.
 - **same element** covers a field one array deep. A path through an array inside another array needs nested `$elemMatch`, so those filter with dot notation only.
 - GridFS buckets are not browsable, and change streams are unsupported.
-- `db.getSiblingDB(…)` is not supported. A query runs against the database the connection is on; switch with `Cmd+K`.
+- A script that loops without touching the database cannot be stopped: JavaScriptCore has no public way to interrupt one. `Cmd+.` stops anything that reads, writes or prints, which covers every query. A script silent for 120 seconds is abandoned and the shell restarts.
+- Field names that look like integers (`"0"`, `"12"`) sort ahead of the rest in a document literal, which is what JavaScript does with them.
 
 ## Troubleshooting
 

--- a/project.yml
+++ b/project.yml
@@ -404,6 +404,14 @@ targets:
       - Plugins/MongoDBDriverPlugin/MongoDBSSLMapping.swift
       - Plugins/MongoDBDriverPlugin/MongoDBStatementGenerator.swift
       - Plugins/MongoDBDriverPlugin/MongoDBTimeoutPolicy.swift
+      - Plugins/MongoDBDriverPlugin/MongoScriptCommandBuilder.swift
+      - Plugins/MongoDBDriverPlugin/MongoShellCommandLine.swift
+      - Plugins/MongoDBDriverPlugin/MongoScriptCursorOptions.swift
+      - Plugins/MongoDBDriverPlugin/MongoScriptError.swift
+      - Plugins/MongoDBDriverPlugin/MongoScriptJson.swift
+      - Plugins/MongoDBDriverPlugin/MongoScriptObjectId.swift
+      - Plugins/MongoDBDriverPlugin/MongoScriptPrelude.swift
+      - Plugins/MongoDBDriverPlugin/MongoScriptText.swift
       - Plugins/MongoDBDriverPlugin/MongoStreamProjection.swift
       - Plugins/OracleDriverPlugin/OracleObjectQueries.swift
       - Plugins/MySQLDriverPlugin/MySQLColumnDefinitionSQL.swift


### PR DESCRIPTION
MongoDB queries now run through a real JavaScript engine, so a filter written the way mongosh takes it works, and so do scripts.

## The bug

`db.dt_DispatchRule.find()` worked. `db.dt_DispatchRule.find({status: 1})` failed.

`MongoShellParser` was a string slicer: it located `db.<collection>.<method>(`, took the text between the parentheses, and handed that string to libbson's `bson_new_from_json`, which is a strict JSON parser. Measured with a C probe compiled against the vendored `Libs/libbson_arm64.a`:

```
OK    {"status": 1}
FAIL  {status: 1}        -> Got parse error at "s", position 1: "SPECIAL_EXPECTED"
FAIL  {'status': 1}      FAIL  {"a": 1,}        FAIL  {"name": /abc/i}
FAIL  {age: {$gt: 21}}   FAIL  [{$match: {}}]   FAIL  {"a": 1 /* x */}
```

`find()` worked because the parser substituted the literal `"{}"`. Anything else was a JavaScript object literal, and the user saw the raw string `Invalid JSON filter: {status: 1}`.

Three more defects came from the same design:

- `.sort()` and `.projection()` went through `JSONSerialization`, which reports failure by returning nil. An unparseable sort was dropped and the query ran unsorted while reporting success (`MongoDBConnection+SyncHelpers.swift:93`).
- MongoDB resolved to `SqlDialect.generic`, so the editor split scripts at every semicolon. `var x = ...; x.forEach(...)` ran as two disconnected programs.
- No variables, functions, loops, cursors or `print`.

## The fix

A mongosh-shaped shell on JavaScriptCore, one per connection.

**`MongoScriptRuntime`** owns a `JSContext` on a queue of its own and evaluates one statement per call, so `var`, functions and `use` survive between statements the way a shell's do.

**`MongoScriptPrelude`** is the `db` API, written in JavaScript rather than bridged through `JSExport`: `db.<anything>.<anything>()` has to resolve without the host knowing the collection names, which is what `Proxy` gives. It covers collection methods, a lazy `Cursor` with the mongosh modifiers and iterators, the BSON value constructors, `EJSON`, `print`/`printjson`/`console`, `use` and `show`.

**`MongoScriptHost`** is the single bridge function. Values cross as Extended JSON *text* in both directions and are spliced into command documents verbatim, never rebuilt through `JSONSerialization`: a document round-tripped through a Swift dictionary comes back reordered, and BSON field order decides how an embedded document compares and where `_id` sits.

**`JavaScriptStatementScanner`** replaces semicolon splitting for MongoDB, selected by a curated `QueryStatementModel` (curated app-side rather than read off a `DriverPlugin` static, for the `EXC_BAD_INSTRUCTION` reason `buildMetadataSnapshot` records). Its bias is coarse on purpose: merging two statements still runs correct code, splitting one in half is a syntax error.

**Diagnostics** parse with `JSCheckScriptSyntax` instead of matching method names against a list, so `forEach` stops being underlined as unsupported and a missing brace starts being reported.

A cursor stays lazy until something reads it, which is what lets a streaming export read the query plan off it rather than materialising the documents twice, and what lets a statement whose value is a cursor go straight to the grid without its documents crossing into JavaScript at all.

### Measured (probe in the session scratchpad)

| | |
|---|---|
| `Proxy`, host callback, blocking bridge, exception unwind | all work |
| 5,000 documents through `JSON.parse` | 2.1 ms |
| `JSContextGroupSetExecutionTimeLimit` | **absent from the SDK headers**, private symbol only |

### Cancelling

JavaScriptCore's public API cannot interrupt a running script, so cancellation happens at host-call granularity: `Cmd+.` throws at the next `db` call, `print` or cursor step, which unwinds the whole script and covers everything that touches the database. A script that spins without one is abandoned after 120 seconds of silence, measured from its last host call so a long `forEach` is never cut off, and the shell restarts. No private API is used.

## Scope

Removed from the driver: `executeOperation`, `executeCommandOperation`, `executeWrite` and `buildExplainQuery`, 327 lines the runtime replaces. `MongoShellParser` and `MongoShellValueTranslator` stay in TableProPluginKit unused, because an already-installed MongoDB plugin binary hard-references them and removing a published symbol fails its load.

**Nothing new in TableProPluginKit at all**, deliberately. A new public symbol there is missing from every already-shipped app, so a plugin built against it fails to load on the version most people are running, and MongoDB is registry-only: this plugin ships ahead of the app. So the shell-command rewrite stays inside the plugin, and the editor's diagnostics recognise the same two lines through their own `MongoShellCommandRecognizer`, which only has to decide when *not* to look for a syntax error rather than what to rewrite. No ABI bump, no `TableProMinAppVersion` floor, no re-release of any other plugin.

That means the fix reaches users on the current app as soon as the plugin publishes. On an older app the editor still splits at semicolons, so a multi-statement script runs a statement at a time; everything else works. The JavaScript splitting arrives with the app.

## Review

A Codex adversarial pass over the diff returned 23 findings, 12 of them P1. All 23 are fixed in this
branch. The ones worth knowing about:

**Data safety**
- `LegacyJavaUUID`, `LegacyCSharpUUID`, `LegacyPythonUUID` and the short aliases all delegated to
  `UUID`, so a subtype 3 value came back out as subtype 4 in identity order: the filter matched zero
  documents and a write stored different bytes. Each constructor now carries its own tag to
  `MongoDBUuidCodec`, which is what the per-driver byte order depends on.
- A streaming export evaluated the statement to look for a cursor, then evaluated it again to fill
  the stream. For `findOneAndUpdate` that applied the write twice. Export now evaluates once and
  reuses what it got.
- A script that computed silently past the watchdog and then reached a write could still perform it
  after the caller had been told it timed out. Poisoning an engine cancels its host.
- `use reporting` reported success and then queried the old database, because every scoped execution
  re-pins the driver to the tab's database. The shell's `db` no longer follows that re-pin.

**Crashes and hangs**
- `Double(Int64.max)` rounds up to 2^63, so the range check still admitted a value that trapped in
  `Int64(_:)`. `Int64(exactly:)` is the check that holds, and it also stops `.limit(1.5)` silently
  becoming 1.
- `print` is not a `handle` call, so `while (true) print("x")` saw neither the cancel latch nor the
  watchdog, and refreshed the activity clock on every pass. It observes both now.

**Security**
- `db["dropDatabase"]()` is valid JavaScript that `QueryClassifier.invokedMethodNames` did not see,
  so an external or assistant client could run it without the destructive confirmation. Bracket-form
  names are classified too.

**Correctness**
- Allman bracing split into two invalid fragments; comment-only spans counted as statements.
- `:active` in a script was read as a SQL bind placeholder and rewritten to `?`.
- Regex literals broke both the bracket diagnostics (`/[)]/` reported an unmatched closer) and the
  formatter (`/a{2,3}/` reflowed to `/a{2, 3}/`, a different pattern).
- An empty `find` rendered as write-success; `distinct` rendered ObjectIds as a `$oid` column;
  an upsert reported `matchedCount: 1`; `bulkWrite` reported only its first counter; `.explain()`
  dropped the cursor's own options; `.projection()` on an aggregation was accepted and ignored.
- `EJSON.parse` took an object rather than a string; `MinKey()`/`MaxKey()` had stopped being
  callable; `Date("2020-01-01")` returned today as a string.

## Tested

- `MongoScriptPreludeTests` drives the real prelude in a real `JSContext` against a recording host: the reported query, operators, regex literals, single quotes, value constructors, chained modifiers, `forEach` with `print`, document revival, shell state across statements, write result shapes, insert field order, the modifier-after-start error, driver error propagation, `use`, and aggregation pipelines.
- `JavaScriptStatementScannerTests` covers semicolons in strings, template literals, comments, regex literals and `for` headers, function declarations, `if`/`else`, `try`/`catch`, ASI at a newline, and a leading dot on the next line.
- `MongoScriptCommandTests` covers the JSON helpers' field-order preservation, cursor options (including the dropped-sort bug), the command builder, ObjectId generation, and the `use`/`show` rewrite.
- `MongoDiagnosticsProducerTests` and `JavaScriptSyntaxCheckerTests`.
- `QueryStatementModelTests`.

Two existing assertions encoded the old behaviour and changed with it: `db.users.frobnicate({})` is now valid JavaScript syntax rather than an unsupported-method error, and `//` now starts a comment.

Verification, all on this branch:

```
generate           PASS
build TablePro     PASS
build MongoDBDriver PASS
test               PASS  470 executed, 470 passed  (new suites plus every neighbouring suite)
lint               0 violations
docs               PASS
```

`verify.sh plugins` (the AllPlugins aggregate) fails on this machine before it reaches MongoDB, on
`macro expansion @TaskLocal:1:2: error: unknown attribute 'usableFromInlinenonisolated'` from the
vendored oracle-nio fork. That is a toolchain incompatibility in that package, not this change, and
it stops the aggregate for any branch that touches `Plugins/`. The MongoDB plugin target was built
on its own instead, and CI runs the aggregate on its own toolchain.

No UI automation: the flow needs a live MongoDB server, which `TableProUITests` has no fixture for. The deterministic parts, statement splitting and diagnostics and the whole prelude, are covered by unit tests that drive the real JavaScriptCore engine.

No before/after screenshots: the change is what the editor accepts, not what it draws, and reproducing it needs a MongoDB server. The docs page keeps its existing connection-form shot, which is unaffected.
