### PR TITLE
feat(datagrid): move the cell editor to the row above or below with the arrow keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Per-connection MongoDB shell state, so a variable or function survives from one statement to the next.
 - Cursor method autocomplete after `find()` and `aggregate()`.
 - Copy To and Duplicate Database in the sidebar and the Database menu, carrying structure, data or both to any connection. (#2487)
+- `Up` and `Down` while editing a cell, moving the editor to the same column of the row above or below. (#2569)
 - Tab rows in Settings > General > Tabs, wrapping the strip instead of scrolling it. (#2438)
 - Autoscrolling while dragging a tab, so a tab can be moved past the run currently on screen. (#2438)
 
@@ -31,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tab drag released on a neighbour's exact centre leaving the order unchanged. (#2438)
 - Compare & Sync unable to drop an overloaded PostgreSQL routine, or any trigger.
 - PostgreSQL sequence DDL naming the schema it was read from, in SQL export and the structure editor.
+- Half-composed input method text saved and left behind when `Tab` moved the cell editor.
+- Cell editor opening off screen when `Tab` wrapped onto a row below the visible ones.
+- Cell cursor left on the old column after `Tab` carried the editor to the next one.
+- Every data grid switching to its accessibility layout after one `Tab` press, with no assistive app attached.
 
 ## [0.69.0] - 2026-08-27
 

--- a/TablePro/Views/Results/CellEditorMovement.swift
+++ b/TablePro/Views/Results/CellEditorMovement.swift
@@ -1,0 +1,57 @@
+//
+//  CellEditorMovement.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Which way an inline cell editor was left.
+///
+/// The cases are AppKit's own vocabulary for leaving one field for the next: `NSTextMovement`
+/// declares `up` and `down` beside `tab` and `backtab` as "movement codes for movement between
+/// fields". The overlay editor is a standalone text view rather than a field editor, so it reads
+/// the four selectors itself and reports them here.
+enum CellEditorMovement {
+    case tab
+    case backtab
+    case up
+    case down
+}
+
+/// Whether Up or Down in an inline cell editor moves the caret or leaves the cell.
+///
+/// A cell value can hold line breaks, so the arrow keys belong to the value's own lines first and
+/// the editor is left only from the line at that end. A value on one line has no line to move to
+/// in either direction, so both arrows leave it, including straight after the editor opens with
+/// the whole value selected.
+///
+/// A line break is the only thing that starts a line here, because the overlay never wraps text
+/// (`CellOverlayBase.applyCellTextLayout`, pinned by `CellOverlayTextLayoutTests`).
+struct CellEditorArrowExit {
+    let canExitUp: Bool
+    let canExitDown: Bool
+
+    init(text: NSString, selection: NSRange) {
+        let length = text.length
+        let start = min(max(selection.location, 0), length)
+        let end = start + min(max(selection.length, 0), length - start)
+        let breakAbove = Self.containsLineBreak(text, NSRange(location: 0, length: start))
+        let breakBelow = Self.containsLineBreak(text, NSRange(location: end, length: length - end))
+
+        guard start != end else {
+            canExitUp = !breakAbove
+            canExitDown = !breakBelow
+            return
+        }
+
+        let isSingleLine = !breakAbove && !breakBelow
+            && !Self.containsLineBreak(text, NSRange(location: start, length: end - start))
+        canExitUp = isSingleLine
+        canExitDown = isSingleLine
+    }
+
+    private static func containsLineBreak(_ text: NSString, _ range: NSRange) -> Bool {
+        guard range.length > 0 else { return false }
+        return text.rangeOfCharacter(from: .newlines, range: range).location != NSNotFound
+    }
+}

--- a/TablePro/Views/Results/CellOverlayEditor.swift
+++ b/TablePro/Views/Results/CellOverlayEditor.swift
@@ -11,7 +11,7 @@ final class CellOverlayEditor: CellOverlayBase, NSTextViewDelegate {
     private var initialValue: String = ""
 
     var onCommit: ((_ row: Int, _ columnIndex: Int, _ newValue: String) -> Void)?
-    var onTabNavigation: ((_ row: Int, _ column: Int, _ forward: Bool) -> Void)?
+    var onMovement: ((_ row: Int, _ column: Int, _ movement: CellEditorMovement) -> Void)?
 
     func show(
         in tableView: NSTableView,
@@ -90,20 +90,50 @@ final class CellOverlayEditor: CellOverlayBase, NSTextViewDelegate {
         }
 
         if commandSelector == #selector(NSResponder.insertTab(_:)) {
-            let dismissRow = row, dismissColumn = column
-            dismiss(commit: true)
-            onTabNavigation?(dismissRow, dismissColumn, true)
-            return true
+            return leave(with: .tab, from: textView)
         }
 
         if commandSelector == #selector(NSResponder.insertBacktab(_:)) {
-            let dismissRow = row, dismissColumn = column
-            dismiss(commit: true)
-            onTabNavigation?(dismissRow, dismissColumn, false)
-            return true
+            return leave(with: .backtab, from: textView)
+        }
+
+        if commandSelector == #selector(NSResponder.moveUp(_:)) {
+            return leaveVertically(.up, from: textView)
+        }
+
+        if commandSelector == #selector(NSResponder.moveDown(_:)) {
+            return leaveVertically(.down, from: textView)
         }
 
         return false
+    }
+
+    /// Only the plain arrows are read. Shift, Option and Command each map to a selector of their
+    /// own, so extending a selection or jumping to the end of the value keeps its native meaning.
+    ///
+    /// An unhandled arrow moves the caret inside marked text, which is what it is for, so a
+    /// composition takes it back rather than having it swallowed.
+    private func leaveVertically(_ movement: CellEditorMovement, from textView: NSTextView) -> Bool {
+        guard !textView.hasMarkedText() else { return false }
+        let exit = CellEditorArrowExit(
+            text: textView.string as NSString,
+            selection: textView.selectedRange()
+        )
+        let leaves = movement == .up ? exit.canExitUp : exit.canExitDown
+        guard leaves else { return false }
+        return leave(with: movement, from: textView)
+    }
+
+    /// A composition in progress owns the keystroke. Until the input method commits it the text
+    /// view holds provisional text, and leaving the cell would save that half-composed value and
+    /// carry the editor off it. The key is swallowed rather than passed back, because a literal
+    /// tab in a cell is not what Tab was pressed for.
+    private func leave(with movement: CellEditorMovement, from textView: NSTextView) -> Bool {
+        guard !textView.hasMarkedText() else { return true }
+        let dismissRow = row, dismissColumn = column
+        dismiss(commit: true)
+        onMovement?(dismissRow, dismissColumn, movement)
+        return true
     }
 }
 

