### PR TITLE
fix(sidebar): key routine, trigger, type and schema fetches by scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Last line of a helper process's output lost when it exits right after writing it.
+- Sidebar routines, triggers and types from the previous database after switching while it was still loading.
 - Silent fallback order when foreign keys between the exported tables form a cycle. (#2517)
 - Foreign keys declared twice in a SQL export on MySQL, SQL Server, DuckDB, Snowflake, CockroachDB and Redshift, and as an unsupported `ALTER TABLE` on SQLite, libSQL and Cloudflare D1. (#2517)
 - Foreign keys missing from Redshift's reconstructed `CREATE TABLE`.

--- a/TablePro/Core/Database/EnumLabelEditor.swift
+++ b/TablePro/Core/Database/EnumLabelEditor.swift
@@ -127,9 +127,14 @@ struct EnumLabelEditor {
             database: objectRef.database,
             schema: objectRef.schema
         )
+        let scope = DatabaseManager.shared.browseScope(for: connectionId)
         do {
             try await DatabaseManager.shared.withBrowseMetadataDriver(connectionId: connectionId) { driver in
-                await SchemaService.shared.reloadUserDefinedTypes(connectionId: connectionId, driver: driver)
+                await SchemaService.shared.reloadUserDefinedTypes(
+                    connectionId: connectionId,
+                    driver: driver,
+                    scope: scope
+                )
             }
         } catch {
             Self.logger.warning("type listing refresh failed: \(error.localizedDescription, privacy: .public)")

--- a/TablePro/Core/Services/Query/SchemaRefreshService.swift
+++ b/TablePro/Core/Services/Query/SchemaRefreshService.swift
@@ -216,12 +216,20 @@ final class SchemaRefreshService {
             ) { [schemaService] driver in
                 /// All run, and none short circuits another: a failed routine fetch must not skip
                 /// the trigger fetch that would still have succeeded.
-                let routines = await schemaService.reloadRoutines(connectionId: connectionId, driver: driver)
+                let routines = await schemaService.reloadRoutines(
+                    connectionId: connectionId,
+                    driver: driver,
+                    scope: scope
+                )
                 let triggers = browsesTriggers
-                    ? await schemaService.reloadTriggers(connectionId: connectionId, driver: driver)
+                    ? await schemaService.reloadTriggers(connectionId: connectionId, driver: driver, scope: scope)
                     : true
                 let types = browsesTypes
-                    ? await schemaService.reloadUserDefinedTypes(connectionId: connectionId, driver: driver)
+                    ? await schemaService.reloadUserDefinedTypes(
+                        connectionId: connectionId,
+                        driver: driver,
+                        scope: scope
+                    )
                     : true
                 return routines && triggers && types
             }

--- a/TablePro/Core/Services/Query/SchemaService.swift
+++ b/TablePro/Core/Services/Query/SchemaService.swift
@@ -31,10 +31,10 @@ final class SchemaService {
     }
 
     @ObservationIgnored private let loadDedup = OnceTask<LoadKey, [TableInfo]>()
-    @ObservationIgnored private let routinesDedup = OnceTask<UUID, [RoutineInfo]>()
-    @ObservationIgnored private let triggersDedup = OnceTask<UUID, [TriggerInfo]>()
-    @ObservationIgnored private let typesDedup = OnceTask<UUID, [UserDefinedTypeInfo]>()
-    @ObservationIgnored private let schemasDedup = OnceTask<UUID, [String]>()
+    @ObservationIgnored private let routinesDedup = OnceTask<LoadKey, [RoutineInfo]>()
+    @ObservationIgnored private let triggersDedup = OnceTask<LoadKey, [TriggerInfo]>()
+    @ObservationIgnored private let typesDedup = OnceTask<LoadKey, [UserDefinedTypeInfo]>()
+    @ObservationIgnored private let schemasDedup = OnceTask<LoadKey, [String]>()
     @ObservationIgnored private let perSchemaDedup = OnceTask<SchemaKey, [TableInfo]>()
 
     struct SchemaKey: Hashable, Sendable {
@@ -43,7 +43,9 @@ final class SchemaService {
     }
 
     /// Two windows browsing the same scope share one fetch; two windows browsing different
-    /// scopes must not, or the second stamps the first's tables with its own scope.
+    /// scopes must not, or the second stamps the first's tables with its own scope. Every
+    /// object kind is keyed this way, because a routine, trigger, type or schema list fetched
+    /// from the database being left describes that database, not the one being entered.
     struct LoadKey: Hashable, Sendable {
         let connectionId: UUID
         let scope: DatabaseScope?
@@ -245,9 +247,9 @@ final class SchemaService {
     /// Returns false when the stored list is still the one from before the call, so a caller that
     /// is about to record what its refresh covered can tell a real reload from a swallowed error.
     @discardableResult
-    func reloadRoutines(connectionId: UUID, driver: DatabaseDriver) async -> Bool {
+    func reloadRoutines(connectionId: UUID, driver: DatabaseDriver, scope: DatabaseScope?) async -> Bool {
         do {
-            let loaded = try await routinesDedup.execute(key: connectionId) {
+            let loaded = try await routinesDedup.execute(key: LoadKey(connectionId: connectionId, scope: scope)) {
                 try await driver.fetchRoutines(schema: nil)
             }
             routines[connectionId] = loaded
@@ -264,9 +266,9 @@ final class SchemaService {
     }
 
     @discardableResult
-    func reloadTriggers(connectionId: UUID, driver: DatabaseDriver) async -> Bool {
+    func reloadTriggers(connectionId: UUID, driver: DatabaseDriver, scope: DatabaseScope?) async -> Bool {
         do {
-            let loaded = try await triggersDedup.execute(key: connectionId) {
+            let loaded = try await triggersDedup.execute(key: LoadKey(connectionId: connectionId, scope: scope)) {
                 try await driver.fetchAllTriggers(schema: nil)
             }
             triggers[connectionId] = loaded
@@ -283,9 +285,9 @@ final class SchemaService {
     }
 
     @discardableResult
-    func reloadUserDefinedTypes(connectionId: UUID, driver: DatabaseDriver) async -> Bool {
+    func reloadUserDefinedTypes(connectionId: UUID, driver: DatabaseDriver, scope: DatabaseScope?) async -> Bool {
         do {
-            let loaded = try await typesDedup.execute(key: connectionId) {
+            let loaded = try await typesDedup.execute(key: LoadKey(connectionId: connectionId, scope: scope)) {
                 try await driver.fetchUserDefinedTypes(schema: nil)
             }
             userDefinedTypes[connectionId] = loaded
@@ -309,10 +311,10 @@ final class SchemaService {
 
     private func cancelInFlightLoads(connectionId: UUID) async {
         await loadDedup.cancel { $0.connectionId == connectionId }
-        await routinesDedup.cancel(key: connectionId)
-        await triggersDedup.cancel(key: connectionId)
-        await typesDedup.cancel(key: connectionId)
-        await schemasDedup.cancel(key: connectionId)
+        await routinesDedup.cancel { $0.connectionId == connectionId }
+        await triggersDedup.cancel { $0.connectionId == connectionId }
+        await typesDedup.cancel { $0.connectionId == connectionId }
+        await schemasDedup.cancel { $0.connectionId == connectionId }
         await perSchemaDedup.cancel { $0.connectionId == connectionId }
     }
 
@@ -379,26 +381,24 @@ final class SchemaService {
             schemasInOrder.removeValue(forKey: connectionId)
         }
 
+        let loadKey = LoadKey(connectionId: connectionId, scope: scope)
         let grouping = PluginManager.shared.databaseGroupingStrategy(for: connection.type)
         if grouping == .hierarchicalSchema {
             await runHierarchicalLoad(
-                connectionId: connectionId,
+                loadKey: loadKey,
                 driver: driver,
                 browsesTriggers: connection.type.supportsDatabaseTriggerBrowse,
                 browsesTypes: connection.type.supportsUserDefinedTypeBrowse,
-                generation: generation,
-                scope: scope
+                generation: generation
             )
             return
         }
 
-        async let tablesTask: [TableInfo] = loadDedup.execute(
-            key: LoadKey(connectionId: connectionId, scope: scope)
-        ) {
+        async let tablesTask: [TableInfo] = loadDedup.execute(key: loadKey) {
             try await driver.fetchTables()
         }
         async let routinesTask: [RoutineInfo]? = Self.fetchObjectsSafely(
-            connectionId: connectionId,
+            key: loadKey,
             label: "routines",
             dedup: routinesDedup,
             fetch: { try await driver.fetchRoutines(schema: nil) }
@@ -406,7 +406,7 @@ final class SchemaService {
         let browsesTriggers = connection.type.supportsDatabaseTriggerBrowse
         async let triggersTask: [TriggerInfo]? = browsesTriggers
             ? Self.fetchObjectsSafely(
-                connectionId: connectionId,
+                key: loadKey,
                 label: "triggers",
                 dedup: triggersDedup,
                 fetch: { try await driver.fetchAllTriggers(schema: nil) }
@@ -415,7 +415,7 @@ final class SchemaService {
         let browsesTypes = connection.type.supportsUserDefinedTypeBrowse
         async let typesTask: [UserDefinedTypeInfo]? = browsesTypes
             ? Self.fetchObjectsSafely(
-                connectionId: connectionId,
+                key: loadKey,
                 label: "types",
                 dedup: typesDedup,
                 fetch: { try await driver.fetchUserDefinedTypes(schema: nil) }
@@ -423,7 +423,7 @@ final class SchemaService {
             : nil
         async let schemasTask: [String]? = supportsSchemas
             ? Self.fetchSchemasSafely(
-                connectionId: connectionId,
+                key: loadKey,
                 dedup: schemasDedup,
                 fetch: { try await driver.fetchSchemas() }
             )
@@ -493,23 +493,24 @@ final class SchemaService {
     }
 
     private func runHierarchicalLoad(
-        connectionId: UUID,
+        loadKey: LoadKey,
         driver: DatabaseDriver,
         browsesTriggers: Bool,
         browsesTypes: Bool,
-        generation: Int,
-        scope: DatabaseScope?
+        generation: Int
     ) async {
+        let connectionId = loadKey.connectionId
+        let scope = loadKey.scope
         let scopeChanged = scope != nil && loadedScopes[connectionId] != scope
         async let routinesTask: [RoutineInfo]? = Self.fetchObjectsSafely(
-            connectionId: connectionId,
+            key: loadKey,
             label: "routines",
             dedup: routinesDedup,
             fetch: { try await driver.fetchRoutines(schema: nil) }
         )
         async let triggersTask: [TriggerInfo]? = browsesTriggers
             ? Self.fetchObjectsSafely(
-                connectionId: connectionId,
+                key: loadKey,
                 label: "triggers",
                 dedup: triggersDedup,
                 fetch: { try await driver.fetchAllTriggers(schema: nil) }
@@ -517,7 +518,7 @@ final class SchemaService {
             : nil
         async let typesTask: [UserDefinedTypeInfo]? = browsesTypes
             ? Self.fetchObjectsSafely(
-                connectionId: connectionId,
+                key: loadKey,
                 label: "types",
                 dedup: typesDedup,
                 fetch: { try await driver.fetchUserDefinedTypes(schema: nil) }
@@ -530,7 +531,7 @@ final class SchemaService {
 
         let loadedSchemas: [String]
         do {
-            loadedSchemas = try await schemasDedup.execute(key: connectionId) {
+            loadedSchemas = try await schemasDedup.execute(key: loadKey) {
                 try await driver.fetchSchemas()
             }
         } catch is CancellationError {
@@ -626,17 +627,17 @@ final class SchemaService {
     }
 
     private static func fetchSchemasSafely(
-        connectionId: UUID,
-        dedup: OnceTask<UUID, [String]>,
+        key: LoadKey,
+        dedup: OnceTask<LoadKey, [String]>,
         fetch: @Sendable @escaping () async throws -> [String]
     ) async -> [String]? {
         do {
-            return try await dedup.execute(key: connectionId, work: fetch)
+            return try await dedup.execute(key: key, work: fetch)
         } catch is CancellationError {
             return nil
         } catch {
             Self.logger.warning(
-                "[schema] fetchSchemas failed connId=\(connectionId, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+                "[schema] fetchSchemas failed connId=\(key.connectionId, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
             )
             return nil
         }
@@ -649,18 +650,18 @@ final class SchemaService {
     /// dropped connection emptied the sidebar's procedures and functions while the refresh
     /// reported success, with nothing scheduled to put them back.
     private static func fetchObjectsSafely<Value: Sendable>(
-        connectionId: UUID,
+        key: LoadKey,
         label: String,
-        dedup: OnceTask<UUID, [Value]>,
+        dedup: OnceTask<LoadKey, [Value]>,
         fetch: @Sendable @escaping () async throws -> [Value]
     ) async -> [Value]? {
         do {
-            return try await dedup.execute(key: connectionId, work: fetch)
+            return try await dedup.execute(key: key, work: fetch)
         } catch is CancellationError {
             return nil
         } catch {
             logger.warning(
-                "[schema] \(label, privacy: .public) load failed connId=\(connectionId, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+                "[schema] \(label, privacy: .public) load failed connId=\(key.connectionId, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
             )
             return nil
         }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -797,22 +797,29 @@ final class MainContentCoordinator {
     }
 
     func refreshRoutines() async {
+        let scope = services.databaseManager.browseScope(for: connectionId)
         try? await services.databaseManager.withBrowseMetadataDriver(connectionId: connectionId) { [services, connectionId] driver in
-            _ = await services.schemaService.reloadRoutines(connectionId: connectionId, driver: driver)
+            _ = await services.schemaService.reloadRoutines(connectionId: connectionId, driver: driver, scope: scope)
         }
     }
 
     func refreshTriggers() async {
         guard connection.type.supportsDatabaseTriggerBrowse else { return }
+        let scope = services.databaseManager.browseScope(for: connectionId)
         try? await services.databaseManager.withBrowseMetadataDriver(connectionId: connectionId) { [services, connectionId] driver in
-            _ = await services.schemaService.reloadTriggers(connectionId: connectionId, driver: driver)
+            _ = await services.schemaService.reloadTriggers(connectionId: connectionId, driver: driver, scope: scope)
         }
     }
 
     func refreshUserDefinedTypes() async {
         guard connection.type.supportsUserDefinedTypeBrowse else { return }
+        let scope = services.databaseManager.browseScope(for: connectionId)
         try? await services.databaseManager.withBrowseMetadataDriver(connectionId: connectionId) { [services, connectionId] driver in
-            _ = await services.schemaService.reloadUserDefinedTypes(connectionId: connectionId, driver: driver)
+            _ = await services.schemaService.reloadUserDefinedTypes(
+                connectionId: connectionId,
+                driver: driver,
+                scope: scope
+            )
         }
     }
 

--- a/TableProTests/Services/SchemaServiceRoutinesTests.swift
+++ b/TableProTests/Services/SchemaServiceRoutinesTests.swift
@@ -187,6 +187,7 @@ private final class BlockingAuxiliaryDriver: DatabaseDriver, @unchecked Sendable
     var proceduresToReturn: [RoutineInfo] = []
     var functionsToReturn: [RoutineInfo] = []
     var schemasToReturn: [String] = []
+    var routinesCallCount = 0
 
     let tablesGate = AsyncGate()
     let routinesGate = AsyncGate()
@@ -253,6 +254,7 @@ private final class BlockingAuxiliaryDriver: DatabaseDriver, @unchecked Sendable
     func rollbackTransaction() async throws {}
 
     func fetchRoutines(schema: String?) async throws -> [RoutineInfo] {
+        routinesCallCount += 1
         await routinesGate.wait()
         return proceduresToReturn + functionsToReturn
     }
@@ -410,11 +412,54 @@ struct SchemaServiceRoutinesTests {
         #expect(service.schemas(for: connectionId) == ["public"])
     }
 
+    /// The tables fetch was keyed by scope and the routine fetch by connection alone, so a load
+    /// for the database being entered joined the in-flight routine fetch of the one being left
+    /// and committed that database's routines under the new scope.
+    @Test("A load for another scope never joins the routine fetch of the scope being left")
+    func scopeChangeDoesNotJoinInFlightRoutineFetch() async {
+        let service = SchemaService()
+        let connectionId = UUID()
+        let connection = TestFixtures.makeConnection(id: connectionId, type: .postgresql)
+        let driver = BlockingAuxiliaryDriver(connection: connection)
+        driver.tablesToReturn = [TestFixtures.makeTableInfo(name: "users")]
+        driver.proceduresToReturn = [RoutineInfo(name: "add_user", kind: .procedure, schema: "public")]
+        driver.schemasToReturn = ["public"]
+        let primary = DatabaseScope(connectionId: connectionId, database: "primary", schema: "public")
+        let analytics = DatabaseScope(connectionId: connectionId, database: "analytics", schema: "public")
+
+        let primaryLoad = Task {
+            await service.load(connectionId: connectionId, driver: driver, connection: connection, scope: primary)
+        }
+        await driver.tablesGate.open()
+        await waitForLoadedState(service, connectionId: connectionId)
+        await waitUntil { driver.routinesCallCount == 1 }
+
+        let analyticsLoad = Task {
+            await service.load(connectionId: connectionId, driver: driver, connection: connection, scope: analytics)
+        }
+        await waitUntil { driver.routinesCallCount == 2 }
+        #expect(driver.routinesCallCount == 2)
+
+        await driver.routinesGate.open()
+        await driver.schemasGate.open()
+        await primaryLoad.value
+        await analyticsLoad.value
+
+        #expect(service.loadedScope(for: connectionId) == analytics)
+        #expect(service.procedures(for: connectionId).map(\.name) == ["add_user"])
+    }
+
     private func waitForLoadedState(_ service: SchemaService, connectionId: UUID) async {
         while true {
             if case .loaded = service.state(for: connectionId) {
                 return
             }
+            await Task.yield()
+        }
+    }
+
+    private func waitUntil(_ condition: () -> Bool) async {
+        for _ in 0..<10_000 where !condition() {
             await Task.yield()
         }
     }
@@ -437,7 +482,7 @@ struct SchemaServiceRoutinesTests {
             RoutineInfo(name: "p2", kind: .procedure)
         ]
         driver.functionsToReturn = [RoutineInfo(name: "f2", kind: .function)]
-        await service.reloadRoutines(connectionId: connectionId, driver: driver)
+        await service.reloadRoutines(connectionId: connectionId, driver: driver, scope: nil)
 
         #expect(driver.proceduresCallCount == firstCount + 1)
         #expect(service.procedures(for: connectionId).map(\.name) == ["p1", "p2"])

--- a/TableProTests/Services/SchemaServiceUserDefinedTypesTests.swift
+++ b/TableProTests/Services/SchemaServiceUserDefinedTypesTests.swift
@@ -145,7 +145,7 @@ struct SchemaServiceUserDefinedTypesTests {
 
         let status = UserDefinedTypeInfo(name: "status", kind: .domain, schema: "public", baseType: "text")
         driver.typesToReturn = [mood, status]
-        let reloaded = await service.reloadUserDefinedTypes(connectionId: connectionId, driver: driver)
+        let reloaded = await service.reloadUserDefinedTypes(connectionId: connectionId, driver: driver, scope: nil)
 
         #expect(reloaded)
         #expect(service.userDefinedTypes(for: connectionId).map(\.name) == ["mood", "status"])
@@ -162,7 +162,7 @@ struct SchemaServiceUserDefinedTypesTests {
         await service.load(connectionId: connectionId, driver: driver, connection: connection)
 
         driver.typesShouldFail = true
-        let reloaded = await service.reloadUserDefinedTypes(connectionId: connectionId, driver: driver)
+        let reloaded = await service.reloadUserDefinedTypes(connectionId: connectionId, driver: driver, scope: nil)
 
         #expect(!reloaded)
         #expect(service.userDefinedTypes(for: connectionId) == [mood])


### PR DESCRIPTION
## Root cause

`SchemaService` shares one in-flight fetch per key so two windows on the same connection do not run the same catalog query twice. The tables fetch was keyed by connection and scope (`LoadKey`), but the routine, trigger, type and schema fetches were keyed by connection alone. A load for the database being entered therefore joined the in-flight fetch of the database being left, took its answer, and committed that database's routines, triggers and types under the new scope. The stale load is discarded by the generation check, but the joined result is not stale from the new load's point of view: it simply came from the wrong database. Found as a collateral item while working on #2484.

## Fix

- Every object-kind dedup is keyed by `LoadKey` (connection + scope), the same key the tables fetch already used.
- `reloadRoutines`, `reloadTriggers` and `reloadUserDefinedTypes` take the scope they refresh, so a targeted reload shares a fetch only with a load of the same scope. The schema-switch refresh passes the scope it already resolved; the coordinator's refresh actions and the enum label editor pass the browse scope, which is the scope the driver they use is on.
- Cancellation on disconnect and `prepareForReload` cancels every key of the connection, whatever its scope.

## Tests

`SchemaServiceRoutinesTests`: a new case starts a load for one scope, blocks its routine fetch, starts a load for another scope, and asserts a second routine fetch is issued and the second scope wins. It fails on `main`, where the count stays at one. The four SchemaService suites pass (34 cases).

## Changelog

Fixed: Sidebar routines, triggers and types from the previous database after switching while it was still loading.

https://claude.ai/code/session_014THhVdsUjbCboxNLnQB1dR
