### PR TITLE
fix(tabs): keep the editor tabs reachable to accessibility over the pointer's owner

### DIFF
--- a/TablePro/Views/Main/EditorTabInteractionView.swift
+++ b/TablePro/Views/Main/EditorTabInteractionView.swift
@@ -31,6 +31,7 @@ internal final class EditorTabInteractionView: NSView {
     /// the content.
     internal var onRowCountChanged: ((Int) -> Void)?
 
+    private var isResolvingAccessibilityHit = false
     private var hoverTrackingArea: NSTrackingArea?
     private var lastActivatedTabId: UUID?
 
@@ -110,10 +111,25 @@ internal final class EditorTabInteractionView: NSView {
 
     /// Claims the track and nothing else, so a press on a tab is this view's and a press on the
     /// new-tab button, on the band's insets or on the chrome below the track is not.
+    ///
+    /// The claim is for the pointer alone. Accessibility resolves a screen point through this same
+    /// method, so claiming it unconditionally answered "the strip" for every tab and took all of
+    /// them out of reach of VoiceOver, Switch Control, Voice Control and XCUITest at once: this
+    /// view publishes nothing, so there was no element under a tab to speak, press or click. That
+    /// shipped in #2571 and turned the whole UI suite red from the commit that merged it.
     override internal func hitTest(_ point: NSPoint) -> NSView? {
+        guard !isResolvingAccessibilityHit else { return super.hitTest(point) }
         let local = convert(point, from: superview)
         guard trackRect.contains(local) else { return super.hitTest(point) }
         return self
+    }
+
+    /// Answers from the SwiftUI tree, which is where the tabs publish themselves. The pointer's
+    /// claim is lifted for the length of the question.
+    override internal func accessibilityHitTest(_ point: NSPoint) -> Any? {
+        isResolvingAccessibilityHit = true
+        defer { isResolvingAccessibilityHit = false }
+        return super.accessibilityHitTest(point)
     }
 
     private func tabIndex(atViewPoint point: CGPoint) -> Int? {

--- a/TableProUITests/EditorTabDetachUITests.swift
+++ b/TableProUITests/EditorTabDetachUITests.swift
@@ -80,7 +80,7 @@ final class EditorTabDetachUITests: UITestCase {
         let target = try XCTUnwrap(tabLabels(in: window).last)
         tab(named: target, in: window).rightClick()
 
-        let item = app.menuItems["Move Tab to New Window"]
+        let item = app.menuItems.matching(identifier: "Move Tab to New Window").firstMatch
         XCTAssertTrue(item.waitToExist(timeout: 5), "The command must be listed")
         XCTAssertTrue(item.isEnabled, "It must be offered on an idle tab among others")
         app.typeKey(XCUIKeyboardKey.escape, modifierFlags: [])
@@ -92,7 +92,7 @@ final class EditorTabDetachUITests: UITestCase {
         let target = tab(named: name, in: window)
         XCTAssertTrue(waitUntilHittable(target, timeout: 20), "The tab must be hittable")
         target.rightClick()
-        let item = app.menuItems["Move Tab to New Window"]
+        let item = app.menuItems.matching(identifier: "Move Tab to New Window").firstMatch
         XCTAssertTrue(item.waitToExist(timeout: 5), "The command must be listed")
         item.click()
     }


### PR DESCRIPTION
`main` has been red since #2571 merged. This is why, and the fix.

## What broke

`EditorTabInteractionView.hitTest` claims the tab track so the pointer has a single owner, which is what #2571 was for. Accessibility resolves a screen point through that same method, so the claim answered "the strip" for every tab, and the strip publishes nothing: there was no element under a tab to speak, press or click.

So this was never only a test problem. VoiceOver, Switch Control and Voice Control lost the tabs at the same time XCUITest did.

The claim is now lifted for the length of an `accessibilityHitTest`, and the pointer keeps it.

## The failures it accounts for

Six cases across all three UI shards, in two suites I added and one that predates the change:

| Suite | Case | Message |
| --- | --- | --- |
| `EditorTabReorderUITests` | `testAFastDragReordersTheStrip` | The dragged tab must be hittable |
| `EditorTabReorderUITests` | `testDraggingATabNeverMovesTheWindow` | The dragged tab must be hittable |
| `EditorTabDetachUITests` | `testMoveTabToNewWindowTakesTheTabOutOfTheStrip` | The tab must be hittable |
| `EditorTabDetachUITests` | `testClosingTheDetachedWindowLeavesTheOriginalWorking` | The tab must be hittable |
| `QueryInsightsTabUITests` | `testTheQueryInsightsTabOpensOnceCarriesItsFiltersAndStaysGatedWithoutALicense` | A tab in the strip must be clickable |
| `EditorTabDetachUITests` | `testTheCommandIsOfferedOnAnIdleTab` | Multiple matching elements found |

The last one is separate and is mine: **Move Tab to New Window** exists on the AppKit contextual menu the pointer uses and on the SwiftUI menu kept for VoiceOver, so the query matched twice. It now takes `firstMatch`.

`QueryInsightsTabUITests` is the one that shows the blast radius: it predates all of this and was green until #2571.

## Why I am confident without a local reproduction

`main` was green at `bb0371ea2`, the commit before #2571, and has failed every run since `f48d20217`, which is #2571 itself. The failures are all "not hittable" on `editor-tab`, and the only change to how those elements are hit-tested is the `hitTest` claim.

I could not reproduce it here: `TableProUITests` does not run on this machine at all, at clean `main` as well as on a branch, and a standalone harness cannot answer the question either because SwiftUI builds no accessibility tree until a client attaches. CI is the verification for this one.

## Verified

- `build` PASS.
- `swiftlint lint --strict` clean.
- The six failing cases above are the gate. They are not quarantined, so CI on this PR is the check that matters.

https://claude.ai/code/session_01L7uaHbJBPV1LaWL5QXzxyp
