### PR TITLE
test: make main green again after the schema change route moved to the pool

### DIFF
--- a/TablePro/Core/Database/TriggerEditing.swift
+++ b/TablePro/Core/Database/TriggerEditing.swift
@@ -53,9 +53,10 @@ enum TriggerEditing {
         sql: String,
         isEdit: Bool,
         originalName: String?,
-        originalDefinition: String?
+        originalDefinition: String?,
+        gate: any ExecutionGate = ExecutionGateProvider.shared
     ) async throws {
-        let decision = await ExecutionGateProvider.shared.authorize(
+        let decision = await gate.authorize(
             OperationRequest(
                 connectionId: connection.id,
                 databaseType: connection.type,
@@ -95,7 +96,13 @@ enum TriggerEditing {
         AppCommands.shared.refreshData.send(DataRefreshRequest(connectionId: connection.id, scope: scope))
     }
 
-    static func drop(scope: DatabaseScope, connection: DatabaseConnection, tableName: String, name: String) async throws {
+    static func drop(
+        scope: DatabaseScope,
+        connection: DatabaseConnection,
+        tableName: String,
+        name: String,
+        gate: any ExecutionGate = ExecutionGateProvider.shared
+    ) async throws {
         guard let driver = DatabaseManager.shared.driver(for: connection.id) else {
             throw TriggerEditingError.notConnected
         }
@@ -103,7 +110,7 @@ enum TriggerEditing {
             throw TriggerEditingError.dropUnavailable
         }
 
-        let decision = await ExecutionGateProvider.shared.authorize(
+        let decision = await gate.authorize(
             OperationRequest(
                 connectionId: connection.id,
                 databaseType: connection.type,

--- a/TableProTests/Core/Compare/CompareSyncExecutorTests.swift
+++ b/TableProTests/Core/Compare/CompareSyncExecutorTests.swift
@@ -52,24 +52,6 @@ private final class RecordingDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 }
 
-private struct AlwaysAllowGate: ExecutionGate {
-    func authorize(_ request: OperationRequest) async -> OperationDecision {
-        .authorized(OperationReceipt(
-            connectionId: request.connectionId,
-            kind: request.kind,
-            effectiveWrite: true,
-            grantedAt: Date(),
-            token: UUID()
-        ))
-    }
-}
-
-private struct AlwaysDenyGate: ExecutionGate {
-    func authorize(_ request: OperationRequest) async -> OperationDecision {
-        .denied(reason: "Read-Only connection")
-    }
-}
-
 final class CompareSyncExecutorTests: XCTestCase {
     private func endpoint() -> DatabaseEndpoint {
         DatabaseEndpoint(

--- a/TableProTests/Core/Database/TriggerInfoMappingTests.swift
+++ b/TableProTests/Core/Database/TriggerInfoMappingTests.swift
@@ -244,6 +244,11 @@ struct TriggerApplyExecutionTests {
 
     /// The session driver holds whatever transaction a query tab left open, so a trigger edit
     /// with a BEGIN of its own ran inside it and committed or rolled back the tab's work.
+    ///
+    /// The gate is supplied rather than taken from `ExecutionGateProvider`. A drop is a
+    /// `.destructiveQuery`, which the real gate confirms with an `NSAlert`, and an alert raised
+    /// with no window runs application-modal: on a CI runner nobody answers it, so the whole
+    /// unit job stops there and is killed by its timeout rather than failing.
     @Test("Apply and drop run on the pooled connection and leave the session driver alone")
     func applyAndDropRunOnThePooledConnection() async throws {
         let connection = TestFixtures.makeConnection(database: "app", type: .postgresql)
@@ -272,9 +277,16 @@ struct TriggerApplyExecutionTests {
             sql: "CREATE TRIGGER t",
             isEdit: false,
             originalName: nil,
-            originalDefinition: nil
+            originalDefinition: nil,
+            gate: AlwaysAllowGate()
         )
-        try await TriggerEditing.drop(scope: scope, connection: connection, tableName: "orders", name: "t")
+        try await TriggerEditing.drop(
+            scope: scope,
+            connection: connection,
+            tableName: "orders",
+            name: "t",
+            gate: AlwaysAllowGate()
+        )
 
         #expect(pooledStub.executedQueries == ["BEGIN", "CREATE TRIGGER t", "COMMIT", "DROP TRIGGER t"])
         #expect(sessionStub.executedQueries.isEmpty)

--- a/TableProTests/Helpers/StubExecutionGates.swift
+++ b/TableProTests/Helpers/StubExecutionGates.swift
@@ -1,0 +1,36 @@
+//
+//  StubExecutionGates.swift
+//  TableProTests
+//
+//  The real gate confirms a destructive statement with an NSAlert, and an alert raised with no
+//  window runs application-modal. Nothing answers it on a CI runner, so a test that reaches the
+//  real gate stops the whole job there. Every test that drives a gated operation supplies one of
+//  these instead and asserts on what ran, not on who was asked.
+//
+
+import Foundation
+@testable import TablePro
+
+internal struct AlwaysAllowGate: ExecutionGate {
+    internal func authorize(_ request: OperationRequest) async -> OperationDecision {
+        .authorized(OperationReceipt(
+            connectionId: request.connectionId,
+            kind: request.kind,
+            effectiveWrite: true,
+            grantedAt: Date(),
+            token: UUID()
+        ))
+    }
+}
+
+internal struct AlwaysDenyGate: ExecutionGate {
+    internal let reason: String
+
+    internal init(reason: String = "Read-Only connection") {
+        self.reason = reason
+    }
+
+    internal func authorize(_ request: OperationRequest) async -> OperationDecision {
+        .denied(reason: reason)
+    }
+}

--- a/TableProTests/Views/Structure/StructureEditingSessionTests.swift
+++ b/TableProTests/Views/Structure/StructureEditingSessionTests.swift
@@ -156,17 +156,29 @@ struct StructureEditingSessionTests {
     /// The save no longer needs a mounted structure view. This is the whole point: `hasUnsavedWork`
     /// reads the session, so the prompt offering Save can be raised by a tab showing its Data view
     /// or by a background tab in a batch close, and the save it offers has to reach the work.
+    ///
+    /// The ALTER lands on a pooled connection, not the session driver, because a save runs on the
+    /// schema change route. The pool is seeded here for the same reason it is in
+    /// `DatabaseManagerSchemaChangeRoutingTests`: no plugin loads under XCTest, so a pool left to
+    /// open its own connection reports the driver missing and nothing runs.
     @Test("A session applies its staged edits with no view mounted")
     func applyRunsWithoutAView() async throws {
         let connection = TestFixtures.makeConnection(database: "testdb")
-        let driver = StructureSessionDriver()
-        let adapter = PluginDriverAdapter(connection: connection, pluginDriver: driver)
-        var connectionSession = ConnectionSession(connection: connection, driver: adapter)
+        let sessionDriver = StructureSessionDriver()
+        var connectionSession = ConnectionSession(
+            connection: connection,
+            driver: PluginDriverAdapter(connection: connection, pluginDriver: sessionDriver)
+        )
         connectionSession.browseDatabase = "testdb"
         DatabaseManager.shared.injectSession(connectionSession, for: connection.id)
-        defer { DatabaseManager.shared.removeSession(for: connection.id) }
 
         let session = Self.makeSession(connection: connection)
+        let pooledDriver = try await Self.seedPooledDriver(connection, scope: session.scope)
+        defer {
+            MetadataConnectionPool.shared.closeAll(connectionId: connection.id)
+            DatabaseManager.shared.removeSession(for: connection.id)
+        }
+
         Self.stageAColumn(on: session)
         #expect(session.changeManager.hasChanges)
 
@@ -174,9 +186,22 @@ struct StructureEditingSessionTests {
 
         #expect(outcome == .applied)
         #expect(outcome.allowsClose)
-        #expect(driver.executedQueries.contains { $0.contains("ADD COLUMN") })
+        #expect(pooledDriver.executedQueries.contains { $0.contains("ADD COLUMN") })
+        #expect(sessionDriver.executedQueries.isEmpty)
         #expect(!session.changeManager.hasChanges)
         #expect(session.appliedVersion == 1)
         #expect(!session.hasLoaded)
+    }
+
+    /// Stands in for the connection the pool would open on the scope.
+    private static func seedPooledDriver(
+        _ connection: DatabaseConnection,
+        scope: DatabaseScope
+    ) async throws -> StructureSessionDriver {
+        let driver = StructureSessionDriver()
+        let adapter = PluginDriverAdapter(connection: connection, pluginDriver: driver)
+        try await adapter.connect()
+        MetadataConnectionPool.shared.injectEntry(adapter, scope: scope)
+        return driver
     }
 }

--- a/TableProUITests/StructureColumnMoveUITests.swift
+++ b/TableProUITests/StructureColumnMoveUITests.swift
@@ -20,7 +20,7 @@ final class StructureColumnMoveUITests: UITestCase {
         XCTAssertTrue(row.waitToExist(timeout: 20), "The object browser must list Album")
         clickAtCenter(row)
 
-        showStructure(in: window)
+        showStructure(in: app, window: window)
         let grid = window.tables.matching(identifier: "data-grid").firstMatch
         XCTAssertTrue(grid.waitToExist(timeout: 30), "The structure editor must draw its column grid")
         XCTAssertTrue(
@@ -35,9 +35,7 @@ final class StructureColumnMoveUITests: UITestCase {
             "The grid must be laid out before a coordinate is taken off it"
         )
 
-        /// A point offset from the grid, never a row or cell element: the grid's columns are
-        /// siblings of its rows and later in the tree, so XCUITest reads both as obscured.
-        let target = grid.coordinate(withNormalizedOffset: .zero).withOffset(CGVector(dx: 80, dy: 40))
+        let target = gridPoint(in: grid, of: window, dy: 40)
 
         /// Right-clicking an unselected row falls through to the row view's own `menu(for:)`.
         target.rightClick()
@@ -65,13 +63,5 @@ final class StructureColumnMoveUITests: UITestCase {
             up.isEnabled || down.isEnabled,
             "SQLite reorders by rebuilding, so a column has at least one direction it can move"
         )
-    }
-
-    private func showStructure(in window: XCUIElement) {
-        let modePicker = window.radioGroups["results-view-mode-picker"].firstMatch
-        XCTAssertTrue(modePicker.waitToExist(timeout: 20), "The result must expose its view modes")
-        let structure = modePicker.radioButtons["Structure"].firstMatch
-        XCTAssertTrue(structure.waitToExist(timeout: 20), "Structure must be one of them")
-        structure.click()
     }
 }

--- a/TableProUITests/StructureConstraintsTabUITests.swift
+++ b/TableProUITests/StructureConstraintsTabUITests.swift
@@ -17,7 +17,7 @@ final class StructureConstraintsTabUITests: UITestCase {
         XCTAssertTrue(row.waitToExist(timeout: 20), "The object browser must list Album")
         clickAtCenter(row)
 
-        showStructure(in: window)
+        showStructure(in: app, window: window)
 
         let constraints = subTab(named: "Constraints", in: window)
         XCTAssertTrue(
@@ -36,14 +36,6 @@ final class StructureConstraintsTabUITests: UITestCase {
     /// instead, so `isSelected` reads as false however the picker is set.
     private func isSelected(_ segment: XCUIElement) -> Bool {
         (segment.value as? NSNumber)?.intValue == 1
-    }
-
-    private func showStructure(in window: XCUIElement) {
-        let modePicker = window.radioGroups["results-view-mode-picker"].firstMatch
-        XCTAssertTrue(modePicker.waitToExist(timeout: 20), "The result must expose its view modes")
-        let structure = modePicker.radioButtons["Structure"].firstMatch
-        XCTAssertTrue(structure.waitToExist(timeout: 20), "Structure must be one of them")
-        structure.click()
     }
 
     /// The sub-tab labels carry item counts, so they are matched by prefix rather than exactly.

--- a/TableProUITests/StructureRowMenuParityUITests.swift
+++ b/TableProUITests/StructureRowMenuParityUITests.swift
@@ -28,7 +28,7 @@ final class StructureRowMenuParityUITests: UITestCase {
         XCTAssertTrue(row.waitToExist(timeout: 20), "The object browser must list Album")
         clickAtCenter(row)
 
-        showStructure(in: window)
+        showStructure(in: app, window: window)
         let grid = window.tables.matching(identifier: "data-grid").firstMatch
         XCTAssertTrue(grid.waitToExist(timeout: 30), "The structure editor must draw its column grid")
         XCTAssertTrue(
@@ -43,9 +43,7 @@ final class StructureRowMenuParityUITests: UITestCase {
             "The grid must be laid out before a coordinate is taken off it"
         )
 
-        /// A point offset from the grid, never a row or cell element: the grid's columns are
-        /// siblings of its rows and later in the tree, so XCUITest reads both as obscured.
-        let target = grid.coordinate(withNormalizedOffset: .zero).withOffset(CGVector(dx: 80, dy: 40))
+        let target = gridPoint(in: grid, of: window, dy: 40)
 
         target.rightClick()
         assertStructureMenu(in: app, path: "an unselected column row")
@@ -67,13 +65,5 @@ final class StructureRowMenuParityUITests: UITestCase {
             contextMenuItem(structureOnlyItem, in: app).waitToExist(timeout: 15),
             "\(path) must offer \(structureOnlyItem), which only the structure menu builds"
         )
-    }
-
-    private func showStructure(in window: XCUIElement) {
-        let modePicker = window.radioGroups["results-view-mode-picker"].firstMatch
-        XCTAssertTrue(modePicker.waitToExist(timeout: 20), "The result must expose its view modes")
-        let structure = modePicker.radioButtons["Structure"].firstMatch
-        XCTAssertTrue(structure.waitToExist(timeout: 20), "Structure must be one of them")
-        structure.click()
     }
 }

--- a/TableProUITests/StructureTabIdentityUITests.swift
+++ b/TableProUITests/StructureTabIdentityUITests.swift
@@ -18,7 +18,7 @@ final class StructureTabIdentityUITests: UITestCase {
         XCTAssertTrue(row.waitToExist(timeout: 20), "The object browser must list Album")
         clickAtCenter(row)
 
-        showStructure(in: window)
+        showStructure(in: app, window: window)
         let indexes = subTab(named: "Indexes", in: window)
         XCTAssertTrue(indexes.waitToExist(timeout: 20), "The structure editor must offer Indexes")
         indexes.click()
@@ -32,7 +32,7 @@ final class StructureTabIdentityUITests: UITestCase {
         XCTAssertTrue(openInNewTab.waitToExist(timeout: 15), "The sidebar must offer Open in New Tab")
         openInNewTab.click()
 
-        showStructure(in: window)
+        showStructure(in: app, window: window)
         let columns = subTab(named: "Columns", in: window)
         XCTAssertTrue(columns.waitToExist(timeout: 20), "The second tab must have its own structure editor")
         XCTAssertTrue(
@@ -45,14 +45,6 @@ final class StructureTabIdentityUITests: UITestCase {
     /// instead, so `isSelected` reads as false however the picker is set.
     private func isSelected(_ segment: XCUIElement) -> Bool {
         (segment.value as? NSNumber)?.intValue == 1
-    }
-
-    private func showStructure(in window: XCUIElement) {
-        let modePicker = window.radioGroups["results-view-mode-picker"].firstMatch
-        XCTAssertTrue(modePicker.waitToExist(timeout: 20), "The result must expose its view modes")
-        let structure = modePicker.radioButtons["Structure"].firstMatch
-        XCTAssertTrue(structure.waitToExist(timeout: 20), "Structure must be one of them")
-        structure.click()
     }
 
     /// The sub-tab labels carry item counts, so they are matched by prefix rather than exactly.

--- a/TableProUITests/Support/UITestCase.swift
+++ b/TableProUITests/Support/UITestCase.swift
@@ -182,6 +182,50 @@ internal class UITestCase: XCTestCase {
         waitForPredicate(timeout: timeout) { element.exists && element.isHittable }
     }
 
+    /// Switches the result to its Structure editor, through **View > Result View > Structure**
+    /// rather than the `Structure` segment of the results status bar.
+    ///
+    /// The segment cannot be clicked on the runner. Its screen is 1024x768, and a window that
+    /// wide cannot hold the sidebar, the detail pane at its minimum width and the row inspector
+    /// at once: the detail pane keeps its minimum and is drawn under the sidebar, taking the
+    /// leading half of the status bar with it. XCUITest still reports the segment as existing and
+    /// hittable, because its accessibility frame is where the layout says it is, so the click is
+    /// posted at (314, 691) and lands on the sidebar. Nothing fails there. The result stays on
+    /// Data, and the suite's next assertion reads the data grid as though it were the structure
+    /// grid, or waits out its timeout for a structure tab picker that was never going to appear.
+    /// (Run 33734073855, where the element tree captured the mode picker still reporting
+    /// `Data` selected after the click.)
+    ///
+    /// The menu item carries no geometry, so it is reachable whatever the window is doing.
+    /// Nothing probes for it first: XCUITest resolves a menu item by opening its parent, and a
+    /// probe that resolves it leaves that menu open, so the click's own traversal then fails with
+    /// "open menu during menu traversal" and waits out a ten second watchdog. Waiting on the menu
+    /// bar costs nothing and waiting for the tab picker afterwards is what makes the switch
+    /// observed rather than assumed.
+    internal func showStructure(in app: XCUIApplication, window: XCUIElement) {
+        let menuBar = app.menuBars.firstMatch
+        XCTAssertTrue(menuBar.waitToExist(timeout: 20), "The app must publish its menu bar")
+        menuBar.menuItems["Structure"].click()
+        XCTAssertTrue(
+            window.radioGroups["structure-tab-picker"].firstMatch.waitToExist(timeout: 30),
+            "The structure editor must open on the Structure result view"
+        )
+    }
+
+    /// A point inside the data grid that an overlapping pane cannot steal.
+    ///
+    /// A coordinate is the only way to click a row at all: the grid's columns are siblings of its
+    /// rows and later in the tree, so XCUITest reads every row and every cell as obscured and
+    /// refuses to click either. The grid's leading edge is not safe to measure from, though. On
+    /// the runner the detail pane is drawn under the sidebar, so a point 80pt in from that edge
+    /// lands on the object browser and a right-click raises its menu rather than the grid's.
+    /// Starting from whichever edge is further right keeps the point on the grid at any width.
+    internal func gridPoint(in grid: XCUIElement, of window: XCUIElement, dy: CGFloat) -> XCUICoordinate {
+        let clearOfBrowser = window.outlines.firstMatch.frame.maxX + 40 - grid.frame.minX
+        return grid.coordinate(withNormalizedOffset: .zero)
+            .withOffset(CGVector(dx: max(80, clearOfBrowser), dy: dy))
+    }
+
     /// The object browser draws its rows as hosted cells, so a row's name arrives as the static
     /// text's `value`, carrying the object kind the row reads out to VoiceOver, rather than as a
     /// label or an identifier. Matching on `value` is what finds them.


### PR DESCRIPTION
Main has been red since #2616. Run [33734073855](https://github.com/TableProApp/TablePro/actions/runs/33734073855) failed the unit job and one UI shard, and the unit job did not fail so much as stop: it ran for its full 30 minute timeout and was killed.

Three separate problems, one per commit.

## The save runs on a pooled connection now, and one test still watched the session driver

#2616 moved `executeSchemaChanges` from `executionRoute` to `schemaChangeRoute`, which is the metadata route. It updated `DatabaseManagerSchemaChangeRoutingTests` to seed the pool and left `StructureEditingSessionTests` behind, so `A session applies its staged edits with no view mounted` asked the pool to open a connection of its own. No plugin loads under XCTest, so it came back with "MySQL driver plugin not loaded" after ten seconds and every one of the five expectations failed.

The test now seeds a pooled driver on the session's own scope, the same way the routing suite does, and asserts the ALTER landed there with the session driver untouched. That is the behaviour #2616 shipped.

## The trigger test raised an alert nobody could answer

`Apply and drop run on the pooled connection` is the first test to call `TriggerEditing.drop` end to end. A drop is a `.destructiveQuery`, so `DefaultExecutionGate` always confirms it, and `AlertOperationConfirming` runs an `NSAlert`. With no window to hang a sheet on, `AlertHelper.present` falls through to `alert.runModal()`, which is a nested modal run loop on the main thread. On a headless runner nothing dismisses it. That is where the job stopped: the last test to report was 23 minutes before the timeout killed it.

`TriggerEditing.apply` and `drop` now take their gate, defaulting to `ExecutionGateProvider.shared`, the same shape `CompareSyncExecutor` already uses. `AlwaysAllowGate` and `AlwaysDenyGate` move out of `CompareSyncExecutorTests` into `TableProTests/Helpers` so both suites share one.

## The Structure segment is under the sidebar on the runner

`StructureColumnMoveUITests` and `StructureTabIdentityUITests` both failed twice with the result still on Data. The element tree the failure captured says why: the mode picker reports `Data` selected with value 1 after the click, and the detail pane's content is laid out 710pt wide starting at x=199 inside a pane that starts at x=354. The runner's screen is 1024x768, and at that width the sidebar, the detail pane and the row inspector do not fit, so the detail content keeps its own width and is drawn under the sidebar. The `Structure` segment's accessibility frame is where the layout says it is, so XCUITest reports it as hittable and posts the click at (314, 691), which lands on the object browser. Nothing fails there, so the suites went on to read the data grid as though it were the structure grid.

Four suites carried a byte-identical `showStructure` helper. It moves to `UITestCase` and drives **View > Result View > Structure** instead, which has no geometry to be occluded, then waits for the structure tab picker so the switch is observed rather than assumed. The two suites that right-click inside the grid take their point through a new `gridPoint(in:of:dy:)` that starts from whichever is further right, the grid's leading edge or the object browser's trailing edge.

The underlying layout defect is not fixed here: at 1024pt with the sidebar and inspector open, the detail pane's content overflows both of its neighbours instead of compressing. It is worth its own issue.

## Verification

- `TableProTests`: StructureEditingSessionTests, TriggerApplyExecutionTests, DatabaseManagerSchemaChangeRoutingTests, CompareSyncExecutorTests: 30 executed, 30 passed. No hang.
- `TableProUITests`: StructureColumnMoveUITests, StructureTabIdentityUITests, StructureConstraintsTabUITests, StructureRowMenuParityUITests: 8 executed, 8 passed. This machine's display is larger than the runner's, so it proves the menu route works, not that the occlusion is gone.

https://claude.ai/code/session_01NdXqgRevM8nxhW8HXhN7aU
