### PR TITLE
fix(datagrid): value-filter popover value font and row alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MongoDB `.sort()` and `.projection()` silently ignored when written with unquoted keys.
 - Compare & Sync unable to drop an overloaded PostgreSQL routine, or any trigger.
 - PostgreSQL sequence DDL naming the schema it was read from, in SQL export and the structure editor.
+- Value-filter popover listing values in the system font, with rows indented differently than Select All.
 
 ## [0.69.0] - 2026-08-27
 

--- a/TablePro/Views/Results/ColumnValueFilterPopover.swift
+++ b/TablePro/Views/Results/ColumnValueFilterPopover.swift
@@ -18,6 +18,7 @@ struct ColumnValueFilterPopover: View {
 
     private static let nullLabel = String(localized: "(NULL)")
     private static let emptyLabel = String(localized: "(Empty)")
+    private static let horizontalInset: CGFloat = 14
 
     init(
         columnName: String,
@@ -65,7 +66,7 @@ struct ColumnValueFilterPopover: View {
                 .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 14)
+        .padding(.horizontal, Self.horizontalInset)
         .padding(.top, 12)
         .padding(.bottom, 8)
     }
@@ -89,7 +90,7 @@ struct ColumnValueFilterPopover: View {
                 Spacer()
             }
         }
-        .padding(.horizontal, 14)
+        .padding(.horizontal, Self.horizontalInset)
         .padding(.vertical, 8)
     }
 
@@ -99,6 +100,7 @@ struct ColumnValueFilterPopover: View {
                 Toggle(isOn: binding(for: value)) {
                     HStack(spacing: 8) {
                         Text(label(for: value))
+                            .font(ThemeEngine.shared.valueFontSwiftUI)
                             .lineLimit(1)
                             .truncationMode(.tail)
                             .foregroundStyle(value.isNull ? Color.secondary : Color.primary)
@@ -109,6 +111,9 @@ struct ColumnValueFilterPopover: View {
                     }
                 }
                 .toggleStyle(.checkbox)
+                .listRowInsets(EdgeInsets(
+                    top: 2, leading: Self.horizontalInset, bottom: 2, trailing: Self.horizontalInset
+                ))
             }
         }
         .listStyle(.plain)

--- a/TableProTests/Theme/ValueFontTests.swift
+++ b/TableProTests/Theme/ValueFontTests.swift
@@ -98,6 +98,7 @@ struct ValueFontTests {
             "TablePro/Views/RightSidebar/FieldEditors/SetPickerView.swift",
             "TablePro/Views/Results/CellOverlayEditor.swift",
             "TablePro/Views/Results/CellOverlayViewer.swift",
+            "TablePro/Views/Results/ColumnValueFilterPopover.swift",
             "TablePro/Views/Results/TextViewerWindowController.swift",
             "TablePro/Views/Results/HexEditorContentView.swift",
             "TablePro/Views/Results/ForeignKeyPreviewView.swift",


### PR DESCRIPTION
## Problem

The column value-filter popover renders its distinct values in the system font instead of the Data Grid Font, and its value rows sit at a different left edge than the Select All row above them, so the two checkbox columns do not line up.

## Root cause

The value `Text` carried no font modifier, so it fell back to the system face. That is the #2393 defect class: it looks right only while the user leaves the Data Grid Font at the default, so it ships invisibly. The alignment gap comes from two owners of the left edge: the Select All row is padded `.horizontal, 14` while the value rows keep the plain `List` style's default row insets.

## Fix

- The value label resolves `ThemeEngine.shared.valueFontSwiftUI`, the same way every other value-rendering popover does. The occurrence count keeps `.callout.monospacedDigit()`; it is metadata, not a stored value.
- One private `horizontalInset` constant now owns the left edge, consumed by the header, the controls row and the value rows' `.listRowInsets`, so the columns cannot drift apart again. Same pattern `ColumnVisibilityPopover` uses for its rows.

## Tests

`ColumnValueFilterPopover.swift` added to `ValueFontTests.standaloneValueViewsResolveTheValueFont`, the source-scanning guard that fails when a value-rendering view stops resolving the value font. Suite passes (7 tests). The alignment itself is a shared-constant layout fact with no deterministic UI-test surface; the popover needs a live connection and a loaded column to open.
