### PR TITLE
fix(connections): keep a helper process last stderr line when it exits right after writing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Last line of a helper process's output lost when it exits right after writing it.
 - Silent fallback order when foreign keys between the exported tables form a cycle. (#2517)
 - Foreign keys declared twice in a SQL export on MySQL, SQL Server, DuckDB, Snowflake, CockroachDB and Redshift, and as an unsupported `ALTER TABLE` on SQLite, libSQL and Cloudflare D1. (#2517)
 - Foreign keys missing from Redshift's reconstructed `CREATE TABLE`.

--- a/TablePro/Core/Process/SupervisedProcessRunner.swift
+++ b/TablePro/Core/Process/SupervisedProcessRunner.swift
@@ -24,6 +24,13 @@ final class ProcessSupervisedRunner: SupervisedProcessRunner, @unchecked Sendabl
     private let stderrPipe = Pipe()
     private let stateLock = NSLock()
 
+    /// Held for the whole of a stderr read, from taking the bytes off the pipe to handing the
+    /// lines to the stream, and for the whole of `finish`. The readability callback runs on
+    /// Foundation's queue and the termination handler on another thread, so without it a chunk
+    /// read just before the process exited could still be on its way to the stream when
+    /// `finish` drained an already empty pipe and closed the stream under it.
+    private let ingestLock = NSLock()
+
     private var partialLine = ""
     private var wasRequested = false
     private var terminationResult: SubprocessTermination?
@@ -56,8 +63,11 @@ final class ProcessSupervisedRunner: SupervisedProcessRunner, @unchecked Sendabl
         }
 
         stderrPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            guard let self else { return }
+            self.ingestLock.lock()
+            defer { self.ingestLock.unlock() }
             let chunk = handle.availableData
-            guard !chunk.isEmpty, let self else { return }
+            guard !chunk.isEmpty else { return }
             self.ingestStderr(chunk)
         }
 
@@ -108,13 +118,17 @@ final class ProcessSupervisedRunner: SupervisedProcessRunner, @unchecked Sendabl
     }
 
     private func finish(exitCode: Int32) {
+        ingestLock.lock()
+        defer { ingestLock.unlock() }
         stdoutPipe.fileHandleForReading.readabilityHandler = nil
         stderrPipe.fileHandleForReading.readabilityHandler = nil
 
         /// The termination handler can run before the pipe delivers its last readability
         /// callback, and clearing the handler above cancels that callback outright. Whatever is
         /// still buffered is drained here, because a dropped final line is how a process that
-        /// announced itself ready right before exiting reads as one that never did.
+        /// announced itself ready right before exiting reads as one that never did. A callback
+        /// already dispatched waits on the lock and then finds the pipe at end of file, so it
+        /// cannot hand the stream a line after it has been closed.
         if let remaining = try? stderrPipe.fileHandleForReading.readToEnd(), !remaining.isEmpty {
             ingestStderr(remaining)
         }

--- a/TableProTests/Core/Process/SupervisedProcessRunnerTests.swift
+++ b/TableProTests/Core/Process/SupervisedProcessRunnerTests.swift
@@ -70,6 +70,23 @@ struct SupervisedProcessRunnerTests {
         #expect(lines == ["first", "second"])
     }
 
+    /// The readability callback and the termination handler run on different threads, so a line
+    /// read just before the process exited used to race the stream's close and lose. One run
+    /// shows it rarely; a hundred in a row showed it on CI.
+    @Test("A line written right before exit is delivered every time")
+    func lastLineSurvivesExit() async throws {
+        for _ in 0..<100 {
+            let runner = try runner(script: "echo first >&2; echo second >&2; exit 0")
+
+            var lines: [String] = []
+            for await line in runner.stderrLines {
+                lines.append(line)
+            }
+
+            #expect(lines == ["first", "second"])
+        }
+    }
+
     @Test("A trailing line without a newline is still delivered")
     func deliversTrailingLine() async throws {
         let runner = try runner(script: "printf 'no trailing newline' >&2; exit 0")


### PR DESCRIPTION
## What failed

`macOS Tests` on `main` at `210f6474f` (run 33711652837) failed one case: suite "Supervised process runner", "Standard error is delivered line by line and the stream finishes", with `["first"]` where `["first", "second"]` was expected. A rerun passed. Neither merge that morning touched the runner.

## Root cause

`ProcessSupervisedRunner` reads stderr in a `readabilityHandler`, which Foundation dispatches on its own queue, and closes the stream from `finish(exitCode:)`, which runs on the termination handler's thread. When the process writes its last line and exits at once, the readability callback for that chunk can be past `availableData` (the bytes are off the pipe) but not yet at `yield`, while `finish` nils the handler, drains an already empty pipe with `readToEnd()`, and calls `finish()` on the stream. The late `yield` lands on a closed stream and is dropped. The existing drain in `finish` covers the callback that never fires; this is the callback that fires and loses.

For the app that is a helper such as `cloud-sql-proxy` or `cloudflared` whose readiness or failure line is the last thing it writes.

## Fix

One lock, `ingestLock`, held for the whole of a stderr read, from taking the bytes off the pipe to handing the lines to the stream, and for the whole of `finish`. A callback dispatched before the handler was cleared waits on the lock, then finds the pipe at end of file and does nothing, so no line can slip between the drain and the close. `stateLock` is only ever taken inside `ingestLock`, never the other way round.

## Verified

- A standalone harness compiled from the runner alone, 16 runners at a time for 200 rounds: the runner on `main` lost the second line in 2 of 3,200 runs; the patched runner lost none in 3,200 and none in a further 8,000.
- `SupervisedProcessRunnerTests` gains a case that runs the two-line script 100 times; the existing cases, `CloudflareTunnelManagerTests` and `CloudSQLProxyManagerTests` pass. `verify.sh generate`, `build`, `lint`: see the thread.

https://claude.ai/code/session_014THhVdsUjbCboxNLnQB1dR