--- a/TablePro/Views/Results/Extensions/DataGridView+Editing.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Editing.swift
@@ -97,8 +97,8 @@ extension TableViewCoordinator {
         editor.onCommit = { [weak self] row, columnIndex, newValue in
             self?.commitCellEdit(row: row, columnIndex: columnIndex, newValue: newValue)
         }
-        editor.onTabNavigation = { [weak self] row, column, forward in
-            self?.handleOverlayTabNavigation(row: row, column: column, forward: forward)
+        editor.onMovement = { [weak self] row, column, movement in
+            self?.handleOverlayMovement(row: row, column: column, movement: movement)
         }
         overlayViewer?.dismiss()
         editor.show(in: tableView, row: row, column: column, columnIndex: columnIndex, value: value)
@@ -116,30 +116,31 @@ extension TableViewCoordinator {
         viewer.show(in: tableView, row: row, column: column, columnIndex: columnIndex, value: value)
     }
 
-    func handleOverlayTabNavigation(row: Int, column: Int, forward: Bool) {
-        guard let tableView = tableView,
-              let target = tabNavigationTarget(from: (row, column), forward: forward, in: tableView)
+    /// The cell cursor moves with the editor, through the same `focusCell` the grid's own Tab uses.
+    /// Selecting the row alone left the cursor on the column the editor came from, so closing the
+    /// editor put it back where the editing was not, and it never scrolled the target row into
+    /// view, so a wrap onto the row below the last visible one opened the editor off screen.
+    func handleOverlayMovement(row: Int, column: Int, movement: CellEditorMovement) {
+        guard let tableView = tableView as? KeyHandlingTableView,
+              let target = movementTarget(from: (row, column), movement: movement, in: tableView)
         else { return }
 
-        let nextRow = target.row
-        let nextColumn = target.column
-        tableView.selectRowIndexes(IndexSet(integer: nextRow), byExtendingSelection: false)
-        scrollColumnToVisible(tableColumnIndex: nextColumn)
+        tableView.focusCell(row: target.row, column: target.column)
 
-        guard let nextColumnIndex = DataGridView.dataColumnIndex(
-                for: nextColumn,
+        guard let targetColumnIndex = DataGridView.dataColumnIndex(
+                for: target.column,
                 in: tableView,
                 schema: identitySchema
               ),
-              nextColumnIndex >= 0,
-              case .editable(let value) = editEligibility(row: nextRow, columnIndex: nextColumnIndex)
+              targetColumnIndex >= 0,
+              case .editable(let value) = editEligibility(row: target.row, columnIndex: targetColumnIndex)
         else { return }
 
         showOverlayEditor(
             tableView: tableView,
-            row: nextRow,
-            column: nextColumn,
-            columnIndex: nextColumnIndex,
+            row: target.row,
+            column: target.column,
+            columnIndex: targetColumnIndex,
             value: value
         )
     }
@@ -148,22 +149,34 @@ extension TableViewCoordinator {
     /// previous row's last. Both ends are resolved rather than assumed: the window's spacers and
     /// the pool's surplus slots are attached columns too, so neither end of `tableColumns` holds a
     /// data column and a fixed position lands on a spacer that swallows the keystroke.
-    private func tabNavigationTarget(
+    ///
+    /// Up and Down hold the column and step one row, and neither wraps: a column is a column of one
+    /// kind of value, so carrying the editor from the last row round to the first is a jump the
+    /// user did not ask for.
+    func movementTarget(
         from cell: (row: Int, column: Int),
-        forward: Bool,
+        movement: CellEditorMovement,
         in tableView: NSTableView
     ) -> (row: Int, column: Int)? {
-        if forward {
+        switch movement {
+        case .tab:
             if let next = nextPresentedColumnIndex(after: cell.column) {
                 return (cell.row, next)
             }
             guard cell.row + 1 < tableView.numberOfRows, let first = firstPresentedColumnIndex() else { return nil }
             return (cell.row + 1, first)
+        case .backtab:
+            if let previous = previousPresentedColumnIndex(before: cell.column) {
+                return (cell.row, previous)
+            }
+            guard cell.row > 0, let last = lastPresentedColumnIndex() else { return nil }
+            return (cell.row - 1, last)
+        case .up:
+            guard cell.row > 0 else { return nil }
+            return (cell.row - 1, cell.column)
+        case .down:
+            guard cell.row + 1 < tableView.numberOfRows else { return nil }
+            return (cell.row + 1, cell.column)
         }
-        if let previous = previousPresentedColumnIndex(before: cell.column) {
-            return (cell.row, previous)
-        }
-        guard cell.row > 0, let last = lastPresentedColumnIndex() else { return nil }
-        return (cell.row - 1, last)
     }
 }

--- a/TablePro/Views/Results/KeyHandlingTableView.swift
+++ b/TablePro/Views/Results/KeyHandlingTableView.swift
@@ -521,7 +521,13 @@ final class KeyHandlingTableView: NSTableView {
     ///
     /// A cell is drawn rather than mounted, so the element comes from the row's own accessibility
     /// children rather than from a cell view.
+    ///
+    /// Nothing is posted until a client has asked the grid something. The element does not exist
+    /// before that, so the notification had nowhere to land, and asking for it was itself enough to
+    /// mount a view per visible cell in every grid: the cost `#2381` removed, charged to a session
+    /// that pressed Tab once.
     internal func postCellCursorMoved() {
+        guard DataGridAccessibility.isActive else { return }
         guard selectedRow >= 0, presentsDataColumn(at: focusedColumn) else { return }
         guard let element = accessibilityCellElement(row: selectedRow, tableColumnIndex: focusedColumn) else { return }
         NSAccessibility.post(element: element, notification: .focusedUIElementChanged)
@@ -621,7 +627,9 @@ final class KeyHandlingTableView: NSTableView {
         return true
     }
 
-    private func focusCell(row: Int, column: Int) {
+    /// The one way the cell cursor is moved by a keystroke, used by Tab inside the grid and by the
+    /// inline editor's own Tab and arrow navigation.
+    internal func focusCell(row: Int, column: Int) {
         selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false)
         focusedRow = row
         focusedColumn = column

--- a/TableProTests/Views/Results/CellEditorArrowExitTests.swift
+++ b/TableProTests/Views/Results/CellEditorArrowExitTests.swift
@@ -1,0 +1,104 @@
+//
+//  CellEditorArrowExitTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+/// Up and Down carry the inline editor to the adjacent row, so a value that holds line breaks has
+/// to keep them for its own lines and give them up only at the line at that end (#2569).
+@Suite("Cell editor arrow exit")
+struct CellEditorArrowExitTests {
+    private func exit(_ value: String, selection: NSRange) -> CellEditorArrowExit {
+        CellEditorArrowExit(text: value as NSString, selection: selection)
+    }
+
+    @Test("A single line leaves the cell in both directions")
+    func singleLineLeavesInBothDirections() {
+        let placement = exit("alpha", selection: NSRange(location: 2, length: 0))
+
+        #expect(placement.canExitUp)
+        #expect(placement.canExitDown)
+    }
+
+    /// The editor opens with the whole value selected, which is where the first arrow press lands.
+    @Test("A fully selected single line still leaves the cell")
+    func fullySelectedSingleLineStillLeaves() {
+        let placement = exit("alpha", selection: NSRange(location: 0, length: 5))
+
+        #expect(placement.canExitUp)
+        #expect(placement.canExitDown)
+    }
+
+    @Test("An empty value leaves the cell in both directions")
+    func emptyValueLeaves() {
+        let placement = exit("", selection: NSRange(location: 0, length: 0))
+
+        #expect(placement.canExitUp)
+        #expect(placement.canExitDown)
+    }
+
+    @Test("The middle line of a multi-line value keeps both arrows")
+    func middleLineKeepsBothArrows() {
+        let placement = exit("a\nb\nc", selection: NSRange(location: 2, length: 0))
+
+        #expect(!placement.canExitUp)
+        #expect(!placement.canExitDown)
+    }
+
+    @Test("The first line of a multi-line value leaves upwards only")
+    func firstLineLeavesUpwardsOnly() {
+        let placement = exit("a\nb\nc", selection: NSRange(location: 0, length: 0))
+
+        #expect(placement.canExitUp)
+        #expect(!placement.canExitDown)
+    }
+
+    @Test("The last line of a multi-line value leaves downwards only")
+    func lastLineLeavesDownwardsOnly() {
+        let placement = exit("a\nb\nc", selection: NSRange(location: 5, length: 0))
+
+        #expect(!placement.canExitUp)
+        #expect(placement.canExitDown)
+    }
+
+    /// A caret sitting just before the closing break is still on the line above the empty one.
+    @Test("A trailing break still counts as a line below")
+    func trailingBreakCountsAsLineBelow() {
+        let placement = exit("a\n", selection: NSRange(location: 1, length: 0))
+
+        #expect(placement.canExitUp)
+        #expect(!placement.canExitDown)
+    }
+
+    /// A selection is a text-editing gesture in its own right, so the arrow collapses it first and
+    /// the press after that is the one that leaves.
+    @Test("A selection inside a multi-line value keeps both arrows")
+    func selectionInsideMultiLineKeepsBothArrows() {
+        let placement = exit("a\nb\nc", selection: NSRange(location: 0, length: 5))
+
+        #expect(!placement.canExitUp)
+        #expect(!placement.canExitDown)
+    }
+
+    @Test("A carriage return starts a line the same way a newline does")
+    func carriageReturnStartsALine() {
+        let placement = exit("a\r\nb", selection: NSRange(location: 4, length: 0))
+
+        #expect(!placement.canExitUp)
+        #expect(placement.canExitDown)
+    }
+
+    /// The selection comes from the text view, so it is already inside the value, but a stale one
+    /// must not read past the end.
+    @Test("A selection past the end of the value is clamped")
+    func selectionPastTheEndIsClamped() {
+        let placement = exit("alpha", selection: NSRange(location: 40, length: 10))
+
+        #expect(placement.canExitUp)
+        #expect(placement.canExitDown)
+    }
+}

--- a/TableProTests/Views/Results/CellEditorMovementTargetTests.swift
+++ b/TableProTests/Views/Results/CellEditorMovementTargetTests.swift
@@ -1,0 +1,205 @@
+//
+//  CellEditorMovementTargetTests.swift
+//  TableProTests
+//
+
+import AppKit
+import Foundation
+import SwiftUI
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+@MainActor
+private final class StubLayoutPersister: ColumnLayoutPersisting {
+    func load(for key: ColumnLayoutTableKey) -> ColumnLayoutState? { nil }
+    func save(_ layout: ColumnLayoutState, for key: ColumnLayoutTableKey) {}
+    func clear(for key: ColumnLayoutTableKey) {}
+}
+
+/// Where the inline editor goes when it is left with Tab, Shift+Tab, Up or Down, and what moving
+/// the cell cursor there costs. Tab wraps across rows because that is what Tab means; Up and Down
+/// hold the column and stop at the ends (#2569).
+@Suite("Cell editor movement target")
+@MainActor
+struct CellEditorMovementTargetTests {
+    private struct Grid {
+        let coordinator: TableViewCoordinator
+        let tableView: KeyHandlingTableView
+        let dataColumns: [Int]
+    }
+
+    private func makeGrid(rowCount: Int, columnNames: [String]) -> Grid {
+        let tableView = KeyHandlingTableView()
+        tableView.columnAutoresizingStyle = .noColumnAutoresizing
+        tableView.style = .plain
+        let rowNumberColumn = NSTableColumn(identifier: ColumnIdentitySchema.rowNumberIdentifier)
+        rowNumberColumn.width = 40
+        tableView.addTableColumn(rowNumberColumn)
+
+        let coordinator = TableViewCoordinator(
+            changeManager: AnyChangeManager(DataChangeManager()),
+            isEditable: true,
+            selectedRowIndices: .constant([]),
+            delegate: nil,
+            layoutPersister: StubLayoutPersister()
+        )
+        let rows = TableRows.from(
+            queryRows: (0..<rowCount).map { row in
+                columnNames.indices.map { PluginCellValue.text("r\(row)c\($0)") }
+            },
+            columns: columnNames,
+            columnTypes: columnNames.map { _ in ColumnType.text(rawType: "TEXT") }
+        )
+
+        coordinator.tableView = tableView
+        tableView.coordinator = coordinator
+        coordinator.tableRowsProvider = { rows }
+        coordinator.rebuildColumnMetadataCache(from: rows)
+        coordinator.columnPool.reconcile(
+            tableView: tableView,
+            schema: coordinator.identitySchema,
+            columnTypes: rows.columnTypes,
+            savedLayout: nil,
+            isEditable: true,
+            hiddenColumnNames: [],
+            widthCalculator: { _, _ in 100 }
+        )
+        tableView.dataSource = coordinator
+        coordinator.updateCache()
+        tableView.reloadData()
+
+        let dataColumns = tableView.tableColumns.indices.filter {
+            coordinator.presentsColumn(atTableColumnIndex: $0)
+        }
+        return Grid(coordinator: coordinator, tableView: tableView, dataColumns: dataColumns)
+    }
+
+    private func target(
+        _ grid: Grid,
+        row: Int,
+        column: Int,
+        movement: CellEditorMovement
+    ) -> (row: Int, column: Int)? {
+        grid.coordinator.movementTarget(
+            from: (row: row, column: column),
+            movement: movement,
+            in: grid.tableView
+        )
+    }
+
+    @Test("The grid harness presents every data column")
+    func harnessPresentsEveryDataColumn() {
+        let grid = makeGrid(rowCount: 3, columnNames: ["id", "name"])
+
+        #expect(grid.dataColumns.count == 2)
+        #expect(grid.tableView.numberOfRows == 3)
+    }
+
+    @Test("Down steps one row and holds the column")
+    func downStepsOneRowAndHoldsTheColumn() throws {
+        let grid = makeGrid(rowCount: 3, columnNames: ["id", "name"])
+        let column = try #require(grid.dataColumns.last)
+
+        let moved = try #require(target(grid, row: 0, column: column, movement: .down))
+
+        #expect(moved.row == 1)
+        #expect(moved.column == column)
+    }
+
+    @Test("Up steps one row and holds the column")
+    func upStepsOneRowAndHoldsTheColumn() throws {
+        let grid = makeGrid(rowCount: 3, columnNames: ["id", "name"])
+        let column = try #require(grid.dataColumns.first)
+
+        let moved = try #require(target(grid, row: 2, column: column, movement: .up))
+
+        #expect(moved.row == 1)
+        #expect(moved.column == column)
+    }
+
+    @Test("Down on the last row does not wrap")
+    func downOnTheLastRowDoesNotWrap() throws {
+        let grid = makeGrid(rowCount: 3, columnNames: ["id", "name"])
+        let column = try #require(grid.dataColumns.first)
+
+        let past = target(grid, row: 2, column: column, movement: .down)
+        #expect(past == nil)
+    }
+
+    @Test("Up on the first row does not wrap")
+    func upOnTheFirstRowDoesNotWrap() throws {
+        let grid = makeGrid(rowCount: 3, columnNames: ["id", "name"])
+        let column = try #require(grid.dataColumns.first)
+
+        let past = target(grid, row: 0, column: column, movement: .up)
+        #expect(past == nil)
+    }
+
+    @Test("Tab walks the row and wraps onto the next row's first column")
+    func tabWalksTheRowAndWraps() throws {
+        let grid = makeGrid(rowCount: 3, columnNames: ["id", "name"])
+        let first = try #require(grid.dataColumns.first)
+        let last = try #require(grid.dataColumns.last)
+
+        let within = try #require(target(grid, row: 0, column: first, movement: .tab))
+        #expect(within.row == 0)
+        #expect(within.column == last)
+
+        let wrapped = try #require(target(grid, row: 0, column: last, movement: .tab))
+        #expect(wrapped.row == 1)
+        #expect(wrapped.column == first)
+
+        let past = target(grid, row: 2, column: last, movement: .tab)
+        #expect(past == nil)
+    }
+
+    @Test("Shift+Tab walks back and wraps onto the previous row's last column")
+    func backtabWalksBackAndWraps() throws {
+        let grid = makeGrid(rowCount: 3, columnNames: ["id", "name"])
+        let first = try #require(grid.dataColumns.first)
+        let last = try #require(grid.dataColumns.last)
+
+        let within = try #require(target(grid, row: 1, column: last, movement: .backtab))
+        #expect(within.row == 1)
+        #expect(within.column == first)
+
+        let wrapped = try #require(target(grid, row: 1, column: first, movement: .backtab))
+        #expect(wrapped.row == 0)
+        #expect(wrapped.column == last)
+
+        let past = target(grid, row: 0, column: first, movement: .backtab)
+        #expect(past == nil)
+    }
+
+    /// A vertical step keeps whatever position it was given, so the row-number column and the
+    /// pool's spacers never come into it the way they do for Tab.
+    @Test("A vertical step never resolves a column of its own")
+    func verticalStepNeverResolvesAColumn() throws {
+        let grid = makeGrid(rowCount: 3, columnNames: ["id", "name", "email"])
+        let middle = grid.dataColumns[1]
+
+        let moved = try #require(target(grid, row: 1, column: middle, movement: .down))
+
+        #expect(moved.column == middle)
+    }
+
+    /// Reaching for a cell's accessibility element is what marks the grid active, and an active
+    /// grid mounts a view per visible cell. Moving the cursor asked for one every time, so a single
+    /// Tab press bought every grid in the session the cost `#2381` removed.
+    @Test("Moving the cell cursor leaves the accessibility layout alone")
+    func movingTheCursorLeavesAccessibilityAlone() throws {
+        let wasActive = DataGridAccessibility.isActive
+        DataGridAccessibility.isActive = false
+        defer { DataGridAccessibility.isActive = wasActive }
+        let grid = makeGrid(rowCount: 3, columnNames: ["id", "name"])
+        let column = try #require(grid.dataColumns.first)
+
+        grid.tableView.focusCell(row: 1, column: column)
+
+        #expect(!DataGridAccessibility.isActive)
+        #expect(grid.tableView.focusedRow == 1)
+        #expect(grid.tableView.focusedColumn == column)
+    }
+}

--- a/TableProTests/Views/Results/CellOverlayEditorMovementTests.swift
+++ b/TableProTests/Views/Results/CellOverlayEditorMovementTests.swift
@@ -1,0 +1,157 @@
+//
+//  CellOverlayEditorMovementTests.swift
+//  TableProTests
+//
+
+import AppKit
+import Foundation
+import Testing
+
+@testable import TablePro
+
+/// The overlay is a text view rather than a field editor, so the four selectors AppKit would have
+/// turned into an `NSTextMovement` are read here instead (#2569).
+@Suite("Cell overlay editor movement")
+@MainActor
+struct CellOverlayEditorMovementTests {
+    private struct Editing {
+        let editor: CellOverlayEditor
+        let textView: NSTextView
+        let tableView: KeyHandlingTableView
+    }
+
+    private func makeEditing(value: String, selection: NSRange) -> Editing {
+        let tableView = KeyHandlingTableView()
+        let editor = CellOverlayEditor()
+        editor.install(
+            in: tableView,
+            row: 4,
+            column: 2,
+            columnIndex: 1,
+            container: CellOverlayContainerView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        )
+        let textView = NSTextView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        CellOverlayBase.applyCellTextLayout(to: textView)
+        textView.string = value
+        textView.setSelectedRange(selection)
+        return Editing(editor: editor, textView: textView, tableView: tableView)
+    }
+
+    private struct Outcome {
+        let handled: Bool
+        let movement: CellEditorMovement?
+        let cell: (row: Int, column: Int)?
+    }
+
+    private func send(_ selector: Selector, to editing: Editing) -> Outcome {
+        var movement: CellEditorMovement?
+        var cell: (row: Int, column: Int)?
+        editing.editor.onMovement = { row, column, reported in
+            movement = reported
+            cell = (row, column)
+        }
+        let handled = editing.editor.textView(editing.textView, doCommandBy: selector)
+        editing.editor.removeOverlay()
+        return Outcome(handled: handled, movement: movement, cell: cell)
+    }
+
+    @Test("Down leaves a single-line value for the row below")
+    func downLeavesSingleLineValue() throws {
+        let editing = makeEditing(value: "alpha", selection: NSRange(location: 0, length: 5))
+
+        let result = send(#selector(NSResponder.moveDown(_:)), to: editing)
+
+        #expect(result.handled)
+        #expect(result.movement == .down)
+        let cell = try #require(result.cell)
+        #expect(cell.row == 4)
+        #expect(cell.column == 2)
+    }
+
+    @Test("Up leaves a single-line value for the row above")
+    func upLeavesSingleLineValue() {
+        let editing = makeEditing(value: "alpha", selection: NSRange(location: 2, length: 0))
+
+        let result = send(#selector(NSResponder.moveUp(_:)), to: editing)
+
+        #expect(result.handled)
+        #expect(result.movement == .up)
+    }
+
+    @Test("Down inside a multi-line value stays in the text view")
+    func downInsideMultiLineValueStays() {
+        let editing = makeEditing(value: "a\nb\nc", selection: NSRange(location: 0, length: 0))
+
+        let result = send(#selector(NSResponder.moveDown(_:)), to: editing)
+
+        #expect(!result.handled)
+        #expect(result.movement == nil)
+    }
+
+    @Test("Down from the last line of a multi-line value leaves the cell")
+    func downFromLastLineLeaves() {
+        let editing = makeEditing(value: "a\nb\nc", selection: NSRange(location: 5, length: 0))
+
+        let result = send(#selector(NSResponder.moveDown(_:)), to: editing)
+
+        #expect(result.handled)
+        #expect(result.movement == .down)
+    }
+
+    /// Shift+Down is `moveDownAndModifySelection:`, so extending a selection keeps its own meaning.
+    @Test("A selection-extending arrow is left to the text view")
+    func selectionExtendingArrowIsLeftAlone() {
+        let editing = makeEditing(value: "alpha", selection: NSRange(location: 0, length: 0))
+
+        let result = send(#selector(NSResponder.moveDownAndModifySelection(_:)), to: editing)
+
+        #expect(!result.handled)
+        #expect(result.movement == nil)
+    }
+
+    /// The text view holds provisional text until the input method commits it, so a movement here
+    /// would save a half-composed value. The arrow goes back to the composition, which is what
+    /// moves the caret through it; Tab is swallowed rather than turned into a literal tab.
+    @Test("An arrow during an IME composition stays with the composition")
+    func arrowDuringCompositionStaysWithTheComposition() {
+        let editing = makeEditing(value: "", selection: NSRange(location: 0, length: 0))
+        editing.textView.setMarkedText(
+            "\u{304B}",
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: 0, length: 0)
+        )
+
+        let result = send(#selector(NSResponder.moveDown(_:)), to: editing)
+
+        #expect(editing.textView.hasMarkedText())
+        #expect(!result.handled)
+        #expect(result.movement == nil)
+    }
+
+    @Test("Tab during an IME composition is swallowed rather than leaving the cell")
+    func tabDuringCompositionIsSwallowed() {
+        let editing = makeEditing(value: "", selection: NSRange(location: 0, length: 0))
+        editing.textView.setMarkedText(
+            "\u{304B}",
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: 0, length: 0)
+        )
+
+        let result = send(#selector(NSResponder.insertTab(_:)), to: editing)
+
+        #expect(result.handled)
+        #expect(result.movement == nil)
+    }
+
+    @Test("Tab and Shift+Tab report their own movements")
+    func tabAndBacktabReportTheirMovements() {
+        let caret = NSRange(location: 0, length: 0)
+        let forward = send(#selector(NSResponder.insertTab(_:)), to: makeEditing(value: "alpha", selection: caret))
+        let backward = send(#selector(NSResponder.insertBacktab(_:)), to: makeEditing(value: "alpha", selection: caret))
+
+        #expect(forward.handled)
+        #expect(forward.movement == .tab)
+        #expect(backward.handled)
+        #expect(backward.movement == .backtab)
+    }
+}

--- a/docs/features/keyboard-shortcuts.mdx
+++ b/docs/features/keyboard-shortcuts.mdx
@@ -100,6 +100,8 @@ Every row except Find, Find Next and Find Previous is built into the editor and 
 | Action | Shortcut |
 |--------|----------|
 | Edit cell | `Enter` |
+| Edit the next / previous cell | `Tab` / `Shift+Tab` |
+| Edit the cell above / below | `Up` / `Down` |
 | Insert a line break while editing | `Option+Enter` |
 | Cancel edit | `Escape` |
 | Add row | `Cmd+Shift+N` |
@@ -110,6 +112,8 @@ Every row except Find, Find Next and Find Previous is built into the editor and 
 | Commit changes | `Cmd+S` |
 | Undo change | `Cmd+Z` |
 | Redo change | `Cmd+Shift+Z` |
+
+`Tab`, `Shift+Tab`, `Up` and `Down` save the cell before they move. In a value that holds line breaks, `Up` and `Down` move the insertion point between its lines and leave the cell only from the first or last one.
 
 Truncate table opens a dialog with **Cascade** and **Ignore foreign key checks**, then stages a pending truncate that `Cmd+S` runs.
 


### PR DESCRIPTION
## What

`Up` and `Down` in a cell's inline editor now save the cell and reopen the editor on the same column of the row above or below, the way `Tab` and `Shift+Tab` already walk the row.

Fixes #2569.

## Root cause

The inline editor is a standalone `NSTextView` overlay (`CellOverlayEditor`), not a field editor. Its `textView(_:doCommandBy:)` read `insertNewline:`, `cancelOperation:`, `insertTab:` and `insertBacktab:` and nothing else, so `moveUp:` and `moveDown:` fell through to the text view, where a single-line value has no line to move to and the keystroke did nothing.

AppKit already has the vocabulary for the missing half. `NSTextMovement` declares `up` and `down` beside `tab` and `backtab` as "movement codes for movement between fields", and a field editor reports them when the user leaves the field with an arrow key. The overlay is not a field editor, so it has to read the four selectors itself.

## The fix

`onTabNavigation(row:column:forward:)` was a boolean-flagged callback that could only ever express two of the four movements. It becomes `onMovement(row:column:movement:)` carrying a `CellEditorMovement` enum with the same four cases AppKit names, and `TableViewCoordinator.movementTarget(from:movement:in:)` resolves all four in one switch. `Tab` and `Shift+Tab` keep their existing meaning, including the wrap onto the next or previous row. `Up` and `Down` hold the column, step one row, and stop at the ends rather than wrapping.

A cell value can hold line breaks (`Option+Return` inserts one), so the arrows belong to the value's own lines first. `CellEditorArrowExit` is the rule, and it is pure: the editor is left when the value is a single line, or when the caret sits on the first or last line with nothing selected. A line break is the only thing that starts a line here because the overlay never wraps text, which `CellOverlayTextLayoutTests` already pins.

Both `Shift+Arrow` (`moveUpAndModifySelection:`) and `Option`/`Command` arrows map to selectors of their own, so extending a selection and jumping to the ends of the value keep their native meaning. `Control+P` and `Control+N` do map to `moveUp:`/`moveDown:` in `StandardKeyBinding.dict`, and they leave the cell too: Cocoa's key bindings exist so code answers the command rather than the key, and gating on a key code would break both those and a user's own `DefaultKeyBinding.dict`.

An active input method keeps the key. Until the composition is committed the text view holds provisional text, so leaving the cell would save a half-composed value and carry the editor off it. `hasMarkedText()` now guards all four movements, not just the two new ones: `Tab` and `Shift+Tab` had the same hole. An arrow is handed back so the caret still moves through the marked text; `Tab` is swallowed rather than turned into a literal tab.

## Why commit-then-navigate is safe against a re-sort

The editor commits before the target row is resolved, which raises the obvious question of whether the commit can reorder the grid under the number about to be used. It cannot, in the same runloop turn. Nothing recomputes a display position synchronously from a cell edit: the structure grid's `currentProvider` is a stored property the view sets per render, the CSV inspector's `recomputeDisplay()` hands its filter and sort to a detached task, and the data tab's `.fullReplace` lives in `applyDelta`, which no cell commit reaches. A later render cannot disturb an open editor either, because `DataGridView.updateNSView` returns at its third line while one is active. The reorder lands when the editor closes, with no editor open to be wrong about.

## Four defects found in the same routine, fixed with it

The IME hole above is the first: `Tab` and `Shift+Tab` have shipped committing a half-composed value since the overlay editor existed.


The other three are in cursor handling. The vertical step needs the cell cursor to follow the editor, and the tab path's own turned out to be incomplete in three ways, all fixed by routing both through the grid's existing `KeyHandlingTableView.focusCell(row:column:)`:

- `handleOverlayTabNavigation` selected the target row but never scrolled it into view, so `Tab` wrapping onto the row below the last visible one opened the editor off screen and typing went into an invisible field.
- It never moved `focusedColumn`, so after `Tab` carried the editor to the next column, closing it put the cell cursor back on the column the editing did not happen in.
- `postCellCursorMoved()` reached for the cell's accessibility element unconditionally, and asking for one calls `DataGridAccessibility.markActive()`. One `Tab` press in the grid therefore switched every grid in the session to its accessibility layout, mounting a view per visible cell, with no assistive client attached: exactly the cost #2381 removed. It now returns early unless a client has already asked the grid something, which is the only state in which the element it posts about exists at all.

## Testing

- `CellEditorArrowExitTests` (10 cases): the caret rule, over single-line, empty, multi-line, trailing-break, `\r\n`, selection and out-of-range-selection inputs.
- `CellEditorMovementTargetTests` (9 cases): target resolution on a real grid harness, covering the vertical step, both ends, the existing tab and backtab wraps, and that moving the cursor no longer activates the accessibility layout.
- `CellOverlayEditorMovementTests` (8 cases): which selectors the editor takes and which it leaves to the text view, the movement each one reports, and both IME cases driven through `setMarkedText`.
- `verify.sh build`: PASS.
- `verify.sh test` over the three new suites plus `KeyHandlingTableViewOverlayTests`, `CellOverlayTextLayoutTests`, `DrawnCellReachabilityTests`, `DataGridRowIdentityTests`, `FocusedColumnResolutionTests`, `KeyHandlingTableViewCopyTests` and `TableViewCoordinatorLayoutTests`: PASS.
- `verify.sh docs`: PASS.
- `swiftlint --strict` over all seven changed files: 0 violations. `verify.sh lint` itself reports FAIL, on three findings in `MainSplitViewController+TabStripAccessory.swift` and `EditorTabContextMenuBuilder.swift` and one stale `AXCell` symbol in `CLAUDE.md`. All four are on `main` already: those files are byte-identical to `origin/main` on this branch.
- The accessibility guard was checked in the negative as well: removing it makes `movingTheCursorLeavesAccessibilityAlone()` the single failure out of the suite's nine.

No `TableProUITests` coverage. Driving this flow needs a click into a cell of a live editable table and then a read of the overlay's contents, and the drawn-cell grid publishes no element for either: a row is as wide as the grid so its centre is empty width, columns are siblings of rows and later in the tree, so XCUITest reads every row and cell as obscured and refuses to click them, and the overlay text view carries no identifier of its own. Adding one purely to be asserted on would be test machinery in shipping code.

## Screenshots

Not included: the change is a keystroke, and every frame of it looks like the editor already looks. The visible difference is which row the editor is on after the key, which a still does not carry.
