### PR TITLE
fix(localization): unbreak main and translate the 742 catalog entries that shipped in English

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recognition of SQLite and DuckDB databases by their contents, whatever they are named. (#2476)
 - `.parquet` files in Finder's Open With, read through DuckDB. (#2476)
 - Prompt to install the driver a file needs, before the file opens. (#2476)
+- Korean, Turkish, Vietnamese and Chinese for the 742 untranslated strings, and for the document kinds Finder shows.
 
 ### Changed
 

--- a/TablePro/InfoPlist.xcstrings
+++ b/TablePro/InfoPlist.xcstrings
@@ -2,7 +2,38 @@
   "sourceLanguage" : "en",
   "strings" : {
     "Beancount Ledger" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beancount 원장"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beancount Defteri"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sổ cái Beancount"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beancount 账本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beancount 帳本"
+          }
+        }
+      }
     },
     "CFBundleDisplayName" : {
       "comment" : "Bundle display name",
@@ -14,7 +45,8 @@
             "value" : "TablePro"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "CFBundleName" : {
       "comment" : "Bundle name",
@@ -26,10 +58,42 @@
             "value" : "TablePro"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "DuckDB Database" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DuckDB 데이터베이스"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DuckDB Veritabanı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cơ sở dữ liệu DuckDB"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DuckDB 数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DuckDB 資料庫"
+          }
+        }
+      }
     },
     "NSDesktopFolderUsageDescription" : {
       "comment" : "Privacy - Desktop Folder Usage Description",
@@ -200,19 +264,174 @@
       }
     },
     "SQL File" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL 파일"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL Dosyası"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tệp SQL"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL 文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQL 檔案"
+          }
+        }
+      }
     },
     "SQLite Database" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQLite 데이터베이스"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQLite Veritabanı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cơ sở dữ liệu SQLite"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQLite 数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SQLite 資料庫"
+          }
+        }
+      }
     },
     "TablePro Connection" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 연결"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro Bağlantısı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết nối TablePro"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 連線"
+          }
+        }
+      }
     },
     "TablePro Filter Row" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 필터 행"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro Filtre Satırı"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hàng lọc TablePro"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 筛选行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 篩選列"
+          }
+        }
+      }
     },
     "TablePro Plugin" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 플러그인"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro Eklentisi"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plugin TablePro"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 插件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TablePro 外掛"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -453,7 +453,38 @@
       }
     },
     "'%@' has no primary key, so identical rows cannot be told apart. Add a primary key, or edit the rows with a query." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "'%@'에 기본 키가 없어 동일한 행을 구분할 수 없습니다. 기본 키를 추가하거나 쿼리로 행을 편집하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "'%@' birincil anahtara sahip değil, bu yüzden aynı satırlar birbirinden ayırt edilemiyor. Bir birincil anahtar ekleyin veya satırları bir sorguyla düzenleyin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "'%@' không có khoá chính nên không thể phân biệt các dòng giống nhau. Hãy thêm khoá chính, hoặc sửa các dòng bằng truy vấn.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "'%@' 没有主键，因此无法区分完全相同的行。请添加主键，或用查询编辑这些行。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "'%@' 沒有主鍵，因此無法區分完全相同的列。請新增主鍵，或用查詢編輯這些列。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "'%@' is a reserved Windows device name" : {
       "extractionState" : "stale",
@@ -491,7 +522,38 @@
       }
     },
     "'since' must not be later than 'until'." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "'since'는 'until'보다 늦을 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "'since', 'until' değerinden sonra olamaz.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "'since' không được muộn hơn 'until'.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "'since' 不能晚于 'until'。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "'since' 不能晚於 'until'。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "“%@” owns database objects" : {
       "localizations" : {
@@ -1519,7 +1581,38 @@
       }
     },
     "%@\nPreview tab. Double-click to keep it open." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@\n미리보기 탭입니다. 계속 열어 두려면 두 번 클릭하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@\nÖnizleme sekmesi. Açık tutmak için çift tıklayın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%@\nTab xem trước. Nhấp đúp để giữ tab mở.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%@\n预览标签页。双击可保持打开。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%@\n預覽標籤頁。連按兩下可保持開啟。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%@ · You" : {
       "localizations" : {
@@ -1865,7 +1958,38 @@
       }
     },
     "%@ accepted the SSH connection but refused the SFTP subsystem." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@이(가) SSH 연결은 수락했지만 SFTP 하위 시스템은 거부했습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ SSH bağlantısını kabul etti ancak SFTP alt sistemini reddetti.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%@ đã chấp nhận kết nối SSH nhưng từ chối hệ thống con SFTP.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%@ 接受了 SSH 连接，但拒绝了 SFTP 子系统。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%@ 接受了 SSH 連線，但拒絕了 SFTP 子系統。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%@ cannot be compared, because its driver does not expose metadata." : {
       "localizations" : {
@@ -2004,7 +2128,38 @@
       }
     },
     "%@ cannot restore a deleted row with its original key." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@은(는) 삭제된 행을 원래 키로 복원할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@, silinmiş bir satırı özgün anahtarıyla geri yükleyemiyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%@ không thể khôi phục dòng đã xoá với khoá gốc của nó.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%@ 无法用原来的键恢复已删除的行。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%@ 無法用原來的鍵還原已刪除的列。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%@ completed" : {
       "localizations" : {
@@ -2041,7 +2196,38 @@
       }
     },
     "%@ connections open a server, not a database file, so there is nothing to fetch over SSH." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@ 연결은 데이터베이스 파일이 아니라 서버를 여는 것이므로 SSH로 가져올 것이 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ bağlantıları bir veritabanı dosyasını değil bir sunucuyu açar, bu yüzden SSH üzerinden alınacak bir şey yok.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kết nối %@ mở một máy chủ chứ không phải tệp cơ sở dữ liệu, nên không có gì để tải qua SSH.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%@ 连接打开的是服务器而不是数据库文件，因此没有内容需要通过 SSH 获取。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%@ 連線開啟的是伺服器而不是資料庫檔案，因此沒有內容需要透過 SSH 取得。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%@ could not be loaded" : {
       "localizations" : {
@@ -2317,7 +2503,38 @@
       }
     },
     "%@ is a directory, not a database file." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@은(는) 데이터베이스 파일이 아니라 디렉터리입니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ bir veritabanı dosyası değil, bir dizin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%@ là một thư mục, không phải tệp cơ sở dữ liệu.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%@ 是一个目录，不是数据库文件。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%@ 是一個目錄，不是資料庫檔案。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%@ is already assigned to \"%@\". Reassigning will remove it from that action." : {
       "extractionState" : "stale",
@@ -2952,7 +3169,38 @@
       }
     },
     "%@ row" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@행",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ satır",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%@ dòng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%@ 行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%@ 列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%@ rows" : {
       "comment" : "Total rows for a query shape, %@ is a count",
@@ -3340,7 +3588,38 @@
       }
     },
     "%@, finished" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@, 완료됨",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@, bitti",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%@, đã xong",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%@，已完成",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%@，已完成",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%@, pinned" : {
       "localizations" : {
@@ -3377,7 +3656,38 @@
       }
     },
     "%@, preview tab" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@, 미리보기 탭",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@, önizleme sekmesi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%@, tab xem trước",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%@，预览标签页",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%@，預覽標籤頁",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%@, Pro feature" : {
       "localizations" : {
@@ -3909,7 +4219,38 @@
       }
     },
     "%1$@ … %2$d lines" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%1$@ … %2$d줄",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%1$@ … %2$d satır",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%1$@ … %2$d dòng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%1$@ … %2$d 行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%1$@ … %2$d 行",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%1$@ · %2$@" : {
       "localizations" : {
@@ -4049,7 +4390,38 @@
       }
     },
     "%1$@ • Color: %2$@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%1$@ • 색상: %2$@",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%1$@ • Renk: %2$@",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%1$@ • Màu: %2$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%1$@ • 颜色：%2$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%1$@ • 顏色：%2$@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%1$@ → %2$@" : {
       "localizations" : {
@@ -4233,7 +4605,38 @@
       }
     },
     "%1$@ in %2$@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%2$@의 %1$@",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%2$@ içinde %1$@",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%1$@ trong %2$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%2$@ 中的 %1$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%2$@ 中的 %1$@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%1$@ of %2$@" : {
       "localizations" : {
@@ -4375,16 +4778,140 @@
       "shouldTranslate" : false
     },
     "%1$@, %2$@, saved %3$@. Triggers, audit rows and cascade deletes are not reversed." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%1$@, %2$@, %3$@에 저장됨. 트리거, 감사 행, 연쇄 삭제는 되돌리지 않습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%1$@, %2$@, %3$@ kaydedildi. Tetikleyiciler, denetim satırları ve zincirleme silmeler geri alınmaz.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%1$@, %2$@, đã lưu %3$@. Trigger, dòng kiểm toán và xoá dây chuyền không được hoàn tác.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%1$@，%2$@，保存于 %3$@。触发器、审计行和级联删除不会被撤销。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%1$@，%2$@，儲存於 %3$@。觸發器、稽核列和串聯刪除不會被還原。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%1$@, color %2$@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%1$@, 색상 %2$@",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%1$@, renk %2$@",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%1$@, màu %2$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%1$@，颜色 %2$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%1$@，顏色 %2$@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%1$@, returns %2$@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%1$@, %2$@ 반환",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%1$@, %2$@ döndürür",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%1$@, trả về %2$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%1$@，返回 %2$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%1$@，回傳 %2$@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%1$@, schema %2$@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%1$@, 스키마 %2$@",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%1$@, şema %2$@",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%1$@, schema %2$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%1$@，Schema %2$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%1$@，綱要 %2$@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%1$@: %2$@" : {
       "comment" : "A list of failed drops, one per line.",
@@ -4663,7 +5190,38 @@
       }
     },
     "%1$d will be restored, %2$d left alone" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%1$d개는 복원되고 %2$d개는 그대로 둡니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%1$d tanesi geri yüklenecek, %2$d tanesine dokunulmayacak",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%1$d sẽ được khôi phục, %2$d giữ nguyên",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "将恢复 %1$d 个，保留 %2$d 个不变",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "將還原 %1$d 個，保留 %2$d 個不變",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%1$lld of %2$lld devices" : {
       "localizations" : {
@@ -4769,7 +5327,38 @@
       }
     },
     "%1$lld of %2$lld statements were already written, and %3$@ cannot roll them back." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%2$lld개 명령문 중 %1$lld개가 이미 기록되었으며, %3$@은(는) 이를 롤백할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%2$lld ifadeden %1$lld tanesi zaten yazıldı ve %3$@ bunları geri alamıyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%1$lld trên %2$lld câu lệnh đã được ghi, và %3$@ không thể rollback chúng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%2$lld 条语句中已有 %1$lld 条写入，%3$@ 无法回滚它们。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%2$lld 條陳述式中已有 %1$lld 條寫入，%3$@ 無法回復它們。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%1$lld of %2$lld statements were applied. This connection does not roll back user and role changes." : {
       "localizations" : {
@@ -4876,13 +5465,106 @@
       }
     },
     "%1$lldh %2$02lldm" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%1$lld시간 %2$02lld분",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%1$lld sa %2$02lld dk",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%1$lld giờ %2$02lld phút",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%1$lld 小时 %2$02lld 分",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%1$lld 小時 %2$02lld 分",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%1$lldm %2$02llds" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%1$lld분 %2$02lld초",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%1$lld dk %2$02lld sn",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%1$lld phút %2$02lld giây",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%1$lld 分 %2$02lld 秒",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%1$lld 分 %2$02lld 秒",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%d added" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%d개 추가됨",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%d eklendi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%d đã thêm",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已添加 %d 个",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已新增 %d 個",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%d bytes" : {
       "localizations" : {
@@ -5200,10 +5882,72 @@
       }
     },
     "%d deleted" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%d개 삭제됨",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%d silindi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%d đã xoá",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已删除 %d 个",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已刪除 %d 個",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%d edited" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%d개 편집됨",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%d düzenlendi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%d đã sửa",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已编辑 %d 个",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已編輯 %d 個",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%d elements" : {
       "comment" : "A label showing the number of elements in an array. The argument is the number of elements in the array.",
@@ -5242,7 +5986,38 @@
       }
     },
     "%d exported row(s)" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "내보낸 행 %d개",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%d satır dışa aktarıldı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%d dòng đã xuất",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已导出 %d 行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已匯出 %d 列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%d favorites will be permanently deleted." : {
       "localizations" : {
@@ -5381,7 +6156,38 @@
       }
     },
     "%d lines" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%d줄",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%d satır",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%d dòng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%d 行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%d 行",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%d more" : {
       "localizations" : {
@@ -5418,7 +6224,38 @@
       }
     },
     "%d more lines" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%d줄 더",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%d satır daha",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%d dòng nữa",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "还有 %d 行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "還有 %d 行",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%d of %d" : {
       "localizations" : {
@@ -5857,7 +6694,38 @@
       }
     },
     "%d rows will be restored" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%d개 행이 복원됩니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%d satır geri yüklenecek",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%d dòng sẽ được khôi phục",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "将恢复 %d 行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "將還原 %d 列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%d selected" : {
       "extractionState" : "stale",
@@ -6549,7 +7417,38 @@
       }
     },
     "%lld minutes" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%lld분",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%lld dakika",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%lld phút",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%lld 分钟",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%lld 分鐘",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "%lld objects" : {
       "localizations" : {
@@ -7706,7 +8605,38 @@
       }
     },
     "%llds" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%lld초",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%lld sn",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "%lld giây",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%lld 秒",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%lld 秒",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "•" : {
       "extractionState" : "stale",
@@ -7779,7 +8709,38 @@
       }
     },
     "`%1$@` exited with status %2$d on the server: %3$@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "서버에서 `%1$@`이(가) 상태 %2$d(으)로 종료되었습니다: %3$@",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "`%1$@` sunucuda %2$d durumuyla sonlandı: %3$@",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "`%1$@` kết thúc với mã trạng thái %2$d trên máy chủ: %3$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "`%1$@` 在服务器上以状态 %2$d 退出：%3$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "`%1$@` 在伺服器上以狀態 %2$d 結束：%3$@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "© 2026 Ngo Quoc Dat.\n%@" : {
       "extractionState" : "stale",
@@ -9834,7 +10795,38 @@
       }
     },
     "A column was set to a default or a function, so its stored value is unknown." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "어떤 열이 기본값이나 함수로 설정되어 저장된 값을 알 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir sütun varsayılana veya bir fonksiyona ayarlandı, bu yüzden saklanan değeri bilinmiyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Một cột được đặt thành giá trị mặc định hoặc một hàm, nên giá trị lưu trữ của nó không xác định.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "某个列被设为默认值或函数，因此其存储的值未知。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "某個欄位被設為預設值或函式，因此其儲存的值未知。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "A command named \"/%@\" already exists." : {
       "localizations" : {
@@ -10077,7 +11069,38 @@
       }
     },
     "a destructive statement" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "파괴적인 명령문",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "yıkıcı bir ifade",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "một câu lệnh có tính phá huỷ",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "一条破坏性语句",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "一條破壞性陳述式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "A different file already exists at %@." : {
       "localizations" : {
@@ -10352,7 +11375,38 @@
       }
     },
     "A row with this key already exists" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 키를 가진 행이 이미 있습니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu anahtara sahip bir satır zaten var",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đã có dòng với khoá này",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已存在使用此键的行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已存在使用此鍵的列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "A run is already in progress." : {
       "localizations" : {
@@ -10389,10 +11443,72 @@
       }
     },
     "A save is already running in this window." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 창에서 저장이 이미 실행 중입니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu pencerede zaten bir kaydetme çalışıyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đã có một thao tác lưu đang chạy trong cửa sổ này.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此窗口中已有一个保存正在进行。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此視窗中已有一個儲存正在進行。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "A SELECT to export. Use instead of 'tables'." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "내보낼 SELECT입니다. 'tables' 대신 사용하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Dışa aktarılacak bir SELECT. 'tables' yerine kullanın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Câu SELECT để xuất. Dùng thay cho 'tables'.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要导出的 SELECT 语句。用它代替 'tables'。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要匯出的 SELECT 陳述式。用它取代 'tables'。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "A service account key is required" : {
       "localizations" : {
@@ -10429,10 +11545,72 @@
       }
     },
     "A statement on '%1$@' matched %2$d rows instead of %3$d, so nothing was saved." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "'%1$@'의 명령문이 %3$d개가 아니라 %2$d개 행과 일치하여 아무것도 저장되지 않았습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "'%1$@' üzerindeki bir ifade %3$d yerine %2$d satırla eşleşti, bu yüzden hiçbir şey kaydedilmedi.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Một câu lệnh trên '%1$@' khớp %2$d dòng thay vì %3$d, nên không có gì được lưu.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "'%1$@' 上的语句匹配了 %2$d 行而不是 %3$d 行，因此未保存任何内容。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "'%1$@' 上的陳述式符合 %2$d 列而不是 %3$d 列，因此未儲存任何內容。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "A statement on '%1$@' matched %2$d rows instead of %3$d." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "'%1$@'의 명령문이 %3$d개가 아니라 %2$d개 행과 일치했습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "'%1$@' üzerindeki bir ifade %3$d yerine %2$d satırla eşleşti.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Một câu lệnh trên '%1$@' khớp %2$d dòng thay vì %3$d.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "'%1$@' 上的语句匹配了 %2$d 行而不是 %3$d 行。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "'%1$@' 上的陳述式符合 %2$d 列而不是 %3$d 列。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "A superuser bypasses all permission checks." : {
       "localizations" : {
@@ -10606,7 +11784,38 @@
       }
     },
     "A value was too large to keep." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "값이 너무 커서 보관할 수 없었습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir değer saklanamayacak kadar büyüktü.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Một giá trị quá lớn để giữ lại.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "有一个值太大，无法保留。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "有一個值太大，無法保留。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "About TablePro" : {
       "localizations" : {
@@ -10643,7 +11852,38 @@
       }
     },
     "Absolute, or relative to the SSH account's home directory. `~` works." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "절대 경로이거나 SSH 계정의 홈 디렉터리 기준 상대 경로입니다. `~`도 사용할 수 있습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Mutlak yol veya SSH hesabının ana dizinine göre göreli yol. `~` çalışır.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đường dẫn tuyệt đối, hoặc tương đối với thư mục nhà của tài khoản SSH. `~` dùng được.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "绝对路径，或相对于 SSH 账户主目录的路径。可以使用 `~`。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "絕對路徑，或相對於 SSH 帳號家目錄的路徑。可以使用 `~`。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Accent Color:" : {
       "extractionState" : "stale",
@@ -11034,7 +12274,38 @@
       }
     },
     "Acknowledgements" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "감사의 글",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Teşekkürler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Ghi nhận",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "致谢",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "致謝",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Action" : {
       "localizations" : {
@@ -12069,7 +13340,38 @@
       }
     },
     "Add a connection before comparing." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "비교하기 전에 연결을 추가하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Karşılaştırmadan önce bir bağlantı ekleyin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hãy thêm một kết nối trước khi so sánh.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "请先添加一个连接再比较。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "請先新增一個連線再比較。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Add Another SQL Folder..." : {
       "extractionState" : "stale",
@@ -13314,10 +14616,72 @@
       }
     },
     "Adding check constraint %@ scans the table and fails if any existing row violates it." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "CHECK 제약 조건 %@을(를) 추가하면 테이블을 검사하며, 기존 행 중 하나라도 위반하면 실패합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ kontrol kısıtlaması eklemek tabloyu tarar ve mevcut satırlardan biri bunu ihlal ederse başarısız olur.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thêm ràng buộc CHECK %@ sẽ quét toàn bảng và thất bại nếu có dòng hiện có vi phạm.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "添加 CHECK 约束 %@ 会扫描整张表，若有任何现有行违反约束则会失败。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "新增 CHECK 約束 %@ 會掃描整張資料表，若有任何現有列違反約束則會失敗。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Additional Bootstrap Servers" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "추가 부트스트랩 서버",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Ek Bootstrap Sunucuları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Máy chủ bootstrap bổ sung",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "额外的 Bootstrap 服务器",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "額外的 Bootstrap 伺服器",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Address" : {
       "localizations" : {
@@ -13363,25 +14727,25 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Pencerenin sol kenarında açık her bağlantıyı ve veritabanını listeleyen dar bir şerit ekler; tek tıkla geçiş yaparsınız."
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Thêm một dải hẹp ở cạnh trái cửa sổ liệt kê mọi kết nối và cơ sở dữ liệu đang mở, chỉ cần một cú nhấp để chuyển sang."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "在窗口前缘添加一条窄栏，列出所有已打开的连接和数据库，单击即可切换。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "在視窗前緣加入一條窄列，列出所有已開啟的連線與資料庫，單擊即可切換。"
           }
         }
@@ -13864,7 +15228,38 @@
       }
     },
     "AI access policy" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "AI 접근 정책",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "AI erişim politikası",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chính sách truy cập AI",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "AI 访问策略",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "AI 存取政策",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "AI and MCP" : {
       "localizations" : {
@@ -13901,7 +15296,38 @@
       }
     },
     "AI and MCP queries" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "AI 및 MCP 쿼리",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "AI ve MCP sorguları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Truy vấn AI và MCP",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "AI 和 MCP 查询",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "AI 和 MCP 查詢",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "AI Chat" : {
       "localizations" : {
@@ -15278,6 +16704,36 @@
             "state" : "new",
             "value" : "Allow %1$@ on '%2$@'?"
           }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "value" : "'%2$@'에서 %1$@을(를) 허용하시겠습니까?",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "'%2$@' üzerinde %1$@ izni verilsin mi?",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cho phép %1$@ trên '%2$@'?",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "允许在 '%2$@' 上执行 %1$@ 吗？",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "允許在 '%2$@' 上執行 %1$@ 嗎？",
+            "state" : "translated"
+          }
         }
       }
     },
@@ -15453,7 +16909,38 @@
       }
     },
     "Allowed values" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "허용되는 값",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İzin verilen değerler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giá trị được phép",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "允许的值",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "允許的值",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Allowing a statement applies to this run only. It is never saved." : {
       "localizations" : {
@@ -15490,7 +16977,38 @@
       }
     },
     "Already restored" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이미 복원됨",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Zaten geri yüklendi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đã khôi phục",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已恢复",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已還原",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Also handles" : {
       "localizations" : {
@@ -15631,25 +17149,242 @@
       }
     },
     "Always 'connected' on success" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "성공 시 항상 'connected'",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Başarılı olduğunda her zaman 'connected'",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Luôn là 'connected' khi thành công",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "成功时始终为 'connected'",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "成功時一律為 'connected'",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Always 'created' on success" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "성공 시 항상 'created'",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Başarılı olduğunda her zaman 'created'",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Luôn là 'created' khi thành công",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "成功时始终为 'created'",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "成功時一律為 'created'",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Always 'disconnected' on success" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "성공 시 항상 'disconnected'",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Başarılı olduğunda her zaman 'disconnected'",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Luôn là 'disconnected' khi thành công",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "成功时始终为 'disconnected'",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "成功時一律為 'disconnected'",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Always 'dropped' on success" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "성공 시 항상 'dropped'",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Başarılı olduğunda her zaman 'dropped'",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Luôn là 'dropped' khi thành công",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "成功时始终为 'dropped'",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "成功時一律為 'dropped'",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Always 'focused' on success" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "성공 시 항상 'focused'",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Başarılı olduğunda her zaman 'focused'",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Luôn là 'focused' khi thành công",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "成功时始终为 'focused'",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "成功時一律為 'focused'",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Always 'opened' on success" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "성공 시 항상 'opened'",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Başarılı olduğunda her zaman 'opened'",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Luôn là 'opened' khi thành công",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "成功时始终为 'opened'",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "成功時一律為 'opened'",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Always 'switched' on success" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "성공 시 항상 'switched'",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Başarılı olduğunda her zaman 'switched'",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Luôn là 'switched' khi thành công",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "成功时始终为 'switched'",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "成功時一律為 'switched'",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Always Allow" : {
       "localizations" : {
@@ -15890,7 +17625,38 @@
       }
     },
     "an explain" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "실행 계획 조회",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "bir açıklama",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "một lệnh explain",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "一次 explain",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "一次 explain",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "an export" : {
       "localizations" : {
@@ -16432,10 +18198,72 @@
       }
     },
     "Anonymous (loopback)" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "익명(루프백)",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Anonim (loopback)",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Ẩn danh (loopback)",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "匿名（回环）",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "匿名（回送）",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Another Connection" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "다른 연결",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Başka Bir Bağlantı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kết nối khác",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "另一个连接",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "另一個連線",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Another install is already in progress for this plugin" : {
       "localizations" : {
@@ -16540,10 +18368,72 @@
       }
     },
     "any element" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "임의 요소",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "herhangi bir öğe",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "phần tử bất kỳ",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "任一元素",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "任一元素",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Any element of %@ may match this row on its own" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@의 어느 요소든 단독으로 이 행과 일치할 수 있습니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ öğelerinden herhangi biri tek başına bu satırla eşleşebilir",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bất kỳ phần tử nào của %@ đều có thể tự khớp với dòng này",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%@ 中的任一元素都可以单独匹配此行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%@ 中的任一元素都可以單獨符合此列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Any Outcome" : {
       "localizations" : {
@@ -17972,7 +19862,38 @@
       }
     },
     "Approximate row count, when requested" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "요청 시 대략적인 행 수",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İstendiğinde yaklaşık satır sayısı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số dòng ước tính, khi được yêu cầu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "请求时返回的大致行数",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "請求時回傳的大致列數",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Are you sure you want to cancel the running query for this session?" : {
       "localizations" : {
@@ -18351,10 +20272,72 @@
       }
     },
     "Argument list the engine reports, such as (date), when it reports one" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "엔진이 보고하는 인수 목록입니다. 보고할 경우 (date)와 같은 형식입니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Motorun bildirdiği argüman listesi, bildirdiğinde (date) gibi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Danh sách tham số mà engine báo cáo, ví dụ (date), khi nó có báo cáo",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "引擎报告的参数列表，例如 (date)，前提是它有报告",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "引擎回報的參數清單，例如 (date)，前提是它有回報",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Array element scope" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "배열 요소 범위",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Dizi öğesi kapsamı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Phạm vi phần tử mảng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "数组元素作用域",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "陣列元素範圍",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "As Copy" : {
       "localizations" : {
@@ -18734,7 +20717,38 @@
       }
     },
     "Ask the engine for the plan of a statement and return both the raw plan text and, where TablePro can parse it, a node tree with costs and row estimates. Setting 'analyze' runs the statement for real, so an analyzed write needs tools:write and Safe Mode approval." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "엔진에 명령문의 실행 계획을 요청하여 원본 계획 텍스트와, TablePro가 해석할 수 있는 경우 비용 및 행 추정치를 담은 노드 트리를 함께 반환합니다. 'analyze'를 설정하면 명령문을 실제로 실행하므로, 분석되는 쓰기 작업에는 tools:write와 안전 모드 승인이 필요합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Motordan bir ifadenin planını ister ve hem ham plan metnini hem de TablePro'nun ayrıştırabildiği yerlerde maliyetler ve satır tahminleri içeren bir düğüm ağacı döndürür. 'analyze' ayarlandığında ifade gerçekten çalıştırılır, bu yüzden analiz edilen bir yazma işlemi tools:write ve Güvenli Mod onayı gerektirir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hỏi engine về kế hoạch thực thi của một câu lệnh và trả về cả văn bản kế hoạch gốc lẫn, ở những nơi TablePro phân tích được, một cây node kèm chi phí và ước lượng số dòng. Đặt 'analyze' sẽ chạy câu lệnh thật, nên một thao tác ghi có phân tích cần tools:write và phê duyệt Chế độ an toàn.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "向引擎请求某条语句的执行计划，返回原始计划文本，并在 TablePro 能够解析时返回带有代价和行数估算的节点树。设置 'analyze' 会真正执行该语句，因此被分析的写操作需要 tools:write 和安全模式批准。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "向引擎請求某條陳述式的執行計畫，回傳原始計畫文字，並在 TablePro 能夠解析時回傳帶有成本和列數估算的節點樹。設定 'analyze' 會真正執行該陳述式，因此被分析的寫入操作需要 tools:write 和安全模式核准。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Ask: read-only schema lookups. AI can browse but not run queries." : {
       "localizations" : {
@@ -18840,10 +20854,72 @@
       }
     },
     "Attribute key" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "속성 키",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Öznitelik anahtarı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Khoá thuộc tính",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "属性键",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "屬性鍵",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Attribute label" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "속성 레이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Öznitelik etiketi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Nhãn thuộc tính",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "属性标签",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "屬性標籤",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Attributes" : {
       "localizations" : {
@@ -18880,7 +20956,38 @@
       }
     },
     "Audience" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "대상",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Hedef Kitle",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đối tượng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "受众",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "對象",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Auth" : {
       "localizations" : {
@@ -19948,7 +22055,38 @@
       }
     },
     "Average row length" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "평균 행 길이",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Ortalama satır uzunluğu",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Độ dài dòng trung bình",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "平均行长度",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "平均列長度",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Average Time" : {
       "localizations" : {
@@ -20510,10 +22648,72 @@
       }
     },
     "Backup finished" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "백업 완료",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yedekleme bitti",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Sao lưu xong",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "备份完成",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "備份完成",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Backups" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "백업",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yedekler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bản sao lưu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "备份",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "備份",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Badge Background" : {
       "localizations" : {
@@ -20720,10 +22920,72 @@
       }
     },
     "BEFORE, AFTER, or INSTEAD OF" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "BEFORE, AFTER 또는 INSTEAD OF",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "BEFORE, AFTER veya INSTEAD OF",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "BEFORE, AFTER hoặc INSTEAD OF",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "BEFORE、AFTER 或 INSTEAD OF",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "BEFORE、AFTER 或 INSTEAD OF",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Begin, commit, or roll back a transaction on the connection's shared session. The transaction stays open across calls until committed or rolled back, and it is the same session the user's own tabs run on, so leave nothing open. Needs tools:write." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "연결의 공유 세션에서 트랜잭션을 시작, 커밋 또는 롤백합니다. 트랜잭션은 커밋되거나 롤백될 때까지 여러 호출에 걸쳐 열려 있으며, 사용자의 탭이 실행되는 것과 같은 세션이므로 열어 둔 채로 두지 마십시오. tools:write가 필요합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bağlantının paylaşılan oturumunda bir işlemi başlatır, işler veya geri alır. İşlem, işlenene veya geri alınana kadar çağrılar arasında açık kalır ve kullanıcının kendi sekmelerinin çalıştığı oturumun aynısıdır, bu yüzden hiçbir şeyi açık bırakmayın. tools:write gerektirir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bắt đầu, commit hoặc rollback một transaction trên phiên dùng chung của kết nối. Transaction vẫn mở qua nhiều lần gọi cho tới khi được commit hoặc rollback, và đó chính là phiên mà các tab của người dùng đang chạy, nên đừng để lại gì đang mở. Cần tools:write.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "在连接的共享会话上开始、提交或回滚事务。事务会跨调用保持打开，直到被提交或回滚，而且它和用户自己的标签页运行在同一个会话上，所以不要留下任何未结束的事务。需要 tools:write。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "在連線的共用工作階段上開始、提交或回復交易。交易會跨呼叫保持開啟，直到被提交或回復，而且它和使用者自己的標籤頁執行在同一個工作階段上，所以不要留下任何未結束的交易。需要 tools:write。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "between" : {
       "localizations" : {
@@ -21246,10 +23508,72 @@
       }
     },
     "Bring an open tab to the front, using a tab id from list_recent_tabs." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "list_recent_tabs에서 얻은 탭 id로 열려 있는 탭을 앞으로 가져옵니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "list_recent_tabs'ten alınan bir sekme kimliğiyle açık bir sekmeyi öne getirir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đưa một tab đang mở lên trước, dùng tab id lấy từ list_recent_tabs.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "使用 list_recent_tabs 返回的标签页 id 把一个已打开的标签页带到最前。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "使用 list_recent_tabs 回傳的標籤頁 id 把一個已開啟的標籤頁帶到最前。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Broker Addresses" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "브로커 주소",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Broker Adresleri",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Địa chỉ broker",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "Broker 地址",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "Broker 位址",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Browse" : {
       "localizations" : {
@@ -21286,7 +23610,38 @@
       }
     },
     "Browse Table" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블 탐색",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tabloya Göz At",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Duyệt bảng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "浏览表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "瀏覽資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Browse, edit, and manage your data with ease" : {
       "localizations" : {
@@ -22422,10 +24777,72 @@
       }
     },
     "cancel stops the query, kill ends the session (default cancel)" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "cancel은 쿼리를 중지하고 kill은 세션을 종료합니다(기본값 cancel)",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "cancel sorguyu durdurur, kill oturumu sonlandırır (varsayılan cancel)",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "cancel dừng truy vấn, kill kết thúc phiên (mặc định cancel)",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "cancel 停止查询，kill 结束会话（默认 cancel）",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "cancel 停止查詢，kill 結束工作階段（預設 cancel）",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Cancel the running query on a server session, or kill the session outright. Takes a process id from get_server_dashboard. Needs tools:write and the user's approval." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "서버 세션에서 실행 중인 쿼리를 취소하거나 세션 자체를 종료합니다. get_server_dashboard에서 얻은 프로세스 id를 사용합니다. tools:write와 사용자 승인이 필요합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir sunucu oturumunda çalışan sorguyu iptal eder veya oturumu tamamen sonlandırır. get_server_dashboard'dan alınan bir işlem kimliği alır. tools:write ve kullanıcının onayı gerekir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Huỷ truy vấn đang chạy trên một phiên máy chủ, hoặc kết thúc hẳn phiên đó. Nhận process id từ get_server_dashboard. Cần tools:write và sự phê duyệt của người dùng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "取消服务器会话上正在运行的查询，或者直接终止该会话。需要来自 get_server_dashboard 的进程 id。需要 tools:write 和用户批准。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "取消伺服器工作階段上正在執行的查詢，或者直接終止該工作階段。需要來自 get_server_dashboard 的行程 id。需要 tools:write 和使用者核准。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Cancelled" : {
       "localizations" : {
@@ -22530,7 +24947,38 @@
       }
     },
     "cancelling a server query" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "서버 쿼리 취소",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "bir sunucu sorgusunu iptal etme",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "huỷ một truy vấn trên máy chủ",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "取消一个服务器查询",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "取消一個伺服器查詢",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Cancelling…" : {
       "localizations" : {
@@ -22601,7 +25049,38 @@
       }
     },
     "Cannot delete rows in '%@'. Some rows could not be identified." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "'%@'의 행을 삭제할 수 없습니다. 일부 행을 식별할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "'%@' içindeki satırlar silinemiyor. Bazı satırlar tanımlanamadı.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không thể xoá dòng trong '%@'. Một số dòng không xác định được.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "无法删除 '%@' 中的行。有些行无法被识别。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "無法刪除 '%@' 中的列。有些列無法被識別。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Cannot execute write queries: connection is read-only" : {
       "extractionState" : "stale",
