### PR TITLE
feat(connections): list saved connections under their groups in Switch Connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Breakdown of a query's time into server, first row and transfer, behind the toolbar's duration readout. (#2503)
 - Exclude the AUTO_INCREMENT counter and Exclude DEFINER clauses in the SQL export, both on by default. (#2516)
 - Jump to Column in the grid, a fuzzy search over the result's columns with their type and position. (#2495)
+- Connection groups in Switch Connection, with `Cmd`-click to open a saved connection in a new window. (#1311)
 
 ### Changed
 

--- a/TablePro/Core/Services/Infrastructure/TabRouter.swift
+++ b/TablePro/Core/Services/Infrastructure/TabRouter.swift
@@ -99,6 +99,38 @@ internal final class TabRouter {
         try await openConnection(id: connection.id, transientConnection: connection)
     }
 
+    /// Open a saved connection in a window of its own. One some window already hosts takes the
+    /// ordinary route instead, which selects it where it already is.
+    ///
+    /// The host is checked here rather than by the caller. A caller decides on a modifier key and
+    /// the work runs a main-actor job later, and anything else that opens a connection in between,
+    /// the MCP tool among them, would leave that answer stale and two workspaces restoring the same
+    /// tabs. Nothing is awaited between the question and the window.
+    ///
+    /// No pre-connect script prompt here, matching the window-opening half of `openConnection`. A
+    /// window whose connection carries a script does not auto-connect at all: it waits in its
+    /// not-connected state, where Connect asks. Asking first would put the same question twice and
+    /// the first answer would change nothing.
+    internal func openConnectionPreferringNewWindow(id: UUID) async throws {
+        guard WindowManager.shared.window(for: id) == nil else {
+            try await openConnection(id: id)
+            return
+        }
+        guard let connection = ConnectionStorage.shared.loadConnections().first(where: { $0.id == id }) else {
+            throw TabRouterError.connectionNotFound(id)
+        }
+
+        let payload = EditorTabPayload(connectionId: connection.id, intent: .restoreOrDefault)
+        WindowManager.shared.openInNewWindow(
+            payload: payload,
+            activate: true,
+            autoConnect: true,
+            joinsTabGroup: false
+        )
+        AppActivationPolicyController.shared.activate(ignoringOtherApps: true)
+        WindowOpener.shared.closeWelcome()
+    }
+
     private func openConnection(id: UUID, transientConnection: DatabaseConnection? = nil) async throws {
         let connection: DatabaseConnection
         if let stored = ConnectionStorage.shared.loadConnections().first(where: { $0.id == id }) {

--- a/TablePro/Core/Services/Infrastructure/WindowManager.swift
+++ b/TablePro/Core/Services/Infrastructure/WindowManager.swift
@@ -254,7 +254,18 @@ internal final class WindowManager {
         return true
     }
 
-    private func openInNewWindow(payload: EditorTabPayload, activate: Bool, autoConnect: Bool) {
+    /// Forced, rather than the adoption `openTab` prefers.
+    ///
+    /// `joinsTabGroup` is the difference between "not in the window it would have been adopted
+    /// into" and "in a window of its own". Left alone, this joins the existing group, so a caller
+    /// that wants two connections side by side has to say so: without it the new window arrives as
+    /// a native tab of the very window it was meant to sit beside.
+    internal func openInNewWindow(
+        payload: EditorTabPayload,
+        activate: Bool,
+        autoConnect: Bool,
+        joinsTabGroup: Bool = true
+    ) {
         let t0 = Date()
         Self.lifecycleLogger.info(
             "[open] WindowManager.openTab start payloadId=\(payload.id, privacy: .public) connId=\(payload.connectionId, privacy: .public) intent=\(String(describing: payload.intent), privacy: .public) skipAutoExecute=\(payload.skipAutoExecute) activate=\(activate)"
@@ -282,8 +293,9 @@ internal final class WindowManager {
         // orderFront before addTabbedWindow avoids a synchronous full-tree
         // SwiftUI layout pass that adds 700-900ms per open.
         let tabbingId = window.tabbingIdentifier
+        let sibling = joinsTabGroup ? findSibling(tabbingIdentifier: tabbingId, excluding: window) : nil
 
-        if let sibling = findSibling(tabbingIdentifier: tabbingId, excluding: window) {
+        if let sibling {
             let target = sibling.tabbedWindows?.last ?? sibling
             target.addTabbedWindow(window, ordered: .above)
             if activate {
@@ -293,11 +305,21 @@ internal final class WindowManager {
                 "[open] WindowManager joined existing tab group payloadId=\(payload.id, privacy: .public) tabbingId=\(tabbingId, privacy: .public)"
             )
         } else {
+            /// The system preference can tab a window on its own, without anyone asking AppKit to,
+            /// so a window asked to stand apart refuses for the moment it is placed and allows it
+            /// again straight after: standing apart now does not cost it the right to be merged by
+            /// hand later.
+            if !joinsTabGroup {
+                window.tabbingMode = .disallowed
+            }
             if activate {
                 window.makeKeyAndOrderFront(nil)
                 AppActivationPolicyController.shared.activate(ignoringOtherApps: true)
             } else {
                 window.orderFront(nil)
+            }
+            if !joinsTabGroup {
+                window.tabbingMode = .automatic
             }
             Self.lifecycleLogger.info(
                 "[open] WindowManager standalone window payloadId=\(payload.id, privacy: .public) tabbingId=\(tabbingId, privacy: .public)"

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -4528,6 +4528,40 @@
         }
       }
     },
+    "UNGROUPED" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "그룹 없음"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GRUPSUZ"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KHÔNG THUỘC NHÓM"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未分组"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未分組"
+          }
+        }
+      }
+    },
     "%@x" : {
       "localizations" : {
         "ko" : {

--- a/TablePro/Views/Shared/FieldDrivenList.swift
+++ b/TablePro/Views/Shared/FieldDrivenList.swift
@@ -9,11 +9,15 @@ import SwiftUI
 internal struct FieldDrivenListSection<Item: Identifiable>: Identifiable {
     internal let id: String
     internal let title: String?
+    /// Drawn as a dot beside the title, for a section that stands for something the user gave a
+    /// colour to. Nil leaves the header as a plain label.
+    internal let accentColor: NSColor?
     internal let items: [Item]
 
-    internal init(id: String, title: String? = nil, items: [Item]) {
+    internal init(id: String, title: String? = nil, accentColor: NSColor? = nil, items: [Item]) {
         self.id = id
         self.title = title
+        self.accentColor = accentColor
         self.items = items
     }
 }
@@ -213,8 +217,8 @@ internal struct FieldDrivenList<Item: Identifiable, Row: View>: NSViewRepresenta
         internal func tableView(_ tableView: NSTableView, viewFor column: NSTableColumn?, row: Int) -> NSView? {
             guard row < entries.count else { return nil }
             switch entries[row] {
-            case .header(_, let title):
-                return FieldDrivenHeaderView.make(title: title)
+            case .header(_, let title, let accentColor):
+                return FieldDrivenHeaderView.make(title: title, accentColor: accentColor)
             case .item(let item):
                 let cell = tableView.makeView(
                     withIdentifier: FieldDrivenCellView<Row>.reuseIdentifier,
@@ -445,7 +449,9 @@ internal final class FieldDrivenCellView<Row: View>: NSTableCellView {
 }
 
 internal enum FieldDrivenHeaderView {
-    internal static func make(title: String) -> NSView {
+    private static let dotSize: CGFloat = 6
+
+    internal static func make(title: String, accentColor: NSColor? = nil) -> NSView {
         let label = NSTextField(labelWithString: title)
         label.font = .preferredFont(forTextStyle: .caption1)
         label.textColor = .secondaryLabelColor
@@ -454,10 +460,46 @@ internal enum FieldDrivenHeaderView {
         let container = NSView()
         container.addSubview(label)
         NSLayoutConstraint.activate([
-            label.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 4),
             label.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor),
             label.centerYAnchor.constraint(equalTo: container.centerYAnchor),
         ])
+
+        guard let accentColor else {
+            label.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 4).isActive = true
+            return container
+        }
+
+        let dot = ColorDotView(color: accentColor)
+        dot.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(dot)
+        NSLayoutConstraint.activate([
+            dot.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 4),
+            dot.centerYAnchor.constraint(equalTo: label.centerYAnchor),
+            dot.widthAnchor.constraint(equalToConstant: dotSize),
+            dot.heightAnchor.constraint(equalToConstant: dotSize),
+            label.leadingAnchor.constraint(equalTo: dot.trailingAnchor, constant: 5),
+        ])
         return container
+    }
+}
+
+/// A dot that repaints itself when the appearance changes, because a dynamic system colour
+/// resolved once into a layer stays at the appearance it was resolved in.
+private final class ColorDotView: NSView {
+    private let color: NSColor
+
+    init(color: NSColor) {
+        self.color = color
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("ColorDotView does not support NSCoder init")
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        color.setFill()
+        NSBezierPath(ovalIn: bounds).fill()
     }
 }

--- a/TablePro/Views/Shared/FieldDrivenListEntry.swift
+++ b/TablePro/Views/Shared/FieldDrivenListEntry.swift
@@ -3,12 +3,12 @@
 //  TablePro
 //
 
-import Foundation
+import AppKit
 
 /// One row of a `FieldDrivenList`, after sections have been flattened into the single index space
 /// an `NSTableView` works in.
 internal enum FieldDrivenListEntry<Item: Identifiable> where Item.ID: Hashable {
-    case header(id: String, title: String)
+    case header(id: String, title: String, accentColor: NSColor?)
     case item(Item)
 
     internal var isHeader: Bool {
@@ -23,10 +23,16 @@ internal enum FieldDrivenListEntry<Item: Identifiable> where Item.ID: Hashable {
 
     /// Identity, not content. A refilter that produces the same rows in the same order reloads
     /// nothing, which keeps the hosted SwiftUI views and their state alive.
+    ///
+    /// A header is the exception: only item rows are refreshed in place, so a header identified by
+    /// its section id alone would keep a group's old name and colour on screen after a rename
+    /// arrives from another device. Its drawn content is part of what identifies it.
     internal var identity: AnyHashable {
         switch self {
-        case .header(let id, _): return AnyHashable("header:" + id)
-        case .item(let item): return AnyHashable(item.id)
+        case .header(let id, let title, let accentColor):
+            return AnyHashable(HeaderIdentity(id: id, title: title, accentColor: accentColor))
+        case .item(let item):
+            return AnyHashable(item.id)
         }
     }
 
@@ -37,7 +43,13 @@ internal enum FieldDrivenListEntry<Item: Identifiable> where Item.ID: Hashable {
             guard !section.items.isEmpty else { return [] }
             let rows = section.items.map { FieldDrivenListEntry.item($0) }
             guard let title = section.title else { return rows }
-            return [.header(id: section.id, title: title)] + rows
+            return [.header(id: section.id, title: title, accentColor: section.accentColor)] + rows
         }
     }
+}
+
+private struct HeaderIdentity: Hashable {
+    let id: String
+    let title: String
+    let accentColor: NSColor?
 }

--- a/TablePro/Views/Toolbar/ConnectionSwitcherPopover.swift
+++ b/TablePro/Views/Toolbar/ConnectionSwitcherPopover.swift
@@ -4,6 +4,7 @@
 //
 
 import AppKit
+import Combine
 import SwiftUI
 import TableProPluginKit
 
@@ -43,6 +44,8 @@ struct ConnectionSwitcherPopover: View {
     let dismiss: () -> Void
 
     @State private var savedConnections: [DatabaseConnection] = []
+    @State private var groups: [ConnectionGroup] = []
+    @State private var hostedWithoutSession: [DatabaseConnection] = []
     @State private var selectedConnectionId: UUID?
     @State private var searchText = ""
 
@@ -62,20 +65,54 @@ struct ConnectionSwitcherPopover: View {
         Array(activeSessions.values).sorted { $0.lastActiveAt > $1.lastActiveAt }
     }
 
-    private var inactiveSaved: [DatabaseConnection] {
-        savedConnections.filter { activeSessions[$0.id] == nil }
+    /// Open means a window hosts it, which is not the same as a session existing for it. A
+    /// workspace outlives its session, so a connect that failed, one the user cancelled and an
+    /// explicit disconnect all leave a connection open with nothing in `activeSessions`. Listing
+    /// those under a group would put a connection the window is already showing in the library
+    /// half, where Command-click promises a window it will not get.
+    ///
+    /// Held in state rather than read during `body`, because `WindowManager` is not observable and
+    /// nothing would re-evaluate this when a window opens or closes.
+    private var openEntries: [ConnectionSwitcherEntry] {
+        var entries = sortedSessions.map {
+            ConnectionSwitcherEntry(
+                id: $0.id,
+                connection: $0.connection,
+                isActive: $0.id == currentSessionId,
+                isConnected: $0.status.isConnected
+            )
+        }
+        entries += hostedWithoutSession.map {
+            ConnectionSwitcherEntry(id: $0.id, connection: $0, isActive: false, isConnected: false)
+        }
+        return entries
     }
 
-    private var filteredSessions: [ConnectionSession] {
-        sortedSessions.filter { ConnectionSwitcherFilter.matches($0.connection, query: searchText) }
+    private var openConnectionIds: Set<UUID> {
+        Set(activeSessions.keys).union(hostedWithoutSession.map(\.id))
+    }
+
+    private var inactiveSaved: [DatabaseConnection] {
+        let open = openConnectionIds
+        return savedConnections.filter { !open.contains($0.id) }
+    }
+
+    private var filteredOpen: [ConnectionSwitcherEntry] {
+        openEntries.filter { ConnectionSwitcherFilter.matches($0.connection, query: searchText) }
     }
 
     private var filteredSaved: [DatabaseConnection] {
         inactiveSaved.filter { ConnectionSwitcherFilter.matches($0, query: searchText) }
     }
 
+    /// Read off the sections rather than assembled a second time, so the order the arrow keys walk
+    /// is the order the list draws by construction.
     private var orderedIds: [UUID] {
-        filteredSessions.map(\.id) + filteredSaved.map(\.id)
+        sections.flatMap { $0.items.map(\.id) }
+    }
+
+    private var isFiltering: Bool {
+        !searchText.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
     var body: some View {
@@ -92,15 +129,23 @@ struct ConnectionSwitcherPopover: View {
         }
         .frame(width: Self.contentSize.width, height: Self.contentSize.height)
         .onAppear {
-            savedConnections = ConnectionStorage.shared.loadConnections()
+            reload()
             if selectedConnectionId == nil {
                 selectedConnectionId = currentSessionId ?? orderedIds.first
             }
         }
+        /// The subject itself, not a `receive(on:)` wrapper: that builds a new publisher on every
+        /// body pass, and every sender is already on the main actor.
+        .onReceive(AppEvents.shared.connectionUpdated) { _ in
+            reload()
+            settleSelection()
+        }
+        .onReceive(AppEvents.shared.connectionWindowsChanged) { _ in
+            reload()
+            settleSelection()
+        }
         .onChange(of: searchText) { _, _ in
-            let ids = orderedIds
-            if let id = selectedConnectionId, ids.contains(id) { return }
-            selectedConnectionId = ids.first
+            settleSelection()
         }
     }
 
@@ -127,27 +172,12 @@ struct ConnectionSwitcherPopover: View {
     }
 
     private var sections: [FieldDrivenListSection<ConnectionSwitcherEntry>] {
-        [
-            FieldDrivenListSection(
-                id: "active",
-                title: String(localized: "ACTIVE CONNECTIONS"),
-                items: filteredSessions.map {
-                    ConnectionSwitcherEntry(
-                        id: $0.id,
-                        connection: $0.connection,
-                        isActive: $0.id == currentSessionId,
-                        isConnected: $0.status.isConnected
-                    )
-                }
-            ),
-            FieldDrivenListSection(
-                id: "saved",
-                title: String(localized: "SAVED CONNECTIONS"),
-                items: filteredSaved.map {
-                    ConnectionSwitcherEntry(id: $0.id, connection: $0, isActive: false, isConnected: false)
-                }
-            ),
-        ]
+        ConnectionSwitcherSections.build(
+            active: filteredOpen,
+            saved: filteredSaved,
+            groups: groups,
+            isFiltering: isFiltering
+        )
     }
 
     /// The search field keeps focus for the whole flow, so the list is a presentation of that
@@ -273,6 +303,24 @@ struct ConnectionSwitcherPopover: View {
 
     // MARK: - Selection
 
+    private func reload() {
+        let saved = ConnectionStorage.shared.loadConnections()
+        savedConnections = saved
+        groups = GroupStorage.shared.loadGroups()
+
+        hostedWithoutSession = ConnectionSwitcherSections.hostedWithoutSession(
+            workspaces: WindowManager.shared.hostedWorkspaces().map { ($0.connectionId, $0.connection) },
+            sessionIds: Set(DatabaseManager.shared.activeSessions.keys),
+            saved: saved
+        )
+    }
+
+    private func settleSelection() {
+        let ids = orderedIds
+        if let id = selectedConnectionId, ids.contains(id) { return }
+        selectedConnectionId = ids.first
+    }
+
     private func moveSelection(by offset: Int) {
         if let next = ConnectionSwitcherSelection.moved(in: orderedIds, from: selectedConnectionId, by: offset) {
             selectedConnectionId = next
@@ -284,11 +332,22 @@ struct ConnectionSwitcherPopover: View {
         activate(connectionId: id)
     }
 
+    /// Command-click opens a saved connection in a window of its own, the modifier Finder and
+    /// Safari use for the same intent. A connection already open is switched to either way: moving
+    /// one between windows belongs to the connections strip, which owns that arrangement.
+    ///
+    /// Whether a window already hosts it is settled by the router, next to the window it builds,
+    /// rather than here where the answer would be a main-actor job old by the time it is used.
     private func activate(connectionId: UUID) {
+        let opensNewWindow = NSApp.currentEvent?.modifierFlags.contains(.command) == true
         dismiss()
         Task {
             do {
-                try await TabRouter.shared.route(.openConnection(connectionId))
+                if opensNewWindow {
+                    try await TabRouter.shared.openConnectionPreferringNewWindow(id: connectionId)
+                } else {
+                    try await TabRouter.shared.route(.openConnection(connectionId))
+                }
             } catch {
                 await MainActor.run {
                     AlertHelper.showErrorSheet(
@@ -307,5 +366,132 @@ struct ConnectionSwitcherPopover: View {
         }
         let port = connection.port != connection.type.defaultPort ? ":\(connection.port)" : ""
         return "\(connection.host)\(port)/\(connection.database)"
+    }
+}
+
+// MARK: - Sections
+
+internal enum ConnectionSwitcherSections {
+    /// Open connections keep their own section at the top: they are the working set, and burying
+    /// one inside its group would put the two connections a user switches between furthest apart.
+    /// Everything below is the library, and that is where the group hierarchy belongs.
+    ///
+    /// A filter collapses the groups back into one list. A search is a lookup rather than a browse,
+    /// and a connection matching in each of eight groups would otherwise be eight one-row sections.
+    internal static func build(
+        active: [ConnectionSwitcherEntry],
+        saved: [DatabaseConnection],
+        groups: [ConnectionGroup],
+        isFiltering: Bool
+    ) -> [FieldDrivenListSection<ConnectionSwitcherEntry>] {
+        var sections = [
+            FieldDrivenListSection(
+                id: "active",
+                title: String(localized: "ACTIVE CONNECTIONS"),
+                items: active
+            ),
+        ]
+
+        guard !isFiltering else {
+            sections.append(
+                FieldDrivenListSection(
+                    id: "saved",
+                    title: String(localized: "SAVED CONNECTIONS"),
+                    items: saved.map(entry)
+                )
+            )
+            return sections
+        }
+
+        var ungrouped: [DatabaseConnection] = []
+        let sectionsBeforeGroups = sections.count
+        append(
+            buildGroupTreeIndexed(groups: groups, connections: saved),
+            path: [],
+            into: &sections,
+            ungrouped: &ungrouped
+        )
+
+        guard !ungrouped.isEmpty else { return sections }
+
+        /// "Ungrouped" only means anything beside a group. With no groups on screen there is
+        /// nothing for it to contrast with, and the list is just the saved connections.
+        let hasGroups = sections.count > sectionsBeforeGroups
+        sections.append(
+            FieldDrivenListSection(
+                id: "ungrouped",
+                title: hasGroups ? String(localized: "UNGROUPED") : String(localized: "SAVED CONNECTIONS"),
+                items: ungrouped.map(entry)
+            )
+        )
+        return sections
+    }
+
+    /// The connections a window still holds with no session behind them, deduplicated and named.
+    ///
+    /// One connection can be hosted twice once it has been moved into a window of its own, and a
+    /// workspace that never got as far as a session has no record of its own, so the saved list
+    /// answers for it.
+    internal static func hostedWithoutSession(
+        workspaces: [(connectionId: UUID, connection: DatabaseConnection?)],
+        sessionIds: Set<UUID>,
+        saved: [DatabaseConnection]
+    ) -> [DatabaseConnection] {
+        var seen: Set<UUID> = []
+        return workspaces.compactMap { workspace in
+            guard !sessionIds.contains(workspace.connectionId),
+                  seen.insert(workspace.connectionId).inserted else { return nil }
+            return workspace.connection ?? saved.first { $0.id == workspace.connectionId }
+        }
+        .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+
+    private static func entry(for connection: DatabaseConnection) -> ConnectionSwitcherEntry {
+        ConnectionSwitcherEntry(id: connection.id, connection: connection, isActive: false, isConnected: false)
+    }
+
+    /// One section per group, in the order the connection list shows them, with a nested group
+    /// naming its whole path. The header carries the group's own colour, and the connections that
+    /// belong to no group come last, which is where the tree puts them too.
+    private static func append(
+        _ nodes: [ConnectionGroupTreeNode],
+        path: [String],
+        into sections: inout [FieldDrivenListSection<ConnectionSwitcherEntry>],
+        ungrouped: inout [DatabaseConnection]
+    ) {
+        for node in nodes {
+            switch node {
+            case .connection(let connection):
+                ungrouped.append(connection)
+            case .group(let group, let children):
+                var connections: [DatabaseConnection] = []
+                var subgroups: [ConnectionGroupTreeNode] = []
+                for child in children {
+                    if case .connection(let connection) = child {
+                        connections.append(connection)
+                    } else {
+                        subgroups.append(child)
+                    }
+                }
+
+                /// A group with nothing under it draws no header, so it contributes no section
+                /// either. Leaving an empty one in made the list claim a hierarchy it was not
+                /// showing, and the loose connections then read as "ungrouped" against nothing.
+                /// A parent whose own connections are elsewhere still names itself through its
+                /// children's path.
+                let names = path + [group.name]
+                if !connections.isEmpty {
+                    sections.append(
+                        FieldDrivenListSection(
+                            id: "group-\(group.id)",
+                            title: names.joined(separator: " / ").localizedUppercase,
+                            accentColor: group.color.indicatorColor.map(NSColor.init),
+                            items: connections.map(entry)
+                        )
+                    )
+                }
+                append(subgroups, path: names, into: &sections, ungrouped: &ungrouped)
+            }
+        }
     }
 }

--- a/TableProTests/Views/FieldDrivenListEntryTests.swift
+++ b/TableProTests/Views/FieldDrivenListEntryTests.swift
@@ -3,6 +3,7 @@
 //  TableProTests
 //
 
+import AppKit
 @testable import TablePro
 import Testing
 
@@ -69,6 +70,33 @@ struct FieldDrivenListEntryTests {
         let first = FieldDrivenListEntry.flatten([section("a", title: nil, ["one", "two"])])
         let second = FieldDrivenListEntry.flatten([section("a", title: nil, ["one"])])
         #expect(first.map(\.identity) != second.map(\.identity))
+    }
+
+    /// Only item rows are refreshed in place, so a header that keeps its identity keeps whatever
+    /// it was already drawing. A group renamed on another device would have stayed on screen under
+    /// its old name.
+    @Test("A renamed section is a different header")
+    func headerIdentityFollowsItsTitle() {
+        let before = FieldDrivenListEntry.flatten([section("g", title: "ACME", ["one"])])
+        let after = FieldDrivenListEntry.flatten([section("g", title: "ACME CORP", ["one"])])
+
+        #expect(before.map(\.identity) != after.map(\.identity))
+    }
+
+    @Test("A recoloured section is a different header")
+    func headerIdentityFollowsItsAccent() {
+        let plain = FieldDrivenListSection(id: "g", title: "ACME", items: [Item(id: "one")])
+        let coloured = FieldDrivenListSection(
+            id: "g",
+            title: "ACME",
+            accentColor: .systemRed,
+            items: [Item(id: "one")]
+        )
+
+        #expect(
+            FieldDrivenListEntry.flatten([plain]).map(\.identity)
+                != FieldDrivenListEntry.flatten([coloured]).map(\.identity)
+        )
     }
 
     @Test("A header never reports an item id")

--- a/TableProTests/Views/Toolbar/ConnectionSwitcherFilterTests.swift
+++ b/TableProTests/Views/Toolbar/ConnectionSwitcherFilterTests.swift
@@ -81,3 +81,215 @@ struct ConnectionSwitcherSelectionTests {
         #expect(ConnectionSwitcherSelection.moved(in: [a, b, c], from: c, by: 1) == c)
     }
 }
+
+@Suite("Connection Switcher Sections")
+struct ConnectionSwitcherSectionsTests {
+    private func connection(_ name: String, groupId: UUID? = nil, sortOrder: Int = 0) -> DatabaseConnection {
+        DatabaseConnection(name: name, groupId: groupId, sortOrder: sortOrder)
+    }
+
+    private func titles(_ sections: [FieldDrivenListSection<ConnectionSwitcherEntry>]) -> [String] {
+        sections.compactMap(\.title)
+    }
+
+    private func names(_ sections: [FieldDrivenListSection<ConnectionSwitcherEntry>]) -> [[String]] {
+        sections.map { $0.items.map(\.connection.name) }
+    }
+
+    @Test("Saved connections are grouped, and the ones in no group come last")
+    func groupsBecomeSections() {
+        let acme = ConnectionGroup(name: "Acme", sortOrder: 0)
+        let saved = [
+            connection("acme-local", groupId: acme.id, sortOrder: 0),
+            connection("acme-prod", groupId: acme.id, sortOrder: 1),
+            connection("scratch"),
+        ]
+
+        let sections = ConnectionSwitcherSections.build(
+            active: [], saved: saved, groups: [acme], isFiltering: false
+        )
+
+        #expect(titles(sections) == ["ACTIVE CONNECTIONS", "ACME", "UNGROUPED"])
+        #expect(names(sections) == [[], ["acme-local", "acme-prod"], ["scratch"]])
+    }
+
+    // MARK: - Open without a session
+
+    /// A workspace outlives its session, so a connect that failed, one the user cancelled and an
+    /// explicit disconnect all leave a connection open with nothing in `activeSessions`.
+    @Test("A hosted connection with no session is still open")
+    func hostedWithoutSessionIsOpen() {
+        let disconnected = connection("acme-prod")
+
+        let open = ConnectionSwitcherSections.hostedWithoutSession(
+            workspaces: [(disconnected.id, disconnected)],
+            sessionIds: [],
+            saved: [disconnected]
+        )
+
+        #expect(open.map(\.id) == [disconnected.id])
+    }
+
+    @Test("A connection hosted by two windows is listed once")
+    func hostedTwiceIsListedOnce() {
+        let detached = connection("acme-prod")
+
+        let open = ConnectionSwitcherSections.hostedWithoutSession(
+            workspaces: [(detached.id, detached), (detached.id, detached)],
+            sessionIds: [],
+            saved: []
+        )
+
+        #expect(open.count == 1)
+    }
+
+    @Test("A workspace with no record of its own is named by the saved list")
+    func aWorkspaceWithoutARecordFallsBackToStorage() {
+        let saved = connection("acme-prod")
+
+        let open = ConnectionSwitcherSections.hostedWithoutSession(
+            workspaces: [(saved.id, nil)],
+            sessionIds: [],
+            saved: [saved]
+        )
+
+        #expect(open.map(\.name) == ["acme-prod"])
+    }
+
+    @Test("A connection that has a session is left to the session list")
+    func aSessionBackedConnectionIsNotDuplicated() {
+        let live = connection("acme-local")
+
+        let open = ConnectionSwitcherSections.hostedWithoutSession(
+            workspaces: [(live.id, live)],
+            sessionIds: [live.id],
+            saved: [live]
+        )
+
+        #expect(open.isEmpty)
+    }
+
+    @Test("With no groups at all the saved connections keep their own name")
+    func noGroupsKeepsTheSavedHeading() {
+        let sections = ConnectionSwitcherSections.build(
+            active: [], saved: [connection("scratch")], groups: [], isFiltering: false
+        )
+
+        #expect(titles(sections) == ["ACTIVE CONNECTIONS", "SAVED CONNECTIONS"])
+    }
+
+    /// The group draws no header once its only connection is open, so the connections beside it
+    /// are not "ungrouped" against anything the reader can see.
+    @Test("A group whose connections are all open leaves the saved heading alone")
+    func anEmptiedGroupDoesNotRenameTheLooseSection() {
+        let acme = ConnectionGroup(name: "Acme")
+        let open = connection("acme-local", groupId: acme.id)
+
+        let sections = ConnectionSwitcherSections.build(
+            active: [ConnectionSwitcherEntry(id: open.id, connection: open, isActive: true, isConnected: true)],
+            saved: [connection("scratch")],
+            groups: [acme],
+            isFiltering: false
+        )
+
+        #expect(titles(sections) == ["ACTIVE CONNECTIONS", "SAVED CONNECTIONS"])
+    }
+
+    @Test("A nested group names its whole path, under the parent that has connections of its own")
+    func nestedGroupNamesItsPath() {
+        let acme = ConnectionGroup(name: "Acme")
+        let europe = ConnectionGroup(name: "Europe", parentId: acme.id)
+        let saved = [
+            connection("acme-prod", groupId: acme.id),
+            connection("eu-prod", groupId: europe.id),
+        ]
+
+        let sections = ConnectionSwitcherSections.build(
+            active: [], saved: saved, groups: [acme, europe], isFiltering: false
+        )
+
+        #expect(titles(sections) == ["ACTIVE CONNECTIONS", "ACME", "ACME / EUROPE"])
+        #expect(names(sections).last == ["eu-prod"])
+    }
+
+    /// The parent draws no header of its own, and the child still says where it sits.
+    @Test("A group holding only subgroups is named through its children rather than on its own")
+    func aParentWithNoConnectionsOfItsOwnIsSkipped() {
+        let acme = ConnectionGroup(name: "Acme")
+        let europe = ConnectionGroup(name: "Europe", parentId: acme.id)
+        let saved = [connection("eu-prod", groupId: europe.id)]
+
+        let sections = ConnectionSwitcherSections.build(
+            active: [], saved: saved, groups: [acme, europe], isFiltering: false
+        )
+
+        #expect(titles(sections) == ["ACTIVE CONNECTIONS", "ACME / EUROPE"])
+    }
+
+    @Test("A group carries its own colour onto the header, and no colour means no dot")
+    func groupColourReachesTheHeader() {
+        let coloured = ConnectionGroup(name: "Prod", color: .red)
+        let plain = ConnectionGroup(name: "Scratch", sortOrder: 1)
+
+        let sections = ConnectionSwitcherSections.build(
+            active: [],
+            saved: [connection("a", groupId: coloured.id), connection("b", groupId: plain.id)],
+            groups: [coloured, plain],
+            isFiltering: false
+        )
+
+        #expect(sections.first { $0.title == "PROD" }?.accentColor != nil)
+        #expect(sections.first { $0.title == "SCRATCH" }?.accentColor == nil)
+    }
+
+    /// A search is a lookup rather than a browse: one match in each of eight groups would otherwise
+    /// be eight one-row sections, and a header cannot be selected to get out of them.
+    @Test("A filter collapses the groups back into one saved section")
+    func filteringFlattens() {
+        let acme = ConnectionGroup(name: "Acme")
+        let saved = [connection("acme-prod", groupId: acme.id), connection("scratch")]
+
+        let sections = ConnectionSwitcherSections.build(
+            active: [], saved: saved, groups: [acme], isFiltering: true
+        )
+
+        #expect(titles(sections) == ["ACTIVE CONNECTIONS", "SAVED CONNECTIONS"])
+        #expect(names(sections).last == ["acme-prod", "scratch"])
+    }
+
+    @Test("A group whose connections are all open draws no rows of its own")
+    func emptyGroupDrawsNothing() {
+        let acme = ConnectionGroup(name: "Acme")
+        let open = connection("acme-local", groupId: acme.id)
+
+        let sections = ConnectionSwitcherSections.build(
+            active: [ConnectionSwitcherEntry(id: open.id, connection: open, isActive: true, isConnected: true)],
+            saved: [],
+            groups: [acme],
+            isFiltering: false
+        )
+        let rows = FieldDrivenListEntry.flatten(sections)
+
+        #expect(rows.filter(\.isHeader).count == 1)
+        #expect(rows.compactMap(\.itemId) == [open.id])
+    }
+
+    @Test("The row order the arrow keys walk is the order the sections draw")
+    func rowOrderFollowsTheSections() {
+        let acme = ConnectionGroup(name: "Acme")
+        let open = connection("acme-local", groupId: acme.id)
+        let saved = [connection("acme-prod", groupId: acme.id), connection("scratch")]
+
+        let sections = ConnectionSwitcherSections.build(
+            active: [ConnectionSwitcherEntry(id: open.id, connection: open, isActive: true, isConnected: true)],
+            saved: saved,
+            groups: [acme],
+            isFiltering: false
+        )
+
+        #expect(
+            FieldDrivenListEntry.flatten(sections).compactMap(\.itemId)
+                == [open.id, saved[0].id, saved[1].id]
+        )
+    }
+}

--- a/docs/connections/index.mdx
+++ b/docs/connections/index.mdx
@@ -78,11 +78,13 @@ A connection's group, tags, and favorite star sync through iCloud unless it is m
 
 ## Switch connections and databases
 
-**Switch Connection** (`Ctrl+Cmd+C`) lists active sessions and saved connections: type to filter, arrow keys to move, Return to switch. **Open Database** (`Cmd+K`) moves to another database on the same server.
+Press `Ctrl+Cmd+C` for **Switch Connection**. Whatever is already open sits at the top, and the rest are listed under the group they belong to, a nested group carrying its full path. Arrow keys move, `Return` switches the window to that connection, and `Cmd`-click opens a saved one in a window of its own. Typing searches every group at once and collapses the matches into a single list.
+
+**Open Database** (`Cmd+K`) moves to another database on the same server.
 
 <Frame caption="Database switcher in toolbar">
-  <img className="block dark:hidden" src="/images/database-switcher-toolbar.png" alt="Database switcher in toolbar" />
-  <img className="hidden dark:block" src="/images/database-switcher-toolbar-dark.png" alt="Database switcher in toolbar" />
+  <img className="block dark:hidden" src="/images/database-switcher-toolbar.png" alt="Database list with the current database checked" />
+  <img className="hidden dark:block" src="/images/database-switcher-toolbar-dark.png" alt="Database list with the current database checked" />
 </Frame>
 
 Leaving **Database** empty on MySQL, MariaDB, MongoDB, SQL Server, and ClickHouse browses every database the user can reach. PostgreSQL and Redshift need one to connect at all: use `postgres` (Redshift: `dev`) and switch with `Cmd+K`. To hide the rest, choose **View > Filter Databases** and check the ones you want; the choice is saved per connection.


### PR DESCRIPTION
Fixes #1311.

## What the issue asked for, and what is left of it

The issue is from May, and it predates the two refactors that answered most of it. #2035 added the
connections strip and #2097 made one window host every connection, so clicking a connection already
switches the window in place instead of piling up tabs, which was the reporter's actual complaint.

What none of that delivered is the first half of the request: the group hierarchy is invisible from
a main window. `ConnectionGroup` carries a parent, a colour and a sort order, and it syncs, but the
only surface that renders it is the welcome window. Switch Connection, the one place inside the
window that lists every saved connection, showed a flat list with the group reduced to a badge.

## Why the panel and not the sidebar

The request as written is the DataGrip and DBeaver shape, one tree holding groups, connections,
databases, schemas and tables. Two things rule it out.

The HIG's sidebar page: *"In general, show no more than two levels of hierarchy in a sidebar. When
a data hierarchy is deeper than two levels, consider using a split view interface that includes a
content list."* The sidebar already holds database, schema, object kind and table. Groups and
connections on top of that is six levels.

And no macOS-native client does it. TablePlus keeps saved connections on its welcome screen and its
second sidebar lists only what is open, gated on there being more than one, which is the same shape
as our connections strip. Postico, Sequel Ace and Querious are the same. The two that merge the
trees are cross-platform IDEs.

The strip cannot carry it either, and not for want of room: `WorkspaceRailStore.entries` is derived
from the windows that host a connection, and `WorkspaceID` is keyed on a connection plus the
container it is browsing. A connection that is not open has neither.

So the hierarchy goes where the library already lives.

## What changed

- Switch Connection lists saved connections under their groups, in the order the connection list
  shows them, a nested group naming its whole path (`ACME / EUROPE`) and each header carrying the
  group's own colour. Connections in no group come last, which is where the tree puts them.
- A group with nothing under it contributes no section. The rendered list was already right, since
  an empty section draws no header, but the model claimed a hierarchy that was not on screen and
  that is what decides the last section's name: with no group visible it stays **SAVED
  CONNECTIONS**, because "ungrouped" needs a group beside it to mean anything. A parent holding
  only subgroups names itself through its children's path instead of drawing an empty header.
- Open connections keep their own section at the top. Burying one in its group would put the two
  connections a user switches between furthest apart, and the section already excludes them from
  the saved half, so nothing is listed twice.
- Typing collapses the groups back into one list. A search is a lookup rather than a browse, and one
  match in each of eight groups is eight one-row sections. It also keeps the arrow keys away from
  header rows, which is TablePlus issue #2134, open since 2020.
- `Cmd`-click opens a saved connection in a window of its own, the modifier Finder and Safari use
  for the same intent. A connection already open is switched to either way: moving one between
  windows belongs to the connections strip, which owns that arrangement.
- "Already open" is a window hosting the connection, not an entry in `activeSessions`, and that
  now decides both halves. A workspace outlives its session, so a connect that failed, one the user
  cancelled and an explicit disconnect all leave a connection open with no session; the old rule
  listed those under a group, where `Cmd`-click promised a window they would never get, and in a
  shared window the ordinary route then switched away from the connection on screen to reconnect a
  hidden one. The top section is derived from `WindowManager.hostedWorkspaces()` and the saved rows
  are what is left, with `connectionWindowsChanged` observed so the split follows a window opening
  or closing. That is CLAUDE.md's "A workspace's content is a function of its own
  `ConnectionWindowPhase`, never of `activeSessions` membership".
- The host check lives in the router, next to the window it builds. Deciding it in the click
  handler left a main-actor job between the question and the answer, and anything that opened the
  same connection in between, the MCP tool among them, would have left two workspaces restoring the
  same tabs. Nothing is awaited between the two now.
- `openInNewWindow` gained `joinsTabGroup`. Left alone it joins the existing tab group on purpose,
  which is what once made Open in New Window produce a native tab of the window it was asked to
  leave, so the switcher passes `false` and gets a window that stands apart. Tabbing is refused for
  the moment the window is placed and allowed again straight after, so standing apart now does not
  cost it the right to be merged by hand later.
- A section header is identified by what it draws, not by its section id. Only item rows are
  refreshed in place, so a group renamed or recoloured on another device kept its old header on
  screen until something structural forced a full reload.
- The panel follows `connectionUpdated` instead of reading storage once in `onAppear`, so a group
  renamed or a connection added while it is open is reflected. That event only exists on the group
  path since #2619. It subscribes to the subject itself rather than a `receive(on:)` wrapper, which
  would build a new publisher on every body pass; every sender is already on the main actor.
- `FieldDrivenListSection` gained an optional accent colour, drawn as a dot beside the header title.
  It defaults to nil, so the database switcher and the history pane are untouched.

## Non-goal: collapsing a group

This is a transient panel with a search field, and neither Spotlight nor Xcode's Open Quickly lets
you fold a section away. Collapsing would need a click path to a header row, which
`clickedItemId()` cannot reach because a header carries no item id, plus somewhere to persist the
state, logic to hide the descendants of a collapsed group, and an auto-expand that walks the whole
ancestor chain of the active connection. If it turns out to be wanted, the honest answer is an
`NSOutlineView` on the existing `SidebarOutlineScaffold` rather than bolting it onto a table.

## What the new-window path deliberately does not do

It never prompts for a pre-connect script. A window whose connection carries one does not
auto-connect at all: `MainSplitViewController+Connection.swift:37` sends it to its not-connected
state, where **Connect** asks. Prompting in the router as well would ask the same question twice and
the first answer would change nothing, which is why the window-opening half of `openConnection` has
never called it either.

## Verification

- `verify.sh generate`, `verify.sh build`: PASS
- `verify.sh test ConnectionSwitcherFilterTests ConnectionSwitcherSectionsTests StringCatalogIntegrityTests`: PASS
- `verify.sh uitest SwitcherEscapeUITests`: PASS
- `verify.sh docs`: PASS, both the house-style and the source-claim check
- `swiftlint --strict` on every changed file: clean

Section building moved out of the view into `ConnectionSwitcherSections`, so the part that decides
what is listed and in what order is testable without a window. Six new cases cover group ordering,
the path title of a nested group, the accent colour, the flattening under a filter, a group whose
connections are all open drawing no rows, and the row order the arrow keys walk matching the
sections.

No new UI automation. Seeding a group tree needs a launch hook the app does not have: the only two
it exposes are the sandbox root and "open the sample database", and a UI test target cannot import
the app to write the connection store itself. Adding one would be production code with no user. The
panel itself stays covered by `SwitcherEscapeUITests`, which drives it through real key presses.


https://claude.ai/code/session_01L81TaoPWxkLd15CGw2riPq
