### PR TITLE
refactor: share the database endpoint picker and the create-database form

### DIFF
--- a/TablePro/Core/Compare/CompareMetadataService.swift
+++ b/TablePro/Core/Compare/CompareMetadataService.swift
@@ -67,7 +67,7 @@ internal struct CompareMetadataService {
         }
     }
 
-    internal func schemas(for endpoint: CompareSyncEndpoint, connection: DatabaseConnection) async throws -> [String] {
+    internal func schemas(for endpoint: DatabaseEndpoint, connection: DatabaseConnection) async throws -> [String] {
         try await manager.ensureConnected(connection)
         return try await manager.withMetadataDriver(scope: endpoint.scope) { driver in
             try await driver.fetchSchemas()
@@ -77,7 +77,7 @@ internal struct CompareMetadataService {
     // MARK: - Capability
 
     internal func refusalReason(
-        for endpoint: CompareSyncEndpoint,
+        for endpoint: DatabaseEndpoint,
         connection: DatabaseConnection,
         mode: CompareSyncMode
     ) async throws -> String? {
@@ -100,7 +100,7 @@ internal struct CompareMetadataService {
     /// to abort the whole run, which is why `TableDiffResult.comparisonError` was read by the UI and
     /// written by nothing.
     internal func tableReads(
-        for endpoint: CompareSyncEndpoint,
+        for endpoint: DatabaseEndpoint,
         connection: DatabaseConnection,
         includeViews: Bool
     ) async throws -> [TableStructureRead] {
@@ -126,7 +126,7 @@ internal struct CompareMetadataService {
     /// be read is still listed, with an empty definition, so it shows as present rather than
     /// vanishing from the comparison.
     internal func routineReads(
-        for endpoint: CompareSyncEndpoint,
+        for endpoint: DatabaseEndpoint,
         connection: DatabaseConnection
     ) async throws -> [RoutineSourceRead] {
         try await manager.ensureConnected(connection)
@@ -157,7 +157,7 @@ internal struct CompareMetadataService {
     /// read already listed are the ones asked. A trigger on a table that is not in scope is not in
     /// scope either.
     internal func triggerReads(
-        for endpoint: CompareSyncEndpoint,
+        for endpoint: DatabaseEndpoint,
         connection: DatabaseConnection,
         tables: [String]
     ) async throws -> [RoutineSourceRead] {
@@ -184,7 +184,7 @@ internal struct CompareMetadataService {
     }
 
     internal func viewDefinitions(
-        for endpoint: CompareSyncEndpoint,
+        for endpoint: DatabaseEndpoint,
         connection: DatabaseConnection,
         views: [PluginTableInfo]
     ) async throws -> [RoutineSourceRead] {

--- a/TablePro/Core/Compare/CompareRowService.swift
+++ b/TablePro/Core/Compare/CompareRowService.swift
@@ -26,8 +26,8 @@ internal struct CompareRowService {
     }
 
     internal func concurrentReadRefusal(
-        source: CompareSyncEndpoint,
-        target: CompareSyncEndpoint
+        source: DatabaseEndpoint,
+        target: DatabaseEndpoint
     ) -> String? {
         guard source.connectionId == target.connectionId else { return nil }
         let routes = [manager.metadataRoute(for: source.scope), manager.metadataRoute(for: target.scope)]
@@ -42,9 +42,9 @@ internal struct CompareRowService {
 
     internal func compare(
         plan: DataComparePlan,
-        source: CompareSyncEndpoint,
+        source: DatabaseEndpoint,
         sourceConnection: DatabaseConnection,
-        target: CompareSyncEndpoint,
+        target: DatabaseEndpoint,
         targetConnection: DatabaseConnection,
         options: DataCompareOptions
     ) async throws -> DataDiffSummary {
@@ -62,9 +62,9 @@ internal struct CompareRowService {
     /// 12,000 row difference and reported the run as complete.
     internal func buildStatements(
         plan: DataComparePlan,
-        source: CompareSyncEndpoint,
+        source: DatabaseEndpoint,
         sourceConnection: DatabaseConnection,
-        target: CompareSyncEndpoint,
+        target: DatabaseEndpoint,
         targetConnection: DatabaseConnection,
         options: DataCompareOptions,
         excludedKeys: Set<String>
@@ -94,9 +94,9 @@ internal struct CompareRowService {
     // MARK: - Plumbing
 
     private func withBothSides<T: Sendable>(
-        source: CompareSyncEndpoint,
+        source: DatabaseEndpoint,
         sourceConnection: DatabaseConnection,
-        target: CompareSyncEndpoint,
+        target: DatabaseEndpoint,
         targetConnection: DatabaseConnection,
         plan: DataComparePlan,
         options: DataCompareOptions,
@@ -155,9 +155,9 @@ internal struct CompareRowService {
     }
 
     private func withBothSides<T: Sendable>(
-        source: CompareSyncEndpoint,
+        source: DatabaseEndpoint,
         sourceConnection: DatabaseConnection,
-        target: CompareSyncEndpoint,
+        target: DatabaseEndpoint,
         targetConnection: DatabaseConnection,
         plan: DataComparePlan,
         options: DataCompareOptions,

--- a/TablePro/Core/Compare/CompareRunner.swift
+++ b/TablePro/Core/Compare/CompareRunner.swift
@@ -151,8 +151,8 @@ internal struct CompareRunner {
     // MARK: - Context
 
     internal struct Context {
-        internal let source: CompareSyncEndpoint
-        internal let target: CompareSyncEndpoint
+        internal let source: DatabaseEndpoint
+        internal let target: DatabaseEndpoint
         internal let sourceConnection: DatabaseConnection
         internal let targetConnection: DatabaseConnection
     }
@@ -174,7 +174,7 @@ internal struct CompareRunner {
         )
     }
 
-    private func missingConnection(_ endpoint: CompareSyncEndpoint) -> String {
+    private func missingConnection(_ endpoint: DatabaseEndpoint) -> String {
         String(
             format: String(localized: "%@ is no longer a saved connection."),
             endpoint.connectionName

--- a/TablePro/Core/Compare/CompareSyncEligibility.swift
+++ b/TablePro/Core/Compare/CompareSyncEligibility.swift
@@ -1,0 +1,32 @@
+//
+//  CompareSyncEligibility.swift
+//  TablePro
+//
+//  Whether a driver reports enough for the comparison the user asked for.
+//
+
+import Foundation
+import TableProPluginKit
+
+internal enum CompareSyncEligibility {
+    static func refusalReason(
+        for driver: any PluginDatabaseDriver,
+        mode: CompareSyncMode,
+        endpointName: String
+    ) -> String? {
+        let required: PluginCapabilities = mode == .structure ? .schemaCompare : .dataCompare
+        guard !driver.capabilities.contains(required) else { return nil }
+        switch mode {
+        case .structure:
+            return String(
+                format: String(localized: "%@ does not report structure metadata that can be compared."),
+                endpointName
+            )
+        case .data:
+            return String(
+                format: String(localized: "%@ does not support reading rows in key order, which data compare needs."),
+                endpointName
+            )
+        }
+    }
+}

--- a/TablePro/Core/Compare/CompareSyncExecutor.swift
+++ b/TablePro/Core/Compare/CompareSyncExecutor.swift
@@ -105,7 +105,7 @@ internal actor CompareSyncExecutor {
         statements: [SyncStatement],
         mode: CompareSyncMode,
         settings: CompareSyncExecutionSettings,
-        target: CompareSyncEndpoint,
+        target: DatabaseEndpoint,
         driver: any PluginDatabaseDriver,
         progress: Progress
     ) async throws -> CompareSyncRunResult {

--- a/TablePro/Core/Compare/CompareSyncSession.swift
+++ b/TablePro/Core/Compare/CompareSyncSession.swift
@@ -50,8 +50,8 @@ internal final class CompareSyncSession {
     // MARK: - Setup
 
     internal var mode: CompareSyncMode = .structure
-    internal var source: CompareSyncEndpoint?
-    internal var target: CompareSyncEndpoint?
+    internal var source: DatabaseEndpoint?
+    internal var target: DatabaseEndpoint?
     internal var structureOptions = StructureCompareOptions.default
     internal var dataOptions = DataCompareOptions.default
     internal var executionSettings = CompareSyncExecutionSettings()

--- a/TablePro/Core/Database/DatabaseEndpoint.swift
+++ b/TablePro/Core/Database/DatabaseEndpoint.swift
@@ -1,19 +1,22 @@
 //
-//  CompareSyncEndpoint.swift
+//  DatabaseEndpoint.swift
 //  TablePro
 //
-//  One side of a comparison. The source never changes; the target is written to.
+//  One database, on one connection, named well enough to act on.
 //
 //  An endpoint is a `DatabaseScope`, not a connection id. A connection reaches
 //  many databases, so identifying a side by connection alone made two databases
 //  on one server impossible to compare and left the schema unset, which is how
 //  the reads went out unqualified while the writes went out qualified.
 //
+//  Compare & Sync named this type first and copying objects needs the same
+//  answer, so it lives here rather than under either of them.
+//
 
 import Foundation
 import TableProPluginKit
 
-internal struct CompareSyncEndpoint: Hashable, Identifiable, Sendable {
+internal struct DatabaseEndpoint: Hashable, Identifiable, Sendable {
     internal let scope: DatabaseScope
     internal let connectionName: String
     internal let databaseType: DatabaseType
@@ -83,8 +86,8 @@ internal struct CompareSyncEndpoint: Hashable, Identifiable, Sendable {
         return "\(databaseLabel).\(schema)"
     }
 
-    internal func withDatabase(_ database: String, label: String? = nil) -> CompareSyncEndpoint {
-        CompareSyncEndpoint(
+    internal func withDatabase(_ database: String, label: String? = nil) -> DatabaseEndpoint {
+        DatabaseEndpoint(
             scope: DatabaseScope(connectionId: scope.connectionId, database: database, schema: nil),
             connectionName: connectionName,
             databaseType: databaseType,
@@ -94,8 +97,8 @@ internal struct CompareSyncEndpoint: Hashable, Identifiable, Sendable {
         )
     }
 
-    internal func withSchema(_ schema: String?) -> CompareSyncEndpoint {
-        CompareSyncEndpoint(
+    internal func withSchema(_ schema: String?) -> DatabaseEndpoint {
+        DatabaseEndpoint(
             scope: DatabaseScope(connectionId: scope.connectionId, database: scope.database, schema: schema),
             connectionName: connectionName,
             databaseType: databaseType,
@@ -107,14 +110,14 @@ internal struct CompareSyncEndpoint: Hashable, Identifiable, Sendable {
 }
 
 @MainActor
-internal extension CompareSyncEndpoint {
+internal extension DatabaseEndpoint {
     static func from(
         connection: DatabaseConnection,
         database: String? = nil,
         schema: String? = nil
-    ) -> CompareSyncEndpoint {
+    ) -> DatabaseEndpoint {
         let resolved = database ?? connection.database ?? ""
-        return CompareSyncEndpoint(
+        return DatabaseEndpoint(
             scope: DatabaseScope(connectionId: connection.id, database: resolved, schema: schema),
             connectionName: connection.name,
             databaseType: connection.type,
@@ -124,7 +127,7 @@ internal extension CompareSyncEndpoint {
         )
     }
 
-    static func candidates(from connections: [DatabaseConnection]) -> [CompareSyncEndpoint] {
+    static func candidates(from connections: [DatabaseConnection]) -> [DatabaseEndpoint] {
         connections.map { from(connection: $0) }
     }
 
@@ -133,28 +136,5 @@ internal extension CompareSyncEndpoint {
     static func label(for database: String, type: DatabaseType) -> String {
         guard PluginManager.shared.connectionMode(for: type) == .fileBased else { return database }
         return (database as NSString).lastPathComponent
-    }
-}
-
-internal enum CompareSyncEligibility {
-    static func refusalReason(
-        for driver: any PluginDatabaseDriver,
-        mode: CompareSyncMode,
-        endpointName: String
-    ) -> String? {
-        let required: PluginCapabilities = mode == .structure ? .schemaCompare : .dataCompare
-        guard !driver.capabilities.contains(required) else { return nil }
-        switch mode {
-        case .structure:
-            return String(
-                format: String(localized: "%@ does not report structure metadata that can be compared."),
-                endpointName
-            )
-        case .data:
-            return String(
-                format: String(localized: "%@ does not support reading rows in key order, which data compare needs."),
-                endpointName
-            )
-        }
     }
 }

--- a/TablePro/Views/Compare/CompareEndpointToolbarController.swift
+++ b/TablePro/Views/Compare/CompareEndpointToolbarController.swift
@@ -18,7 +18,7 @@ internal final class CompareEndpointToolbarController: NSObject {
     private let onChange: () -> Void
     private let windowProvider: () -> NSWindow?
 
-    private var identifiers: [CompareEndpointSide: NSToolbarItem.Identifier] = [:]
+    private var identifiers: [DatabaseEndpointSide: NSToolbarItem.Identifier] = [:]
     private var popover: NSPopover?
     private var closeObserver: (any NSObjectProtocol)?
 
@@ -33,7 +33,7 @@ internal final class CompareEndpointToolbarController: NSObject {
         super.init()
     }
 
-    internal func item(for side: CompareEndpointSide, identifier: NSToolbarItem.Identifier) -> NSToolbarItem {
+    internal func item(for side: DatabaseEndpointSide, identifier: NSToolbarItem.Identifier) -> NSToolbarItem {
         identifiers[side] = identifier
         let item = NSToolbarItem(itemIdentifier: identifier)
         item.label = side.title
@@ -59,13 +59,13 @@ internal final class CompareEndpointToolbarController: NSObject {
         }
     }
 
-    private func apply(_ side: CompareEndpointSide, to item: NSToolbarItem) {
+    private func apply(_ side: DatabaseEndpointSide, to item: NSToolbarItem) {
         let endpoint = endpoint(for: side)
         item.title = endpoint?.qualifiedDescription ?? side.placeholderTitle
         item.toolTip = endpoint?.fullDescription ?? side.caption
     }
 
-    private func endpoint(for side: CompareEndpointSide) -> CompareSyncEndpoint? {
+    private func endpoint(for side: DatabaseEndpointSide) -> DatabaseEndpoint? {
         side == .source ? session.source : session.target
     }
 
@@ -81,7 +81,7 @@ internal final class CompareEndpointToolbarController: NSObject {
 
     /// Pressing the button again closes the chooser, which is what a pull-down control does and
     /// what the popover's own `.transient` dismissal would otherwise fight.
-    private func present(_ side: CompareEndpointSide) {
+    private func present(_ side: DatabaseEndpointSide) {
         guard popover?.isShown != true else {
             dismiss()
             return
@@ -91,10 +91,10 @@ internal final class CompareEndpointToolbarController: NSObject {
 
         let shown = PopoverPresenter.show(
             relativeTo: anchor,
-            contentSize: CompareEndpointPicker.contentSize,
+            contentSize: DatabaseEndpointPicker.contentSize,
             behavior: .transient
         ) { dismiss in
-            CompareEndpointPicker(
+            DatabaseEndpointPicker(
                 side: side,
                 current: self.endpoint(for: side),
                 onPick: { [weak self] endpoint in self?.pick(endpoint, for: side) },
@@ -129,7 +129,7 @@ internal final class CompareEndpointToolbarController: NSObject {
 
     /// Re-picking the endpoint that is already chosen must not reach `onChange`, which resets the
     /// comparison: the report, both snapshots, every data plan and the user's per-object choices.
-    private func pick(_ endpoint: CompareSyncEndpoint, for side: CompareEndpointSide) {
+    private func pick(_ endpoint: DatabaseEndpoint, for side: DatabaseEndpointSide) {
         guard self.endpoint(for: side)?.id != endpoint.id else { return }
         switch side {
         case .source: session.source = endpoint

--- a/TablePro/Views/Compare/CompareSyncWindowController.swift
+++ b/TablePro/Views/Compare/CompareSyncWindowController.swift
@@ -104,7 +104,7 @@ internal final class CompareSyncWindowController: NSWindowController,
         guard let connectionId else { return }
         let connections = ConnectionStorage.shared.loadConnections()
         guard let match = connections.first(where: { $0.id == connectionId }) else { return }
-        session.source = CompareSyncEndpoint.from(connection: match)
+        session.source = DatabaseEndpoint.from(connection: match)
     }
 
     /// The strip belongs to the window frame, not to the content: it reports what the window is

--- a/TablePro/Views/Components/DatabaseEndpointPicker.swift
+++ b/TablePro/Views/Components/DatabaseEndpointPicker.swift
@@ -1,8 +1,8 @@
 //
-//  CompareEndpointPicker.swift
+//  DatabaseEndpointPicker.swift
 //  TablePro
 //
-//  Choosing the database a comparison reads or writes.
+//  Choosing the database an operation reads or writes.
 //
 //  This was an NSMenu whose submenus fetched on open, which cannot work:
 //  AppKit runs a tracking session in `NSEventTrackingRunLoopMode`, the main
@@ -17,7 +17,7 @@
 import AppKit
 import SwiftUI
 
-internal enum CompareEndpointSide: Hashable {
+internal enum DatabaseEndpointSide: Hashable {
     case source
     case target
 
@@ -49,23 +49,23 @@ internal enum CompareEndpointSide: Hashable {
     }
 }
 
-internal struct CompareEndpointPicker: View {
-    internal let side: CompareEndpointSide
-    internal let current: CompareSyncEndpoint?
-    internal let onPick: (CompareSyncEndpoint) -> Void
+internal struct DatabaseEndpointPicker: View {
+    internal let side: DatabaseEndpointSide
+    internal let current: DatabaseEndpoint?
+    internal let onPick: (DatabaseEndpoint) -> Void
     internal let dismiss: () -> Void
 
     internal static let contentSize = NSSize(width: 320, height: 400)
 
-    @State private var model = CompareEndpointPickerModel()
-    @State private var path: [CompareEndpointRoute] = []
+    @State private var model = DatabaseEndpointPickerModel()
+    @State private var path: [DatabaseEndpointRoute] = []
     @State private var connections: [DatabaseConnection] = []
 
     internal var body: some View {
         NavigationStack(path: $path) {
             connectionList
                 .navigationTitle(side.title)
-                .navigationDestination(for: CompareEndpointRoute.self) { route in
+                .navigationDestination(for: DatabaseEndpointRoute.self) { route in
                     destination(route)
                 }
         }
@@ -81,7 +81,7 @@ internal struct CompareEndpointPicker: View {
                 ContentUnavailableView {
                     Label("No Saved Connections", systemImage: "externaldrive.badge.questionmark")
                 } description: {
-                    Text("Add a connection before comparing.")
+                    Text("Add a connection first.")
                 }
             } else {
                 List(connections) { connection in
@@ -94,7 +94,7 @@ internal struct CompareEndpointPicker: View {
 
     @ViewBuilder
     private func connectionRow(_ connection: DatabaseConnection) -> some View {
-        let endpoint = CompareSyncEndpoint.from(connection: connection)
+        let endpoint = DatabaseEndpoint.from(connection: connection)
         if side == .target, let reason = endpoint.ineligibleAsTargetReason {
             Label {
                 VStack(alignment: .leading, spacing: 1) {
@@ -108,7 +108,7 @@ internal struct CompareEndpointPicker: View {
             }
             .foregroundStyle(.tertiary)
         } else {
-            NavigationLink(value: CompareEndpointRoute.databases(connection.id)) {
+            NavigationLink(value: DatabaseEndpointRoute.databases(connection.id)) {
                 Label {
                     Text(connection.name)
                 } icon: {
@@ -121,7 +121,7 @@ internal struct CompareEndpointPicker: View {
     // MARK: - Databases and schemas
 
     @ViewBuilder
-    private func destination(_ route: CompareEndpointRoute) -> some View {
+    private func destination(_ route: DatabaseEndpointRoute) -> some View {
         switch route {
         case let .databases(connectionId):
             if let connection = connections.first(where: { $0.id == connectionId }) {
@@ -146,7 +146,7 @@ internal struct CompareEndpointPicker: View {
         case let .failed(message):
             failurePane(message) { await model.loadDatabases(for: connection, reload: true) }
         case let .loaded(names):
-            let base = CompareSyncEndpoint.from(connection: connection)
+            let base = DatabaseEndpoint.from(connection: connection)
             if names.isEmpty {
                 List {
                     endpointRow(base, title: base.databaseLabel.isEmpty ? connection.name : base.databaseLabel)
@@ -162,9 +162,9 @@ internal struct CompareEndpointPicker: View {
     }
 
     @ViewBuilder
-    private func databaseRow(_ endpoint: CompareSyncEndpoint, connection: DatabaseConnection) -> some View {
+    private func databaseRow(_ endpoint: DatabaseEndpoint, connection: DatabaseConnection) -> some View {
         if PluginManager.shared.supportsSchemaSwitching(for: connection.type) {
-            NavigationLink(value: CompareEndpointRoute.schemas(endpoint, connection.id)) {
+            NavigationLink(value: DatabaseEndpointRoute.schemas(endpoint, connection.id)) {
                 Text(endpoint.databaseLabel)
             }
         } else {
@@ -176,7 +176,7 @@ internal struct CompareEndpointPicker: View {
     /// same-named tables as one object, and the generated ALTER carries no schema of its own, so it
     /// would land on whichever schema the connection happens to be on.
     @ViewBuilder
-    private func schemaList(_ endpoint: CompareSyncEndpoint, connection: DatabaseConnection) -> some View {
+    private func schemaList(_ endpoint: DatabaseEndpoint, connection: DatabaseConnection) -> some View {
         switch model.schemas(for: endpoint) {
         case .loading:
             loadingPane
@@ -187,7 +187,7 @@ internal struct CompareEndpointPicker: View {
                 ContentUnavailableView {
                     Label("No Schemas", systemImage: "tray")
                 } description: {
-                    Text("This database reports no schemas to compare.")
+                    Text("This database reports no schemas.")
                 }
             } else {
                 List(names, id: \.self) { name in
@@ -198,7 +198,7 @@ internal struct CompareEndpointPicker: View {
         }
     }
 
-    private func endpointRow(_ endpoint: CompareSyncEndpoint, title: String) -> some View {
+    private func endpointRow(_ endpoint: DatabaseEndpoint, title: String) -> some View {
         Button {
             onPick(endpoint)
             dismiss()
@@ -249,11 +249,11 @@ internal struct CompareEndpointPicker: View {
     }
 
     private func label(_ database: String, _ connection: DatabaseConnection) -> String {
-        CompareSyncEndpoint.label(for: database, type: connection.type)
+        DatabaseEndpoint.label(for: database, type: connection.type)
     }
 }
 
-internal enum CompareEndpointRoute: Hashable {
+internal enum DatabaseEndpointRoute: Hashable {
     case databases(UUID)
-    case schemas(CompareSyncEndpoint, UUID)
+    case schemas(DatabaseEndpoint, UUID)
 }

--- a/TablePro/Views/Components/DatabaseEndpointPickerModel.swift
+++ b/TablePro/Views/Components/DatabaseEndpointPickerModel.swift
@@ -1,5 +1,5 @@
 //
-//  CompareEndpointPickerModel.swift
+//  DatabaseEndpointPickerModel.swift
 //  TablePro
 //
 //  The databases and schemas the endpoint picker browses, loaded on demand and
@@ -14,7 +14,7 @@
 
 import Foundation
 
-internal enum CompareEndpointListState: Equatable {
+internal enum DatabaseEndpointListState: Equatable {
     case loading
     case loaded([String])
     case failed(String)
@@ -22,12 +22,12 @@ internal enum CompareEndpointListState: Equatable {
 
 @MainActor
 @Observable
-internal final class CompareEndpointPickerModel {
-    private var databaseStates: [UUID: CompareEndpointListState] = [:]
-    private var schemaStates: [String: CompareEndpointListState] = [:]
+internal final class DatabaseEndpointPickerModel {
+    private var databaseStates: [UUID: DatabaseEndpointListState] = [:]
+    private var schemaStates: [String: DatabaseEndpointListState] = [:]
     @ObservationIgnored private var inFlight: Set<String> = []
     @ObservationIgnored private let databaseLoader: (DatabaseConnection) async throws -> [String]
-    @ObservationIgnored private let schemaLoader: (CompareSyncEndpoint, DatabaseConnection) async throws -> [String]
+    @ObservationIgnored private let schemaLoader: (DatabaseEndpoint, DatabaseConnection) async throws -> [String]
 
     internal convenience init() {
         let metadata = CompareMetadataService()
@@ -39,17 +39,17 @@ internal final class CompareEndpointPickerModel {
 
     internal init(
         databaseLoader: @escaping (DatabaseConnection) async throws -> [String],
-        schemaLoader: @escaping (CompareSyncEndpoint, DatabaseConnection) async throws -> [String]
+        schemaLoader: @escaping (DatabaseEndpoint, DatabaseConnection) async throws -> [String]
     ) {
         self.databaseLoader = databaseLoader
         self.schemaLoader = schemaLoader
     }
 
-    internal func databases(for connectionId: UUID) -> CompareEndpointListState {
+    internal func databases(for connectionId: UUID) -> DatabaseEndpointListState {
         databaseStates[connectionId] ?? .loading
     }
 
-    internal func schemas(for endpoint: CompareSyncEndpoint) -> CompareEndpointListState {
+    internal func schemas(for endpoint: DatabaseEndpoint) -> DatabaseEndpointListState {
         schemaStates[Self.schemaKey(endpoint)] ?? .loading
     }
 
@@ -67,7 +67,7 @@ internal final class CompareEndpointPickerModel {
     }
 
     internal func loadSchemas(
-        for endpoint: CompareSyncEndpoint,
+        for endpoint: DatabaseEndpoint,
         connection: DatabaseConnection,
         reload: Bool = false
     ) async {
@@ -83,24 +83,24 @@ internal final class CompareEndpointPickerModel {
         }
     }
 
-    private func shouldLoad(current: CompareEndpointListState?, key: String, reload: Bool) -> Bool {
+    private func shouldLoad(current: DatabaseEndpointListState?, key: String, reload: Bool) -> Bool {
         if !reload, current != nil, !isFailed(current) { return false }
         return inFlight.insert(key).inserted
     }
 
     /// Only a level with nothing to show becomes a spinner. A reload keeps the list it is
     /// replacing on screen, so retrying never blanks a pane that already had an answer.
-    private func beginLoading(_ state: inout CompareEndpointListState?) {
+    private func beginLoading(_ state: inout DatabaseEndpointListState?) {
         guard state == nil || isFailed(state) else { return }
         state = .loading
     }
 
-    private func isFailed(_ state: CompareEndpointListState?) -> Bool {
+    private func isFailed(_ state: DatabaseEndpointListState?) -> Bool {
         guard case .failed = state else { return false }
         return true
     }
 
-    private static func schemaKey(_ endpoint: CompareSyncEndpoint) -> String {
+    private static func schemaKey(_ endpoint: DatabaseEndpoint) -> String {
         "\(endpoint.connectionId.uuidString)\u{1F}\(endpoint.database)"
     }
 }

--- a/TablePro/Views/DatabaseSwitcher/CreateDatabaseFormRules.swift
+++ b/TablePro/Views/DatabaseSwitcher/CreateDatabaseFormRules.swift
@@ -1,0 +1,124 @@
+//
+//  CreateDatabaseFormRules.swift
+//  TablePro
+//
+//  What a driver's create-database form does with its own answers.
+//
+//  A field can be hidden by another field's value, and a field's options can be
+//  grouped by another field's value, so changing one answer can invalidate
+//  another. Those rules used to live inside the sheet, which meant a second
+//  caller either duplicated them or lost them. They are pure, so they are also
+//  the part worth asserting.
+//
+
+import Foundation
+
+internal enum CreateDatabaseFormRules {
+    /// The driver's preferred answer where it has one, the first option where it does not.
+    internal static func initialValues(for spec: CreateDatabaseFormSpec) -> [String: String] {
+        var initial: [String: String] = [:]
+        for field in spec.fields {
+            let optionValues = options(from: field.kind).map(\.value)
+            if let preferred = defaultValue(from: field.kind), optionValues.contains(preferred) {
+                initial[field.id] = preferred
+            } else if let first = optionValues.first {
+                initial[field.id] = first
+            }
+        }
+        return initial
+    }
+
+    /// The fields whose value decides another field's options, so a change to one has to reset the
+    /// fields grouped under it.
+    internal static func groupSourceFieldIds(in spec: CreateDatabaseFormSpec) -> Set<String> {
+        Set(spec.fields.compactMap(\.groupedBy))
+    }
+
+    internal static func visibleFields(
+        in spec: CreateDatabaseFormSpec,
+        values: [String: String]
+    ) -> [CreateDatabaseFormSpec.Field] {
+        spec.fields.filter { isVisible($0, values: values) }
+    }
+
+    internal static func isVisible(_ field: CreateDatabaseFormSpec.Field, values: [String: String]) -> Bool {
+        guard let visibility = field.visibleWhen else { return true }
+        return values[visibility.fieldId] == visibility.equals
+    }
+
+    internal static func filteredOptions(
+        for field: CreateDatabaseFormSpec.Field,
+        values: [String: String]
+    ) -> [CreateDatabaseFormSpec.Option] {
+        let allOptions = options(from: field.kind)
+        guard allOptions.contains(where: { $0.group != nil }) else { return allOptions }
+        guard let sourceId = field.groupedBy, let groupValue = values[sourceId] else { return allOptions }
+        return allOptions.filter { $0.group == groupValue }
+    }
+
+    /// A collation that belongs to the charset the user just moved away from is no longer offered,
+    /// so leaving it selected would submit a pair the server refuses.
+    internal static func resettingGroupedFields(
+        after sourceId: String,
+        in spec: CreateDatabaseFormSpec,
+        values: [String: String]
+    ) -> [String: String] {
+        var updated = values
+        for field in spec.fields where field.groupedBy == sourceId {
+            let visible = filteredOptions(for: field, values: updated).map(\.value)
+            if let preferred = defaultValue(from: field.kind), visible.contains(preferred) {
+                updated[field.id] = preferred
+            } else {
+                updated[field.id] = visible.first ?? ""
+            }
+        }
+        return updated
+    }
+
+    /// A hidden field's answer is stale rather than chosen, so it never reaches the server.
+    internal static func submissionValues(
+        from values: [String: String],
+        spec: CreateDatabaseFormSpec
+    ) -> [String: String] {
+        values.filter { shouldSubmit($0.key, in: spec, values: values) }
+    }
+
+    internal static func missingRequiredInput(
+        in spec: CreateDatabaseFormSpec,
+        values: [String: String]
+    ) -> Bool {
+        spec.textInputs.contains { input in
+            guard input.isRequired else { return false }
+            return (values[input.id] ?? "").trimmingCharacters(in: .whitespaces).isEmpty
+        }
+    }
+
+    internal static func displayLabel(for option: CreateDatabaseFormSpec.Option) -> String {
+        guard let subtitle = option.subtitle, !subtitle.isEmpty else { return option.label }
+        return "\(option.label) \(subtitle)"
+    }
+
+    private static func shouldSubmit(
+        _ fieldId: String,
+        in spec: CreateDatabaseFormSpec,
+        values: [String: String]
+    ) -> Bool {
+        if spec.textInputs.contains(where: { $0.id == fieldId }) { return true }
+        guard let field = spec.fields.first(where: { $0.id == fieldId }) else { return false }
+        return isVisible(field, values: values)
+    }
+
+    private static func options(from kind: CreateDatabaseFormSpec.FieldKind) -> [CreateDatabaseFormSpec.Option] {
+        switch kind {
+        case .picker(let options, _), .searchable(let options, _):
+            return options
+        }
+    }
+
+    private static func defaultValue(from kind: CreateDatabaseFormSpec.FieldKind) -> String? {
+        switch kind {
+        case .picker(_, let defaultValue), .searchable(_, let defaultValue):
+            return defaultValue
+        }
+    }
+}

--- a/TablePro/Views/DatabaseSwitcher/CreateDatabaseOptionsView.swift
+++ b/TablePro/Views/DatabaseSwitcher/CreateDatabaseOptionsView.swift
@@ -1,0 +1,68 @@
+//
+//  CreateDatabaseOptionsView.swift
+//  TablePro
+//
+//  The driver's own create-database options, wherever a database is created.
+//
+//  Two callers: the New Database sheet, and Duplicate Database, which offers the
+//  same charset and collation so a duplicate does not silently take the server's
+//  default instead of the source's.
+//
+
+import SwiftUI
+
+internal struct CreateDatabaseOptionsView: View {
+    internal let spec: CreateDatabaseFormSpec
+    @Binding internal var values: [String: String]
+
+    internal var body: some View {
+        Group {
+            ForEach(spec.textInputs) { input in
+                TextField(
+                    input.label,
+                    text: textBinding(for: input),
+                    prompt: input.placeholder.map { Text($0) }
+                )
+            }
+            ForEach(CreateDatabaseFormRules.visibleFields(in: spec, values: values)) { field in
+                picker(for: field)
+                    .pickerStyle(.menu)
+            }
+            if let footnote = spec.footnote {
+                Text(footnote)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func textBinding(for input: CreateDatabaseFormSpec.TextInput) -> Binding<String> {
+        Binding<String>(
+            get: { values[input.id] ?? "" },
+            set: { values[input.id] = $0 }
+        )
+    }
+
+    private func picker(for field: CreateDatabaseFormSpec.Field) -> some View {
+        let sources = CreateDatabaseFormRules.groupSourceFieldIds(in: spec)
+        let binding = Binding<String>(
+            get: { values[field.id] ?? "" },
+            set: { newValue in
+                var updated = values
+                updated[field.id] = newValue
+                guard sources.contains(field.id) else {
+                    values = updated
+                    return
+                }
+                values = CreateDatabaseFormRules.resettingGroupedFields(
+                    after: field.id, in: spec, values: updated
+                )
+            }
+        )
+        return Picker(field.label, selection: binding) {
+            ForEach(CreateDatabaseFormRules.filteredOptions(for: field, values: values), id: \.value) { option in
+                Text(CreateDatabaseFormRules.displayLabel(for: option)).tag(option.value)
+            }
+        }
+    }
+}

--- a/TablePro/Views/DatabaseSwitcher/CreateDatabaseSheet.swift
+++ b/TablePro/Views/DatabaseSwitcher/CreateDatabaseSheet.swift
@@ -10,7 +10,6 @@ struct CreateDatabaseSheet: View {
     @State private var loadState: LoadState = .loading
     @State private var databaseName = ""
     @State private var values: [String: String] = [:]
-    @State private var groupSourceFieldIds: Set<String> = []
     @State private var isCreating = false
     @State private var errorMessage: String?
 
@@ -74,13 +73,7 @@ struct CreateDatabaseSheet: View {
             case .loading:
                 loadingRow
             case .ready(let spec):
-                textInputsList(spec: spec)
-                fieldsList(spec: spec)
-                if let footnote = spec.footnote {
-                    Text(footnote)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                }
+                CreateDatabaseOptionsView(spec: spec, values: $values)
             case .unsupported:
                 Text(String(localized: "This engine does not support creating databases."))
                     .foregroundStyle(.secondary)
@@ -147,116 +140,10 @@ struct CreateDatabaseSheet: View {
         .padding(.vertical, 14)
     }
 
-    @ViewBuilder
-    private func textInputsList(spec: CreateDatabaseFormSpec) -> some View {
-        ForEach(spec.textInputs) { input in
-            TextField(
-                input.label,
-                text: textInputBinding(for: input),
-                prompt: input.placeholder.map { Text($0) }
-            )
-        }
-    }
-
-    private func textInputBinding(for input: CreateDatabaseFormSpec.TextInput) -> Binding<String> {
-        Binding<String>(
-            get: { values[input.id] ?? "" },
-            set: { values[input.id] = $0 }
-        )
-    }
-
-    @ViewBuilder
-    private func fieldsList(spec: CreateDatabaseFormSpec) -> some View {
-        ForEach(visibleFields(in: spec)) { field in
-            fieldRow(field: field, spec: spec)
-        }
-    }
-
-    private func fieldRow(field: CreateDatabaseFormSpec.Field, spec: CreateDatabaseFormSpec) -> some View {
-        picker(for: field, spec: spec)
-            .pickerStyle(.menu)
-    }
-
-    private func picker(for field: CreateDatabaseFormSpec.Field, spec: CreateDatabaseFormSpec) -> some View {
-        let binding = Binding<String>(
-            get: { values[field.id] ?? "" },
-            set: { newValue in
-                values[field.id] = newValue
-                if groupSourceFieldIds.contains(field.id) {
-                    resetGroupedFields(after: field.id, in: spec)
-                }
-            }
-        )
-        let options = filteredOptions(for: field)
-        return Picker(field.label, selection: binding) {
-            ForEach(options, id: \.value) { option in
-                Text(displayLabel(for: option)).tag(option.value)
-            }
-        }
-    }
-
     private var canSubmit: Bool {
         guard !databaseName.isEmpty, !isCreating else { return false }
         guard case .ready(let spec) = loadState else { return false }
-        return spec.textInputs.allSatisfy { input in
-            guard input.isRequired else { return true }
-            return !(values[input.id] ?? "").trimmingCharacters(in: .whitespaces).isEmpty
-        }
-    }
-
-    private func visibleFields(in spec: CreateDatabaseFormSpec) -> [CreateDatabaseFormSpec.Field] {
-        spec.fields.filter(isVisible(_:))
-    }
-
-    private func isVisible(_ field: CreateDatabaseFormSpec.Field) -> Bool {
-        guard let visibility = field.visibleWhen else { return true }
-        return values[visibility.fieldId] == visibility.equals
-    }
-
-    private func shouldSubmit(_ fieldId: String, in spec: CreateDatabaseFormSpec) -> Bool {
-        if spec.textInputs.contains(where: { $0.id == fieldId }) { return true }
-        guard let field = spec.fields.first(where: { $0.id == fieldId }) else { return false }
-        return isVisible(field)
-    }
-
-    private func filteredOptions(for field: CreateDatabaseFormSpec.Field) -> [CreateDatabaseFormSpec.Option] {
-        let allOptions = options(from: field.kind)
-        guard allOptions.contains(where: { $0.group != nil }) else { return allOptions }
-        guard let sourceId = field.groupedBy,
-              let groupValue = values[sourceId] else {
-            return allOptions
-        }
-        return allOptions.filter { $0.group == groupValue }
-    }
-
-    private func resetGroupedFields(after sourceId: String, in spec: CreateDatabaseFormSpec) {
-        for field in spec.fields where field.groupedBy == sourceId {
-            let visible = filteredOptions(for: field).map(\.value)
-            if let preferred = defaultValue(from: field.kind), visible.contains(preferred) {
-                values[field.id] = preferred
-            } else {
-                values[field.id] = visible.first ?? ""
-            }
-        }
-    }
-
-    private func options(from kind: CreateDatabaseFormSpec.FieldKind) -> [CreateDatabaseFormSpec.Option] {
-        switch kind {
-        case .picker(let options, _), .searchable(let options, _):
-            return options
-        }
-    }
-
-    private func defaultValue(from kind: CreateDatabaseFormSpec.FieldKind) -> String? {
-        switch kind {
-        case .picker(_, let defaultValue), .searchable(_, let defaultValue):
-            return defaultValue
-        }
-    }
-
-    private func displayLabel(for option: CreateDatabaseFormSpec.Option) -> String {
-        guard let subtitle = option.subtitle, !subtitle.isEmpty else { return option.label }
-        return "\(option.label) \(subtitle)"
+        return !CreateDatabaseFormRules.missingRequiredInput(in: spec, values: values)
     }
 
     private func load() async {
@@ -267,29 +154,11 @@ struct CreateDatabaseSheet: View {
                 loadState = .unsupported
                 return
             }
-            initializeValues(from: spec)
+            values = CreateDatabaseFormRules.initialValues(for: spec)
             loadState = .ready(spec)
         } catch {
             loadState = .failed(error.localizedDescription)
         }
-    }
-
-    private func initializeValues(from spec: CreateDatabaseFormSpec) {
-        var initial: [String: String] = [:]
-        var sources: Set<String> = []
-        for field in spec.fields {
-            let optionValues = options(from: field.kind).map(\.value)
-            if let preferred = defaultValue(from: field.kind), optionValues.contains(preferred) {
-                initial[field.id] = preferred
-            } else if let first = optionValues.first {
-                initial[field.id] = first
-            }
-            if let sourceId = field.groupedBy {
-                sources.insert(sourceId)
-            }
-        }
-        values = initial
-        groupSourceFieldIds = sources
     }
 
     private func submit() {
@@ -300,7 +169,7 @@ struct CreateDatabaseSheet: View {
         errorMessage = nil
 
         let name = databaseName
-        let submissionValues = values.filter { shouldSubmit($0.key, in: spec) }
+        let submissionValues = CreateDatabaseFormRules.submissionValues(from: values, spec: spec)
 
         Task {
             do {

--- a/TableProTests/Core/Compare/CompareObjectScopeTests.swift
+++ b/TableProTests/Core/Compare/CompareObjectScopeTests.swift
@@ -2,71 +2,13 @@
 //  CompareObjectScopeTests.swift
 //  TableProTests
 //
-//  Two things the comparison used to get wrong before an endpoint was a scope and an object had a
-//  kind: it could not address two databases on one server, and `fetchTables` reports views
-//  alongside tables so a view reached the table paths and produced CREATE TABLE for a view.
+//  What the comparison used to get wrong before an object had a kind: `fetchTables` reports views
+//  alongside tables, so a view reached the table paths and produced CREATE TABLE for a view.
 //
 
 @testable import TablePro
 import TableProPluginKit
 import XCTest
-
-final class CompareSyncEndpointScopeTests: XCTestCase {
-    private let connectionId = UUID()
-
-    private func endpoint(database: String, schema: String? = nil) -> CompareSyncEndpoint {
-        CompareSyncEndpoint(
-            scope: DatabaseScope(connectionId: connectionId, database: database, schema: schema),
-            connectionName: "server",
-            databaseType: .postgresql,
-            safeModeLevel: .silent,
-            color: .blue
-        )
-    }
-
-    /// `canCompare` used to key on the connection id, which made this pair identical and refused
-    /// the comparison the issue asks for by name: two versions of a schema on one server.
-    func testTwoDatabasesOnOneConnectionAreDistinctEndpoints() {
-        XCTAssertNotEqual(endpoint(database: "app_prod").id, endpoint(database: "app_staging").id)
-    }
-
-    func testTwoSchemasInOneDatabaseAreDistinctEndpoints() {
-        XCTAssertNotEqual(
-            endpoint(database: "app", schema: "public").id,
-            endpoint(database: "app", schema: "sales").id
-        )
-    }
-
-    func testTheSameScopeIsTheSameEndpoint() {
-        XCTAssertEqual(endpoint(database: "app", schema: "public").id, endpoint(database: "app", schema: "public").id)
-    }
-
-    func testQualifiedDescriptionNamesEveryLevelThatIsSet() {
-        XCTAssertEqual(endpoint(database: "app", schema: "public").qualifiedDescription, "server / app / public")
-        XCTAssertEqual(endpoint(database: "app").qualifiedDescription, "server / app")
-        XCTAssertEqual(endpoint(database: "").qualifiedDescription, "server")
-    }
-
-    func testChangingDatabaseClearsTheSchema() {
-        let moved = endpoint(database: "app", schema: "public").withDatabase("other")
-
-        XCTAssertEqual(moved.database, "other")
-        XCTAssertNil(moved.schema)
-    }
-
-    func testReadOnlyEndpointIsRefusedAsATarget() {
-        let readOnly = CompareSyncEndpoint(
-            scope: DatabaseScope(connectionId: connectionId, database: "prod", schema: nil),
-            connectionName: "prod",
-            databaseType: .postgresql,
-            safeModeLevel: .readOnly,
-            color: .red
-        )
-
-        XCTAssertFalse(readOnly.canBeWrittenTo)
-        XCTAssertNotNil(readOnly.ineligibleAsTargetReason)
-    }
-}
 
 final class CompareTableKindClassifierTests: XCTestCase {
     private func table(_ type: String) -> PluginTableInfo {

--- a/TableProTests/Core/Compare/CompareSyncExecutorTests.swift
+++ b/TableProTests/Core/Compare/CompareSyncExecutorTests.swift
@@ -71,8 +71,8 @@ private struct AlwaysDenyGate: ExecutionGate {
 }
 
 final class CompareSyncExecutorTests: XCTestCase {
-    private func endpoint() -> CompareSyncEndpoint {
-        CompareSyncEndpoint(
+    private func endpoint() -> DatabaseEndpoint {
+        DatabaseEndpoint(
             scope: DatabaseScope(connectionId: UUID(), database: "app", schema: nil),
             connectionName: "staging",
             databaseType: .mysql,
@@ -339,9 +339,9 @@ final class CompareSyncEligibilityTests: XCTestCase {
     }
 }
 
-final class CompareSyncEndpointTests: XCTestCase {
-    private func endpoint(_ level: SafeModeLevel) -> CompareSyncEndpoint {
-        CompareSyncEndpoint(
+final class DatabaseEndpointSafeModeTests: XCTestCase {
+    private func endpoint(_ level: SafeModeLevel) -> DatabaseEndpoint {
+        DatabaseEndpoint(
             scope: DatabaseScope(connectionId: UUID(), database: "prod", schema: nil),
             connectionName: "prod",
             databaseType: .postgresql,

--- a/TableProTests/Core/Compare/CompareSyncStartStateTests.swift
+++ b/TableProTests/Core/Compare/CompareSyncStartStateTests.swift
@@ -16,8 +16,8 @@ import XCTest
 
 @MainActor
 final class CompareSyncStartStateTests: XCTestCase {
-    private func endpoint(name: String, safeModeLevel: SafeModeLevel = .silent) -> CompareSyncEndpoint {
-        CompareSyncEndpoint(
+    private func endpoint(name: String, safeModeLevel: SafeModeLevel = .silent) -> DatabaseEndpoint {
+        DatabaseEndpoint(
             scope: DatabaseScope(connectionId: UUID(), database: "app", schema: nil),
             connectionName: name,
             databaseType: .postgresql,
@@ -34,8 +34,8 @@ final class CompareSyncStartStateTests: XCTestCase {
     }
 
     func testBothPickersReadAsUnchosen() {
-        XCTAssertEqual(CompareEndpointSide.source.placeholderTitle, "Choose Source")
-        XCTAssertEqual(CompareEndpointSide.target.placeholderTitle, "Choose Target")
+        XCTAssertEqual(DatabaseEndpointSide.source.placeholderTitle, "Choose Source")
+        XCTAssertEqual(DatabaseEndpointSide.target.placeholderTitle, "Choose Target")
     }
 
     func testCompareRefusesUntilBothEndpointsAreChosen() {

--- a/TableProTests/Core/Database/DatabaseEndpointPickerModelTests.swift
+++ b/TableProTests/Core/Database/DatabaseEndpointPickerModelTests.swift
@@ -1,5 +1,5 @@
 //
-//  CompareEndpointPickerModelTests.swift
+//  DatabaseEndpointPickerModelTests.swift
 //  TableProTests
 //
 //  The chooser's loading rules. Each of these was a defect in the NSMenu this
@@ -11,7 +11,7 @@
 import XCTest
 
 @MainActor
-final class CompareEndpointPickerModelTests: XCTestCase {
+final class DatabaseEndpointPickerModelTests: XCTestCase {
     private struct Unreachable: LocalizedError {
         var errorDescription: String? { "Connection refused" }
     }
@@ -22,9 +22,9 @@ final class CompareEndpointPickerModelTests: XCTestCase {
 
     private func model(
         databases: @escaping (DatabaseConnection) async throws -> [String] = { _ in [] },
-        schemas: @escaping (CompareSyncEndpoint, DatabaseConnection) async throws -> [String] = { _, _ in [] }
-    ) -> CompareEndpointPickerModel {
-        CompareEndpointPickerModel(databaseLoader: databases, schemaLoader: schemas)
+        schemas: @escaping (DatabaseEndpoint, DatabaseConnection) async throws -> [String] = { _, _ in [] }
+    ) -> DatabaseEndpointPickerModel {
+        DatabaseEndpointPickerModel(databaseLoader: databases, schemaLoader: schemas)
     }
 
     func testAnUnopenedConnectionReportsLoadingRatherThanAnEmptyList() {
@@ -98,8 +98,8 @@ final class CompareEndpointPickerModelTests: XCTestCase {
     func testSchemasAreKeyedPerDatabaseRatherThanPerConnection() async {
         let subject = model(schemas: { endpoint, _ in [endpoint.database + "_schema"] })
         let connection = connection()
-        let orders = CompareSyncEndpoint.from(connection: connection, database: "orders")
-        let audit = CompareSyncEndpoint.from(connection: connection, database: "audit")
+        let orders = DatabaseEndpoint.from(connection: connection, database: "orders")
+        let audit = DatabaseEndpoint.from(connection: connection, database: "audit")
 
         await subject.loadSchemas(for: orders, connection: connection)
         await subject.loadSchemas(for: audit, connection: connection)

--- a/TableProTests/Core/Database/DatabaseEndpointTests.swift
+++ b/TableProTests/Core/Database/DatabaseEndpointTests.swift
@@ -1,0 +1,68 @@
+//
+//  DatabaseEndpointTests.swift
+//  TableProTests
+//
+//  What an endpoint used to get wrong before it was a scope rather than a connection id: it could
+//  not address two databases on one server.
+//
+
+@testable import TablePro
+import TableProPluginKit
+import XCTest
+
+final class DatabaseEndpointTests: XCTestCase {
+    private let connectionId = UUID()
+
+    private func endpoint(database: String, schema: String? = nil) -> DatabaseEndpoint {
+        DatabaseEndpoint(
+            scope: DatabaseScope(connectionId: connectionId, database: database, schema: schema),
+            connectionName: "server",
+            databaseType: .postgresql,
+            safeModeLevel: .silent,
+            color: .blue
+        )
+    }
+
+    /// `canCompare` used to key on the connection id, which made this pair identical and refused
+    /// the comparison the issue asks for by name: two versions of a schema on one server.
+    func testTwoDatabasesOnOneConnectionAreDistinctEndpoints() {
+        XCTAssertNotEqual(endpoint(database: "app_prod").id, endpoint(database: "app_staging").id)
+    }
+
+    func testTwoSchemasInOneDatabaseAreDistinctEndpoints() {
+        XCTAssertNotEqual(
+            endpoint(database: "app", schema: "public").id,
+            endpoint(database: "app", schema: "sales").id
+        )
+    }
+
+    func testTheSameScopeIsTheSameEndpoint() {
+        XCTAssertEqual(endpoint(database: "app", schema: "public").id, endpoint(database: "app", schema: "public").id)
+    }
+
+    func testQualifiedDescriptionNamesEveryLevelThatIsSet() {
+        XCTAssertEqual(endpoint(database: "app", schema: "public").qualifiedDescription, "server / app / public")
+        XCTAssertEqual(endpoint(database: "app").qualifiedDescription, "server / app")
+        XCTAssertEqual(endpoint(database: "").qualifiedDescription, "server")
+    }
+
+    func testChangingDatabaseClearsTheSchema() {
+        let moved = endpoint(database: "app", schema: "public").withDatabase("other")
+
+        XCTAssertEqual(moved.database, "other")
+        XCTAssertNil(moved.schema)
+    }
+
+    func testReadOnlyEndpointIsRefusedAsATarget() {
+        let readOnly = DatabaseEndpoint(
+            scope: DatabaseScope(connectionId: connectionId, database: "prod", schema: nil),
+            connectionName: "prod",
+            databaseType: .postgresql,
+            safeModeLevel: .readOnly,
+            color: .red
+        )
+
+        XCTAssertFalse(readOnly.canBeWrittenTo)
+        XCTAssertNotNil(readOnly.ineligibleAsTargetReason)
+    }
+}

--- a/TableProTests/Views/DatabaseSwitcher/CreateDatabaseFormRulesTests.swift
+++ b/TableProTests/Views/DatabaseSwitcher/CreateDatabaseFormRulesTests.swift
@@ -1,0 +1,172 @@
+//
+//  CreateDatabaseFormRulesTests.swift
+//  TableProTests
+//
+//  The create-database form's own rules, now that two callers share them: the
+//  New Database sheet and Duplicate Database.
+//
+
+@testable import TablePro
+import TableProPluginKit
+import XCTest
+
+final class CreateDatabaseFormRulesTests: XCTestCase {
+    private func option(
+        _ value: String,
+        subtitle: String? = nil,
+        group: String? = nil
+    ) -> CreateDatabaseFormSpec.Option {
+        CreateDatabaseFormSpec.Option(value: value, label: value, subtitle: subtitle, group: group)
+    }
+
+    private func field(
+        _ id: String,
+        options: [CreateDatabaseFormSpec.Option],
+        defaultValue: String?,
+        visibleWhen: CreateDatabaseFormSpec.Visibility? = nil,
+        groupedBy: String? = nil
+    ) -> CreateDatabaseFormSpec.Field {
+        CreateDatabaseFormSpec.Field(
+            id: id,
+            label: id,
+            kind: .picker(options: options, defaultValue: defaultValue),
+            visibleWhen: visibleWhen,
+            groupedBy: groupedBy
+        )
+    }
+
+    private func spec(
+        fields: [CreateDatabaseFormSpec.Field],
+        textInputs: [CreateDatabaseFormSpec.TextInput] = []
+    ) -> CreateDatabaseFormSpec {
+        CreateDatabaseFormSpec(fields: fields, footnote: nil, textInputs: textInputs)
+    }
+
+    private func charsetSpec() -> CreateDatabaseFormSpec {
+        spec(fields: [
+            field("charset", options: [option("utf8mb4"), option("latin1")], defaultValue: "utf8mb4"),
+            field(
+                "collation",
+                options: [
+                    option("utf8mb4_general_ci", group: "utf8mb4"),
+                    option("utf8mb4_unicode_ci", group: "utf8mb4"),
+                    option("latin1_swedish_ci", group: "latin1")
+                ],
+                defaultValue: "utf8mb4_general_ci",
+                groupedBy: "charset"
+            )
+        ])
+    }
+
+    func testTheDriversPreferredAnswerIsChosenFirst() {
+        let values = CreateDatabaseFormRules.initialValues(for: charsetSpec())
+
+        XCTAssertEqual(values["charset"], "utf8mb4")
+        XCTAssertEqual(values["collation"], "utf8mb4_general_ci")
+    }
+
+    func testAFieldWithNoPreferredAnswerTakesItsFirstOption() {
+        let subject = spec(fields: [field("owner", options: [option("postgres")], defaultValue: nil)])
+
+        XCTAssertEqual(CreateDatabaseFormRules.initialValues(for: subject)["owner"], "postgres")
+    }
+
+    func testACollationIsOnlyOfferedForTheChosenCharacterSet() {
+        let offered = CreateDatabaseFormRules.filteredOptions(
+            for: charsetSpec().fields[1], values: ["charset": "latin1"]
+        )
+
+        XCTAssertEqual(offered.map(\.value), ["latin1_swedish_ci"])
+    }
+
+    /// Leaving a collation from the character set the user just moved away from would submit a
+    /// pair the server refuses.
+    func testChangingTheCharacterSetResetsTheCollation() {
+        let updated = CreateDatabaseFormRules.resettingGroupedFields(
+            after: "charset",
+            in: charsetSpec(),
+            values: ["charset": "latin1", "collation": "utf8mb4_general_ci"]
+        )
+
+        XCTAssertEqual(updated["collation"], "latin1_swedish_ci")
+    }
+
+    func testGroupSourcesAreTheFieldsOthersAreGroupedBy() {
+        XCTAssertEqual(CreateDatabaseFormRules.groupSourceFieldIds(in: charsetSpec()), ["charset"])
+    }
+
+    // MARK: - Visibility
+
+    private func conditionalSpec() -> CreateDatabaseFormSpec {
+        spec(fields: [
+            field("kind", options: [option("standard"), option("clone")], defaultValue: "standard"),
+            field(
+                "source",
+                options: [option("app")],
+                defaultValue: "app",
+                visibleWhen: CreateDatabaseFormSpec.Visibility(fieldId: "kind", equals: "clone")
+            )
+        ])
+    }
+
+    func testAHiddenFieldIsNotOffered() {
+        let visible = CreateDatabaseFormRules.visibleFields(
+            in: conditionalSpec(), values: ["kind": "standard"]
+        )
+
+        XCTAssertEqual(visible.map(\.id), ["kind"])
+    }
+
+    /// A hidden field holds a stale answer rather than a chosen one.
+    func testAHiddenFieldIsNotSubmitted() {
+        let submitted = CreateDatabaseFormRules.submissionValues(
+            from: ["kind": "standard", "source": "app"], spec: conditionalSpec()
+        )
+
+        XCTAssertEqual(submitted, ["kind": "standard"])
+    }
+
+    func testAVisibleFieldIsSubmitted() {
+        let submitted = CreateDatabaseFormRules.submissionValues(
+            from: ["kind": "clone", "source": "app"], spec: conditionalSpec()
+        )
+
+        XCTAssertEqual(submitted, ["kind": "clone", "source": "app"])
+    }
+
+    // MARK: - Required text
+
+    func testAnEmptyRequiredInputBlocksSubmission() {
+        let subject = spec(
+            fields: [],
+            textInputs: [CreateDatabaseFormSpec.TextInput(
+                id: "owner", label: "Owner", placeholder: nil, isRequired: true
+            )]
+        )
+
+        XCTAssertTrue(CreateDatabaseFormRules.missingRequiredInput(in: subject, values: ["owner": "  "]))
+        XCTAssertFalse(CreateDatabaseFormRules.missingRequiredInput(in: subject, values: ["owner": "admin"]))
+    }
+
+    func testAnOptionalInputDoesNotBlockSubmission() {
+        let subject = spec(
+            fields: [],
+            textInputs: [CreateDatabaseFormSpec.TextInput(
+                id: "note", label: "Note", placeholder: nil, isRequired: false
+            )]
+        )
+
+        XCTAssertFalse(CreateDatabaseFormRules.missingRequiredInput(in: subject, values: [:]))
+    }
+
+    func testASubtitleIsAppendedToTheOptionLabel() {
+        XCTAssertEqual(
+            CreateDatabaseFormRules.displayLabel(for: option("utf8mb4", subtitle: "(default)")),
+            "utf8mb4 (default)"
+        )
+    }
+
+    func testAnOptionWithNoSubtitleKeepsItsLabel() {
+        XCTAssertEqual(CreateDatabaseFormRules.displayLabel(for: option("utf8mb4")), "utf8mb4")
+    }
+}

--- a/TableProUITests/CompareSyncUITests.swift
+++ b/TableProUITests/CompareSyncUITests.swift
@@ -8,7 +8,7 @@ import XCTest
 /// "Choose a connection" and on a Compare button, none of which exist: the window never opens
 /// without a license, and the rebuilt toolbar spells its placeholder "Choose Source". It could not
 /// pass on any machine. The window's own contract now lives in `CompareSyncSessionTests` and
-/// `CompareEndpointSideTests`, which reach it without a license.
+/// `DatabaseEndpointTests`, which reach it without a license.
 final class CompareSyncUITests: UITestCase {
     private let licenseAlertMessage = "Compare & Sync requires a license"
 


### PR DESCRIPTION
Two shared-code changes pulled out of the work on #2487, so that issue's own branch reviews as a
feature rather than as a feature plus a rename. Nothing here changes behaviour.

## `CompareSyncEndpoint` becomes `DatabaseEndpoint`

The type is "one database, on one connection, named well enough to act on". Compare & Sync named it
first, but it answers a question any cross-database operation asks, and the copy work in #2487 needs
the same answer. It moves to `Core/Database/`, and its chooser, which walks connection then database
then schema, moves to `Views/Components/` as `DatabaseEndpointPicker`.

`CompareSyncEligibility` stays behind in `Core/Compare/`: whether a driver reports enough for a
*comparison* is Compare's question, not a shared one.

Pure rename, compiler-verified. The endpoint's own tests move with it to
`TableProTests/Core/Database/`.

## The create-database form's rules become shared and testable

`CreateDatabaseSheet` held the whole form contract inline: which fields are visible, which options
belong to which group, what resets when a grouped field's source changes, and which answers are
stale enough that they must not be submitted. A second caller either duplicates that or loses it.

It splits into `CreateDatabaseFormRules`, which is pure, and `CreateDatabaseOptionsView`, which
renders it. The sheet keeps its own state and loses about 110 lines.

The rules had no tests. They have 12 now, including the two that matter and were never asserted:

- a collation from the character set the user just moved away from is reset rather than submitted as
  a pair the server refuses
- a hidden field's answer is stale rather than chosen, so it never reaches `CREATE DATABASE`

## What I built and tested

| Step | Verdict |
|---|---|
| `verify.sh build` | PASS |
| `verify.sh test` (touched suites) | PASS, 45/45 |
| `verify.sh lint TablePro TableProTests` | 0 violations |

`verify.sh plugins` and `verify.sh abi` were not run and are not needed: nothing under `Plugins/`
changed.

No CHANGELOG entry: nothing user-facing changes, and the rename is internal.