@@ -22707,16 +25186,140 @@
       }
     },
     "Cannot generate statements for %@: the driver is not loaded." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@에 대한 명령문을 생성할 수 없습니다: 드라이버가 로드되지 않았습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ için ifadeler üretilemiyor: sürücü yüklü değil.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không thể tạo câu lệnh cho %@: driver chưa được nạp.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "无法为 %@ 生成语句：驱动未加载。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "無法為 %@ 產生陳述式：驅動程式未載入。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Cannot insert rows into '%@'." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "'%@'에 행을 삽입할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "'%@' içine satır eklenemiyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không thể chèn dòng vào '%@'.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "无法向 '%@' 插入行。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "無法向 '%@' 插入列。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Cannot Read This Connection" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 연결을 읽을 수 없음",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu Bağlantı Okunamıyor",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không đọc được kết nối này",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "无法读取此连接",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "無法讀取此連線",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Cannot save changes to '%@'. Some rows could not be identified." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "'%@'의 변경 사항을 저장할 수 없습니다. 일부 행을 식별할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "'%@' üzerindeki değişiklikler kaydedilemiyor. Bazı satırlar tanımlanamadı.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không thể lưu thay đổi vào '%@'. Một số dòng không xác định được.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "无法保存对 '%@' 的更改。有些行无法被识别。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "無法儲存對 '%@' 的變更。有些列無法被識別。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Cannot save changes: connection is read-only" : {
       "extractionState" : "stale",
@@ -23279,7 +25882,38 @@
       }
     },
     "Case-insensitive substring to look for" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "찾을 부분 문자열이며 대소문자를 구분하지 않습니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Aranacak, büyük/küçük harfe duyarsız alt dize",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chuỗi con cần tìm, không phân biệt hoa thường",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要查找的子串，不区分大小写",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要尋找的子字串，不區分大小寫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Category" : {
       "localizations" : {
@@ -23454,7 +26088,38 @@
       }
     },
     "Cell value: string, number, boolean, or null" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "셀 값: 문자열, 숫자, 불리언 또는 null",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Hücre değeri: dize, sayı, boole veya null",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giá trị ô: chuỗi, số, boolean hoặc null",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "单元格值：字符串、数字、布尔值或 null",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "儲存格值：字串、數字、布林值或 null",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Certificate" : {
       "localizations" : {
@@ -24004,7 +26669,38 @@
       }
     },
     "Changed since the save" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "저장 후 변경됨",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kaydetmeden bu yana değişti",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đã thay đổi kể từ lần lưu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "自保存后已更改",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "自儲存後已變更",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Changes" : {
       "localizations" : {
@@ -24041,10 +26737,72 @@
       }
     },
     "Changes applied" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "변경 사항 적용됨",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Değişiklikler uygulandı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đã áp dụng thay đổi",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "更改已应用",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "變更已套用",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Changes saved" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "변경 사항 저장됨",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Değişiklikler kaydedildi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đã lưu thay đổi",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "更改已保存",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "變更已儲存",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Changing %@ from %@ to %@ can truncate existing values." : {
       "localizations" : {
@@ -24087,7 +26845,38 @@
       }
     },
     "Changing check constraint %@ re-checks every existing row and fails if any violates it." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "CHECK 제약 조건 %@을(를) 변경하면 기존 행을 모두 다시 검사하며, 하나라도 위반하면 실패합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ kontrol kısıtlamasını değiştirmek mevcut her satırı yeniden denetler ve herhangi biri ihlal ederse başarısız olur.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thay đổi ràng buộc CHECK %@ sẽ kiểm tra lại mọi dòng hiện có và thất bại nếu có dòng vi phạm.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "修改 CHECK 约束 %@ 会重新检查每一个现有行，若有任何行违反则会失败。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "修改 CHECK 約束 %@ 會重新檢查每一個現有列，若有任何列違反則會失敗。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Changing the collation of %@ can change sort order and uniqueness." : {
       "localizations" : {
@@ -24535,7 +27324,38 @@
       }
     },
     "Check a query for correctness, cost, and risk against the live schema before running it" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "쿼리를 실행하기 전에 실제 스키마를 기준으로 정확성, 비용, 위험을 점검합니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir sorguyu çalıştırmadan önce canlı şemaya karşı doğruluk, maliyet ve risk açısından denetler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kiểm tra truy vấn về tính đúng đắn, chi phí và rủi ro dựa trên schema thực tế trước khi chạy",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "在运行查询前，对照实时 Schema 检查其正确性、代价和风险",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "在執行查詢前，對照即時綱要檢查其正確性、成本和風險",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Check Again" : {
       "localizations" : {
@@ -24681,10 +27501,72 @@
       }
     },
     "Check that the SSH server enables the sftp subsystem for this account." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "SSH 서버가 이 계정에 대해 sftp 하위 시스템을 활성화했는지 확인하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "SSH sunucusunun bu hesap için sftp alt sistemini etkinleştirdiğini doğrulayın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hãy kiểm tra xem máy chủ SSH có bật hệ thống con sftp cho tài khoản này không.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "请检查 SSH 服务器是否为该账户启用了 sftp 子系统。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "請檢查 SSH 伺服器是否為該帳號啟用了 sftp 子系統。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Check the remote path, including its capitalisation." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "대소문자를 포함하여 원격 경로를 확인하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Uzak yolu, büyük/küçük harfleri dahil olmak üzere denetleyin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hãy kiểm tra đường dẫn từ xa, kể cả chữ hoa chữ thường.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "请检查远程路径，包括其大小写。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "請檢查遠端路徑，包括其大小寫。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Check the tunnel host and your network, then try again." : {
       "localizations" : {
@@ -26910,13 +29792,106 @@
       }
     },
     "Clear saved changes" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "저장된 변경 사항 지우기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kaydedilen değişiklikleri sil",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Xoá các thay đổi đã lưu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "清除已保存的更改",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "清除已儲存的變更",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Clear Saved Changes?" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "저장된 변경 사항을 지우시겠습니까?",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kaydedilen Değişiklikler Silinsin mi?",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Xoá các thay đổi đã lưu?",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要清除已保存的更改吗？",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要清除已儲存的變更嗎？",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Clear Saved Changes…" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "저장된 변경 사항 지우기…",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kaydedilen Değişiklikleri Sil…",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Xoá các thay đổi đã lưu…",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "清除已保存的更改…",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "清除已儲存的變更…",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Clear search" : {
       "extractionState" : "stale",
@@ -28641,7 +31616,38 @@
       }
     },
     "Close the open session for a connection." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "연결의 열린 세션을 닫습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir bağlantı için açık oturumu kapatır.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đóng phiên đang mở của một kết nối.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "关闭某个连接已打开的会话。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "關閉某個連線已開啟的工作階段。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Close Window" : {
       "localizations" : {
@@ -29462,7 +32468,38 @@
       }
     },
     "Code folding" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "코드 접기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kod katlama",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thu gọn mã",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "代码折叠",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "程式碼摺疊",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "collapse" : {
       "extractionState" : "stale",
@@ -29806,7 +32843,38 @@
       }
     },
     "color %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "색상 %@",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "renk %@",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "màu %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "颜色 %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "顏色 %@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Color %@" : {
       "localizations" : {
@@ -29843,7 +32911,38 @@
       }
     },
     "Color: %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "색상: %@",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Renk: %@",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Màu: %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "颜色：%@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "顏色：%@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Colors" : {
       "localizations" : {
@@ -29914,7 +33013,38 @@
       }
     },
     "Column comment" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "열 주석",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sütun yorumu",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Ghi chú cột",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列注释",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "欄位註解",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Column count mismatch on line %d: expected %d columns, found %d." : {
       "localizations" : {
@@ -29998,7 +33128,38 @@
       }
     },
     "Column default expression" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "열 기본값 표현식",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sütun varsayılan ifadesi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Biểu thức mặc định của cột",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列默认值表达式",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "欄位預設值運算式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Column Details" : {
       "extractionState" : "stale",
@@ -30105,7 +33266,38 @@
       }
     },
     "Column names in result order" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "결과 순서대로 나열한 열 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sonuç sırasına göre sütun adları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên cột theo thứ tự kết quả",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "按结果顺序排列的列名",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "按結果順序排列的欄位名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Column names must be unique." : {
       "localizations" : {
@@ -30142,7 +33334,38 @@
       }
     },
     "Column names, matching each row's value order" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "각 행의 값 순서와 일치하는 열 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Her satırın değer sırasıyla eşleşen sütun adları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên cột, khớp với thứ tự giá trị của mỗi dòng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列名，与每行的值顺序一一对应",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "欄位名稱，與每列的值順序一一對應",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Column order" : {
       "localizations" : {
@@ -30315,13 +33538,106 @@
       }
     },
     "Column to filter on" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "필터링할 열",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Filtrelenecek sütun",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cột để lọc",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "用于筛选的列",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "用於篩選的欄位",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Column to sort on" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "정렬할 열",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sıralanacak sütun",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cột để sắp xếp",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "用于排序的列",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "用於排序的欄位",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Column type, for a column match" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "열이 일치할 때의 열 유형",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir sütun eşleşmesi için sütun türü",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kiểu cột, khi khớp theo cột",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列类型，用于列匹配",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "欄位類型，用於欄位比對",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Column-oriented OLAP for big data" : {
       "localizations" : {
@@ -30461,13 +33777,106 @@
       }
     },
     "Columns in declaration order" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "선언 순서대로 나열한 열",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bildirim sırasına göre sütunlar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cột theo thứ tự khai báo",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "按声明顺序排列的列",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "按宣告順序排列的欄位",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Columns to select. Omit for all." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "선택할 열입니다. 모두 선택하려면 생략하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Seçilecek sütunlar. Tümü için boş bırakın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các cột cần chọn. Bỏ trống để lấy tất cả.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要选择的列。省略则表示全部。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要選取的欄位。省略則表示全部。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Columns, indexes, foreign keys and an approximate row count for one table." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "한 테이블의 열, 인덱스, 외래 키 및 대략적인 행 수입니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir tablonun sütunları, indeksleri, yabancı anahtarları ve yaklaşık satır sayısı.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cột, chỉ mục, khoá ngoại và số dòng ước tính của một bảng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "一张表的列、索引、外键和大致行数。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "一張資料表的欄位、索引、外鍵和大致列數。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Comfortable" : {
       "localizations" : {
@@ -30538,7 +33947,38 @@
       }
     },
     "Comma-separated tables to use. All loaded tables when omitted" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "사용할 테이블을 쉼표로 구분합니다. 생략하면 로드된 모든 테이블입니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kullanılacak, virgülle ayrılmış tablolar. Boş bırakıldığında yüklü tüm tablolar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Danh sách bảng cần dùng, phân tách bằng dấu phẩy. Bỏ trống nghĩa là mọi bảng đã nạp",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要使用的表，用逗号分隔。省略则表示所有已加载的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要使用的資料表，用逗號分隔。省略則表示所有已載入的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Comma-separated values. Compatible with Excel and most tools." : {
       "localizations" : {
@@ -31472,7 +34912,38 @@
       }
     },
     "Comparison operator" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "비교 연산자",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Karşılaştırma operatörü",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Toán tử so sánh",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "比较运算符",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "比較運算子",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Comparison Options…" : {
       "localizations" : {
@@ -32211,7 +35682,38 @@
       }
     },
     "Connect Timeout (seconds)" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "연결 제한 시간(초)",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bağlanma Zaman Aşımı (saniye)",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thời gian chờ kết nối (giây)",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "连接超时（秒）",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "連線逾時（秒）",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Connect to a saved database" : {
       "extractionState" : "stale",
@@ -32806,7 +36308,38 @@
       }
     },
     "Connection display name" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "연결 표시 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bağlantı görünen adı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên hiển thị của kết nối",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "连接的显示名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "連線的顯示名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "connection failed" : {
       "localizations" : {
@@ -33051,7 +36584,38 @@
       }
     },
     "Connection it ran on" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "실행된 연결",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Çalıştığı bağlantı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kết nối mà nó đã chạy trên đó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "它运行所在的连接",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "它執行所在的連線",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Connection limit" : {
       "localizations" : {
@@ -33604,13 +37168,106 @@
       }
     },
     "Connection the tab belongs to" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "탭이 속한 연결",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sekmenin ait olduğu bağlantı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kết nối mà tab thuộc về",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该标签页所属的连接",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該標籤頁所屬的連線",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Connection the transaction runs on" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "트랜잭션이 실행되는 연결",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İşlemin çalıştığı bağlantı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kết nối mà transaction chạy trên đó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "事务运行所在的连接",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "交易執行所在的連線",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Connection the window shows" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "창이 표시하는 연결",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Pencerenin gösterdiği bağlantı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kết nối mà cửa sổ đang hiển thị",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该窗口显示的连接",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該視窗顯示的連線",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Connection Type" : {
       "localizations" : {
@@ -33749,7 +37406,38 @@
       }
     },
     "Connection UUID" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "연결 UUID",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bağlantı UUID'si",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "UUID kết nối",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "连接 UUID",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "連線 UUID",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Connection: %@" : {
       "localizations" : {
@@ -33894,7 +37582,38 @@
       }
     },
     "Connections the client may use, ordered by name" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "클라이언트가 사용할 수 있는 연결이며 이름순으로 정렬됩니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İstemcinin kullanabileceği bağlantılar, ada göre sıralı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các kết nối mà client được dùng, sắp xếp theo tên",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "客户端可以使用的连接，按名称排序",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "用戶端可以使用的連線，按名稱排序",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Connections:" : {
       "extractionState" : "stale",
@@ -33966,7 +37685,38 @@
       }
     },
     "Constraints" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "제약 조건",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kısıtlamalar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Ràng buộc",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "约束",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "約束",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Container service name, may be unreachable" : {
       "localizations" : {
@@ -34071,10 +37821,72 @@
       }
     },
     "Context id" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "컨텍스트 id",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bağlam kimliği",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Context id",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "上下文 id",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "情境 id",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Context label" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "컨텍스트 레이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bağlam etiketi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Nhãn context",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "上下文标签",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "情境標籤",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Continue" : {
       "localizations" : {
@@ -35139,7 +38951,38 @@
       }
     },
     "Copy Error" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "오류 복사",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Hatayı Kopyala",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Sao chép lỗi",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "复制错误",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "複製錯誤",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Copy error message" : {
       "localizations" : {
@@ -35864,7 +39707,38 @@
       }
     },
     "Copy Table Name" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블 이름 복사",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tablo Adını Kopyala",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Sao chép tên bảng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "复制表名",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "複製資料表名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Copy TablePro Link" : {
       "localizations" : {
@@ -36245,10 +40119,72 @@
       }
     },
     "Could not build an INSERT for %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@에 대한 INSERT를 만들 수 없습니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ için bir INSERT oluşturulamadı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không dựng được câu INSERT cho %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "无法为 %@ 构建 INSERT 语句",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "無法為 %@ 建立 INSERT 陳述式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Could not build an INSERT for the mapped columns" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "매핑된 열에 대한 INSERT를 만들 수 없습니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Eşlenen sütunlar için bir INSERT oluşturulamadı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không dựng được câu INSERT cho các cột đã ánh xạ",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "无法为已映射的列构建 INSERT 语句",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "無法為已對應的欄位建立 INSERT 陳述式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Could not build the CREATE TABLE statement" : {
       "localizations" : {
@@ -36775,7 +40711,38 @@
       }
     },
     "Could not generate SQL for '%@'." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "'%@'에 대한 SQL을 생성할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "'%@' için SQL üretilemedi.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không tạo được SQL cho '%@'.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "无法为 '%@' 生成 SQL。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "無法為 '%@' 產生 SQL。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Could not generate SQL for changes." : {
       "localizations" : {
@@ -37050,10 +41017,72 @@
       }
     },
     "Could Not Prepare the Restore" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "복원을 준비할 수 없음",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Geri Yükleme Hazırlanamadı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không chuẩn bị được việc khôi phục",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "无法准备恢复",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "無法準備還原",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Could not protect the save history." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "저장 기록을 보호할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kaydetme geçmişi korunamadı.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không bảo vệ được lịch sử lưu.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "无法保护保存历史。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "無法保護儲存記錄。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Could not reach the license server. Check your internet connection and try again." : {
       "localizations" : {
@@ -37641,7 +41670,38 @@
       }
     },
     "Count every row rather than estimating" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "추정하지 않고 모든 행을 셉니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tahmin etmek yerine her satırı sayar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đếm từng dòng thay vì ước lượng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "逐行统计而不是估算",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "逐列統計而不是估算",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Count exactly" : {
       "extractionState" : "stale",
@@ -37713,7 +41773,38 @@
       }
     },
     "Count Rows" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "행 수 세기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Satırları Say",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đếm dòng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "统计行数",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "統計列數",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Count rows if estimate less than:" : {
       "localizations" : {
@@ -37750,7 +41841,38 @@
       }
     },
     "Count rows in a table. Without filters it returns the engine's fast estimate unless 'exact' is set; with filters it always counts for real." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블의 행 수를 셉니다. 필터가 없으면 'exact'를 설정하지 않는 한 엔진의 빠른 추정치를 반환하고, 필터가 있으면 항상 실제로 셉니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir tablodaki satırları sayar. Filtre yoksa, 'exact' ayarlanmadıkça motorun hızlı tahminini döndürür; filtre varsa her zaman gerçekten sayar.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đếm số dòng trong một bảng. Không có bộ lọc thì trả về ước lượng nhanh của engine trừ khi đặt 'exact'; có bộ lọc thì luôn đếm thật.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "统计表中的行数。没有筛选条件时，除非设置了 'exact'，否则返回引擎的快速估算值；有筛选条件时始终真实统计。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "統計資料表中的列數。沒有篩選條件時，除非設定了 'exact'，否則回傳引擎的快速估算值；有篩選條件時一律真實統計。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Counting rows" : {
       "localizations" : {
@@ -37992,7 +42114,38 @@
       }
     },
     "Create a database using the engine's own form options. Call describe_create_database_options first to see which options this engine takes. Needs tools:write and the user's approval." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "엔진 고유의 폼 옵션을 사용해 데이터베이스를 만듭니다. 이 엔진이 받는 옵션을 보려면 먼저 describe_create_database_options를 호출하십시오. tools:write와 사용자 승인이 필요합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Motorun kendi form seçeneklerini kullanarak bir veritabanı oluşturur. Bu motorun hangi seçenekleri aldığını görmek için önce describe_create_database_options çağırın. tools:write ve kullanıcının onayı gerekir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tạo một cơ sở dữ liệu bằng chính các tuỳ chọn biểu mẫu của engine. Hãy gọi describe_create_database_options trước để xem engine này nhận những tuỳ chọn nào. Cần tools:write và sự phê duyệt của người dùng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "使用引擎自己的表单选项创建数据库。请先调用 describe_create_database_options 查看该引擎接受哪些选项。需要 tools:write 和用户批准。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "使用引擎自己的表單選項建立資料庫。請先呼叫 describe_create_database_options 查看該引擎接受哪些選項。需要 tools:write 和使用者核准。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Create a new table or view" : {
       "extractionState" : "stale",
@@ -38516,7 +42669,38 @@
       }
     },
     "CREATE statement, when the engine can produce one" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "엔진이 생성할 수 있는 경우의 CREATE 명령문",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Motor üretebiliyorsa CREATE ifadesi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Câu lệnh CREATE, khi engine tạo được",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "引擎能生成时返回的 CREATE 语句",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "引擎能產生時回傳的 CREATE 陳述式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Create Table" : {
       "localizations" : {
@@ -38758,7 +42942,38 @@
       }
     },
     "creating a database" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "데이터베이스 생성",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "bir veritabanı oluşturma",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "tạo một cơ sở dữ liệu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "创建一个数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "建立一個資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Creating Backup Dump" : {
       "comment" : "A title for a backup progress sheet.",
@@ -39673,10 +43888,72 @@
       }
     },
     "Current statement" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "현재 명령문",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Geçerli ifade",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Câu lệnh hiện tại",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "当前语句",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "目前陳述式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Current value" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "현재 값",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Geçerli değer",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giá trị hiện tại",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "当前值",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "目前值",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "CURRENT_TIMESTAMP()" : {
       "extractionState" : "stale",
@@ -40626,14 +44903,106 @@
             "state" : "new",
             "value" : "Data quality audit for %1$@ on %2$@"
           }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%2$@의 %1$@에 대한 데이터 품질 감사",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%2$@ üzerindeki %1$@ için veri kalitesi denetimi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kiểm định chất lượng dữ liệu cho %1$@ trên %2$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "对 %2$@ 上 %1$@ 的数据质量审计",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "對 %2$@ 上 %1$@ 的資料品質稽核",
+            "state" : "translated"
+          }
         }
       }
     },
     "Data Rewind" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "데이터 되감기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Veri Geri Sarma",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tua lại dữ liệu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "数据回溯",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "資料回溯",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Data Rewind needs a Starter license" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "데이터 되감기에는 Starter 라이선스가 필요합니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Veri Geri Sarma bir Starter lisansı gerektirir",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tua lại dữ liệu cần giấy phép Starter",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "数据回溯需要 Starter 许可证",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "資料回溯需要 Starter 授權",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Data Size" : {
       "localizations" : {
@@ -40875,7 +45244,38 @@
       }
     },
     "Database engine" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "데이터베이스 엔진",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Veritabanı motoru",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Engine cơ sở dữ liệu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "数据库引擎",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "資料庫引擎",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database Favorites" : {
       "localizations" : {
@@ -41083,16 +45483,140 @@
       }
     },
     "Database it lives in" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "속해 있는 데이터베이스",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İçinde bulunduğu veritabanı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu chứa nó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "它所在的数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "它所在的資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database it ran against" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "실행 대상 데이터베이스",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Karşı çalıştığı veritabanı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu mà nó chạy trên đó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "它所针对的数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "它所針對的資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database it ran on" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "실행된 데이터베이스",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Çalıştığı veritabanı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu mà nó đã chạy trên đó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "它运行所在的数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "它執行所在的資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database List" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "데이터베이스 목록",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Veritabanı Listesi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Danh sách cơ sở dữ liệu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "数据库列表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "資料庫清單",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database name" : {
       "localizations" : {
@@ -41302,19 +45826,174 @@
       }
     },
     "Database name. Uses the connection's current database when omitted." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "데이터베이스 이름입니다. 생략하면 연결의 현재 데이터베이스를 사용합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Veritabanı adı. Boş bırakıldığında bağlantının geçerli veritabanını kullanır.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên cơ sở dữ liệu. Bỏ trống thì dùng cơ sở dữ liệu hiện tại của kết nối.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "数据库名称。省略时使用该连接的当前数据库。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "資料庫名稱。省略時使用該連線的目前資料庫。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database names a connection can reach." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "연결이 접근할 수 있는 데이터베이스 이름입니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir bağlantının erişebildiği veritabanı adları.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên các cơ sở dữ liệu mà một kết nối có thể truy cập.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "某个连接可以访问的数据库名称。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "某個連線可以存取的資料庫名稱。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database names this connection can reach" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 연결이 접근할 수 있는 데이터베이스 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu bağlantının erişebildiği veritabanı adları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên các cơ sở dữ liệu mà kết nối này có thể truy cập",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此连接可以访问的数据库名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此連線可以存取的資料庫名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database names, sorted" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "정렬된 데이터베이스 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Veritabanı adları, sıralı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên cơ sở dữ liệu, đã sắp xếp",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已排序的数据库名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已排序的資料庫名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database now selected" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "현재 선택된 데이터베이스",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Şu anda seçili veritabanı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu đang được chọn",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "当前已选中的数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "目前已選取的資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database Schema" : {
       "localizations" : {
@@ -41455,37 +46134,378 @@
       }
     },
     "Database that was created" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "생성된 데이터베이스",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Oluşturulan veritabanı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu đã được tạo",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已创建的数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已建立的資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database that was dropped" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "삭제된 데이터베이스",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Silinen veritabanı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu đã bị xoá",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已删除的数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已刪除的資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database the listing covers" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "목록이 다루는 데이터베이스",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Listelemenin kapsadığı veritabanı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu mà danh sách bao gồm",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该列表涵盖的数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該清單涵蓋的資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database the schemas belong to" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "스키마가 속한 데이터베이스",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Şemaların ait olduğu veritabanı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu mà các schema thuộc về",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "这些 Schema 所属的数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "這些綱要所屬的資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database the session is on" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "세션이 사용 중인 데이터베이스",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Oturumun bulunduğu veritabanı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu mà phiên đang dùng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该会话所在的数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該工作階段所在的資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database the session opened on" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "세션이 열린 데이터베이스",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Oturumun açıldığı veritabanı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu mà phiên đã mở trên đó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该会话打开时所在的数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該工作階段開啟時所在的資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database the statement ran against" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "명령문이 실행된 데이터베이스",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İfadenin karşı çalıştığı veritabanı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu mà câu lệnh đã chạy trên đó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该语句所针对的数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該陳述式所針對的資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database the tab is on" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "탭이 사용 중인 데이터베이스",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sekmenin bulunduğu veritabanı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu mà tab đang dùng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该标签页所在的数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該標籤頁所在的資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database the table lives in" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블이 속한 데이터베이스",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tablonun içinde bulunduğu veritabanı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu chứa bảng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该表所在的数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該資料表所在的資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database to read. Uses the connection's current database when omitted" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "읽을 데이터베이스입니다. 생략하면 연결의 현재 데이터베이스를 사용합니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Okunacak veritabanı. Boş bırakıldığında bağlantının geçerli veritabanını kullanır",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu cần đọc. Bỏ trống thì dùng cơ sở dữ liệu hiện tại của kết nối",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要读取的数据库。省略时使用该连接的当前数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要讀取的資料庫。省略時使用該連線的目前資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database to report on. Omit for all." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "보고할 데이터베이스입니다. 모두 보려면 생략하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Hakkında rapor verilecek veritabanı. Tümü için boş bırakın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu cần báo cáo. Bỏ trống để lấy tất cả.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要报告的数据库。省略则表示全部。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要報告的資料庫。省略則表示全部。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Database Type" : {
       "localizations" : {
@@ -41799,10 +46819,72 @@
       }
     },
     "Databases of %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@의 데이터베이스",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ veritabanları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu của %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%@ 的数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%@ 的資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Databases, sorted by name" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이름순으로 정렬된 데이터베이스",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Ada göre sıralanmış veritabanları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu, sắp xếp theo tên",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "按名称排序的数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "按名稱排序的資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Date" : {
       "localizations" : {
@@ -42251,7 +47333,38 @@
       }
     },
     "Declared column type" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "선언된 열 유형",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bildirilen sütun türü",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kiểu cột đã khai báo",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "声明的列类型",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "宣告的欄位類型",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Decompression failed with exit status %d" : {
       "localizations" : {
@@ -42493,7 +47606,38 @@
       }
     },
     "Default collation" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "기본 콜레이션",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Varsayılan karşılaştırma kuralı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Collation mặc định",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "默认排序规则",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "預設定序",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Default Column" : {
       "localizations" : {
@@ -44584,10 +49728,72 @@
       }
     },
     "Describe Create Database Options" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "데이터베이스 생성 옵션 설명",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Veritabanı Oluşturma Seçeneklerini Açıkla",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Mô tả tuỳ chọn tạo cơ sở dữ liệu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "说明创建数据库的选项",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "說明建立資料庫的選項",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Describe one table: columns, indexes, foreign keys, DDL, and an approximate row count. Every part is read against the same database and schema." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "한 테이블을 설명합니다: 열, 인덱스, 외래 키, DDL, 대략적인 행 수. 모든 부분은 동일한 데이터베이스와 스키마를 기준으로 읽습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir tabloyu açıklar: sütunlar, indeksler, yabancı anahtarlar, DDL ve yaklaşık satır sayısı. Her bölüm aynı veritabanı ve şema üzerinden okunur.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Mô tả một bảng: cột, chỉ mục, khoá ngoại, DDL và số dòng ước tính. Mọi phần đều được đọc trên cùng một cơ sở dữ liệu và schema.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "描述一张表：列、索引、外键、DDL 和大致行数。每一部分都在同一个数据库和 Schema 上读取。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "描述一張資料表：欄位、索引、外鍵、DDL 和大致列數。每一部分都在同一個資料庫和綱要上讀取。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Describe Table" : {
       "localizations" : {
@@ -45372,7 +50578,38 @@
       }
     },
     "Direct partitions" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "직접 파티션",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Doğrudan bölümler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Phân vùng trực tiếp",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "直接分区",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "直接分割區",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Disable" : {
       "localizations" : {
@@ -46128,7 +51365,38 @@
       }
     },
     "Display name" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "표시 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Görünen ad",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên hiển thị",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "显示名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "顯示名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Distributed key-value store for service discovery" : {
       "localizations" : {
@@ -46712,7 +51980,38 @@
       }
     },
     "Dotted scope path, '*' for server" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "점으로 구분된 범위 경로이며, 서버는 '*'입니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Noktalı kapsam yolu, sunucu için '*'",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đường dẫn phạm vi phân tách bằng dấu chấm, '*' cho máy chủ",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "以点分隔的作用域路径，服务器用 '*'",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "以點分隔的範圍路徑，伺服器用 '*'",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Double Quote  \"" : {
       "localizations" : {
@@ -46887,7 +52186,38 @@
       }
     },
     "Draft a data quality audit" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "데이터 품질 감사 초안 작성",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir veri kalitesi denetimi taslağı hazırla",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Soạn một bản kiểm định chất lượng dữ liệu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "起草一份数据质量审计",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "草擬一份資料品質稽核",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Drag to reorder this filter" : {
       "localizations" : {
@@ -46994,7 +52324,38 @@
       }
     },
     "Driver status message, when the engine sent one" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "엔진이 보낸 경우의 드라이버 상태 메시지",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Motor gönderdiyse sürücü durum mesajı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thông báo trạng thái của driver, khi engine có gửi",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "引擎发送时返回的驱动状态消息",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "引擎傳送時回傳的驅動程式狀態訊息",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Drop" : {
       "localizations" : {
@@ -47381,7 +52742,38 @@
       }
     },
     "Drop a whole database or a whole schema. This deletes everything inside it and cannot be undone, so the user approves it first. Needs tools:write on a connection left writable for external clients." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "데이터베이스 또는 스키마 전체를 삭제합니다. 내부의 모든 것이 지워지고 되돌릴 수 없으므로 사용자가 먼저 승인합니다. 외부 클라이언트에 쓰기가 허용된 연결에서 tools:write가 필요합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir veritabanının veya şemanın tamamını siler. İçindeki her şeyi siler ve geri alınamaz, bu yüzden önce kullanıcı onaylar. Dış istemcilere yazılabilir bırakılmış bir bağlantıda tools:write gerektirir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Xoá toàn bộ một cơ sở dữ liệu hoặc một schema. Thao tác này xoá mọi thứ bên trong và không thể hoàn tác, nên người dùng phải phê duyệt trước. Cần tools:write trên một kết nối được để ghi cho client bên ngoài.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "删除整个数据库或整个 Schema。这会删除其中的一切且无法撤销，因此需要用户先行批准。需要在对外部客户端可写的连接上具备 tools:write。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "刪除整個資料庫或整個綱要。這會刪除其中的一切且無法還原，因此需要使用者先行核准。需要在對外部用戶端可寫入的連線上具備 tools:write。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Drop all tables that depend on this table" : {
       "localizations" : {
@@ -47523,7 +52915,38 @@
       }
     },
     "Drop Database or Schema" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "데이터베이스 또는 스키마 삭제",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Veritabanını veya Şemayı Sil",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Xoá cơ sở dữ liệu hoặc schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "删除数据库或 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "刪除資料庫或綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Drop Database..." : {
       "extractionState" : "stale",
@@ -48147,6 +53570,36 @@
             "state" : "new",
             "value" : "dropping %1$@ '%2$@'"
           }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%1$@ '%2$@' 삭제",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%1$@ '%2$@' silme",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "xoá %1$@ '%2$@'",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "删除 %1$@ '%2$@'",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "刪除 %1$@ '%2$@'",
+            "state" : "translated"
+          }
         }
       }
     },
@@ -48185,7 +53638,38 @@
       }
     },
     "Dropping check constraint %@ stops it validating new rows." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "CHECK 제약 조건 %@을(를) 삭제하면 새 행에 대한 검증이 중단됩니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ kontrol kısıtlamasını silmek, yeni satırları doğrulamasını durdurur.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Xoá ràng buộc CHECK %@ sẽ khiến nó ngừng kiểm tra các dòng mới.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "删除 CHECK 约束 %@ 后，它将不再校验新行。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "刪除 CHECK 約束 %@ 後，它將不再驗證新列。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Dropping column %@ permanently removes its data." : {
       "localizations" : {
@@ -48840,7 +54324,38 @@
       }
     },
     "Duration in milliseconds" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "밀리초 단위 소요 시간",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Milisaniye cinsinden süre",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thời lượng tính bằng mili giây",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "以毫秒计的时长",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "以毫秒計的時長",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Dynamic" : {
       "localizations" : {
@@ -49015,7 +54530,38 @@
       }
     },
     "Earliest executed_at, Unix epoch seconds" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "가장 이른 executed_at이며 Unix epoch 초 단위입니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "En erken executed_at, Unix epoch saniyesi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "executed_at sớm nhất, tính bằng giây Unix epoch",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "最早的 executed_at，Unix 纪元秒",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "最早的 executed_at，Unix 紀元秒",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Edit" : {
       "localizations" : {
@@ -49192,7 +54738,38 @@
       }
     },
     "Edit Check Constraint" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "CHECK 제약 조건 편집",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kontrol Kısıtlamasını Düzenle",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Sửa ràng buộc CHECK",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "编辑 CHECK 约束",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "編輯 CHECK 約束",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Edit Column" : {
       "localizations" : {
@@ -51223,10 +56800,72 @@
       }
     },
     "Engine-specific attribute flags" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "엔진별 속성 플래그",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Motora özgü öznitelik bayrakları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cờ thuộc tính riêng của engine",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "引擎特有的属性标志",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "引擎特有的屬性旗標",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Engine-specific column attributes" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "엔진별 열 속성",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Motora özgü sütun öznitelikleri",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thuộc tính cột riêng của engine",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "引擎特有的列属性",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "引擎特有的欄位屬性",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Engine:" : {
       "localizations" : {
@@ -51850,10 +57489,72 @@
       }
     },
     "Entry id" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "항목 id",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Girdi kimliği",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Id mục",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "条目 id",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "項目 id",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Enumerated values the column accepts" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "열이 허용하는 열거 값",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sütunun kabul ettiği sıralı değerler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các giá trị liệt kê mà cột chấp nhận",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该列接受的枚举值",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該欄位接受的列舉值",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Environment" : {
       "localizations" : {
@@ -52334,10 +58035,72 @@
       }
     },
     "Escaped literals, in the order supplied" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "제공된 순서대로 이스케이프된 리터럴",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Verilen sırayla kaçışlanmış değişmez değerler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các literal đã escape, theo thứ tự được cung cấp",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已转义的字面量，按提供的顺序排列",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已跳脫的字面值，按提供的順序排列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Estimated row count" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "추정 행 수",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tahmini satır sayısı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số dòng ước tính",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "估算行数",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "估算列數",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Estimated rows" : {
       "localizations" : {
@@ -52612,10 +58375,72 @@
       }
     },
     "Event Streaming" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이벤트 스트리밍",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Olay Akışı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Event streaming",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "事件流",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "事件串流",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Event streaming platform" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이벤트 스트리밍 플랫폼",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Olay akışı platformu",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Nền tảng event streaming",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "事件流平台",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "事件串流平台",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Every included column needs a name." : {
       "localizations" : {
@@ -52686,10 +58511,72 @@
       }
     },
     "Every row must be an array with one value per column." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "모든 행은 열마다 값 하나를 가진 배열이어야 합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Her satır, sütun başına bir değer içeren bir dizi olmalıdır.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Mỗi dòng phải là một mảng có một giá trị cho mỗi cột.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "每一行都必须是数组，每列对应一个值。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "每一列都必須是陣列，每個欄位對應一個值。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Every saved connection this client may use, with its live session state" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 클라이언트가 사용할 수 있는 저장된 모든 연결과 실시간 세션 상태",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu istemcinin kullanabileceği kayıtlı tüm bağlantılar ve canlı oturum durumları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Mọi kết nối đã lưu mà client này được dùng, kèm trạng thái phiên hiện thời",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此客户端可以使用的所有已保存连接，及其实时会话状态",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此用戶端可以使用的所有已儲存連線，及其即時工作階段狀態",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Every shared column is generated, so there is nothing to write." : {
       "localizations" : {
@@ -54135,10 +60022,72 @@
       }
     },
     "Explain a schema" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "스키마 설명",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir şemayı açıkla",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giải thích một schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "讲解一个 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "講解一個綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Explain a table" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블 설명",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir tabloyu açıkla",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giải thích một bảng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "讲解一张表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "講解一張資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "EXPLAIN is not supported for this database type." : {
       "localizations" : {
@@ -54175,10 +60124,72 @@
       }
     },
     "Explain one table's columns, keys, indexes, and DDL to someone who has never used it" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "한 테이블의 열, 키, 인덱스, DDL을 처음 접하는 사람에게 설명합니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir tablonun sütunlarını, anahtarlarını, indekslerini ve DDL'ini daha önce hiç kullanmamış birine açıklar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giải thích cột, khoá, chỉ mục và DDL của một bảng cho người chưa từng dùng nó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "向从未用过这张表的人讲解它的列、键、索引和 DDL",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "向從未用過這張資料表的人講解它的欄位、鍵、索引和 DDL",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Explain plan" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "실행 계획",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sorgu planı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kế hoạch thực thi",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "执行计划",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "執行計畫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Explain Query" : {
       "localizations" : {
@@ -54284,10 +60295,72 @@
       }
     },
     "Explain variant id for this engine. Call with no variant to see the list." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 엔진의 EXPLAIN 변형 id입니다. 목록을 보려면 변형 없이 호출하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu motor için açıklama varyantı kimliği. Listeyi görmek için varyant vermeden çağırın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Id biến thể EXPLAIN cho engine này. Gọi mà không truyền biến thể để xem danh sách.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此引擎的 EXPLAIN 变体 id。不带变体调用即可查看列表。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此引擎的 EXPLAIN 變體 id。不帶變體呼叫即可查看清單。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Explain variants this engine declares" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 엔진이 선언하는 EXPLAIN 변형",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu motorun bildirdiği açıklama varyantları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các biến thể EXPLAIN mà engine này khai báo",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此引擎声明的 EXPLAIN 变体",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此引擎宣告的 EXPLAIN 變體",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Explain with AI" : {
       "localizations" : {
@@ -54329,6 +60402,36 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Explanation of %1$@ on %2$@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%2$@의 %1$@에 대한 설명",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%2$@ üzerindeki %1$@ açıklaması",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giải thích về %1$@ trên %2$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "对 %2$@ 上 %1$@ 的讲解",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "對 %2$@ 上 %1$@ 的講解",
+            "state" : "translated"
           }
         }
       }
