### PR TITLE
fix(ssh): select agent identities by IdentityFile instead of offering every key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Script that checks the SQLite whole-schema reads against the per-table ones.
 - Middle-click on a tab to close it. (#2595)
 - Launch trace in Instruments' Points of Interest, and `TABLEPRO_LAUNCH_TRACE=1` for the same table on standard error.
+- Identity File on SSH Agent connections, and `IdentitiesOnly` from `~/.ssh/config`. (#2601)
 
 ### Changed
 
@@ -40,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A failed whole-schema trigger read counting as a schema with no triggers.
 - Compare & Sync publishing one pair's results after the pickers moved to another.
 - Clicks and hovers in the scrolled tab strip's edge padding landing on a tab clipped off the edge.
+- SSH Agent auth offering every key the agent holds, exhausting the server's `MaxAuthTries`. (#2601)
 
 ## [0.70.0] - 2026-09-01
 

--- a/TablePro/Core/SSH/Auth/AgentAuthenticator.swift
+++ b/TablePro/Core/SSH/Auth/AgentAuthenticator.swift
@@ -11,8 +11,25 @@ import CLibSSH2
 internal struct AgentAuthenticator: SSHAuthenticator {
     private static let logger = Logger(subsystem: "com.TablePro", category: "AgentAuthenticator")
 
+    /// `MaxAuthTries` ends in an `SSH_MSG_DISCONNECT`, which `_libssh2_packet_add` answers by
+    /// setting `socket_state` and returning `LIBSSH2_ERROR_SOCKET_DISCONNECT`. That code is the
+    /// only one here on purpose: libssh2's agent backend reports its own socket failures as
+    /// `LIBSSH2_ERROR_SOCKET_SEND` and `LIBSSH2_ERROR_SOCKET_RECV`, so an agent that quit
+    /// mid-signing is indistinguishable from a server that hung up if either is included, and it
+    /// only ever returns `SOCKET_DISCONNECT` from `agent_disconnect_unix`, which
+    /// `libssh2_agent_userauth` never reaches. A refused key is
+    /// `LIBSSH2_ERROR_AUTHENTICATION_FAILED` or `LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED`, so an
+    /// ordinary rejection still moves on to the next key.
+    private static let serverHungUp = LIBSSH2_ERROR_SOCKET_DISCONNECT
+
     let socketPath: String?
     let socketOrigin: AgentSocketOrigin
+
+    /// The `IdentityFile` entries resolved for this host, from `~/.ssh/config` or the form.
+    var identityFiles: [String] = []
+
+    /// `IdentitiesOnly yes`, which drops every agent key that no identity file named.
+    var identitiesOnly: Bool = false
 
     /// Resolve SSH_AUTH_SOCK via launchctl for GUI apps that don't inherit shell env.
     private static func resolveSocketViaLaunchctl() -> String? {
@@ -81,44 +98,106 @@ internal struct AgentAuthenticator: SSHAuthenticator {
             throw SSHTunnelError.authenticationFailed(reason: .agentUnavailable(socketOrigin))
         }
 
-        var previousIdentity: UnsafeMutablePointer<libssh2_agent_publickey>?
-        var currentIdentity: UnsafeMutablePointer<libssh2_agent_publickey>?
-        var offeredCount = 0
+        let identities = try collectIdentities(from: agent)
+
+        // An agent that answered but offered nothing is a locked or empty agent, which the user
+        // fixes somewhere entirely different from an agent whose keys the server refused.
+        guard !identities.isEmpty else {
+            Self.logger.error("SSH agent offered no identities")
+            throw SSHTunnelError.authenticationFailed(reason: .agentNoIdentities(socketOrigin))
+        }
+
+        let order = try offerOrder(for: identities)
+        for (position, index) in order.enumerated() {
+            let authRc = libssh2_agent_userauth(agent, username, identities[index])
+            if authRc == 0 {
+                Self.logger.info("SSH agent authentication succeeded on key \(position + 1) of \(order.count)")
+                return
+            }
+            if authRc == Self.serverHungUp {
+                Self.logger.error(
+                    "SSH server closed the connection after \(position + 1) of \(order.count) agent keys (rc=\(authRc))"
+                )
+                throw SSHTunnelError.authenticationFailed(reason: .agentServerClosedConnection)
+            }
+        }
+
+        Self.logger.error("SSH agent authentication failed: none of \(order.count) identities accepted")
+        throw SSHTunnelError.authenticationFailed(reason: .agentRejected)
+    }
+
+    /// Walks the whole identity list before anything is offered, because the order to offer them
+    /// in is not the order the agent lists them in. The pointers belong to the agent handle and
+    /// stay valid until `libssh2_agent_free`, which the caller's `defer` runs after the last
+    /// `libssh2_agent_userauth`.
+    private func collectIdentities(
+        from agent: OpaquePointer
+    ) throws -> [UnsafeMutablePointer<libssh2_agent_publickey>] {
+        var identities: [UnsafeMutablePointer<libssh2_agent_publickey>] = []
+        var previous: UnsafeMutablePointer<libssh2_agent_publickey>?
+        var current: UnsafeMutablePointer<libssh2_agent_publickey>?
 
         while true {
-            rc = libssh2_agent_get_identity(agent, &currentIdentity, previousIdentity)
-
+            let rc = libssh2_agent_get_identity(agent, &current, previous)
             if rc == 1 {
-                // End of identity list, none worked
-                break
+                return identities
             }
             if rc < 0 {
                 Self.logger.error("Failed to get SSH agent identity (rc=\(rc))")
                 throw SSHTunnelError.authenticationFailed(reason: .agentUnavailable(socketOrigin))
             }
-
-            guard let identity = currentIdentity else {
-                break
+            guard let identity = current else {
+                return identities
             }
+            identities.append(identity)
+            previous = identity
+        }
+    }
 
-            offeredCount += 1
-            let authRc = libssh2_agent_userauth(agent, username, identity)
-            if authRc == 0 {
-                Self.logger.info("SSH agent authentication succeeded")
-                return
-            }
+    private func offerOrder(
+        for identities: [UnsafeMutablePointer<libssh2_agent_publickey>]
+    ) throws -> [Int] {
+        let preferred = identityFiles.flatMap { SSHPublicKeyFile.blobs(atIdentityPath: $0) }
+        guard !preferred.isEmpty else { return try unfilteredOrder(for: identities) }
 
-            previousIdentity = identity
+        let blobs = identities.map { identity -> Data in
+            guard let bytes = identity.pointee.blob, identity.pointee.blob_len > 0 else { return Data() }
+            return Data(bytes: bytes, count: identity.pointee.blob_len)
+        }
+        let order = AgentIdentityPreference.offerOrder(
+            agentIdentities: blobs,
+            preferred: preferred,
+            identitiesOnly: identitiesOnly
+        )
+
+        guard !order.isEmpty else {
+            Self.logger.error("No agent identity matches the identity files for this host")
+            throw SSHTunnelError.authenticationFailed(reason: .agentNoMatchingIdentity(socketOrigin))
         }
 
-        // An agent that answered but offered nothing is a locked or empty agent, which the user
-        // fixes somewhere entirely different from an agent whose keys the server refused.
-        guard offeredCount > 0 else {
-            Self.logger.error("SSH agent offered no identities")
-            throw SSHTunnelError.authenticationFailed(reason: .agentNoIdentities(socketOrigin))
+        Self.logger.debug("Offering \(order.count) of \(identities.count) agent identities")
+        return order
+    }
+
+    /// Reached when no identity file yielded a public key, which is two different situations.
+    ///
+    /// No identity file at all is the ordinary case: the agent's own order stands and every key is
+    /// offered, exactly as before there was a preference. An identity file that named nothing
+    /// readable is a configuration mistake, and quietly offering every key there would hand the
+    /// user back the `MaxAuthTries` failure they set the file to avoid, with no clue why. Under
+    /// `IdentitiesOnly` that is refused outright; without it, `ssh` also falls back to the rest of
+    /// the agent, so the warning is the whole report.
+    private func unfilteredOrder(
+        for identities: [UnsafeMutablePointer<libssh2_agent_publickey>]
+    ) throws -> [Int] {
+        guard !identityFiles.isEmpty else { return Array(identities.indices) }
+
+        guard !identitiesOnly else {
+            Self.logger.error("IdentitiesOnly is set and no identity file yielded a public key")
+            throw SSHTunnelError.authenticationFailed(reason: .agentIdentityFileUnreadable)
         }
 
-        Self.logger.error("SSH agent authentication failed: none of \(offeredCount) identities accepted")
-        throw SSHTunnelError.authenticationFailed(reason: .agentRejected)
+        Self.logger.warning("No identity file yielded a public key, so every agent key is offered")
+        return Array(identities.indices)
     }
 }

--- a/TablePro/Core/SSH/Auth/AgentIdentityPreference.swift
+++ b/TablePro/Core/SSH/Auth/AgentIdentityPreference.swift
@@ -1,0 +1,49 @@
+//
+//  AgentIdentityPreference.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Which of an agent's keys to offer, and in what order.
+///
+/// An agent that holds one key per server holds a lot of keys, and `MaxAuthTries` defaults to 6,
+/// so offering them in agent order disconnects long before the right one is reached. OpenSSH's
+/// `pubkey_prepare()` states the order it uses:
+///
+///     1. certificates listed in the config file
+///     2. agent keys that are found in the config file
+///     3. other agent keys
+///
+/// and it builds group 3 only under `!options.identities_only`. That is the whole rule, and
+/// keeping it here rather than in the offer loop is what makes it testable without an agent or a
+/// server.
+internal enum AgentIdentityPreference {
+    /// Indices into `agentIdentities`, in the order they should be offered.
+    ///
+    /// An empty `preferred` list means nothing named an identity, so the agent's own order stands
+    /// and every key is offered, exactly as before there was a preference at all.
+    static func offerOrder(
+        agentIdentities: [Data],
+        preferred: [SSHPublicKeyBlob],
+        identitiesOnly: Bool
+    ) -> [Int] {
+        guard !preferred.isEmpty else { return Array(agentIdentities.indices) }
+
+        let ordered = preferred.filter(\.isCertificate) + preferred.filter { !$0.isCertificate }
+        var matched: [Int] = []
+        var taken = Set<Int>()
+
+        for identity in ordered {
+            let match = agentIdentities.indices.first { index in
+                !taken.contains(index) && agentIdentities[index] == identity.blob
+            }
+            guard let match else { continue }
+            taken.insert(match)
+            matched.append(match)
+        }
+
+        guard !identitiesOnly else { return matched }
+        return matched + agentIdentities.indices.filter { !taken.contains($0) }
+    }
+}

--- a/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
+++ b/TablePro/Core/SSH/LibSSH2TunnelFactory.swift
@@ -524,7 +524,12 @@ internal enum LibSSH2TunnelFactory {
 
             return CompositeAuthenticator(
                 authenticators: [
-                    AgentAuthenticator(socketPath: socketPath, socketOrigin: resolved.agentSocketOrigin),
+                    AgentAuthenticator(
+                        socketPath: socketPath,
+                        socketOrigin: resolved.agentSocketOrigin,
+                        identityFiles: resolved.identityFiles,
+                        identitiesOnly: resolved.identitiesOnly
+                    ),
                     KeyboardInteractiveAuthenticator(
                         password: nil,
                         totpProvider: buildTOTPProvider(config: config, credentials: credentials),
@@ -534,6 +539,8 @@ internal enum LibSSH2TunnelFactory {
                 endsChainOn: Set(
                     AgentSocketOrigin.allCases.map(AuthFailureReason.agentUnavailable)
                         + AgentSocketOrigin.allCases.map(AuthFailureReason.agentNoIdentities)
+                        + AgentSocketOrigin.allCases.map(AuthFailureReason.agentNoMatchingIdentity)
+                        + [.agentIdentityFileUnreadable, .agentServerClosedConnection]
                 )
             )
 
@@ -672,7 +679,12 @@ internal enum LibSSH2TunnelFactory {
                 : CompositeAuthenticator(authenticators: authenticators)
         case .sshAgent:
             let socketPath: String? = resolved.agentSocketPath.isEmpty ? nil : resolved.agentSocketPath
-            let agent = AgentAuthenticator(socketPath: socketPath, socketOrigin: resolved.agentSocketOrigin)
+            let agent = AgentAuthenticator(
+                socketPath: socketPath,
+                socketOrigin: resolved.agentSocketOrigin,
+                identityFiles: resolved.identityFiles,
+                identitiesOnly: resolved.identitiesOnly
+            )
             if !jumpHost.privateKeyPath.isEmpty {
                 let keyAuth = KeyFileAuthenticator(
                     keyPath: jumpHost.privateKeyPath,

--- a/TablePro/Core/SSH/SSHPublicKeyFile.swift
+++ b/TablePro/Core/SSH/SSHPublicKeyFile.swift
@@ -1,0 +1,85 @@
+//
+//  SSHPublicKeyFile.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+/// One public key in the form both an OpenSSH `.pub` file and the agent protocol carry it: the SSH
+/// wire blob, whose leading string names the key type.
+internal struct SSHPublicKeyBlob: Hashable, Sendable {
+    let keyType: String
+    let blob: Data
+
+    /// `pubkey_prepare()` in OpenSSH offers certificates before plain keys.
+    var isCertificate: Bool {
+        keyType.hasSuffix("-cert-v01@openssh.com")
+    }
+}
+
+/// Reads the public half of an `IdentityFile` the way OpenSSH does: the named path, then its
+/// `.pub` sidecar, then the `-cert.pub` certificate beside it.
+///
+/// Naming a `.pub` is the documented way to pick one key out of an agent that holds many, and it
+/// is the whole point of the directive when the private key lives somewhere TablePro cannot read
+/// it, as it does for 1Password and Secretive.
+internal enum SSHPublicKeyFile {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "SSHPublicKeyFile")
+
+    /// A `.pub` line is a few hundred bytes. The cap is here because the same path may name a
+    /// private key, a directory entry, or something else entirely.
+    private static let maximumFileSize = 64 * 1024
+
+    /// Every public key an identity file resolves to, in the order OpenSSH looks for them.
+    static func blobs(atIdentityPath path: String) -> [SSHPublicKeyBlob] {
+        let expanded = SSHPathUtilities.expandTilde(path)
+        guard !expanded.isEmpty else { return [] }
+
+        var seen = Set<Data>()
+        var found: [SSHPublicKeyBlob] = []
+        for candidate in [expanded, expanded + ".pub", expanded + "-cert.pub"] {
+            guard let parsed = parse(contentsOfFileAt: candidate) else { continue }
+            guard seen.insert(parsed.blob).inserted else { continue }
+            found.append(parsed)
+        }
+        if found.isEmpty {
+            logger.debug("No public key read for identity file: \(expanded, privacy: .private)")
+        }
+        return found
+    }
+
+    /// Parses an OpenSSH public key line, `<type> <base64> [comment]`. A private key file, a
+    /// `known_hosts` entry or any other text fails the self-description check and yields nothing.
+    static func parse(publicKeyLine line: String) -> SSHPublicKeyBlob? {
+        let fields = line.split(whereSeparator: \.isWhitespace)
+        guard fields.count >= 2 else { return nil }
+
+        let keyType = String(fields[0])
+        guard let blob = Data(base64Encoded: String(fields[1])) else { return nil }
+        guard leadingString(of: blob) == keyType else { return nil }
+        return SSHPublicKeyBlob(keyType: keyType, blob: blob)
+    }
+
+    private static func parse(contentsOfFileAt path: String) -> SSHPublicKeyBlob? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path),
+              let size = attributes[.size] as? Int,
+              size > 0,
+              size <= maximumFileSize,
+              let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let text = String(data: data, encoding: .utf8),
+              let line = text.split(whereSeparator: \.isNewline).first
+        else { return nil }
+        return parse(publicKeyLine: String(line))
+    }
+
+    /// The first `string` field of an SSH blob: a big-endian length followed by that many bytes.
+    private static func leadingString(of blob: Data) -> String? {
+        let bytes = [UInt8](blob)
+        guard bytes.count >= 4 else { return nil }
+
+        let length = bytes[0 ..< 4].reduce(Int(0)) { ($0 << 8) | Int($1) }
+        guard length > 0, length <= 64, bytes.count >= 4 + length else { return nil }
+        return String(bytes: bytes[4 ..< (4 + length)], encoding: .utf8)
+    }
+}

--- a/TablePro/Core/SSH/SSHTunnelManager.swift
+++ b/TablePro/Core/SSH/SSHTunnelManager.swift
@@ -17,7 +17,10 @@ enum AuthFailureReason: Sendable, Hashable, CaseIterable {
     case privateKey
     case agentUnavailable(AgentSocketOrigin)
     case agentNoIdentities(AgentSocketOrigin)
+    case agentNoMatchingIdentity(AgentSocketOrigin)
+    case agentIdentityFileUnreadable
     case agentRejected
+    case agentServerClosedConnection
     case passwordlessRejected
     case keyboardInteractive
     case methodUnavailable
@@ -30,8 +33,9 @@ enum AuthFailureReason: Sendable, Hashable, CaseIterable {
         [.password, .verificationCode, .privateKey]
             + AgentSocketOrigin.allCases.map(AuthFailureReason.agentUnavailable)
             + AgentSocketOrigin.allCases.map(AuthFailureReason.agentNoIdentities)
-            + [.agentRejected, .passwordlessRejected, .keyboardInteractive, .methodUnavailable,
-               .cancelled, .generic]
+            + AgentSocketOrigin.allCases.map(AuthFailureReason.agentNoMatchingIdentity)
+            + [.agentIdentityFileUnreadable, .agentRejected, .agentServerClosedConnection, .passwordlessRejected,
+               .keyboardInteractive, .methodUnavailable, .cancelled, .generic]
     }
 }
 
@@ -110,8 +114,35 @@ enum SSHTunnelError: Error, LocalizedError, Equatable, Sendable {
                     origin.whereTheSocketCameFrom,
                     origin.howToLoadAKey
                 )
+            case .agentNoMatchingIdentity(let origin):
+                return String(
+                    format: String(
+                        localized: """
+                        The SSH agent from %@ holds no key matching the identity file set for this host. Check that \
+                        the file names a key the agent has, or clear it to offer every key.
+                        """
+                    ),
+                    origin.whereTheSocketCameFrom
+                )
+            case .agentIdentityFileUnreadable:
+                return String(
+                    localized: """
+                    No public key could be read from the identity file set for this host, and IdentitiesOnly yes \
+                    allows no other key. Check the path, and that the file is an OpenSSH public key or has a .pub \
+                    beside it.
+                    """
+                )
             case .agentRejected:
                 return String(localized: "SSH agent did not authenticate. Run ssh-add -l to check loaded keys.")
+            case .agentServerClosedConnection:
+                return String(
+                    localized: """
+                    The SSH server closed the connection while the agent's keys were being offered. Servers accept \
+                    a limited number of tries, 6 by default, and an agent holding more keys than that runs out \
+                    before the right one. Name the key with IdentityFile and IdentitiesOnly yes for this host in \
+                    ~/.ssh/config, or set Identity File on this connection.
+                    """
+                )
             case .passwordlessRejected:
                 return String(localized: "The SSH server did not accept passwordless authentication. Choose Password, Private Key, or SSH Agent.")
             case .keyboardInteractive:

--- a/TablePro/Views/Connection/ConnectionSSHTunnelView.swift
+++ b/TablePro/Views/Connection/ConnectionSSHTunnelView.swift
@@ -90,7 +90,12 @@ struct ConnectionSSHTunnelView: View {
                     LabeledContent(String(localized: "Username"), value: profile.username)
                     LabeledContent(String(localized: "Authentication Method"), value: profile.authMethod.rawValue)
                     if !profile.privateKeyPath.isEmpty {
-                        LabeledContent(String(localized: "Key File"), value: profile.privateKeyPath)
+                        LabeledContent(
+                            profile.authMethod == .sshAgent
+                                ? String(localized: "Identity File")
+                                : String(localized: "Key File"),
+                            value: profile.privateKeyPath
+                        )
                     }
                     if !profile.jumpHosts.isEmpty {
                         LabeledContent(String(localized: "Jump Hosts"), value: "\(profile.jumpHosts.count)")
@@ -195,6 +200,27 @@ struct ConnectionSSHTunnelView: View {
                         )
                     }
                     Text(sshState.agentSocketOption.explanation)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    LabeledContent(String(localized: "Identity File")) {
+                        HStack {
+                            TextField(
+                                "",
+                                text: $sshState.privateKeyPath,
+                                prompt: Text("~/.ssh/id_ed25519.pub")
+                            )
+                            Button(String(localized: "Browse")) {
+                                browseForKeyFile(
+                                    message: String(localized: "Choose a public key file")
+                                ) { sshState.privateKeyPath = $0 }
+                            }
+                            .controlSize(.small)
+                        }
+                    }
+                    Text(String(localized: """
+                    Offers the agent key matching this public key file first. With IdentitiesOnly yes \
+                    in ~/.ssh/config, only that key is offered.
+                    """))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 } else if sshState.authMethod == .keyboardInteractive {
@@ -345,13 +371,16 @@ struct ConnectionSSHTunnelView: View {
 
     // MARK: - Helper Methods
 
-    private func browseForKeyFile(onSelect: @escaping (String) -> Void) {
+    private func browseForKeyFile(
+        message: String = String(localized: "Choose a private key file"),
+        onSelect: @escaping (String) -> Void
+    ) {
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
         panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh")
         panel.showsHiddenFiles = true
-        panel.message = String(localized: "Choose a private key file")
+        panel.message = message
         panel.begin { response in
             if response == .OK, let url = panel.url {
                 onSelect(url.path(percentEncoded: false))

--- a/TablePro/Views/Connection/SSHProfileEditorView.swift
+++ b/TablePro/Views/Connection/SSHProfileEditorView.swift
@@ -162,6 +162,19 @@ struct SSHProfileEditorView: View {
                 Text(agentSocketOption.explanation)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                LabeledContent(String(localized: "Identity File")) {
+                    HStack {
+                        TextField("", text: $privateKeyPath, prompt: Text("~/.ssh/id_ed25519.pub"))
+                        Button(String(localized: "Browse")) { browseForPrivateKey() }
+                            .controlSize(.small)
+                    }
+                }
+                Text(String(localized: """
+                Offers the agent key matching this public key file first. With IdentitiesOnly yes \
+                in ~/.ssh/config, only that key is offered.
+                """))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             } else if authMethod == .keyboardInteractive {
                 SecureField(String(localized: "Password"), text: $sshPassword)
                 Text(String(localized: "Password is sent via keyboard-interactive challenge-response."))

--- a/TableProTests/Core/SSH/Auth/AgentAuthenticationReportingTests.swift
+++ b/TableProTests/Core/SSH/Auth/AgentAuthenticationReportingTests.swift
@@ -187,6 +187,151 @@ struct AgentAuthenticatorFailureTests {
             }
         }
     }
+
+    /// The reported case: a 1Password agent holding one key per server, and an `IdentityFile`
+    /// naming a key that is not in it. Offering all thirty is what `MaxAuthTries 6` disconnects
+    /// on, so nothing should be offered at all and the message should say why (#2601).
+    @Test("IdentitiesOnly with no agent key matching the identity file offers nothing (#2601)")
+    func identitiesOnlyWithoutAMatchReportsNoMatchingIdentity() throws {
+        let agent = try #require(FakeSSHAgent(identities: Self.identities(count: 30, from: 1)))
+        defer { agent.stop() }
+        let identityFile = try Self.writeIdentityFile(seed: 200)
+        defer { try? FileManager.default.removeItem(at: identityFile.deletingLastPathComponent()) }
+
+        try withTransportlessSession { session in
+            #expect(
+                throws: SSHTunnelError.authenticationFailed(reason: .agentNoMatchingIdentity(.agentSocketSetting))
+            ) {
+                try AgentAuthenticator(
+                    socketPath: agent.path,
+                    socketOrigin: .agentSocketSetting,
+                    identityFiles: [identityFile.path],
+                    identitiesOnly: true
+                ).authenticate(session: session, username: "alice")
+            }
+        }
+    }
+
+    /// The other half: a match is offered, so the run gets as far as `libssh2_agent_userauth` and
+    /// fails on the missing transport rather than on identity selection.
+    @Test("IdentitiesOnly with a matching identity file offers that key (#2601)")
+    func identitiesOnlyWithAMatchReachesUserauth() throws {
+        let agent = try #require(FakeSSHAgent(identities: Self.identities(count: 30, from: 1)))
+        defer { agent.stop() }
+        let identityFile = try Self.writeIdentityFile(seed: 20)
+        defer { try? FileManager.default.removeItem(at: identityFile.deletingLastPathComponent()) }
+
+        try withTransportlessSession { session in
+            let reason = Self.failureReason {
+                try AgentAuthenticator(
+                    socketPath: agent.path,
+                    socketOrigin: .agentSocketSetting,
+                    identityFiles: [identityFile.path],
+                    identitiesOnly: true
+                ).authenticate(session: session, username: "alice")
+            }
+
+            #expect(reason != .agentNoMatchingIdentity(.agentSocketSetting))
+            #expect(reason != .agentNoIdentities(.agentSocketSetting))
+            #expect(reason != nil)
+        }
+    }
+
+    /// An identity file that names nothing readable is a typo or a moved key, not "no preference".
+    /// Quietly offering all thirty keys there hands back the `MaxAuthTries` failure the file was
+    /// set to avoid, with nothing to say why (#2601).
+    @Test("IdentitiesOnly with an unreadable identity file refuses rather than offering every key (#2601)")
+    func identitiesOnlyWithAnUnreadableIdentityFileRefuses() throws {
+        let agent = try #require(FakeSSHAgent(identities: Self.identities(count: 30, from: 1)))
+        defer { agent.stop() }
+        let absent = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tp-absent-\(UUID().uuidString).pub").path
+
+        try withTransportlessSession { session in
+            #expect(throws: SSHTunnelError.authenticationFailed(reason: .agentIdentityFileUnreadable)) {
+                try AgentAuthenticator(
+                    socketPath: agent.path,
+                    socketOrigin: .agentSocketSetting,
+                    identityFiles: [absent],
+                    identitiesOnly: true
+                ).authenticate(session: session, username: "alice")
+            }
+        }
+    }
+
+    /// Without `IdentitiesOnly`, `ssh` also falls back to the rest of the agent, so an unreadable
+    /// identity file must not turn a working connection into a hard failure.
+    @Test("An unreadable identity file without IdentitiesOnly still offers the agent's keys (#2601)")
+    func unreadableIdentityFileWithoutIdentitiesOnlyStillOffersKeys() throws {
+        let agent = try #require(FakeSSHAgent(identities: Self.identities(count: 3, from: 1)))
+        defer { agent.stop() }
+        let absent = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tp-absent-\(UUID().uuidString).pub").path
+
+        try withTransportlessSession { session in
+            let reason = Self.failureReason {
+                try AgentAuthenticator(
+                    socketPath: agent.path,
+                    socketOrigin: .agentSocketSetting,
+                    identityFiles: [absent],
+                    identitiesOnly: false
+                ).authenticate(session: session, username: "alice")
+            }
+
+            #expect(reason != .agentIdentityFileUnreadable)
+            #expect(reason != .agentNoMatchingIdentity(.agentSocketSetting))
+        }
+    }
+
+    /// No identity file means no preference, which has to stay exactly what it was: every key the
+    /// agent holds, in the agent's order.
+    @Test("An agent with no identity file configured still offers its keys (#2601)")
+    func noIdentityFileOffersEveryKey() throws {
+        let agent = try #require(FakeSSHAgent(identities: Self.identities(count: 3, from: 1)))
+        defer { agent.stop() }
+
+        try withTransportlessSession { session in
+            let reason = Self.failureReason {
+                try AgentAuthenticator(socketPath: agent.path, socketOrigin: .agentSocketSetting)
+                    .authenticate(session: session, username: "alice")
+            }
+
+            #expect(reason != .agentNoMatchingIdentity(.agentSocketSetting))
+            #expect(reason != .agentNoIdentities(.agentSocketSetting))
+        }
+    }
+
+    private static func identities(count: Int, from first: UInt8) -> [(blob: [UInt8], comment: String)] {
+        (0 ..< count).map { offset in
+            let seed = first &+ UInt8(offset)
+            return (
+                blob: [UInt8](SSHPublicKeyFixture.blob(type: "ssh-ed25519", seed: seed)),
+                comment: "key-\(offset + 1)"
+            )
+        }
+    }
+
+    private static func writeIdentityFile(seed: UInt8) throws -> URL {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tp-identity-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("selected.pub")
+        try SSHPublicKeyFixture.line(type: "ssh-ed25519", seed: seed)
+            .write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private static func failureReason(_ body: () throws -> Void) -> AuthFailureReason? {
+        do {
+            try body()
+            return nil
+        } catch let error as SSHTunnelError {
+            guard case .authenticationFailed(let reason) = error else { return nil }
+            return reason
+        } catch {
+            return nil
+        }
+    }
 }
 
 private struct ThrowingAuthenticator: SSHAuthenticator {

--- a/TableProTests/Core/SSH/Auth/AgentIdentityPreferenceTests.swift
+++ b/TableProTests/Core/SSH/Auth/AgentIdentityPreferenceTests.swift
@@ -1,0 +1,142 @@
+//
+//  AgentIdentityPreferenceTests.swift
+//  TableProTests
+//
+//  A 1Password agent holds one key per server, and `MaxAuthTries` defaults to 6, so the order
+//  keys are offered in decides whether the connection works at all (#2601). The order under test
+//  is the one `pubkey_prepare()` in OpenSSH documents: certificates from the config, then agent
+//  keys the config named, then the rest, and the rest only without `IdentitiesOnly`.
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("Agent identity preference")
+struct AgentIdentityPreferenceTests {
+    private static let ed25519 = "ssh-ed25519"
+    private static let certificate = "ssh-ed25519-cert-v01@openssh.com"
+
+    private static func agent(_ seeds: [UInt8]) -> [Data] {
+        seeds.map { SSHPublicKeyFixture.blob(type: ed25519, seed: $0) }
+    }
+
+    private static func preferred(_ seeds: [UInt8]) -> [SSHPublicKeyBlob] {
+        seeds.map {
+            SSHPublicKeyBlob(keyType: ed25519, blob: SSHPublicKeyFixture.blob(type: ed25519, seed: $0))
+        }
+    }
+
+    @Test("No identity file leaves the agent's own order in place")
+    func noPreferenceOffersEverythingInAgentOrder() {
+        let order = AgentIdentityPreference.offerOrder(
+            agentIdentities: Self.agent([1, 2, 3]),
+            preferred: [],
+            identitiesOnly: false
+        )
+
+        #expect(order == [0, 1, 2])
+    }
+
+    @Test("IdentitiesOnly with no identity file still offers everything, rather than nothing")
+    func identitiesOnlyWithoutPreferenceDoesNotFilter() {
+        let order = AgentIdentityPreference.offerOrder(
+            agentIdentities: Self.agent([1, 2, 3]),
+            preferred: [],
+            identitiesOnly: true
+        )
+
+        #expect(order == [0, 1, 2])
+    }
+
+    @Test("The key an identity file names is offered first, then the rest in agent order")
+    func matchedKeyLeadsTheOffer() {
+        let order = AgentIdentityPreference.offerOrder(
+            agentIdentities: Self.agent(Array(1...30)),
+            preferred: Self.preferred([20]),
+            identitiesOnly: false
+        )
+
+        #expect(order.first == 19)
+        #expect(order.count == 30)
+        #expect(Set(order).count == 30)
+    }
+
+    @Test("IdentitiesOnly offers the matched key alone")
+    func identitiesOnlyDropsTheRest() {
+        let order = AgentIdentityPreference.offerOrder(
+            agentIdentities: Self.agent(Array(1...30)),
+            preferred: Self.preferred([20]),
+            identitiesOnly: true
+        )
+
+        #expect(order == [19])
+    }
+
+    @Test("Several identity files are offered in the order the config lists them")
+    func preferredOrderIsConfigOrder() {
+        let order = AgentIdentityPreference.offerOrder(
+            agentIdentities: Self.agent([1, 2, 3, 4]),
+            preferred: Self.preferred([4, 2]),
+            identitiesOnly: true
+        )
+
+        #expect(order == [3, 1])
+    }
+
+    @Test("A certificate is offered before a plain key, whatever order the config lists them in")
+    func certificatesComeFirst() {
+        let plain = SSHPublicKeyBlob(
+            keyType: Self.ed25519,
+            blob: SSHPublicKeyFixture.blob(type: Self.ed25519, seed: 1)
+        )
+        let cert = SSHPublicKeyBlob(
+            keyType: Self.certificate,
+            blob: SSHPublicKeyFixture.blob(type: Self.certificate, seed: 2)
+        )
+
+        let order = AgentIdentityPreference.offerOrder(
+            agentIdentities: [plain.blob, cert.blob],
+            preferred: [plain, cert],
+            identitiesOnly: true
+        )
+
+        #expect(order == [1, 0])
+    }
+
+    @Test("IdentitiesOnly with nothing matching offers nothing, so the caller can say why")
+    func identitiesOnlyWithNoMatchOffersNothing() {
+        let order = AgentIdentityPreference.offerOrder(
+            agentIdentities: Self.agent([1, 2, 3]),
+            preferred: Self.preferred([99]),
+            identitiesOnly: true
+        )
+
+        #expect(order.isEmpty)
+    }
+
+    @Test("Without IdentitiesOnly, an identity file the agent lacks still offers every agent key")
+    func unmatchedPreferenceKeepsEveryKey() {
+        let order = AgentIdentityPreference.offerOrder(
+            agentIdentities: Self.agent([1, 2, 3]),
+            preferred: Self.preferred([99]),
+            identitiesOnly: false
+        )
+
+        #expect(order == [0, 1, 2])
+    }
+
+    @Test("An agent holding the same key twice matches it once per identity file")
+    func duplicateAgentEntriesAreNotOfferedTwice() {
+        let blob = SSHPublicKeyFixture.blob(type: Self.ed25519, seed: 1)
+
+        let order = AgentIdentityPreference.offerOrder(
+            agentIdentities: [blob, blob, SSHPublicKeyFixture.blob(type: Self.ed25519, seed: 2)],
+            preferred: Self.preferred([1]),
+            identitiesOnly: true
+        )
+
+        #expect(order == [0])
+    }
+}

--- a/TableProTests/Core/SSH/Auth/BuildAuthenticatorTests.swift
+++ b/TableProTests/Core/SSH/Auth/BuildAuthenticatorTests.swift
@@ -27,6 +27,7 @@ struct BuildAuthenticatorTests {
         username: String = "alice",
         port: Int = 22,
         identityFiles: [String] = [],
+        identitiesOnly: Bool = false,
         agentSocketOrigin: AgentSocketOrigin = .environment
     ) -> ResolvedSSHTarget {
         ResolvedSSHTarget(
@@ -37,7 +38,7 @@ struct BuildAuthenticatorTests {
             identityFiles: identityFiles,
             agentSocketPath: "",
             agentSocketOrigin: agentSocketOrigin,
-            identitiesOnly: false,
+            identitiesOnly: identitiesOnly,
             useKeychain: false,
             addKeysToAgent: false,
             proxyJump: []
@@ -167,18 +168,27 @@ struct BuildAuthenticatorTests {
         #expect(composite.authenticators.last is KeyboardInteractiveAuthenticator)
     }
 
-    @Test("SSH agent auth never falls back to an identity file from ~/.ssh/config (#2583)")
-    func sshAgentIgnoresResolvedIdentityFiles() throws {
+    /// An identity file reaches the agent as the key to select, never as a key file to read: the
+    /// agent is the credential, and reading one the user never chose put TablePro's own passphrase
+    /// prompt over an agent that had simply not been reached (#2583). Selecting with it is what
+    /// keeps an agent holding more keys than the server allows tries usable (#2601), so the chain
+    /// stays two long while the files themselves are handed to the agent step.
+    @Test("SSH agent auth selects with an identity file rather than reading one (#2583, #2601)")
+    func sshAgentSelectsWithResolvedIdentityFiles() throws {
+        let identityFiles = ["/home/alice/.ssh/id_ed25519", "/home/alice/.ssh/id_rsa"]
         let authenticator = try LibSSH2TunnelFactory.buildAuthenticator(
             config: config(authMethod: .sshAgent, totpMode: .none),
-            resolved: resolved(identityFiles: ["/home/alice/.ssh/id_ed25519", "/home/alice/.ssh/id_rsa"]),
+            resolved: resolved(identityFiles: identityFiles, identitiesOnly: true),
             credentials: credentials()
         )
         let composite = try #require(authenticator as? CompositeAuthenticator)
 
         #expect(composite.authenticators.count == 2)
-        #expect(composite.authenticators.first is AgentAuthenticator)
         #expect(composite.authenticators.last is KeyboardInteractiveAuthenticator)
+
+        let agent = try #require(composite.authenticators.first as? AgentAuthenticator)
+        #expect(agent.identityFiles == identityFiles)
+        #expect(agent.identitiesOnly)
     }
 
     @Test("Private key auth still tries every resolved identity file")

--- a/TableProTests/Core/SSH/SSHPublicKeyFileTests.swift
+++ b/TableProTests/Core/SSH/SSHPublicKeyFileTests.swift
@@ -1,0 +1,181 @@
+//
+//  SSHPublicKeyFileTests.swift
+//  TableProTests
+//
+//  Reading the public half of an `IdentityFile` is what lets TablePro pick one key out of an
+//  agent that holds thirty, so a `.pub` that fails to parse is the difference between a working
+//  connection and "Too many authentication failures" (#2601).
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+/// Builds the SSH wire encodings both a `.pub` file and the agent protocol carry, so no fixture
+/// is a hand-typed base64 string that has to be trusted.
+enum SSHPublicKeyFixture {
+    /// An SSH `string`: a big-endian length followed by that many bytes.
+    static func wireString(_ value: String) -> [UInt8] {
+        let bytes = Array(value.utf8)
+        let length = UInt32(bytes.count)
+        return [
+            UInt8(length >> 24 & 0xFF),
+            UInt8(length >> 16 & 0xFF),
+            UInt8(length >> 8 & 0xFF),
+            UInt8(length & 0xFF),
+        ] + bytes
+    }
+
+    /// A public key blob: its type, then whatever stands in for the key material.
+    static func blob(type: String, seed: UInt8) -> Data {
+        Data(wireString(type) + [UInt8](repeating: seed, count: 32))
+    }
+
+    static func line(type: String, seed: UInt8, comment: String = "alice@example.com") -> String {
+        "\(type) \(blob(type: type, seed: seed).base64EncodedString()) \(comment)"
+    }
+}
+
+@Suite("SSH public key file")
+struct SSHPublicKeyFileTests {
+    private static let ed25519 = "ssh-ed25519"
+    private static let certificate = "ssh-ed25519-cert-v01@openssh.com"
+
+    private static func directory() throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tp-pubkey-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private static func write(_ contents: String, to url: URL) throws {
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    @Test("A public key line parses into its type and wire blob")
+    func parsesAPublicKeyLine() throws {
+        let line = SSHPublicKeyFixture.line(type: Self.ed25519, seed: 1)
+        let parsed = try #require(SSHPublicKeyFile.parse(publicKeyLine: line))
+
+        #expect(parsed.keyType == Self.ed25519)
+        #expect(parsed.blob == SSHPublicKeyFixture.blob(type: Self.ed25519, seed: 1))
+        #expect(parsed.isCertificate == false)
+    }
+
+    @Test("A certificate line reports itself as one")
+    func recognisesACertificate() throws {
+        let line = SSHPublicKeyFixture.line(type: Self.certificate, seed: 2)
+        let parsed = try #require(SSHPublicKeyFile.parse(publicKeyLine: line))
+
+        #expect(parsed.isCertificate)
+    }
+
+    @Test("A line whose blob does not describe the declared type is rejected")
+    func rejectsATypeMismatch() {
+        let blob = SSHPublicKeyFixture.blob(type: Self.ed25519, seed: 3).base64EncodedString()
+
+        #expect(SSHPublicKeyFile.parse(publicKeyLine: "ssh-rsa \(blob) alice") == nil)
+    }
+
+    @Test("A private key file is not a public key")
+    func rejectsAPrivateKeyHeader() {
+        #expect(SSHPublicKeyFile.parse(publicKeyLine: "-----BEGIN OPENSSH PRIVATE KEY-----") == nil)
+        #expect(SSHPublicKeyFile.parse(publicKeyLine: "-----BEGIN RSA PRIVATE KEY-----") == nil)
+    }
+
+    @Test("A line with no base64 field is rejected")
+    func rejectsAShortLine() {
+        #expect(SSHPublicKeyFile.parse(publicKeyLine: "ssh-ed25519") == nil)
+        #expect(SSHPublicKeyFile.parse(publicKeyLine: "") == nil)
+    }
+
+    @Test("Base64 that is not valid is rejected")
+    func rejectsBadBase64() {
+        #expect(SSHPublicKeyFile.parse(publicKeyLine: "ssh-ed25519 !!!notbase64!!! alice") == nil)
+    }
+
+    @Test("An identity file naming a .pub reads it directly")
+    func readsAPubFileNamedDirectly() throws {
+        let directory = try Self.directory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let path = directory.appendingPathComponent("db.pub")
+        try Self.write(SSHPublicKeyFixture.line(type: Self.ed25519, seed: 4) + "\n", to: path)
+
+        let blobs = SSHPublicKeyFile.blobs(atIdentityPath: path.path)
+
+        #expect(blobs.count == 1)
+        #expect(blobs.first?.blob == SSHPublicKeyFixture.blob(type: Self.ed25519, seed: 4))
+    }
+
+    @Test("An identity file naming a private key reads the .pub beside it")
+    func fallsBackToTheSidecar() throws {
+        let directory = try Self.directory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let key = directory.appendingPathComponent("id_ed25519")
+        try Self.write("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXk\n", to: key)
+        try Self.write(
+            SSHPublicKeyFixture.line(type: Self.ed25519, seed: 5) + "\n",
+            to: directory.appendingPathComponent("id_ed25519.pub")
+        )
+
+        let blobs = SSHPublicKeyFile.blobs(atIdentityPath: key.path)
+
+        #expect(blobs.count == 1)
+        #expect(blobs.first?.blob == SSHPublicKeyFixture.blob(type: Self.ed25519, seed: 5))
+    }
+
+    @Test("A certificate beside the key is read alongside the key itself")
+    func readsTheCertificateSidecar() throws {
+        let directory = try Self.directory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let key = directory.appendingPathComponent("id_ed25519")
+        try Self.write(
+            SSHPublicKeyFixture.line(type: Self.ed25519, seed: 6) + "\n",
+            to: directory.appendingPathComponent("id_ed25519.pub")
+        )
+        try Self.write(
+            SSHPublicKeyFixture.line(type: Self.certificate, seed: 7) + "\n",
+            to: directory.appendingPathComponent("id_ed25519-cert.pub")
+        )
+
+        let blobs = SSHPublicKeyFile.blobs(atIdentityPath: key.path)
+
+        #expect(blobs.count == 2)
+        #expect(blobs.contains { $0.isCertificate })
+        #expect(blobs.contains { !$0.isCertificate })
+    }
+
+    @Test("The same key reached by two candidate paths is returned once")
+    func deduplicatesIdenticalBlobs() throws {
+        let directory = try Self.directory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let line = SSHPublicKeyFixture.line(type: Self.ed25519, seed: 8) + "\n"
+        let key = directory.appendingPathComponent("id_ed25519")
+        try Self.write(line, to: key)
+        try Self.write(line, to: directory.appendingPathComponent("id_ed25519.pub"))
+
+        #expect(SSHPublicKeyFile.blobs(atIdentityPath: key.path).count == 1)
+    }
+
+    @Test("An identity file that resolves to nothing yields no keys")
+    func missingFileYieldsNothing() throws {
+        let directory = try Self.directory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(SSHPublicKeyFile.blobs(atIdentityPath: directory.appendingPathComponent("absent").path).isEmpty)
+        #expect(SSHPublicKeyFile.blobs(atIdentityPath: "").isEmpty)
+    }
+
+    @Test("A tilde in the identity path is expanded")
+    func expandsTilde() throws {
+        let name = "tp-pubkey-\(UUID().uuidString).pub"
+        let path = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(name)
+        try Self.write(SSHPublicKeyFixture.line(type: Self.ed25519, seed: 9) + "\n", to: path)
+        defer { try? FileManager.default.removeItem(at: path) }
+
+        let blobs = SSHPublicKeyFile.blobs(atIdentityPath: "~/\(name)")
+
+        #expect(blobs.first?.blob == SSHPublicKeyFixture.blob(type: Self.ed25519, seed: 9))
+    }
+}

--- a/docs/connections/ssh-tunneling.mdx
+++ b/docs/connections/ssh-tunneling.mdx
@@ -45,7 +45,7 @@ There is no **SSH Tunnel** pane on SQLite, PGlite, libSQL, Beancount, BigQuery, 
 |---|---|
 | **Password** | The SSH password. Prefer a key on anything production |
 | **Private Key** | **Key File**, with **Browse** to pick one, and **Passphrase** if the key is encrypted. Leaving **Key File** empty auto-detects from `~/.ssh/config` and the default key locations |
-| **SSH Agent** | **Agent Socket**: **SSH_AUTH_SOCK** for the `ssh-agent` macOS runs, **1Password** for its socket at `~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock`, or **Custom Path** for Secretive or your own. Signing stays in the agent; the key is never read, and no key file is tried if the agent refuses |
+| **SSH Agent** | **Agent Socket**: **SSH_AUTH_SOCK** for the `ssh-agent` macOS runs, **1Password** for its socket at `~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock`, or **Custom Path** for Secretive or your own. **Identity File** takes a `.pub` and offers that key ahead of the others; empty offers every key the agent holds. Signing stays in the agent; the key is never read, and no key file is tried if the agent refuses |
 | **Keyboard Interactive** | The SSH password, sent through SSH's challenge-response. Use it when the server rejects plain password auth, common with PAM |
 | **None** | Nothing, for a server that authenticates the connection itself such as a [Tailscale SSH](https://tailscale.com/kb/1193/tailscale-ssh) host. A server that does want credentials fails the connect with a message naming the other methods |
 
@@ -65,7 +65,9 @@ If a trusted server's key later changes, an **SSH Host Key Changed** alert lists
 
 ## Using ~/.ssh/config
 
-Pick an alias from the **Config Host** picker and `HostName`, `User`, `Port`, `IdentityFile`, `IdentityAgent`, and `ProxyJump` are resolved from the config at connect time. Anything typed into the form overrides the file, which is re-read whenever it or an `Include`d file changes.
+Pick an alias from the **Config Host** picker and `HostName`, `User`, `Port`, `IdentityFile`, `IdentitiesOnly`, `IdentityAgent`, and `ProxyJump` are resolved from the config at connect time. Anything typed into the form overrides the file, which is re-read whenever it or an `Include`d file changes.
+
+`IdentityFile` picks which agent key is offered, not only which key file is read, and a `.pub` is enough. That is how a 1Password or Secretive key gets pinned to a host. `IdentitiesOnly yes` then drops every agent key the config did not name, which is what keeps a thirty-key agent inside a server's `MaxAuthTries`.
 
 <Frame caption="Picking a host from ~/.ssh/config">
   <img className="block dark:hidden" src="/images/ssh-config-hosts.png" alt="Config Host picker" />
@@ -134,9 +136,21 @@ A jump host has no **Agent Socket** field of its own, so its agent comes from `I
 
 The agent answered and offered nothing. 1Password serves keys only while it is running and unlocked, and Secretive only while its agent is loaded; unlock it and add the key there. `ssh-add` loads keys into the `SSH_AUTH_SOCK` agent alone, so it is the fix only when that is the socket in the message.
 
+### "The SSH agent from … holds no key matching the identity file set for this host. …"
+
+The agent has keys, and none of them is the one `IdentityFile` or **Identity File** names. List what that agent holds with `SSH_AUTH_SOCK=<the socket the message names> ssh-add -L`, since a bare `ssh-add` reads the shell's `SSH_AUTH_SOCK` rather than the socket TablePro used. Point the setting at a key in that list, or clear it to go back to offering every key.
+
+### "No public key could be read from the identity file set for this host, …"
+
+`IdentityFile` or **Identity File** names a path, and neither it, its `.pub` sidecar, nor its `-cert.pub` parses as an OpenSSH public key. Check the path, and run `ssh-keygen -l -f <path>` to confirm the file itself. `ssh-keygen -y -f <private key> > <private key>.pub` writes the sidecar when only the private key exists.
+
 ### "SSH agent did not authenticate. …"
 
 The agent offered keys and the server accepted none of them. Check the public key is in `~/.ssh/authorized_keys` on the server for the **SSH User** you filled in, and that the key you expect is in the agent rather than only on disk.
+
+### "The SSH server closed the connection while the agent's keys were being offered. …"
+
+The server reached `MaxAuthTries`, 6 by default, before a key it accepts came up. Count that agent's keys with `SSH_AUTH_SOCK=<the socket in **Agent Socket**> ssh-add -L`: past six, the right one may never be offered. Name it with `IdentityFile` and `IdentitiesOnly yes` for the host in `~/.ssh/config`, or fill in **Identity File** on the connection.
 
 ### The tunnel connects and the database refuses the login
 


### PR DESCRIPTION
Fixes #2601.

## The bug

`AgentAuthenticator.authenticate` walked the agent's whole identity list and offered every key with `libssh2_agent_userauth`, in agent order, with no filter. A 1Password agent holds one key per server, around 30. The OpenSSH default `MaxAuthTries` is 6, so the server disconnects after the sixth rejected key and the one that would have worked is never offered. The connect ends on "SSH agent did not authenticate. Run ssh-add -l to check loaded keys.", which points at the wrong thing.

`ssh db-server` works for the same user because `~/.ssh/config` pins `IdentityFile ~/.ssh/db-server.pub` and `IdentitiesOnly yes`. `ResolvedSSHTarget` already carried `identityFiles` and `identitiesOnly`, fully resolved from the config including `%h`/`%p` expansion. `LibSSH2TunnelFactory` read them only for the Private Key method, so on the agent path they were resolved and then dropped.

## The fix

Select agent identities the way `ssh` documents. `ssh_config(5)` says `IdentityFile` may name a public key file, so ssh picks the matching private key already loaded in `ssh-agent(1)` when the private key is not readable locally. `pubkey_prepare()` in OpenSSH's `sshconnect2.c` states the order:

```
 * 1. certificates listed in the config file
 * 2. agent keys that are found in the config file
 * 3. other agent keys
```

and builds group 3 only under `!options.identities_only`.

The agent loop had nowhere to hold a preference list and could not reorder, because it authenticated inside the enumeration. It now splits into enumerate, plan, offer, and the two decisions that are not libssh2's become pure types that unit-test without an agent or a server:

- `SSHPublicKeyFile` reads the public half of an identity file: the named path, then its `.pub` sidecar, then `-cert.pub`, parsing `<type> <base64> [comment]` and rejecting anything whose blob does not describe the declared type. A private key file, a `known_hosts` line and malformed base64 all yield nothing.
- `AgentIdentityPreference.offerOrder` returns the indices to offer, in OpenSSH's order: certificates first, then other matches in config order, then the unmatched keys unless `IdentitiesOnly` is set. Matching is byte equality on the SSH wire blob, which is what `ssh-add -L` prints and what the `.pub` holds.

`AgentAuthenticator` gains `identityFiles` and `identitiesOnly`, and both construction sites pass them: the target and each SSH Agent jump hop.

A connection that names no identity file is untouched: the agent's own order stands and every key is offered, exactly as before. An identity file that names nothing readable is a different case and is reported rather than ignored, see below.

## Three failures that had no message

- `.agentNoMatchingIdentity` when identity files resolved to public keys and `IdentitiesOnly` left nothing to offer. The message names the file to check against the agent.
- `.agentIdentityFileUnreadable` when identity files were configured and none of them, their `.pub` sidecars or their `-cert.pub` parsed as a public key. Under `IdentitiesOnly` that is refused outright, because quietly offering all thirty keys there hands the user back the `MaxAuthTries` failure the file was set to avoid, with nothing to say why. Without `IdentitiesOnly`, `ssh` also falls back to the rest of the agent, so it logs a warning and proceeds.
- `.agentServerClosedConnection` when `libssh2_agent_userauth` returns `LIBSSH2_ERROR_SOCKET_DISCONNECT`. `MaxAuthTries` ends in an `SSH_MSG_DISCONNECT`, which `_libssh2_packet_add` answers by setting `socket_state` and returning exactly that code. The loop used to keep offering keys into a dead session and then report a plain rejection.

That last classification is deliberately narrow. libssh2's agent backend reports its own socket failures as `LIBSSH2_ERROR_SOCKET_SEND` and `LIBSSH2_ERROR_SOCKET_RECV`, so including either would make an agent that quit mid-signing indistinguishable from a server that hung up; `agent.c` only ever returns `SOCKET_DISCONNECT` from `agent_disconnect_unix`, which `libssh2_agent_userauth` never reaches.

All three end the authenticator chain, so an agent selection problem no longer falls through to keyboard-interactive and reports "SSH password rejected" on a connection with no password (#2583).

## The field that had to become visible

`SSHConfigResolver` lets a non-empty form key path override the config's `IdentityFile`, and `SSHTunnelFormState` never clears `privateKeyPath` when the method changes. The Key File field is hidden for SSH Agent, so after this change a stale, invisible value would silently decide which agent keys get offered.

The same field is now shown for SSH Agent as **Identity File**, which also delivers the per-connection identity the issue asks for as optional. It reuses `privateKeyPath`, already a verified CloudKit field (`SSHProfileSyncField.privateKeyPath`), so there is no schema change and no sync deployment.

## Verified

| Step | Verdict |
|---|---|
| `verify.sh generate` | PASS |
| `verify.sh build` | PASS |
| `verify.sh test` (10 SSH suites) | PASS, 0 failed |
| `verify.sh lint TablePro` | 0 SwiftLint violations |
| `verify.sh docs` | PASS |

Suites run: `SSHPublicKeyFileTests`, `AgentIdentityPreferenceTests`, `AgentAuthenticatorFailureTests`, `CompositeAuthenticatorFailureReportingTests`, `KeyboardInteractiveFailureReasonTests`, `AuthFailureReasonTests`, `CompositeAuthenticatorCancellationTests`, `BuildAuthenticatorTests`, `SSHConfigResolverTests`, `SSHTunnelErrorTests`.

New coverage: 12 cases over public key file reading, 9 over the offer order, and 5 driving the existing `FakeSSHAgent` unix socket with up to 30 identities. Those five pin that an identity file the agent lacks offers nothing under `IdentitiesOnly`, that a match reaches `libssh2_agent_userauth`, that an unreadable identity file refuses under `IdentitiesOnly` and still offers every key without it, and that no identity file at all keeps the old behaviour. `AuthFailureReasonTests` already loops `AuthFailureReason.allCases` asserting distinct non-empty messages, so all three new reasons are covered there.

`BuildAuthenticatorTests.sshAgentIgnoresResolvedIdentityFiles` was renamed to `sshAgentSelectsWithResolvedIdentityFiles`: its #2583 invariant (agent auth never adds a key-file authenticator) still holds and is still asserted, but its old name described behaviour this change deliberately reverses. It now also asserts the identity files and `IdentitiesOnly` actually reach the `AgentAuthenticator`.

The lint step reports one stale symbol, `CLAUDE.md:220: AXCell`. It is pre-existing on `main` and this branch does not touch `CLAUDE.md`.

No UI automation: both edited panes live inside the modal connection form's SSH pane, and `TableProUITests` has no coverage of that pane to extend.

Not verified end to end against a live agent: this machine has no `sshd` and no running agent, so the last mile is a real 1Password agent against a stock `sshd`. Everything the fix decides is covered by the pure types and the fake agent, and the libssh2 error classification is verified against libssh2 1.11.1's own `packet.c` and `agent.c` rather than a live server.

Reviewed by Codex, which raised three findings. All three are fixed here: the dropped filter on an unreadable identity file, the misclassification of local agent socket failures as a server disconnect, and troubleshooting steps that told the reader to run `ssh-add -L` against the shell's agent rather than the socket TablePro used.

https://claude.ai/code/session_019kGmKcZEWNuQN6m7TDAhrT
