### PR TITLE
feat(plugins)!: order SQL exports by foreign key dependency and report what the order cannot fix (#2517)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- PluginKit ABI 21. Every registry plugin needs rebuilding before or with this release.
+- Export summary reports the warnings an export produced, instead of a bare "Export completed". (#2517)
+
+### Fixed
+
+- Silent fallback order when foreign keys between the exported tables form a cycle. (#2517)
+- Foreign keys declared twice in a SQL export on MySQL, SQL Server, DuckDB, Snowflake, CockroachDB and Redshift, and as an unsupported `ALTER TABLE` on SQLite, libSQL and Cloudflare D1. (#2517)
+- Foreign keys missing from Redshift's reconstructed `CREATE TABLE`.
+
 ## [0.71.0] - 2026-09-02
 
 ### Added

--- a/Plugins/BeancountDriverPlugin/Info.plist
+++ b/Plugins/BeancountDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Beancount</string>

--- a/Plugins/BigQueryDriverPlugin/Info.plist
+++ b/Plugins/BigQueryDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 </dict>
 </plist>

--- a/Plugins/CSVExportPlugin/Info.plist
+++ b/Plugins/CSVExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>csv</string>

--- a/Plugins/CSVImportPlugin/Info.plist
+++ b/Plugins/CSVImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>csv</string>

--- a/Plugins/CassandraDriverPlugin/Info.plist
+++ b/Plugins/CassandraDriverPlugin/Info.plist
@@ -21,6 +21,6 @@
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).CassandraPlugin</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 </dict>
 </plist>

--- a/Plugins/ClickHouseDriverPlugin/Info.plist
+++ b/Plugins/ClickHouseDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>ClickHouse</string>

--- a/Plugins/CloudflareD1DriverPlugin/CloudflareD1PluginDriver.swift
+++ b/Plugins/CloudflareD1DriverPlugin/CloudflareD1PluginDriver.swift
@@ -315,6 +315,8 @@ final class CloudflareD1PluginDriver: PluginDatabaseDriver, @unchecked Sendable 
 
     var providesBulkForeignKeyFetch: Bool { true }
 
+    var tableDDLIncludesForeignKeys: Bool { true }
+
     func fetchAllForeignKeys(schema: String?) async throws -> [String: [PluginForeignKeyInfo]] {
         let query = """
             SELECT m.name AS table_name, p.id, p."table" AS referenced_table,

--- a/Plugins/CloudflareD1DriverPlugin/Info.plist
+++ b/Plugins/CloudflareD1DriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 </dict>
 </plist>

--- a/Plugins/DamengDriverPlugin/Info.plist
+++ b/Plugins/DamengDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Dameng</string>

--- a/Plugins/DuckDBDriverPlugin/DuckDBPlugin.swift
+++ b/Plugins/DuckDBDriverPlugin/DuckDBPlugin.swift
@@ -602,6 +602,8 @@ final class DuckDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         }
     }
 
+    var tableDDLIncludesForeignKeys: Bool { true }
+
     func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] {
         let schemaName = resolveSchema(schema)
         let catalog = try requireCatalog()

--- a/Plugins/DuckDBDriverPlugin/Info.plist
+++ b/Plugins/DuckDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 </dict>
 </plist>

--- a/Plugins/DynamoDBDriverPlugin/Info.plist
+++ b/Plugins/DynamoDBDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 </dict>
 </plist>

--- a/Plugins/ElasticsearchDriverPlugin/Info.plist
+++ b/Plugins/ElasticsearchDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.53.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 </dict>
 </plist>

--- a/Plugins/EtcdDriverPlugin/Info.plist
+++ b/Plugins/EtcdDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 </dict>
 </plist>

--- a/Plugins/JSONExportPlugin/Info.plist
+++ b/Plugins/JSONExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>json</string>

--- a/Plugins/JSONImportPlugin/Info.plist
+++ b/Plugins/JSONImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>json</string>

--- a/Plugins/KafkaDriverPlugin/Info.plist
+++ b/Plugins/KafkaDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Kafka</string>

--- a/Plugins/LibSQLDriverPlugin/Info.plist
+++ b/Plugins/LibSQLDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 </dict>
 </plist>

--- a/Plugins/LibSQLDriverPlugin/LibSQLPluginDriver.swift
+++ b/Plugins/LibSQLDriverPlugin/LibSQLPluginDriver.swift
@@ -389,6 +389,8 @@ final class LibSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     var providesBulkForeignKeyFetch: Bool { true }
 
+    var tableDDLIncludesForeignKeys: Bool { true }
+
     func fetchAllForeignKeys(schema: String?) async throws -> [String: [PluginForeignKeyInfo]] {
         let query = """
             SELECT m.name AS table_name, p.id, p."table" AS referenced_table,

--- a/Plugins/MQLExportPlugin/Info.plist
+++ b/Plugins/MQLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>mql</string>

--- a/Plugins/MSSQLDriverPlugin/Info.plist
+++ b/Plugins/MSSQLDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 </dict>
 </plist>

--- a/Plugins/MSSQLDriverPlugin/MSSQLPluginDriver+Schema.swift
+++ b/Plugins/MSSQLDriverPlugin/MSSQLPluginDriver+Schema.swift
@@ -331,6 +331,8 @@ extension MSSQLPluginDriver {
 
     var providesBulkForeignKeyFetch: Bool { true }
 
+    var tableDDLIncludesForeignKeys: Bool { true }
+
     func fetchAllForeignKeys(schema: String?) async throws -> [String: [PluginForeignKeyInfo]] {
         let esc = effectiveSchemaEscaped(schema)
         let sql = """

--- a/Plugins/MongoDBDriverPlugin/Info.plist
+++ b/Plugins/MongoDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 </dict>
 </plist>

--- a/Plugins/MySQLDriverPlugin/Info.plist
+++ b/Plugins/MySQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>MySQL</string>

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
@@ -501,6 +501,8 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     var providesBulkForeignKeyFetch: Bool { true }
 
+    var tableDDLIncludesForeignKeys: Bool { true }
+
     func fetchAllForeignKeys(schema: String?) async throws -> [String: [PluginForeignKeyInfo]] {
         let dbName = _activeDatabase
         let escapedDb = dbName.replacingOccurrences(of: "'", with: "''")

--- a/Plugins/OracleDriverPlugin/Info.plist
+++ b/Plugins/OracleDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 </dict>
 </plist>

--- a/Plugins/PostgreSQLDriverPlugin/CockroachPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/CockroachPluginDriver.swift
@@ -141,6 +141,8 @@ final class CockroachPluginDriver: LibPQBackedDriver, @unchecked Sendable {
         }
     }
 
+    var tableDDLIncludesForeignKeys: Bool { true }
+
     func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] {
         let safeTable = escapeLiteral(table)
         let schemaLiteral = escapeLiteral(schema ?? core.currentSchema)

--- a/Plugins/PostgreSQLDriverPlugin/Info.plist
+++ b/Plugins/PostgreSQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>PostgreSQL</string>

--- a/Plugins/PostgreSQLDriverPlugin/RedshiftPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/RedshiftPluginDriver.swift
@@ -362,6 +362,8 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
         return indexes
     }
 
+    var tableDDLIncludesForeignKeys: Bool { true }
+
     func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] {
         let safeTable = escapeLiteral(table)
         let query = """
@@ -455,8 +457,11 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
             throw LibPQPluginError(message: "Failed to fetch DDL for table '\(table)'", sqlState: nil, detail: nil)
         }
 
+        var parts = columnDefs
+        parts.append(contentsOf: try await foreignKeyClauses(table: table, schema: schema))
+
         let ddl = "CREATE TABLE \(quotedSchema).\(quotedTable) (\n  " +
-            columnDefs.joined(separator: ",\n  ") +
+            parts.joined(separator: ",\n  ") +
             "\n);"
 
         do {
@@ -477,6 +482,32 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
             Self.logger.debug("Could not fetch DISTKEY/SORTKEY info: \(error.localizedDescription)")
         }
         return ddl
+    }
+
+    /// `SHOW TABLE` declares foreign keys inline, so the reconstruction below has to as well or
+    /// `tableDDLIncludesForeignKeys` would be true of one path and false of the other, and a SQL
+    /// export would drop every constraint whenever the fallback ran. A failed lookup therefore
+    /// throws rather than returning nothing, because nothing here is indistinguishable from a
+    /// table that has no foreign keys.
+    private func foreignKeyClauses(table: String, schema: String?) async throws -> [String] {
+        let foreignKeys = try await fetchForeignKeys(table: table, schema: schema)
+        var orderedNames: [String] = []
+        var grouped: [String: [PluginForeignKeyInfo]] = [:]
+        for foreignKey in foreignKeys {
+            if grouped[foreignKey.name] == nil { orderedNames.append(foreignKey.name) }
+            grouped[foreignKey.name, default: []].append(foreignKey)
+        }
+        return orderedNames.compactMap { name in
+            guard let group = grouped[name], let first = group.first else { return nil }
+            let columns = group.map { quoteIdentifier($0.column) }.joined(separator: ", ")
+            let referencedColumns = group.map { quoteIdentifier($0.referencedColumn) }.joined(separator: ", ")
+            let referencedSchema = first.referencedSchema.flatMap { $0.isEmpty ? nil : $0 }
+            let referencedTable = referencedSchema.map {
+                "\(quoteIdentifier($0)).\(quoteIdentifier(first.referencedTable))"
+            } ?? quoteIdentifier(first.referencedTable)
+            return "CONSTRAINT \(quoteIdentifier(name)) FOREIGN KEY (\(columns))"
+                + " REFERENCES \(referencedTable) (\(referencedColumns))"
+        }
     }
 
     func fetchViewDefinition(view: String, schema: String?) async throws -> String {

--- a/Plugins/RedisDriverPlugin/Info.plist
+++ b/Plugins/RedisDriverPlugin/Info.plist
@@ -21,7 +21,7 @@
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).RedisPlugin</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Redis</string>

--- a/Plugins/SQLExportPlugin/Info.plist
+++ b/Plugins/SQLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>sql</string>

--- a/Plugins/SQLExportPlugin/SQLExportPlugin.swift
+++ b/Plugins/SQLExportPlugin/SQLExportPlugin.swift
@@ -35,6 +35,11 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
     var ddlFailures: [String] = []
     var metadataWarnings: [String] = []
 
+    /// The tables a foreign key cycle left the ordering unable to place. They keep the order the
+    /// export tree gave them, which is the only order left once no parent-first one exists, and
+    /// the dump says so rather than reading as if it were restorable with the checks on.
+    var tablesUnorderedByCycle: [String] = []
+
     /// A dump refers to its tables unqualified whenever every selected table lives in one
     /// container, which is what makes it restorable into any database. Qualifying became necessary
     /// only once an export could span two containers holding the same table name: unqualified there
@@ -77,6 +82,7 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
         ddlFailures = []
         metadataWarnings = []
         exportSpansContainers = false
+        tablesUnorderedByCycle = []
 
         let actualDestination: URL
         let gzipTempURL: URL?
@@ -105,6 +111,7 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
             let fkMap = await prefetchForeignKeys(tables: tables, dataSource: dataSource)
             let sortedTables = topologicallySort(tables, fkMap: fkMap)
             noteContainerSpan(of: sortedTables)
+            try writeDependencyCycleNote(to: fileHandle)
 
             try writeDropPhase(sortedTables: sortedTables, dataSource: dataSource, to: fileHandle)
             try await writeDependentTypesAndSequences(
@@ -146,7 +153,8 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
         var warnings: [String] = []
         if !ddlFailures.isEmpty {
             let failedTables = ddlFailures.joined(separator: ", ")
-            warnings.append("Could not fetch table structure for: \(failedTables)")
+            warnings.append(String(
+                format: String(localized: "Could not fetch table structure for: %@"), failedTables))
         }
         warnings.append(contentsOf: metadataWarnings)
         return ExportFormatResult(warnings: warnings)
@@ -200,8 +208,8 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
             }
         }
         if anyGroupFailed {
-            metadataWarnings.append(
-                "Could not fetch foreign keys; FK constraints may be missing from the export.")
+            metadataWarnings.append(String(localized:
+                "Could not fetch foreign keys, so foreign key constraints may be missing from the export."))
         }
         return merged
     }
@@ -224,8 +232,8 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
             }
         }
         if anyGroupFailed {
-            metadataWarnings.append(
-                "Could not fetch column metadata; identity columns and generated columns may not round-trip correctly.")
+            metadataWarnings.append(String(localized:
+                "Could not fetch column metadata, so identity and generated columns may not round-trip correctly."))
         }
         return merged
     }