@@ -55217,7 +61320,38 @@
       }
     },
     "Export finished" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "내보내기 완료",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Dışa aktarma bitti",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Xuất xong",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "导出完成",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "匯出完成",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Export Format" : {
       "localizations" : {
@@ -55737,7 +61871,38 @@
       }
     },
     "Export the result of a query, or whole tables, as CSV, JSON, or SQL INSERT statements. With output_path the file is written inside the user's Downloads folder and never overwrites an existing file; without it the text comes back inline. SQL output uses the connection's own quoting and literal rules, so exporting a query needs 'sql_table' to name the target table." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "쿼리 결과 또는 테이블 전체를 CSV, JSON 또는 SQL INSERT 명령문으로 내보냅니다. output_path를 주면 사용자의 다운로드 폴더 안에 파일을 쓰며 기존 파일을 덮어쓰지 않습니다. 주지 않으면 텍스트를 그대로 반환합니다. SQL 출력은 연결 고유의 인용 및 리터럴 규칙을 따르므로, 쿼리를 내보낼 때는 대상 테이블을 지정하는 'sql_table'이 필요합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir sorgunun sonucunu veya tabloların tamamını CSV, JSON ya da SQL INSERT ifadeleri olarak dışa aktarır. output_path verildiğinde dosya kullanıcının İndirilenler klasörüne yazılır ve mevcut bir dosyanın üzerine asla yazmaz; verilmediğinde metin doğrudan döner. SQL çıktısı bağlantının kendi tırnak ve değişmez değer kurallarını kullanır, bu yüzden bir sorguyu dışa aktarmak hedef tabloyu adlandıran 'sql_table' gerektirir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Xuất kết quả của một truy vấn, hoặc toàn bộ bảng, dưới dạng CSV, JSON hoặc câu lệnh SQL INSERT. Có output_path thì tệp được ghi vào thư mục Downloads của người dùng và không bao giờ ghi đè tệp có sẵn; không có thì văn bản trả về trực tiếp. Đầu ra SQL dùng quy tắc trích dẫn và literal riêng của kết nối, nên xuất một truy vấn cần 'sql_table' để đặt tên bảng đích.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "把一个查询的结果，或者整张表，导出为 CSV、JSON 或 SQL INSERT 语句。提供 output_path 时，文件写入用户的下载文件夹，且绝不覆盖已有文件；不提供时，文本直接返回。SQL 输出使用该连接自己的引号和字面量规则，因此导出查询需要用 'sql_table' 指定目标表。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "把一個查詢的結果，或者整張資料表，匯出為 CSV、JSON 或 SQL INSERT 陳述式。提供 output_path 時，檔案寫入使用者的下載檔案夾，且絕不覆蓋已有檔案；不提供時，文字直接回傳。SQL 輸出使用該連線自己的引號和字面值規則，因此匯出查詢需要用 'sql_table' 指定目標資料表。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Export to File…" : {
       "localizations" : {
@@ -55808,13 +61973,106 @@
       }
     },
     "Exported text. Omitted when the export was written to a file." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "내보낸 텍스트입니다. 파일로 내보낸 경우에는 생략됩니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Dışa aktarılan metin. Dışa aktarma bir dosyaya yazıldığında bulunmaz.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Văn bản đã xuất. Bị bỏ qua khi bản xuất được ghi ra tệp.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "导出的文本。当导出被写入文件时省略。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "匯出的文字。當匯出被寫入檔案時省略。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Exported to %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@(으)로 내보냄",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ konumuna dışa aktarıldı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đã xuất sang %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已导出到 %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已匯出到 %@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Exports" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "내보내기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Dışa Aktarımlar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bản xuất",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "导出",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "匯出",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Exports data as mongosh-compatible scripts. Drop, Indexes, and Data options are configured per collection in the collection list." : {
       "extractionState" : "stale",
@@ -55886,7 +62144,38 @@
       }
     },
     "Expression" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "표현식",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İfade",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Biểu thức",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "表达式",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "運算式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Expression (e.g., age >= 0)" : {
       "extractionState" : "stale",
@@ -56128,7 +62417,38 @@
       }
     },
     "External client access level" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "외부 클라이언트 접근 수준",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Dış istemci erişim düzeyi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Mức truy cập cho client bên ngoài",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "外部客户端访问级别",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "外部用戶端存取層級",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "External Clients" : {
       "localizations" : {
@@ -56336,10 +62656,72 @@
       }
     },
     "Failed after %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@ 후 실패",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ sonra başarısız oldu",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thất bại sau %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%@ 后失败",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%@ 後失敗",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Failed after %1$@: %2$@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%1$@ 후 실패: %2$@",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%1$@ sonra başarısız oldu: %2$@",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thất bại sau %1$@: %2$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%1$@ 后失败：%2$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%1$@ 後失敗：%2$@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Failed at line %lld" : {
       "extractionState" : "stale",
@@ -58498,7 +64880,38 @@
       }
     },
     "Fetch all rows" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "모든 행 가져오기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tüm satırları getir",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tải tất cả các dòng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "获取全部行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "取得全部列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Fetch All Rows" : {
       "localizations" : {
@@ -58535,7 +64948,38 @@
       }
     },
     "Fetch an approximate row count per table (default false)" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블마다 대략적인 행 수를 가져옵니다(기본값 false)",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tablo başına yaklaşık satır sayısı getirir (varsayılan false)",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Lấy số dòng ước tính cho mỗi bảng (mặc định false)",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "为每张表获取大致行数（默认 false）",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "為每張資料表取得大致列數（預設 false）",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Fetching models…" : {
       "localizations" : {
@@ -58847,7 +65291,38 @@
       }
     },
     "File name or path inside Downloads. Omit to get the text inline." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "다운로드 폴더 안의 파일 이름 또는 경로입니다. 텍스트를 그대로 받으려면 생략하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İndirilenler içindeki dosya adı veya yolu. Metni doğrudan almak için boş bırakın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên tệp hoặc đường dẫn bên trong thư mục Downloads. Bỏ trống để nhận văn bản trực tiếp.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "下载文件夹内的文件名或路径。省略则直接返回文本。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "下載檔案夾內的檔案名稱或路徑。省略則直接回傳文字。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "File not found" : {
       "extractionState" : "stale",
@@ -58954,7 +65429,38 @@
       }
     },
     "File that was written, when output_path was given" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "output_path를 지정한 경우 기록된 파일",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "output_path verildiğinde yazılan dosya",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tệp đã được ghi, khi có output_path",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "提供 output_path 时写入的文件",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "提供 output_path 時寫入的檔案",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Filename cannot be '.' or '..' or contain path traversal" : {
       "extractionState" : "stale",
@@ -59644,7 +66150,38 @@
       }
     },
     "Filter on a nested field path" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "중첩된 필드 경로로 필터링",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İç içe bir alan yoluna göre filtreler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Lọc theo đường dẫn trường lồng nhau",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "按嵌套字段路径筛选",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "按巢狀欄位路徑篩選",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Filter operator" : {
       "localizations" : {
@@ -60230,7 +66767,38 @@
       }
     },
     "Filters combined with 'logic'" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "'logic'으로 결합된 필터",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "'logic' ile birleştirilen filtreler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các bộ lọc được kết hợp bằng 'logic'",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "用 'logic' 组合的筛选条件",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "用 'logic' 組合的篩選條件",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Find" : {
       "localizations" : {
@@ -60369,7 +66937,38 @@
       }
     },
     "Find tables and columns whose name contains a substring, so a column can be located without describing every table." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이름에 특정 부분 문자열이 들어간 테이블과 열을 찾아, 모든 테이블을 설명하지 않고도 열을 찾을 수 있게 합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Adı bir alt dize içeren tabloları ve sütunları bulur, böylece her tabloyu açıklamadan bir sütun bulunabilir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tìm các bảng và cột có tên chứa một chuỗi con, để tìm được một cột mà không cần mô tả mọi bảng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "查找名称包含某个子串的表和列，这样不必描述每一张表也能定位到某个列。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "尋找名稱包含某個子字串的資料表和欄位，這樣不必描述每一張資料表也能定位到某個欄位。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Find this on the instance's overview page in the Google Cloud console." : {
       "localizations" : {
@@ -60747,7 +67346,38 @@
       }
     },
     "Flattened plan text" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "평탄화된 계획 텍스트",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Düzleştirilmiş plan metni",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Văn bản kế hoạch đã làm phẳng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "扁平化的计划文本",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "扁平化的計畫文字",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Focus an already-open tab by id (returned from list_recent_tabs)." : {
       "extractionState" : "stale",
@@ -60888,7 +67518,38 @@
       }
     },
     "Focus Tab" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "탭으로 이동",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sekmeye Odaklan",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chuyển tới tab",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "聚焦标签页",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "聚焦標籤頁",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Focus the query editor to insert" : {
       "extractionState" : "stale",
@@ -60960,7 +67621,38 @@
       }
     },
     "Fold All" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "모두 접기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tümünü Katla",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thu gọn tất cả",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "全部折叠",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "全部摺疊",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Folder" : {
       "localizations" : {
@@ -61319,7 +68011,38 @@
       }
     },
     "Foreign keys the table declares" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블이 선언한 외래 키",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tablonun bildirdiği yabancı anahtarlar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các khoá ngoại mà bảng khai báo",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该表声明的外键",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該資料表宣告的外鍵",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Foreign Table" : {
       "localizations" : {
@@ -61665,7 +68388,38 @@
       }
     },
     "Format that was produced" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "생성된 형식",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Üretilen biçim",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Định dạng đã tạo ra",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "生成的格式",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "產生的格式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Format:" : {
       "localizations" : {
@@ -61702,7 +68456,38 @@
       }
     },
     "Formatted duration" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "형식이 적용된 소요 시간",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Biçimlendirilmiş süre",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thời lượng đã định dạng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已格式化的时长",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已格式化的時長",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Formatter error: %@" : {
       "localizations" : {
@@ -61943,7 +68728,38 @@
       }
     },
     "Full CREATE TRIGGER statement" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "전체 CREATE TRIGGER 명령문",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tam CREATE TRIGGER ifadesi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Câu lệnh CREATE TRIGGER đầy đủ",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "完整的 CREATE TRIGGER 语句",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "完整的 CREATE TRIGGER 陳述式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Function" : {
       "localizations" : {
@@ -62422,7 +69238,38 @@
       }
     },
     "Get Database Statistics" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "데이터베이스 통계 가져오기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Veritabanı İstatistiklerini Al",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Lấy thống kê cơ sở dữ liệu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "获取数据库统计信息",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "取得資料庫統計資訊",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Get detailed status for a specific database connection." : {
       "localizations" : {
@@ -62632,7 +69479,38 @@
       }
     },
     "Get Server Dashboard" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "서버 대시보드 가져오기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sunucu Panosunu Al",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Lấy bảng điều khiển máy chủ",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "获取服务器仪表板",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "取得伺服器儀表板",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Get Started" : {
       "localizations" : {
@@ -62703,7 +69581,38 @@
       }
     },
     "Get Table Statistics" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블 통계 가져오기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tablo İstatistiklerini Al",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Lấy thống kê bảng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "获取表统计信息",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "取得資料表統計資訊",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Get the CREATE TABLE DDL statement for a table" : {
       "extractionState" : "stale",
@@ -62775,7 +69684,38 @@
       }
     },
     "Get View Definition" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "뷰 정의 가져오기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Görünüm Tanımını Al",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Lấy định nghĩa view",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "获取视图定义",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "取得檢視表定義",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "GitHub Repository" : {
       "localizations" : {
@@ -63187,7 +70127,38 @@
       }
     },
     "Grant the SSH account read access, or connect as a user that already has it." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "SSH 계정에 읽기 권한을 부여하거나, 이미 권한이 있는 사용자로 연결하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "SSH hesabına okuma izni verin veya bu izne zaten sahip bir kullanıcıyla bağlanın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hãy cấp quyền đọc cho tài khoản SSH, hoặc kết nối bằng một người dùng đã có quyền đó.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "请给该 SSH 账户授予读取权限，或改用已有该权限的用户连接。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "請給該 SSH 帳號授予讀取權限，或改用已有該權限的使用者連線。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Granted" : {
       "localizations" : {
@@ -63258,7 +70229,38 @@
       }
     },
     "Grants, sorted by privilege then scope" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "권한순, 그다음 범위순으로 정렬된 부여 권한",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Önce ayrıcalığa sonra kapsama göre sıralanmış yetkiler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các quyền được cấp, sắp xếp theo đặc quyền rồi tới phạm vi",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "先按权限再按作用域排序的授权",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "先按權限再按範圍排序的授權",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Graphite" : {
       "extractionState" : "stale",
@@ -64329,25 +71331,25 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Çalışma Alanı Şeridini Gizle"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Ẩn thanh không gian làm việc"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "隐藏工作区栏"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "隱藏工作區列"
           }
         }
@@ -64836,10 +71838,72 @@
       }
     },
     "Host scope, for engines that use one" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "호스트 범위를 사용하는 엔진의 호스트 범위",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kullanan motorlar için ana makine kapsamı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Phạm vi host, với những engine có dùng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "主机作用域，适用于使用它的引擎",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "主機範圍，適用於使用它的引擎",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Host scope, where the engine has one" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "엔진에 호스트 범위가 있는 경우의 호스트 범위",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Motorda varsa ana makine kapsamı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Phạm vi host, khi engine có nó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "主机作用域，前提是引擎有这个概念",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "主機範圍，前提是引擎有這個概念",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Host:" : {
       "localizations" : {
@@ -65047,16 +72111,140 @@
       }
     },
     "How filters combine (default and)" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "필터를 결합하는 방식입니다(기본값 and)",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Filtrelerin nasıl birleştirileceği (varsayılan and)",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cách kết hợp các bộ lọc (mặc định and)",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "筛选条件的组合方式（默认 and）",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "篩選條件的組合方式（預設 and）",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "How long it has run" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "실행된 시간",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Ne kadar süredir çalıştığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Nó đã chạy được bao lâu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已经运行了多久",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已經執行了多久",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "How many filters were applied" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "적용된 필터 수",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kaç filtre uygulandığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đã áp dụng bao nhiêu bộ lọc",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "应用了多少个筛选条件",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "套用了多少個篩選條件",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "How many statements to include, 1 to 500. Defaults to 50" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "포함할 명령문 수이며 1에서 500까지입니다. 기본값은 50입니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kaç ifadenin dahil edileceği, 1 ile 500 arası. Varsayılan 50",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số câu lệnh cần lấy, từ 1 đến 500. Mặc định là 50",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要包含多少条语句，1 到 500。默认为 50",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要包含多少條陳述式，1 到 500。預設為 50",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Huge" : {
       "extractionState" : "stale",
@@ -65094,7 +72282,38 @@
       }
     },
     "Human label" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "사람이 읽을 레이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İnsan tarafından okunabilir etiket",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Nhãn dễ đọc",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "供人阅读的标签",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "供人閱讀的標籤",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "iCloud account is not available. Sign in to iCloud in System Settings." : {
       "extractionState" : "stale",
@@ -66351,7 +73570,38 @@
       }
     },
     "Import finished" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "가져오기 완료",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İçe aktarma bitti",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Nhập xong",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "导入完成",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "匯入完成",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Import Format" : {
       "localizations" : {
@@ -68172,10 +75422,72 @@
       }
     },
     "Index proposal on %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@에 대한 인덱스 제안",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ üzerinde indeks önerisi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đề xuất chỉ mục trên %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "针对 %@ 的索引建议",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "針對 %@ 的索引建議",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Index size" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "인덱스 크기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İndeks boyutu",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kích thước chỉ mục",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "索引大小",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "索引大小",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Index Size" : {
       "localizations" : {
@@ -68212,10 +75524,72 @@
       }
     },
     "Index type reported by the engine" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "엔진이 보고한 인덱스 유형",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Motorun bildirdiği indeks türü",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kiểu chỉ mục do engine báo cáo",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "引擎报告的索引类型",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "引擎回報的索引類型",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Indexed columns in order" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "순서대로 나열한 인덱스 열",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sırayla indekslenen sütunlar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các cột được lập chỉ mục, theo thứ tự",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "按顺序排列的索引列",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "按順序排列的索引欄位",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Indexes" : {
       "localizations" : {
@@ -68252,7 +75626,38 @@
       }
     },
     "Indexes on the table" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블의 인덱스",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tablodaki indeksler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các chỉ mục trên bảng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该表上的索引",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該資料表上的索引",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Info" : {
       "localizations" : {
@@ -68499,7 +75904,38 @@
       }
     },
     "Insert at most %d rows per call." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "호출당 최대 %d개 행까지 삽입합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Çağrı başına en fazla %d satır ekleyin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Mỗi lần gọi chỉ chèn tối đa %d dòng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "每次调用最多插入 %d 行。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "每次呼叫最多插入 %d 列。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Insert Column" : {
       "localizations" : {
@@ -68918,7 +76354,38 @@
       }
     },
     "Insert rows into a table using bound parameters, so values are never spliced into SQL text. Needs tools:write and goes through the connection's Safe Mode approval." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "바인딩된 매개변수로 테이블에 행을 삽입하므로 값이 SQL 텍스트에 직접 끼워 넣어지지 않습니다. tools:write가 필요하며 연결의 안전 모드 승인을 거칩니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bağlı parametreler kullanarak bir tabloya satır ekler, böylece değerler SQL metnine hiçbir zaman eklenmez. tools:write gerektirir ve bağlantının Güvenli Mod onayından geçer.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chèn các dòng vào bảng bằng tham số ràng buộc, nên giá trị không bao giờ bị ghép thẳng vào chuỗi SQL. Cần tools:write và phải qua phê duyệt Chế độ an toàn của kết nối.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "使用绑定参数向表中插入行，因此值绝不会被拼接进 SQL 文本。需要 tools:write，并且要经过该连接的安全模式批准。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "使用繫結參數向資料表中插入列，因此值絕不會被拼接進 SQL 文字。需要 tools:write，並且要經過該連線的安全模式核准。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Insert rows the target is missing" : {
       "localizations" : {
@@ -68989,7 +76456,38 @@
       }
     },
     "INSERT, UPDATE, or DELETE" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "INSERT, UPDATE 또는 DELETE",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "INSERT, UPDATE veya DELETE",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "INSERT, UPDATE hoặc DELETE",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "INSERT、UPDATE 或 DELETE",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "INSERT、UPDATE 或 DELETE",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Inserted" : {
       "localizations" : {
@@ -69026,10 +76524,72 @@
       }
     },
     "inserting %d row(s)" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%d개 행 삽입",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%d satır ekleme",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "chèn %d dòng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "插入 %d 行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "插入 %d 列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Inside an array" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "배열 내부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir dizinin içinde",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bên trong một mảng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "在数组内",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "在陣列內",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Inspector" : {
       "extractionState" : "stale",
@@ -70677,16 +78237,140 @@
       }
     },
     "ISO 8601 connect time" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "ISO 8601 연결 시각",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "ISO 8601 bağlanma zamanı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thời điểm kết nối theo ISO 8601",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "ISO 8601 连接时间",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "ISO 8601 連線時間",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "ISO 8601 creation time" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "ISO 8601 생성 시각",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "ISO 8601 oluşturulma zamanı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thời điểm tạo theo ISO 8601",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "ISO 8601 创建时间",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "ISO 8601 建立時間",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "ISO 8601 last activity time" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "ISO 8601 마지막 활동 시각",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "ISO 8601 son etkinlik zamanı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thời điểm hoạt động cuối theo ISO 8601",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "ISO 8601 最后活动时间",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "ISO 8601 最後活動時間",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "ISO 8601 last change time" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "ISO 8601 마지막 변경 시각",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "ISO 8601 son değişiklik zamanı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thời điểm thay đổi cuối theo ISO 8601",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "ISO 8601 最后更改时间",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "ISO 8601 最後變更時間",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "ISO Date (2024-12-31)" : {
       "localizations" : {
@@ -71132,7 +78816,38 @@
       }
     },
     "Jump to Definition" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "정의로 이동",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tanıma Git",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Nhảy tới định nghĩa",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "跳转到定义",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "跳至定義",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Jump to lines" : {
       "localizations" : {
@@ -71306,7 +79021,38 @@
       }
     },
     "Keep Open" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "계속 열어 두기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Açık Tut",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giữ mở",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "保持打开",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "保持開啟",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Keep Other Version" : {
       "extractionState" : "stale",
@@ -71412,7 +79158,38 @@
       }
     },
     "Keep saved changes for restoring" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "복원을 위해 저장된 변경 사항 유지",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Geri yükleme için kaydedilen değişiklikleri sakla",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giữ lại các thay đổi đã lưu để khôi phục",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "保留已保存的更改以便恢复",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "保留已儲存的變更以便還原",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Keep This Mac's Version" : {
       "extractionState" : "stale",
@@ -71484,7 +79261,38 @@
       }
     },
     "Keeps what rows looked like before each save, on this Mac only, for 7 days. It is encrypted, and never synced." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "각 저장 이전의 행 상태를 이 Mac에만 7일 동안 보관합니다. 암호화되며 동기화되지 않습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Her kaydetmeden önce satırların nasıl göründüğünü yalnızca bu Mac'te 7 gün saklar. Şifrelenir ve asla eşitlenmez.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giữ lại trạng thái của các dòng trước mỗi lần lưu, chỉ trên máy Mac này, trong 7 ngày. Dữ liệu được mã hoá và không bao giờ đồng bộ.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "仅在这台 Mac 上保留每次保存之前的行内容，保留 7 天。它是加密的，且从不同步。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "僅在這台 Mac 上保留每次儲存之前的列內容，保留 7 天。它是加密的，且從不同步。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Kerberos authentication failed: %@" : {
       "extractionState" : "stale",
@@ -71862,7 +79670,38 @@
       }
     },
     "Key Separator" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "키 구분자",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Anahtar Ayırıcı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Ký tự phân tách khoá",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "键分隔符",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "鍵分隔符號",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Key-Value" : {
       "localizations" : {
@@ -72172,7 +80011,38 @@
       }
     },
     "killing a server session" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "서버 세션 종료",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "bir sunucu oturumunu sonlandırma",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "kết thúc một phiên máy chủ",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "终止一个服务器会话",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "終止一個伺服器工作階段",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Kind" : {
       "localizations" : {
@@ -72209,7 +80079,38 @@
       }
     },
     "Kind of tab" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "탭 종류",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sekme türü",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Loại tab",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "标签页种类",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "標籤頁種類",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Kind:" : {
       "localizations" : {
@@ -72246,10 +80147,72 @@
       }
     },
     "Language %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "언어 %@",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ dili",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Ngôn ngữ %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "语言 %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "語言 %@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Language the routine is written in" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "루틴이 작성된 언어",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Rutinin yazıldığı dil",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Ngôn ngữ mà routine được viết bằng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该例程所用的语言",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該常式所用的語言",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Language:" : {
       "localizations" : {
@@ -73038,7 +81001,38 @@
       }
     },
     "Latest executed_at, Unix epoch seconds" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "가장 늦은 executed_at이며 Unix epoch 초 단위입니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "En geç executed_at, Unix epoch saniyesi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "executed_at muộn nhất, tính bằng giây Unix epoch",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "最晚的 executed_at，Unix 纪元秒",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "最晚的 executed_at，Unix 紀元秒",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Layout" : {
       "extractionState" : "stale",
@@ -73110,7 +81104,38 @@
       }
     },
     "Leading keyword class" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "선행 키워드 분류",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Baştaki anahtar sözcük sınıfı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Lớp từ khoá đứng đầu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "起始关键字类别",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "起始關鍵字類別",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Leave blank to connect without authentication. The password is stored in the macOS Keychain." : {
       "localizations" : {
@@ -73770,10 +81795,72 @@
       }
     },
     "License not verified in 30 days. Connect to the internet to check it." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "30일 동안 라이선스를 확인하지 못했습니다. 인터넷에 연결해 확인하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Lisans 30 gündür doğrulanmadı. Denetlemek için internete bağlanın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giấy phép chưa được xác minh trong 30 ngày. Hãy kết nối internet để kiểm tra.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "许可证已有 30 天未验证。请连接互联网进行检查。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "授權已有 30 天未驗證。請連線到網際網路進行檢查。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "License Not Yet Confirmed" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "라이선스가 아직 확인되지 않음",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Lisans Henüz Doğrulanmadı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giấy phép chưa được xác nhận",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "许可证尚未确认",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "授權尚未確認",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "License public key is invalid." : {
       "localizations" : {
@@ -74924,25 +83011,242 @@
       }
     },
     "List Favorite Tables" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "즐겨찾는 테이블 목록",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sık Kullanılan Tabloları Listele",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê bảng yêu thích",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出收藏的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出收藏的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List Foreign Keys" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "외래 키 목록",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yabancı Anahtarları Listele",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê khoá ngoại",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出外键",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出外鍵",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List foreign keys for one table, or for the whole schema when 'table' is omitted, so joins can be written from the real relationships rather than guessed from column names." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "한 테이블의 외래 키를 나열하며, 'table'을 생략하면 스키마 전체를 나열합니다. 열 이름으로 추측하지 않고 실제 관계를 보고 조인을 작성할 수 있습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir tablonun, 'table' verilmediğinde ise şemanın tamamının yabancı anahtarlarını listeler; böylece birleştirmeler sütun adlarından tahmin edilmek yerine gerçek ilişkilerden yazılabilir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê khoá ngoại của một bảng, hoặc của cả schema khi bỏ trống 'table', để viết join dựa trên quan hệ thật thay vì đoán từ tên cột.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出一张表的外键，或者在省略 'table' 时列出整个 Schema 的外键，这样 JOIN 可以依据真实关系来写，而不是从列名猜测。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出一張資料表的外鍵，或者在省略 'table' 時列出整個綱要的外鍵，這樣 JOIN 可以依據真實關聯來寫，而不是從欄位名稱猜測。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List Grants" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "부여 권한 목록",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yetkileri Listele",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê quyền được cấp",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出授权",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出授權",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List Indexes" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "인덱스 목록",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İndeksleri Listele",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê chỉ mục",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出索引",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出索引",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List indexes for one table, or for every table in the schema when 'table' is omitted. Use it to see what a query can actually use before proposing one." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "한 테이블의 인덱스를 나열하며, 'table'을 생략하면 스키마의 모든 테이블을 나열합니다. 쿼리를 제안하기 전에 실제로 사용할 수 있는 인덱스를 확인하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir tablonun, 'table' verilmediğinde ise şemadaki her tablonun indekslerini listeler. Bir sorgu önermeden önce sorgunun gerçekte neyi kullanabileceğini görmek için kullanın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê chỉ mục của một bảng, hoặc của mọi bảng trong schema khi bỏ trống 'table'. Dùng nó để biết một truy vấn thực sự dùng được gì trước khi đề xuất truy vấn.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出一张表的索引，或者在省略 'table' 时列出该 Schema 中每张表的索引。在提出查询之前用它了解查询真正能用到什么。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出一張資料表的索引，或者在省略 'table' 時列出該綱要中每張資料表的索引。在提出查詢之前用它了解查詢真正能用到什麼。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List Maintenance Operations" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "유지 관리 작업 목록",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bakım İşlemlerini Listele",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê thao tác bảo trì",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出维护操作",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出維護作業",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List of all saved database connections with metadata" : {
       "extractionState" : "stale",
