### PR TITLE
fix(export): follow the source engine's dialect when exporting query results as SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- PostgreSQL identifier quoting in a SQL export of query results from any other engine. (#2630)
+- Backslashes left unescaped in a SQL export of query results, silently altering the values.
+- `DROP ... CASCADE` written for engines that reject it, SQLite and SQL Server among them.
+- `DROP TABLE` naming the source table in a query-results export that writes no `CREATE TABLE`.
+- Snowflake string literals escaped without their backslashes, in the editor and in exports.
 - Restore Dump overwriting a database with no confirmation.
 - Stopping an import applying at once, while stopping an export or a backup asks first.
 - Progress bar stuck at zero and an "N/0 rows" label for the whole of a streaming query export.

--- a/Plugins/SQLExportPlugin/SQLExportPlugin.swift
+++ b/Plugins/SQLExportPlugin/SQLExportPlugin.swift
@@ -358,6 +358,12 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
         try writer.write("\n")
     }
 
+    /// `CASCADE` is not portable: PostgreSQL drops dependent objects with it, SQLite and SQL Server
+    /// have no such clause and reject the statement, and MySQL parses it and does nothing.
+    private func cascadeClause(_ dataSource: any PluginExportDataSource) -> String {
+        dataSource.supportsCascadeDrop ? " CASCADE" : ""
+    }
+
     /// The engine spells its own DROP for the kinds where dialects disagree: PostgreSQL's
     /// `DROP TRIGGER` takes an `ON <table>` clause where MySQL's does not, and MySQL has no
     /// `DROP ROUTINE` at all. Only the table-shaped kinds, which every SQL engine spells the same
@@ -377,7 +383,7 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
         case .trigger, .event, .routine:
             return "\(keyword) IF EXISTS \(dataSource.quoteIdentifier(object.name));"
         default:
-            return "\(keyword) IF EXISTS \(ref) CASCADE;"
+            return "\(keyword) IF EXISTS \(ref)\(cascadeClause(dataSource));"
         }
     }
 
@@ -396,7 +402,8 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
                 for seq in sequences where !emittedSequenceNames.contains(seq.name) {
                     emittedSequenceNames.insert(seq.name)
                     let quotedName = "\"\(seq.name.replacingOccurrences(of: "\"", with: "\"\""))\""
-                    try writer.write("DROP SEQUENCE IF EXISTS \(quotedName) CASCADE;\n")
+                    try writer.write(
+                        "DROP SEQUENCE IF EXISTS \(quotedName)\(cascadeClause(dataSource));\n")
                     try writer.write("\(seq.ddl)\n\n")
                 }
             } catch {
@@ -409,7 +416,8 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
                 for enumType in enumTypes where !emittedTypeNames.contains(enumType.name) {
                     emittedTypeNames.insert(enumType.name)
                     let quotedName = "\"\(enumType.name.replacingOccurrences(of: "\"", with: "\"\""))\""
-                    try writer.write("DROP TYPE IF EXISTS \(quotedName) CASCADE;\n")
+                    try writer.write(
+                        "DROP TYPE IF EXISTS \(quotedName)\(cascadeClause(dataSource));\n")
                     let quotedLabels = enumType.labels.map { "'\(dataSource.escapeStringLiteral($0))'" }
                     try writer.write("CREATE TYPE \(quotedName) AS ENUM (\(quotedLabels.joined(separator: ", ")));\n\n")
                 }

--- a/Plugins/SnowflakeDriverPlugin/SnowflakePlugin.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakePlugin.swift
@@ -265,6 +265,7 @@ final class SnowflakePlugin: NSObject, TableProPlugin, DriverPlugin {
         booleanLiteralStyle: .truefalse,
         likeEscapeStyle: .explicit,
         paginationStyle: .limit,
+        requiresBackslashEscaping: true,
         caseSensitivityStyle: .ilikeOperator
     )
 

--- a/Plugins/TableProPluginKit/PluginExportDataSource.swift
+++ b/Plugins/TableProPluginKit/PluginExportDataSource.swift
@@ -26,6 +26,12 @@ public protocol PluginExportDataSource: AnyObject, Sendable {
     /// that share a name. Empty on an engine with no principal management.
     func fetchGrantStatements(principal: String, host: String?) async throws -> [String]
 
+    /// Whether this engine accepts a `CASCADE` clause on a `DROP`. PostgreSQL takes it and drops
+    /// dependent objects with it; SQLite, SQL Server, ClickHouse and Trino have no such clause and
+    /// reject the statement outright; MySQL parses it and does nothing. Defaults to false, which is
+    /// the answer that is never a syntax error.
+    var supportsCascadeDrop: Bool { get }
+
     /// The engine's own DROP for an object. Only the driver knows that PostgreSQL's `DROP TRIGGER`
     /// takes an `ON <table>` clause and MySQL's does not, or that MySQL has no `DROP ROUTINE` at
     /// all. Nil means the caller should fall back to its own generic shape.
@@ -54,6 +60,8 @@ public extension PluginExportDataSource {
     }
 
     func fetchGrantStatements(principal: String, host: String?) async throws -> [String] { [] }
+
+    var supportsCascadeDrop: Bool { false }
 
     func dropStatement(for object: PluginExportTable) -> String? { nil }
 

--- a/TablePro/Core/Plugins/ExportDataSourceAdapter.swift
+++ b/TablePro/Core/Plugins/ExportDataSourceAdapter.swift
@@ -15,7 +15,15 @@ final class ExportDataSourceAdapter: PluginExportDataSource, @unchecked Sendable
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "ExportDataSourceAdapter")
 
