### PR TITLE
fix(csv): keep document opening on the main actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A failed whole-schema trigger read counting as a schema with no triggers.
 - Compare & Sync publishing one pair's results after the pickers moved to another.
 - Clicks and hovers in the scrolled tab strip's edge padding landing on a tab clipped off the edge.
+- Crash when opening CSV and TSV files on macOS 27.
 
 ## [0.70.0] - 2026-09-01
 

--- a/Plugins/CSVInspectorPlugin/CSVDocument.swift
+++ b/Plugins/CSVInspectorPlugin/CSVDocument.swift
@@ -20,8 +20,6 @@ public final class CSVDocument: NSDocument, CSVConfigurableDocument {
 
     override public class var autosavesInPlace: Bool { false }
 
-    override public class func canConcurrentlyReadDocuments(ofType typeName: String) -> Bool { true }
-
     override public class var readableTypes: [String] {
         ["public.comma-separated-values-text", "public.tab-separated-values-text"]
     }

--- a/TableProTests/Plugins/CSVDocumentConcurrencyTests.swift
+++ b/TableProTests/Plugins/CSVDocumentConcurrencyTests.swift
@@ -1,0 +1,17 @@
+import AppKit
+import Testing
+
+@MainActor
+@Suite("CSVDocument opening concurrency")
+struct CSVDocumentConcurrencyTests {
+    @Test(
+        "Documents stay on the main actor while opening",
+        arguments: [
+            "public.comma-separated-values-text",
+            "public.tab-separated-values-text"
+        ]
+    )
+    func documentOpeningIsNotConcurrent(typeName: String) {
+        #expect(!CSVDocument.canConcurrentlyReadDocuments(ofType: typeName))
+    }
+}


### PR DESCRIPTION
## What changed

- Keep CSV and TSV document opening on AppKit's main actor by inheriting `NSDocument`'s default serial-read behavior.
- Add a regression test covering both advertised CSV and TSV document types.
- Record the macOS 27 crash fix in the changelog.

## Why

Opening a CSV or TSV on macOS 27 can terminate TablePro with `EXC_BREAKPOINT` / `SIGTRAP`, with `_dispatch_assert_queue_fail` and `_swift_task_checkIsolatedSwift` reached from the `NSDocumentController` opening queue. Under Swift 6, `NSDocument` is main-actor isolated, but `CSVDocument` opted into concurrent reads, allowing AppKit to open it on a background queue. Removing that override restores the framework default and keeps document construction and reading on the actor AppKit requires. This matches the underlying AppKit concurrency issue tracked in [Apple Feedback #38](https://github.com/1024jp/AppleFeedback/issues/38).

## Usage

No usage change.

## Verification

- `git diff --check origin/main..HEAD`: pass.
- Roborev reviewed the final commit; the correctness fix and regression coverage were accepted.
- Xcode build, test execution, and manual macOS 27 verification were not run because this work was completed on Linux. CI or a macOS checkout still needs to open a sanitized CSV and TSV before merge.

Serial document opening can make existing up-front row indexing visible on the main actor for very large files. Moving that indexing behind an async boundary is separate work; this PR restores actor correctness without widening scope.