@@ -74980,13 +83284,106 @@
       }
     },
     "List Open Tabs" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "열린 탭 목록",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Açık Sekmeleri Listele",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê tab đang mở",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出已打开的标签页",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出已開啟的標籤頁",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List Partitions" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "파티션 목록",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bölümleri Listele",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê phân vùng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出分区",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出分割區",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List Recent Tables" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "최근 테이블 목록",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Son Tabloları Listele",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê bảng gần đây",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出最近的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出最近的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List Recent Tabs" : {
       "extractionState" : "stale",
@@ -75024,7 +83421,38 @@
       }
     },
     "List Routines" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "루틴 목록",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Rutinleri Listele",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê routine",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出例程",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出常式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List Schemas" : {
       "localizations" : {
@@ -75130,10 +83558,72 @@
       }
     },
     "List Session Contexts" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "세션 컨텍스트 목록",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Oturum Bağlamlarını Listele",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê context phiên",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出会话上下文",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出工作階段情境",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List stored procedures and user-defined functions in a schema." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "스키마의 저장 프로시저와 사용자 정의 함수를 나열합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir şemadaki saklı yordamları ve kullanıcı tanımlı fonksiyonları listeler.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê các stored procedure và hàm do người dùng định nghĩa trong một schema.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出某个 Schema 中的存储过程和用户自定义函数。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出某個綱要中的預存程序和使用者自訂函式。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List Tables" : {
       "localizations" : {
@@ -75239,52 +83729,548 @@
       }
     },
     "List the databases on the server, sorted by name." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "서버의 데이터베이스를 이름순으로 나열합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sunucudaki veritabanlarını ada göre sıralayarak listeler.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê các cơ sở dữ liệu trên máy chủ, sắp xếp theo tên.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出服务器上的数据库，按名称排序。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出伺服器上的資料庫，按名稱排序。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List the direct partitions of a partitioned table. Empty for engines without partitioning." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "분할된 테이블의 직접 파티션을 나열합니다. 파티셔닝이 없는 엔진에서는 비어 있습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bölümlenmiş bir tablonun doğrudan bölümlerini listeler. Bölümleme desteklemeyen motorlarda boştur.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê các phân vùng trực tiếp của một bảng được phân vùng. Rỗng với những engine không có phân vùng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出分区表的直接分区。对于不支持分区的引擎则为空。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出分割資料表的直接分割區。對於不支援分割的引擎則為空。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List the maintenance operations this engine supports, such as VACUUM, ANALYZE, or OPTIMIZE." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 엔진이 지원하는 VACUUM, ANALYZE, OPTIMIZE 같은 유지 관리 작업을 나열합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu motorun desteklediği VACUUM, ANALYZE veya OPTIMIZE gibi bakım işlemlerini listeler.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê các thao tác bảo trì mà engine này hỗ trợ, chẳng hạn VACUUM, ANALYZE hoặc OPTIMIZE.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出该引擎支持的维护操作，例如 VACUUM、ANALYZE 或 OPTIMIZE。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出該引擎支援的維護作業，例如 VACUUM、ANALYZE 或 OPTIMIZE。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List the options create_database accepts on this engine, with their allowed values." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 엔진에서 create_database가 받는 옵션과 허용되는 값을 나열합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu motorda create_database'in kabul ettiği seçenekleri ve izin verilen değerlerini listeler.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê các tuỳ chọn mà create_database chấp nhận trên engine này, kèm giá trị được phép.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出 create_database 在该引擎上接受的选项及其允许的值。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出 create_database 在該引擎上接受的選項及其允許的值。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List the privileges granted to one user or role, with the scope each applies to." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "한 사용자 또는 역할에 부여된 권한과 각 권한이 적용되는 범위를 나열합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir kullanıcıya veya role verilen ayrıcalıkları, her birinin geçerli olduğu kapsamla birlikte listeler.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê các đặc quyền được cấp cho một người dùng hoặc vai trò, kèm phạm vi áp dụng của từng quyền.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出授予某个用户或角色的权限，以及每项权限适用的作用域。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出授予某個使用者或角色的權限，以及每項權限適用的範圍。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List the saved database connections this client may use, with their live status. Connections the token cannot reach, or that the user blocked for external clients, are omitted." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 클라이언트가 사용할 수 있는 저장된 데이터베이스 연결과 실시간 상태를 나열합니다. 토큰이 접근할 수 없거나 사용자가 외부 클라이언트에 대해 차단한 연결은 제외됩니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu istemcinin kullanabileceği kayıtlı veritabanı bağlantılarını canlı durumlarıyla listeler. Belirtecin erişemediği veya kullanıcının dış istemcilere kapattığı bağlantılar dahil edilmez.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê các kết nối cơ sở dữ liệu đã lưu mà client này được dùng, kèm trạng thái hiện thời. Những kết nối mà token không truy cập được, hoặc người dùng đã chặn với client bên ngoài, sẽ bị bỏ qua.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出此客户端可以使用的已保存数据库连接及其实时状态。令牌无法访问的连接，或用户对外部客户端屏蔽的连接，会被略去。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出此用戶端可以使用的已儲存資料庫連線及其即時狀態。權杖無法存取的連線，或使用者對外部用戶端封鎖的連線，會被略去。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List the schemas inside one database, sorted by name." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "한 데이터베이스 안의 스키마를 이름순으로 나열합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir veritabanının içindeki şemaları ada göre sıralayarak listeler.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê các schema bên trong một cơ sở dữ liệu, sắp xếp theo tên.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出某个数据库中的 Schema，按名称排序。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出某個資料庫中的綱要，按名稱排序。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List the session-level contexts this engine exposes, such as a warehouse or a role, with the value the session currently holds." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 엔진이 노출하는 웨어하우스나 역할 같은 세션 수준 컨텍스트와 세션이 현재 가진 값을 나열합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu motorun sunduğu, bir ambar veya rol gibi oturum düzeyindeki bağlamları, oturumun şu anda tuttuğu değerle birlikte listeler.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê các context ở mức phiên mà engine này để lộ ra, chẳng hạn warehouse hoặc role, kèm giá trị mà phiên đang giữ.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出该引擎暴露的会话级上下文，例如仓库或角色，以及会话当前持有的值。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出該引擎公開的工作階段層級情境，例如倉儲或角色，以及工作階段目前持有的值。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List the tables and views in one database and schema, sorted by schema then name. Row counts are approximate and are fetched per table, so they are skipped when the schema holds more than 200 objects." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "한 데이터베이스와 스키마의 테이블과 뷰를 스키마순, 그다음 이름순으로 나열합니다. 행 수는 대략적인 값이며 테이블마다 가져오므로, 스키마에 객체가 200개를 넘으면 건너뜁니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir veritabanı ve şemadaki tabloları ve görünümleri önce şemaya sonra ada göre sıralayarak listeler. Satır sayıları yaklaşıktır ve tablo başına alınır, bu yüzden şema 200'den fazla nesne barındırdığında atlanır.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê các bảng và view trong một cơ sở dữ liệu và schema, sắp xếp theo schema rồi tới tên. Số dòng chỉ là ước tính và được lấy theo từng bảng, nên sẽ bị bỏ qua khi schema có hơn 200 đối tượng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出某个数据库和 Schema 中的表和视图，先按 Schema 再按名称排序。行数是估算值且按表逐个获取，因此当该 Schema 中的对象超过 200 个时会跳过。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出某個資料庫和綱要中的資料表和檢視表，先按綱要再按名稱排序。列數是估算值且按資料表逐個取得，因此當該綱要中的物件超過 200 個時會略過。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List the tables the user opened most recently on a connection, newest first." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "사용자가 연결에서 가장 최근에 연 테이블을 최신순으로 나열합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kullanıcının bir bağlantıda en son açtığı tabloları, en yeniden başlayarak listeler.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê các bảng mà người dùng mở gần đây nhất trên một kết nối, mới nhất trước.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出用户在某个连接上最近打开的表，最新的在前。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出使用者在某個連線上最近開啟的資料表，最新的在前。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List the tables the user starred on a connection. A good hint at what matters in this database." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "사용자가 연결에서 즐겨찾기한 테이블을 나열합니다. 이 데이터베이스에서 무엇이 중요한지 알려 주는 좋은 단서입니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kullanıcının bir bağlantıda yıldızladığı tabloları listeler. Bu veritabanında neyin önemli olduğuna dair iyi bir ipucu.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê các bảng mà người dùng đã đánh dấu sao trên một kết nối. Một gợi ý tốt về điều gì quan trọng trong cơ sở dữ liệu này.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出用户在某个连接上收藏的表。这能很好地提示这个数据库中什么最重要。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出使用者在某個連線上收藏的資料表。這能很好地提示這個資料庫中什麼最重要。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List the tabs open in TablePro for connections this client may reach. Each entry carries the tab id that focus_query_tab takes and the window id that open_table_tab returns." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 클라이언트가 접근할 수 있는 연결에 대해 TablePro에 열려 있는 탭을 나열합니다. 각 항목에는 focus_query_tab이 받는 탭 id와 open_table_tab이 반환하는 창 id가 들어 있습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu istemcinin erişebildiği bağlantılar için TablePro'da açık olan sekmeleri listeler. Her girdi, focus_query_tab'in aldığı sekme kimliğini ve open_table_tab'in döndürdüğü pencere kimliğini taşır.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê các tab đang mở trong TablePro cho những kết nối mà client này truy cập được. Mỗi mục mang tab id mà focus_query_tab nhận và window id mà open_table_tab trả về.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出 TablePro 中为此客户端可访问的连接打开的标签页。每一项都带有 focus_query_tab 接受的标签页 id 和 open_table_tab 返回的窗口 id。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出 TablePro 中為此用戶端可存取的連線開啟的標籤頁。每一項都帶有 focus_query_tab 接受的標籤頁 id 和 open_table_tab 回傳的視窗 id。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List the triggers attached to one table, with their timing, event, and body." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "한 테이블에 연결된 트리거를 타이밍, 이벤트, 본문과 함께 나열합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir tabloya bağlı tetikleyicileri zamanlaması, olayı ve gövdesiyle birlikte listeler.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê các trigger gắn với một bảng, kèm thời điểm kích hoạt, sự kiện và thân trigger.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出附加在一张表上的触发器，包括其触发时机、事件和主体。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出附加在一張資料表上的觸發器，包括其觸發時機、事件和主體。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List the users and roles defined on the server, with their attributes and role memberships." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "서버에 정의된 사용자와 역할을 속성 및 역할 소속과 함께 나열합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sunucuda tanımlı kullanıcıları ve rolleri, öznitelikleri ve rol üyelikleriyle birlikte listeler.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê các người dùng và vai trò được định nghĩa trên máy chủ, kèm thuộc tính và tư cách thành viên vai trò.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出服务器上定义的用户和角色，以及它们的属性和角色成员关系。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出伺服器上定義的使用者和角色，以及它們的屬性和角色成員關係。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List Triggers" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "트리거 목록",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tetikleyicileri Listele",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê trigger",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出触发器",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出觸發器",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "List Users and Roles" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "사용자 및 역할 목록",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kullanıcıları ve Rolleri Listele",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Liệt kê người dùng và vai trò",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "列出用户和角色",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列出使用者和角色",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Listens on all interfaces (0.0.0.0), reachable from your local network." : {
       "localizations" : {
@@ -77078,7 +86064,38 @@
       }
     },
     "maintenance operation %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "유지 관리 작업 %@",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ bakım işlemi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "thao tác bảo trì %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "维护操作 %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "維護作業 %@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Majority" : {
       "extractionState" : "stale",
@@ -77696,7 +86713,38 @@
       }
     },
     "Match case exactly" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "대소문자를 정확히 일치",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Büyük/küçük harfi tam eşleştir",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Khớp chính xác chữ hoa chữ thường",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "精确匹配大小写",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "精確比對大小寫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Match System" : {
       "comment" : "Text for a sidebar row size preference that matches the system's sidebar row size.",
@@ -77771,7 +86819,38 @@
       }
     },
     "Matched name" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "일치한 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Eşleşen ad",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên đã khớp",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "匹配到的名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "符合的名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "matches regex" : {
       "localizations" : {
@@ -77808,7 +86887,38 @@
       }
     },
     "Matching history entries, newest first" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "일치하는 기록 항목이며 최신순입니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Eşleşen geçmiş girdileri, en yeniden başlayarak",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các mục lịch sử khớp, mới nhất trước",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "匹配的历史条目，最新的在前",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "符合的記錄項目，最新的在前",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Matching ignores case" : {
       "localizations" : {
@@ -77879,7 +86989,38 @@
       }
     },
     "Matching tables first, then matching columns" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "일치하는 테이블을 먼저, 그다음 일치하는 열",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Önce eşleşen tablolar, sonra eşleşen sütunlar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng khớp trước, rồi tới cột khớp",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "先是匹配的表，然后是匹配的列",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "先是符合的資料表，然後是符合的欄位",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Materialized View" : {
       "localizations" : {
@@ -78292,7 +87433,38 @@
       }
     },
     "Maximum entries to return (1-500, default 50)" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "반환할 최대 항목 수(1~500, 기본값 50)",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Döndürülecek en fazla girdi (1-500, varsayılan 50)",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số mục tối đa trả về (1-500, mặc định 50)",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "最多返回多少条目（1-500，默认 50）",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "最多回傳多少項目（1-500，預設 50）",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Maximum entries:" : {
       "localizations" : {
@@ -78329,7 +87501,38 @@
       }
     },
     "Maximum matches to return (1-500, default 50)" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "반환할 최대 일치 수(1~500, 기본값 50)",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Döndürülecek en fazla eşleşme (1-500, varsayılan 50)",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số kết quả khớp tối đa trả về (1-500, mặc định 50)",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "最多返回多少匹配项（1-500，默认 50）",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "最多回傳多少符合項目（1-500，預設 50）",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Maximum number of activations reached." : {
       "localizations" : {
@@ -78435,7 +87638,38 @@
       }
     },
     "Maximum rows per export. Defaults to the server's configured row limit." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "내보내기당 최대 행 수입니다. 기본값은 서버에 설정된 행 제한입니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Dışa aktarma başına en fazla satır. Varsayılan olarak sunucunun yapılandırılmış satır sınırıdır.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số dòng tối đa cho mỗi lần xuất. Mặc định là giới hạn dòng được cấu hình trên máy chủ.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "每次导出的最大行数。默认为服务器配置的行数上限。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "每次匯出的最大列數。預設為伺服器設定的列數上限。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Maximum rows to export (default 50000)" : {
       "extractionState" : "stale",
@@ -78578,10 +87812,72 @@
       }
     },
     "Maximum rows to return. Defaults to the server's configured row limit." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "반환할 최대 행 수입니다. 기본값은 서버에 설정된 행 제한입니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Döndürülecek en fazla satır. Varsayılan olarak sunucunun yapılandırılmış satır sınırıdır.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số dòng tối đa trả về. Mặc định là giới hạn dòng được cấu hình trên máy chủ.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "返回的最大行数。默认为服务器配置的行数上限。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "回傳的最大列數。預設為伺服器設定的列數上限。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Maximum tabs to return (1-500, default 20)" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "반환할 최대 탭 수(1~500, 기본값 20)",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Döndürülecek en fazla sekme (1-500, varsayılan 20)",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số tab tối đa trả về (1-500, mặc định 20)",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "最多返回多少标签页（1-500，默认 20）",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "最多回傳多少標籤頁（1-500，預設 20）",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Maximum time to wait for a query to complete. Set to 0 for no limit. Applied to new connections." : {
       "localizations" : {
@@ -79482,16 +88778,140 @@
       }
     },
     "Metric id" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "지표 id",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Metrik kimliği",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Id chỉ số",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "指标 id",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "指標 id",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Metric label" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "지표 레이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Metrik etiketi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Nhãn chỉ số",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "指标标签",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "指標標籤",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Metric unit" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "지표 단위",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Metrik birimi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đơn vị chỉ số",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "指标单位",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "指標單位",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Metric value" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "지표 값",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Metrik değeri",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giá trị chỉ số",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "指标值",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "指標值",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "MFA Passcode (TOTP)" : {
       "localizations" : {
@@ -79698,7 +89118,38 @@
       }
     },
     "Migration plan for %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@에 대한 마이그레이션 계획",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ için geçiş planı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kế hoạch migration cho %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%@ 的迁移方案",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%@ 的遷移方案",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Minimal" : {
       "localizations" : {
@@ -80694,10 +90145,72 @@
       }
     },
     "Move Tab Left" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "탭 왼쪽으로 이동",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sekmeyi Sola Taşı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chuyển tab sang trái",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "将标签页左移",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "將標籤頁左移",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Move Tab Right" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "탭 오른쪽으로 이동",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sekmeyi Sağa Taşı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chuyển tab sang phải",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "将标签页右移",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "將標籤頁右移",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Move Tab to New Window" : {
       "localizations" : {
@@ -80734,10 +90247,72 @@
       }
     },
     "Move the connection's browse cursor to another database. This changes what the user sees in TablePro. To run one statement elsewhere, pass 'database' to that tool instead." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "연결의 탐색 위치를 다른 데이터베이스로 옮깁니다. 사용자가 TablePro에서 보는 내용이 바뀝니다. 한 개의 명령문만 다른 곳에서 실행하려면 해당 도구에 'database'를 전달하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bağlantının gezinme imlecini başka bir veritabanına taşır. Bu, kullanıcının TablePro'da gördüğünü değiştirir. Tek bir ifadeyi başka yerde çalıştırmak için bunun yerine ilgili araca 'database' geçirin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chuyển con trỏ duyệt của kết nối sang một cơ sở dữ liệu khác. Điều này thay đổi những gì người dùng thấy trong TablePro. Để chạy một câu lệnh ở nơi khác, hãy truyền 'database' cho công cụ đó thay vì dùng cách này.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "把连接的浏览位置切换到另一个数据库。这会改变用户在 TablePro 中看到的内容。若只想在别处运行一条语句，请改为向那个工具传入 'database'。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "把連線的瀏覽位置切換到另一個資料庫。這會改變使用者在 TablePro 中看到的內容。若只想在別處執行一條陳述式，請改為向那個工具傳入 'database'。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Move the connection's browse cursor to another schema. This changes what the user sees." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "연결의 탐색 위치를 다른 스키마로 옮깁니다. 사용자가 보는 내용이 바뀝니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bağlantının gezinme imlecini başka bir şemaya taşır. Bu, kullanıcının gördüğünü değiştirir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chuyển con trỏ duyệt của kết nối sang một schema khác. Điều này thay đổi những gì người dùng thấy.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "把连接的浏览位置切换到另一个 Schema。这会改变用户看到的内容。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "把連線的瀏覽位置切換到另一個綱要。這會改變使用者看到的內容。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Move to" : {
       "localizations" : {
@@ -81566,19 +91141,174 @@
       }
     },
     "Name as supplied" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "입력한 그대로의 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Verildiği haliyle ad",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên đúng như được cung cấp",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "按提供时的原样名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "按提供時的原樣名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Name for the new database" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "새 데이터베이스 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yeni veritabanının adı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên cho cơ sở dữ liệu mới",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "新数据库的名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "新資料庫的名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Name of the database or schema" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "데이터베이스 또는 스키마 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Veritabanının veya şemanın adı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên của cơ sở dữ liệu hoặc schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "数据库或 Schema 的名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "資料庫或綱要的名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Name or UUID of a TablePro connection" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "TablePro 연결의 이름 또는 UUID",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir TablePro bağlantısının adı veya UUID'si",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên hoặc UUID của một kết nối TablePro",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "TablePro 连接的名称或 UUID",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "TablePro 連線的名稱或 UUID",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Name quoted for this engine" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 엔진에 맞게 인용된 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu motor için tırnaklanmış ad",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên đã được trích dẫn theo engine này",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "按该引擎规则加引号的名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "按該引擎規則加引號的名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Name:" : {
       "localizations" : {
@@ -81856,7 +91586,38 @@
       }
     },
     "Nested field path" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "중첩된 필드 경로",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İç içe alan yolu",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đường dẫn trường lồng nhau",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "嵌套字段路径",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "巢狀欄位路徑",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Network" : {
       "extractionState" : "stale",
@@ -84777,7 +94538,38 @@
       }
     },
     "No database to run against. Pass a database name." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "실행할 데이터베이스가 없습니다. 데이터베이스 이름을 전달하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Karşı çalıştırılacak veritabanı yok. Bir veritabanı adı geçirin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không có cơ sở dữ liệu để chạy. Hãy truyền một tên cơ sở dữ liệu.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "没有可运行的数据库。请传入一个数据库名称。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "沒有可執行的資料庫。請傳入一個資料庫名稱。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "No databases" : {
       "localizations" : {
@@ -85258,7 +95050,38 @@
       }
     },
     "No file at %@ on the server." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "서버의 %@에 파일이 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sunucuda %@ konumunda dosya yok.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không có tệp tại %@ trên máy chủ.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "服务器上 %@ 处没有文件。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "伺服器上 %@ 處沒有檔案。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "No filters applied" : {
       "localizations" : {
@@ -85329,7 +95152,38 @@
       }
     },
     "No foreign tables" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "외부 테이블 없음",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yabancı tablo yok",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không có bảng ngoại",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "没有外部表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "沒有外部資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "No free port in range %d-%d" : {
       "extractionState" : "stale",
@@ -85373,7 +95227,38 @@
       }
     },
     "No functions" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "함수 없음",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Fonksiyon yok",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không có hàm",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "没有函数",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "沒有函式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "No iCloud" : {
       "localizations" : {
@@ -85513,7 +95398,38 @@
       }
     },
     "No License Information" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "라이선스 정보 없음",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Lisans Bilgisi Yok",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không có thông tin giấy phép",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "没有许可证信息",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "沒有授權資訊",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "No limit" : {
       "localizations" : {
@@ -85859,7 +95775,38 @@
       }
     },
     "No matching field path" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "일치하는 필드 경로 없음",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Eşleşen alan yolu yok",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không có đường dẫn trường nào khớp",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "没有匹配的字段路径",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "沒有符合的欄位路徑",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "No matching fields" : {
       "localizations" : {
@@ -86103,7 +96050,38 @@
       }
     },
     "No materialized views" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "구체화된 뷰 없음",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Somutlaştırılmış görünüm yok",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không có materialized view",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "没有物化视图",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "沒有具體化檢視表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "No measurable change" : {
       "localizations" : {
@@ -86487,7 +96465,38 @@
       }
     },
     "No open tab this client may reach has that id." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 클라이언트가 접근할 수 있는 열린 탭 중 해당 id를 가진 탭이 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu istemcinin erişebildiği açık sekmeler arasında bu kimliğe sahip bir sekme yok.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không có tab đang mở nào mà client này truy cập được có id đó.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此客户端可访问的已打开标签页中没有这个 id。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此用戶端可存取的已開啟標籤頁中沒有這個 id。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "No Operations Available" : {
       "localizations" : {
@@ -86868,7 +96877,38 @@
       }
     },
     "No procedures" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "프로시저 없음",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yordam yok",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không có procedure",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "没有存储过程",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "沒有預存程序",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "No providers configured" : {
       "localizations" : {
@@ -87315,7 +97355,38 @@
       }
     },
     "No remote database file was named for this connection." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 연결에 대해 원격 데이터베이스 파일이 지정되지 않았습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu bağlantı için uzak bir veritabanı dosyası belirtilmedi.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chưa có tệp cơ sở dữ liệu từ xa nào được đặt cho kết nối này.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此连接没有指定远程数据库文件。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此連線沒有指定遠端資料庫檔案。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "No Results" : {
       "localizations" : {
@@ -87488,10 +97559,72 @@
       }
     },
     "No saved changes to '%@' are being kept." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "'%@'에 대해 보관 중인 저장된 변경 사항이 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "'%@' için saklanan kaydedilmiş değişiklik yok.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không có thay đổi đã lưu nào của '%@' đang được giữ lại.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "没有为 '%@' 保留任何已保存的更改。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "沒有為 '%@' 保留任何已儲存的變更。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "No saved connection has that id." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "해당 id를 가진 저장된 연결이 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu kimliğe sahip kayıtlı bir bağlantı yok.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không có kết nối đã lưu nào có id đó.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "没有已保存的连接使用这个 id。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "沒有已儲存的連線使用這個 id。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "No saved connection named \"%@\"." : {
       "extractionState" : "stale",
@@ -87597,7 +97730,38 @@
       }
     },
     "No Saved Connections" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "저장된 연결 없음",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kayıtlı Bağlantı Yok",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không có kết nối đã lưu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "没有已保存的连接",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "沒有已儲存的連線",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "No saved customizations yet. Column widths, order, visibility, and per-table filters you set appear here so you can review and reset them." : {
       "extractionState" : "stale",
@@ -87739,7 +97903,38 @@
       }
     },
     "No Schemas" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "스키마 없음",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Şema Yok",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không có schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "没有 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "沒有綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "No Schemas Available" : {
       "comment" : "Placeholder text displayed in the schemas menu when the user has no schemas available.",
@@ -88359,7 +98554,38 @@
       }
     },
     "No triggers" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "트리거 없음",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tetikleyici yok",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không có trigger",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "没有触发器",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "沒有觸發器",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "No Triggers" : {
       "localizations" : {
@@ -88533,10 +98759,72 @@
       }
     },
     "No values in this row matched the column mapping" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 행의 어떤 값도 열 매핑과 일치하지 않았습니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu satırdaki hiçbir değer sütun eşlemesiyle eşleşmedi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không có giá trị nào trong dòng này khớp với ánh xạ cột",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此行中没有值与列映射相匹配",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此列中沒有值與欄位對應相符",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "No views" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "뷰 없음",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Görünüm yok",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không có view",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "没有视图",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "沒有檢視表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "No Warnings" : {
       "localizations" : {
@@ -89289,7 +99577,38 @@
       }
     },
     "Not generated" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "생성되지 않음",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Üretilmedi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không được tạo",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "未生成",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "未產生",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Not granted" : {
       "localizations" : {
@@ -89428,7 +99747,38 @@
       }
     },
     "Not Now" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "나중에",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Şimdi Değil",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Để sau",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "以后再说",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "稍後再說",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "NOT NULL" : {
       "extractionState" : "stale",
@@ -90147,7 +100497,38 @@
       }
     },
     "Nothing to Restore" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "복원할 항목 없음",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Geri Yüklenecek Bir Şey Yok",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không có gì để khôi phục",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "没有可恢复的内容",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "沒有可還原的內容",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Nothing to Show" : {
       "localizations" : {
@@ -90218,13 +100599,106 @@
       }
     },
     "Notifications are turned off for TablePro in System Settings." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "시스템 설정에서 TablePro의 알림이 꺼져 있습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sistem Ayarları'nda TablePro için bildirimler kapalı.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thông báo cho TablePro đang tắt trong Cài đặt hệ thống.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "在系统设置中，TablePro 的通知已关闭。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "在系統設定中，TablePro 的通知已關閉。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Notify about" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "알림 대상",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Şunlar için bildir",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thông báo về",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "通知内容",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "通知內容",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Notify when long-running work finishes" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "오래 걸리는 작업이 끝나면 알림",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Uzun süren işler bittiğinde bildir",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thông báo khi công việc chạy lâu kết thúc",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "长时间运行的操作完成时通知",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "長時間執行的作業完成時通知",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "NOW()" : {
       "extractionState" : "stale",
@@ -90742,13 +101216,106 @@
       }
     },
     "Number of rows" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "행 수",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Satır sayısı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số dòng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "行数",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列數",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Number of rows returned" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "반환된 행 수",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Döndürülen satır sayısı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số dòng trả về",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "返回的行数",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "回傳的列數",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Number of tables" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블 수",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tablo sayısı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số bảng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "表的数量",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "資料表數量",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Numeric tolerance" : {
       "localizations" : {
@@ -90955,10 +101522,72 @@
       }
     },
     "Object type reported by the engine" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "엔진이 보고한 객체 유형",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Motorun bildirdiği nesne türü",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kiểu đối tượng do engine báo cáo",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "引擎报告的对象类型",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "引擎回報的物件類型",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Object type, for a table match" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블이 일치할 때의 객체 유형",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir tablo eşleşmesi için nesne türü",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kiểu đối tượng, khi khớp theo bảng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "对象类型，用于表匹配",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "物件類型，用於資料表比對",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Objects that depend on them will be dropped too." : {
       "comment" : "Message in a confirmation alert when the user has selected to drop all objects that depend on the dropped objects.",
@@ -91272,7 +101901,38 @@
       }
     },
     "ON DELETE action" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "ON DELETE 동작",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "ON DELETE eylemi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hành vi ON DELETE",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "ON DELETE 动作",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "ON DELETE 動作",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "On Disk" : {
       "localizations" : {
@@ -91411,19 +102071,174 @@
       }
     },
     "ON UPDATE action" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "ON UPDATE 동작",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "ON UPDATE eylemi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hành vi ON UPDATE",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "ON UPDATE 动作",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "ON UPDATE 動作",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "One entry per query or table" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "쿼리 또는 테이블마다 한 항목",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sorgu veya tablo başına bir girdi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Mỗi truy vấn hoặc bảng một mục",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "每个查询或每张表一个条目",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "每個查詢或每張資料表一個項目",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "One result per statement" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "명령문마다 결과 하나",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İfade başına bir sonuç",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Mỗi câu lệnh một kết quả",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "每条语句一个结果",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "每條陳述式一個結果",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "One SQL or NoSQL statement" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "SQL 또는 NoSQL 명령문 하나",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tek bir SQL veya NoSQL ifadesi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Một câu lệnh SQL hoặc NoSQL",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "一条 SQL 或 NoSQL 语句",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "一條 SQL 或 NoSQL 陳述式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Only %1$d of %2$d bytes of %3$@ arrived." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%3$@의 %2$d바이트 중 %1$d바이트만 도착했습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%3$@ için %2$d baytın yalnızca %1$d baytı ulaştı.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chỉ %1$d trên %2$d byte của %3$@ đã tới.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%3$@ 的 %2$d 字节中只到达了 %1$d 字节。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%3$@ 的 %2$d 位元組中只到達了 %1$d 位元組。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Only affects new saves. Re-save a password to update its sync." : {
       "localizations" : {
@@ -91460,7 +102275,38 @@
       }
     },
     "Only after" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이후만",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yalnızca şundan sonra",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chỉ sau",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "仅在此之后",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "僅在此之後",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Only in Source" : {
       "localizations" : {
@@ -91599,7 +102445,38 @@
       }
     },
     "Only use the bootstrap address" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "부트스트랩 주소만 사용",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yalnızca bootstrap adresini kullan",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chỉ dùng địa chỉ bootstrap",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "只使用 bootstrap 地址",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "只使用 bootstrap 位址",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Open" : {
       "localizations" : {
@@ -91841,7 +102718,38 @@
       }
     },
     "Open a database file on an SSH server" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "SSH 서버의 데이터베이스 파일 열기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir SSH sunucusundaki veritabanı dosyasını aç",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Mở một tệp cơ sở dữ liệu trên máy chủ SSH",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "打开 SSH 服务器上的数据库文件",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "開啟 SSH 伺服器上的資料庫檔案",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Open a different file from the Welcome window." : {
       "localizations" : {
@@ -91878,10 +102786,72 @@
       }
     },
     "Open a session for a saved connection. Returns only after the driver is connected." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "저장된 연결의 세션을 엽니다. 드라이버가 연결된 뒤에만 반환합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kayıtlı bir bağlantı için oturum açar. Yalnızca sürücü bağlandıktan sonra döner.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Mở một phiên cho kết nối đã lưu. Chỉ trả về sau khi driver đã kết nối.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "为一个已保存的连接打开会话。仅在驱动连接成功后才返回。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "為一個已儲存的連線開啟工作階段。僅在驅動程式連線成功後才回傳。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Open a table in TablePro and bring it forward. Returns once the tab exists, with the same tab id and window id that list_recent_tabs reports. Connects the connection if it is not open yet." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "TablePro에서 테이블을 열고 앞으로 가져옵니다. 탭이 생기면 list_recent_tabs가 보고하는 것과 같은 탭 id 및 창 id와 함께 반환합니다. 연결이 아직 열려 있지 않으면 연결합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "TablePro'da bir tablo açar ve öne getirir. Sekme oluştuğunda, list_recent_tabs'in bildirdiği sekme kimliği ve pencere kimliğiyle döner. Bağlantı henüz açık değilse bağlanır.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Mở một bảng trong TablePro và đưa nó lên trước. Trả về ngay khi tab tồn tại, kèm đúng tab id và window id mà list_recent_tabs báo cáo. Sẽ kết nối nếu kết nối chưa mở.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "在 TablePro 中打开一张表并将其带到最前。标签页建立后即返回，带有与 list_recent_tabs 相同的标签页 id 和窗口 id。若连接尚未打开则会先连接。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "在 TablePro 中開啟一張資料表並將其帶到最前。標籤頁建立後即回傳，帶有與 list_recent_tabs 相同的標籤頁 id 和視窗 id。若連線尚未開啟則會先連線。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Open a table tab in TablePro for the given connection." : {
       "extractionState" : "stale",
@@ -92782,7 +103752,38 @@
       }
     },
     "Open or focus a TablePro window for a saved connection. Returns once the window has a tab, with the window id that list_recent_tabs reports." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "저장된 연결의 TablePro 창을 열거나 앞으로 가져옵니다. 창에 탭이 생기면 list_recent_tabs가 보고하는 창 id와 함께 반환합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kayıtlı bir bağlantı için bir TablePro penceresi açar veya öne getirir. Pencerede bir sekme oluştuğunda, list_recent_tabs'in bildirdiği pencere kimliğiyle döner.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Mở hoặc chuyển tới một cửa sổ TablePro cho kết nối đã lưu. Trả về ngay khi cửa sổ có tab, kèm window id mà list_recent_tabs báo cáo.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "为一个已保存的连接打开或聚焦 TablePro 窗口。窗口有标签页后即返回，带有 list_recent_tabs 报告的窗口 id。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "為一個已儲存的連線開啟或聚焦 TablePro 視窗。視窗有標籤頁後即回傳，帶有 list_recent_tabs 回報的視窗 id。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Open Plugin Settings" : {
       "localizations" : {
@@ -92964,25 +103965,25 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Hızlı Aç"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Mở nhanh"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "快速打开"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "快速打開"
           }
         }
@@ -92998,25 +103999,25 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Hızlı Aç…"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Mở nhanh…"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "快速打开…"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "快速打開…"
           }
         }
@@ -93161,7 +104162,38 @@
       }
     },
     "Open Source Libraries" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "오픈 소스 라이브러리",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Açık Kaynak Kitaplıklar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thư viện mã nguồn mở",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "开源库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "開源程式庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Open SQL Editor" : {
       "extractionState" : "stale",
@@ -93233,7 +104265,38 @@
       }
     },
     "Open System Settings" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "시스템 설정 열기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sistem Ayarları'nı Aç",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Mở Cài đặt hệ thống",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "打开系统设置",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "打開系統設定",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Open Table" : {
       "comment" : "A context menu option to open a table in the main view.",
@@ -93306,7 +104369,38 @@
       }
     },
     "Open tabs, ordered by connection then title" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "연결순, 그다음 제목순으로 정렬된 열린 탭",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Önce bağlantıya sonra başlığa göre sıralanmış açık sekmeler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các tab đang mở, sắp xếp theo kết nối rồi tới tiêu đề",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已打开的标签页，先按连接再按标题排序",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已開啟的標籤頁，先按連線再按標題排序",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Open Terminal" : {
       "extractionState" : "stale",
@@ -93390,25 +104484,25 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Açık Çalışma Alanları"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Không gian làm việc đang mở"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "已打开的工作区"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "已開啟的工作區"
           }
         }
@@ -93791,10 +104885,72 @@
       }
     },
     "Operation name from list_maintenance_operations" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "list_maintenance_operations에서 얻은 작업 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "list_maintenance_operations'tan alınan işlem adı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên thao tác lấy từ list_maintenance_operations",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "来自 list_maintenance_operations 的操作名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "來自 list_maintenance_operations 的作業名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Operation names, sorted" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "정렬된 작업 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İşlem adları, sıralı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên các thao tác, đã sắp xếp",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已排序的操作名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已排序的作業名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Operation not permitted" : {
       "localizations" : {
@@ -93831,7 +104987,38 @@
       }
     },
     "Operation that ran" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "실행된 작업",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Çalıştırılan işlem",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thao tác đã chạy",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已运行的操作",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已執行的作業",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Operator" : {
       "localizations" : {
@@ -94075,7 +105262,38 @@
       }
     },
     "Option key to pass in 'options'" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "'options'에 전달할 옵션 키",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "'options' içinde geçirilecek seçenek anahtarı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Khoá tuỳ chọn để truyền trong 'options'",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要在 'options' 中传入的选项键",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要在 'options' 中傳入的選項鍵",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Optional" : {
       "localizations" : {
@@ -94283,7 +105501,38 @@
       }
     },
     "Options the engine offers" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "엔진이 제공하는 옵션",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Motorun sunduğu seçenekler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các tuỳ chọn mà engine cung cấp",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该引擎提供的选项",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該引擎提供的選項",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "OR" : {
       "extractionState" : "stale",