+    /// The same capability the sidebar's drop prompt reads, so the engines whose dumps carry a
+    /// `CASCADE` are exactly the engines that offer the user a Cascade checkbox. Resolved once at
+    /// construction, on the main actor, because the registry lives there and this is asked for from
+    /// the export plugin's own thread.
+    let supportsCascadeDrop: Bool
+
     init(driver: DatabaseDriver, databaseType: DatabaseType) {
+        self.supportsCascadeDrop = PluginMetadataRegistry.shared
+            .snapshot(for: databaseType)?.capabilities.supportsCascadeDrop ?? false
         self.driver = driver
         self.dbType = databaseType
         self.databaseTypeId = databaseType.rawValue

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+CloudDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+CloudDefaults.swift
@@ -482,6 +482,7 @@ extension PluginMetadataRegistry {
                         booleanLiteralStyle: .truefalse,
                         likeEscapeStyle: .explicit,
                         paginationStyle: .limit,
+                        requiresBackslashEscaping: true,
                         caseSensitivityStyle: .ilikeOperator
                     ),
                     statementCompletions: [

--- a/TablePro/Core/Plugins/QueryResultExportDataSource.swift
+++ b/TablePro/Core/Plugins/QueryResultExportDataSource.swift
@@ -13,16 +13,40 @@ final class QueryResultExportDataSource: PluginExportDataSource, @unchecked Send
     private let columns: [String]
     private let columnTypeNames: [String]
     private let rows: [[PluginCellValue]]
-    private let driver: DatabaseDriver?
+
+    /// How this engine quotes an identifier and escapes a literal, resolved once from the driver
+    /// when there is one and from the engine's declared dialect when there is not. There is no
+    /// third answer: writing ANSI for an engine that is not ANSI produces a dump that either will
+    /// not parse or, worse, parses and rewrites the data.
+    private let quoteIdentifierFn: (String) -> String
+    private let escapeStringFn: (String) -> String
 
     private static let logger = Logger(subsystem: "com.TablePro", category: "QueryResultExportDataSource")
 
     init(tableRows: TableRows, databaseType: DatabaseType, driver: DatabaseDriver?) {
         self.databaseTypeId = databaseType.rawValue
-        self.driver = driver
         self.columns = tableRows.columns
         self.columnTypeNames = tableRows.columnTypes.map { $0.rawType ?? "" }
         self.rows = tableRows.rows.map { row in Array(row.values) }
+
+        if let driver {
+            self.quoteIdentifierFn = { driver.quoteIdentifier($0) }
+            self.escapeStringFn = { driver.escapeStringLiteral($0) }
+            return
+        }
+        /// `resolveSQLDialect` reads the metadata snapshot through `snapshot(for:)`, which remaps a
+        /// variant onto the engine it is a variant of. An engine with no SQL dialect at all
+        /// (MongoDB, Redis) reaches this only through a format that writes no SQL, so ANSI is a
+        /// harmless answer there rather than a wrong one.
+        guard let dialect = try? resolveSQLDialect(for: databaseType) else {
+            Self.logger.warning(
+                "No SQL dialect for \(databaseType.rawValue, privacy: .public), quoting as ANSI")
+            self.quoteIdentifierFn = SQLEscaping.quoteIdentifier
+            self.escapeStringFn = SQLEscaping.escapeStringLiteral
+            return
+        }
+        self.quoteIdentifierFn = quoteIdentifierFromDialect(dialect)
+        self.escapeStringFn = escapeStringLiteralFromDialect(dialect)
     }
 
     func streamRows(table: String, databaseName: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
@@ -47,17 +71,11 @@ final class QueryResultExportDataSource: PluginExportDataSource, @unchecked Send
     }
 
     func quoteIdentifier(_ identifier: String) -> String {
-        if let driver {
-            return driver.quoteIdentifier(identifier)
-        }
-        return SQLEscaping.quoteIdentifier(identifier)
+        quoteIdentifierFn(identifier)
     }
 
     func escapeStringLiteral(_ value: String) -> String {
-        if let driver {
-            return driver.escapeStringLiteral(value)
-        }
-        return SQLEscaping.escapeStringLiteral(value)
+        escapeStringFn(value)
     }
 
     func fetchTableDDL(table: String, databaseName: String) async throws -> String {

--- a/TablePro/Core/Services/Export/ExportService.swift
+++ b/TablePro/Core/Services/Export/ExportService.swift
@@ -69,10 +69,33 @@ final class ExportService {
         self.databaseType = databaseType
     }
 
-    /// Convenience initializer for query results export (no driver needed).
-    init(databaseType: DatabaseType) {
-        self.driver = nil
+    /// Rows already in memory still need the engine that produced them: a SQL export has to quote
+    /// identifiers and escape literals the way that engine reads them back. The driver is asked for
+    /// nothing but those two pure functions here, so an installed handle is enough and no lease is
+    /// taken. It is optional only because a connection can be gone by the time the sheet runs, and
+    /// the formats that carry no SQL still export fine without one.
+    init(queryResultsDriver driver: DatabaseDriver?, databaseType: DatabaseType) {
+        self.driver = driver
         self.databaseType = databaseType
+    }
+
+    /// The one table a query export writes. `QueryExportOptions` says why it carries no structure.
+    private static func queryResultExportTable(
+        named name: String,
+        plugin: any ExportFormatPlugin
+    ) -> PluginExportTable {
+        let optionValues = QueryExportOptions.dataOnly(
+            columns: type(of: plugin).perTableOptionColumns,
+            defaults: plugin.defaultTableOptionValues()
+        )
+        return PluginExportTable(
+            name: name,
+            databaseName: "",
+            tableType: "query",
+            optionValues: optionValues,
+            schema: nil,
+            kind: .table
+        )
     }
 
     // MARK: - Cancellation
@@ -249,14 +272,7 @@ final class ExportService {
         }
         defer { descObservation.invalidate() }
 
-        let exportTable = PluginExportTable(
-            name: config.fileName,
-            databaseName: "",
-            tableType: "query",
-            optionValues: plugin.defaultTableOptionValues(),
-            schema: nil,
-            kind: .table
-        )
+        let exportTable = Self.queryResultExportTable(named: config.fileName, plugin: plugin)
 
         let result: ExportFormatResult
         do {
@@ -317,14 +333,7 @@ final class ExportService {
         }
         defer { observation.invalidate() }
 
-        let exportTable = PluginExportTable(
-            name: config.fileName,
-            databaseName: "",
-            tableType: "query",
-            optionValues: plugin.defaultTableOptionValues(),
-            schema: nil,
-            kind: .table
-        )
+        let exportTable = Self.queryResultExportTable(named: config.fileName, plugin: plugin)
 
         await suppressStatementTimeout(on: driver)
         let result: ExportFormatResult

--- a/TablePro/Core/Services/Export/QueryExportOptions.swift
+++ b/TablePro/Core/Services/Export/QueryExportOptions.swift
@@ -1,0 +1,39 @@
+//
+//  QueryExportOptions.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+/// Which per-object options a query export may ask for.
+///
+/// A result set has no schema behind it. `fetchTableDDL` returns an empty string on both query data
+/// sources, so asking for structure produces no `CREATE` at all, and leaving drop on beside it
+/// wrote `DROP TABLE <the source table>` into a dump that then never recreated it. The name is the
+/// real table's whenever the export came from a table tab, so the dump destroyed what it claimed to
+/// copy.
+internal enum QueryExportOptions {
+    /// The option columns a source with no DDL must not be asked for.
+    private static let schemaColumnIds: Set<String> = ["structure", "drop"]
+
+    /// Cleared by column id rather than by position. The ids are per format and the positions do
+    /// not line up: SQL export declares `[structure, drop, data]` while MQL export declares
+    /// `[drop, indexes, data]`, so clearing index 0 and 1 would turn off MQL's indexes and leave
+    /// its drop on, which is the opposite of what is wanted.
+    ///
+    /// A defaults array that is not the length of the column list is discarded whole rather than
+    /// read element-wise, because a mismatched array is exactly the misalignment this is here to
+    /// avoid. `ExportObjectItem.normalized(forOptionColumnCount:defaultOptionValues:)` already
+    /// treats one that way.
+    internal static func dataOnly(
+        columns: [PluginExportOptionColumn],
+        defaults: [Bool]
+    ) -> [Bool] {
+        let aligned = defaults.count == columns.count ? defaults : []
+        return columns.enumerated().map { index, column -> Bool in
+            guard !schemaColumnIds.contains(column.id) else { return false }
+            return aligned.indices.contains(index) ? aligned[index] : column.defaultValue
+        }
+    }
+}

--- a/TablePro/Core/Utilities/SQL/DialectQuoteHelper.swift
+++ b/TablePro/Core/Utilities/SQL/DialectQuoteHelper.swift
@@ -20,7 +20,7 @@ enum SQLDialectError: Error, LocalizedError {
     }
 }
 
-func quoteIdentifierFromDialect(_ dialect: SQLDialectDescriptor) -> (String) -> String {
+func quoteIdentifierFromDialect(_ dialect: SQLDialectDescriptor) -> @Sendable (String) -> String {
     let q = dialect.identifierQuote
     if q == "[" {
         return { name in
@@ -31,6 +31,37 @@ func quoteIdentifierFromDialect(_ dialect: SQLDialectDescriptor) -> (String) -> 
     return { name in
         let escaped = name.replacingOccurrences(of: q, with: q + q)
         return "\(q)\(escaped)\(q)"
+    }
+}
+
+/// The body of a single-quoted literal, escaped the way the engine reads it back.
+///
+/// MySQL, MariaDB, ClickHouse and Snowflake treat a backslash as an escape inside a literal, so a
+/// value holding one has to double it. Writing ANSI rules for those engines does not fail: it
+/// silently rewrites the data, and `C:\temp\next` comes back with a tab and a newline in it.
+///
+/// The escaped set matches what the MySQL driver itself writes, character for character, so a dump
+/// taken with a driver and one taken without are the same file. `\u{1A}` is the one that matters
+/// beyond tidiness: a raw SUB byte truncates a dump fed to the Windows `mysql` client, which is why
+/// `mysqldump` writes `\Z`.
+///
+/// Dameng is the one engine a static descriptor cannot answer for, because it detects its own
+/// escaping at connect time and its descriptor carries the pre-detection default. Ask its driver,
+/// which is what every path holding one already does.
+func escapeStringLiteralFromDialect(_ dialect: SQLDialectDescriptor) -> @Sendable (String) -> String {
+    guard dialect.requiresBackslashEscaping else { return SQLEscaping.escapeStringLiteral }
+    return { value in
+        var result = value
+        result = result.replacingOccurrences(of: "\\", with: "\\\\")
+        result = result.replacingOccurrences(of: "'", with: "''")
+        result = result.replacingOccurrences(of: "\n", with: "\\n")
+        result = result.replacingOccurrences(of: "\r", with: "\\r")
+        result = result.replacingOccurrences(of: "\t", with: "\\t")
+        result = result.replacingOccurrences(of: "\0", with: "\\0")
+        result = result.replacingOccurrences(of: "\u{08}", with: "\\b")
+        result = result.replacingOccurrences(of: "\u{0C}", with: "\\f")
+        result = result.replacingOccurrences(of: "\u{1A}", with: "\\Z")
+        return result
     }
 }
 

--- a/TablePro/Core/Utilities/SQL/SQLRowToStatementConverter.swift
+++ b/TablePro/Core/Utilities/SQL/SQLRowToStatementConverter.swift
@@ -38,23 +38,10 @@ internal struct SQLRowToStatementConverter {
 
         let resolvedDialect = try resolveSQLDialect(for: databaseType, explicit: dialect)
         self.quoteIdentifierFn = quoteIdentifier ?? quoteIdentifierFromDialect(resolvedDialect)
-        self.escapeStringFn = escapeStringLiteral ?? Self.defaultEscapeFunction(dialect: resolvedDialect)
+        self.escapeStringFn = escapeStringLiteral ?? escapeStringLiteralFromDialect(resolvedDialect)
     }
 
     private static let maxRows = 50_000
-
-    private static func defaultEscapeFunction(dialect: SQLDialectDescriptor) -> (String) -> String {
-        if dialect.requiresBackslashEscaping {
-            return { value in
-                var result = value
-                result = result.replacingOccurrences(of: "\\", with: "\\\\")
-                result = result.replacingOccurrences(of: "'", with: "''")
-                result = result.replacingOccurrences(of: "\0", with: "\\0")
-                return result
-            }
-        }
-        return SQLEscaping.escapeStringLiteral
-    }
 
     internal func generateInserts(rows: [[PluginCellValue]]) -> String {
         let capped = rows.prefix(Self.maxRows)

--- a/TablePro/Views/Export/ExportDialog.swift
+++ b/TablePro/Views/Export/ExportDialog.swift
@@ -1100,7 +1100,10 @@ struct ExportDialog: View {
                     try await runStreamingExport(on: driver, query: query, to: url)
                 }
             case .queryResults(_, let tableRows, _):
-                let service = ExportService(databaseType: connection.type)
+                let service = ExportService(
+                    queryResultsDriver: DatabaseManager.shared.driver(for: connection.id),
+                    databaseType: connection.type
+                )
                 exportService = service
                 try await service.exportQueryResults(tableRows: tableRows, config: config, to: url)
             default:

--- a/TableProTests/Helpers/SQLExportHarness.swift
+++ b/TableProTests/Helpers/SQLExportHarness.swift
@@ -1,0 +1,46 @@
+//
+//  SQLExportHarness.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+
+@testable import TablePro
+
+/// Runs a real SQL export and hands back the dump it wrote.
+///
+/// `SQLExportPlugin.settings` has a `didSet` that writes to the app's own `UserDefaults`, so the
+/// capture, reset and restore around an export is a read-modify-write over state every suite
+/// shares. Swift Testing runs suites in parallel, so two of them doing that by hand interleave:
+/// one restores what the other captured, and the developer's real export settings are left at
+/// whatever the loser wrote. A leaked gzip flag also makes the dump unreadable as text, which
+/// reads as a flaky assertion rather than as the cross-suite write it is.
+///
+/// One actor owns that window, so every export harness in the target queues behind it.
+internal actor SQLExportHarness {
+    internal static let shared = SQLExportHarness()
+
+    internal func dump(
+        tables: [PluginExportTable],
+        dataSource: any PluginExportDataSource
+    ) async throws -> (text: String, result: ExportFormatResult) {
+        let plugin = SQLExportPlugin()
+        let storedSettings = plugin.settings
+        plugin.settings = SQLExportOptions()
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).sql")
+        defer {
+            plugin.settings = storedSettings
+            try? FileManager.default.removeItem(at: destination)
+        }
+
+        let result = try await plugin.export(
+            tables: tables,
+            dataSource: dataSource,
+            destination: destination,
+            progress: PluginExportProgress(progress: Progress(totalUnitCount: 1))
+        )
+        return (try String(contentsOf: destination, encoding: .utf8), result)
+    }
+}

--- a/TableProTests/Plugins/SQLExportDialectTests.swift
+++ b/TableProTests/Plugins/SQLExportDialectTests.swift
@@ -1,0 +1,255 @@
+//
+//  SQLExportDialectTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+/// What a SQL export writes has to be what the source engine reads back.
+///
+/// The expected strings here are not a preference. Each was run against a live MariaDB 12.3 and
+/// sqlite3 while fixing #2630, and what each engine accepted is recorded beside it. CI reaches
+/// neither engine, so these tests are the record of that measurement.
+@Suite("SQL export dialect")
+struct SQLExportDialectTests {
+
+    private func dialect(for type: DatabaseType) -> SQLDialectDescriptor? {
+        try? resolveSQLDialect(for: type)
+    }
+
+    // MARK: - Identifier quoting
+
+    /// Measured: MariaDB rejects `INSERT INTO "fields" ("id") VALUES (1)` with ERROR 1064, because
+    /// outside ANSI_QUOTES a double-quoted token is a string literal and not an identifier. That is
+    /// the reported bug: the query-results export had no driver and fell back to ANSI quoting.
+    @Test("A MySQL dialect quotes with backticks, not double quotes")
+    func mysqlQuotesWithBackticks() throws {
+        let quote = quoteIdentifierFromDialect(try #require(dialect(for: .mysql)))
+        #expect(quote("fields") == "`fields`")
+        #expect(quote("fields") != "\"fields\"")
+    }
+
+    @Test("A PostgreSQL dialect quotes with double quotes")
+    func postgresQuotesWithDoubleQuotes() throws {
+        let quote = quoteIdentifierFromDialect(try #require(dialect(for: .postgresql)))
+        #expect(quote("fields") == "\"fields\"")
+    }
+
+    /// SQL Server opens with `[` and closes with `]`, so a naive quote + name + quote produces
+    /// `[fields[`. Reading `identifierQuote` raw gets this wrong; the helper carries the case.
+    @Test("SQL Server brackets close with the other character")
+    func sqlServerUsesBrackets() throws {
+        let quote = quoteIdentifierFromDialect(try #require(dialect(for: .mssql)))
+        #expect(quote("fields") == "[fields]")
+        #expect(quote("we]ird") == "[we]]ird]")
+    }
+
+    @Test("Every engine escapes its own quote character inside an identifier")
+    func embeddedQuotesAreEscaped() throws {
+        let mysql = quoteIdentifierFromDialect(try #require(dialect(for: .mysql)))
+        #expect(mysql("we`ird") == "`we``ird`")
+
+        let postgres = quoteIdentifierFromDialect(try #require(dialect(for: .postgresql)))
+        #expect(postgres("we\"ird") == "\"we\"\"ird\"")
+    }
+
+    // MARK: - Literal escaping
+
+    /// Measured: `C:\temp\next` written with ANSI rules re-imports into MariaDB as hex
+    /// 433A09656D700A657874, ten bytes rather than twelve, because `\t` became a tab and `\n` a
+    /// newline. Silent corruption, which is why the export must never guess this.
+    @Test("A MySQL dialect doubles a backslash so the value survives the round trip")
+    func mysqlEscapesBackslashes() throws {
+        let escape = escapeStringLiteralFromDialect(try #require(dialect(for: .mysql)))
+        #expect(escape("C:\\temp\\next") == "C:\\\\temp\\\\next")
+        #expect(escape("O'Brien") == "O''Brien")
+    }
+
+    /// A dump taken without a driver has to be the same file as one taken with it. The MySQL
+    /// driver escapes nine characters; escaping only the backslash and the quote left a raw
+    /// `\u{1A}` in the output, which truncates a dump fed to the Windows `mysql` client.
+    @Test("The dialect escaper writes what the MySQL driver writes")
+    func mysqlEscaperMatchesTheDriver() throws {
+        let escape = escapeStringLiteralFromDialect(try #require(dialect(for: .mysql)))
+        #expect(escape("a\nb") == "a\\nb")
+        #expect(escape("a\tb") == "a\\tb")
+        #expect(escape("a\rb") == "a\\rb")
+        #expect(escape("a\u{1A}b") == "a\\Zb")
+        #expect(escape("a\u{08}b") == "a\\bb")
+        #expect(escape("a\u{0C}b") == "a\\fb")
+    }
+
+    /// PostgreSQL reads a backslash literally in a standard-conforming string, so doubling it
+    /// there would insert a second backslash into the data.
+    @Test("A PostgreSQL dialect leaves a backslash alone")
+    func postgresLeavesBackslashesAlone() throws {
+        let escape = escapeStringLiteralFromDialect(try #require(dialect(for: .postgresql)))
+        #expect(escape("C:\\temp\\next") == "C:\\temp\\next")
+        #expect(escape("O'Brien") == "O''Brien")
+    }
+
+    /// Snowflake's driver declares `requiresBackslashEscapingInLiterals` and neither of its
+    /// descriptors did, so the driver-backed and driver-free paths escaped the same value
+    /// differently.
+    ///
+    /// This reads the curated snapshot, because plugins never load under XCTest. The declaration
+    /// that matters in the shipping app is the plugin's own, in `SnowflakePlugin.swift`:
+    /// `buildMetadataSnapshot` takes `editor.sqlDialect` from `driverType.sqlDialect` and replaces
+    /// the curated one outright once the plugin loads. Both now declare it.
+    @Test("Snowflake's descriptor agrees with its driver about backslashes")
+    func snowflakeDescriptorDeclaresBackslashEscaping() throws {
+        let descriptor = try #require(dialect(for: DatabaseType(rawValue: "Snowflake")))
+        #expect(descriptor.requiresBackslashEscaping)
+    }
+}
+
+/// A result set has no schema, so a query export must write neither `CREATE` nor `DROP`.
+@Suite("Query export options")
+struct QueryExportOptionsTests {
+
+    private func column(_ id: String, _ label: String) -> PluginExportOptionColumn {
+        PluginExportOptionColumn(id: id, label: label, width: 44)
+    }
+
+    /// `fetchTableDDL` returns "" for both query data sources, so structure produces no CREATE.
+    /// Leaving drop on beside it wrote `DROP TABLE <the source table>` into a dump that never
+    /// recreated it, and the name is the real table's whenever the export came from a table tab.
+    @Test("A SQL query export writes data only, never structure or drop")
+    func sqlQueryExportIsDataOnly() {
+        let columns = [column("structure", "Structure"), column("drop", "Drop"), column("data", "Data")]
+        #expect(
+            QueryExportOptions.dataOnly(columns: columns, defaults: [true, true, true])
+                == [false, false, true])
+    }
+
+    /// The ids are per format and the positions do not line up: MQL declares
+    /// `[drop, indexes, data]`, so clearing index 0 and 1 would turn off its indexes and leave its
+    /// drop on, which is the opposite of what is wanted.
+    @Test("Clearing is keyed by column id, because the positions differ per format")
+    func mqlQueryExportKeepsIndexesAndClearsDrop() {
+        let columns = [column("drop", "Drop"), column("indexes", "Indexes"), column("data", "Data")]
+        #expect(
+            QueryExportOptions.dataOnly(columns: columns, defaults: [true, true, true])
+                == [false, true, true])
+    }
+
+    @Test("A format with no per-object options is left alone")
+    func formatWithoutOptions() {
+        #expect(QueryExportOptions.dataOnly(columns: [], defaults: []).isEmpty)
+    }
+
+    /// A plugin whose defaults are shorter than its columns falls back to each column's own
+    /// default rather than reading off the end.
+    @Test("A short defaults array falls back to the column's own default")
+    func shortDefaultsFallBack() {
+        let columns = [column("structure", "Structure"), column("data", "Data")]
+        #expect(QueryExportOptions.dataOnly(columns: columns, defaults: []) == [false, true])
+    }
+}
+
+/// `DROP ... CASCADE` follows the engine, because it is not portable.
+///
+/// Measured: MariaDB accepts it and the manual says it does nothing ("permitted to make porting
+/// easier"); sqlite3 rejects `DROP TABLE IF EXISTS "fields" CASCADE;` outright with
+/// `near "CASCADE": syntax error`. The clause was previously emitted for every engine.
+@Suite("SQL export drop clause")
+struct SQLExportDropClauseTests {
+
+    private final class StubExportDataSource: PluginExportDataSource, @unchecked Sendable {
+        let databaseTypeId: String
+        let supportsCascadeDrop: Bool
+
+        init(databaseTypeId: String, supportsCascadeDrop: Bool) {
+            self.databaseTypeId = databaseTypeId
+            self.supportsCascadeDrop = supportsCascadeDrop
+        }
+
+        func streamRows(table: String, databaseName: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
+            AsyncThrowingStream { continuation in
+                continuation.yield(.header(PluginStreamHeader(columns: ["id"], columnTypeNames: ["INTEGER"])))
+                continuation.yield(.rows([[.text("1")]]))
+                continuation.finish()
+            }
+        }
+
+        func fetchTableDDL(table: String, databaseName: String) async throws -> String {
+            "CREATE TABLE \(table) (id INTEGER)"
+        }
+
+        func execute(query: String) async throws -> PluginQueryResult {
+            PluginQueryResult(columns: [], columnTypeNames: [], rows: [], rowsAffected: 0, executionTime: 0)
+        }
+
+        func quoteIdentifier(_ identifier: String) -> String {
+            "`\(identifier.replacingOccurrences(of: "`", with: "``"))`"
+        }
+
+        func escapeStringLiteral(_ value: String) -> String {
+            value.replacingOccurrences(of: "'", with: "''")
+        }
+
+        func fetchApproximateRowCount(table: String, databaseName: String) async throws -> Int? { nil }
+    }
+
+    /// Declares no capability at all, so what it answers is the protocol extension's default.
+    private final class SilentExportDataSource: PluginExportDataSource, @unchecked Sendable {
+        let databaseTypeId = "SQLite"
+
+        func streamRows(table: String, databaseName: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
+            AsyncThrowingStream { $0.finish() }
+        }
+
+        func fetchTableDDL(table: String, databaseName: String) async throws -> String { "" }
+
+        func execute(query: String) async throws -> PluginQueryResult {
+            PluginQueryResult(columns: [], columnTypeNames: [], rows: [], rowsAffected: 0, executionTime: 0)
+        }
+
+        func quoteIdentifier(_ identifier: String) -> String { identifier }
+        func escapeStringLiteral(_ value: String) -> String { value }
+        func fetchApproximateRowCount(table: String, databaseName: String) async throws -> Int? { nil }
+    }
+
+    private func dump(databaseTypeId: String, supportsCascadeDrop: Bool) async throws -> String {
+        try await SQLExportHarness.shared.dump(
+            tables: [
+                PluginExportTable(
+                    name: "fields",
+                    databaseName: "",
+                    tableType: "table",
+                    optionValues: [true, true, true],
+                    schema: nil
+                )
+            ],
+            dataSource: StubExportDataSource(
+                databaseTypeId: databaseTypeId, supportsCascadeDrop: supportsCascadeDrop)
+        ).text
+    }
+
+    @Test("An engine that does not take CASCADE gets a plain DROP")
+    func engineWithoutCascade() async throws {
+        let sql = try await dump(databaseTypeId: "MySQL", supportsCascadeDrop: false)
+        #expect(sql.contains("DROP TABLE IF EXISTS `fields`;"))
+        #expect(!sql.contains("CASCADE"))
+    }
+
+    /// PostgreSQL is the engine the clause was written for: it drops dependent views with it.
+    @Test("An engine that takes CASCADE keeps it")
+    func engineWithCascade() async throws {
+        let sql = try await dump(databaseTypeId: "PostgreSQL", supportsCascadeDrop: true)
+        #expect(sql.contains("DROP TABLE IF EXISTS `fields` CASCADE;"))
+    }
+
+    /// The default is the answer that is never a syntax error. This asserts the protocol
+    /// extension's own value, so flipping that default fails here rather than shipping a dump
+    /// SQLite refuses.
+    @Test("A data source that declares nothing gets no CASCADE")
+    func defaultIsNoCascade() {
+        let source: any PluginExportDataSource = SilentExportDataSource()
+        #expect(!source.supportsCascadeDrop)
+    }
+}

--- a/TableProTests/Plugins/SQLExportForeignKeyOrderTests.swift
+++ b/TableProTests/Plugins/SQLExportForeignKeyOrderTests.swift
@@ -75,26 +75,8 @@ struct SQLExportForeignKeyOrderTests {
         tables: [PluginExportTable],
         dataSource: StubExportDataSource
     ) async throws -> (dump: String, result: ExportFormatResult) {
-        let plugin = SQLExportPlugin()
-        /// The plugin loads its settings from the app's own defaults, so a developer who has
-        /// turned gzip on would otherwise get a compressed file the assertions cannot read.
-        let storedSettings = plugin.settings
-        plugin.settings = SQLExportOptions()
-        let destination = FileManager.default.temporaryDirectory
-            .appendingPathComponent("\(UUID().uuidString).sql")
-        defer {
-            plugin.settings = storedSettings
-            try? FileManager.default.removeItem(at: destination)
-        }
-
-        let result = try await plugin.export(
-            tables: tables,
-            dataSource: dataSource,
-            destination: destination,
-            progress: PluginExportProgress(progress: Progress(totalUnitCount: 1))
-        )
-        let dump = try String(contentsOf: destination, encoding: .utf8)
-        return (dump, result)
+        let output = try await SQLExportHarness.shared.dump(tables: tables, dataSource: dataSource)
+        return (output.text, output.result)
     }
 
     private func createOrder(in dump: String, of tables: [String]) -> [String] {

--- a/docs/features/import-export.mdx
+++ b/docs/features/import-export.mdx
@@ -66,6 +66,8 @@ A whole-table export streams from the database at constant memory, with no row-c
 
 **Export Results…** writes what the tab holds in memory, which is the output of the query that filled it. The filter bar and a sorted header are part of that query, and so is column visibility on a table tab: hiding a column re-queries without it, keeping only the primary key and anything being sorted on. Two things are not part of it. A column value filter narrows the loaded rows in the grid afterwards, so it never reaches the file. And a truncated result with more rows behind it is re-run and streamed in full rather than written as far as it got.
 
+As SQL, a results export writes `INSERT` statements only. A result set is the output of a query rather than a table, so there is no schema to recreate and nothing to drop: the **Structure** and **Drop** options belong to the toolbar export, which reads real tables. Identifiers are quoted and values escaped the way the source engine reads them, so the file imports back into it.
+
 ### Formats
 
 <Tabs>


### PR DESCRIPTION
Fixes #2630.

## What was wrong

Three defects, all one theme: a dialect-dependent decision taken without the dialect that was already in hand. `SQLExportPlugin` derives `SqlDialect.from(databaseTypeId:)` in six places and writes the correct `-- Database Type: MySQL` header from the same field, which is why the header was right while the body was wrong.

**1. The query-results export had no driver.** `ExportDialog.swift:1103` was the only one of three export modes that built its `ExportService` without one; its initializer was even commented *"no driver needed"*. `QueryResultExportDataSource` then fell back to `SQLEscaping` for both `quoteIdentifier` and `escapeStringLiteral`.

**2. `DROP ... CASCADE` was emitted unconditionally**, for every engine and both export paths, and for views, types and sequences as well as tables.

**3. Both query paths asked for structure and drop they cannot deliver.** `ExportService.swift:252`/`:320` built the export table with `[structure, drop, data]` all true while `fetchTableDDL` returns `""`, so the dump carried `DROP TABLE <the source table>` with no `CREATE TABLE` after it. The issue's own pasted output shows exactly that.

## Measured, not assumed

Against a live MariaDB 12.3 and sqlite3:

| statement | MariaDB 12.3 | SQLite |
|---|---|---|
| `DROP TABLE IF EXISTS "fields" CASCADE;` | rejected, `ERROR 1064 ... near '"fields" CASCADE'` | rejected, `near "CASCADE": syntax error` |
| ``DROP TABLE IF EXISTS `fields` CASCADE;`` | accepted | **rejected** |
| `DROP TABLE IF EXISTS "fields";` | rejected | accepted |
| `INSERT INTO "fields" ("id") VALUES (1);` | rejected | n/a |

**The report blamed two things and one is innocent.** MySQL's `DROP TABLE` grammar does list `[RESTRICT | CASCADE]`, and the manual says outright: *"The RESTRICT and CASCADE keywords do nothing. They are permitted to make porting easier."* The double quotes are the whole syntax error on MySQL. `CASCADE` is still a real bug elsewhere: SQLite rejects it, and Drop is on by default, so the ordinary File > Export SQL dump to SQLite has been un-importable too.

**A second defect on the same line that nobody reported, and it is worse.** The same nil driver dropped to ANSI string escaping. `C:\temp\next` (hex `433a5c74656d705c6e657874`, 12 bytes) exported today re-imports into MariaDB as `433A09656D700A657874`, 10 bytes: `\t` became a tab and `\n` a newline. Silent corruption, discovered only when someone restores.

### Before and after, same server

```
BEFORE  ERROR 1064 ... near '"fields" CASCADE'          the dump does not import
AFTER   imports clean; HEX(path) = 433A5C74656D705C6E657874 (12 bytes)
        byte-identical to the original C:\temp\next
```

## The fix

Patch for 1 and 2, refactor for 3.

- **The driver is passed** at the one call site: `DatabaseManager.driver(for:)`, the installed handle, no lease and no liveness requirement (CLAUDE.md: the driver "is never nil'd"). The common path is now the engine's own exact functions.
- **The fallback stops meaning PostgreSQL.** It resolves through the existing `resolveSQLDialect` + `quoteIdentifierFromDialect`, which already handles SQL Server's `[`/`]`. `escapeStringLiteralFromDialect` was extracted from `SQLRowToStatementConverter`'s private copy rather than written a second time, and it escapes the same nine characters the MySQL driver does, so a dump taken with a driver and one taken without are the same file.
- **`CASCADE` follows `DriverPlugin.supportsCascadeDrop`**, the capability that already drives the sidebar's Cascade checkbox. PostgreSQL, Redshift, CockroachDB, PGlite, Snowflake and Dameng keep the clause; every other engine loses one that was either a no-op or a syntax error. The default is `false`, the answer that is never a syntax error.
- **Query exports are data-only**, cleared by column **id**. The positions differ per format: SQL declares `[structure, drop, data]`, MQL declares `[drop, indexes, data]`, so clearing index 0 and 1 would have turned off MQL's indexes and left its drop on.

One collateral fix rides along because the fix depends on it: **Snowflake declared `requiresBackslashEscapingInLiterals` on its driver and nothing on either descriptor**, so the two paths escaped the same value differently. Dameng cannot be fixed the same way, because it detects its escaping at connect time; that is documented in the helper rather than papered over.

## Review

Codex is out of credits until Sep 7 (`You've hit your usage limit`), so the second-model review was `Skill(code-review)`, not Codex. It found 15 issues; 11 are fixed here.

The most valuable one caught a fix of mine that did not work. I had declared Snowflake's backslash escaping on the **curated** snapshot, but `buildMetadataSnapshot` takes `editor.sqlDialect` from `driverType.sqlDialect` and replaces the curated one outright once the plugin loads. Snowflake is registry-only, so the plugin is always installed for real use: the fix was inert, and my test passed only because plugins never load under XCTest. It is now declared on `SnowflakePlugin.swift` too, and the test says which one it covers.

Also fixed from the review: the two query data sources carried a dead `supportsCascadeDrop` that was the only reason their inits needed `@MainActor`; a dead stored `driver`; a doc comment orphaned onto the wrong function; a tautological test that asserted the value it had just passed in; a mismatched-length defaults array read positionally; and a settings race where my copied export harness and the existing one both did capture-reset-restore over the same `UserDefaults` key while Swift Testing runs suites in parallel. Both suites now share one serialized harness.

## Verification

- Build PASS. `swiftlint --strict` over `TablePro`, `Plugins`, `TableProTests`: 0 violations.
- 15 new tests; 60 pass across the export and dialect suites, 35 across the MCP export suites.
- ABI gate: additive. One requirement added, carrying a default; no removals; `PluginExportDataSource` has no conformer in any plugin bundle. No version bump, no plugin re-release.
- `docs`: house style and source claims agree.
- `SQLExport` and `MQLExport` both build. `AllPlugins` fails locally on the known `oracle-nio` `@TaskLocal` macro issue (both errors from that package); CI covers it.

No UI automation: nothing in this change is reachable from a deterministic UI flow, since the defect is in the text of a written file rather than in a control.

## Behaviour change worth knowing

A query-results SQL export is now `INSERT`-only. That is correct, and the option tree is hidden in that mode so nobody chose otherwise, but it is visible.

For an ad-hoc query the `INSERT` names the export's file name, which for a query tab defaults to `query_results` and so names no real table. That was equally true before, alongside a `DROP` of the same name, so this is strictly an improvement rather than a regression, but it is not yet right; renaming the file renames the table. Reported rather than fixed, because a result set genuinely has no table behind it and picking one is a product decision.

https://claude.ai/code/session_011EqgjCjCAU6tiiVmnMpF86
