### PR TITLE
fix(plugin-postgresql): show composite, range and extension-typed columns by their own name instead of ENUM(...)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Last line of a helper process's output lost when it exits right after writing it.
+- Composite, range and extension-typed PostgreSQL columns labelled `ENUM(…)` in the structure editor.
 - Silent fallback order when foreign keys between the exported tables form a cycle. (#2517)
 - Foreign keys declared twice in a SQL export on MySQL, SQL Server, DuckDB, Snowflake, CockroachDB and Redshift, and as an unsupported `ALTER TABLE` on SQLite, libSQL and Cloudflare D1. (#2517)
 - Foreign keys missing from Redshift's reconstructed `CREATE TABLE`.

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Columns.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Columns.swift
@@ -92,10 +92,13 @@ extension PostgreSQLPluginDriver {
         var map: [String: [String]] = [:]
         for row in result.rows {
             guard let schemaName = row[safe: 0]?.asText,
-                  let typeName = row[safe: 1]?.asText,
-                  let label = row[safe: 2]?.asText else { continue }
+                  let typeName = row[safe: 1]?.asText else { continue }
             let key = PostgresColumnTypeResolver.qualifiedName(schema: schemaName, name: typeName)
-            map[key, default: []].append(label)
+            var labels = map[key] ?? []
+            if let label = row[safe: 2]?.asText {
+                labels.append(label)
+            }
+            map[key] = labels
         }
         return map
     }

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLSchemaQueries.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLSchemaQueries.swift
@@ -201,11 +201,15 @@ enum PostgreSQLSchemaQueries {
         WHERE t.typtype = 'e'
         """
 
+    /// Every enum appears, with a NULL label where it has none, so the column resolver can tell
+    /// an enum apart from a composite, a range or an extension's base type: all four reach it as
+    /// `USER-DEFINED`, and only an enum has a row here.
     static let enumLabelQuery = """
         SELECT n.nspname, t.typname, e.enumlabel
         FROM pg_catalog.pg_type t
         JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
-        JOIN pg_catalog.pg_enum e ON e.enumtypid = t.oid
+        LEFT JOIN pg_catalog.pg_enum e ON e.enumtypid = t.oid
+        WHERE t.typtype = 'e'
         ORDER BY n.nspname, t.typname, e.enumsortorder
         """
 

--- a/Plugins/TableProPluginKit/PostgresColumnTypeResolver.swift
+++ b/Plugins/TableProPluginKit/PostgresColumnTypeResolver.swift
@@ -54,7 +54,7 @@ public enum PostgresColumnTypeResolver {
 
         if upper == "USER-DEFINED" {
             guard let labels = enumLabelsByQualifiedName[key] else {
-                return Resolution(dataType: "ENUM(\(udtName))", allowedValues: nil)
+                return Resolution(dataType: udtName, allowedValues: nil)
             }
             return Resolution(dataType: "ENUM", allowedValues: labels)
         }

--- a/TableProTests/Plugins/PostgresColumnTypeResolverTests.swift
+++ b/TableProTests/Plugins/PostgresColumnTypeResolverTests.swift
@@ -72,11 +72,38 @@ struct PostgresColumnTypeResolverTests {
         #expect(resolve("ARRAY", schema: "public", udt: "_pair").allowedValues == nil)
     }
 
-    @Test("An enum with no catalog entry keeps the existing named fallback")
-    func fallsBackForUnknownEnum() {
-        let resolution = resolve("USER-DEFINED", schema: "app", udt: "nope")
-        #expect(resolution.dataType == "ENUM(nope)")
-        #expect(resolution.allowedValues == nil)
+    /// A composite, a range and an extension's base type all reach the resolver as
+    /// `USER-DEFINED`, exactly like an enum. Only an enum has a catalog entry, so a name without
+    /// one is a type of another kind and is shown as itself rather than as an enum it is not.
+    @Test("A user-defined type with no enum entry keeps its own name")
+    func keepsNameForNonEnumUserType() {
+        for udt in ["point3d", "floatrange", "hstore", "geometry"] {
+            let resolution = resolve("USER-DEFINED", schema: "app", udt: udt)
+            #expect(resolution.dataType == udt)
+            #expect(resolution.allowedValues == nil)
+        }
+    }
+
+    @Test("An enum declared with no labels is still an enum")
+    func resolvesEmptyEnum() {
+        let resolution = PostgresColumnTypeResolver.resolve(
+            rawDataType: "USER-DEFINED",
+            udtSchema: "app",
+            udtName: "empty",
+            enumLabelsByQualifiedName: ["app.empty": []],
+            arrayTypesByQualifiedName: [:]
+        )
+        #expect(resolution.dataType == "ENUM")
+        #expect(resolution.allowedValues?.isEmpty == true)
+    }
+
+    /// The catalog read has to list an enum with no labels, or the resolver could not tell it
+    /// from a composite.
+    @Test("The enum label query lists every enum, labels or not")
+    func enumLabelQueryListsLabellessEnums() {
+        let sql = PostgreSQLSchemaQueries.enumLabelQuery
+        #expect(sql.contains("LEFT JOIN pg_catalog.pg_enum"))
+        #expect(sql.contains("WHERE t.typtype = 'e'"))
     }
 
     @Test("Ordinary columns pass through unchanged")


### PR DESCRIPTION
## Root cause

`information_schema.columns.data_type` reports `USER-DEFINED` for every column whose type is not a built-in: enums, composites, ranges and extension base types alike. `PostgresColumnTypeResolver` treated that one word as "this is an enum": it looked the type up in the enum label map and, when the lookup missed, labelled the column `ENUM(<name>)` anyway. So a `point3d` composite, a `floatrange` range and an `hstore` column all showed up in the structure editor as `ENUM(point3d)`, `ENUM(floatrange)` and `ENUM(hstore)`. This was found as a collateral item while working on #2484.

## Fix

- A `USER-DEFINED` column with no entry in the enum label map keeps its own type name (`point3d`, `hstore`).
- The enum label query now `LEFT JOIN`s `pg_enum` and filters on `typtype = 'e'`, so an enum declared with no labels still has a map entry and still resolves to `ENUM` with an empty value list. Before, that enum was indistinguishable from a composite.
- `fetchEnumLabelMap` registers the type even when its label column is NULL.

## Evidence

Probed against a throwaway PostgreSQL 17 cluster: `information_schema.columns` reports `USER-DEFINED` for `point3d` (composite), `hstore` (extension), `floatrange` (range) and `empty_enum` (enum with no labels), and the new query lists `empty_enum` with a NULL label while the old `JOIN` dropped it.

## Tests

`PostgresColumnTypeResolverTests`: non-enum user types keep their name, a labelless enum still resolves as `ENUM`, and the label query keeps its `LEFT JOIN` and `typtype` filter. The five PostgreSQL column suites pass (14 cases).

## Changelog

Fixed: Composite, range and extension-typed PostgreSQL columns labelled `ENUM(…)` in the structure editor.

https://claude.ai/code/session_014THhVdsUjbCboxNLnQB1dR