@@ -94629,16 +105878,140 @@
       }
     },
     "Outgoing foreign keys" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "나가는 외래 키",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Giden yabancı anahtarlar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Khoá ngoại đi ra",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "出向外键",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "出向外鍵",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Output format" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "출력 형식",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Çıktı biçimi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Định dạng đầu ra",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "输出格式",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "輸出格式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Output of EXPLAIN for this query, if you have it" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 쿼리에 대한 EXPLAIN 출력이며, 있는 경우에 한합니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Varsa bu sorgu için EXPLAIN çıktısı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kết quả EXPLAIN của truy vấn này, nếu bạn có",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该查询的 EXPLAIN 输出，如果你有的话",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該查詢的 EXPLAIN 輸出，如果你有的話",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Output of EXPLAIN or EXPLAIN ANALYZE for this query" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 쿼리에 대한 EXPLAIN 또는 EXPLAIN ANALYZE 출력",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu sorgu için EXPLAIN veya EXPLAIN ANALYZE çıktısı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kết quả EXPLAIN hoặc EXPLAIN ANALYZE của truy vấn này",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该查询的 EXPLAIN 或 EXPLAIN ANALYZE 输出",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該查詢的 EXPLAIN 或 EXPLAIN ANALYZE 輸出",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Output truncated for display" : {
       "localizations" : {
@@ -94675,13 +106048,106 @@
       }
     },
     "output_path must end in .%@ for this format." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 형식에서는 output_path가 .%@(으)로 끝나야 합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu biçim için output_path .%@ ile bitmelidir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Với định dạng này, output_path phải kết thúc bằng .%@.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "对于此格式，output_path 必须以 .%@ 结尾。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "對於此格式，output_path 必須以 .%@ 結尾。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "output_path must name a file inside the Downloads folder." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "output_path는 다운로드 폴더 안의 파일을 가리켜야 합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "output_path, İndirilenler klasörünün içindeki bir dosyayı belirtmelidir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "output_path phải trỏ tới một tệp bên trong thư mục Downloads.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "output_path 必须指向下载文件夹内的文件。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "output_path 必須指向下載檔案夾內的檔案。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "output_path must not name a hidden file." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "output_path는 숨김 파일을 가리킬 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "output_path gizli bir dosyayı belirtmemelidir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "output_path không được trỏ tới một tệp ẩn.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "output_path 不能指向隐藏文件。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "output_path 不能指向隱藏檔案。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Over an SSH tunnel, TablePro connects directly to the first host. Replica set failover is not available." : {
       "localizations" : {
@@ -94787,7 +106253,38 @@
       }
     },
     "Owning table, for a column match" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "열이 일치할 때 소유 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir sütun eşleşmesi için sahip tablo",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng sở hữu, khi khớp theo cột",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "所属表，用于列匹配",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "所屬資料表，用於欄位比對",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Page" : {
       "localizations" : {
@@ -95245,7 +106742,38 @@
       }
     },
     "Panels to read. Omit for all." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "읽을 패널입니다. 모두 읽으려면 생략하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Okunacak paneller. Tümü için boş bırakın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các bảng cần đọc. Bỏ trống để lấy tất cả.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要读取的面板。省略则表示全部。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要讀取的面板。省略則表示全部。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Parameters" : {
       "localizations" : {
@@ -95316,7 +106844,38 @@
       }
     },
     "Parent table" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "상위 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Üst tablo",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng cha",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "父表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "父資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Part Mutations" : {
       "localizations" : {
@@ -95387,7 +106946,38 @@
       }
     },
     "Partial index predicate" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "부분 인덱스 조건식",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kısmi indeks koşulu",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Điều kiện của chỉ mục một phần",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "部分索引的谓词",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "部分索引的述詞",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Partition" : {
       "localizations" : {
@@ -95492,25 +107082,242 @@
       }
     },
     "Pass 'query' or 'tables', not both." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "'query' 또는 'tables' 중 하나만 전달하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "'query' veya 'tables' geçirin, ikisini birden değil.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hãy truyền 'query' hoặc 'tables', không truyền cả hai.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "请传入 'query' 或 'tables'，不能同时传两个。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "請傳入 'query' 或 'tables'，不能同時傳兩個。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Pass 'sql_table' to name the table the INSERT statements target." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "INSERT 명령문의 대상 테이블을 지정하려면 'sql_table'을 전달하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "INSERT ifadelerinin hedeflediği tabloyu adlandırmak için 'sql_table' geçirin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hãy truyền 'sql_table' để đặt tên bảng đích của các câu lệnh INSERT.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "请传入 'sql_table' 来指定 INSERT 语句的目标表。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "請傳入 'sql_table' 來指定 INSERT 陳述式的目標資料表。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Pass at least one column." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "열을 하나 이상 전달하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "En az bir sütun geçirin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hãy truyền ít nhất một cột.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "请至少传入一个列。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "請至少傳入一個欄位。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Pass at least one identifier or literal." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "식별자 또는 리터럴을 하나 이상 전달하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "En az bir tanımlayıcı veya değişmez değer geçirin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hãy truyền ít nhất một định danh hoặc literal.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "请至少传入一个标识符或字面量。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "請至少傳入一個識別符號或字面值。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Pass at least one row." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "행을 하나 이상 전달하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "En az bir satır geçirin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hãy truyền ít nhất một dòng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "请至少传入一行。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "請至少傳入一列。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Pass at least one table." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블을 하나 이상 전달하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "En az bir tablo geçirin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hãy truyền ít nhất một bảng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "请至少传入一张表。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "請至少傳入一張資料表。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Pass either 'query' or 'tables'." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "'query' 또는 'tables' 중 하나를 전달하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "'query' ya da 'tables' geçirin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hãy truyền 'query' hoặc 'tables'.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "请传入 'query' 或 'tables'。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "請傳入 'query' 或 'tables'。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Passphrase" : {
       "localizations" : {
@@ -96516,7 +108323,38 @@
       }
     },
     "Pending changes reach more than one database. Save or discard one database at a time." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "대기 중인 변경 사항이 여러 데이터베이스에 걸쳐 있습니다. 데이터베이스별로 하나씩 저장하거나 버리십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bekleyen değişiklikler birden fazla veritabanına uzanıyor. Her seferinde tek bir veritabanını kaydedin veya değişikliklerini atın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các thay đổi đang chờ trải trên nhiều cơ sở dữ liệu. Hãy lưu hoặc huỷ từng cơ sở dữ liệu một.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "待处理的更改涉及多个数据库。请一次保存或放弃一个数据库。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "待處理的變更涉及多個資料庫。請一次儲存或捨棄一個資料庫。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "pending delete" : {
       "localizations" : {
@@ -96553,7 +108391,38 @@
       }
     },
     "Pending table changes belong to %@. Switch to that database to save them, or discard them." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "대기 중인 테이블 변경 사항은 %@에 속합니다. 저장하려면 해당 데이터베이스로 전환하거나, 변경 사항을 버리십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bekleyen tablo değişiklikleri %@ veritabanına ait. Kaydetmek için o veritabanına geçin ya da değişiklikleri atın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các thay đổi bảng đang chờ thuộc về %@. Hãy chuyển sang cơ sở dữ liệu đó để lưu, hoặc huỷ chúng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "待处理的表更改属于 %@。请切换到该数据库进行保存，或者放弃这些更改。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "待處理的資料表變更屬於 %@。請切換到該資料庫進行儲存，或者捨棄這些變更。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "pending truncate" : {
       "localizations" : {
@@ -96624,7 +108493,38 @@
       }
     },
     "Period to summarize: today, this_week, this_month, or all" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "요약할 기간입니다: today, this_week, this_month 또는 all",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Özetlenecek dönem: today, this_week, this_month veya all",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Khoảng thời gian để tổng hợp: today, this_week, this_month hoặc all",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要汇总的时间段：today、this_week、this_month 或 all",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要彙總的時間範圍：today、this_week、this_month 或 all",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Permission" : {
       "localizations" : {
@@ -98939,10 +110839,72 @@
       }
     },
     "Prefix the variant applies" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "변형이 적용하는 접두사",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Varyantın uyguladığı ön ek",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tiền tố mà biến thể áp dụng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该变体应用的前缀",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該變體套用的前綴",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Preparing the metadata connection timed out." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "메타데이터 연결을 준비하는 동안 시간이 초과되었습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Meta veri bağlantısı hazırlanırken zaman aşımına uğradı.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Việc chuẩn bị kết nối metadata đã hết thời gian chờ.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "准备元数据连接超时。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "準備中繼資料連線逾時。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Preparing the session" : {
       "localizations" : {
@@ -100151,10 +112113,72 @@
       }
     },
     "Principal name" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "주체 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Asıl adı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên principal",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "主体名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "主體名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Principal the grants belong to" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "부여 권한이 속한 주체",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yetkilerin ait olduğu asıl",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Principal mà các quyền thuộc về",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "这些授权所属的主体",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "這些授權所屬的主體",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Priority %d" : {
       "localizations" : {
@@ -100395,7 +112419,38 @@
       }
     },
     "Privilege name" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "권한 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Ayrıcalık adı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên đặc quyền",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "权限名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "權限名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Privileges" : {
       "localizations" : {
@@ -100707,7 +112762,38 @@
       }
     },
     "PROCEDURE or FUNCTION" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "PROCEDURE 또는 FUNCTION",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "PROCEDURE veya FUNCTION",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "PROCEDURE hoặc FUNCTION",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "PROCEDURE 或 FUNCTION",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "PROCEDURE 或 FUNCTION",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Procedure: %@" : {
       "localizations" : {
@@ -100812,10 +112898,72 @@
       }
     },
     "Process id from get_server_dashboard" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "get_server_dashboard에서 얻은 프로세스 id",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "get_server_dashboard'dan alınan işlem kimliği",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Process id lấy từ get_server_dashboard",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "来自 get_server_dashboard 的进程 id",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "來自 get_server_dashboard 的行程 id",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Process id, accepted by stop_server_session" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "stop_server_session이 받는 프로세스 id",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "stop_server_session tarafından kabul edilen işlem kimliği",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Process id, được stop_server_session chấp nhận",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "进程 id，可被 stop_server_session 接受",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "行程 id，可被 stop_server_session 接受",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Production" : {
       "localizations" : {
@@ -101211,7 +113359,38 @@
       }
     },
     "Propose indexes for a slow query" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "느린 쿼리를 위한 인덱스 제안",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yavaş bir sorgu için indeks öner",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đề xuất chỉ mục cho một truy vấn chậm",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "为慢查询提出索引建议",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "為慢查詢提出索引建議",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "protected" : {
       "localizations" : {
@@ -101837,7 +114016,38 @@
       }
     },
     "Put the row back" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "행 되돌리기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Satırı geri koy",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đưa dòng trở lại",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "把该行放回去",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "把該列放回去",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Put the suggested SQL into the query editor" : {
       "localizations" : {
@@ -101910,10 +114120,72 @@
       }
     },
     "Queries recently run against a connection, newest first. limit is 1 to 500 and defaults to 50, search matches the query text, and date_filter is today, thisWeek or thisMonth." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "연결에서 최근에 실행한 쿼리를 최신순으로 반환합니다. limit은 1에서 500까지이고 기본값은 50이며, search는 쿼리 텍스트와 일치시키고, date_filter는 today, thisWeek 또는 thisMonth입니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir bağlantıda son çalıştırılan sorgular, en yeniden başlayarak. limit 1 ile 500 arasındadır ve varsayılanı 50'dir, search sorgu metniyle eşleşir ve date_filter today, thisWeek ya da thisMonth olur.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các truy vấn chạy gần đây trên một kết nối, mới nhất trước. limit từ 1 đến 500 và mặc định là 50, search khớp với nội dung truy vấn, còn date_filter là today, thisWeek hoặc thisMonth.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "某个连接上最近运行的查询，最新的在前。limit 取值 1 到 500，默认 50；search 匹配查询文本；date_filter 取 today、thisWeek 或 thisMonth。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "某個連線上最近執行的查詢，最新的在前。limit 取值 1 到 500，預設 50；search 比對查詢文字；date_filter 取 today、thisWeek 或 thisMonth。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Queries recently run against this connection, newest first" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 연결에서 최근에 실행한 쿼리이며 최신순입니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu bağlantıda son çalıştırılan sorgular, en yeniden başlayarak",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các truy vấn chạy gần đây trên kết nối này, mới nhất trước",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此连接上最近运行的查询，最新的在前",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此連線上最近執行的查詢，最新的在前",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Queries you run appear here." : {
       "localizations" : {
@@ -102331,7 +114603,38 @@
       }
     },
     "Query for a question on %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@에 대한 질문의 쿼리",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ üzerindeki bir soru için sorgu",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Truy vấn cho một câu hỏi trên %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "针对 %@ 上某个问题的查询",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "針對 %@ 上某個問題的查詢",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Query History" : {
       "localizations" : {
@@ -102473,10 +114776,72 @@
       }
     },
     "Query history of %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@의 쿼리 기록",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ sorgu geçmişi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Lịch sử truy vấn của %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%@ 的查询历史",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%@ 的查詢記錄",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Query history summary for %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@의 쿼리 기록 요약",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ için sorgu geçmişi özeti",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tóm tắt lịch sử truy vấn của %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%@ 的查询历史摘要",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%@ 的查詢記錄摘要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Query History:" : {
       "extractionState" : "stale",
@@ -102802,10 +115167,72 @@
       }
     },
     "Query review on %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@에 대한 쿼리 검토",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ üzerinde sorgu incelemesi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Rà soát truy vấn trên %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "在 %@ 上的查询审查",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "在 %@ 上的查詢審查",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Query timed out after %d seconds" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%d초 후 쿼리 시간이 초과되었습니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sorgu %d saniye sonra zaman aşımına uğradı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Truy vấn đã hết thời gian chờ sau %d giây",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "查询在 %d 秒后超时",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "查詢在 %d 秒後逾時",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Query timeout" : {
       "localizations" : {
@@ -103016,7 +115443,38 @@
       }
     },
     "Question" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "질문",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Soru",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Câu hỏi",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "问题",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "問題",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "QUICK" : {
       "localizations" : {
@@ -103433,10 +115891,72 @@
       }
     },
     "Quote Identifiers" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "식별자 인용",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tanımlayıcıları Tırnakla",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Trích dẫn định danh",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "为标识符加引号",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "為識別符號加引號",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Quote identifiers and escape string literals using the connection's own driver rules. Use it before putting any name or value into hand-written SQL." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "연결 고유의 드라이버 규칙에 따라 식별자를 인용하고 문자열 리터럴을 이스케이프합니다. 손으로 작성한 SQL에 이름이나 값을 넣기 전에 사용하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bağlantının kendi sürücü kurallarını kullanarak tanımlayıcıları tırnaklar ve dize değişmez değerlerini kaçışlar. Elle yazılmış SQL'e herhangi bir ad veya değer koymadan önce kullanın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Trích dẫn định danh và escape các literal chuỗi theo đúng quy tắc driver của kết nối. Hãy dùng nó trước khi đưa bất kỳ tên hay giá trị nào vào SQL viết tay.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "按该连接自己的驱动规则为标识符加引号并转义字符串字面量。在把任何名称或值放进手写 SQL 之前请先使用它。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "按該連線自己的驅動程式規則為識別符號加引號並跳脫字串字面值。在把任何名稱或值放進手寫 SQL 之前請先使用它。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Quote if needed" : {
       "extractionState" : "stale",
@@ -103474,7 +115994,38 @@
       }
     },
     "Quoted identifiers, in the order supplied" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "제공된 순서대로 인용된 식별자",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Verilen sırayla tırnaklanmış tanımlayıcılar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các định danh đã trích dẫn, theo thứ tự được cung cấp",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已加引号的标识符，按提供的顺序排列",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已加引號的識別符號，按提供的順序排列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Ran" : {
       "localizations" : {
@@ -103511,10 +116062,72 @@
       }
     },
     "Ran %@ statement" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@ 명령문 실행됨",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ ifade çalıştırıldı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đã chạy %@ câu lệnh",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已运行 %@ 条语句",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已執行 %@ 條陳述式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Ran %@ statements" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@개 명령문 실행됨",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ ifade çalıştırıldı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đã chạy %@ câu lệnh",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已运行 %@ 条语句",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已執行 %@ 條陳述式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "ran %@×" : {
       "comment" : "Run count in a detail line, %@ is a count",
@@ -103722,13 +116335,106 @@
       }
     },
     "Raw Filter" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "원시 필터",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Ham Filtre",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bộ lọc thô",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "原始筛选条件",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "原始篩選條件",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Raw result columns" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "원시 결과 열",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Ham sonuç sütunları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cột kết quả thô",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "原始结果列",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "原始結果欄位",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Raw result rows" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "원시 결과 행",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Ham sonuç satırları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Dòng kết quả thô",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "原始结果行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "原始結果列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Raw SQL" : {
       "localizations" : {
@@ -103799,7 +116505,38 @@
       }
     },
     "Raw SQL filters are not available over MCP." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "원시 SQL 필터는 MCP를 통해 사용할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Ham SQL filtreleri MCP üzerinden kullanılamaz.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bộ lọc SQL thô không dùng được qua MCP.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "原始 SQL 筛选条件无法通过 MCP 使用。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "原始 SQL 篩選條件無法透過 MCP 使用。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Raw Value" : {
       "localizations" : {
@@ -104076,7 +116813,38 @@
       }
     },
     "Read rows from a table with filters, sorting and paging, built by TablePro's own query builder for this engine. Prefer it over hand-writing SELECT: it quotes identifiers, escapes values, and pages the way the app does." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 엔진용 TablePro 자체 쿼리 빌더가 만든 필터, 정렬, 페이징으로 테이블의 행을 읽습니다. SELECT를 직접 작성하는 대신 이것을 사용하십시오. 식별자를 인용하고 값을 이스케이프하며 앱과 동일한 방식으로 페이징합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu motor için TablePro'nun kendi sorgu oluşturucusunun ürettiği filtreler, sıralama ve sayfalama ile bir tablodan satır okur. SELECT'i elle yazmak yerine bunu tercih edin: tanımlayıcıları tırnaklar, değerleri kaçışlar ve uygulamanın yaptığı gibi sayfalar.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đọc các dòng từ một bảng với bộ lọc, sắp xếp và phân trang, do chính query builder của TablePro dựng cho engine này. Hãy ưu tiên nó thay vì tự viết SELECT: nó trích dẫn định danh, escape giá trị và phân trang đúng như ứng dụng làm.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "从表中读取行，带有筛选、排序和分页，由 TablePro 自己针对该引擎的查询构建器生成。请优先用它而不是手写 SELECT：它会为标识符加引号、转义值，并采用与应用相同的分页方式。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "從資料表中讀取列，帶有篩選、排序和分頁，由 TablePro 自己針對該引擎的查詢建構器產生。請優先用它而不是手寫 SELECT：它會為識別符號加引號、跳脫值，並採用與應用程式相同的分頁方式。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Read saved passwords from Keychain (requires permission)" : {
       "localizations" : {
@@ -104181,7 +116949,38 @@
       }
     },
     "Read the live server panels TablePro shows: active sessions, server metrics, and slow queries. Available on PostgreSQL, MySQL, SQL Server, ClickHouse, DuckDB, and SQLite." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "TablePro가 표시하는 실시간 서버 패널을 읽습니다: 활성 세션, 서버 지표, 느린 쿼리. PostgreSQL, MySQL, SQL Server, ClickHouse, DuckDB, SQLite에서 사용할 수 있습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "TablePro'nun gösterdiği canlı sunucu panellerini okur: etkin oturumlar, sunucu metrikleri ve yavaş sorgular. PostgreSQL, MySQL, SQL Server, ClickHouse, DuckDB ve SQLite'ta kullanılabilir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đọc các bảng máy chủ trực tiếp mà TablePro hiển thị: phiên đang hoạt động, chỉ số máy chủ và truy vấn chậm. Có trên PostgreSQL, MySQL, SQL Server, ClickHouse, DuckDB và SQLite.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "读取 TablePro 显示的实时服务器面板：活动会话、服务器指标和慢查询。可用于 PostgreSQL、MySQL、SQL Server、ClickHouse、DuckDB 和 SQLite。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "讀取 TablePro 顯示的即時伺服器面板：作用中工作階段、伺服器指標和慢查詢。可用於 PostgreSQL、MySQL、SQL Server、ClickHouse、DuckDB 和 SQLite。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Read-only" : {
       "extractionState" : "stale",
@@ -104943,7 +117742,38 @@
       }
     },
     "Recently opened tables, newest first" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "최근에 연 테이블이며 최신순입니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Son açılan tablolar, en yeniden başlayarak",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các bảng mở gần đây, mới nhất trước",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "最近打开的表，最新的在前",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "最近開啟的資料表，最新的在前",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Recheck" : {
       "localizations" : {
@@ -105219,10 +118049,72 @@
       }
     },
     "Redacted error text when the status is error" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "상태가 오류일 때 편집된 오류 텍스트",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Durum hata olduğunda maskelenmiş hata metni",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Nội dung lỗi đã lược bỏ thông tin nhạy cảm, khi trạng thái là lỗi",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "状态为错误时经过脱敏的错误文本",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "狀態為錯誤時經過去識別化的錯誤文字",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Redacted failure text" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "편집된 실패 텍스트",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Maskelenmiş hata metni",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Nội dung lỗi đã lược bỏ thông tin nhạy cảm",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "经过脱敏的失败文本",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "經過去識別化的失敗文字",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Redis" : {
       "extractionState" : "stale",
@@ -105430,7 +118322,38 @@
       }
     },
     "Referenced column" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "참조된 열",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Başvurulan sütun",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cột được tham chiếu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "被引用的列",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "被參照的欄位",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Referenced columns (comma-separated)" : {
       "extractionState" : "stale",
@@ -105502,7 +118425,38 @@
       }
     },
     "Referenced schema" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "참조된 스키마",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Başvurulan şema",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Schema được tham chiếu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "被引用的 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "被參照的綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Referenced table" : {
       "localizations" : {
@@ -105539,10 +118493,72 @@
       }
     },
     "Referencing column" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "참조하는 열",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Başvuran sütun",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cột tham chiếu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "发起引用的列",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "發起參照的欄位",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Referencing table" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "참조하는 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Başvuran tablo",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng tham chiếu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "发起引用的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "發起參照的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Refresh" : {
       "localizations" : {
@@ -105828,7 +118844,38 @@
       }
     },
     "Refresh the table to see what was written. Saving again would write those rows a second time." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "무엇이 기록되었는지 보려면 테이블을 새로 고치십시오. 다시 저장하면 해당 행이 한 번 더 기록됩니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Neyin yazıldığını görmek için tabloyu yenileyin. Yeniden kaydetmek bu satırları ikinci kez yazar.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hãy làm mới bảng để xem những gì đã được ghi. Lưu lần nữa sẽ ghi các dòng đó thêm một lần.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "刷新该表以查看写入了什么。再次保存会把这些行再写一遍。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "重新整理該資料表以查看寫入了什麼。再次儲存會把這些列再寫一遍。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Refreshing" : {
       "localizations" : {
@@ -106308,7 +119355,38 @@
       }
     },
     "Reload from the database" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "데이터베이스에서 다시 로드",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Veritabanından yeniden yükle",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tải lại từ cơ sở dữ liệu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "从数据库重新加载",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "從資料庫重新載入",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Reload with new properties?" : {
       "localizations" : {
@@ -106448,13 +119526,106 @@
       }
     },
     "Remote Database File" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "원격 데이터베이스 파일",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Uzak Veritabanı Dosyası",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tệp cơ sở dữ liệu từ xa",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "远程数据库文件",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "遠端資料庫檔案",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Remote database file path is required" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "원격 데이터베이스 파일 경로가 필요합니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Uzak veritabanı dosya yolu gerekli",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cần có đường dẫn tệp cơ sở dữ liệu từ xa",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "必须填写远程数据库文件路径",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "必須填寫遠端資料庫檔案路徑",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Remote File" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "원격 파일",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Uzak Dosya",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tệp từ xa",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "远程文件",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "遠端檔案",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Remove" : {
       "localizations" : {
@@ -106696,7 +119867,38 @@
       }
     },
     "Remove Check Constraint" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "CHECK 제약 조건 제거",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kontrol Kısıtlamasını Kaldır",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Xoá ràng buộc CHECK",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "移除 CHECK 约束",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "移除 CHECK 約束",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Remove Column" : {
       "localizations" : {
@@ -107491,7 +120693,38 @@
       }
     },
     "Remove the added row" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "추가한 행 제거",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Eklenen satırı kaldır",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Xoá dòng vừa thêm",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "移除新增的行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "移除新增的列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Removed" : {
       "localizations" : {
@@ -107562,10 +120795,72 @@
       }
     },
     "Rename %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@ 이름 변경",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ adını değiştir",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đổi tên %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "重命名 %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "重新命名 %@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Rename %1$@ to %2$@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%1$@의 이름을 %2$@(으)로 변경",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%1$@ adını %2$@ olarak değiştir",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đổi tên %1$@ thành %2$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "将 %1$@ 重命名为 %2$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "將 %1$@ 重新命名為 %2$@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Rename Column" : {
       "localizations" : {
@@ -107636,7 +120931,38 @@
       }
     },
     "Rename Failed" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이름 변경 실패",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yeniden Adlandırma Başarısız",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đổi tên thất bại",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "重命名失败",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "重新命名失敗",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Rename Group" : {
       "localizations" : {
@@ -108200,7 +121526,38 @@
       }
     },
     "Report whether a connection is open, which database and schema it is on, and the server version." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "연결이 열려 있는지, 어떤 데이터베이스와 스키마를 사용 중인지, 서버 버전은 무엇인지 보고합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir bağlantının açık olup olmadığını, hangi veritabanı ve şemada olduğunu ve sunucu sürümünü bildirir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Báo cáo xem một kết nối có đang mở không, nó đang ở cơ sở dữ liệu và schema nào, và phiên bản máy chủ.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "报告某个连接是否已打开、它位于哪个数据库和 Schema，以及服务器版本。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "回報某個連線是否已開啟、它位於哪個資料庫和綱要，以及伺服器版本。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Require authentication" : {
       "localizations" : {
@@ -109259,7 +122616,38 @@
       }
     },
     "Restore" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "복원",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Geri Yükle",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Khôi phục",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "恢复",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "還原",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Restore Database" : {
       "localizations" : {
@@ -109440,7 +122828,38 @@
       }
     },
     "Restore Failed" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "복원 실패",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Geri Yükleme Başarısız",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Khôi phục thất bại",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "恢复失败",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "還原失敗",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Restore from" : {
       "comment" : "A label displayed above the name of the source database.",
@@ -109513,25 +122932,242 @@
       }
     },
     "Restore previous values" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이전 값 복원",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Önceki değerleri geri yükle",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Khôi phục giá trị trước đó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "恢复之前的值",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "還原先前的值",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Restore Previous Values" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이전 값 복원",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Önceki Değerleri Geri Yükle",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Khôi phục giá trị trước đó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "恢复之前的值",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "還原先前的值",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Restore Previous Values…" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이전 값 복원…",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Önceki Değerleri Geri Yükle…",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Khôi phục giá trị trước đó…",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "恢复之前的值…",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "還原先前的值…",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Restore the previous values of a save" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "저장 이전의 값 복원",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir kaydetmenin önceki değerlerini geri yükle",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Khôi phục giá trị trước một lần lưu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "恢复某次保存之前的值",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "還原某次儲存之前的值",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Restore the previous values of rows you already saved." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이미 저장한 행의 이전 값을 복원합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Zaten kaydettiğiniz satırların önceki değerlerini geri yükler.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Khôi phục giá trị trước đó của các dòng bạn đã lưu.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "恢复你已经保存的那些行之前的值。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "還原你已經儲存的那些列先前的值。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Restore the previous values of rows you already saved. Saves are kept on this Mac for 7 days, encrypted, and never leave it." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이미 저장한 행의 이전 값을 복원합니다. 저장 기록은 이 Mac에 7일 동안 암호화되어 보관되며 밖으로 나가지 않습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Zaten kaydettiğiniz satırların önceki değerlerini geri yükler. Kayıtlar bu Mac'te 7 gün boyunca şifrelenmiş olarak tutulur ve buradan hiç çıkmaz.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Khôi phục giá trị trước đó của các dòng bạn đã lưu. Các bản lưu được giữ trên máy Mac này trong 7 ngày, được mã hoá và không bao giờ rời khỏi máy.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "恢复你已经保存的那些行之前的值。保存记录在这台 Mac 上加密保留 7 天，且绝不外传。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "還原你已經儲存的那些列先前的值。儲存記錄在這台 Mac 上加密保留 7 天，且絕不外傳。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Restore the row by inserting it again, then check anything that referenced its key." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "행을 다시 삽입해 복원한 뒤, 그 키를 참조하던 항목을 모두 확인하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Satırı yeniden ekleyerek geri yükleyin, ardından anahtarına başvuran her şeyi denetleyin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Khôi phục dòng bằng cách chèn lại nó, rồi kiểm tra mọi thứ từng tham chiếu tới khoá của nó.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "通过再次插入来恢复该行，然后检查所有引用过它的键的内容。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "透過再次插入來還原該列，然後檢查所有參照過它的鍵的內容。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Restore…" : {
       "localizations" : {
@@ -109608,7 +123244,38 @@
       }
     },
     "Restoring a save that already committed needs a Starter license." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이미 커밋된 저장을 복원하려면 Starter 라이선스가 필요합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Zaten işlenmiş bir kaydı geri yüklemek bir Starter lisansı gerektirir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Khôi phục một lần lưu đã commit cần giấy phép Starter.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "恢复一次已提交的保存需要 Starter 许可证。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "還原一次已提交的儲存需要 Starter 授權。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Restoring Dump" : {
       "comment" : "A title for a progress sheet that is displayed when restoring a database dump.",
@@ -109682,13 +123349,106 @@
       }
     },
     "Restrict to one connection" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "한 연결로 제한",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tek bir bağlantıyla sınırla",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giới hạn trong một kết nối",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "限定为一个连接",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "限定為一個連線",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Restrict to one connection. Omit for every readable connection." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "한 연결로 제한합니다. 읽을 수 있는 모든 연결을 대상으로 하려면 생략하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tek bir bağlantıyla sınırlar. Okunabilir tüm bağlantılar için boş bırakın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giới hạn trong một kết nối. Bỏ trống để lấy mọi kết nối đọc được.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "限定为一个连接。省略则表示所有可读的连接。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "限定為一個連線。省略則表示所有可讀取的連線。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Restrict to one kind. Omit for both." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "한 종류로 제한합니다. 둘 다 보려면 생략하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tek bir türle sınırlar. İkisi için de boş bırakın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giới hạn trong một loại. Bỏ trống để lấy cả hai.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "限定为一种。省略则表示两种都要。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "限定為一種。省略則表示兩種都要。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Result" : {
       "localizations" : {
@@ -110140,19 +123900,174 @@
       }
     },
     "Return size, engine, collation, and timestamps the engine records for one table." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "엔진이 한 테이블에 대해 기록하는 크기, 엔진, 콜레이션, 타임스탬프를 반환합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Motorun bir tablo için kaydettiği boyutu, motoru, karşılaştırma kuralını ve zaman damgalarını döndürür.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Trả về kích thước, engine, collation và các dấu thời gian mà engine ghi lại cho một bảng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "返回引擎为某张表记录的大小、引擎、排序规则和时间戳。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "回傳引擎為某張資料表記錄的大小、引擎、定序和時間戳記。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Return table counts and sizes for one database, or for every database when 'database' is omitted." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "한 데이터베이스의 테이블 수와 크기를 반환하며, 'database'를 생략하면 모든 데이터베이스를 대상으로 합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir veritabanı için, 'database' verilmediğinde ise her veritabanı için tablo sayılarını ve boyutlarını döndürür.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Trả về số lượng bảng và kích thước cho một cơ sở dữ liệu, hoặc cho mọi cơ sở dữ liệu khi bỏ trống 'database'.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "返回某个数据库的表数量和大小；省略 'database' 时返回每个数据库的。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "回傳某個資料庫的資料表數量和大小；省略 'database' 時回傳每個資料庫的。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Return the CREATE statement for one table or view." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "한 테이블 또는 뷰의 CREATE 명령문을 반환합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir tablo veya görünüm için CREATE ifadesini döndürür.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Trả về câu lệnh CREATE cho một bảng hoặc view.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "返回某张表或视图的 CREATE 语句。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "回傳某張資料表或檢視表的 CREATE 陳述式。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Return the SELECT statement a view is defined by." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "뷰를 정의하는 SELECT 명령문을 반환합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir görünümü tanımlayan SELECT ifadesini döndürür.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Trả về câu lệnh SELECT định nghĩa một view.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "返回定义某个视图的 SELECT 语句。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "回傳定義某個檢視表的 SELECT 陳述式。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Returns %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@ 반환",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ döndürür",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Trả về %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "返回 %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "回傳 %@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Reuse clean table tab" : {
       "extractionState" : "stale",
@@ -110292,7 +124207,38 @@
       }
     },
     "Review a query before it runs" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "실행 전 쿼리 검토",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir sorguyu çalışmadan önce incele",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Rà soát một truy vấn trước khi chạy",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "在查询运行前先审查它",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "在查詢執行前先審查它",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Revoke" : {
       "localizations" : {
@@ -110603,7 +124549,38 @@
       }
     },
     "Roles it belongs to" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "속해 있는 역할",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Ait olduğu roller",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các vai trò mà nó thuộc về",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "它所属的角色",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "它所屬的角色",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "root" : {
       "extractionState" : "stale",
@@ -110709,7 +124686,38 @@
       }
     },
     "Round trip in milliseconds" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "밀리초 단위 왕복 시간",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Milisaniye cinsinden gidiş dönüş süresi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thời gian khứ hồi tính bằng mili giây",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "以毫秒计的往返时间",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "以毫秒計的往返時間",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Routes this connection through a SOCKS5 proxy. The database hostname is resolved by the proxy, so names that only resolve behind it still work." : {
       "localizations" : {
@@ -110746,10 +124754,72 @@
       }
     },
     "Routine name" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "루틴 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Rutin adı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên routine",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "例程名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "常式名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Routines, sorted by qualified name" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "정규화된 이름순으로 정렬된 루틴",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Nitelikli ada göre sıralanmış rutinler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các routine, sắp xếp theo tên đầy đủ",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "按限定名排序的例程",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "按限定名稱排序的常式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Row" : {
       "localizations" : {
@@ -110970,13 +125040,106 @@
       }
     },
     "Row count the engine reports" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "엔진이 보고한 행 수",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Motorun bildirdiği satır sayısı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số dòng do engine báo cáo",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "引擎报告的行数",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "引擎回報的列數",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Row counts come from engine statistics, not COUNT(*)" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "행 수는 COUNT(*)가 아니라 엔진 통계에서 가져옵니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Satır sayıları COUNT(*) yerine motor istatistiklerinden gelir",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số dòng lấy từ thống kê của engine, không phải COUNT(*)",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "行数来自引擎统计信息，而不是 COUNT(*)",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列數來自引擎統計資訊，而不是 COUNT(*)",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Row data size" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "행 데이터 크기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Satır veri boyutu",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kích thước dữ liệu dòng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "行数据大小",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列資料大小",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Row Details" : {
       "extractionState" : "stale",
@@ -111014,7 +125177,38 @@
       }
     },
     "Row edits" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "행 편집",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Satır düzenlemeleri",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chỉnh sửa dòng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "行编辑",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列編輯",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Row Edits" : {
       "localizations" : {
@@ -111155,7 +125349,38 @@
       }
     },
     "Row no longer exists" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "행이 더 이상 존재하지 않습니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Satır artık yok",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Dòng không còn tồn tại",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该行已不存在",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該列已不存在",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Row number" : {
       "localizations" : {
@@ -111226,7 +125451,38 @@
       }
     },
     "ROW or STATEMENT" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "ROW 또는 STATEMENT",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "ROW veya STATEMENT",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "ROW hoặc STATEMENT",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "ROW 或 STATEMENT",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "ROW 或 STATEMENT",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Row size:" : {
       "comment" : "A label for the size of the sidebar rows.",
@@ -111367,7 +125623,38 @@
       }
     },
     "Rows in this export" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 내보내기의 행",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu dışa aktarmadaki satırlar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số dòng trong bản xuất này",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此次导出中的行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此次匯出中的列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Rows per INSERT" : {
       "extractionState" : "stale",
