### PR TITLE
fix(mongodb): implement dropObjectStatement to support dropping collections from UI

### DIFF
--- a/Plugins/MongoDBDriverPlugin/MongoDBPluginDriver.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBPluginDriver.swift
@@ -634,11 +634,11 @@ final class MongoDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         )
     }
 
-    /// A collection drop is a shell statement, not a SQL one: `db.<collection>.drop()`. The
-    /// app-level fallback would emit `DROP TABLE <name>`, which the Mongo shell parser rejects.
+    /// A collection drop is a shell statement, not a SQL one: `db.getCollection("<name>").drop()`.
+    /// The app-level fallback would emit `DROP TABLE <name>`, which the Mongo shell parser rejects.
     /// Mongo has no schemas or cascade, so both are ignored.
     func dropObjectStatement(name: String, objectType: String, schema: String?, cascade: Bool) -> String? {
-        "db.\(name).drop()"
+        "db.getCollection(\"\(escapeJsonString(name))\").drop()"
     }
 
     func dropDatabase(name: String) async throws {

--- a/Plugins/MongoDBDriverPlugin/MongoDBPluginDriver.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBPluginDriver.swift
@@ -634,6 +634,13 @@ final class MongoDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         )
     }
 
+    /// A collection drop is a shell statement, not a SQL one: `db.<collection>.drop()`. The
+    /// app-level fallback would emit `DROP TABLE <name>`, which the Mongo shell parser rejects.
+    /// Mongo has no schemas or cascade, so both are ignored.
+    func dropObjectStatement(name: String, objectType: String, schema: String?, cascade: Bool) -> String? {
+        "db.\(name).drop()"
+    }
+
     func dropDatabase(name: String) async throws {
         guard let conn = mongoConnection else {
             throw MongoDBPluginError.notConnected

--- a/TableProTests/Core/MongoDB/MongoShellParserTests.swift
+++ b/TableProTests/Core/MongoDB/MongoShellParserTests.swift
@@ -312,11 +312,21 @@ struct MongoShellParserTests {
         }
     }
 
+    @Test("getCollection with drop")
+    func testGetCollectionDrop() throws {
+        let op = try MongoShellParser.parse("db.getCollection(\"audit-logs.2026\").drop()")
+        if case .drop(let collection) = op {
+            #expect(collection == "audit-logs.2026")
+        } else {
+            Issue.record("Expected .drop operation")
+        }
+    }
+
     @Test("SQL DROP TABLE fallback is rejected for MongoDB collections")
     func testDropTableFallbackIsRejected() {
         // The sidebar's drop used to fall through to the SQL fallback and emit
         // `DROP TABLE "<collection>"`, which the Mongo shell parser rejects. Dropping a
-        // collection must go through `db.<collection>.drop()` instead.
+        // collection must go through `db.getCollection("<collection>").drop()` instead.
         do {
             _ = try MongoShellParser.parse("DROP TABLE \"users\"")
             Issue.record("Expected the SQL DROP TABLE fallback to be rejected")

--- a/TableProTests/Core/MongoDB/MongoShellParserTests.swift
+++ b/TableProTests/Core/MongoDB/MongoShellParserTests.swift
@@ -312,6 +312,19 @@ struct MongoShellParserTests {
         }
     }
 
+    @Test("SQL DROP TABLE fallback is rejected for MongoDB collections")
+    func testDropTableFallbackIsRejected() {
+        // The sidebar's drop used to fall through to the SQL fallback and emit
+        // `DROP TABLE "<collection>"`, which the Mongo shell parser rejects. Dropping a
+        // collection must go through `db.<collection>.drop()` instead.
+        do {
+            _ = try MongoShellParser.parse("DROP TABLE \"users\"")
+            Issue.record("Expected the SQL DROP TABLE fallback to be rejected")
+        } catch {
+            // Any parse failure is the point: a Mongo connection must never send SQL.
+        }
+    }
+
     @Test("runCommand")
     func testRunCommand() throws {
         let op = try MongoShellParser.parse("db.runCommand({\"ping\": 1})")


### PR DESCRIPTION
### Summary of Changes
Fixes the issue where dropping a MongoDB collection from the sidebar UI failed with the error:
> `Invalid MongoDB syntax: Query must start with 'db.' or be a JSON command`

### Root Cause
Collection drop requests from the sidebar route through `batchToggleDelete` → `TableOperationSQLBuilder.dropObjectStatement` → `PluginDriverAdapter.dropObjectStatement`. When the underlying plugin does not implement `dropObjectStatement`, it defaults to the generic SQL fallback (`DROP <objectType> <name>`). Because `MongoDBPluginDriver` did not implement this method, it produced raw SQL (`DROP TABLE "<name>"`), which was rejected by `MongoShellParser`.

### Solution
- Implemented `dropObjectStatement` in `MongoDBPluginDriver` to return `db.<collection>.drop()`, enabling proper execution through the embedded `mongosh` runtime.
- Added regression test `testDropTableFallbackIsRejected` in `MongoShellParserTests`.

### Verification
- Built `MongoDBDriver` and the full `TablePro` target in Debug configuration.
- Executed and passed all 113 tests in `MongoShellParserTests` and `PluginDriverAdapterTableOpsTests`.

Closes #2581