@@ -237,8 +245,28 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
         let byIdentifier = Dictionary(
             tables.map { (node(for: $0).identifier, $0) },
             uniquingKeysWith: { first, _ in first })
-        let ordered = ForeignKeyTopologicalSort.ordered(tables.map { node(for: $0) }, foreignKeysByTable: fkMap)
-        return ordered.compactMap { byIdentifier[$0.identifier] }
+        let ordering = ForeignKeyTopologicalSort.order(tables.map { node(for: $0) }, foreignKeysByTable: fkMap)
+        tablesUnorderedByCycle = ordering.unorderedByCycle.map { $0.identifier }
+        return ordering.tables.compactMap { byIdentifier[$0.identifier] }
+    }
+
+    /// The warning states what the file is rather than prescribing a remedy, because the remedy is
+    /// not the same everywhere: `foreignKeyDisableStatements` is nil on SQL Server, Oracle,
+    /// Snowflake and DuckDB, so telling every user to import with the checks off would be wrong on
+    /// the engines that cannot turn them off.
+    private func writeDependencyCycleNote(to fileHandle: FileHandle) throws {
+        guard !tablesUnorderedByCycle.isEmpty else { return }
+        let names = tablesUnorderedByCycle.joined(separator: ", ")
+        metadataWarnings.append(String(
+            format: String(localized: """
+                Foreign keys between %@ reference each other, so no order puts every parent before \
+                its children. Those tables are written in the order they were listed, and the dump \
+                cannot be restored while foreign keys are enforced.
+                """),
+            names))
+        let note = "-- Warning: \(PluginExportUtilities.sanitizeForSQLComment(names)) reference each other.\n"
+            + "-- No parent-first order exists, so they are written in the order they were listed.\n\n"
+        try fileHandle.write(contentsOf: note.toUTF8Data())
     }
 
     private func writeDropPhase(
@@ -361,13 +389,19 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
         to fileHandle: FileHandle
     ) throws {
         var emittedAnything = false
-        for table in sortedTables where optionValue(table, at: 0) {
-            let fks = fkMap[node(for: table).identifier] ?? []
-            let grouped = groupForeignKeysByConstraint(fks)
-            for group in grouped {
-                let alter = renderAddConstraintFK(table: table, group: group, dataSource: dataSource)
-                try fileHandle.write(contentsOf: "\(alter)\n".toUTF8Data())
-                emittedAnything = true
+        /// A driver that hands back the server's own CREATE statement has already declared these
+        /// constraints inline, so adding them again names each one twice: MySQL and SQL Server
+        /// reject the duplicate, and SQLite has no ADD CONSTRAINT to reject it with. The phase
+        /// exists for the drivers whose DDL leaves foreign keys out, PostgreSQL and Oracle.
+        if !dataSource.tableDDLIncludesForeignKeys {
+            for table in sortedTables where optionValue(table, at: 0) {
+                let fks = fkMap[node(for: table).identifier] ?? []
+                let grouped = groupForeignKeysByConstraint(fks)
+                for group in grouped {
+                    let alter = renderAddConstraintFK(table: table, group: group, dataSource: dataSource)
+                    try fileHandle.write(contentsOf: "\(alter)\n".toUTF8Data())
+                    emittedAnything = true
+                }
             }
         }
 
@@ -425,11 +459,13 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
         let containers = Set(tables.map { $0.containerName ?? "" })
         exportSpansContainers = containers.count > 1
         guard exportSpansContainers else { return }
-        metadataWarnings.append(
-            "Warning: this export spans \(containers.count) databases or schemas. Table references are "
-                + "qualified, but CREATE TABLE comes from the server unqualified, so restore it into the "
-                + "matching database or schema."
-        )
+        metadataWarnings.append(String(
+            format: String(localized: """
+                This export spans %lld databases or schemas. Table references are qualified, but \
+                CREATE TABLE comes from the server unqualified, so restore it into the matching \
+                database or schema.
+                """),
+            Int64(containers.count)))
     }
 
     private func qualifiedRef(

--- a/Plugins/SQLImportPlugin/Info.plist
+++ b/Plugins/SQLImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>sql</string>

--- a/Plugins/SQLiteDriverPlugin/Info.plist
+++ b/Plugins/SQLiteDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>SQLite</string>

--- a/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
+++ b/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
@@ -873,6 +873,8 @@ final class SQLitePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     var providesBulkForeignKeyFetch: Bool { true }
 
+    var tableDDLIncludesForeignKeys: Bool { true }
+
     func fetchAllForeignKeys(schema: String?) async throws -> [String: [PluginForeignKeyInfo]] {
         let query = """
             SELECT m.name AS table_name, p.id, p."table" AS referenced_table,

--- a/Plugins/SnowflakeDriverPlugin/Info.plist
+++ b/Plugins/SnowflakeDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.48.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 </dict>
 </plist>

--- a/Plugins/SnowflakeDriverPlugin/SnowflakePluginDriver.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakePluginDriver.swift
@@ -450,6 +450,8 @@ final class SnowflakePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         return SnowflakeSchemaQueries.parseClusterBy(clusterBy)
     }
 
+    var tableDDLIncludesForeignKeys: Bool { true }
+
     func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] {
         let database = connection?.currentDatabase
         let targetSchema = schema ?? connection?.currentSchema

--- a/Plugins/SurrealDBDriverPlugin/Info.plist
+++ b/Plugins/SurrealDBDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>SurrealDB</string>

--- a/Plugins/TableProPluginKit/ForeignKeyTopologicalSort.swift
+++ b/Plugins/TableProPluginKit/ForeignKeyTopologicalSort.swift
@@ -18,23 +18,46 @@ public enum ForeignKeyTopologicalSort {
         }
     }
 
+    /// The ordering, and the tables a dependency cycle left it unable to place. A caller that
+    /// writes a script the order has to be right for reads `unorderedByCycle` to say so, because
+    /// `tables` alone cannot distinguish a parent-first order from a partial one.
+    public struct Ordering: Sendable {
+        public let tables: [Table]
+        public let unorderedByCycle: [Table]
+
+        public init(tables: [Table], unorderedByCycle: [Table]) {
+            self.tables = tables
+            self.unorderedByCycle = unorderedByCycle
+        }
+    }
+
     /// Orders `tables` so a parent precedes every child that references it. Identity is
     /// `Table.identifier` throughout: `foreignKeysByTable` is keyed by it, and a foreign key
     /// that names no `referencedSchema` points inside the referencing table's own schema.
-    /// A dependency cycle falls back to the tables the traversal could not place, in identifier
-    /// order, so the result holds every distinct input table exactly once.
+    /// Tables caught in a cycle keep the order they were given, and everything outside the cycle
+    /// is still ordered around them, so the result holds every distinct input table exactly once.
     public static func ordered(
         _ tables: [Table],
         foreignKeysByTable: [String: [PluginForeignKeyInfo]],
         childrenFirst: Bool = false
     ) -> [Table] {
+        order(tables, foreignKeysByTable: foreignKeysByTable, childrenFirst: childrenFirst).tables
+    }
+
+    /// `ordered`, plus the tables that sit inside a foreign key cycle. Tables are grouped into
+    /// strongly connected components and the component graph is ordered, so a table that merely
+    /// descends from a cycle still lands after it and is not reported as part of it. Only a
+    /// component holding more than one table is unorderable, and its members keep their input order.
+    public static func order(
+        _ tables: [Table],
+        foreignKeysByTable: [String: [PluginForeignKeyInfo]],
+        childrenFirst: Bool = false
+    ) -> Ordering {
         let nodes = distinct(tables)
-        guard nodes.count > 1 else { return nodes }
+        guard nodes.count > 1 else { return Ordering(tables: nodes, unorderedByCycle: []) }
 
         let byIdentifier = Dictionary(nodes.map { ($0.identifier, $0) }, uniquingKeysWith: { first, _ in first })
-        var indegree: [String: Int] = [:]
         var children: [String: Set<String>] = [:]
-        for node in nodes { indegree[node.identifier] = 0 }
 
         for node in nodes {
             let identifier = node.identifier
@@ -48,30 +71,112 @@ public enum ForeignKeyTopologicalSort {
                       byIdentifier[parent] != nil,
                       seenParents.insert(parent).inserted else { continue }
                 children[parent, default: []].insert(identifier)
-                indegree[identifier, default: 0] += 1
             }
         }
 
-        var queue = nodes.map { $0.identifier }.filter { (indegree[$0] ?? 0) == 0 }.sorted()
+        let components = stronglyConnectedComponents(of: nodes, children: children)
+        let componentOf = Dictionary(
+            components.enumerated().flatMap { index, members in members.map { ($0, index) } },
+            uniquingKeysWith: { first, _ in first })
+
+        var componentIndegree = [Int](repeating: 0, count: components.count)
+        var componentChildren: [Set<Int>] = Array(repeating: [], count: components.count)
+        for (parent, kids) in children {
+            guard let parentComponent = componentOf[parent] else { continue }
+            for kid in kids {
+                guard let kidComponent = componentOf[kid],
+                      kidComponent != parentComponent,
+                      componentChildren[parentComponent].insert(kidComponent).inserted else { continue }
+                componentIndegree[kidComponent] += 1
+            }
+        }
+
+        let componentKey = components.map { $0.min() ?? "" }
+        var queue = (0 ..< components.count)
+            .filter { componentIndegree[$0] == 0 }
+            .sorted { componentKey[$0] < componentKey[$1] }
         var placed: [String] = []
+        var unordered: [String] = []
         while !queue.isEmpty {
             let head = queue.removeFirst()
-            placed.append(head)
-            for child in (children[head] ?? []).sorted() {
-                indegree[child] = (indegree[child] ?? 0) - 1
-                if indegree[child] == 0 {
+            placed.append(contentsOf: components[head])
+            if components[head].count > 1 {
+                unordered.append(contentsOf: components[head])
+            }
+            for child in componentChildren[head].sorted(by: { componentKey[$0] < componentKey[$1] }) {
+                componentIndegree[child] -= 1
+                if componentIndegree[child] == 0 {
                     queue.append(child)
                 }
             }
         }
 
-        if placed.count < nodes.count {
-            let settled = Set(placed)
-            placed += nodes.map { $0.identifier }.filter { !settled.contains($0) }.sorted()
+        let resolved = placed.compactMap { byIdentifier[$0] }
+        return Ordering(
+            tables: childrenFirst ? resolved.reversed() : resolved,
+            unorderedByCycle: unordered.compactMap { byIdentifier[$0] }
+        )
+    }
+
+    /// Tarjan, iterative so a deep dependency chain cannot overflow the stack. Members come back
+    /// in the order `nodes` gave them, and a component of more than one table is a cycle: nothing
+    /// in it can be written before the rest. A table that merely descends from one is its own
+    /// component and still lands after it, which is why the two are reported separately.
+    private static func stronglyConnectedComponents(
+        of nodes: [Table],
+        children: [String: Set<String>]
+    ) -> [[String]] {
+        let order = Dictionary(uniqueKeysWithValues: nodes.enumerated().map { ($1.identifier, $0) })
+        var index: [String: Int] = [:]
+        var lowLink: [String: Int] = [:]
+        var onStack: Set<String> = []
+        var stack: [String] = []
+        var nextIndex = 0
+        var components: [[String]] = []
+
+        for root in nodes.map({ $0.identifier }) where index[root] == nil {
+            var work: [(node: String, next: Int, neighbours: [String])] = [
+                (root, 0, (children[root] ?? []).sorted())
+            ]
+            index[root] = nextIndex
+            lowLink[root] = nextIndex
+            nextIndex += 1
+            stack.append(root)
+            onStack.insert(root)
+
+            while let frame = work.last {
+                if frame.next < frame.neighbours.count {
+                    work[work.count - 1].next += 1
+                    let neighbour = frame.neighbours[frame.next]
+                    if index[neighbour] == nil {
+                        index[neighbour] = nextIndex
+                        lowLink[neighbour] = nextIndex
+                        nextIndex += 1
+                        stack.append(neighbour)
+                        onStack.insert(neighbour)
+                        work.append((neighbour, 0, (children[neighbour] ?? []).sorted()))
+                    } else if onStack.contains(neighbour) {
+                        lowLink[frame.node] = min(lowLink[frame.node] ?? 0, index[neighbour] ?? 0)
+                    }
+                    continue
+                }
+
+                work.removeLast()
+                if let parent = work.last?.node {
+                    lowLink[parent] = min(lowLink[parent] ?? 0, lowLink[frame.node] ?? 0)
+                }
+                guard lowLink[frame.node] == index[frame.node] else { continue }
+                var members: [String] = []
+                while let member = stack.popLast() {
+                    onStack.remove(member)
+                    members.append(member)
+                    if member == frame.node { break }
+                }
+                components.append(members.sorted { (order[$0] ?? 0) < (order[$1] ?? 0) })
+            }
         }
 
-        let resolved = placed.compactMap { byIdentifier[$0] }
-        return childrenFirst ? resolved.reversed() : resolved
+        return components
     }
 
     private static func distinct(_ tables: [Table]) -> [Table] {

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -139,6 +139,7 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
     func sampleFieldPaths(table: String, schema: String?, limit: Int) async throws -> [PluginFieldPath]
     func fetchAllForeignKeys(schema: String?) async throws -> [String: [PluginForeignKeyInfo]]
     var providesBulkForeignKeyFetch: Bool { get }
+    var tableDDLIncludesForeignKeys: Bool { get }
     func fetchAllIndexes(schema: String?) async throws -> [String: [PluginIndexInfo]]
     var providesBulkIndexFetch: Bool { get }
     func fetchAllTableMetadata(schema: String?) async throws -> [String: PluginTableMetadata]
@@ -457,6 +458,16 @@ public extension PluginDatabaseDriver {
     func sampleFieldPaths(table: String, schema: String?, limit: Int) async throws -> [PluginFieldPath] {
         []
     }
+
+    /// Answers whether `fetchTableDDL` already carries the table's FOREIGN KEY constraints, which
+    /// every driver returning the server's own CREATE statement does. A SQL export defers foreign
+    /// keys to `ALTER TABLE ... ADD CONSTRAINT` after the data, so it must skip that for a driver
+    /// answering `true` or the dump declares each constraint twice, and SQLite has no such
+    /// statement to declare it with at all.
+    ///
+    /// Defaults to `false`, which is the behaviour every driver shipped before this existed: the
+    /// export adds the foreign keys itself. A driver whose DDL carries them overrides it.
+    var tableDDLIncludesForeignKeys: Bool { false }
 
     /// Answers whether `fetchAllForeignKeys` is a single query rather than the N+1 default below.
     /// The app reads this before fetching a whole schema's foreign keys up front, so a driver that

--- a/Plugins/TableProPluginKit/PluginExportDataSource.swift
+++ b/Plugins/TableProPluginKit/PluginExportDataSource.swift
@@ -14,6 +14,7 @@ public protocol PluginExportDataSource: AnyObject, Sendable {
     func fetchAllColumns(databaseName: String) async throws -> [String: [PluginColumnInfo]]
     func fetchForeignKeys(table: String, databaseName: String) async throws -> [PluginForeignKeyInfo]
     func fetchAllForeignKeys(databaseName: String) async throws -> [String: [PluginForeignKeyInfo]]
+    var tableDDLIncludesForeignKeys: Bool { get }
 }
 
 public extension PluginExportDataSource {
@@ -23,4 +24,9 @@ public extension PluginExportDataSource {
     func fetchAllColumns(databaseName: String) async throws -> [String: [PluginColumnInfo]] { [:] }
     func fetchForeignKeys(table: String, databaseName: String) async throws -> [PluginForeignKeyInfo] { [] }
     func fetchAllForeignKeys(databaseName: String) async throws -> [String: [PluginForeignKeyInfo]] { [:] }
+
+    /// Mirrors `PluginDatabaseDriver.tableDDLIncludesForeignKeys` for the export side: `true` means
+    /// `fetchTableDDL` already declares them, so a format that defers foreign keys must not add
+    /// them a second time.
+    var tableDDLIncludesForeignKeys: Bool { false }
 }

--- a/Plugins/TeradataDriverPlugin/Info.plist
+++ b/Plugins/TeradataDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 </dict>
 </plist>

--- a/Plugins/TrinoDriverPlugin/Info.plist
+++ b/Plugins/TrinoDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 </dict>
 </plist>

--- a/Plugins/XLSXExportPlugin/Info.plist
+++ b/Plugins/XLSXExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>20</integer>
+	<integer>21</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>xlsx</string>

--- a/TablePro/Core/Plugins/ExportDataSourceAdapter.swift
+++ b/TablePro/Core/Plugins/ExportDataSourceAdapter.swift
@@ -113,6 +113,10 @@ final class ExportDataSourceAdapter: PluginExportDataSource, @unchecked Sendable
         return try await pluginDriver.fetchAllForeignKeys(schema: exportSchema(for: databaseName))
     }
 
+    var tableDDLIncludesForeignKeys: Bool {
+        pluginDriver?.tableDDLIncludesForeignKeys ?? false
+    }
+
     // MARK: - Helpers
 
     /// The export tree names every group after a schema on a schema-aware engine and after a

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -23,7 +23,7 @@ final class PluginManager {
     /// v19 host. Measured on a rebuilt CassandraDriver, which implements none of them and imports
     /// all six. Left at 19, such a plugin passes `validateBundleVersions` in a shipped v19 app and
     /// then fails `Bundle.loadAndReturnError`; at 20 that app refuses it and says to update.
-    nonisolated static let currentPluginKitVersion = 20
+    nonisolated static let currentPluginKitVersion = 21
 
     /// Still 19, so every plugin already published for the previous release keeps loading.
     nonisolated static let minimumCompatiblePluginKitVersion = 19

--- a/TablePro/Core/Services/Export/ExportService.swift
+++ b/TablePro/Core/Services/Export/ExportService.swift
@@ -50,7 +50,7 @@ struct ExportState {
     var totalRows: Int = 0
     var statusMessage: String = ""
     var errorMessage: String?
-    var warningMessage: String?
+    var warnings: [String] = []
 }
 
 // MARK: - Export Service
@@ -171,9 +171,7 @@ final class ExportService {
 
         state.processedRows = progress.processedRows
 
-        if !result.warnings.isEmpty {
-            state.warningMessage = result.warnings.joined(separator: "\n")
-        }
+        state.warnings = result.warnings
     }
 
     // MARK: - Statement Timeout
@@ -269,9 +267,7 @@ final class ExportService {
 
         state.processedRows = progress.processedRows
 
-        if !result.warnings.isEmpty {
-            state.warningMessage = result.warnings.joined(separator: "\n")
-        }
+        state.warnings = result.warnings
     }
 
     func exportStreamingQuery(
@@ -341,9 +337,7 @@ final class ExportService {
 
         state.processedRows = progress.processedRows
 
-        if !result.warnings.isEmpty {
-            state.warningMessage = result.warnings.joined(separator: "\n")
-        }
+        state.warnings = result.warnings
     }
 
     // MARK: - Row Count Fetching

--- a/TablePro/Views/Components/TransferResultAlert.swift
+++ b/TablePro/Views/Components/TransferResultAlert.swift
@@ -18,16 +18,23 @@ internal enum TransferResultAlert {
         case close
     }
 
+    /// An export that finished with something to report says so here, the way an import already
+    /// does. The suppression checkbox is offered only on a clean run: the alert the user turned
+    /// off is the routine one, and hiding a warning behind that switch loses it for good.
     internal static func presentExportSuccess(
+        warnings: [String],
         window: NSWindow?,
         completion: @escaping @MainActor (ExportChoice) -> Void
     ) {
         let alert = NSAlert()
-        alert.messageText = String(localized: "Export completed")
-        alert.alertStyle = .informational
+        alert.messageText = warnings.isEmpty
+            ? String(localized: "Export completed")
+            : String(localized: "Export completed with warnings")
+        alert.alertStyle = warnings.isEmpty ? .informational : .warning
+        alert.informativeText = warnings.joined(separator: "\n\n")
         alert.addButton(withTitle: String(localized: "Open in Finder"))
         alert.addButton(withTitle: String(localized: "Done"))
-        alert.showsSuppressionButton = true
+        alert.showsSuppressionButton = warnings.isEmpty
         alert.suppressionButton?.title = String(localized: "Do not show this again")
 
         let deliver: @MainActor (NSApplication.ModalResponse) -> Void = { response in

--- a/TablePro/Views/Export/ExportDialog.swift
+++ b/TablePro/Views/Export/ExportDialog.swift
@@ -161,7 +161,10 @@ struct ExportDialog: View {
         }
         .onChange(of: showSuccessDialog) { _, isShowing in
             guard isShowing else { return }
-            TransferResultAlert.presentExportSuccess(window: hostWindow) { choice in
+            TransferResultAlert.presentExportSuccess(
+                warnings: exportService?.state.warnings ?? [],
+                window: hostWindow
+            ) { choice in
                 showSuccessDialog = false
                 if choice == .openFolder {
                     openContainingFolder()
@@ -838,7 +841,7 @@ struct ExportDialog: View {
             isExporting = false
             recordSuccessfulExport()
 
-            if hideSuccessDialog {
+            if hideSuccessDialog, exportService?.state.warnings.isEmpty ?? true {
                 isPresented = false
             } else {
                 showSuccessDialog = true
@@ -905,7 +908,7 @@ struct ExportDialog: View {
             isExporting = false
             recordSuccessfulExport()
 
-            if hideSuccessDialog {
+            if hideSuccessDialog, exportService?.state.warnings.isEmpty ?? true {
                 isPresented = false
             } else {
                 showSuccessDialog = true

--- a/TableProTests/Core/Compare/ForeignKeyTopologicalSortTests.swift
+++ b/TableProTests/Core/Compare/ForeignKeyTopologicalSortTests.swift
@@ -110,6 +110,49 @@ struct ForeignKeyTopologicalSortTests {
         #expect(Set(identifiers) == ["public.orders", "public.customers", "sales.orders"])
     }
 
+    @Test("A cycle names its own members, in the order they were given")
+    func cycleNamesItsMembersInInputOrder() {
+        let ordering = ForeignKeyTopologicalSort.order(
+            [table("orders", "public"), table("regions", "public"), table("customers", "public")],
+            foreignKeysByTable: [
+                "public.orders": [foreignKey(to: "customers", schema: "public")],
+                "public.customers": [foreignKey(to: "orders", schema: "public")]
+            ]
+        )
+
+        #expect(ordering.unorderedByCycle.map { $0.identifier } == ["public.orders", "public.customers"])
+        #expect(Set(ordering.tables.map { $0.identifier })
+            == ["public.orders", "public.customers", "public.regions"])
+    }
+
+    @Test("A table that only descends from a cycle is ordered after it, not reported inside it")
+    func descendantOfACycleIsOrderedAfterIt() {
+        let ordering = ForeignKeyTopologicalSort.order(
+            [table("audit", "public"), table("orders", "public"), table("customers", "public")],
+            foreignKeysByTable: [
+                "public.orders": [foreignKey(to: "customers", schema: "public")],
+                "public.customers": [foreignKey(to: "orders", schema: "public")],
+                "public.audit": [foreignKey(to: "orders", schema: "public")]
+            ]
+        )
+        let identifiers = ordering.tables.map { $0.identifier }
+
+        #expect(ordering.unorderedByCycle.map { $0.identifier } == ["public.orders", "public.customers"])
+        #expect(identifiers.last == "public.audit")
+        #expect(identifiers.count == 3)
+    }
+
+    @Test("An acyclic graph strands nothing")
+    func acyclicGraphStrandsNothing() {
+        let ordering = ForeignKeyTopologicalSort.order(
+            [table("orders", "public"), table("customers", "public")],
+            foreignKeysByTable: ["public.orders": [foreignKey(to: "customers", schema: "public")]]
+        )
+
+        #expect(ordering.unorderedByCycle.isEmpty)
+        #expect(ordering.tables.map { $0.identifier } == ["public.customers", "public.orders"])
+    }
+
     @Test("A self-referencing foreign key does not strand its table")
     func selfReferenceDoesNotStrandTheTable() {
         let ordered = ForeignKeyTopologicalSort.ordered(

--- a/TableProTests/Core/Services/ExportStateTests.swift
+++ b/TableProTests/Core/Services/ExportStateTests.swift
@@ -23,7 +23,7 @@ struct ExportStateTests {
         #expect(state.totalRows == 0)
         #expect(state.statusMessage == "")
         #expect(state.errorMessage == nil)
-        #expect(state.warningMessage == nil)
+        #expect(state.warnings.isEmpty)
     }
 
     @Test("Value semantics — copy is independent")
@@ -83,7 +83,7 @@ struct ExportStateTests {
         state.errorMessage = "Some error"
         #expect(state.errorMessage == "Some error")
 
-        state.warningMessage = "Some warning"
-        #expect(state.warningMessage == "Some warning")
+        state.warnings = ["Some warning"]
+        #expect(state.warnings == ["Some warning"])
     }
 }

--- a/TableProTests/Plugins/SQLExportForeignKeyOrderTests.swift
+++ b/TableProTests/Plugins/SQLExportForeignKeyOrderTests.swift
@@ -1,0 +1,235 @@
+//
+//  SQLExportForeignKeyOrderTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@Suite("SQL export foreign key ordering")
+struct SQLExportForeignKeyOrderTests {
+    private final class StubExportDataSource: PluginExportDataSource, @unchecked Sendable {
+        let databaseTypeId: String
+        let tableDDLIncludesForeignKeys: Bool
+        let foreignKeys: [String: [PluginForeignKeyInfo]]
+        let ddlByTable: [String: String]
+
+        init(
+            databaseTypeId: String,
+            tableDDLIncludesForeignKeys: Bool,
+            foreignKeys: [String: [PluginForeignKeyInfo]] = [:],
+            ddlByTable: [String: String] = [:]
+        ) {
+            self.databaseTypeId = databaseTypeId
+            self.tableDDLIncludesForeignKeys = tableDDLIncludesForeignKeys
+            self.foreignKeys = foreignKeys
+            self.ddlByTable = ddlByTable
+        }
+
+        func streamRows(table: String, databaseName: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
+            AsyncThrowingStream { continuation in
+                continuation.yield(.header(PluginStreamHeader(columns: ["id"], columnTypeNames: ["INTEGER"])))
+                continuation.yield(.rows([[.text("1")]]))
+                continuation.finish()
+            }
+        }
+
+        func fetchTableDDL(table: String, databaseName: String) async throws -> String {
+            ddlByTable[table] ?? "CREATE TABLE \(table) (id INTEGER)"
+        }
+
+        func execute(query: String) async throws -> PluginQueryResult {
+            PluginQueryResult(columns: [], columnTypeNames: [], rows: [], rowsAffected: 0, executionTime: 0)
+        }
+
+        func quoteIdentifier(_ identifier: String) -> String {
+            "\"\(identifier.replacingOccurrences(of: "\"", with: "\"\""))\""
+        }
+
+        func escapeStringLiteral(_ value: String) -> String {
+            value.replacingOccurrences(of: "'", with: "''")
+        }
+
+        func fetchApproximateRowCount(table: String, databaseName: String) async throws -> Int? { nil }
+
+        func fetchAllForeignKeys(databaseName: String) async throws -> [String: [PluginForeignKeyInfo]] {
+            foreignKeys
+        }
+    }
+
+    private func table(_ name: String) -> PluginExportTable {
+        PluginExportTable(name: name, databaseName: "", tableType: "table", optionValues: [true, true, true], schema: nil)
+    }
+
+    private func foreignKey(_ name: String, from column: String, to referencedTable: String) -> PluginForeignKeyInfo {
+        PluginForeignKeyInfo(
+            name: name,
+            column: column,
+            referencedTable: referencedTable,
+            referencedColumn: "id"
+        )
+    }
+
+    private func runExport(
+        tables: [PluginExportTable],
+        dataSource: StubExportDataSource
+    ) async throws -> (dump: String, result: ExportFormatResult) {
+        let plugin = SQLExportPlugin()
+        /// The plugin loads its settings from the app's own defaults, so a developer who has
+        /// turned gzip on would otherwise get a compressed file the assertions cannot read.
+        let storedSettings = plugin.settings
+        plugin.settings = SQLExportOptions()
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).sql")
+        defer {
+            plugin.settings = storedSettings
+            try? FileManager.default.removeItem(at: destination)
+        }
+
+        let result = try await plugin.export(
+            tables: tables,
+            dataSource: dataSource,
+            destination: destination,
+            progress: PluginExportProgress(progress: Progress(totalUnitCount: 1))
+        )
+        let dump = try String(contentsOf: destination, encoding: .utf8)
+        return (dump, result)
+    }
+
+    private func createOrder(in dump: String, of tables: [String]) -> [String] {
+        tables
+            .compactMap { name -> (String, Int)? in
+                guard let range = dump.range(of: "-- Table: \(name)\n") else { return nil }
+                return (name, dump.distance(from: dump.startIndex, to: range.lowerBound))
+            }
+            .sorted { $0.1 < $1.1 }
+            .map(\.0)
+    }
+
+    @Test("A parent's CREATE precedes its child's however the tree listed them")
+    func parentIsCreatedBeforeChild() async throws {
+        let source = StubExportDataSource(
+            databaseTypeId: "PostgreSQL",
+            tableDDLIncludesForeignKeys: false,
+            foreignKeys: ["orders": [foreignKey("fk_orders_customer", from: "customer_id", to: "customers")]]
+        )
+
+        let (dump, _) = try await runExport(tables: [table("orders"), table("customers")], dataSource: source)
+
+        #expect(createOrder(in: dump, of: ["orders", "customers"]) == ["customers", "orders"])
+    }
+
+    @Test("A child is dropped before the parent it references")
+    func childIsDroppedBeforeParent() async throws {
+        let source = StubExportDataSource(
+            databaseTypeId: "PostgreSQL",
+            tableDDLIncludesForeignKeys: false,
+            foreignKeys: ["orders": [foreignKey("fk_orders_customer", from: "customer_id", to: "customers")]]
+        )
+
+        let (dump, _) = try await runExport(tables: [table("customers"), table("orders")], dataSource: source)
+
+        let dropOrders = try #require(dump.range(of: "DROP TABLE IF EXISTS \"orders\""))
+        let dropCustomers = try #require(dump.range(of: "DROP TABLE IF EXISTS \"customers\""))
+        #expect(dropOrders.lowerBound < dropCustomers.lowerBound)
+    }
+
+    @Test("A dependency cycle is reported in the warnings and in the dump")
+    func cycleIsReported() async throws {
+        let source = StubExportDataSource(
+            databaseTypeId: "PostgreSQL",
+            tableDDLIncludesForeignKeys: false,
+            foreignKeys: [
+                "orders": [foreignKey("fk_orders_customer", from: "customer_id", to: "customers")],
+                "customers": [foreignKey("fk_customers_order", from: "last_order_id", to: "orders")]
+            ]
+        )
+
+        let (dump, result) = try await runExport(tables: [table("orders"), table("customers")], dataSource: source)
+
+        #expect(result.warnings.contains { $0.contains("orders") && $0.contains("customers") })
+        #expect(dump.contains("-- Warning: orders, customers reference each other."))
+    }
+
+    @Test("A cycle keeps the tables in the order the export listed them")
+    func cycleFallsBackToTheGivenOrder() async throws {
+        let source = StubExportDataSource(
+            databaseTypeId: "PostgreSQL",
+            tableDDLIncludesForeignKeys: false,
+            foreignKeys: [
+                "orders": [foreignKey("fk_orders_customer", from: "customer_id", to: "customers")],
+                "customers": [foreignKey("fk_customers_order", from: "last_order_id", to: "orders")]
+            ]
+        )
+
+        let (dump, _) = try await runExport(tables: [table("orders"), table("customers")], dataSource: source)
+
+        #expect(createOrder(in: dump, of: ["orders", "customers"]) == ["orders", "customers"])
+    }
+
+    @Test("An acyclic export reports no warnings")
+    func acyclicExportIsSilent() async throws {
+        let source = StubExportDataSource(
+            databaseTypeId: "PostgreSQL",
+            tableDDLIncludesForeignKeys: false,
+            foreignKeys: ["orders": [foreignKey("fk_orders_customer", from: "customer_id", to: "customers")]]
+        )
+
+        let (dump, result) = try await runExport(tables: [table("orders"), table("customers")], dataSource: source)
+
+        #expect(result.warnings.isEmpty)
+        #expect(!dump.contains("-- Warning:"))
+    }
+
+    @Test("A table that only descends from a cycle is not reported as part of it")
+    func descendantOfACycleIsNotReportedAsACycleMember() async throws {
+        let source = StubExportDataSource(
+            databaseTypeId: "PostgreSQL",
+            tableDDLIncludesForeignKeys: false,
+            foreignKeys: [
+                "orders": [foreignKey("fk_orders_customer", from: "customer_id", to: "customers")],
+                "customers": [foreignKey("fk_customers_order", from: "last_order_id", to: "orders")],
+                "audit": [foreignKey("fk_audit_order", from: "order_id", to: "orders")]
+            ]
+        )
+
+        let (dump, result) = try await runExport(
+            tables: [table("audit"), table("orders"), table("customers")], dataSource: source)
+
+        #expect(result.warnings.contains { $0.contains("orders") && !$0.contains("audit") })
+        #expect(createOrder(in: dump, of: ["audit", "orders", "customers"]).last == "audit")
+    }
+
+    @Test("A driver whose DDL omits foreign keys gets them back as ALTER TABLE")
+    func deferredForeignKeysAreAdded() async throws {
+        let source = StubExportDataSource(
+            databaseTypeId: "PostgreSQL",
+            tableDDLIncludesForeignKeys: false,
+            foreignKeys: ["orders": [foreignKey("fk_orders_customer", from: "customer_id", to: "customers")]]
+        )
+
+        let (dump, _) = try await runExport(tables: [table("orders"), table("customers")], dataSource: source)
+
+        #expect(dump.contains(
+            "ALTER TABLE \"orders\" ADD CONSTRAINT \"fk_orders_customer\" "
+                + "FOREIGN KEY (\"customer_id\") REFERENCES \"customers\" (\"id\");"))
+    }
+
+    @Test("A driver whose DDL carries foreign keys does not declare them a second time")
+    func inlineForeignKeysAreNotDuplicated() async throws {
+        let source = StubExportDataSource(
+            databaseTypeId: "SQLite",
+            tableDDLIncludesForeignKeys: true,
+            foreignKeys: ["orders": [foreignKey("fk_orders_0", from: "customer_id", to: "customers")]],
+            ddlByTable: [
+                "orders": "CREATE TABLE orders (id INTEGER, customer_id INTEGER REFERENCES customers(id))"
+            ]
+        )
+
+        let (dump, _) = try await runExport(tables: [table("orders"), table("customers")], dataSource: source)
+
+        #expect(!dump.contains("ADD CONSTRAINT"))
+        #expect(dump.contains("REFERENCES customers(id)"))
+    }
+}

--- a/docs/development/plugin-development.mdx
+++ b/docs/development/plugin-development.mdx
@@ -13,7 +13,7 @@ A plugin is a macOS loadable bundle target with `WRAPPER_EXTENSION = tableplugin
 
 | Key | Type | Required | Purpose |
 |-----|------|----------|---------|
-| `TableProPluginKitVersion` | integer | Yes | The PluginKit ABI the plugin was built against. Current value: 20 |
+| `TableProPluginKitVersion` | integer | Yes | The PluginKit ABI the plugin was built against. Current value: 21 |
 | `TableProProvidesDatabaseTypeIds` | array of strings | Recommended | Database type IDs the plugin serves, which is what makes lazy loading possible |
 | `CFBundleShortVersionString` | string | Yes | Plugin version, read by registry update checks |
 | `TableProMinAppVersion` | string | No | The loader rejects the plugin on an older app |

--- a/docs/development/plugin-registry.mdx
+++ b/docs/development/plugin-registry.mdx
@@ -68,13 +68,13 @@ Themes carry no native code, so they match on architecture alone.
   "binaries": [
     {
       "architecture": "arm64",
-      "pluginKitVersion": 20,
+      "pluginKitVersion": 21,
       "downloadURL": "https://github.com/TableProApp/TablePro/releases/download/plugin-oracle-v1.0.26/OracleDriver-arm64.zip",
       "sha256": "<sha256>"
     },
     {
       "architecture": "x86_64",
-      "pluginKitVersion": 20,
+      "pluginKitVersion": 21,
       "downloadURL": "https://github.com/TableProApp/TablePro/releases/download/plugin-oracle-v1.0.26/OracleDriver-x86_64.zip",
       "sha256": "<sha256>"
     }

--- a/docs/features/import-export.mdx
+++ b/docs/features/import-export.mdx
@@ -70,6 +70,8 @@ A whole-table export streams from the database at constant memory, with no row-c
     All three are on by default, so an SQL export carries `DROP TABLE IF EXISTS` unless you untick **Drop**. Run that file against the wrong database and it drops the tables first.
     </Warning>
 
+    A multi-table export orders the tables by their foreign keys, so a parent is created and filled before the rows that reference it and dropped after them. Foreign keys between two tables that reference each other leave no such order: those tables keep the order the export listed them in, the file says so in a comment, and the summary repeats it. Import that one with **Disable foreign key checks** ticked.
+
     Not available on MongoDB or Redis.
   </Tab>
   <Tab title="MQL">
@@ -147,7 +149,7 @@ The checkbox runs a different statement per engine, and one of them needs a priv
 | SQLite, libSQL, Cloudflare D1 | `PRAGMA foreign_keys = OFF` | Nothing |
 | Everything else | Nothing. The option is ignored | |
 
-A server that rejects the statement stops the import with that error, so clear the checkbox and run it again. A dump TablePro exported needs no privilege: it adds foreign keys with `ALTER TABLE … ADD CONSTRAINT` after the data.
+A server that rejects the statement stops the import with that error, so clear the checkbox and run it again. A dump TablePro exported usually needs no privilege, because its tables are already ordered parents first. On PostgreSQL and Oracle, whose `CREATE TABLE` leaves foreign keys out, the dump adds them with `ALTER TABLE … ADD CONSTRAINT` after the data instead.
 
 ### Import JSON
 

--- a/project.yml
+++ b/project.yml
@@ -484,6 +484,9 @@ targets:
       - Plugins/RedisDriverPlugin/RedisSentinelResolver.swift
       - Plugins/RedisDriverPlugin/RedisStatementGenerator.swift
       - Plugins/RedisDriverPlugin/RedisTopologyDiagnostics.swift
+      - Plugins/SQLExportPlugin/SQLExportModels.swift
+      - Plugins/SQLExportPlugin/SQLExportOptionsView.swift
+      - Plugins/SQLExportPlugin/SQLExportPlugin.swift
       - Plugins/SQLImportPlugin/SQLImportFailure.swift
       - Plugins/SQLImportPlugin/SQLImportOptions.swift
       - Plugins/SQLImportPlugin/SQLImportOptionsView.swift


### PR DESCRIPTION
Fixes #2517.

## What was already there

The topological sort the issue asks for has been in the SQL export since #1126: `SQLExportPlugin.topologicallySort` runs every export through `ForeignKeyTopologicalSort`, the CREATE and data phases follow that order, and the drop phase walks it backwards. So item 1 of the issue and item 3's `ALTER TABLE … ADD CONSTRAINT` were both in place. What was missing is item 2, and one thing the issue could not have known about.

## Root cause

Two holes, both variations on the export being unable to tell you it wrote something questionable.

**The sort cannot report a cycle.** `ForeignKeyTopologicalSort.ordered` returns `[Table]`, so a caller cannot tell a parent-first order from a partial one. On a cycle it silently appended the tables it could not place in alphabetical identifier order, discarding the order the export tree gave them.

**There is no export summary to report it in.** `ExportFormatResult.warnings` reaches `ExportService.state.warningMessage` and stops there: nothing reads it, and `TransferResultAlert.presentExportSuccess` took no result and showed a fixed "Export completed". Every warning the SQL export already produced (a DDL fetch that failed, a metadata fetch that failed, an export spanning two schemas) has been invisible since it was written. The import side already does this properly through `presentImportSuccess(result:)`.

**And item 3's premise does not hold.** `writeFinalizationPhase` emitted `ALTER TABLE … ADD CONSTRAINT` for every foreign key regardless of engine, while most drivers' `fetchTableDDL` hands back the server's own `CREATE TABLE`, which already declares them:

- MySQL and MariaDB: `SHOW CREATE TABLE` carries `CONSTRAINT … FOREIGN KEY`, so the import fails with error 1826, duplicate foreign key constraint name
- SQL Server: `MSSQLPluginDriver+Schema.swift` appends the same clauses itself
- SQLite, libSQL, Cloudflare D1: `sqlite_master.sql` keeps the inline `REFERENCES`, and SQLite has no `ALTER TABLE … ADD CONSTRAINT` at all, so the statement is a syntax error
- DuckDB, Snowflake, CockroachDB, Redshift: same, from `duckdb_tables()`, `GET_DDL`, and `SHOW CREATE TABLE` / `SHOW TABLE`

PostgreSQL and Oracle are the two whose builders leave foreign keys out. PostgreSQL's constraint query filters `con.contype IN ('p', 'u', 'c')` and Oracle's emits columns only, which is exactly why the phase exists.

Verified with a probe rather than from the docs:

```
$ sqlite3 probe.db "SELECT sql FROM sqlite_master WHERE name='orders';"
CREATE TABLE orders (id INTEGER PRIMARY KEY, customer_id INTEGER REFERENCES customers(id))

$ sqlite3 probe.db 'ALTER TABLE "orders" ADD CONSTRAINT "fk_orders_0" FOREIGN KEY ("customer_id") REFERENCES "customers" ("id");'
Parse error: near "FOREIGN": syntax error
```

## The fix

**PluginKit.** `ForeignKeyTopologicalSort` gains `Ordering` and `order(_:foreignKeysByTable:childrenFirst:)`, which returns the ordering alongside the tables a cycle left unorderable. `ordered(...)` keeps its exact signature and delegates, so the existing symbol is untouched.

Kahn's algorithm cannot answer this on its own, because the set of tables it fails to place also holds every table that merely *descends* from a cycle. With `orders` and `customers` referencing each other and `audit` referencing `orders`, all three come back unplaced, so a warning built on that set names `audit` as part of a cycle it is not in, and the fallback can put `audit` before its own parent. The sort now groups tables into strongly connected components with an iterative Tarjan pass and orders the component graph instead. Only a component holding more than one table is unorderable; its members keep their input order, and a descendant is its own component that still lands after the cycle.

**The capability.** `PluginDatabaseDriver.tableDDLIncludesForeignKeys` says whether `fetchTableDDL` already declares them. It defaults to `false`, which is what every driver shipped before this existed, so a plugin that is not rebuilt behaves exactly as it does today. The nine drivers listed above override it to `true`, and `PluginExportDataSource` mirrors it for the export side. `writeFinalizationPhase` then runs only where the DDL leaves foreign keys out.

Redshift needed one more thing to be honest about the flag: its `SHOW TABLE` path declares foreign keys and its hand-built fallback did not, so the fallback now emits them too.

**The summary.** `ExportState.warnings` replaces `warningMessage`, `presentExportSuccess` takes the warnings and mirrors the import alert ("Export completed with warnings", `.warning` style, the text in `informativeText`), and the suppression checkbox is offered only on a clean run, because the alert a user turned off is the routine one. `ExportDialog` shows the alert even when the success dialog is suppressed, if there is something to say.

**The cycle itself** is reported twice: as a warning in that summary, and as a `--` note near the top of the dump, so the file still says so after the dialog is gone. The warning states what the file is rather than prescribing a remedy, because `foreignKeyDisableStatements()` is nil on SQL Server, Oracle, Snowflake and DuckDB: telling every user to import with the checks off would be wrong on the engines that cannot turn them off. All four of the export's warnings are localized while they are here, since this is the change that first puts them in front of a user.

## PluginKit ABI 21

`tableDDLIncludesForeignKeys` is a new protocol requirement. It has a default, so an already-built plugin keeps loading, but a plugin rebuilt against it hard-references the new method descriptor **and** the default-implementation symbol, and would fail `Bundle.loadAndReturnError` in an older app. `validateBundleVersions` only rejects `declared > current`, so without a bump that plugin is accepted and its driver then vanishes. `currentPluginKitVersion` goes to 21 with `minimumCompatiblePluginKitVersion` left at 19, so an older app refuses a new plugin cleanly instead. Every plugin `Info.plist` is bumped to match. This is the same reasoning that shipped PluginKit 20 in #2597.

`CLAUDE.md:120-124` still says an additive requirement needs no bump. That is true only old-plugin-in-new-host, and it is worth correcting separately.

**`scripts/release-all-plugins.sh 21` has to run before or with the app release**, or users on the new app hit `noCompatibleBinary` until the registry catches up. It has not been run.

## Verification

| Step | Result |
| --- | --- |
| `generate` | PASS |
| `build` (app) | PASS |
| `test` | PASS, 61 executed and 61 passed across 10 suites, then 37 and 16 on the re-runs |
| `lint` (12 paths) | PASS, 0 violations |
| `docs` | PASS |
| `abi origin/main` | additive: 14 additions, **0 removals**, `ordered` untouched |
| `plugins` (aggregate) | blocked before it reached this branch's code, see below |

`AllPlugins` fails locally on the vendored oracle-nio fork, `macro expansion @TaskLocal:1:2: error: unknown attribute 'usableFromInlinenonisolated'` in target `OracleNIO`, which is a toolchain incompatibility that stops the aggregate for any change under `Plugins/`. Every plugin target this branch touches was built on its own instead, and all ten pass: `TableProPluginKit`, `SQLExport`, `MySQLDriver`, `PostgreSQLDriver`, `SQLiteDriver`, `CloudflareD1DriverPlugin`, `DuckDBDriver`, `LibSQLDriverPlugin`, `MSSQLDriver`, `SnowflakeDriverPlugin`. CI runs the aggregate on its own toolchain.

One lint finding is pre-existing and not from this branch: `CLAUDE.md:220` references `AXCell`, a symbol in no Swift source. `CLAUDE.md` is not in this diff.

New `SQLExportForeignKeyOrderTests` covers parent-before-child creation, child-before-parent drops, the cycle warning in both the summary and the dump, the input-order fallback, a descendant of a cycle not being reported as part of it, a silent acyclic run, and both sides of the capability gate. `SQLExportPlugin` is added to the test target's sources, which is what makes those runnable at all. `ForeignKeyTopologicalSortTests` gains three cases for cycle membership. The export tests snapshot and restore the plugin's stored settings, because `SQLExportPlugin()` reads the app's real defaults and a developer with gzip enabled would otherwise get a compressed file the assertions cannot read.

A second model reviewed the diff: `codex review`, which raised six findings. Four are fixed here (the cycle-vs-descendant set, Redshift swallowing a failed foreign key lookup behind `try?`, the warning prescribing a remedy some engines lack, and the test reading real preferences), one is extended beyond what it asked (localizing all four warnings, not only the new one), and one is declined with its reason in the section above.

No UI automation: the export flow needs a live database connection and a save panel, so it does not run deterministically under `TableProUITests`.

No screenshots: the visible change is the text of an `NSAlert` that only appears after a real export against a real server.


https://claude.ai/code/session_01S9ckdzeugurfqNmDpGU2M7