@@ -111474,31 +125761,310 @@
       }
     },
     "Rows per page. Defaults to the server's configured row limit." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "페이지당 행 수입니다. 기본값은 서버에 설정된 행 제한입니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sayfa başına satır. Varsayılan olarak sunucunun yapılandırılmış satır sınırıdır.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số dòng mỗi trang. Mặc định là giới hạn dòng được cấu hình trên máy chủ.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "每页的行数。默认为服务器配置的行数上限。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "每頁的列數。預設為伺服器設定的列數上限。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Rows sent" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "전송된 행",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Gönderilen satırlar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số dòng đã gửi",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已发送的行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已傳送的列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Rows set to “same element” must all match one %@ element" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "“동일 요소”로 설정된 행은 모두 하나의 %@ 요소와 일치해야 합니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "“Aynı öğe” olarak ayarlanan satırların tümü tek bir %@ öğesiyle eşleşmelidir",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các dòng đặt là “cùng một phần tử” đều phải khớp với một phần tử %@ duy nhất",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "设为“同一元素”的行必须全部匹配同一个 %@ 元素",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "設為“同一元素”的列必須全部符合同一個 %@ 元素",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Rows the engine reported inserting" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "엔진이 삽입했다고 보고한 행",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Motorun eklediğini bildirdiği satırlar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số dòng mà engine báo cáo đã chèn",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "引擎报告已插入的行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "引擎回報已插入的列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Rows the statement changed" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "명령문이 변경한 행",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İfadenin değiştirdiği satırlar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số dòng mà câu lệnh đã thay đổi",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该语句更改的行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該陳述式變更的列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Rows the statement returned" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "명령문이 반환한 행",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İfadenin döndürdüğü satırlar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số dòng mà câu lệnh trả về",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该语句返回的行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該陳述式回傳的列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Rows to insert, each an array aligned with 'columns'" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "삽입할 행이며 각 행은 'columns'와 정렬된 배열입니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Eklenecek satırlar, her biri 'columns' ile hizalanmış bir dizi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các dòng cần chèn, mỗi dòng là một mảng khớp với 'columns'",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要插入的行，每行是与 'columns' 对齐的数组",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要插入的列，每列是與 'columns' 對齊的陣列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Rows to skip (default 0)" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "건너뛸 행 수(기본값 0)",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Atlanacak satırlar (varsayılan 0)",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Số dòng cần bỏ qua (mặc định 0)",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要跳过的行数（默认 0）",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要略過的列數（預設 0）",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Rows, each an array aligned with columns" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "행이며 각 행은 열과 정렬된 배열입니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Satırlar, her biri sütunlarla hizalanmış bir dizi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các dòng, mỗi dòng là một mảng khớp với các cột",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "行，每行是与列对齐的数组",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列，每列是與欄位對齊的陣列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Rules" : {
       "localizations" : {
@@ -111569,7 +126135,38 @@
       }
     },
     "Run a maintenance operation the engine supports, on one table or on the whole database. TablePro generates the statements; the user approves them. Needs tools:write." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "엔진이 지원하는 유지 관리 작업을 한 테이블 또는 데이터베이스 전체에 실행합니다. TablePro가 명령문을 생성하고 사용자가 승인합니다. tools:write가 필요합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Motorun desteklediği bir bakım işlemini tek bir tabloda veya veritabanının tamamında çalıştırır. İfadeleri TablePro üretir; kullanıcı onaylar. tools:write gerektirir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chạy một thao tác bảo trì mà engine hỗ trợ, trên một bảng hoặc trên toàn bộ cơ sở dữ liệu. TablePro tạo ra các câu lệnh; người dùng phê duyệt chúng. Cần tools:write.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "在一张表或整个数据库上运行该引擎支持的维护操作。语句由 TablePro 生成，由用户批准。需要 tools:write。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "在一張資料表或整個資料庫上執行該引擎支援的維護作業。陳述式由 TablePro 產生，由使用者核准。需要 tools:write。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Run a query to see execution time" : {
       "localizations" : {
@@ -111778,16 +126375,140 @@
       }
     },
     "Run Ledger Plugins" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "원장 플러그인 실행",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Defter Eklentilerini Çalıştır",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chạy plugin sổ cái",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "运行账本插件",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "執行帳本外掛",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Run Maintenance" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "유지 관리 실행",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bakımı Çalıştır",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chạy bảo trì",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "运行维护",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "執行維護",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Run one destructive statement (DROP, TRUNCATE, ALTER...DROP). The user approves it before it runs: through your elicitation prompt when your client supports elicitation, otherwise through TablePro's own confirmation dialog on the user's Mac. Needs tools:write and a connection the user left writable for external clients." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "파괴적인 명령문(DROP, TRUNCATE, ALTER...DROP) 하나를 실행합니다. 실행 전에 사용자가 승인합니다. 클라이언트가 elicitation을 지원하면 해당 프롬프트로, 그렇지 않으면 사용자의 Mac에 표시되는 TablePro 자체 확인 대화상자로 승인합니다. tools:write와, 사용자가 외부 클라이언트에 쓰기를 허용한 연결이 필요합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yıkıcı tek bir ifade (DROP, TRUNCATE, ALTER...DROP) çalıştırır. Çalışmadan önce kullanıcı onaylar: istemciniz elicitation destekliyorsa sizin sorunuzla, aksi halde kullanıcının Mac'indeki TablePro onay penceresiyle. tools:write ve kullanıcının dış istemcilere yazılabilir bıraktığı bir bağlantı gerektirir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chạy một câu lệnh có tính phá huỷ (DROP, TRUNCATE, ALTER...DROP). Người dùng phê duyệt trước khi nó chạy: qua lời nhắc elicitation nếu client của bạn hỗ trợ, nếu không thì qua hộp thoại xác nhận của chính TablePro trên máy Mac của người dùng. Cần tools:write và một kết nối mà người dùng để ghi được cho client bên ngoài.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "运行一条破坏性语句（DROP、TRUNCATE、ALTER...DROP）。运行前由用户批准：若你的客户端支持 elicitation，则通过你的询问提示；否则通过用户 Mac 上 TablePro 自己的确认对话框。需要 tools:write，以及一个用户对外部客户端保留可写的连接。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "執行一條破壞性陳述式（DROP、TRUNCATE、ALTER...DROP）。執行前由使用者核准：若你的用戶端支援 elicitation，則透過你的詢問提示；否則透過使用者 Mac 上 TablePro 自己的確認對話框。需要 tools:write，以及一個使用者對外部用戶端保留可寫入的連線。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Run one statement. Reads need tools:read; anything that writes needs tools:write and is subject to the connection's Safe Mode, which asks the user to approve it. DROP and TRUNCATE go through confirm_destructive_operation instead. Statements that read or write files, or run server-side code, are refused. Send one statement per call." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "명령문 하나를 실행합니다. 읽기에는 tools:read가 필요하고, 쓰기에는 tools:write가 필요하며 연결의 안전 모드가 적용되어 사용자에게 승인을 요청합니다. DROP과 TRUNCATE는 대신 confirm_destructive_operation을 거칩니다. 파일을 읽거나 쓰거나 서버 측 코드를 실행하는 명령문은 거부됩니다. 호출당 명령문 하나만 보내십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tek bir ifade çalıştırır. Okumalar tools:read gerektirir; yazan her şey tools:write gerektirir ve kullanıcıdan onay isteyen bağlantının Güvenli Modu'na tabidir. DROP ve TRUNCATE bunun yerine confirm_destructive_operation üzerinden gider. Dosya okuyan veya yazan ya da sunucu tarafında kod çalıştıran ifadeler reddedilir. Çağrı başına tek ifade gönderin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chạy một câu lệnh. Thao tác đọc cần tools:read; bất cứ thao tác ghi nào cũng cần tools:write và phải tuân theo Chế độ an toàn của kết nối, vốn sẽ hỏi người dùng phê duyệt. DROP và TRUNCATE thì đi qua confirm_destructive_operation. Các câu lệnh đọc hoặc ghi tệp, hoặc chạy mã phía máy chủ, sẽ bị từ chối. Mỗi lần gọi chỉ gửi một câu lệnh.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "运行一条语句。读取需要 tools:read；任何写入都需要 tools:write，并受该连接安全模式的约束，会请求用户批准。DROP 和 TRUNCATE 改走 confirm_destructive_operation。读写文件或运行服务端代码的语句会被拒绝。每次调用只发送一条语句。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "執行一條陳述式。讀取需要 tools:read；任何寫入都需要 tools:write，並受該連線安全模式的約束，會請求使用者核准。DROP 和 TRUNCATE 改走 confirm_destructive_operation。讀寫檔案或執行伺服器端程式碼的陳述式會被拒絕。每次呼叫只傳送一條陳述式。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Run Script" : {
       "localizations" : {
@@ -111994,7 +126715,38 @@
       }
     },
     "Run the statement and report actual timings (default false)" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "명령문을 실행하고 실제 소요 시간을 보고합니다(기본값 false)",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İfadeyi çalıştırır ve gerçek süreleri bildirir (varsayılan false)",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chạy câu lệnh và báo cáo thời gian thực tế (mặc định false)",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "运行该语句并报告实际耗时（默认 false）",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "執行該陳述式並回報實際耗時（預設 false）",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Run the statement starting on line %d" : {
       "localizations" : {
@@ -112303,7 +127055,38 @@
       }
     },
     "Safe mode level" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "안전 모드 수준",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Güvenli mod düzeyi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Mức Chế độ an toàn",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "安全模式级别",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "安全模式層級",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Safe Mode, Safe Mode (Full), and Read-Only require a Pro license." : {
       "extractionState" : "stale",
@@ -112409,7 +127192,38 @@
       }
     },
     "same element" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "동일 요소",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "aynı öğe",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "cùng một phần tử",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "同一元素",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "同一元素",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Same options will be applied to all selected tables." : {
       "localizations" : {
@@ -112515,7 +127329,38 @@
       }
     },
     "SASL Mechanism" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "SASL 메커니즘",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "SASL Mekanizması",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ chế SASL",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "SASL 机制",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "SASL 機制",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Save" : {
       "localizations" : {
@@ -113209,7 +128054,38 @@
       }
     },
     "Save Incomplete" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "저장이 완료되지 않음",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kaydetme Tamamlanmadı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Lưu chưa hoàn tất",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "保存未完成",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "儲存未完成",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Save passphrase in Keychain" : {
       "localizations" : {
@@ -113699,7 +128575,38 @@
       }
     },
     "Saves already committed stay committed. You will not be able to restore their previous values." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이미 커밋된 저장은 그대로 유지됩니다. 이전 값을 복원할 수 없게 됩니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Zaten işlenmiş kayıtlar işlenmiş kalır. Önceki değerlerini geri yükleyemezsiniz.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các lần lưu đã commit vẫn giữ nguyên. Bạn sẽ không thể khôi phục giá trị trước đó của chúng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已提交的保存仍然保持提交状态。你将无法恢复它们之前的值。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已提交的儲存仍然保持提交狀態。你將無法還原它們先前的值。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Scale" : {
       "extractionState" : "stale",
@@ -113849,25 +128756,25 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "şema %@"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "schema %@"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "架构 %@"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "綱要 %@"
           }
         }
@@ -113977,13 +128884,106 @@
       }
     },
     "Schema it lives in" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "속해 있는 스키마",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İçinde bulunduğu şema",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Schema chứa nó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "它所在的 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "它所在的綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema it ran against" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "실행 대상 스키마",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Karşı çalıştığı şema",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Schema mà nó chạy trên đó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "它所针对的 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "它所針對的綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema List" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "스키마 목록",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Şema Listesi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Danh sách schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "Schema 列表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "綱要清單",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema name (for multi-schema databases)" : {
       "extractionState" : "stale",
@@ -114090,19 +129090,174 @@
       }
     },
     "Schema name. Uses the connection's current schema when omitted." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "스키마 이름입니다. 생략하면 연결의 현재 스키마를 사용합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Şema adı. Boş bırakıldığında bağlantının geçerli şemasını kullanır.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên schema. Bỏ trống thì dùng schema hiện tại của kết nối.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "Schema 名称。省略时使用该连接的当前 Schema。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "綱要名稱。省略時使用該連線的目前綱要。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema names inside a database, on engines that have schemas." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "스키마를 지원하는 엔진에서 데이터베이스 안의 스키마 이름입니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Şemaya sahip motorlarda, bir veritabanının içindeki şema adları.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên các schema bên trong một cơ sở dữ liệu, trên những engine có schema.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "在有 Schema 概念的引擎上，某个数据库内的 Schema 名称。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "在有綱要概念的引擎上，某個資料庫內的綱要名稱。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema names, sorted" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "정렬된 스키마 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Şema adları, sıralı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên schema, đã sắp xếp",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已排序的 Schema 名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已排序的綱要名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema now selected" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "현재 선택된 스키마",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Şu anda seçili şema",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Schema đang được chọn",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "当前已选中的 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "目前已選取的綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema of %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@의 스키마",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ şeması",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Schema của %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%@ 的 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%@ 的綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema SQL" : {
       "localizations" : {
@@ -114208,40 +129363,412 @@
       }
     },
     "Schema that was dropped" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "삭제된 스키마",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Silinen şema",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Schema đã bị xoá",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已删除的 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已刪除的綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema the listing covers" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "목록이 다루는 스키마",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Listelemenin kapsadığı şema",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Schema mà danh sách bao gồm",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该列表涵盖的 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該清單涵蓋的綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema the object belongs to" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "객체가 속한 스키마",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Nesnenin ait olduğu şema",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Schema mà đối tượng thuộc về",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该对象所属的 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該物件所屬的綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema the routine lives in" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "루틴이 속한 스키마",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Rutinin içinde bulunduğu şema",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Schema chứa routine",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该例程所在的 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該常式所在的綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema the session is on" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "세션이 사용 중인 스키마",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Oturumun bulunduğu şema",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Schema mà phiên đang dùng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该会话所在的 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該工作階段所在的綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema the session opened on" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "세션이 열린 스키마",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Oturumun açıldığı şema",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Schema mà phiên đã mở trên đó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该会话打开时所在的 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該工作階段開啟時所在的綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema the statement ran against" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "명령문이 실행된 스키마",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İfadenin karşı çalıştığı şema",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Schema mà câu lệnh đã chạy trên đó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该语句所针对的 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該陳述式所針對的綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema the tab is on" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "탭이 사용 중인 스키마",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sekmenin bulunduğu şema",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Schema mà tab đang dùng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该标签页所在的 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該標籤頁所在的綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema the table lives in" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블이 속한 스키마",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tablonun içinde bulunduğu şema",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Schema chứa bảng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该表所在的 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該資料表所在的綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema the trigger belongs to" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "트리거가 속한 스키마",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tetikleyicinin ait olduğu şema",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Schema mà trigger thuộc về",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该触发器所属的 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該觸發器所屬的綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema the view lives in" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "뷰가 속한 스키마",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Görünümün içinde bulunduğu şema",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Schema chứa view",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该视图所在的 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該檢視表所在的綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema to read. Uses the connection's current schema when omitted" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "읽을 스키마입니다. 생략하면 연결의 현재 스키마를 사용합니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Okunacak şema. Boş bırakıldığında bağlantının geçerli şemasını kullanır",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Schema cần đọc. Bỏ trống thì dùng schema hiện tại của kết nối",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要读取的 Schema。省略时使用该连接的当前 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要讀取的綱要。省略時使用該連線的目前綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema tour of %@ on %@" : {
       "localizations" : {
@@ -114250,14 +129777,106 @@
             "state" : "new",
             "value" : "Schema tour of %1$@ on %2$@"
           }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%2$@의 %1$@ 스키마 둘러보기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%2$@ üzerindeki %1$@ şema turu",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tham quan schema %1$@ trên %2$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%2$@ 上 %1$@ 的 Schema 导览",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%2$@ 上 %1$@ 的綱要導覽",
+            "state" : "translated"
+          }
         }
       }
     },
     "Schema-qualified name" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "스키마로 정규화된 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Şema nitelikli ad",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên có kèm schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "带 Schema 限定的名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "帶綱要限定的名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema, for a table match" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블이 일치할 때의 스키마",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir tablo eşleşmesi için şema",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Schema, khi khớp theo bảng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "Schema，用于表匹配",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "綱要，用於資料表比對",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Schema: %@" : {
       "extractionState" : "stale",
@@ -114910,7 +130529,38 @@
       }
     },
     "Search or type a field path…" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "검색하거나 필드 경로를 입력하십시오…",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Arayın veya bir alan yolu yazın…",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tìm kiếm hoặc nhập đường dẫn trường…",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "搜索或输入字段路径…",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "搜尋或輸入欄位路徑…",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Search or type…" : {
       "localizations" : {
@@ -115086,7 +130736,38 @@
       }
     },
     "Search Schema" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "스키마 검색",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Şemada Ara",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tìm trong schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "搜索 Schema",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "搜尋綱要",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Search schemas..." : {
       "extractionState" : "stale",
@@ -115262,7 +130943,38 @@
       }
     },
     "Search the query history TablePro keeps on this Mac. Results cover only connections this client may reach, whether or not connection_id is given." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "TablePro가 이 Mac에 보관하는 쿼리 기록을 검색합니다. connection_id를 지정하든 하지 않든, 결과는 이 클라이언트가 접근할 수 있는 연결만 포함합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "TablePro'nun bu Mac'te tuttuğu sorgu geçmişinde arama yapar. connection_id verilse de verilmese de sonuçlar yalnızca bu istemcinin erişebildiği bağlantıları kapsar.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tìm trong lịch sử truy vấn mà TablePro giữ trên máy Mac này. Kết quả chỉ gồm những kết nối mà client này truy cập được, dù có truyền connection_id hay không.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "搜索 TablePro 保存在这台 Mac 上的查询历史。无论是否给出 connection_id，结果都只涵盖此客户端可访问的连接。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "搜尋 TablePro 儲存在這台 Mac 上的查詢記錄。無論是否給出 connection_id，結果都只涵蓋此用戶端可存取的連線。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Search values" : {
       "localizations" : {
@@ -115681,7 +131393,38 @@
       }
     },
     "Security Protocol" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "보안 프로토콜",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Güvenlik Protokolü",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giao thức bảo mật",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "安全协议",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "安全性協定",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "See which queries you run most, which run slowest, and which got slower." : {
       "localizations" : {
@@ -115923,7 +131666,38 @@
       }
     },
     "Select a Library" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "라이브러리 선택",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir Kitaplık Seçin",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chọn một thư viện",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "选择一个库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "選擇一個程式庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Select a Plugin" : {
       "extractionState" : "stale",
@@ -117064,7 +132838,38 @@
       }
     },
     "Send one statement at a time." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "한 번에 명령문 하나만 보내십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Her seferinde tek bir ifade gönderin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Mỗi lần chỉ gửi một câu lệnh.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "请一次只发送一条语句。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "請一次只傳送一條陳述式。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Send telemetry to GitHub" : {
       "localizations" : {
@@ -117556,10 +133361,72 @@
       }
     },
     "Server host" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "서버 호스트",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sunucu ana makinesi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Host máy chủ",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "服务器主机",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "伺服器主機",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Server metrics" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "서버 지표",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sunucu metrikleri",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chỉ số máy chủ",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "服务器指标",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "伺服器指標",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Server Metrics" : {
       "localizations" : {
@@ -117630,13 +133497,106 @@
       }
     },
     "Server port" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "서버 포트",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sunucu bağlantı noktası",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cổng máy chủ",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "服务器端口",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "伺服器連接埠",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Server round trip in milliseconds" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "밀리초 단위 서버 왕복 시간",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Milisaniye cinsinden sunucu gidiş dönüş süresi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thời gian khứ hồi tới máy chủ tính bằng mili giây",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "以毫秒计的服务器往返时间",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "以毫秒計的伺服器往返時間",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Server version string" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "서버 버전 문자열",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sunucu sürüm dizesi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chuỗi phiên bản máy chủ",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "服务器版本字符串",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "伺服器版本字串",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Serverless SQLite at the edge" : {
       "localizations" : {
@@ -117946,13 +133906,106 @@
       }
     },
     "Session contexts" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "세션 컨텍스트",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Oturum bağlamları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các context phiên",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "会话上下文",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "工作階段情境",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Session state" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "세션 상태",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Oturum durumu",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Trạng thái phiên",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "会话状态",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "工作階段狀態",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Session status" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "세션 상태",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Oturum durumu",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tình trạng phiên",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "会话状况",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "工作階段狀況",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Session Token" : {
       "localizations" : {
@@ -117995,10 +134048,72 @@
       }
     },
     "Session user" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "세션 사용자",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Oturum kullanıcısı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Người dùng của phiên",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "会话用户",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "工作階段使用者",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Sessions the server reports" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "서버가 보고한 세션",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sunucunun bildirdiği oturumlar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các phiên mà máy chủ báo cáo",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "服务器报告的会话",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "伺服器回報的工作階段",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Set as Active" : {
       "localizations" : {
@@ -119692,25 +135807,25 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Sonraki Çalışma Alanını Göster"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Hiện không gian làm việc tiếp theo"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "显示下一个工作区"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "顯示下一個工作區"
           }
         }
@@ -119968,25 +136083,25 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Önceki Çalışma Alanını Göster"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Hiện không gian làm việc trước"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "显示上一个工作区"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "顯示上一個工作區"
           }
         }
@@ -120163,7 +136278,38 @@
       }
     },
     "Show SQL" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "SQL 표시",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "SQL'i Göster",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hiện SQL",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "显示 SQL",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "顯示 SQL",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Show Structure" : {
       "localizations" : {
@@ -120450,25 +136596,25 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Çalışma alanı şeridini göster"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Hiện thanh không gian làm việc"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "显示工作区栏"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "顯示工作區列"
           }
         }
@@ -120485,25 +136631,25 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Çalışma Alanı Şeridini Göster"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Hiện thanh không gian làm việc"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "显示工作区栏"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "顯示工作區列"
           }
         }
@@ -120689,7 +136835,38 @@
       }
     },
     "Showing another result will discard all unsaved changes." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "다른 결과를 표시하면 저장하지 않은 변경 사항이 모두 사라집니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Başka bir sonucu göstermek kaydedilmemiş tüm değişiklikleri atar.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hiển thị một kết quả khác sẽ huỷ mọi thay đổi chưa lưu.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "显示另一个结果会丢弃所有未保存的更改。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "顯示另一個結果會捨棄所有未儲存的變更。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Showing first %lld keys" : {
       "localizations" : {
@@ -122436,7 +138613,38 @@
       }
     },
     "Slow queries the server recorded" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "서버가 기록한 느린 쿼리",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sunucunun kaydettiği yavaş sorgular",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các truy vấn chậm mà máy chủ đã ghi lại",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "服务器记录的慢查询",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "伺服器記錄的慢查詢",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Slowest" : {
       "localizations" : {
@@ -123121,7 +139329,38 @@
       }
     },
     "Sort columns in priority order" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "우선순위 순으로 나열한 정렬 열",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Öncelik sırasına göre sıralama sütunları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các cột sắp xếp, theo thứ tự ưu tiên",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "按优先级顺序排列的排序列",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "按優先順序排列的排序欄位",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Sort Descending" : {
       "localizations" : {
@@ -123158,7 +139397,38 @@
       }
     },
     "Sort direction (default ascending)" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "정렬 방향(기본값 오름차순)",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sıralama yönü (varsayılan artan)",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hướng sắp xếp (mặc định tăng dần)",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "排序方向（默认升序）",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "排序方向（預設遞增）",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Sorted ascending" : {
       "localizations" : {
@@ -123331,7 +139601,38 @@
       }
     },
     "Source Unavailable" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "소스를 사용할 수 없음",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kaynak Kullanılamıyor",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không có nguồn",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "源不可用",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "來源無法使用",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Source:" : {
       "extractionState" : "stale",
@@ -125648,7 +141949,38 @@
       }
     },
     "Starred tables, sorted" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "정렬된 즐겨찾기 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yıldızlanmış tablolar, sıralı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các bảng đã đánh dấu sao, đã sắp xếp",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已排序的收藏表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已排序的收藏資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Start recording queries again" : {
       "localizations" : {
@@ -126137,19 +142469,174 @@
       }
     },
     "Statement batches" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "명령문 배치",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İfade grupları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các lô câu lệnh",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "语句批次",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "陳述式批次",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Statement text" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "명령문 텍스트",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İfade metni",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Nội dung câu lệnh",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "语句文本",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "陳述式文字",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Statement that ran" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "실행된 명령문",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Çalıştırılan ifade",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Câu lệnh đã chạy",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已运行的语句",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已執行的陳述式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Statement timeout" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "명령문 제한 시간",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İfade zaman aşımı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thời gian chờ câu lệnh",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "语句超时",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "陳述式逾時",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Statement timeout. Defaults to the server's configured timeout." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "명령문 제한 시간입니다. 기본값은 서버에 설정된 제한 시간입니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İfade zaman aşımı. Varsayılan olarak sunucunun yapılandırılmış zaman aşımıdır.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thời gian chờ câu lệnh. Mặc định là thời gian chờ được cấu hình trên máy chủ.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "语句超时。默认为服务器配置的超时值。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "陳述式逾時。預設為伺服器設定的逾時值。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Statement:" : {
       "extractionState" : "stale",
@@ -126221,7 +142708,38 @@
       }
     },
     "Statements TablePro generated and ran" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "TablePro가 생성하고 실행한 명령문",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "TablePro'nun ürettiği ve çalıştırdığı ifadeler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các câu lệnh mà TablePro đã tạo và chạy",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "TablePro 生成并运行的语句",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "TablePro 產生並執行的陳述式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Statements that already ran stay applied to %@. Compare again to see where it stands." : {
       "localizations" : {
@@ -126258,7 +142776,38 @@
       }
     },
     "Statements that read or write files, or that run server-side code, cannot be sent through MCP. Run this one in TablePro instead." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "파일을 읽거나 쓰거나 서버 측 코드를 실행하는 명령문은 MCP로 보낼 수 없습니다. 이 명령문은 TablePro에서 직접 실행하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Dosya okuyan veya yazan ya da sunucu tarafında kod çalıştıran ifadeler MCP üzerinden gönderilemez. Bunu TablePro'da çalıştırın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các câu lệnh đọc hoặc ghi tệp, hoặc chạy mã phía máy chủ, không thể gửi qua MCP. Hãy chạy câu này trực tiếp trong TablePro.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "读写文件或运行服务端代码的语句无法通过 MCP 发送。请改在 TablePro 中运行这一条。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "讀寫檔案或執行伺服器端程式碼的陳述式無法透過 MCP 傳送。請改在 TablePro 中執行這一條。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "STATISTICS" : {
       "localizations" : {
@@ -127188,7 +143737,38 @@
       }
     },
     "Stop Server Session" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "서버 세션 중지",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sunucu Oturumunu Durdur",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Dừng phiên máy chủ",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "停止服务器会话",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "停止伺服器工作階段",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Stop Trusting" : {
       "localizations" : {
@@ -127327,7 +143907,38 @@
       }
     },
     "Stopped after %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@ 후 중지됨",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ sonra durdu",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đã dừng sau %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%@ 后已停止",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%@ 後已停止",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Storage engine" : {
       "localizations" : {
@@ -127540,7 +144151,38 @@
       }
     },
     "String values to escape" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이스케이프할 문자열 값",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kaçışlanacak dize değerleri",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các giá trị chuỗi cần escape",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要转义的字符串值",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要跳脫的字串值",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Structure" : {
       "localizations" : {
@@ -127577,7 +144219,38 @@
       }
     },
     "Structure changes" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "구조 변경",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yapı değişiklikleri",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thay đổi cấu trúc",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "结构更改",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "結構變更",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Structure Changes" : {
       "localizations" : {
@@ -127930,7 +144603,38 @@
       }
     },
     "Suggest indexes for a slow query from its plan and the indexes the tables already have" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "실행 계획과 테이블에 이미 있는 인덱스를 바탕으로 느린 쿼리에 필요한 인덱스를 제안합니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yavaş bir sorgu için, planından ve tabloların hâlihazırda sahip olduğu indekslerden yola çıkarak indeks önerir",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đề xuất chỉ mục cho một truy vấn chậm, dựa trên kế hoạch thực thi và những chỉ mục các bảng đã có",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "根据执行计划以及表上已有的索引，为慢查询建议索引",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "根據執行計畫以及資料表上已有的索引，為慢查詢建議索引",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Suggest optimizations for the current query" : {
       "localizations" : {
@@ -128001,10 +144705,72 @@
       }
     },
     "Summarize query history" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "쿼리 기록 요약",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sorgu geçmişini özetle",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tóm tắt lịch sử truy vấn",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "汇总查询历史",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "彙總查詢記錄",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Summarize what was run against a connection over a period, from the recorded history" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "기록된 이력을 바탕으로 일정 기간 동안 연결에서 실행된 내용을 요약합니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kaydedilen geçmişten yola çıkarak bir dönem boyunca bir bağlantıda nelerin çalıştırıldığını özetler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tóm tắt những gì đã chạy trên một kết nối trong một khoảng thời gian, dựa trên lịch sử đã ghi",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "根据记录的历史，汇总某段时间内在某个连接上运行了什么",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "根據記錄的歷程，彙總某段時間內在某個連線上執行了什麼",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Summary" : {
       "localizations" : {
@@ -130155,19 +146921,174 @@
       }
     },
     "Tab id from list_recent_tabs" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "list_recent_tabs에서 얻은 탭 id",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "list_recent_tabs'ten alınan sekme kimliği",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tab id lấy từ list_recent_tabs",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "来自 list_recent_tabs 的标签页 id",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "來自 list_recent_tabs 的標籤頁 id",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Tab id, accepted by focus_query_tab" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "focus_query_tab이 받는 탭 id",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "focus_query_tab tarafından kabul edilen sekme kimliği",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tab id, được focus_query_tab chấp nhận",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "标签页 id，可被 focus_query_tab 接受",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "標籤頁 id，可被 focus_query_tab 接受",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Tab label" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "탭 레이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sekme etiketi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Nhãn tab",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "标签页标签",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "標籤頁標籤",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Tab that came forward" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "앞으로 나온 탭",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Öne gelen sekme",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tab đã được đưa lên trước",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "被带到最前的标签页",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "被帶到最前的標籤頁",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Tab that was raised" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "활성화된 탭",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Öne çıkarılan sekme",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tab đã được kích hoạt",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "被激活的标签页",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "被啟用的標籤頁",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Tab width:" : {
       "localizations" : {
@@ -130307,10 +147228,72 @@
       }
     },
     "Table and view names in a database. Pass database and schema to look outside the browsed one, and row_counts=true for approximate row counts." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "데이터베이스의 테이블 및 뷰 이름입니다. 탐색 중인 곳 밖을 보려면 database와 schema를 전달하고, 대략적인 행 수를 얻으려면 row_counts=true를 전달하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir veritabanındaki tablo ve görünüm adları. Göz atılanın dışına bakmak için database ve schema, yaklaşık satır sayıları için row_counts=true geçirin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên các bảng và view trong một cơ sở dữ liệu. Truyền database và schema để xem ngoài phạm vi đang duyệt, và row_counts=true để lấy số dòng ước tính.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "某个数据库中的表和视图名称。传入 database 和 schema 可查看当前浏览范围之外的内容，传入 row_counts=true 可获得大致行数。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "某個資料庫中的資料表和檢視表名稱。傳入 database 和 schema 可查看目前瀏覽範圍之外的內容，傳入 row_counts=true 可取得大致列數。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table and view names, without columns" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "열을 제외한 테이블 및 뷰 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sütunlar olmadan tablo ve görünüm adları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên bảng và view, không kèm cột",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "表和视图名称，不含列",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "資料表和檢視表名稱，不含欄位",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table Browsing" : {
       "localizations" : {
@@ -130387,7 +147370,38 @@
       }
     },
     "Table comment" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블 주석",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tablo yorumu",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Ghi chú bảng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "表注释",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "資料表註解",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table creation options not available" : {
       "extractionState" : "stale",
@@ -130425,10 +147439,72 @@
       }
     },
     "Table DDL" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블 DDL",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tablo DDL'i",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "DDL của bảng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "表 DDL",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "資料表 DDL",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table Description" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블 설명",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tablo Açıklaması",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Mô tả bảng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "表说明",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "資料表說明",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table Favorites" : {
       "localizations" : {
@@ -130535,7 +147611,38 @@
       }
     },
     "Table List" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블 목록",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tablo Listesi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Danh sách bảng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "表列表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "資料表清單",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table Maintenance" : {
       "localizations" : {
@@ -130641,7 +147748,38 @@
       }
     },
     "Table name '%@' may only contain letters, digits, underscore, and '.'." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블 이름 '%@'에는 문자, 숫자, 밑줄, '.'만 사용할 수 있습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "'%@' tablo adı yalnızca harf, rakam, alt çizgi ve '.' içerebilir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên bảng '%@' chỉ được chứa chữ cái, chữ số, dấu gạch dưới và '.'.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "表名 '%@' 只能包含字母、数字、下划线和 '.'。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "資料表名稱 '%@' 只能包含字母、數字、底線和 '.'。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table name to open" : {
       "extractionState" : "stale",
@@ -130679,7 +147817,38 @@
       }
     },
     "Table name, or 'query'" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블 이름 또는 'query'",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tablo adı veya 'query'",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên bảng, hoặc 'query'",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "表名，或 'query'",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "資料表名稱，或 'query'",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table Name:" : {
       "localizations" : {
@@ -130716,7 +147885,38 @@
       }
     },
     "Table name. Omit to cover the whole schema." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블 이름입니다. 스키마 전체를 대상으로 하려면 생략하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tablo adı. Şemanın tamamını kapsamak için boş bırakın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên bảng. Bỏ trống để bao gồm cả schema.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "表名。省略则涵盖整个 Schema。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "資料表名稱。省略則涵蓋整個綱要。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table names to export (alternative to query)" : {
       "extractionState" : "stale",
