### PR TITLE
feat(datagrid): read binary columns holding UTF-8 as text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Whole-schema index and table metadata reads on the driver protocol.
 - Script that checks the SQLite whole-schema reads against the per-table ones.
 - Middle-click on a tab to close it. (#2595)
+- Text in Display As for binary columns. (#2599)
+- Smart value detection for binary columns holding UTF-8 text. (#2599)
+- Find covering binary columns that a display format renders as text. (#2599)
 - Launch trace in Instruments' Points of Interest, and `TABLEPRO_LAUNCH_TRACE=1` for the same table on standard error.
 
 ### Changed

--- a/TablePro/Core/Coordinators/FindMatcher.swift
+++ b/TablePro/Core/Coordinators/FindMatcher.swift
@@ -6,9 +6,13 @@
 import Foundation
 
 enum FindMatcher {
-    static func isSearchable(_ columnType: ColumnType?) -> Bool {
+    /// A binary column is searchable once a display format has turned its bytes into characters.
+    /// Left as hex it is not, which is why the exclusion was unconditional while hex was the only
+    /// thing a binary column could show.
+    static func isSearchable(_ columnType: ColumnType?, displayFormat: ValueDisplayFormat? = nil) -> Bool {
         switch columnType {
-        case .blob, .spatial: false
+        case .blob: displayFormat?.rendersBinaryAsText == true
+        case .spatial: false
         default: true
         }
     }

--- a/TablePro/Core/Services/Formatting/BinaryTextDecoder.swift
+++ b/TablePro/Core/Services/Formatting/BinaryTextDecoder.swift
@@ -1,0 +1,94 @@
+//
+//  BinaryTextDecoder.swift
+//  TablePro
+//
+//  Reads binary cell bytes as text, and says no when they are not text.
+//
+
+import Foundation
+
+internal enum BinaryTextDecoder {
+    /// A UTF-8 scalar is at most four bytes, so this always covers the grid's 10,000 character cap
+    /// and a LONGBLOB never builds a multi-gigabyte String on the main thread.
+    static let maxDisplayBytes = 40_000
+
+    /// Detection only has to recognise text, not render it, and it runs over ten sample rows of
+    /// every binary column in the result before the grid draws.
+    static let maxProbeBytes = 512
+
+    static let truncationMarker = "…"
+
+    /// The decoded text, or nil when the bytes are not text and belong in the hex fallback.
+    ///
+    /// A value cut at `maxBytes` may end mid-sequence, so the tail is allowed to give up three
+    /// bytes, and the result carries `truncationMarker` so a caller writing it to the clipboard
+    /// cannot pass off a prefix as the whole value. A whole value gives up nothing: dropping bytes
+    /// there would accept binary that happens to start with readable characters.
+    static func decode(
+        _ data: Data,
+        columnType: ColumnType? = nil,
+        maxBytes: Int = maxDisplayBytes
+    ) -> String? {
+        guard data.count > maxBytes else {
+            return decodeWhole(trimmingPadding(data, columnType: columnType))
+        }
+        guard let text = decodeTruncated(data.prefix(maxBytes)) else { return nil }
+        return text + truncationMarker
+    }
+
+    /// The same answer for a driver that hands binary content over as a string, where each
+    /// character stands for one stored byte.
+    static func decode(
+        isoLatin1 value: String,
+        columnType: ColumnType? = nil,
+        maxBytes: Int = maxDisplayBytes
+    ) -> String? {
+        guard let data = value.data(using: .isoLatin1) else { return nil }
+        return decode(data, columnType: columnType, maxBytes: maxBytes)
+    }
+
+    /// `BINARY(N)` right-pads with `0x00`, and trimming that run is what lets a fixed-width column
+    /// holding text read as text at all. No other binary type pads, so a trailing NUL in a `BLOB`
+    /// or a `VARBINARY` is stored data: trimming it there would report `0x6100` as `a`.
+    static func padsToFixedWidth(_ columnType: ColumnType?) -> Bool {
+        guard let columnType, columnType.isBlobType, let raw = columnType.rawType?.uppercased() else { return false }
+        return raw.prefix { $0 != "(" }.trimmingCharacters(in: .whitespaces) == "BINARY"
+    }
+
+    private static func trimmingPadding(_ data: Data, columnType: ColumnType?) -> Data {
+        guard padsToFixedWidth(columnType) else { return data }
+        guard let lastContent = data.lastIndex(where: { $0 != 0 }) else { return Data() }
+        return data.prefix(through: lastContent)
+    }
+
+    private static func decodeWhole(_ data: Data) -> String? {
+        guard !data.isEmpty else { return "" }
+        guard let text = String(data: data, encoding: .utf8), isReadable(text) else { return nil }
+        return text
+    }
+
+    private static func decodeTruncated(_ data: Data) -> String? {
+        for dropped in 0...3 where data.count > dropped {
+            let candidate = data.dropLast(dropped)
+            guard let text = String(data: candidate, encoding: .utf8) else { continue }
+            return isReadable(text) ? text : nil
+        }
+        return nil
+    }
+
+    /// C0 controls, DEL and a lone NUL are what separates a stored string from a hash, an image
+    /// header or a packed integer that happens to decode.
+    private static func isReadable(_ text: String) -> Bool {
+        for scalar in text.unicodeScalars {
+            switch scalar.value {
+            case 0x09, 0x0A, 0x0D:
+                continue
+            case 0x00...0x1F, 0x7F:
+                return false
+            default:
+                continue
+            }
+        }
+        return true
+    }
+}

--- a/TablePro/Core/Services/Formatting/CellDisplayFormatter.swift
+++ b/TablePro/Core/Services/Formatting/CellDisplayFormatter.swift
@@ -25,16 +25,17 @@ enum CellDisplayFormatter {
         case .bytes(let data):
             if let displayFormat,
                displayFormat.isApplicable(to: columnType, databaseType: databaseType),
-               let formatted = ValueDisplayFormatService.applyFormat(data, format: displayFormat) {
-                return formatted
+               let formatted = ValueDisplayFormatService.applyFormat(data, format: displayFormat, columnType: columnType) {
+                return fitToCell(formatted)
             }
             return BlobFormattingService.shared.format(data, for: .grid)
         case .text(let value):
             guard !value.isEmpty else { return value }
             var displayValue = value
             if let displayFormat, displayFormat != .raw,
-               displayFormat.isApplicable(to: columnType, databaseType: databaseType) {
-                displayValue = ValueDisplayFormatService.applyFormat(value, format: displayFormat)
+               displayFormat.isApplicable(to: columnType, databaseType: databaseType),
+               let formatted = ValueDisplayFormatService.applyFormat(value, format: displayFormat, columnType: columnType) {
+                displayValue = formatted
             } else if let columnType {
                 if columnType.isDateType {
                     if let formatted = DateFormattingService.shared.format(
@@ -49,11 +50,19 @@ enum CellDisplayFormatter {
                     )
                 }
             }
-            let nsDisplay = displayValue as NSString
-            if nsDisplay.length > maxDisplayLength {
-                displayValue = nsDisplay.substring(to: maxDisplayLength) + "…"
-            }
-            return displayValue.sanitizedForCellDisplay
+            return fitToCell(displayValue)
         }
+    }
+
+    /// A row is one line, so anything a format produces is capped and stripped of line breaks
+    /// before it reaches a cell. Binary read as text is the case that needs it: a blob carries
+    /// newlines and runs to megabytes where hex never did.
+    private static func fitToCell(_ value: String) -> String {
+        var displayValue = value
+        let nsDisplay = displayValue as NSString
+        if nsDisplay.length > maxDisplayLength {
+            displayValue = nsDisplay.substring(to: maxDisplayLength) + "…"
+        }
+        return displayValue.sanitizedForCellDisplay
     }
 }

--- a/TablePro/Core/Services/Formatting/ValueDisplayDetector.swift
+++ b/TablePro/Core/Services/Formatting/ValueDisplayDetector.swift
@@ -26,6 +26,12 @@ enum ValueDisplayDetector {
 
             if let format = detectUuid(columnType: columnType, columnName: columnName) {
                 results[i] = format
+            } else if let format = detectBinaryText(
+                columnType: columnType,
+                columnIndex: i,
+                sampleValues: sampleValues
+            ) {
+                results[i] = format
             } else if let format = detectTimestamp(columnType: columnType, columnName: columnName, sampleValue: sampleValue) {
                 results[i] = format
             }
@@ -61,6 +67,49 @@ enum ValueDisplayDetector {
         }
 
         return nil
+    }
+
+    // MARK: - Binary Text Detection
+
+    /// A binary column whose every sampled value reads as text is a column holding text, so it
+    /// renders as text instead of as hex nobody can read.
+    ///
+    /// Every sample has to agree, and at least one has to carry content: one readable value among
+    /// hashes is a coincidence, and a column of empty values says nothing either way. A cell that
+    /// disagrees later still falls back to hex on its own, per value.
+    ///
+    /// A `.text` sample opts the column out entirely. That is a driver that already decoded the
+    /// binary itself, MongoDB's legacy UUIDs among them, and second-guessing it would undo the
+    /// per-connection byte order it was decoded under.
+    private static func detectBinaryText(
+        columnType: ColumnType?,
+        columnIndex: Int,
+        sampleValues: [[PluginCellValue]]?
+    ) -> ValueDisplayFormat? {
+        guard let columnType, columnType.isBlobType else { return nil }
+        guard let sampleValues, !sampleValues.isEmpty else { return nil }
+
+        var sawContent = false
+        for row in sampleValues {
+            guard columnIndex < row.count else { continue }
+            switch row[columnIndex] {
+            case .null:
+                continue
+            case .text:
+                return nil
+            case .bytes(let data):
+                guard let text = BinaryTextDecoder.decode(
+                    data,
+                    columnType: columnType,
+                    maxBytes: BinaryTextDecoder.maxProbeBytes
+                ) else {
+                    return nil
+                }
+                sawContent = sawContent || !text.isEmpty
+            }
+        }
+
+        return sawContent ? .text : nil
     }
 
     // MARK: - Timestamp Detection

--- a/TablePro/Core/Services/Formatting/ValueDisplayFormat.swift
+++ b/TablePro/Core/Services/Formatting/ValueDisplayFormat.swift
@@ -11,6 +11,7 @@ import Foundation
 
 enum ValueDisplayFormat: String, Codable, CaseIterable, Identifiable {
     case raw
+    case text
     case uuid
     case unixTimestamp
     case unixTimestampMillis
@@ -22,6 +23,7 @@ enum ValueDisplayFormat: String, Codable, CaseIterable, Identifiable {
     var displayName: String {
         switch self {
         case .raw: return String(localized: "Raw Value")
+        case .text: return String(localized: "Text")
         case .uuid: return String(localized: "UUID")
         case .unixTimestamp: return String(localized: "Unix Timestamp (seconds)")
         case .unixTimestampMillis: return String(localized: "Unix Timestamp (milliseconds)")
@@ -35,6 +37,8 @@ enum ValueDisplayFormat: String, Codable, CaseIterable, Identifiable {
         switch self {
         case .raw:
             return []
+        case .text:
+            return ["blob"]
         case .uuid:
             return ["blob", "text"]
         case .unixTimestamp, .unixTimestampMillis:
@@ -60,6 +64,17 @@ enum ValueDisplayFormat: String, Codable, CaseIterable, Identifiable {
             return false
         }
         return applicableColumnTypes.contains(typeKey)
+    }
+
+    /// Whether this format turns stored bytes into readable characters. A binary column is worth
+    /// searching exactly when one of these is on it; hex is not what anyone types into Find.
+    var rendersBinaryAsText: Bool {
+        switch self {
+        case .text, .uuid:
+            return true
+        case .raw, .unixTimestamp, .unixTimestampMillis, .json, .phpSerialized:
+            return false
+        }
     }
 
     /// Returns applicable formats for a given column type.

--- a/TablePro/Core/Services/Formatting/ValueDisplayFormatService.swift
+++ b/TablePro/Core/Services/Formatting/ValueDisplayFormatService.swift
@@ -26,10 +26,18 @@ final class ValueDisplayFormatService {
 
     // MARK: - Format Application
 
-    static func applyFormat(_ rawValue: String, format: ValueDisplayFormat) -> String {
+    /// nil where the format cannot render this value, so the caller falls back to how the column
+    /// would have read without it rather than showing a value the format did not actually produce.
+    static func applyFormat(
+        _ rawValue: String,
+        format: ValueDisplayFormat,
+        columnType: ColumnType? = nil
+    ) -> String? {
         switch format {
         case .raw:
             return rawValue
+        case .text:
+            return BinaryTextDecoder.decode(isoLatin1: rawValue, columnType: columnType)
         case .uuid:
             return formatAsUuid(rawValue)
         case .unixTimestamp:
@@ -41,9 +49,20 @@ final class ValueDisplayFormatService {
         }
     }
 
-    static func applyFormat(_ rawValue: Data, format: ValueDisplayFormat) -> String? {
-        guard format == .uuid, rawValue.count == 16 else { return nil }
-        return formatAsUuid(rawValue.hexEncoded)
+    static func applyFormat(
+        _ rawValue: Data,
+        format: ValueDisplayFormat,
+        columnType: ColumnType? = nil
+    ) -> String? {
+        switch format {
+        case .text:
+            return BinaryTextDecoder.decode(rawValue, columnType: columnType)
+        case .uuid:
+            guard rawValue.count == 16 else { return nil }
+            return formatAsUuid(rawValue.hexEncoded)
+        case .raw, .unixTimestamp, .unixTimestampMillis, .json, .phpSerialized:
+            return nil
+        }
     }
 
     // MARK: - Effective Format Resolution

--- a/TablePro/Views/Main/Extensions/MainContentView+Bindings.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Bindings.swift
@@ -77,12 +77,12 @@ extension MainContentView {
                 case .text(let s):
                     value = format == .raw
                         ? s
-                        : ValueDisplayFormatService.applyFormat(s, format: format)
+                        : ValueDisplayFormatService.applyFormat(s, format: format, columnType: columnType) ?? s
                 case .bytes(let bytes):
                     value = format.isApplicable(
                         to: columnType,
                         databaseType: coordinator.connection.type
-                    ) ? ValueDisplayFormatService.applyFormat(bytes, format: format) : nil
+                    ) ? ValueDisplayFormatService.applyFormat(bytes, format: format, columnType: columnType) : nil
                     value = value ?? BlobFormattingService.shared.format(bytes, for: .copy)
                 }
             }

--- a/TablePro/Views/Results/CellInteractionResolver.swift
+++ b/TablePro/Views/Results/CellInteractionResolver.swift
@@ -62,7 +62,7 @@ internal struct CellInteractionResolver {
             return isReadOnly ? .viewJson : .editJson
         case .phpSerialized:
             return .viewPhpSerialized
-        case .raw, .uuid, .unixTimestamp, .unixTimestampMillis, .none:
+        case .raw, .text, .uuid, .unixTimestamp, .unixTimestampMillis, .none:
             return plainText(for: context, isReadOnly: isReadOnly)
         }
     }

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -1127,7 +1127,10 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
             isColumnSearchable: { column in
                 guard visible?.contains(column) ?? true else { return false }
                 guard column < columnTypes.count else { return true }
-                return FindMatcher.isSearchable(columnTypes[column])
+                return FindMatcher.isSearchable(
+                    columnTypes[column],
+                    displayFormat: column < columnDisplayFormats.count ? columnDisplayFormats[column] : nil
+                )
             },
             cellText: { [weak self] displayIndex, column in
                 guard let self,
@@ -1135,15 +1138,32 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
                       column < row.values.count
                 else { return nil }
                 let rawValue = row.values[column]
-                guard rawValue.asText != nil else { return nil }
+                let columnType = column < columnTypes.count ? columnTypes[column] : nil
+                guard findSearches(rawValue, column: column, columnType: columnType) else { return nil }
                 return displayValue(
                     forID: row.id,
                     column: column,
                     rawValue: rawValue,
-                    columnType: column < columnTypes.count ? columnTypes[column] : nil
+                    columnType: columnType
                 )
             }
         )
+    }
+
+    /// A binary cell is searched only where its column's format actually turned those bytes into
+    /// characters. The format is chosen per column and the fallback to hex happens per value, so a
+    /// column of readable text can still hold one cell whose hex Find must not match.
+    private func findSearches(_ value: PluginCellValue, column: Int, columnType: ColumnType?) -> Bool {
+        switch value {
+        case .null:
+            return false
+        case .text:
+            return true
+        case .bytes(let data):
+            guard let format = column < columnDisplayFormats.count ? columnDisplayFormats[column] : nil,
+                  format.isApplicable(to: columnType, databaseType: databaseType) else { return false }
+            return ValueDisplayFormatService.applyFormat(data, format: format, columnType: columnType) != nil
+        }
     }
 
     func applyFindMatch(_ match: FindMatch?) {

--- a/TablePro/Views/Results/DataGridView+RowActions.swift
+++ b/TablePro/Views/Results/DataGridView+RowActions.swift
@@ -103,7 +103,7 @@ extension TableViewCoordinator {
             let format = columnIndex < columnDisplayFormats.count ? columnDisplayFormats[columnIndex] : nil
             let value = format.flatMap { format in
                 guard format.isApplicable(to: columnType, databaseType: databaseType) else { return nil }
-                return ValueDisplayFormatService.applyFormat(data, format: format)
+                return ValueDisplayFormatService.applyFormat(data, format: format, columnType: columnType)
             }
                 ?? BlobFormattingService.shared.format(data, for: .copy)
                 ?? ""
@@ -113,8 +113,8 @@ extension TableViewCoordinator {
 
         let value = cell.asText ?? "NULL"
 
-        if columnIndex < columnDisplayFormats.count, let format = columnDisplayFormats[columnIndex], format != .raw {
-            let formatted = ValueDisplayFormatService.applyFormat(value, format: format)
+        if columnIndex < columnDisplayFormats.count, let format = columnDisplayFormats[columnIndex], format != .raw,
+           let formatted = ValueDisplayFormatService.applyFormat(value, format: format, columnType: columnType) {
             ClipboardService.shared.writeText(formatted)
             return
         }

--- a/TablePro/Views/Shared/FieldEditors/FieldEditorResolver.swift
+++ b/TablePro/Views/Shared/FieldEditors/FieldEditorResolver.swift
@@ -42,7 +42,7 @@ internal enum FieldEditorResolver {
                 return .phpSerialized
             case .json:
                 return .json
-            case .uuid, .unixTimestamp, .unixTimestampMillis:
+            case .text, .uuid, .unixTimestamp, .unixTimestampMillis:
                 structuredAllowed = true
             }
         } else {

--- a/TableProTests/Core/Coordinators/FindMatcherTests.swift
+++ b/TableProTests/Core/Coordinators/FindMatcherTests.swift
@@ -80,6 +80,17 @@ struct FindMatcherTests {
         #expect(FindMatcher.isSearchable(nil))
     }
 
+    @Test("a binary column showing characters is searchable, one showing hex is not")
+    func searchableBinaryFollowsItsDisplayFormat() {
+        let blob = ColumnType.blob(rawType: "VARBINARY(255)")
+
+        #expect(FindMatcher.isSearchable(blob, displayFormat: .text))
+        #expect(FindMatcher.isSearchable(blob, displayFormat: .uuid))
+        #expect(FindMatcher.isSearchable(blob, displayFormat: .raw) == false)
+        #expect(FindMatcher.isSearchable(blob, displayFormat: nil) == false)
+        #expect(FindMatcher.isSearchable(.spatial(rawType: "GEOMETRY"), displayFormat: .text) == false)
+    }
+
     @Test("the nearest match to a display row is the first at or after it")
     func nearestMatch() {
         let matches = [

--- a/TableProTests/Core/Services/CellDisplayFormatterTests.swift
+++ b/TableProTests/Core/Services/CellDisplayFormatterTests.swift
@@ -53,6 +53,107 @@ struct CellDisplayFormatterTests {
         #expect(result != ValueDisplayFormatService.applyFormat(hex, format: .uuid))
     }
 
+    @Test("binary read as text shows the text")
+    func binaryTextFormatDecodes() {
+        let result = CellDisplayFormatter.format(
+            .bytes(Data("hello world".utf8)),
+            columnType: .blob(rawType: "VARBINARY(255)"),
+            displayFormat: .text
+        )
+
+        #expect(result == "hello world")
+    }
+
+    @Test("binary that is not text falls back to hex under the text format")
+    func binaryTextFormatFallsBackToHex() {
+        let png = Data([0x89, 0x50, 0x4E, 0x47])
+        let result = CellDisplayFormatter.format(
+            .bytes(png),
+            columnType: .blob(rawType: "BLOB"),
+            displayFormat: .text
+        )
+
+        #expect(result == "0x89504E47")
+    }
+
+    @Test("line breaks in binary read as text are flattened onto the row")
+    func binaryTextFormatSanitizesLineBreaks() {
+        let result = CellDisplayFormatter.format(
+            .bytes(Data("line1\nline2".utf8)),
+            columnType: .blob(rawType: "BLOB"),
+            displayFormat: .text
+        )
+
+        #expect(result == "line1 line2")
+    }
+
+    @Test("binary read as text is capped at the cell length")
+    func binaryTextFormatTruncates() throws {
+        let long = Data(String(repeating: "a", count: CellDisplayFormatter.maxDisplayLength + 500).utf8)
+        let result = try #require(CellDisplayFormatter.format(
+            .bytes(long),
+            columnType: .blob(rawType: "LONGBLOB"),
+            displayFormat: .text
+        ))
+
+        #expect((result as NSString).length == CellDisplayFormatter.maxDisplayLength + 1)
+        #expect(result.hasSuffix("…"))
+    }
+
+    @Test("a trailing NUL is padding on BINARY and stored data everywhere else")
+    func binaryTextFormatTrimsOnlyFixedWidthPadding() {
+        let value = PluginCellValue.bytes(Data([0x61, 0x00]))
+
+        let fixedWidth = CellDisplayFormatter.format(
+            value,
+            columnType: .blob(rawType: "BINARY(2)"),
+            displayFormat: .text
+        )
+        let variableWidth = CellDisplayFormatter.format(
+            value,
+            columnType: .blob(rawType: "VARBINARY(255)"),
+            displayFormat: .text
+        )
+
+        #expect(fixedWidth == "a")
+        #expect(variableWidth == "0x6100")
+    }
+
+    @Test("a text column ignores the text format")
+    func textColumnIgnoresTextFormat() {
+        let result = CellDisplayFormatter.format(
+            .text("hello"),
+            columnType: .text(rawType: "VARCHAR(255)"),
+            displayFormat: .text
+        )
+
+        #expect(result == "hello")
+    }
+
+    @Test("a driver's byte-per-character blob string reads as text too")
+    func carrierStringDecodesUnderTextFormat() {
+        let carrier = String(data: Data("café".utf8), encoding: .isoLatin1) ?? ""
+        let result = CellDisplayFormatter.format(
+            .text(carrier),
+            columnType: .blob(rawType: "BLOB"),
+            displayFormat: .text
+        )
+
+        #expect(result == "café")
+    }
+
+    @Test("a driver's byte-per-character blob string of binary keeps its hex")
+    func carrierStringFallsBackToHexUnderTextFormat() {
+        let carrier = String(data: Data([0x89, 0x50, 0x4E, 0x47]), encoding: .isoLatin1) ?? ""
+        let result = CellDisplayFormatter.format(
+            .text(carrier),
+            columnType: .blob(rawType: "BLOB"),
+            displayFormat: .text
+        )
+
+        #expect(result == "0x89504E47")
+    }
+
     @Test("plain text passes through unchanged")
     func plainTextPassthrough() {
         let result = CellDisplayFormatter.format(.text("hello world"), columnType: nil)

--- a/TableProTests/Core/Services/Formatting/BinaryTextDecoderTests.swift
+++ b/TableProTests/Core/Services/Formatting/BinaryTextDecoderTests.swift
@@ -1,0 +1,152 @@
+//
+//  BinaryTextDecoderTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("BinaryTextDecoder")
+struct BinaryTextDecoderTests {
+    @Test("ASCII bytes decode to their text")
+    func asciiDecodes() {
+        #expect(BinaryTextDecoder.decode(Data("hello world".utf8)) == "hello world")
+    }
+
+    @Test("Multi-byte UTF-8 survives")
+    func multiByteDecodes() {
+        #expect(BinaryTextDecoder.decode(Data("café 日本語 🎉".utf8)) == "café 日本語 🎉")
+    }
+
+    @Test("Tabs and line breaks stay readable")
+    func whitespaceIsText() {
+        #expect(BinaryTextDecoder.decode(Data("a\tb\nc\r\nd".utf8)) == "a\tb\nc\r\nd")
+    }
+
+    @Test("Bytes that are not UTF-8 decode to nothing")
+    func invalidUtf8Rejected() {
+        #expect(BinaryTextDecoder.decode(Data([0xFF, 0xFE, 0xFD])) == nil)
+    }
+
+    @Test("A PNG header decodes to nothing")
+    func pngRejected() {
+        let png = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+        #expect(BinaryTextDecoder.decode(png) == nil)
+    }
+
+    @Test("A gzip header decodes to nothing")
+    func gzipRejected() {
+        #expect(BinaryTextDecoder.decode(Data([0x1F, 0x8B, 0x08, 0x00])) == nil)
+    }
+
+    @Test("Sixteen UUID bytes decode to nothing")
+    func uuidBytesRejected() {
+        let uuid = Data([
+            0x55, 0x0E, 0x84, 0x00, 0xE2, 0x9B, 0x41, 0xD4,
+            0xA7, 0x16, 0x44, 0x66, 0x55, 0x44, 0x00, 0x00,
+        ])
+        #expect(BinaryTextDecoder.decode(uuid) == nil)
+    }
+
+    @Test("A packed IPv4 address decodes to nothing")
+    func packedAddressRejected() {
+        #expect(BinaryTextDecoder.decode(Data([0xC0, 0xA8, 0x01, 0x01])) == nil)
+    }
+
+    @Test("DEL is not text")
+    func deleteCharacterRejected() {
+        #expect(BinaryTextDecoder.decode(Data([0x61, 0x7F, 0x62])) == nil)
+    }
+
+    @Test("BINARY padding is trimmed off the end")
+    func trailingPaddingTrimmed() {
+        var padded = Data("hello".utf8)
+        padded.append(Data(repeating: 0, count: 27))
+        #expect(BinaryTextDecoder.decode(padded, columnType: .blob(rawType: "BINARY(32)")) == "hello")
+    }
+
+    @Test("only a fixed-width BINARY column pads, so no other type gives up a trailing NUL")
+    func trailingNulIsDataOutsideFixedWidthBinary() {
+        let value = Data([0x61, 0x00])
+
+        #expect(BinaryTextDecoder.decode(value, columnType: .blob(rawType: "BINARY(2)")) == "a")
+        #expect(BinaryTextDecoder.decode(value, columnType: .blob(rawType: "VARBINARY(255)")) == nil)
+        #expect(BinaryTextDecoder.decode(value, columnType: .blob(rawType: "BLOB")) == nil)
+        #expect(BinaryTextDecoder.decode(value, columnType: .blob(rawType: "bytea")) == nil)
+        #expect(BinaryTextDecoder.decode(value) == nil)
+    }
+
+    @Test("padding is trimmed for BINARY with or without a declared width")
+    func paddingPolicyReadsTheBaseTypeName() {
+        #expect(BinaryTextDecoder.padsToFixedWidth(.blob(rawType: "BINARY")))
+        #expect(BinaryTextDecoder.padsToFixedWidth(.blob(rawType: "BINARY(16)")))
+        #expect(!BinaryTextDecoder.padsToFixedWidth(.blob(rawType: "VARBINARY(16)")))
+        #expect(!BinaryTextDecoder.padsToFixedWidth(.blob(rawType: "LONGBLOB")))
+        #expect(!BinaryTextDecoder.padsToFixedWidth(.text(rawType: "BINARY")))
+        #expect(!BinaryTextDecoder.padsToFixedWidth(nil))
+    }
+
+    @Test("A NUL inside the value is still binary")
+    func embeddedNulRejected() {
+        let embedded = Data([0x68, 0x00, 0x69])
+        #expect(BinaryTextDecoder.decode(embedded) == nil)
+    }
+
+    @Test("An all-padding value reads as empty rather than as binary")
+    func allPaddingIsEmpty() {
+        let allNul = Data(repeating: 0, count: 16)
+        #expect(BinaryTextDecoder.decode(allNul, columnType: .blob(rawType: "BINARY(16)")) == "")
+        #expect(BinaryTextDecoder.decode(allNul, columnType: .blob(rawType: "BLOB")) == nil)
+    }
+
+    @Test("No bytes read as empty")
+    func emptyIsEmpty() {
+        #expect(BinaryTextDecoder.decode(Data()) == "")
+    }
+
+    @Test("A cut that splits a UTF-8 sequence gives back the characters before it")
+    func truncationBacksOffASplitSequence() {
+        let data = Data("héllo".utf8)
+        let mark = BinaryTextDecoder.truncationMarker
+        #expect(BinaryTextDecoder.decode(data, maxBytes: 2) == "h" + mark)
+        #expect(BinaryTextDecoder.decode(data, maxBytes: 4) == "hél" + mark)
+    }
+
+    @Test("A cut value does not have padding trimmed for it")
+    func truncationDoesNotTrimPadding() {
+        let data = Data([0x68, 0x00, 0x00, 0x00])
+        #expect(BinaryTextDecoder.decode(data, columnType: .blob(rawType: "BINARY(4)"), maxBytes: 2) == nil)
+    }
+
+    @Test("A value longer than the cap is marked, so a copy cannot pass a prefix off as the whole")
+    func longValueIsCappedAndMarked() throws {
+        let data = Data(String(repeating: "a", count: BinaryTextDecoder.maxDisplayBytes + 500).utf8)
+        let decoded = try #require(BinaryTextDecoder.decode(data))
+
+        #expect(decoded.hasSuffix(BinaryTextDecoder.truncationMarker))
+        #expect(decoded.count == BinaryTextDecoder.maxDisplayBytes + 1)
+    }
+
+    @Test("A value at the cap is whole, so it carries no marker")
+    func valueAtTheCapIsNotMarked() throws {
+        let data = Data(String(repeating: "a", count: BinaryTextDecoder.maxDisplayBytes).utf8)
+        let decoded = try #require(BinaryTextDecoder.decode(data))
+
+        #expect(decoded.count == BinaryTextDecoder.maxDisplayBytes)
+        #expect(!decoded.hasSuffix(BinaryTextDecoder.truncationMarker))
+    }
+
+    @Test("A driver's byte-per-character string decodes the same way")
+    func isoLatin1StringDecodes() {
+        let carrier = String(data: Data("café".utf8), encoding: .isoLatin1)
+        #expect(BinaryTextDecoder.decode(isoLatin1: carrier ?? "") == "café")
+    }
+
+    @Test("A byte-per-character string of binary decodes to nothing")
+    func isoLatin1BinaryRejected() {
+        let carrier = String(data: Data([0x89, 0x50, 0x4E, 0x47]), encoding: .isoLatin1)
+        #expect(BinaryTextDecoder.decode(isoLatin1: carrier ?? "") == nil)
+    }
+}

--- a/TableProTests/Core/Services/Formatting/ValueDisplayDetectorTests.swift
+++ b/TableProTests/Core/Services/Formatting/ValueDisplayDetectorTests.swift
@@ -1,0 +1,150 @@
+//
+//  ValueDisplayDetectorTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("ValueDisplayDetector")
+@MainActor
+struct ValueDisplayDetectorTests {
+    private func detect(
+        column: String,
+        type: ColumnType,
+        samples: [PluginCellValue]
+    ) -> ValueDisplayFormat? {
+        ValueDisplayDetector.detect(
+            columns: [column],
+            columnTypes: [type],
+            sampleValues: samples.map { [$0] }
+        )[0]
+    }
+
+    @Test("A binary column holding UTF-8 reads as text")
+    func binaryTextDetected() {
+        let format = detect(
+            column: "payload",
+            type: .blob(rawType: "VARBINARY(255)"),
+            samples: [.bytes(Data("hello".utf8)), .bytes(Data("world".utf8))]
+        )
+
+        #expect(format == .text)
+    }
+
+    @Test("A binary column holding hashes stays raw")
+    func binaryHashNotDetected() {
+        let format = detect(
+            column: "digest",
+            type: .blob(rawType: "BINARY(20)"),
+            samples: [.bytes(Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]))]
+        )
+
+        #expect(format == nil)
+    }
+
+    @Test("One binary value among readable ones keeps the whole column raw")
+    func mixedColumnNotDetected() {
+        let format = detect(
+            column: "payload",
+            type: .blob(rawType: "VARBINARY(255)"),
+            samples: [.bytes(Data("hello".utf8)), .bytes(Data([0xFF, 0xFE]))]
+        )
+
+        #expect(format == nil)
+    }
+
+    @Test("A column of nulls says nothing")
+    func nullColumnNotDetected() {
+        let format = detect(column: "payload", type: .blob(rawType: "BLOB"), samples: [.null, .null])
+
+        #expect(format == nil)
+    }
+
+    @Test("A column of empty values says nothing")
+    func emptyColumnNotDetected() {
+        let format = detect(
+            column: "payload",
+            type: .blob(rawType: "BINARY(16)"),
+            samples: [.bytes(Data(repeating: 0, count: 16)), .bytes(Data())]
+        )
+
+        #expect(format == nil)
+    }
+
+    @Test("A driver that decoded the binary itself keeps its own answer")
+    func driverDecodedColumnNotDetected() {
+        let format = detect(
+            column: "payload",
+            type: .blob(rawType: "BinData"),
+            samples: [.text("already decoded")]
+        )
+
+        #expect(format == nil)
+    }
+
+    @Test("Id-like sixteen-byte columns still read as UUID")
+    func uuidStillWinsOnIdColumns() {
+        let format = detect(
+            column: "id",
+            type: .blob(rawType: "BINARY(16)"),
+            samples: [.bytes(Data("0123456789abcdef".utf8))]
+        )
+
+        #expect(format == .uuid)
+    }
+
+    @Test("A sixteen-byte column with no id in its name reads as text when it holds text")
+    func textWinsWhereUuidDeclines() {
+        let format = detect(
+            column: "payload",
+            type: .blob(rawType: "BINARY(16)"),
+            samples: [.bytes(Data("0123456789abcdef".utf8))]
+        )
+
+        #expect(format == .text)
+    }
+
+    @Test("A trailing NUL keeps a variable-width binary column raw, and pads a fixed-width one")
+    func trailingNulFollowsTheColumnWidth() {
+        let value = PluginCellValue.bytes(Data([0x61, 0x00]))
+
+        #expect(detect(column: "payload", type: .blob(rawType: "VARBINARY(255)"), samples: [value]) == nil)
+        #expect(detect(column: "payload", type: .blob(rawType: "BINARY(2)"), samples: [value]) == .text)
+    }
+
+    @Test("Text columns are left alone")
+    func textColumnNotDetected() {
+        let format = detect(
+            column: "note",
+            type: .text(rawType: "VARCHAR(255)"),
+            samples: [.text("hello")]
+        )
+
+        #expect(format == nil)
+    }
+
+    @Test("Timestamp detection still runs on integer columns")
+    func timestampStillDetected() {
+        let format = detect(
+            column: "created_at",
+            type: .integer(rawType: "BIGINT"),
+            samples: [.text("1700000000")]
+        )
+
+        #expect(format == .unixTimestamp)
+    }
+
+    @Test("A column with no sampled rows says nothing")
+    func noSamplesNotDetected() {
+        let results = ValueDisplayDetector.detect(
+            columns: ["payload"],
+            columnTypes: [.blob(rawType: "VARBINARY(255)")],
+            sampleValues: nil
+        )
+
+        #expect(results[0] == nil)
+    }
+}

--- a/TableProTests/Core/Services/Formatting/ValueDisplayFormatTests.swift
+++ b/TableProTests/Core/Services/Formatting/ValueDisplayFormatTests.swift
@@ -13,11 +13,21 @@ struct ValueDisplayFormatTests {
     @Test("rawValue strings stay stable")
     func rawValueStability() {
         #expect(ValueDisplayFormat.raw.rawValue == "raw")
+        #expect(ValueDisplayFormat.text.rawValue == "text")
         #expect(ValueDisplayFormat.uuid.rawValue == "uuid")
         #expect(ValueDisplayFormat.unixTimestamp.rawValue == "unixTimestamp")
         #expect(ValueDisplayFormat.unixTimestampMillis.rawValue == "unixTimestampMillis")
         #expect(ValueDisplayFormat.json.rawValue == "json")
         #expect(ValueDisplayFormat.phpSerialized.rawValue == "phpSerialized")
+    }
+
+    @Test("only the formats that produce characters count as rendering binary as text")
+    func rendersBinaryAsText() {
+        #expect(ValueDisplayFormat.text.rendersBinaryAsText)
+        #expect(ValueDisplayFormat.uuid.rendersBinaryAsText)
+        #expect(!ValueDisplayFormat.raw.rendersBinaryAsText)
+        #expect(!ValueDisplayFormat.unixTimestamp.rendersBinaryAsText)
+        #expect(!ValueDisplayFormat.json.rendersBinaryAsText)
     }
 
     @Test("Codable round-trip preserves value")
@@ -37,6 +47,7 @@ struct ValueDisplayFormatTests {
         #expect(formats.contains(.uuid))
         #expect(formats.contains(.raw))
         #expect(!formats.contains(.unixTimestamp))
+        #expect(!formats.contains(.text))
     }
 
     @Test("integer column applicable formats do not include json or phpSerialized")
@@ -44,15 +55,16 @@ struct ValueDisplayFormatTests {
         let formats = ValueDisplayFormat.applicableFormats(for: .integer(rawType: "INT"))
         #expect(!formats.contains(.json))
         #expect(!formats.contains(.phpSerialized))
+        #expect(!formats.contains(.text))
         #expect(formats.contains(.unixTimestamp))
     }
 
-    @Test("blob column does not include json or phpSerialized")
+    @Test("blob column offers text and uuid but not json or phpSerialized")
     func applicableForBlob() {
         let formats = ValueDisplayFormat.applicableFormats(for: .blob(rawType: "BLOB"))
         #expect(!formats.contains(.json))
         #expect(!formats.contains(.phpSerialized))
-        #expect(formats.contains(.uuid))
+        #expect(formats == [.raw, .text, .uuid])
     }
 
     @Test("MongoDB binary columns do not offer generic UUID formatting")
@@ -62,7 +74,8 @@ struct ValueDisplayFormatTests {
             databaseType: .mongodb
         )
 
-        #expect(formats == [.raw])
+        #expect(!formats.contains(.uuid))
+        #expect(formats == [.raw, .text])
     }
 
     @Test("nil column type returns only raw")

--- a/TableProTests/Views/Results/TableViewCoordinatorFindTests.swift
+++ b/TableProTests/Views/Results/TableViewCoordinatorFindTests.swift
@@ -1,0 +1,74 @@
+//
+//  TableViewCoordinatorFindTests.swift
+//  TableProTests
+//
+
+import AppKit
+import SwiftUI
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+@Suite("TableViewCoordinator find over binary columns")
+@MainActor
+struct TableViewCoordinatorFindTests {
+    /// Row 0 decodes under Text, row 1 does not and falls back to hex `0x89504E47`.
+    private func makeCoordinator(format: ValueDisplayFormat?) -> TableViewCoordinator {
+        let coordinator = TableViewCoordinator(
+            changeManager: AnyChangeManager(DataChangeManager()),
+            isEditable: true,
+            selectedRowIndices: .constant([]),
+            delegate: nil,
+            layoutPersister: FakeFindLayoutPersister()
+        )
+        let rows: ContiguousArray<Row> = [
+            Row(id: .existing(0), values: [.bytes(Data("signup".utf8))]),
+            Row(id: .existing(1), values: [.bytes(Data([0x89, 0x50, 0x4E, 0x47]))]),
+        ]
+        var captured = TableRows(
+            rows: rows,
+            columns: ["payload"],
+            columnTypes: [.blob(rawType: "VARBINARY(255)")]
+        )
+        coordinator.tableRowsProvider = { captured }
+        coordinator.tableRowsMutator = { (mutation: (inout TableRows) -> Void) in mutation(&captured) }
+        coordinator.updateCache()
+        coordinator.updateDisplayFormats([format])
+        return coordinator
+    }
+
+    @Test("a binary column showing text is searched on the text")
+    func binaryTextColumnIsSearched() {
+        let coordinator = makeCoordinator(format: .text)
+
+        let matches = coordinator.runFind(term: "signup")
+
+        #expect(matches.count == 1)
+        #expect(matches.first?.displayRow == 0)
+    }
+
+    @Test("a cell that fell back to hex is not searched on that hex")
+    func hexFallbackCellIsNotSearched() {
+        let coordinator = makeCoordinator(format: .text)
+
+        #expect(coordinator.runFind(term: "8950").isEmpty)
+        #expect(coordinator.runFind(term: "0x89504E47").isEmpty)
+    }
+
+    @Test("a binary column left on raw is not searched at all")
+    func rawBinaryColumnIsNotSearched() {
+        let coordinator = makeCoordinator(format: nil)
+
+        #expect(coordinator.runFind(term: "signup").isEmpty)
+        #expect(coordinator.runFind(term: "8950").isEmpty)
+    }
+}
+
+private final class FakeFindLayoutPersister: ColumnLayoutPersisting {
+    func load(for key: ColumnLayoutTableKey) -> ColumnLayoutState? { nil }
+
+    func save(_ layout: ColumnLayoutState, for key: ColumnLayoutTableKey) {}
+
+    func clear(for key: ColumnLayoutTableKey) {}
+}

--- a/TableProTests/Views/Results/TableViewCoordinatorValueFilterTests.swift
+++ b/TableProTests/Views/Results/TableViewCoordinatorValueFilterTests.swift
@@ -326,11 +326,11 @@ struct TableViewCoordinatorValueFilterTests {
     }
 
     @Test("Display format remapping is independent of row order")
-    func displayFormatRemapHandlesOverlappingOldAndNewValues() {
-        let oldFirst = ValueDisplayFormatService.applyFormat("1000000", format: .unixTimestamp)
-        let oldSecond = ValueDisplayFormatService.applyFormat("1000", format: .unixTimestamp)
-        let newFirst = ValueDisplayFormatService.applyFormat("1000000", format: .unixTimestampMillis)
-        let newSecond = ValueDisplayFormatService.applyFormat("1000", format: .unixTimestampMillis)
+    func displayFormatRemapHandlesOverlappingOldAndNewValues() throws {
+        let oldFirst = try #require(ValueDisplayFormatService.applyFormat("1000000", format: .unixTimestamp))
+        let oldSecond = try #require(ValueDisplayFormatService.applyFormat("1000", format: .unixTimestamp))
+        let newFirst = try #require(ValueDisplayFormatService.applyFormat("1000000", format: .unixTimestampMillis))
+        let newSecond = try #require(ValueDisplayFormatService.applyFormat("1000", format: .unixTimestampMillis))
         #expect(newFirst == oldSecond)
 
         let tableRows = TableRows(

--- a/docs/customization/data-settings.mdx
+++ b/docs/customization/data-settings.mdx
@@ -22,7 +22,7 @@ The tab is app-wide, so these values apply to every connection you open; filters
 | Show alternate row backgrounds | On | |
 | Show row numbers | On | |
 | Auto-show inspector on row select | Off | Opens the row details inspector when you select a row |
-| Smart value detection | On | Renders UUID, Unix timestamp, JSON, and PHP serialized columns in readable form. Override per column with Display As, see [Data Grid](/features/data-grid) |
+| Smart value detection | On | Reads id-like binary columns as UUIDs, timestamp-named integer columns as dates, and binary columns holding UTF-8 as text. Override per column with Display As, see [Cell and Row Viewers](/features/json-viewer) |
 | Default row sort | No sorting (engine order) | Or Primary key, First column. Applied when a table first opens; clicking a column header overrides it |
 
 ## Pagination

--- a/docs/features/data-grid.mdx
+++ b/docs/features/data-grid.mdx
@@ -44,7 +44,7 @@ Drag a border to resize a column, or double-click it to fit the content; **Size 
 
 Hide columns from the columns button in the status bar or from the header menu. A hidden column is not fetched, so hiding a large one makes the table load faster; the primary key and the sorted column are fetched either way. On a schemaless store the popover lists every field the grid can draw, including ones that turn up only in later documents.
 
-Widths, order, and hidden columns are remembered per table, scoped to the connection, database, and schema; **Reset Columns** in the popover puts them back. Right-click a header and choose **Display As** to render a column as a UUID, a Unix timestamp, JSON, or PHP serialized data; see [Cell and Row Viewers](/features/json-viewer).
+Widths, order, and hidden columns are remembered per table, scoped to the connection, database, and schema; **Reset Columns** in the popover puts them back. Right-click a header and choose **Display As** to read a column's stored values in a different form; [Cell and Row Viewers](/features/json-viewer) lists the formats.
 
 ## Foreign keys
 
@@ -70,7 +70,7 @@ Step back with the Back and Forward buttons at the leading edge of the toolbar, 
 
 ## Find in the loaded rows
 
-`Cmd+F` opens the find bar above the grid. `Return` and `Cmd+G` step forward, `Cmd+Shift+G` back, `Escape` clears the term and then closes the bar. Matching ignores case and accents and runs over the text as displayed; binary and spatial columns are skipped. The counter says which rows were searched:
+`Cmd+F` opens the find bar above the grid. `Return` and `Cmd+G` step forward, `Cmd+Shift+G` back, `Escape` clears the term and then closes the bar. Matching ignores case and accents and runs over the text as displayed; spatial columns are skipped, and so is a binary column still showing hex. The counter says which rows were searched:
 
 | What you see | What it means |
 |---|---|

--- a/docs/features/json-viewer.mdx
+++ b/docs/features/json-viewer.mdx
@@ -14,6 +14,7 @@ Right-click a column header and pick **Display As**. The submenu lists the forma
 | Format | Column types | Effect |
 | --- | --- | --- |
 | Raw Value | all | Shows the stored value, and turns off detection for that column |
+| Text | binary | Reads the bytes as UTF-8, trailing `BINARY(N)` padding trimmed |
 | UUID | binary, text | Renders 16 raw bytes or a 32-digit hex string as a hyphenated UUID |
 | Unix Timestamp (seconds) | integer | Renders the number as a formatted date |
 | Unix Timestamp (milliseconds) | integer | Same, treating the number as milliseconds |
@@ -22,7 +23,9 @@ Right-click a column header and pick **Display As**. The submenu lists the forma
 
 An override persists per column, scoped to the connection and table. A column with a format set copies in that format when you copy the single cell; a block of cells or a whole row always copies the stored value.
 
-Id-like binary and character columns, and integer columns whose names read as timestamps, pick up UUID and date rendering on their own. **Smart value detection** in [Settings > Data](/customization/data-settings) turns that off, and a manual choice always wins over it, **Raw Value** included. MongoDB binary columns never offer UUID, since the driver decodes them under its own Legacy UUID Encoding setting; see [MongoDB](/databases/mongodb).
+Id-like binary and character columns, integer columns whose names read as timestamps, and binary columns whose first rows all read as UTF-8 pick up their format on their own. **Smart value detection** in [Settings > Data](/customization/data-settings) turns that off, and a manual choice always wins over it, **Raw Value** included. MongoDB binary columns never offer UUID, since the driver decodes them under its own Legacy UUID Encoding setting; see [MongoDB](/databases/mongodb).
+
+**Text** decides per cell, not per column: an image or a hash sitting in a column set to **Text** still reads as `0x89504E…`. The cell edits as hex either way.
 
 ## JSON viewer
 
@@ -55,7 +58,7 @@ Set **Display As > PHP Serialized** on a text column, then double-click or press
 
 ## Blob and hex
 
-A blob cell renders in the grid as compact hex (`0x48656C…`). Click the chevron or double-click for the popover: a classic hex dump with offset, byte columns, and ASCII, plus an editable hex field under it on an editable table. That field takes spaced or continuous hex, with or without a `0x` prefix, and invalid hex disables **Save**.
+A blob cell renders in the grid as compact hex (`0x48656C…`), unless its column reads as text. Click the chevron or double-click for the popover: a classic hex dump with offset, byte columns, and ASCII, plus an editable hex field under it on an editable table. That field takes spaced or continuous hex, with or without a `0x` prefix, and invalid hex disables **Save**.
 
 ## Limits
 


### PR DESCRIPTION
Fixes #2599.

## The bug

`ValueDisplayFormat.applicableColumnTypes` mapped binary columns to `[.raw, .uuid]`, so the **Display As** submenu on a `VARBINARY` or `BLOB` header offered Raw Value and UUID and nothing else. A binary column holding UTF-8, which is where MySQL applications put JSON payloads, tokens and message bodies, had no readable form at all: every cell rendered `0x7b226576656e74…`.

Smart value detection could not help either. `ValueDisplayDetector` reads its samples through `PluginCellValue.asText`, which is `nil` for every `.bytes` cell, so a binary column was invisible to it.

## The fix

A new `ValueDisplayFormat.text`, applicable to binary columns. Everything the grid renders funnels through `CellDisplayFormatter.format`, so one case reaches the grid, the per-column value filter, column-width measurement, VoiceOver and single-cell copy at once.

`BinaryTextDecoder` is the whole decision, kept pure and separate because both the format and the detector ask it the same question:

- Trailing `0x00` is trimmed, but only on a column whose base type name is `BINARY`. That is the one type that right-pads, so without the trim a fixed-width column holding text could never read as text, and with the trim anywhere else `0x6100` in a `BLOB` would report as `a`.
- The bytes decode as UTF-8 or the answer is no.
- Anything carrying a C0 control character or DEL is refused, tab, newline and carriage return excepted. That is what separates a stored string from a PNG header, a gzip stream, a SHA-1 digest or a packed IPv4 address, all of which are in the test suite.
- Capped before decoding: 40,000 bytes on the display path, which always covers the grid's 10,000 character cell limit, and 512 bytes on the detection probe. A `LONGBLOB` never builds a multi-gigabyte `String` on the main thread. A cut value carries a `…`, so `Cmd+C` cannot hand back a prefix as if it were the whole thing. A cut that splits a UTF-8 sequence gives up at most three bytes; a whole value never does, since dropping bytes there would accept binary that happens to open with readable characters.

A value the decoder refuses falls back to the hex it always showed, per cell. So an image sitting in a column set to **Text** still reads as `0x89504E…` while its neighbours read as text.

Detection is per column and every sample has to agree: all sampled values decode, and at least one carries content. A `.text` sample opts the column out entirely, which keeps MongoDB's driver-decoded legacy UUIDs on the byte order their connection chose. UUID detection still runs first, so an id-like `BINARY(16)` is unaffected.

`ValueDisplayFormatService.applyFormat(_ String:)` now returns `String?`. "This format cannot render this value" had no spelling before, and the `Data` overload was already optional. `.uuid` and the timestamps are unchanged; only `.text` ever answers nil.

The cell length cap and line-break flattening moved into `CellDisplayFormatter.fitToCell` and now cover the binary branch too. Hex never needed it, since a blob cell was capped at 64 bytes. Decoded text does.

## Find had to move with it

`FindMatcher.isSearchable` excluded every binary column outright, and `runFind` dropped any cell whose value was not already a string. Both were right while hex was the only thing a binary column could show, and both would have silently skipped a column now displaying readable text: the user searches for `signup`, sees it on screen, and Find reports nothing.

A binary column is now searchable when its display format turns bytes into characters, which `ValueDisplayFormat.rendersBinaryAsText` answers. That covers **UUID** as well as **Text**, so a `BINARY(16)` id column showing `550e8400-…` is searchable too. It was not before.

The format is a column-level choice and the fallback to hex is per value, so the two gates are separate: the column passes on its format, and each cell passes only if the format actually rendered those bytes. Without the second one a term like `8950` would match a `0x89504E47` still sitting in a Text column.

Server-side escalation is deliberately unchanged: `isServerSearchable` gates what can go into a `LIKE` without a cast, and `bytea LIKE '…'` fails the whole query on PostgreSQL.

## Scope

Display only. A binary cell keeps the hex editor and the hex popover, exactly as **Display As > UUID** behaves today, and nothing about what is written changes. No PluginKit change, so no ABI bump.

## Tests

47 new cases across six suites. The thirteen suites that own the touched types run 145 cases, all passing.

- `BinaryTextDecoderTests` (21 new): real byte sequences, including a PNG header, a gzip header, a UUID's 16 bytes, a packed IPv4 address, `BINARY(N)` padding against the same bytes in a `BLOB` and a `VARBINARY`, an all-padding value, an embedded NUL, a split multi-byte sequence at the cap, the truncation marker, and the byte-per-character carrier string a driver hands over.
- `ValueDisplayDetectorTests` (12 new): the mixed column, the all-empty column, the driver-decoded column, the trailing NUL under both column widths, and UUID still winning on an id-like `BINARY(16)`.
- `TableViewCoordinatorFindTests` (3 new): Find over a Text column, over a cell that fell back to hex, and over a column left on Raw.
- `CellDisplayFormatterTests` (8 new): the render path, the hex fallback, the padding policy, line-break flattening and the length cap.
- `FindMatcherTests` and `ValueDisplayFormatTests`: searchability per format, and menu contents per column type with MongoDB included.

No `TableProUITests` coverage. The flow is the data grid's column header context menu, and the header is entirely custom-drawn chrome with no addressable element; menu item identifiers also differ on the CI runner. The behaviour is fully covered by the unit suites instead.

## Docs

`features/json-viewer.mdx` owns the Display As table and gained the **Text** row plus the per-cell fallback. `features/data-grid.mdx` and `customization/data-settings.mdx` each carried a copy of the format list; both now point at the table rather than restating it. The Settings row also claimed smart value detection renders JSON and PHP serialized columns, which it never did: `ValueDisplayDetector` only ever returned UUID and Unix timestamps.

## Before / After

Same SQLite fixture in both: `events.payload` is a `BLOB` holding UTF-8 JSON, `events.digest` is a `BLOB` holding 20 random bytes. Captured from 0.70.0 and from this branch, both against throwaway storage.

**Before**, every value in both columns reads as hex:

```
payload                                         digest
0x7B226576656E74223A227369676E6570222C22706…    0x93D1B113CBD3F461A9351A13A38AD9A8E9B55305
0x7B226576656E74223A226C6F67696E222C2272656…    0x9A04BFB1B2C84EC5DE73A74F45672816B90802BB
```

**After**, `payload` reads as text and `digest` correctly stays hex, with no user action:

```
payload                                         digest
{"event":"signup","plan":"pro"}                 0x93D1B113CBD3F461A9351A13A38AD9A8E9B55305
{"event":"login","region":"eu"}                 0x9A04BFB1B2C84EC5DE73A74F45672816B90802BB
```

Full-window PNGs are attached below.

Fixes #2599

https://claude.ai/code/session_01RuTox52znCzCJy8hHstiXU
