### PR TITLE
test(connections): cover reaching a saved connection without opening a window

### DIFF
--- a/TableProUITests/GroupedConnectionSwitcherUITests.swift
+++ b/TableProUITests/GroupedConnectionSwitcherUITests.swift
@@ -1,0 +1,84 @@
+import XCTest
+
+/// Reaching a saved connection from the switcher switches the window it is already in rather than
+/// opening another, which is the promise #1311 asked for and #2097 made.
+///
+/// The connections are written into the sandbox before launch instead of driven through the UI.
+/// A store with no integrity tag beside it is adopted as it stands, the path an install predating
+/// the tag takes, so a test can seed one without the app's own writer.
+///
+/// The group they belong to is not seeded, and cannot be from here: groups live in a `UserDefaults`
+/// suite, the runner is sandboxed and the app is not, so the suite resolves to
+/// `<runner container>/Data/Library/Preferences/com.TablePro.uitest.plist` for one and
+/// `~/Library/Preferences/com.TablePro.uitest.plist` for the other. Anything this process writes
+/// there, the app never reads. `ConnectionSwitcherSectionsTests` covers the grouping itself.
+///
+/// The sample database supplies the main window. Switch Connection belongs to that window, so on
+/// the welcome screen the shortcut reaches nothing and the seeded connections stay unreachable.
+final class GroupedConnectionSwitcherUITests: UITestCase {
+    private let savedConnectionName = "acme-staging"
+
+    /// One window hosts every connection, so reaching a second one must not open another.
+    func testReachingASavedConnectionKeepsOneWindow() throws {
+        try seedConnections()
+        let app = try launchWithSampleDatabase()
+        let windowsBefore = app.windows.count
+
+        app.typeKey("c", modifierFlags: [.command, .control])
+        let field = connectionSearchField(in: app)
+        XCTAssertTrue(field.waitToExist(timeout: 15), "The connection switcher never opened")
+
+        app.typeText(savedConnectionName)
+        app.typeKey(.return, modifierFlags: [])
+
+        XCTAssertTrue(
+            field.waitForNonExistence(timeout: 10),
+            "Activating a connection must dismiss the switcher"
+        )
+        XCTAssertEqual(app.windows.count, windowsBefore, "Switching connection must not open a window")
+    }
+
+    // MARK: - Fixture
+
+    /// Matched on its placeholder, never `searchFields.firstMatch`: the object browser carries a
+    /// filter field of its own that is always on screen, so the loose query answers with that one
+    /// and every wait on it passes without the switcher ever opening.
+    private func connectionSearchField(in app: XCUIApplication) -> XCUIElement {
+        app.searchFields.matching(
+            NSPredicate(format: "placeholderValue BEGINSWITH[c] %@", "Search connections")
+        ).firstMatch
+    }
+
+    private func seedConnections() throws {
+        let root = try XCTUnwrap(sandboxRoot, "setUpWithError did not prepare a sandbox")
+        let supportDirectory = root.appendingPathComponent("TablePro", isDirectory: true)
+        try FileManager.default.createDirectory(at: supportDirectory, withIntermediateDirectories: true)
+
+        let connections = ["acme-local", savedConnectionName, "acme-prod"].enumerated().map {
+            connectionPayload(name: $0.element, sortOrder: $0.offset)
+        }
+        try JSONSerialization.data(withJSONObject: connections, options: [.sortedKeys])
+            .write(to: supportDirectory.appendingPathComponent("connections.json"), options: .atomic)
+    }
+
+    /// Every key the stored form decodes without a default. A key added there without one fails
+    /// this test rather than silently seeding nothing, which is the failure worth having: it is
+    /// also the key every store already on a user's disk would be missing.
+    private func connectionPayload(name: String, sortOrder: Int) -> [String: Any] {
+        [
+            "id": UUID().uuidString,
+            "name": name,
+            "host": "127.0.0.1",
+            "port": 3_306,
+            "database": "app",
+            "username": "root",
+            "type": "MySQL",
+            "sshEnabled": false,
+            "sshHost": "",
+            "sshUsername": "",
+            "sshAuthMethod": "password",
+            "sshPrivateKeyPath": "",
+            "sortOrder": sortOrder,
+        ]
+    }
+}


### PR DESCRIPTION
#2620 shipped the grouped switcher with no UI automation, on the grounds that seeding a fixture
needed a launch hook the app does not have. That was half wrong, so here is the half that works.

Connections are seedable: `AppStorageEnvironment` redirects the Application Support root into the
sandbox `UITestCase` prepares, and `ConnectionStorage` adopts a store with no integrity tag beside
it rather than refusing it, which is the path an install predating the tag takes. Writing
`connections.json` into the sandbox before launch is enough.

The test opens Switch Connection, activates a saved connection, and asserts the window count did
not change. That is what #1311 asked for and what #2097 promised, and nothing was covering it.

## What this test does not cover, and why it cannot from here

The group the connections belong to is not seeded. Groups live in a `UserDefaults` suite, and the
suite name resolves per process container: the runner is sandboxed, the app is not, so the same
name is `<runner container>/Data/Library/Preferences/com.TablePro.uitest.plist` for the test and
`~/Library/Preferences/com.TablePro.uitest.plist` for the app. Both files exist on this machine.
Anything the runner writes there, the app never reads.

`ConnectionSwitcherSectionsTests` covers the grouping itself, and it covers it better than a UI
test would: section order, the path title of a nested group, the accent colour, the collapse under
a filter, and a group whose connections are all open.

## Two things found while writing it

**Every search field in the app answers to `sidebar-filter`.**
`NativeSearchField.accessibilityIdentifier` defaults to that string, and 18 of its 30 call sites
take the default, including the switcher's own field, the database switcher, the welcome window and
several Settings panes. The captured element tree shows the switcher's field as
`identifier: 'sidebar-filter', placeholderValue: 'Search connections'`.

This is not theoretical. The first version of this test waited on `app.searchFields.firstMatch`,
matched the object browser's filter field, and **passed while asserting nothing**: the panel it
meant to drive never had to open. It only came to light because the other assertion in the same
test failed for a real reason. This test now matches on the placeholder, the way
`SwitcherEscapeUITests` already did.

**UI test isolation for `UserDefaults` does not work.**
`UITestCase.setUpWithError` clears `com.TablePro.uitest` so that "one test cannot read what the
last one wrote", but it clears the runner's copy while the app reads and writes its own. The app's
copy currently holds `com.TablePro.sample.openedCount => 229` along with per-connection history
panel state, accumulated across every UI test run this machine has ever done. Every UI test shares
one growing defaults domain, and any test that depends on a clean one is silently reading the
previous run's.

Neither is fixed here. The first is a shared component and its 18 adopters; the second can only be
repaired from the app side, since a sandboxed runner cannot reach the domain the app uses, and that
means production code changed for a test. Both are worth their own change.

## Verification

- `verify.sh generate`: PASS
- `verify.sh uitest GroupedConnectionSwitcherUITests`: PASS
- `swiftlint --strict` on the new file: clean

No CHANGELOG entry: nothing here changes what the app does.


https://claude.ai/code/session_01L81TaoPWxkLd15CGw2riPq