@@ -130754,10 +147954,72 @@
       }
     },
     "Table or column names to quote" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "인용할 테이블 또는 열 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tırnaklanacak tablo veya sütun adları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên bảng hoặc cột cần trích dẫn",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要加引号的表名或列名",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要加引號的資料表或欄位名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table or view name" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블 또는 뷰 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tablo veya görünüm adı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên bảng hoặc view",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "表或视图名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "資料表或檢視表名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table rebuild" : {
       "localizations" : {
@@ -130794,46 +148056,480 @@
       }
     },
     "Table that received the rows" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "행을 받은 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Satırları alan tablo",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng đã nhận các dòng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "接收这些行的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "接收這些列的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table that was counted" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "행 수를 센 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sayılan tablo",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng đã được đếm",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "被统计的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "被統計的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table that was described" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "설명된 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Açıklanan tablo",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng đã được mô tả",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "被描述的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "被描述的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table that was opened" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "열린 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Açılan tablo",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng đã được mở",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "被打开的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "被開啟的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table the change applies to, if it is one table" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "변경이 적용되는 테이블이며, 단일 테이블인 경우에 한합니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tek bir tabloysa değişikliğin uygulandığı tablo",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng mà thay đổi áp dụng lên, nếu chỉ có một bảng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该更改所作用的表，前提是只涉及一张表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該變更所作用的資料表，前提是只涉及一張資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table the DDL describes" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "DDL이 설명하는 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "DDL'in açıkladığı tablo",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng mà DDL mô tả",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该 DDL 所描述的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該 DDL 所描述的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table the statistics describe" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "통계가 설명하는 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İstatistiklerin açıkladığı tablo",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng mà các số liệu thống kê mô tả",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "这些统计信息所描述的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "這些統計資訊所描述的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table the tab shows" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "탭이 표시하는 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sekmenin gösterdiği tablo",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng mà tab đang hiển thị",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该标签页显示的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該標籤頁顯示的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table the trigger fires for" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "트리거가 실행되는 대상 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tetikleyicinin çalıştığı tablo",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng mà trigger kích hoạt cho",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该触发器针对的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該觸發器針對的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table the triggers belong to, when one was named" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블을 지정한 경우 트리거가 속한 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir tablo belirtildiyse tetikleyicilerin ait olduğu tablo",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng mà các trigger thuộc về, khi có chỉ định bảng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "指定了表时，这些触发器所属的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "指定了資料表時，這些觸發器所屬的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table to act on. Omit for the whole database." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "작업할 테이블입니다. 데이터베이스 전체를 대상으로 하려면 생략하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Üzerinde işlem yapılacak tablo. Veritabanının tamamı için boş bırakın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng cần thao tác. Bỏ trống để áp dụng cho cả cơ sở dữ liệu.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要操作的表。省略则表示整个数据库。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要操作的資料表。省略則表示整個資料庫。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table to audit" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "감사할 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Denetlenecek tablo",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng cần kiểm định",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要审计的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要稽核的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table to explain" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "설명할 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Açıklanacak tablo",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng cần giải thích",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要讲解的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要講解的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Table to open" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "열 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Açılacak tablo",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng cần mở",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要打开的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要開啟的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "table_name" : {
       "localizations" : {
@@ -131078,13 +148774,106 @@
       }
     },
     "TablePro did not open a window for that connection in time." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "TablePro가 제한 시간 안에 해당 연결의 창을 열지 못했습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "TablePro, o bağlantı için zamanında bir pencere açmadı.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "TablePro đã không mở kịp cửa sổ cho kết nối đó.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "TablePro 没有及时为该连接打开窗口。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "TablePro 沒有及時為該連線開啟視窗。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "TablePro did not open that table in time." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "TablePro가 제한 시간 안에 해당 테이블을 열지 못했습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "TablePro, o tabloyu zamanında açmadı.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "TablePro đã không mở kịp bảng đó.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "TablePro 没有及时打开那张表。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "TablePro 沒有及時開啟那張資料表。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "TablePro has no server dashboard for this engine." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "TablePro에는 이 엔진용 서버 대시보드가 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "TablePro'nun bu motor için bir sunucu panosu yok.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "TablePro không có bảng điều khiển máy chủ cho engine này.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "TablePro 没有针对该引擎的服务器仪表板。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "TablePro 沒有針對該引擎的伺服器儀表板。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "TablePro has not confirmed this license with the server in 30 days." : {
       "localizations" : {
@@ -131121,7 +148910,38 @@
       }
     },
     "TablePro has not looked up this table's key columns, so it cannot tell which row an edit would change." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "TablePro가 이 테이블의 키 열을 조회하지 않아, 편집이 어떤 행을 바꾸는지 알 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "TablePro bu tablonun anahtar sütunlarını sorgulamadı, bu yüzden bir düzenlemenin hangi satırı değiştireceğini bilemiyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "TablePro chưa tra cứu các cột khoá của bảng này, nên không biết một chỉnh sửa sẽ thay đổi dòng nào.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "TablePro 尚未查询这张表的键列，因此无法判断一次编辑会改动哪一行。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "TablePro 尚未查詢這張資料表的鍵欄位，因此無法判斷一次編輯會改動哪一列。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "TablePro has not reached the license server in 30 days, so Pro features are paused." : {
       "localizations" : {
@@ -131158,16 +148978,140 @@
       }
     },
     "TablePro includes these open source libraries. Pick one to read its license." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "TablePro에는 다음 오픈 소스 라이브러리가 포함되어 있습니다. 라이선스를 읽으려면 하나를 선택하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "TablePro şu açık kaynak kitaplıkları içerir. Lisansını okumak için birini seçin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "TablePro có kèm các thư viện mã nguồn mở sau. Hãy chọn một thư viện để đọc giấy phép của nó.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "TablePro 包含以下开源库。选择其中一个以阅读它的许可证。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "TablePro 包含以下開源程式庫。選擇其中一個以閱讀它的授權條款。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "TablePro is a native macOS database client. This server exposes the connections the user has already configured, so you never handle credentials: name a connection by its id and TablePro opens, reuses and authorizes it for you.\n\nStart with list_connections, then list_databases, list_schemas and list_tables to find your way around, and describe_table before writing any query, because it returns the columns, indexes and foreign keys you need to get the SQL right the first time. Prefer the dedicated tools over hand-written SQL wherever one exists: they quote identifiers correctly for the engine in front of you, apply the user's row limits, and are allowed on connections where raw execution is not.\n\nEvery connection carries the user's own policy. A connection may be read-only for external clients, may be invisible to AI entirely, and may be in a safe mode that asks the user to confirm each write. A refusal is that policy speaking, not a transient error, so do not retry it and do not look for a way around it. Destructive statements need the user's consent, which TablePro collects itself." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "TablePro는 네이티브 macOS 데이터베이스 클라이언트입니다. 이 서버는 사용자가 이미 구성해 둔 연결을 노출하므로 자격 증명을 직접 다룰 일이 없습니다. 연결을 id로 지정하면 TablePro가 대신 열고, 재사용하고, 권한을 부여합니다.\n\nlist_connections로 시작한 뒤 list_databases, list_schemas, list_tables로 구조를 파악하고, 쿼리를 작성하기 전에 describe_table을 호출하십시오. 첫 시도에 올바른 SQL을 쓰는 데 필요한 열, 인덱스, 외래 키를 돌려주기 때문입니다. 전용 도구가 있는 곳에서는 손으로 쓴 SQL보다 그 도구를 사용하십시오. 눈앞의 엔진에 맞게 식별자를 인용하고, 사용자의 행 제한을 적용하며, 원시 실행이 허용되지 않는 연결에서도 사용할 수 있습니다.\n\n모든 연결에는 사용자 고유의 정책이 따라붙습니다. 어떤 연결은 외부 클라이언트에 읽기 전용일 수 있고, AI에게 아예 보이지 않을 수도 있으며, 쓰기마다 사용자 확인을 요구하는 안전 모드일 수도 있습니다. 거부는 일시적인 오류가 아니라 그 정책이 말하는 것이므로, 다시 시도하지 말고 우회하려 하지 마십시오. 파괴적인 명령문에는 사용자의 동의가 필요하며, 이는 TablePro가 직접 받습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "TablePro, yerel bir macOS veritabanı istemcisidir. Bu sunucu, kullanıcının zaten yapılandırdığı bağlantıları sunar, bu yüzden hiçbir zaman kimlik bilgisi ile uğraşmazsınız: bir bağlantıyı kimliğiyle adlandırın, TablePro sizin için onu açar, yeniden kullanır ve yetkilendirir.\n\nlist_connections ile başlayın, sonra yolunuzu bulmak için list_databases, list_schemas ve list_tables kullanın; herhangi bir sorgu yazmadan önce describe_table çağırın, çünkü SQL'i ilk seferde doğru yazmak için gereken sütunları, indeksleri ve yabancı anahtarları döndürür. Özel bir araç varsa elle yazılmış SQL yerine onu tercih edin: önünüzdeki motora göre tanımlayıcıları doğru tırnaklar, kullanıcının satır sınırlarını uygular ve ham çalıştırmanın izinli olmadığı bağlantılarda da kullanılabilir.\n\nHer bağlantı kullanıcının kendi politikasını taşır. Bir bağlantı dış istemciler için salt okunur olabilir, yapay zekâya tamamen görünmez olabilir ve her yazmayı kullanıcıya onaylatan bir güvenli modda olabilir. Bir ret, geçici bir hata değil, o politikanın konuşmasıdır; bu yüzden yeniden denemeyin ve etrafından dolaşmanın yolunu aramayın. Yıkıcı ifadeler kullanıcının onayını gerektirir ve bunu TablePro kendisi toplar.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "TablePro là một ứng dụng khách cơ sở dữ liệu gốc trên macOS. Máy chủ này để lộ ra những kết nối mà người dùng đã cấu hình sẵn, nên bạn không bao giờ phải xử lý thông tin đăng nhập: chỉ cần gọi tên một kết nối bằng id của nó và TablePro sẽ mở, tái sử dụng và cấp quyền thay bạn.\n\nHãy bắt đầu với list_connections, rồi dùng list_databases, list_schemas và list_tables để định hướng, và gọi describe_table trước khi viết bất kỳ truy vấn nào, vì nó trả về các cột, chỉ mục và khoá ngoại bạn cần để viết SQL đúng ngay từ lần đầu. Ở đâu có công cụ chuyên dụng thì hãy ưu tiên nó thay vì SQL viết tay: chúng trích dẫn định danh đúng theo engine trước mặt bạn, áp dụng giới hạn dòng của người dùng, và được phép dùng trên cả những kết nối không cho chạy lệnh thô.\n\nMỗi kết nối mang theo chính sách riêng của người dùng. Một kết nối có thể chỉ đọc với client bên ngoài, có thể hoàn toàn ẩn với AI, và có thể đang ở chế độ an toàn yêu cầu người dùng xác nhận từng thao tác ghi. Một lời từ chối là chính sách đó lên tiếng, không phải lỗi tạm thời, nên đừng thử lại và đừng tìm cách đi vòng. Các câu lệnh có tính phá huỷ cần sự đồng ý của người dùng, và TablePro tự thu thập sự đồng ý đó.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "TablePro 是一款原生 macOS 数据库客户端。此服务器公开用户已经配置好的连接，因此你从不接触凭据：用 id 指名一个连接，TablePro 就会替你打开、复用并授权它。\n\n先从 list_connections 开始，再用 list_databases、list_schemas 和 list_tables 摸清结构，并在写任何查询之前调用 describe_table，因为它会返回你一次写对 SQL 所需的列、索引和外键。凡是有专用工具的地方，都优先用它而不是手写 SQL：它们会按你面前的引擎正确地为标识符加引号、应用用户的行数限制，并且在不允许原始执行的连接上也可以使用。\n\n每个连接都带着用户自己的策略。一个连接可能对外部客户端只读，可能对 AI 完全不可见，也可能处于要求用户逐条确认写入的安全模式。被拒绝是这条策略在说话，而不是临时故障，所以不要重试，也不要找绕过的办法。破坏性语句需要用户同意，而这份同意由 TablePro 自己收集。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "TablePro 是一款原生 macOS 資料庫用戶端。此伺服器公開使用者已經設定好的連線，因此你從不接觸憑證：用 id 指名一個連線，TablePro 就會替你開啟、重複使用並授權它。\n\n先從 list_connections 開始，再用 list_databases、list_schemas 和 list_tables 摸清結構，並在寫任何查詢之前呼叫 describe_table，因為它會回傳你一次寫對 SQL 所需的欄位、索引和外鍵。凡是有專用工具的地方，都優先用它而不是手寫 SQL：它們會按你面前的引擎正確地為識別符號加引號、套用使用者的列數限制，並且在不允許原始執行的連線上也可以使用。\n\n每個連線都帶著使用者自己的政策。一個連線可能對外部用戶端唯讀，可能對 AI 完全不可見，也可能處於要求使用者逐條確認寫入的安全模式。被拒絕是這條政策在說話，而不是暫時故障，所以不要重試，也不要找繞過的辦法。破壞性陳述式需要使用者同意，而這份同意由 TablePro 自己收集。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "TablePro is still trying to reconnect." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "TablePro가 아직 다시 연결을 시도하고 있습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "TablePro hâlâ yeniden bağlanmaya çalışıyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "TablePro vẫn đang thử kết nối lại.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "TablePro 仍在尝试重新连接。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "TablePro 仍在嘗試重新連線。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "TablePro only notifies when the result is not already on screen." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "TablePro는 결과가 화면에 아직 보이지 않을 때만 알립니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "TablePro yalnızca sonuç ekranda değilken bildirir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "TablePro chỉ thông báo khi kết quả chưa hiện trên màn hình.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "只有当结果尚未显示在屏幕上时，TablePro 才会通知。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "只有當結果尚未顯示在螢幕上時，TablePro 才會通知。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "TablePro runs Anthropic's claude tool in headless mode. Claude Code is built for you to use directly, not as a backend for other apps, so this path can break with any Claude Code release." : {
       "localizations" : {
@@ -131306,10 +149250,72 @@
       }
     },
     "TablePro's MCP server does not provide this endpoint." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "TablePro의 MCP 서버는 이 엔드포인트를 제공하지 않습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "TablePro'nun MCP sunucusu bu uç noktayı sağlamıyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Máy chủ MCP của TablePro không cung cấp endpoint này.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "TablePro 的 MCP 服务器不提供此端点。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "TablePro 的 MCP 伺服器不提供此端點。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "TablePro's MCP server has too many open connections." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "TablePro의 MCP 서버에 열린 연결이 너무 많습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "TablePro'nun MCP sunucusunda çok fazla açık bağlantı var.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Máy chủ MCP của TablePro có quá nhiều kết nối đang mở.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "TablePro 的 MCP 服务器打开的连接过多。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "TablePro 的 MCP 伺服器開啟的連線過多。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "TablePro's Safe Mode is set to read-only for this connection. Destructive operations are not permitted." : {
       "localizations" : {
@@ -131448,16 +149454,140 @@
       }
     },
     "Tables and columns of the database this connection is browsing" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 연결이 탐색 중인 데이터베이스의 테이블과 열",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu bağlantının göz attığı veritabanının tabloları ve sütunları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các bảng và cột của cơ sở dữ liệu mà kết nối này đang duyệt",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此连接正在浏览的数据库的表和列",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此連線正在瀏覽的資料庫的資料表和欄位",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Tables and their columns for the database a connection is browsing. Capped at 100 tables." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "연결이 탐색 중인 데이터베이스의 테이블과 각 테이블의 열입니다. 최대 100개 테이블로 제한됩니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir bağlantının göz attığı veritabanı için tablolar ve sütunları. En fazla 100 tabloyla sınırlıdır.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các bảng và cột của chúng cho cơ sở dữ liệu mà một kết nối đang duyệt. Giới hạn ở 100 bảng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "某个连接正在浏览的数据库的表及其列。最多 100 张表。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "某個連線正在瀏覽的資料庫的資料表及其欄位。最多 100 張資料表。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Tables and views in scope" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "범위 안의 테이블과 뷰",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kapsamdaki tablolar ve görünümler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các bảng và view trong phạm vi",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "范围内的表和视图",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "範圍內的資料表和檢視表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Tables of %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@의 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ tabloları",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng của %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%@ 的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%@ 的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Tables start out of the comparison so a first run cannot stream every row." : {
       "localizations" : {
@@ -131494,13 +149624,106 @@
       }
     },
     "Tables that carry at least one foreign key" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "외래 키가 하나 이상 있는 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "En az bir yabancı anahtar taşıyan tablolar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các bảng có ít nhất một khoá ngoại",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "至少带有一个外键的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "至少帶有一個外鍵的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Tables that carry at least one index" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "인덱스가 하나 이상 있는 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "En az bir indeks taşıyan tablolar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các bảng có ít nhất một chỉ mục",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "至少带有一个索引的表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "至少帶有一個索引的資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Tables to export. Use instead of 'query'." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "내보낼 테이블입니다. 'query' 대신 사용하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Dışa aktarılacak tablolar. 'query' yerine kullanın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các bảng cần xuất. Dùng thay cho 'query'.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要导出的表。用它代替 'query'。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要匯出的資料表。用它取代 'query'。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Tables with more estimated rows use approximate counts to avoid slow COUNT(*) queries" : {
       "localizations" : {
@@ -131949,7 +150172,38 @@
       }
     },
     "Target table for SQL output when exporting a query" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "쿼리를 내보낼 때 SQL 출력의 대상 테이블",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir sorgu dışa aktarılırken SQL çıktısı için hedef tablo",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng đích cho đầu ra SQL khi xuất một truy vấn",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "导出查询时 SQL 输出的目标表",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "匯出查詢時 SQL 輸出的目標資料表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Target: %@" : {
       "localizations" : {
@@ -132227,7 +150481,38 @@
       }
     },
     "Term that was searched" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "검색한 용어",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Aranan terim",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Từ khoá đã tìm",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "被搜索的词",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "被搜尋的詞",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Terminal" : {
       "extractionState" : "stale",
@@ -132676,7 +150961,38 @@
       }
     },
     "Text matched against the recorded statement" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "기록된 명령문과 대조할 텍스트",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kaydedilen ifadeyle eşleştirilen metin",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Văn bản được so khớp với câu lệnh đã ghi",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "用于匹配已记录语句的文本",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "用於比對已記錄陳述式的文字",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Text Viewer" : {
       "localizations" : {
@@ -132815,10 +151131,72 @@
       }
     },
     "That filter is incomplete." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "해당 필터가 완전하지 않습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu filtre eksik.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bộ lọc đó chưa đầy đủ.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该筛选条件不完整。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該篩選條件不完整。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "That filter operator is not supported." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "해당 필터 연산자는 지원되지 않습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu filtre operatörü desteklenmiyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Toán tử lọc đó không được hỗ trợ.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "不支持该筛选运算符。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "不支援該篩選運算子。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "That folder could not be read." : {
       "localizations" : {
@@ -132889,7 +151267,38 @@
       }
     },
     "That maintenance operation is not available on this connection." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 연결에서는 해당 유지 관리 작업을 사용할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu bakım işlemi bu bağlantıda kullanılamıyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thao tác bảo trì đó không dùng được trên kết nối này.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该维护操作在此连接上不可用。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該維護作業在此連線上無法使用。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "That regular expression could not be read. Check the syntax and try again." : {
       "localizations" : {
@@ -132926,10 +151335,72 @@
       }
     },
     "That tab no longer has a window." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "해당 탭에는 더 이상 창이 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu sekmenin artık bir penceresi yok.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tab đó không còn cửa sổ nào.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该标签页已没有窗口。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該標籤頁已沒有視窗。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "That table has no readable columns." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "해당 테이블에는 읽을 수 있는 열이 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu tabloda okunabilir sütun yok.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng đó không có cột nào đọc được.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "那张表没有可读的列。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "那張資料表沒有可讀取的欄位。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The %@ command line tool is not installed." : {
       "localizations" : {
@@ -133102,7 +151573,38 @@
       }
     },
     "The action that completed" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "완료된 작업",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tamamlanan eylem",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hành động đã hoàn tất",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已完成的操作",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已完成的動作",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The API key will be permanently deleted." : {
       "localizations" : {
@@ -133689,10 +152191,72 @@
       }
     },
     "The connection is not open. Call connect first." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "연결이 열려 있지 않습니다. 먼저 connect를 호출하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bağlantı açık değil. Önce connect çağırın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kết nối chưa mở. Hãy gọi connect trước.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "连接尚未打开。请先调用 connect。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "連線尚未開啟。請先呼叫 connect。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The connection stopped responding." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "연결이 응답을 멈췄습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bağlantı yanıt vermeyi bıraktı.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kết nối đã ngừng phản hồi.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "连接已停止响应。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "連線已停止回應。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The connection this query was recorded against no longer exists." : {
       "comment" : "Error message shown when a query cannot be opened because the connection it was recorded against no longer exists.",
@@ -133731,7 +152295,38 @@
       }
     },
     "The connection was closed and reconnecting was cancelled." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "연결이 닫혔고 재연결이 취소되었습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bağlantı kapatıldı ve yeniden bağlanma iptal edildi.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kết nối đã bị đóng và việc kết nối lại đã bị huỷ.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "连接已关闭，重新连接已取消。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "連線已關閉，重新連線已取消。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The connection was closed." : {
       "localizations" : {
@@ -133768,10 +152363,72 @@
       }
     },
     "the copy failed its integrity check: %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "복사본이 무결성 검사를 통과하지 못했습니다: %@",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "kopya bütünlük denetiminden geçemedi: %@",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "bản sao không qua được kiểm tra toàn vẹn: %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "副本未通过完整性校验：%@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "副本未通過完整性檢查：%@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The CREATE statement for one table, as the engine reports it." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "엔진이 보고하는 그대로의, 한 테이블에 대한 CREATE 명령문입니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Motorun bildirdiği şekliyle bir tablo için CREATE ifadesi.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Câu lệnh CREATE cho một bảng, đúng như engine báo cáo.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "某张表的 CREATE 语句，按引擎报告的原样。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "某張資料表的 CREATE 陳述式，按引擎回報的原樣。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The Cursor CLI is not installed." : {
       "localizations" : {
@@ -134013,7 +152670,38 @@
       }
     },
     "The destructive statement to run" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "실행할 파괴적인 명령문",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Çalıştırılacak yıkıcı ifade",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Câu lệnh có tính phá huỷ cần chạy",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要运行的破坏性语句",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要執行的破壞性陳述式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The diagram could not be converted to a PNG image." : {
       "comment" : "Error message when the ER diagram could not be exported as PNG.",
@@ -134052,7 +152740,38 @@
       }
     },
     "The Downloads folder is not available." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "다운로드 폴더를 사용할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İndirilenler klasörü kullanılamıyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thư mục Downloads không khả dụng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "下载文件夹不可用。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "下載檔案夾無法使用。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The driver did not return this object's definition, so only its name was compared." : {
       "localizations" : {
@@ -134124,13 +152843,106 @@
       }
     },
     "The engine returned no result set to export." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "엔진이 내보낼 결과 집합을 반환하지 않았습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Motor dışa aktarılacak bir sonuç kümesi döndürmedi.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Engine không trả về tập kết quả nào để xuất.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "引擎没有返回可导出的结果集。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "引擎沒有回傳可匯出的結果集。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The export file could not be written." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "내보내기 파일을 쓸 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Dışa aktarma dosyası yazılamadı.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không ghi được tệp xuất.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "无法写入导出文件。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "無法寫入匯出檔案。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The file is copied to this Mac and opened read-only. The original on the server is never written to." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "파일이 이 Mac으로 복사되어 읽기 전용으로 열립니다. 서버의 원본에는 절대 쓰지 않습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Dosya bu Mac'e kopyalanır ve salt okunur açılır. Sunucudaki özgün dosyaya asla yazılmaz.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tệp được sao chép về máy Mac này và mở ở chế độ chỉ đọc. Bản gốc trên máy chủ không bao giờ bị ghi vào.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该文件会被复制到这台 Mac 并以只读方式打开。服务器上的原始文件绝不会被写入。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該檔案會被複製到這台 Mac 並以唯讀方式開啟。伺服器上的原始檔案絕不會被寫入。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The filter field is not in the toolbar." : {
       "localizations" : {
@@ -134421,7 +153233,38 @@
       }
     },
     "The key that protects your save history is not available." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "저장 기록을 보호하는 키를 사용할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kaydetme geçmişinizi koruyan anahtar kullanılamıyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Khoá bảo vệ lịch sử lưu của bạn hiện không khả dụng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "保护你保存历史的密钥不可用。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "保護你儲存記錄的金鑰無法使用。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The license has been suspended." : {
       "localizations" : {
@@ -134560,7 +153403,38 @@
       }
     },
     "The license text is missing from this build." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 빌드에는 라이선스 본문이 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Lisans metni bu derlemede yok.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bản dựng này thiếu nội dung giấy phép.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此版本缺少许可证文本。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此版本缺少授權條款文字。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The license that covers iCloud Sync has expired. Renew it to start syncing again." : {
       "localizations" : {
@@ -134597,7 +153471,38 @@
       }
     },
     "The list of open source libraries is missing from this build." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 빌드에는 오픈 소스 라이브러리 목록이 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Açık kaynak kitaplıkların listesi bu derlemede yok.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bản dựng này thiếu danh sách thư viện mã nguồn mở.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此版本缺少开源库清单。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此版本缺少開源程式庫清單。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The listener does not know the requested service name" : {
       "extractionState" : "stale",
@@ -134740,13 +153645,106 @@
       }
     },
     "The MCP server could not bind a port (%@)" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "MCP 서버가 포트를 바인딩하지 못했습니다(%@)",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "MCP sunucusu bir bağlantı noktasına bağlanamadı (%@)",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Máy chủ MCP không bind được cổng (%@)",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "MCP 服务器无法绑定端口（%@）",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "MCP 伺服器無法繫結連接埠（%@）",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The MCP server could not issue its bridge credential" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "MCP 서버가 브리지 자격 증명을 발급하지 못했습니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "MCP sunucusu köprü kimlik bilgisini veremedi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Máy chủ MCP không cấp được thông tin xác thực cầu nối",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "MCP 服务器无法签发其桥接凭据",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "MCP 伺服器無法簽發其橋接憑證",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The MCP server started without a port" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "MCP 서버가 포트 없이 시작되었습니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "MCP sunucusu bir bağlantı noktası olmadan başladı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Máy chủ MCP khởi động mà không có cổng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "MCP 服务器启动时没有端口",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "MCP 伺服器啟動時沒有連接埠",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The Microsoft Entra ID access token was rejected by the driver." : {
       "extractionState" : "stale",
@@ -134923,10 +153921,72 @@
       }
     },
     "The pairing challenge is malformed." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "페어링 챌린지의 형식이 잘못되었습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Eşleştirme sınaması hatalı biçimlendirilmiş.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Challenge ghép nối bị sai định dạng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "配对质询格式不正确。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "配對挑戰格式不正確。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The pairing verifier is malformed." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "페어링 검증자의 형식이 잘못되었습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Eşleştirme doğrulayıcısı hatalı biçimlendirilmiş.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Verifier ghép nối bị sai định dạng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "配对验证串格式不正确。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "配對驗證串格式不正確。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The partial backup file will be removed." : {
       "comment" : "A message displayed in a cancel confirmation alert for a backup.",
@@ -135409,7 +154469,38 @@
       }
     },
     "The query exceeds the 100KB limit." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "쿼리가 100KB 제한을 초과합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sorgu 100KB sınırını aşıyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Truy vấn vượt quá giới hạn 100KB.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "查询超过了 100KB 的限制。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "查詢超過了 100KB 的限制。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The query history database could not be opened, so there is nothing to summarize." : {
       "localizations" : {
@@ -135480,16 +154571,140 @@
       }
     },
     "The query is empty." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "쿼리가 비어 있습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sorgu boş.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Truy vấn rỗng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "查询为空。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "查詢為空。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The query to review" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "검토할 쿼리",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İncelenecek sorgu",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Truy vấn cần rà soát",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要审查的查询",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要審查的查詢",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The question to answer, in plain language" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "일상어로 답해야 할 질문",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yanıtlanacak soru, sade dille",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Câu hỏi cần trả lời, bằng ngôn ngữ đời thường",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要回答的问题，用日常语言表达",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要回答的問題，用日常語言表達",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The redirect address is not a local callback, so pairing was refused." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "리디렉션 주소가 로컬 콜백이 아니므로 페어링이 거부되었습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yönlendirme adresi yerel bir geri çağırma değil, bu yüzden eşleştirme reddedildi.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Địa chỉ chuyển hướng không phải callback cục bộ, nên việc ghép nối đã bị từ chối.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "重定向地址不是本地回调，因此配对被拒绝。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "重新導向位址不是本機回呼，因此配對被拒絕。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The run was rolled back. %@ is unchanged." : {
       "localizations" : {
@@ -135526,10 +154741,72 @@
       }
     },
     "The save also truncated or dropped a table." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 저장은 테이블을 잘라내거나 삭제하기도 했습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu kaydetme aynı zamanda bir tabloyu boşalttı veya sildi.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Lần lưu này còn truncate hoặc xoá một bảng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "这次保存还清空或删除了一张表。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "這次儲存還清空或刪除了一張資料表。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The schema change to make, in plain language" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "일상어로 표현한, 적용할 스키마 변경",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yapılacak şema değişikliği, sade dille",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thay đổi schema cần thực hiện, bằng ngôn ngữ đời thường",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要做的 Schema 变更，用日常语言表达",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要做的綱要變更，用日常語言表達",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The script already ran. Compare again to see where the target stands." : {
       "localizations" : {
@@ -135668,7 +154945,38 @@
       }
     },
     "The server chose this row's key." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "서버가 이 행의 키를 정했습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu satırın anahtarını sunucu seçti.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Máy chủ đã chọn khoá cho dòng này.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "这一行的键由服务器选定。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "這一列的鍵由伺服器選定。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The server no longer knows this license key." : {
       "localizations" : {
@@ -135775,7 +155083,38 @@
       }
     },
     "The slow query" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "느린 쿼리",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yavaş sorgu",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Truy vấn chậm",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "慢查询",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "慢查詢",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "the SOCKS proxy" : {
       "localizations" : {
@@ -135914,7 +155253,38 @@
       }
     },
     "The SSH account cannot read %@." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "SSH 계정이 %@을(를) 읽을 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "SSH hesabı %@ dosyasını okuyamıyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tài khoản SSH không đọc được %@.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该 SSH 账户无法读取 %@。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該 SSH 帳號無法讀取 %@。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The SSH server connects to this socket instead of Host and Port. A database on a socket cannot negotiate TLS, so TablePro turns it off; the SSH tunnel still encrypts the whole path." : {
       "localizations" : {
@@ -136173,10 +155543,72 @@
       }
     },
     "The statement that was sent, with its prefix" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "접두사를 포함해 전송된 명령문",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Ön ekiyle birlikte gönderilen ifade",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Câu lệnh đã gửi, kèm tiền tố của nó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已发送的语句，含其前缀",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已傳送的陳述式，含其前綴",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The statement to explain, without an EXPLAIN prefix" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "EXPLAIN 접두사 없이, 설명할 명령문",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "EXPLAIN ön eki olmadan, açıklanacak ifade",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Câu lệnh cần giải thích, không kèm tiền tố EXPLAIN",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要解释的语句，不带 EXPLAIN 前缀",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要解釋的陳述式，不帶 EXPLAIN 前綴",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The statements ran but the transaction could not be committed: %@" : {
       "localizations" : {
@@ -136213,13 +155645,106 @@
       }
     },
     "The table %@ was already created with different columns. Choose another name." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블 %@은(는) 다른 열 구성으로 이미 생성되어 있습니다. 다른 이름을 선택하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ tablosu farklı sütunlarla zaten oluşturulmuş. Başka bir ad seçin.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng %@ đã được tạo với bộ cột khác. Hãy chọn tên khác.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "表 %@ 已经以不同的列创建过了。请另选一个名称。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "資料表 %@ 已經以不同的欄位建立過了。請另選一個名稱。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The table has no primary key, so this row cannot be identified." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블에 기본 키가 없어 이 행을 식별할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tablonun birincil anahtarı yok, bu yüzden bu satır tanımlanamıyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng không có khoá chính nên không xác định được dòng này.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该表没有主键，因此无法识别这一行。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該資料表沒有主鍵，因此無法識別這一列。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The table is no longer reachable." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블에 더 이상 접근할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tabloya artık erişilemiyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không còn truy cập được bảng này.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该表已无法访问。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該資料表已無法存取。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "the target" : {
       "localizations" : {
@@ -136668,13 +156193,106 @@
       }
     },
     "The transfer was cancelled." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "전송이 취소되었습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Aktarım iptal edildi.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Việc truyền đã bị huỷ.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "传输已取消。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "傳輸已取消。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The user cancelled this operation." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "사용자가 이 작업을 취소했습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kullanıcı bu işlemi iptal etti.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Người dùng đã huỷ thao tác này.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "用户取消了此操作。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "使用者取消了此操作。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The user did not approve this operation." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "사용자가 이 작업을 승인하지 않았습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kullanıcı bu işlemi onaylamadı.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Người dùng đã không phê duyệt thao tác này.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "用户未批准此操作。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "使用者未核准此操作。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "The value could not be parsed. Use raw mode to inspect it as text." : {
       "localizations" : {
@@ -136711,7 +156329,38 @@
       }
     },
     "The values this save replaced are no longer being kept." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 저장이 대체한 값은 더 이상 보관되지 않습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu kaydetmenin yerine geçtiği değerler artık saklanmıyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các giá trị mà lần lưu này thay thế không còn được giữ lại.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "这次保存所替换掉的值已不再保留。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "這次儲存所替換掉的值已不再保留。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Theme" : {
       "extractionState" : "stale",
@@ -137024,13 +156673,106 @@
       }
     },
     "These rows came from another database than the one this tab is now using." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 행들은 이 탭이 현재 사용 중인 데이터베이스가 아닌 다른 데이터베이스에서 왔습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu satırlar, bu sekmenin şu anda kullandığından başka bir veritabanından geldi.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các dòng này đến từ một cơ sở dữ liệu khác với cơ sở dữ liệu mà tab này đang dùng.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "这些行来自与此标签页当前所用数据库不同的另一个数据库。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "這些列來自與此標籤頁目前所用資料庫不同的另一個資料庫。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "These rows cannot be edited because TablePro cannot tell which table they came from." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "TablePro가 이 행들이 어느 테이블에서 왔는지 알 수 없어 편집할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "TablePro bu satırların hangi tablodan geldiğini bilemediği için bu satırlar düzenlenemez.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không thể sửa các dòng này vì TablePro không xác định được chúng đến từ bảng nào.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "无法编辑这些行，因为 TablePro 无法判断它们来自哪张表。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "無法編輯這些列，因為 TablePro 無法判斷它們來自哪張資料表。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "These rows come from a view, which cannot be edited." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 행들은 편집할 수 없는 뷰에서 왔습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu satırlar düzenlenemeyen bir görünümden geliyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các dòng này đến từ một view, vốn không sửa được.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "这些行来自视图，视图不可编辑。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "這些列來自檢視表，檢視表不可編輯。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "These two engines cannot share a script." : {
       "localizations" : {
@@ -137136,7 +156878,38 @@
       }
     },
     "This action needs ⌘ or ⌃. Option and Shift can join them, but cannot hold a shortcut on their own." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 동작에는 ⌘ 또는 ⌃가 필요합니다. Option과 Shift는 함께 쓸 수는 있지만 단독으로 단축키를 이룰 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu eylem ⌘ veya ⌃ gerektirir. Option ve Shift bunlara eşlik edebilir, ama tek başlarına bir kısayol tutamaz.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hành động này cần ⌘ hoặc ⌃. Option và Shift có thể đi kèm, nhưng không thể tự mình giữ một phím tắt.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此操作需要 ⌘ 或 ⌃。Option 和 Shift 可以搭配它们，但不能单独构成快捷键。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此操作需要 ⌘ 或 ⌃。Option 和 Shift 可以搭配它們，但不能單獨構成快速鍵。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This action needs a modifier key like ⌘ or ⌥. A plain key won't reach the menu reliably." : {
       "extractionState" : "stale",
@@ -137174,7 +156947,38 @@
       }
     },
     "This client does not have access to that connection." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 클라이언트에는 해당 연결에 대한 접근 권한이 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu istemcinin o bağlantıya erişimi yok.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Client này không có quyền truy cập kết nối đó.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此客户端无权访问该连接。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此用戶端無權存取該連線。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This Connection" : {
       "localizations" : {
@@ -137245,7 +157049,38 @@
       }
     },
     "This connection is read only for external clients." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 연결은 외부 클라이언트에 대해 읽기 전용입니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu bağlantı dış istemciler için salt okunur.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Kết nối này chỉ đọc đối với client bên ngoài.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此连接对外部客户端为只读。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此連線對外部用戶端為唯讀。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This connection runs SQL every time it connects, using your credentials." : {
       "comment" : "A description of the startup SQL for a database connection.",
@@ -137491,7 +157326,38 @@
       }
     },
     "This database cannot restore a row with its original key." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 데이터베이스는 행을 원래 키로 복원할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu veritabanı bir satırı özgün anahtarıyla geri yükleyemiyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu này không thể khôi phục một dòng với khoá gốc của nó.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此数据库无法用原来的键恢复某一行。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此資料庫無法用原來的鍵還原某一列。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This database did not return a query plan for the statement." : {
       "comment" : "Text displayed in a description when the database did not return a query plan for the statement.",
@@ -137600,7 +157466,38 @@
       }
     },
     "This database reports no schemas to compare." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 데이터베이스는 비교할 스키마를 보고하지 않습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu veritabanı karşılaştırılacak şema bildirmiyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cơ sở dữ liệu này không báo cáo schema nào để so sánh.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此数据库没有报告可供比较的 Schema。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此資料庫沒有回報可供比較的綱要。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This DELETE query has no WHERE clause and will delete ALL rows in the table. This action cannot be undone." : {
       "extractionState" : "stale",
