### PR TITLE
feat(tabs): close a tab by middle-clicking it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Middle-click on a tab to close it. (#2595)
 
+### Fixed
+
+- Clicks and hovers in the scrolled tab strip's edge padding landing on a tab clipped off the edge.
+
 ## [0.70.0] - 2026-09-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Middle-click on a tab to close it. (#2595)
+
 ## [0.70.0] - 2026-09-01
 
 ### Added

--- a/TablePro/Core/Services/Infrastructure/WorkspaceRailViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/WorkspaceRailViewController.swift
@@ -30,7 +30,7 @@ internal final class WorkspaceRailTableView: NSTableView {
     internal var onMiddleClick: ((Int) -> Void)?
 
     override internal func otherMouseUp(with event: NSEvent) {
-        guard event.buttonNumber == 2 else {
+        guard event.isMiddleButton else {
             super.otherMouseUp(with: event)
             return
         }

--- a/TablePro/Extensions/NSEvent+MouseButton.swift
+++ b/TablePro/Extensions/NSEvent+MouseButton.swift
@@ -1,0 +1,15 @@
+//
+//  NSEvent+MouseButton.swift
+//  TablePro
+//
+
+import AppKit
+
+internal extension NSEvent {
+    /// The wheel button, which AppKit numbers 2 and reports through the `otherMouse` family rather
+    /// than routing an action for. Everything above it is a side button on a five-button mouse and
+    /// belongs to whatever else claims it.
+    var isMiddleButton: Bool {
+        buttonNumber == 2
+    }
+}

--- a/TablePro/Views/Main/EditorTabInteractionView.swift
+++ b/TablePro/Views/Main/EditorTabInteractionView.swift
@@ -35,6 +35,9 @@ internal final class EditorTabInteractionView: NSView {
     private var hoverTrackingArea: NSTrackingArea?
     private var lastActivatedTabId: UUID?
 
+    /// The tab a middle-click was pressed on, held until the button comes up.
+    private var middleClickTabId: UUID?
+
     internal init(interaction: EditorTabStripInteraction) {
         self.interaction = interaction
         super.init(frame: .zero)
@@ -210,6 +213,48 @@ internal final class EditorTabInteractionView: NSView {
               let commands = interaction.commands
         else { return nil }
         return EditorTabContextMenuBuilder.menu(for: id, commands: commands)
+    }
+
+    // MARK: - Middle click
+
+    /// Middle-click closes the tab under the pointer, the gesture every browser and Xcode answer
+    /// and the one the connections strip already answers here. AppKit routes no action for the
+    /// wheel button, so the tab is resolved from the click point the way `menu(for:)` resolves one.
+    ///
+    /// The press is remembered and the close committed on release, which is the contract every
+    /// AppKit button keeps and the one `trackCloseButton` already keeps for the tab's own close
+    /// button: releasing anywhere else lets a user change their mind. What decides is the release's
+    /// location, never the view under it, because AppKit sends the release to whichever view took
+    /// the press however far the pointer has travelled since. Measured on a titlebar accessory,
+    /// which is where this strip lives.
+    override internal func otherMouseDown(with event: NSEvent) {
+        guard event.isMiddleButton else {
+            super.otherMouseDown(with: event)
+            return
+        }
+        beginMiddleClick(atViewPoint: convert(event.locationInWindow, from: nil))
+    }
+
+    override internal func otherMouseUp(with event: NSEvent) {
+        guard event.isMiddleButton, middleClickTabId != nil else {
+            super.otherMouseUp(with: event)
+            return
+        }
+        endMiddleClick(atViewPoint: convert(event.locationInWindow, from: nil))
+    }
+
+    internal func beginMiddleClick(atViewPoint point: CGPoint) {
+        middleClickTabId = tabIndex(atViewPoint: point).flatMap { tabId(at: $0) }
+    }
+
+    /// Closes only when the release still lands on the tab the press did. A tab that closed under
+    /// the pointer meanwhile leaves a different id in its slot, so the gesture finds nothing and
+    /// takes the tab that replaced it nowhere.
+    internal func endMiddleClick(atViewPoint point: CGPoint) {
+        guard let pressedId = middleClickTabId else { return }
+        middleClickTabId = nil
+        guard let index = tabIndex(atViewPoint: point), tabId(at: index) == pressedId else { return }
+        interaction.commands?.close(pressedId)
     }
 
     // MARK: - Tracking

--- a/TablePro/Views/Main/EditorTabInteractionView.swift
+++ b/TablePro/Views/Main/EditorTabInteractionView.swift
@@ -34,8 +34,6 @@ internal final class EditorTabInteractionView: NSView {
     private var isResolvingAccessibilityHit = false
     private var hoverTrackingArea: NSTrackingArea?
     private var lastActivatedTabId: UUID?
-
-    /// The tab a middle-click was pressed on, held until the button comes up.
     private var middleClickTabId: UUID?
 
     internal init(interaction: EditorTabStripInteraction) {
@@ -142,8 +140,14 @@ internal final class EditorTabInteractionView: NSView {
         return super.accessibilityHitTest(point)
     }
 
+    /// A point outside the viewport names no tab, however a scrolled run would translate it. The
+    /// content offset moves the run under a fixed viewport, so without this the track's own two
+    /// points of padding, and any point the pointer reaches past the track, resolve to whichever
+    /// tab the offset happens to put there: a tab clipped off the leading edge, or one hidden
+    /// behind the new-tab button.
     private func tabIndex(atViewPoint point: CGPoint) -> Int? {
-        EditorTabRunLayoutBuilder.index(at: contentPoint(fromViewPoint: point), in: interaction.run)
+        guard viewportRect.contains(point) else { return nil }
+        return EditorTabRunLayoutBuilder.index(at: contentPoint(fromViewPoint: point), in: interaction.run)
     }
 
     private func tabId(at index: Int) -> UUID? {

--- a/TableProTests/Views/Main/EditorTabMiddleClickTests.swift
+++ b/TableProTests/Views/Main/EditorTabMiddleClickTests.swift
@@ -1,0 +1,212 @@
+//
+//  EditorTabMiddleClickTests.swift
+//  TableProTests
+//
+
+import AppKit
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import TablePro
+
+/// Middle-clicking a tab closes it, resolved against the same run layout the pointer already
+/// hit-tests every other gesture with.
+///
+/// The gesture is driven through the view's own view-point entry points rather than through
+/// synthesized events, because `NSEvent.mouseEvent(with:…)` cannot carry a button number:
+/// measured, it reports 0 for `.otherMouseDown` and `.otherMouseUp` whatever else it is given, and
+/// the only factory that reports 2 is `NSEvent(cgEvent:)`, whose location is a screen point. The
+/// button half of the contract is covered on its own below.
+@MainActor
+@Suite("Editor tab middle click")
+struct EditorTabMiddleClickTests {
+    /// Chosen so the track measures the 604pt the strip's other tests use: the view gives up
+    /// `stripInset` at the leading edge and the new-tab button plus its spacing at the trailing.
+    private static let viewWidth: CGFloat = 652
+    private static let tabCount = 3
+
+    private final class Recorder {
+        var closed: [UUID] = []
+    }
+
+    private func makeView(recorder: Recorder = Recorder()) -> (EditorTabInteractionView, [UUID], Recorder) {
+        let ids = (0 ..< Self.tabCount).map { _ in UUID() }
+        let interaction = EditorTabStripInteraction()
+        interaction.commands = EditorTabCommands(
+            activate: { _ in },
+            keepOpen: { _ in },
+            canKeepOpen: { _ in false },
+            close: { recorder.closed.append($0) },
+            closeOthers: { _ in },
+            closeAll: {},
+            moveTab: { _, _ in },
+            canMove: { _, _ in true },
+            moveBy: { _, _ in },
+            tearOff: { _ in },
+            canTearOff: { _ in false },
+            tooltip: { _ in "" }
+        )
+        interaction.dropClosedTabs(keeping: ids)
+
+        let view = EditorTabInteractionView(interaction: interaction)
+        view.frame = CGRect(x: 0, y: 0, width: Self.viewWidth, height: EditorTabStripLayout.bandHeight)
+        view.rebuildRun()
+        return (view, ids, recorder)
+    }
+
+    /// The centre of a tab, in the view's own flipped coordinates, built from the run the view
+    /// just measured so the test and the code agree by construction rather than by arithmetic.
+    private func centre(ofTabAt index: Int, in view: EditorTabInteractionView) throws -> CGPoint {
+        let placement = try #require(view.interaction.run.placement(at: index))
+        return CGPoint(
+            x: placement.frame.midX + EditorTabStripLayout.stripInset + EditorTabStripLayout.trackPadding,
+            y: placement.frame.midY + EditorTabStripLayout.trackPadding
+        )
+    }
+
+    @Test("A middle-click on a tab closes it")
+    func middleClickClosesTheTab() throws {
+        let (view, ids, recorder) = makeView()
+        let point = try centre(ofTabAt: 1, in: view)
+
+        view.beginMiddleClick(atViewPoint: point)
+        view.endMiddleClick(atViewPoint: point)
+
+        #expect(recorder.closed == [ids[1]])
+    }
+
+    /// The tab's own close button is drawn inside the tab, so a middle-click over it is still a
+    /// middle-click on that tab and must not take the left button's path.
+    @Test("A middle-click over the close button closes the same tab")
+    func middleClickOverTheCloseButtonClosesTheTab() throws {
+        let (view, ids, recorder) = makeView()
+        let placement = try #require(view.interaction.run.placement(at: 2))
+        let button = EditorTabRunLayoutBuilder.closeButtonRect(in: placement.frame)
+        let point = CGPoint(
+            x: button.midX + EditorTabStripLayout.stripInset + EditorTabStripLayout.trackPadding,
+            y: button.midY + EditorTabStripLayout.trackPadding
+        )
+
+        view.beginMiddleClick(atViewPoint: point)
+        view.endMiddleClick(atViewPoint: point)
+
+        #expect(recorder.closed == [ids[2]])
+    }
+
+    /// The same contract the close button keeps: the release has to land where the press did, so a
+    /// user who changes their mind can slide off and let go.
+    @Test("Releasing on another tab closes nothing")
+    func releasingOnAnotherTabClosesNothing() throws {
+        let (view, _, recorder) = makeView()
+
+        view.beginMiddleClick(atViewPoint: try centre(ofTabAt: 0, in: view))
+        view.endMiddleClick(atViewPoint: try centre(ofTabAt: 2, in: view))
+
+        #expect(recorder.closed.isEmpty)
+    }
+
+    @Test("Releasing off the strip closes nothing")
+    func releasingOffTheStripClosesNothing() throws {
+        let (view, _, recorder) = makeView()
+
+        view.beginMiddleClick(atViewPoint: try centre(ofTabAt: 0, in: view))
+        view.endMiddleClick(atViewPoint: CGPoint(x: Self.viewWidth - 4, y: 200))
+
+        #expect(recorder.closed.isEmpty)
+    }
+
+    @Test("A press that missed every tab closes nothing")
+    func pressOffATabClosesNothing() throws {
+        let (view, _, recorder) = makeView()
+
+        view.beginMiddleClick(atViewPoint: CGPoint(x: 2, y: 2))
+        view.endMiddleClick(atViewPoint: try centre(ofTabAt: 1, in: view))
+
+        #expect(recorder.closed.isEmpty)
+    }
+
+    /// The press is spent on release. Without that the strip would keep closing the same tab every
+    /// time the button came up, which is what a mouse with a sticky wheel button would produce.
+    @Test("A second release without a second press closes nothing")
+    func secondReleaseClosesNothing() throws {
+        let (view, ids, recorder) = makeView()
+        let point = try centre(ofTabAt: 1, in: view)
+
+        view.beginMiddleClick(atViewPoint: point)
+        view.endMiddleClick(atViewPoint: point)
+        view.endMiddleClick(atViewPoint: point)
+
+        #expect(recorder.closed == [ids[1]])
+    }
+
+    /// A tab that went while the button was held leaves a different id in its slot, so the gesture
+    /// finds nothing rather than closing whichever tab slid under the pointer.
+    @Test("A tab closed under the pointer takes nothing with it")
+    func tabClosedUnderThePointerTakesNothingWithIt() throws {
+        let (view, ids, recorder) = makeView()
+        let point = try centre(ofTabAt: 2, in: view)
+
+        view.beginMiddleClick(atViewPoint: point)
+        view.interaction.dropClosedTabs(keeping: [ids[0], ids[1]])
+        view.rebuildRun()
+        view.endMiddleClick(atViewPoint: point)
+
+        #expect(recorder.closed.isEmpty)
+    }
+
+    /// The override reads the button before anything else, so the side buttons of a five-button
+    /// mouse pass straight through to whoever else wants them.
+    @Test("A release from another button closes nothing")
+    func releaseFromAnotherButtonClosesNothing() throws {
+        let (view, _, recorder) = makeView()
+        let point = try centre(ofTabAt: 1, in: view)
+        let event = try #require(
+            NSEvent.mouseEvent(
+                with: .otherMouseUp,
+                location: point,
+                modifierFlags: [],
+                timestamp: 0,
+                windowNumber: 0,
+                context: nil,
+                eventNumber: 0,
+                clickCount: 1,
+                pressure: 0
+            )
+        )
+
+        view.beginMiddleClick(atViewPoint: point)
+        view.otherMouseUp(with: event)
+
+        #expect(event.isMiddleButton == false)
+        #expect(recorder.closed.isEmpty)
+    }
+}
+
+/// `buttonNumber` is the only thing that tells the wheel button from the side buttons, and
+/// `NSEvent(cgEvent:)` is the one factory that can carry it into a test.
+@Suite("Middle mouse button")
+struct NSEventMouseButtonTests {
+    private func event(_ button: CGMouseButton) throws -> NSEvent {
+        let cgEvent = try #require(
+            CGEvent(
+                mouseEventSource: nil,
+                mouseType: .otherMouseDown,
+                mouseCursorPosition: .zero,
+                mouseButton: button
+            )
+        )
+        return try #require(NSEvent(cgEvent: cgEvent))
+    }
+
+    @Test("The wheel button is the middle button")
+    func centreButtonIsTheMiddleButton() throws {
+        #expect(try event(.center).isMiddleButton)
+    }
+
+    @Test("Neither of the two main buttons is the middle button")
+    func mainButtonsAreNotTheMiddleButton() throws {
+        #expect(try event(.left).isMiddleButton == false)
+        #expect(try event(.right).isMiddleButton == false)
+    }
+}

--- a/TableProTests/Views/Main/EditorTabMiddleClickTests.swift
+++ b/TableProTests/Views/Main/EditorTabMiddleClickTests.swift
@@ -30,8 +30,11 @@ struct EditorTabMiddleClickTests {
         var closed: [UUID] = []
     }
 
-    private func makeView(recorder: Recorder = Recorder()) -> (EditorTabInteractionView, [UUID], Recorder) {
-        let ids = (0 ..< Self.tabCount).map { _ in UUID() }
+    private func makeView(
+        tabCount: Int = Self.tabCount,
+        recorder: Recorder = Recorder()
+    ) -> (EditorTabInteractionView, [UUID], Recorder) {
+        let ids = (0 ..< tabCount).map { _ in UUID() }
         let interaction = EditorTabStripInteraction()
         interaction.commands = EditorTabCommands(
             activate: { _ in },
@@ -55,14 +58,22 @@ struct EditorTabMiddleClickTests {
         return (view, ids, recorder)
     }
 
-    /// The centre of a tab, in the view's own flipped coordinates, built from the run the view
-    /// just measured so the test and the code agree by construction rather than by arithmetic.
+    /// The view point that lands on a given point of the run's content space, which is where the
+    /// placements live. The two differ by the track's insets and by however far the run has
+    /// scrolled, so a test that hardcodes the insets alone is only right at offset zero.
+    private func viewPoint(ofContent point: CGPoint, in view: EditorTabInteractionView) -> CGPoint {
+        CGPoint(
+            x: point.x - view.interaction.contentOffset
+                + EditorTabStripLayout.stripInset + EditorTabStripLayout.trackPadding,
+            y: point.y + EditorTabStripLayout.trackPadding
+        )
+    }
+
+    /// The centre of a tab, in the view's own flipped coordinates, built from the run the view just
+    /// measured so the test and the code agree by construction rather than by arithmetic.
     private func centre(ofTabAt index: Int, in view: EditorTabInteractionView) throws -> CGPoint {
         let placement = try #require(view.interaction.run.placement(at: index))
-        return CGPoint(
-            x: placement.frame.midX + EditorTabStripLayout.stripInset + EditorTabStripLayout.trackPadding,
-            y: placement.frame.midY + EditorTabStripLayout.trackPadding
-        )
+        return viewPoint(ofContent: CGPoint(x: placement.frame.midX, y: placement.frame.midY), in: view)
     }
 
     @Test("A middle-click on a tab closes it")
@@ -155,6 +166,40 @@ struct EditorTabMiddleClickTests {
         #expect(recorder.closed.isEmpty)
     }
 
+    /// The run scrolls under a fixed viewport, so a point outside the viewport still translates
+    /// into content coordinates, and those land on whichever tab the offset happens to have put
+    /// there. The track's own two points of padding are the nearest such point: pressing them on a
+    /// scrolled strip resolved to a tab clipped off the leading edge and closed it.
+    @Test("A press in the track padding of a scrolled strip closes nothing")
+    func pressInTheTrackPaddingClosesNothing() throws {
+        let (view, _, recorder) = makeView(tabCount: 12)
+        view.interaction.scroll(by: 10_000)
+        #expect(view.interaction.contentOffset > 0)
+        let padding = CGPoint(x: EditorTabStripLayout.stripInset + 1, y: EditorTabStripLayout.trackPadding + 12)
+
+        view.beginMiddleClick(atViewPoint: padding)
+        view.endMiddleClick(atViewPoint: padding)
+
+        #expect(recorder.closed.isEmpty)
+    }
+
+    /// AppKit hands the release to whichever view took the press however far the pointer has
+    /// travelled, so the release arrives here with a location this view does not own. A tab
+    /// straddling the leading edge is the case where the press and the release resolve to the same
+    /// tab across that boundary, which is the one a same-tab check alone cannot catch.
+    @Test("A release in the track padding of a scrolled strip closes nothing")
+    func releaseInTheTrackPaddingClosesNothing() throws {
+        let (view, _, recorder) = makeView(tabCount: 12)
+        view.interaction.scroll(by: 150)
+        let press = try centre(ofTabAt: 1, in: view)
+        let padding = CGPoint(x: EditorTabStripLayout.stripInset + 1, y: press.y)
+
+        view.beginMiddleClick(atViewPoint: press)
+        view.endMiddleClick(atViewPoint: padding)
+
+        #expect(recorder.closed.isEmpty)
+    }
+
     /// The override reads the button before anything else, so the side buttons of a five-button
     /// mouse pass straight through to whoever else wants them.
     @Test("A release from another button closes nothing")
@@ -187,7 +232,7 @@ struct EditorTabMiddleClickTests {
 /// `NSEvent(cgEvent:)` is the one factory that can carry it into a test.
 @Suite("Middle mouse button")
 struct NSEventMouseButtonTests {
-    private func event(_ button: CGMouseButton) throws -> NSEvent {
+    private func press(_ button: CGMouseButton) throws -> NSEvent {
         let cgEvent = try #require(
             CGEvent(
                 mouseEventSource: nil,
@@ -201,12 +246,15 @@ struct NSEventMouseButtonTests {
 
     @Test("The wheel button is the middle button")
     func centreButtonIsTheMiddleButton() throws {
-        #expect(try event(.center).isMiddleButton)
+        let event = try press(.center)
+        #expect(event.isMiddleButton)
     }
 
     @Test("Neither of the two main buttons is the middle button")
     func mainButtonsAreNotTheMiddleButton() throws {
-        #expect(try event(.left).isMiddleButton == false)
-        #expect(try event(.right).isMiddleButton == false)
+        let left = try press(.left)
+        let right = try press(.right)
+        #expect(left.isMiddleButton == false)
+        #expect(right.isMiddleButton == false)
     }
 }

--- a/docs/features/tabs.mdx
+++ b/docs/features/tabs.mdx
@@ -52,7 +52,7 @@ A preview tab turns permanent as soon as you sort it, filter it, or edit data, a
 
 | Action | How |
 |--------|-----|
-| Close one tab | `Cmd+W`, the tab's close button, or **Close Tab** on its contextual menu |
+| Close one tab | `Cmd+W`, the tab's close button, a middle-click anywhere on the tab, or **Close Tab** on its contextual menu |
 | Close the rest | **File > Close Other Tabs**, also on the tab's contextual menu |
 | Close every tab for this connection | **File > Close All Tabs**, also on the tab's contextual menu |
 | Close tabs bound to another database | **File > Close Tabs for Other Databases** |


### PR DESCRIPTION
Middle-clicking an editor tab closes it, the gesture every browser and Xcode answer and the one the connections strip has answered since #2115.

Fixes #2595

## Root cause

`EditorTabInteractionView` is the single owner of pointer input over the tab strip, and it implemented the primary button only. AppKit routes no action for the wheel button, so `otherMouseDown` and `otherMouseUp` fell through `NSResponder`'s default to the next responder and nothing closed. The app was inconsistent with itself as well: `WorkspaceRailTableView.otherMouseUp` already closes the row under the pointer in the connections strip.

## The fix

The press is remembered on `otherMouseDown` and the close committed on `otherMouseUp`, only when the release still lands on the tab the press did. That is the contract every AppKit button keeps, and the one `trackCloseButton` in the same file already keeps for the tab's own close button: sliding off and letting go abandons the gesture. The tab is resolved from the click point against `EditorTabRunLayout`, the same geometry every other gesture on the strip hit-tests against, so a middle-click over the tab's own close button closes that tab like any other point on it.

Closing goes through `EditorTabCommands.close`, the same path as `Cmd+W` and the close button, so the unsaved-work prompt is unchanged.

`NSEvent.isMiddleButton` replaces the bare `buttonNumber == 2` in the connections strip too, which was the only other place that number meant this.

## A pre-existing bug this surfaced

`tabIndex(atViewPoint:)` translated any point into the run's content space without checking it was inside the visible viewport. The content offset moves the run under a fixed viewport, so on a scrolled strip a point outside the viewport resolves to whichever tab the offset happens to have put there. At maximum scroll on a twelve-tab strip, a click in the track's own two points of edge padding maps to content x 839, which is tab 6, clipped entirely off the leading edge.

That predates this branch and reaches hover, the contextual menu and left-click activation, not just the new gesture, so the guard went into `tabIndex` itself rather than into the middle-click path. The reorder is unaffected: it resolves through `linearLocation` and deliberately keeps unrestricted content coordinates so a tab can be dragged past the viewport.

Found by the Codex review pass on this branch. Its two regression tests fail without the guard and only those two, verified by removing the guard and re-running.

## Measured, not assumed

Three standalone `swiftc` harnesses, because the fix rests on how AppKit routes an event nothing in the app had ever received:

1. **A titlebar accessory does receive the wheel button.** The strip lives in one, and AppKit's window drag is a claimant on every press that lands there. A view with `EditorTabInteractionView`'s shape, mounted in an `NSTitlebarAccessoryViewController`, gets `otherMouseDown` and `otherMouseUp` with `buttonNumber == 2` and correct flipped local coordinates.
2. **The release goes to the view that took the press, not to the view under the pointer.** Press on view A, release over view B: both reached A. So the release's *location* has to decide, which is what the fix does, and reading its hit view would have been wrong.
3. **`NSEvent.mouseEvent(with:…)` cannot carry a button number.** It reports 0 for `.otherMouseDown` and `.otherMouseUp` whatever else it is given. `NSEvent(cgEvent:)` with `.center` reports 2. That is why the gesture is tested through the view's own view-point entry points and the button predicate is tested separately.

## Tests

`EditorTabMiddleClickTests`, ten cases: a middle-click closes the tab, a middle-click over the close button closes the same tab, releasing on another tab closes nothing, releasing off the strip closes nothing, a press that missed every tab closes nothing, a second release without a second press closes nothing, a tab closed under the pointer takes nothing with it, a release from another button closes nothing, and the two scrolled-strip cases above.

`NSEventMouseButtonTests` pins `isMiddleButton` against `NSEvent(cgEvent:)` for the wheel button and both main buttons.

**No UI automation.** XCUITest has no tertiary-button API: `XCUIElement` offers `click()` and `rightClick()` and nothing for the wheel. The only way to drive it from a test bundle is `CGEvent.post(tap: .cghidEventTap)`, which moves the real pointer and depends on a TCC grant the CI runner may not give, so it would fail there rather than guard anything. The gesture is covered by the unit suite above instead.

**No screenshots.** Nothing on screen changes: this adds a pointer gesture to an existing control and draws nothing new.

## Verified

- `verify.sh build`, PASS
- `verify.sh test` over `EditorTabMiddleClickTests`, `NSEventMouseButtonTests`, `EditorTabStripInteractionTests`, `EditorTabActivationTests`, `EditorTabRunLayoutTests`, `EditorTabStripGestureConventionTests`, `EditorTabLabelResolverTests`, `EditorTabStripLayoutTests`: 64 executed, 64 passed
- `swiftlint --strict` over the four changed Swift files, 0 violations
- `docs/scripts/check-writing-style.sh` and `docs/scripts/check-docs-against-source.py`, both pass
- Codex review (fixed, see above) and Codex adversarial review on the approach, which returned Ship