@@ -137984,13 +157881,106 @@
       }
     },
     "This engine cannot count rows for that table." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 엔진은 해당 테이블의 행 수를 셀 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu motor o tablonun satırlarını sayamıyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Engine này không đếm được số dòng cho bảng đó.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此引擎无法统计那张表的行数。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此引擎無法統計那張資料表的列數。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This engine cannot stop a session from TablePro." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 엔진은 TablePro에서 세션을 중지할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu motor TablePro üzerinden bir oturumu durduramıyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Engine này không thể dừng một phiên từ TablePro.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此引擎无法从 TablePro 停止会话。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此引擎無法從 TablePro 停止工作階段。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This engine does not expose users and roles." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 엔진은 사용자와 역할을 노출하지 않습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu motor kullanıcıları ve rolleri sunmuyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Engine này không để lộ người dùng và vai trò.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此引擎不公开用户和角色。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此引擎不公開使用者和角色。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This engine does not support creating databases." : {
       "localizations" : {
@@ -138027,16 +158017,140 @@
       }
     },
     "This engine does not support transactions." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 엔진은 트랜잭션을 지원하지 않습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu motor işlemleri desteklemiyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Engine này không hỗ trợ transaction.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此引擎不支持事务。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此引擎不支援交易。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This engine has no SQL dialect, so it cannot produce SQL output." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 엔진에는 SQL 방언이 없어 SQL 출력을 생성할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu motorun bir SQL lehçesi yok, bu yüzden SQL çıktısı üretemiyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Engine này không có phương ngữ SQL nên không thể tạo đầu ra SQL.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此引擎没有 SQL 方言，因此无法生成 SQL 输出。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此引擎沒有 SQL 方言，因此無法產生 SQL 輸出。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This engine has no SQL dialect, so tables cannot be selected generically." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 엔진에는 SQL 방언이 없어 테이블을 일반적인 방식으로 조회할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu motorun bir SQL lehçesi yok, bu yüzden tablolar genel bir şekilde seçilemiyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Engine này không có phương ngữ SQL nên không thể select bảng theo cách tổng quát.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此引擎没有 SQL 方言，因此无法以通用方式查询表。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此引擎沒有 SQL 方言，因此無法以通用方式查詢資料表。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This engine has no transactions, so the extra rows were already written. '%@' has no primary key, so identical rows cannot be told apart." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 엔진에는 트랜잭션이 없어 추가된 행이 이미 기록되었습니다. '%@'에는 기본 키가 없어 동일한 행을 구분할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu motorda işlem yok, bu yüzden fazladan satırlar zaten yazıldı. '%@' birincil anahtara sahip değil, bu yüzden aynı satırlar birbirinden ayırt edilemiyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Engine này không có transaction nên các dòng thừa đã được ghi. '%@' không có khoá chính nên không thể phân biệt các dòng giống nhau.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此引擎没有事务，因此多出来的行已经写入。'%@' 没有主键，因此无法区分完全相同的行。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此引擎沒有交易，因此多出來的列已經寫入。'%@' 沒有主鍵，因此無法區分完全相同的列。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This file is encrypted" : {
       "localizations" : {
@@ -138249,10 +158363,72 @@
       }
     },
     "This Host header is not allowed to reach TablePro's MCP server." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 Host 헤더로는 TablePro의 MCP 서버에 접근할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu Host başlığının TablePro'nun MCP sunucusuna erişmesine izin verilmiyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Header Host này không được phép truy cập máy chủ MCP của TablePro.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "不允许此 Host 头访问 TablePro 的 MCP 服务器。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "不允許此 Host 標頭存取 TablePro 的 MCP 伺服器。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This HTTP method is not supported." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 HTTP 메서드는 지원되지 않습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu HTTP yöntemi desteklenmiyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Phương thức HTTP này không được hỗ trợ.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "不支持此 HTTP 方法。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "不支援此 HTTP 方法。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This is a built-in theme." : {
       "localizations" : {
@@ -138461,7 +158637,38 @@
       }
     },
     "This library's own project publishes no license file, so TablePro cannot state one for it. It is listed here so the gap stays visible instead of looking settled." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 라이브러리의 프로젝트 자체가 라이선스 파일을 공개하지 않아 TablePro가 라이선스를 밝힐 수 없습니다. 해결된 것처럼 보이지 않도록 이 공백을 드러내기 위해 여기에 표시합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu kitaplığın kendi projesi bir lisans dosyası yayımlamıyor, bu yüzden TablePro onun için bir lisans belirtemiyor. Bu boşluk çözülmüş gibi görünmesin diye burada listeleniyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Dự án của chính thư viện này không công bố tệp giấy phép, nên TablePro không thể nêu ra giấy phép cho nó. Nó được liệt kê ở đây để khoảng trống này vẫn hiện rõ thay vì trông như đã xong.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该库自己的项目没有发布许可证文件，因此 TablePro 无法为它指明许可证。把它列在这里，是为了让这个空缺保持可见，而不是看起来已经解决。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該程式庫自己的專案沒有發布授權檔案，因此 TablePro 無法為它指明授權。把它列在這裡，是為了讓這個空缺保持可見，而不是看起來已經解決。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This license expires in %lld days." : {
       "localizations" : {
@@ -138804,7 +159011,38 @@
       }
     },
     "this Mac needs %@ free to open that database" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "해당 데이터베이스를 열려면 이 Mac에 %@의 여유 공간이 필요합니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "bu Mac'in o veritabanını açmak için %@ boş alana ihtiyacı var",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "máy Mac này cần %@ dung lượng trống để mở cơ sở dữ liệu đó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "这台 Mac 需要 %@ 可用空间才能打开该数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "這台 Mac 需要 %@ 可用空間才能開啟該資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This Mac no longer holds a seat." : {
       "localizations" : {
@@ -139048,7 +159286,38 @@
       }
     },
     "This origin is not allowed to reach TablePro's MCP server." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 출처로는 TablePro의 MCP 서버에 접근할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu kaynağın TablePro'nun MCP sunucusuna erişmesine izin verilmiyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Origin này không được phép truy cập máy chủ MCP của TablePro.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "不允许此来源访问 TablePro 的 MCP 服务器。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "不允許此來源存取 TablePro 的 MCP 伺服器。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This permanently deletes the selected rows from the database and can't be undone." : {
       "localizations" : {
@@ -139538,13 +159807,106 @@
       }
     },
     "This row's key cannot be matched, so it cannot be checked before writing." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 행의 키를 일치시킬 수 없어 쓰기 전에 확인할 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu satırın anahtarı eşleştirilemiyor, bu yüzden yazmadan önce denetlenemiyor.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không khớp được khoá của dòng này, nên không thể kiểm tra trước khi ghi.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "无法匹配这一行的键，因此写入前无法核对它。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "無法比對這一列的鍵，因此寫入前無法核對它。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This Save Cannot Be Restored" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 저장은 복원할 수 없음",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu Kayıt Geri Yüklenemez",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Không thể khôi phục lần lưu này",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "这次保存无法恢复",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "這次儲存無法還原",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This save was made on a different connection. Open that connection to restore it." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 저장은 다른 연결에서 이루어졌습니다. 복원하려면 해당 연결을 여십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu kayıt başka bir bağlantıda yapıldı. Geri yüklemek için o bağlantıyı açın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Lần lưu này được thực hiện trên một kết nối khác. Hãy mở kết nối đó để khôi phục.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "这次保存是在另一个连接上进行的。请打开那个连接来恢复它。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "這次儲存是在另一個連線上進行的。請開啟那個連線來還原它。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This server has no databases yet." : {
       "localizations" : {
@@ -139792,7 +160154,38 @@
       }
     },
     "This statement drops or truncates data. Use confirm_destructive_operation for it." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 명령문은 데이터를 삭제하거나 잘라냅니다. 이 경우 confirm_destructive_operation을 사용하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu ifade veriyi siliyor veya boşaltıyor. Bunun için confirm_destructive_operation kullanın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Câu lệnh này xoá hoặc truncate dữ liệu. Hãy dùng confirm_destructive_operation cho nó.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此语句会删除或清空数据。请为它使用 confirm_destructive_operation。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此陳述式會刪除或清空資料。請為它使用 confirm_destructive_operation。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This tab is on %@. Switch the connection to that database to run it." : {
       "localizations" : {
@@ -139897,7 +160290,38 @@
       }
     },
     "This tool only runs destructive statements. Use execute_query for everything else." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 도구는 파괴적인 명령문만 실행합니다. 나머지는 모두 execute_query를 사용하십시오.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu araç yalnızca yıkıcı ifadeleri çalıştırır. Diğer her şey için execute_query kullanın.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Công cụ này chỉ chạy các câu lệnh có tính phá huỷ. Mọi thứ khác hãy dùng execute_query.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此工具只运行破坏性语句。其他一切请使用 execute_query。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此工具只執行破壞性陳述式。其他一切請使用 execute_query。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This TRUNCATE query will permanently delete all rows in the table. This action cannot be undone." : {
       "extractionState" : "stale",
@@ -140319,7 +160743,38 @@
       }
     },
     "This will permanently delete all query history entries, and the saved changes kept for restoring. This action cannot be undone." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "모든 쿼리 기록 항목과 복원을 위해 보관 중인 저장된 변경 사항이 영구히 삭제됩니다. 이 작업은 되돌릴 수 없습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu, tüm sorgu geçmişi girdilerini ve geri yükleme için saklanan kaydedilmiş değişiklikleri kalıcı olarak siler. Bu işlem geri alınamaz.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thao tác này sẽ xoá vĩnh viễn toàn bộ mục lịch sử truy vấn và các thay đổi đã lưu để khôi phục. Không thể hoàn tác.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "这会永久删除所有查询历史条目，以及为恢复而保留的已保存更改。此操作无法撤销。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "這會永久刪除所有查詢記錄項目，以及為還原而保留的已儲存變更。此操作無法還原。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "This will permanently delete all query history entries. This action cannot be undone." : {
       "extractionState" : "stale",
@@ -141614,7 +162069,38 @@
       }
     },
     "Toggle Fold" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "접기 전환",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Katlamayı Aç/Kapat",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bật/tắt thu gọn",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "切换折叠",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "切換摺疊",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Toggle History" : {
       "localizations" : {
@@ -142042,25 +162528,25 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Çalışma Alanı Şeridini Aç/Kapat"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Bật/tắt thanh không gian làm việc"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "切换工作区栏"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "切換工作區列"
           }
         }
@@ -142517,10 +163003,72 @@
       }
     },
     "Total rows written" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "기록된 총 행 수",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yazılan toplam satır",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tổng số dòng đã ghi",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "写入的总行数",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "寫入的總列數",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Total size" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "전체 크기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Toplam boyut",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tổng kích thước",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "总大小",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "總大小",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Total Size" : {
       "localizations" : {
@@ -142557,7 +163105,38 @@
       }
     },
     "Total size in bytes" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "바이트 단위 전체 크기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bayt cinsinden toplam boyut",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tổng kích thước tính bằng byte",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "以字节计的总大小",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "以位元組計的總大小",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Total Time" : {
       "localizations" : {
@@ -142662,7 +163241,38 @@
       }
     },
     "Tour the tables of a live database and how they relate, built from the current schema" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "현재 스키마를 바탕으로, 실제 데이터베이스의 테이블과 그 관계를 둘러봅니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Geçerli şemadan yola çıkarak canlı bir veritabanının tablolarını ve aralarındaki ilişkileri gezer",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tham quan các bảng của một cơ sở dữ liệu đang chạy và cách chúng liên hệ với nhau, dựng từ schema hiện tại",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "根据当前 Schema，导览一个实际数据库的表以及它们之间的关系",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "根據目前綱要，導覽一個實際資料庫的資料表以及它們之間的關聯",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Tradeoffs" : {
       "localizations" : {
@@ -142699,13 +163309,106 @@
       }
     },
     "transaction %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "트랜잭션 %@",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ işlemi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "transaction %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "事务 %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "交易 %@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Transaction action must be begin, commit, or rollback." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "트랜잭션 동작은 begin, commit 또는 rollback이어야 합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İşlem eylemi begin, commit ya da rollback olmalıdır.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Hành động transaction phải là begin, commit hoặc rollback.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "事务操作必须是 begin、commit 或 rollback。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "交易操作必須是 begin、commit 或 rollback。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Transaction Control" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "트랜잭션 제어",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İşlem Denetimi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Điều khiển transaction",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "事务控制",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "交易控制",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Transfer of %@ failed: %@" : {
       "localizations" : {
@@ -142713,6 +163416,36 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Transfer of %1$@ failed: %2$@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%1$@ 전송 실패: %2$@",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%1$@ aktarımı başarısız oldu: %2$@",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Truyền %1$@ thất bại: %2$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "%1$@ 传输失败：%2$@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "%1$@ 傳輸失敗：%2$@",
+            "state" : "translated"
           }
         }
       }
@@ -142786,10 +163519,72 @@
       }
     },
     "Trigger body" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "트리거 본문",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tetikleyici gövdesi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thân trigger",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "触发器主体",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "觸發器主體",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Trigger name" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "트리거 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tetikleyici adı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên trigger",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "触发器名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "觸發器名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Trigger operation failed" : {
       "localizations" : {
@@ -142826,7 +163621,38 @@
       }
     },
     "Trigger: %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "트리거: %@",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tetikleyici: %@",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Trigger: %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "触发器：%@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "觸發器：%@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Triggers" : {
       "localizations" : {
@@ -142863,7 +163689,38 @@
       }
     },
     "Triggers, sorted by table then name" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "테이블순, 그다음 이름순으로 정렬된 트리거",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Önce tabloya sonra ada göre sıralanmış tetikleyiciler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các trigger, sắp xếp theo bảng rồi tới tên",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "先按表再按名称排序的触发器",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "先按資料表再按名稱排序的觸發器",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "true" : {
       "localizations" : {
@@ -143654,10 +164511,72 @@
       }
     },
     "Turn a described schema change into migration statements plus the rollback, for this engine" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "설명된 스키마 변경을 이 엔진에 맞는 마이그레이션 명령문과 롤백으로 바꿉니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Anlatılan bir şema değişikliğini, bu motor için geçiş ifadelerine ve geri alma adımına dönüştürür",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Biến một thay đổi schema được mô tả thành các câu lệnh migration kèm bước rollback, cho engine này",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "把描述出来的 Schema 变更转换为针对该引擎的迁移语句以及回滚语句",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "把描述出來的綱要變更轉換為針對該引擎的遷移陳述式以及回復陳述式",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Turn a question into SQL" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "질문을 SQL로 바꾸기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir soruyu SQL'e dönüştür",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Biến một câu hỏi thành SQL",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "把问题转成 SQL",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "把問題轉成 SQL",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Turn loaded query results into native bar, line, area, and scatter charts." : {
       "localizations" : {
@@ -143694,7 +164613,38 @@
       }
     },
     "Turn one table's structure into a runnable checklist of data quality queries" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "한 테이블의 구조를 실행 가능한 데이터 품질 쿼리 체크리스트로 바꿉니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir tablonun yapısını, çalıştırılabilir bir veri kalitesi sorguları kontrol listesine dönüştürür",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Biến cấu trúc của một bảng thành một danh sách truy vấn kiểm tra chất lượng dữ liệu có thể chạy được",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "把一张表的结构转成一份可运行的数据质量查询清单",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "把一張資料表的結構轉成一份可執行的資料品質查詢清單",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Two-Factor Authentication" : {
       "localizations" : {
@@ -144209,10 +165159,72 @@
       }
     },
     "Unfold" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "펼치기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Aç",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Mở rộng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "展开",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "展開",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Unfold All" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "모두 펼치기",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tümünü Aç",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Mở rộng tất cả",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "全部展开",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "全部展開",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Unified" : {
       "localizations" : {
@@ -144488,7 +165500,38 @@
       }
     },
     "Unix epoch seconds" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "Unix epoch 초",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Unix epoch saniyesi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giây Unix epoch",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "Unix 纪元秒",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "Unix 紀元秒",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Unix Timestamp (milliseconds)" : {
       "localizations" : {
@@ -144627,10 +165670,72 @@
       }
     },
     "Unknown client" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "알 수 없는 클라이언트",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bilinmeyen istemci",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Client không xác định",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "未知客户端",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "未知用戶端",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Unknown column(s): %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "알 수 없는 열: %@",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bilinmeyen sütun(lar): %@",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cột không xác định: %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "未知的列：%@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "未知的欄位：%@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Unknown deep link host: %@" : {
       "localizations" : {
@@ -144701,10 +165806,72 @@
       }
     },
     "Unknown explain variant '%@'." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "알 수 없는 EXPLAIN 변형 '%@'입니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bilinmeyen açıklama varyantı '%@'.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Biến thể EXPLAIN không xác định '%@'.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "未知的 EXPLAIN 变体 '%@'。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "未知的 EXPLAIN 變體 '%@'。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Unknown panel(s): %@" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "알 수 없는 패널: %@",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bilinmeyen panel(ler): %@",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bảng không xác định: %@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "未知的面板：%@",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "未知的面板：%@",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Unknown SSH Host" : {
       "localizations" : {
@@ -145256,7 +166423,38 @@
       }
     },
     "Unsupported export format." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "지원되지 않는 내보내기 형식입니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Desteklenmeyen dışa aktarma biçimi.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Định dạng xuất không được hỗ trợ.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "不支持的导出格式。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "不支援的匯出格式。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Unsupported file format: %@" : {
       "localizations" : {
@@ -145912,10 +167110,72 @@
       }
     },
     "Updated %@ row" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@행 업데이트됨",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ satır güncellendi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đã cập nhật %@ dòng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已更新 %@ 行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已更新 %@ 列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Updated %@ rows" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "%@개 행 업데이트됨",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "%@ satır güncellendi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đã cập nhật %@ dòng",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "已更新 %@ 行",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "已更新 %@ 列",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Updated to v%@" : {
       "localizations" : {
@@ -146054,7 +167314,38 @@
       }
     },
     "Upper bound, for BETWEEN" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "BETWEEN의 상한값",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "BETWEEN için üst sınır",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cận trên, dùng cho BETWEEN",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "上界，用于 BETWEEN",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "上界，用於 BETWEEN",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Uptime" : {
       "localizations" : {
@@ -146193,7 +167484,38 @@
       }
     },
     "Use “%@” anyway" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "그래도 “%@” 사용",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Yine de “%@” kullan",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Vẫn dùng “%@”",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "仍然使用“%@”",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "仍然使用“%@”",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Use {{query}} for the current editor query, {{schema}} for the active schema, {{database}} for the active database name, and {{body}} for any text typed after the command." : {
       "localizations" : {
@@ -146744,7 +168066,38 @@
       }
     },
     "Use the addresses the cluster advertises" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "클러스터가 알리는 주소 사용",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kümenin duyurduğu adresleri kullan",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Dùng các địa chỉ mà cụm quảng bá",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "使用集群通告的地址",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "使用叢集通告的位址",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Use the instance's private IP address instead of its public IP." : {
       "localizations" : {
@@ -146985,7 +168338,38 @@
       }
     },
     "User or role name" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "사용자 또는 역할 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kullanıcı veya rol adı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên người dùng hoặc vai trò",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "用户或角色名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "使用者或角色名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "User Sessions" : {
       "localizations" : {
@@ -147022,7 +168406,38 @@
       }
     },
     "User that ran it" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "실행한 사용자",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Çalıştıran kullanıcı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Người dùng đã chạy nó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "运行它的用户",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "執行它的使用者",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "User-installed" : {
       "localizations" : {
@@ -147195,7 +168610,38 @@
       }
     },
     "Users and roles, sorted by name" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이름순으로 정렬된 사용자 및 역할",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Ada göre sıralanmış kullanıcılar ve roller",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Người dùng và vai trò, sắp xếp theo tên",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "按名称排序的用户和角色",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "按名稱排序的使用者和角色",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Uses this Mac's Application Default Credentials. Run `gcloud auth application-default login` first, or set GOOGLE_APPLICATION_CREDENTIALS." : {
       "localizations" : {
@@ -147718,10 +169164,72 @@
       }
     },
     "Value as supplied" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "입력한 그대로의 값",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Verildiği haliyle değer",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giá trị đúng như được cung cấp",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "按提供时的原样值",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "按提供時的原樣值",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Value escaped for this engine" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 엔진에 맞게 이스케이프된 값",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu motor için kaçışlanmış değer",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giá trị đã escape theo engine này",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "按该引擎规则转义后的值",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "按該引擎規則跳脫後的值",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Value excluded from query" : {
       "extractionState" : "stale",
@@ -147895,7 +169403,38 @@
       }
     },
     "Value the operator compares against" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "연산자가 비교 대상으로 삼는 값",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Operatörün karşılaştırdığı değer",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giá trị mà toán tử so sánh với",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "运算符所比较的值",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "運算子所比較的值",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Value Too Large" : {
       "localizations" : {
@@ -148000,10 +169539,72 @@
       }
     },
     "Values the context accepts" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "컨텍스트가 허용하는 값",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bağlamın kabul ettiği değerler",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Các giá trị mà context chấp nhận",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该上下文接受的值",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該情境接受的值",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Variant id" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "변형 id",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Varyant kimliği",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Id biến thể",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "变体 id",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "變體 id",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "VERBOSE (print progress)" : {
       "localizations" : {
@@ -148664,7 +170265,38 @@
       }
     },
     "View body" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "뷰 본문",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Görünüm gövdesi",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thân view",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "视图主体",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "檢視表主體",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "View ER Diagram" : {
       "localizations" : {
@@ -148769,7 +170401,38 @@
       }
     },
     "View name" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "뷰 이름",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Görünüm adı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tên view",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "视图名称",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "檢視表名稱",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "View on GitHub" : {
       "extractionState" : "stale",
@@ -148841,7 +170504,38 @@
       }
     },
     "View that was read" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "읽은 뷰",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Okunan görünüm",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "View đã được đọc",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "被读取的视图",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "被讀取的檢視表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "View: %@" : {
       "extractionState" : "stale",
@@ -149330,10 +171024,72 @@
       }
     },
     "What a function returns, absent for a procedure" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "함수가 반환하는 값이며 프로시저에는 없습니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir fonksiyonun döndürdüğü şey, yordamlarda bulunmaz",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thứ mà một hàm trả về, không có với procedure",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "函数的返回值，存储过程没有这一项",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "函式的回傳值，預存程序沒有這一項",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "what arrived is not a database file" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "도착한 것은 데이터베이스 파일이 아닙니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "ulaşan şey bir veritabanı dosyası değil",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "thứ nhận được không phải tệp cơ sở dữ liệu",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "收到的不是数据库文件",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "收到的不是資料庫檔案",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "What is switched on here is ignored when two structures are compared. These drift between environments by design." : {
       "localizations" : {
@@ -149370,7 +171126,38 @@
       }
     },
     "What matched" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "일치한 대상",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Neyin eşleştiği",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thứ đã khớp",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "匹配到的内容",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "符合的內容",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "What ran against %@" : {
       "localizations" : {
@@ -149407,7 +171194,38 @@
       }
     },
     "What ran it" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "실행한 주체",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Onu neyin çalıştırdığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thứ đã chạy nó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "运行它的是什么",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "執行它的是什麼",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "What to Compare" : {
       "localizations" : {
@@ -149478,10 +171296,72 @@
       }
     },
     "What to do with the transaction" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "트랜잭션에 대해 수행할 동작",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İşlemle ne yapılacağı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Việc cần làm với transaction",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "对该事务要做什么",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "對該交易要做什麼",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "What to drop" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "삭제할 대상",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Neyin silineceği",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thứ cần xoá",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "要删除什么",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "要刪除什麼",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "What will run against %@" : {
       "localizations" : {
@@ -149760,82 +171640,888 @@
       }
     },
     "Whether a session is open" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "세션이 열려 있는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir oturumun açık olup olmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Có phiên nào đang mở hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "是否有会话打开",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "是否有工作階段開啟",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether it can be killed" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "종료할 수 있는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sonlandırılıp sonlandırılamayacağı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Có thể kết thúc nó hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "是否可以被终止",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "是否可以被終止",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether it can log in" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "로그인할 수 있는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Oturum açıp açamayacağı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Có đăng nhập được hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "是否可以登录",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "是否可以登入",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether it is set" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "설정되어 있는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Ayarlanmış olup olmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đã được đặt hay chưa",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "是否已设置",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "是否已設定",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether it succeeded" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "성공했는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Başarılı olup olmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Có thành công hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "是否成功",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "是否成功",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether its query can be cancelled" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "쿼리를 취소할 수 있는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sorgusunun iptal edilip edilemeyeceği",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Truy vấn của nó có huỷ được hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "它的查询是否可以取消",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "它的查詢是否可以取消",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether row counts were fetched" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "행 수를 가져왔는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Satır sayılarının alınıp alınmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Có lấy số dòng hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "是否获取了行数",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "是否取得了列數",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether the column accepts NULL" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "열이 NULL을 허용하는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sütunun NULL kabul edip etmediği",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cột có chấp nhận NULL hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该列是否接受 NULL",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該欄位是否接受 NULL",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether the column is generated" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "열이 생성된 열인지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sütunun üretilmiş olup olmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cột có phải cột sinh ra hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该列是否为生成列",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該欄位是否為產生欄位",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether the column is part of the primary key" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "열이 기본 키의 일부인지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sütunun birincil anahtarın parçası olup olmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cột có thuộc khoá chính hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该列是否属于主键",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該欄位是否屬於主鍵",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether the count is an estimate" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "행 수가 추정치인지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sayının bir tahmin olup olmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Con số đó có phải ước lượng hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该计数是否为估算值",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該計數是否為估算值",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether the engine owns this database" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "엔진이 이 데이터베이스를 소유하는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu veritabanının motora ait olup olmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Engine có sở hữu cơ sở dữ liệu này hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该数据库是否归引擎所有",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該資料庫是否歸引擎所有",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether the index backs the primary key" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "인덱스가 기본 키를 뒷받침하는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İndeksin birincil anahtarı destekleyip desteklemediği",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chỉ mục có phục vụ khoá chính hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该索引是否支撑主键",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該索引是否支撐主鍵",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether the index enforces uniqueness" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "인덱스가 고유성을 강제하는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "İndeksin benzersizliği zorunlu kılıp kılmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Chỉ mục có ràng buộc tính duy nhất hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该索引是否强制唯一性",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該索引是否強制唯一性",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether the limit clipped the matches" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "제한 때문에 일치 항목이 잘렸는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sınırın eşleşmeleri kırpıp kırpmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giới hạn có cắt bớt kết quả khớp hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该限制是否截断了匹配项",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該限制是否截斷了符合項目",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether the object is a view" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "객체가 뷰인지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Nesnenin bir görünüm olup olmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đối tượng có phải view hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该对象是否为视图",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該物件是否為檢視表",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether the row limit clipped any export" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "행 제한 때문에 내보내기가 잘렸는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Satır sınırının herhangi bir dışa aktarmayı kırpıp kırpmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giới hạn dòng có cắt bớt bản xuất nào hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "行数上限是否截断了任何一次导出",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列數上限是否截斷了任何一次匯出",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether the row limit clipped the result" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "행 제한 때문에 결과가 잘렸는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Satır sınırının sonucu kırpıp kırpmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giới hạn dòng có cắt bớt kết quả hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "行数上限是否截断了结果",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "列數上限是否截斷了結果",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether the session is open" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "세션이 열려 있는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Oturumun açık olup olmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Phiên có đang mở hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该会话是否已打开",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該工作階段是否已開啟",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether the tab is selected in its window" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "탭이 해당 창에서 선택되어 있는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Sekmenin kendi penceresinde seçili olup olmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Tab có đang được chọn trong cửa sổ của nó hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该标签页在其窗口中是否被选中",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該標籤頁在其視窗中是否被選取",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether the trigger is enabled" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "트리거가 활성화되어 있는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Tetikleyicinin etkin olup olmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Trigger có đang bật hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "该触发器是否启用",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "該觸發器是否啟用",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether this engine can create databases" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 엔진이 데이터베이스를 만들 수 있는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu motorun veritabanı oluşturup oluşturamayacağı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Engine này có tạo được cơ sở dữ liệu hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此引擎是否能创建数据库",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此引擎是否能建立資料庫",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether this engine has maintenance at all" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 엔진에 유지 관리 기능이 있는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu motorda bakım olup olmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Engine này có chức năng bảo trì hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此引擎是否有维护功能",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此引擎是否有維護功能",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether this engine has session contexts" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 엔진에 세션 컨텍스트가 있는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu motorda oturum bağlamları olup olmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Engine này có context phiên hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此引擎是否有会话上下文",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此引擎是否有工作階段情境",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether this export was clipped" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "이 내보내기가 잘렸는지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bu dışa aktarmanın kırpılıp kırpılmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Bản xuất này có bị cắt bớt hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "此次导出是否被截断",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "此次匯出是否被截斷",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whether this is a role" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "역할인지 여부",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bunun bir rol olup olmadığı",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Đây có phải một vai trò hay không",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "这是否是一个角色",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "這是否是一個角色",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Whitespace in text" : {
       "localizations" : {
@@ -149872,7 +172558,38 @@
       }
     },
     "Who the explanation is for: newcomer, analyst, or engineer" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "설명 대상입니다: 입문자, 분석가 또는 엔지니어",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Açıklamanın kime yönelik olduğu: yeni başlayan, analist veya mühendis",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Giải thích dành cho ai: người mới, nhà phân tích hoặc kỹ sư",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "这份讲解面向谁：新手、分析师或工程师",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "這份講解面向誰：新手、分析師或工程師",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Wide-Column" : {
       "localizations" : {
@@ -150081,7 +172798,38 @@
       }
     },
     "Will restore" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "복원 예정",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Geri yüklenecek",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Sẽ khôi phục",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "将被恢复",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "將被還原",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Will run" : {
       "localizations" : {
@@ -150186,13 +172934,106 @@
       }
     },
     "Window id, as reported by list_recent_tabs" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "list_recent_tabs가 보고하는 창 id",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "list_recent_tabs'in bildirdiği şekliyle pencere kimliği",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Window id, đúng như list_recent_tabs báo cáo",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "窗口 id，按 list_recent_tabs 报告的样子",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "視窗 id，按 list_recent_tabs 回報的樣子",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Window id, stable across tools" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "도구 간에 일관된 창 id",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Araçlar arasında değişmeyen pencere kimliği",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Window id, ổn định giữa các công cụ",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "窗口 id，在各工具之间保持稳定",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "視窗 id，在各工具之間保持穩定",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Window that came forward" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "앞으로 나온 창",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Öne gelen pencere",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Cửa sổ đã được đưa lên trước",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "被带到最前的窗口",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "被帶到最前的視窗",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Windows Authentication needs the server's hostname, not an IP address. Kerberos service principals aren't registered against IP addresses." : {
       "localizations" : {
@@ -150229,7 +173070,38 @@
       }
     },
     "WITH GRANT OPTION" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "WITH GRANT OPTION",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "WITH GRANT OPTION",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "WITH GRANT OPTION",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "WITH GRANT OPTION",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "WITH GRANT OPTION",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "With Headers" : {
       "localizations" : {
@@ -150335,10 +173207,72 @@
       }
     },
     "Write a migration and its rollback" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "마이그레이션과 롤백 작성",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir geçiş ve geri alma adımı yaz",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Viết một migration và bước rollback của nó",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "写一份迁移及其回滚",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "寫一份遷移及其回復",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Write a query that answers a question, using the real columns of the named tables" : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "지정한 테이블의 실제 열을 사용해 질문에 답하는 쿼리를 작성합니다",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Adı verilen tabloların gerçek sütunlarını kullanarak bir soruyu yanıtlayan bir sorgu yazar",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Viết một truy vấn trả lời câu hỏi, dùng đúng các cột thật của những bảng được nêu tên",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "使用所指定表的真实列，写出一个回答该问题的查询",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "使用所指定資料表的真實欄位，寫出一個回答該問題的查詢",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Write Concern" : {
       "extractionState" : "stale",
@@ -150410,7 +173344,38 @@
       }
     },
     "Writing to a database needs the tools:write scope." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "데이터베이스에 쓰려면 tools:write 범위가 필요합니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Bir veritabanına yazmak tools:write kapsamını gerektirir.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Ghi vào cơ sở dữ liệu cần scope tools:write.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "向数据库写入需要 tools:write 作用域。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "向資料庫寫入需要 tools:write 範圍。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "X Axis" : {
       "localizations" : {
@@ -150961,7 +173926,38 @@
       }
     },
     "Your changes will be lost if you don't save them. Tabs whose changes can only be saved from the tab itself stay open." : {
-
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "value" : "저장하지 않으면 변경 사항이 사라집니다. 탭 안에서만 저장할 수 있는 변경 사항이 있는 탭은 열린 채로 남습니다.",
+            "state" : "translated"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "value" : "Kaydetmezseniz değişiklikleriniz kaybolur. Değişiklikleri yalnızca kendi sekmesinden kaydedilebilen sekmeler açık kalır.",
+            "state" : "translated"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "value" : "Thay đổi của bạn sẽ mất nếu không lưu. Những tab mà thay đổi chỉ có thể lưu từ chính tab đó sẽ vẫn mở.",
+            "state" : "translated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "value" : "如果不保存，你的更改将会丢失。那些只能在标签页内部保存更改的标签页会保持打开。",
+            "state" : "translated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "value" : "如果不儲存，你的變更將會遺失。那些只能在標籤頁內部儲存變更的標籤頁會保持開啟。",
+            "state" : "translated"
+          }
+        }
+      }
     },
     "Your connections file was changed outside TablePro, so this connection's password source was not run. Open the connection and save it again to confirm the change." : {
       "comment" : "Error message when the app is not trusted to access the keychain.",

--- a/TableProTests/Core/Coordinators/RowEditingCoordinatorJsonModeTests.swift
+++ b/TableProTests/Core/Coordinators/RowEditingCoordinatorJsonModeTests.swift
@@ -39,7 +39,8 @@ struct RowEditingCoordinatorJsonModeTests {
                     [.text("3"), .text("Bob")]
                 ],
                 columns: ["id", "name"],
-                columnTypes: [.text(rawType: nil), .text(rawType: nil)]
+                columnTypes: [.text(rawType: nil), .text(rawType: nil)],
+                hasAuthoritativeSchema: true
             ),
             for: tab.id
         )


### PR DESCRIPTION
`main` has been red since #2590, and the string catalogs were 85% translated. This fixes both.

## The red build

`RowEditingCoordinator in JSON mode` / "duplicating in Data mode still selects the new row" has failed on every push to `main` since 33467260408 (#2590, "refuse edits to server-owned columns at the model boundary").

That commit added a `hasAuthoritativeSchema` guard to `duplicateSelectedRow`: a duplicated row is an insert, so it cannot be staged before the schema's account of which columns the server owns exists, or it writes NULL into an identity column. The guard is correct. What was stale is the test fixture, which builds its rows with `TableRows.from(queryRows:columns:columnTypes:)` and takes that parameter's `false` default, so `duplicateSelectedRow` returned before duplicating anything and the selection stayed where the test had put it. The fixture now declares the authoritative schema the path requires.

Nothing in the source changed. The two neighbouring cases in that suite passed only because delete has no such guard, and because JSON mode asserts the selection does *not* move.

## The missing translations

`scripts/localization.py status` reported 4318/5062 for all five languages. The gap was 742 keys with no localization at all, almost all of them MCP tool and parameter descriptions plus the Data Rewind, remote-file and licence surfaces, which reached users in English whatever their language.

- 742 keys × ko, tr, vi, zh-Hans, zh-Hant: 3,710 new units. Coverage is now 5060/5062, the two remainders being the `shouldTranslate: false` format-only strings.
- 44 `needs_review` units (11 workspace-rail keys × 4 languages) read correctly and are promoted to `translated`.
- `InfoPlist.xcstrings`: the seven document kinds Finder shows (`SQLite Database`, `DuckDB Database`, `SQL File`, `Beancount Ledger`, `TablePro Connection`, `TablePro Filter Row`, `TablePro Plugin`) are translated. `CFBundleName` and `CFBundleDisplayName` are marked `shouldTranslate: false`, because the app's name is the same in every language and leaving them listed as untranslated hides that.

Terminology follows what the catalogs already ship: `스키마` / `Şema` / `schema` / `Schema` / `綱要`, row as `행` / `satır` / `dòng` / `行` / `列`, column as `열` / `sütun` / `cột` / `列` / `欄位`.

The merge went through `scripts/localization.py import`, so the diff is additive: `verify` still round-trips both catalogs byte for byte, and a comparison against `HEAD` confirms 0 pre-existing units changed and 3,710 added.

## Tests

`StringCatalogIntegrityTests` is the guard that matters here, and it passes: every translation consumes the arguments its source passes, keeps its `${token}`s, keeps a trailing ellipsis and a terminal sentence mark, carries no `^[...](inflect:)` markup, and introduces no em dash. I ported its six rules to Python and ran them over the batch before merging, so the catalog was never in a failing state.

```
test StringCatalogIntegrityTests StringCatalogRuleTests FormatSpecifierTests RowEditingCoordinatorJsonModeTests
  PASS, 28 executed, 28 passed, 0 failed
test EllipsisConventionTests ResultChartLocalizationTests CompareCountedStringTests
  PASS, 11 executed, 11 passed, 0 failed
```

No UI automation: neither change has a user flow to drive. `TableProUITests` does not run on this machine (the runner times out enabling automation mode before any case starts); CI runs the suites.

## Not done

The iOS catalogs are already complete for the four languages they ship (ko, vi, zh-Hans, zh-Hant) and gain nothing here. Adding Turkish to iOS would be a new language for that app rather than filling a gap, so it is left alone.

https://claude.ai/code/session_01Gy6Q4tzwG3bL9h15SMqep1
