### PR TITLE
fix(editor): colour the SQL keywords, literals and functions the grammar already names (#2634)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- SQL `IN`, `AND`, `OR`, `NOT`, `BY` and `ON` in the editor's plain text colour. (#2634)
+- SQL built-in type names, `ASC`, `DESC` and function calls unhighlighted in the editor.
+- SQL numbers, `TRUE`, `FALSE` and `NULL` in the string colour.
+- No syntax highlighting at all in the MongoDB and Elasticsearch query editors.
+- JSON `true`, `false` and `null` unhighlighted in the row inspector and the JSON viewer.
+- Operator and Function theme colours with no effect on the editor.
 - Restore Dump overwriting a database with no confirmation.
 - Stopping an import applying at once, while stopping an export or a backup asks first.
 - Progress bar stuck at zero and an "N/0 rows" label for the whole of a streaming query export.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SQL built-in type names, `ASC`, `DESC` and function calls unhighlighted in the editor.
 - SQL numbers, `TRUE`, `FALSE` and `NULL` in the string colour.
 - No syntax highlighting at all in the MongoDB and Elasticsearch query editors.
+- JavaScript `locals` and `tags` queries that no longer compiled against the bundled parser.
 - JSON `true`, `false` and `null` unhighlighted in the row inspector and the JSON viewer.
 - Operator and Function theme colours with no effect on the editor.
 

--- a/LocalPackages/CodeEditLanguages/Sources/CodeEditLanguages/Resources/tree-sitter-javascript/highlights.scm
+++ b/LocalPackages/CodeEditLanguages/Sources/CodeEditLanguages/Resources/tree-sitter-javascript/highlights.scm
@@ -23,7 +23,7 @@
 ; Function and method definitions
 ;--------------------------------
 
-(function
+(function_expression
   name: (identifier) @function)
 (function_declaration
   name: (identifier) @function)
@@ -32,20 +32,20 @@
 
 (pair
   key: (property_identifier) @function.method
-  value: [(function) (arrow_function)])
+  value: [(function_expression) (arrow_function)])
 
 (assignment_expression
   left: (member_expression
     property: (property_identifier) @function.method)
-  right: [(function) (arrow_function)])
+  right: [(function_expression) (arrow_function)])
 
 (variable_declarator
   name: (identifier) @function
-  value: [(function) (arrow_function)])
+  value: [(function_expression) (arrow_function)])
 
 (assignment_expression
   left: (identifier) @function
-  right: [(function) (arrow_function)])
+  right: [(function_expression) (arrow_function)])
 
 ; Function and method calls
 ;--------------------------

--- a/LocalPackages/CodeEditLanguages/Sources/CodeEditLanguages/Resources/tree-sitter-javascript/injections.scm
+++ b/LocalPackages/CodeEditLanguages/Sources/CodeEditLanguages/Resources/tree-sitter-javascript/injections.scm
@@ -26,7 +26,3 @@
              (#eq? @_name "hbs"))
   arguments: ((template_string) @glimmer
               (#offset! @glimmer 0 1 0 -1)))
-
-; Ember Unified <template> syntax
-; e.g.: <template><SomeComponent @arg={{double @value}} /></template>
-((glimmer_template) @glimmer)

--- a/LocalPackages/CodeEditLanguages/Sources/CodeEditLanguages/Resources/tree-sitter-javascript/locals.scm
+++ b/LocalPackages/CodeEditLanguages/Sources/CodeEditLanguages/Resources/tree-sitter-javascript/locals.scm
@@ -3,7 +3,7 @@
 
 [
   (statement_block)
-  (function)
+  (function_expression)
   (arrow_function)
   (function_declaration)
   (method_definition)

--- a/LocalPackages/CodeEditLanguages/Sources/CodeEditLanguages/Resources/tree-sitter-javascript/tags.scm
+++ b/LocalPackages/CodeEditLanguages/Sources/CodeEditLanguages/Resources/tree-sitter-javascript/tags.scm
@@ -25,7 +25,7 @@
   (comment)* @doc
   .
   [
-    (function
+    (function_expression
       name: (identifier) @name)
     (function_declaration
       name: (identifier) @name)
@@ -44,7 +44,7 @@
   (lexical_declaration
     (variable_declarator
       name: (identifier) @name
-      value: [(arrow_function) (function)]) @definition.function)
+      value: [(arrow_function) (function_expression)]) @definition.function)
   (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
   (#select-adjacent! @doc @definition.function)
 )
@@ -55,7 +55,7 @@
   (variable_declaration
     (variable_declarator
       name: (identifier) @name
-      value: [(arrow_function) (function)]) @definition.function)
+      value: [(arrow_function) (function_expression)]) @definition.function)
   (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
   (#select-adjacent! @doc @definition.function)
 )
@@ -66,12 +66,12 @@
     (member_expression
       property: (property_identifier) @name)
   ]
-  right: [(arrow_function) (function)]
+  right: [(arrow_function) (function_expression)]
 ) @definition.function
 
 (pair
   key: (property_identifier) @name
-  value: [(arrow_function) (function)]) @definition.function
+  value: [(arrow_function) (function_expression)]) @definition.function
 
 (
   (call_expression

--- a/LocalPackages/CodeEditLanguages/Sources/CodeEditLanguages/Resources/tree-sitter-sql/highlights.scm
+++ b/LocalPackages/CodeEditLanguages/Sources/CodeEditLanguages/Resources/tree-sitter-sql/highlights.scm
@@ -1,9 +1,9 @@
-(object_reference
-  name: (identifier) @type)
-
 (invocation
   (object_reference
     name: (identifier) @function.call))
+
+(object_reference
+  name: (identifier) @type)
 
 [
   (keyword_gist)
@@ -30,22 +30,23 @@
     name: (keyword_cast) @function.call
     parameter: [(literal)]?)))
 
-(literal) @string
-(comment) @comment @spell
-(marginalia) @comment
-
 ((literal) @number
-   (#match? @number "^[-+]?%d+$"))
+   (#match? @number "^[-+]?\\d+$"))
 
 ((literal) @float
-  (#match? @float "^[-+]?%d*\.%d*$"))
-
-(parameter) @parameter
+  (#match? @float "^[-+]?\\d*\\.\\d*$"))
 
 [
  (keyword_true)
  (keyword_false)
-] @boolean
+ (keyword_null)
+] @constant.builtin
+
+(literal) @string
+(comment) @comment @spell
+(marginalia) @comment
+
+(parameter) @parameter
 
 [
  (keyword_asc)
@@ -350,7 +351,6 @@
 
 [
   (keyword_int)
-  (keyword_null)
   (keyword_boolean)
   (keyword_binary)
   (keyword_varbinary)

--- a/LocalPackages/CodeEditSourceEditor/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Extensions/EditorTheme+Default.swift
+++ b/LocalPackages/CodeEditSourceEditor/Example/CodeEditSourceEditorExample/CodeEditSourceEditorExample/Extensions/EditorTheme+Default.swift
@@ -27,7 +27,9 @@ extension EditorTheme {
             numbers: Attribute(color: NSColor(hex: "1C00CF")),
             strings: Attribute(color: NSColor(hex: "C41A16")),
             characters: Attribute(color: NSColor(hex: "1C00CF")),
-            comments: Attribute(color: NSColor(hex: "267507"))
+            comments: Attribute(color: NSColor(hex: "267507")),
+            operators: Attribute(color: NSColor(hex: "000000")),
+            functions: Attribute(color: NSColor(hex: "3900A0"))
         )
     }
     static var dark: EditorTheme {
@@ -47,7 +49,9 @@ extension EditorTheme {
             numbers: Attribute(color: NSColor(hex: "D9C97C")),
             strings: Attribute(color: NSColor(hex: "FF8170")),
             characters: Attribute(color: NSColor(hex: "D9C97C")),
-            comments: Attribute(color: NSColor(hex: "7F8C98"))
+            comments: Attribute(color: NSColor(hex: "7F8C98")),
+            operators: Attribute(color: NSColor(hex: "FFFFFF")),
+            functions: Attribute(color: NSColor(hex: "D0A8FF"))
         )
     }
 }

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Enums/CaptureName.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Enums/CaptureName.swift
@@ -33,6 +33,8 @@ public enum CaptureName: Int8, CaseIterable, Sendable {
     case variableBuiltin
     case keywordReturn
     case keywordFunction
+    case `operator`
+    case constant
 
     var alternate: CaptureName {
         switch self {
@@ -47,8 +49,13 @@ public enum CaptureName: Int8, CaseIterable, Sendable {
     /// - Note: See ``CaptureName`` docs for why this enum isn't a raw representable.
     /// - Parameter string: A string to get the capture name from
     /// - Returns: A `CaptureNames` case
-    public static func fromString(_ string: String?) -> CaptureName? { // swiftlint:disable:this cyclomatic_complexity
+    public static func fromString(_ string: String?) -> CaptureName? {
         guard let string else { return nil }
+        return canonical(string) ?? grammarAlias(string)
+    }
+
+    /// The names this editor's own vocabulary uses, matched exactly.
+    private static func canonical(_ string: String) -> CaptureName? {
         switch string {
         case "include":
             return .include
@@ -92,10 +99,56 @@ public enum CaptureName: Int8, CaseIterable, Sendable {
             return .keywordReturn
         case "keyword.function":
             return .keywordFunction
+        case "operator":
+            return .operator
+        case "constant":
+            return .constant
         default:
             return nil
         }
     }
+
+    /// The nvim-treesitter capture names the bundled grammars emit, mapped onto this editor's vocabulary.
+    ///
+    /// A name absent from both this table and ``canonical(_:)`` carries no colour at all, so
+    /// `SyntaxHighlightingTests` fails on any name a bundled `highlights` query emits that neither
+    /// table answers and ``unstyledGrammarCaptures`` does not list. An `injections` query is exempt:
+    /// its captures name a range for the injection engine rather than for the palette.
+    private static func grammarAlias(_ string: String) -> CaptureName? {
+        switch string {
+        case "keyword.operator", "attribute", "storageclass", "type.qualifier":
+            return .keyword
+        case "type.builtin":
+            return .type
+        case "function.call", "function.builtin":
+            return .function
+        case "function.method":
+            return .method
+        case "constant.builtin":
+            return .constant
+        case "string.special", "string.special.key":
+            return .string
+        default:
+            return nil
+        }
+    }
+
+    /// Capture names a bundled grammar emits that are deliberately left without a colour.
+    ///
+    /// `spell` and `embedded` mark a range for another tool rather than for the palette, and both sit
+    /// on a range another capture already colours. `escape` sits inside a string that is already
+    /// coloured. `field` would put every column identifier on the variable colour. `punctuation`
+    /// keeps brackets and delimiters at the plain text colour, which is what VS Code and TablePlus
+    /// both do, and spares a dense viewport 440 of its 1560 highlight ranges.
+    public static let unstyledGrammarCaptures: Set<String> = [
+        "field",
+        "spell",
+        "escape",
+        "embedded",
+        "punctuation.bracket",
+        "punctuation.delimiter",
+        "punctuation.special",
+    ]
 
     /// See ``CaptureName`` docs for why this enum isn't a raw representable.
     var stringValue: String {
@@ -109,7 +162,7 @@ public enum CaptureName: Int8, CaseIterable, Sendable {
         case .boolean:
             return "boolean"
         case .repeat:
-            return "`repeat`"
+            return "repeat"
         case .conditional:
             return "conditional"
         case .tag:
@@ -142,6 +195,10 @@ public enum CaptureName: Int8, CaseIterable, Sendable {
             return "keywordReturn"
         case .keywordFunction:
             return "keywordFunction"
+        case .operator:
+            return "operator"
+        case .constant:
+            return "constant"
         }
     }
 }

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Theme/EditorTheme.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Theme/EditorTheme.swift
@@ -45,6 +45,8 @@ public struct EditorTheme: Equatable {
     public var strings: Attribute
     public var characters: Attribute
     public var comments: Attribute
+    public var operators: Attribute
+    public var functions: Attribute
 
     public init(
         text: Attribute,
@@ -63,7 +65,9 @@ public struct EditorTheme: Equatable {
         numbers: Attribute,
         strings: Attribute,
         characters: Attribute,
-        comments: Attribute
+        comments: Attribute,
+        operators: Attribute,
+        functions: Attribute
     ) {
         self.text = text
         self.insertionPoint = insertionPoint
@@ -82,6 +86,8 @@ public struct EditorTheme: Equatable {
         self.strings = strings
         self.characters = characters
         self.comments = comments
+        self.operators = operators
+        self.functions = functions
     }
 
     /// Maps a capture type to the attributes for that capture determined by the theme.
@@ -94,12 +100,14 @@ public struct EditorTheme: Equatable {
             return keywords
         case .comment: return comments
         case .variable, .property: return variables
-        case .function, .method: return variables
+        case .function, .method: return functions
         case .number, .float: return numbers
         case .string: return strings
         case .type: return types
         case .parameter: return variables
         case .typeAlternate: return attributes
+        case .operator: return operators
+        case .constant: return values
         default: return text
         }
     }
@@ -108,7 +116,7 @@ public struct EditorTheme: Equatable {
     /// - Parameter capture: The capture name
     /// - Returns: A `NSColor`
     func colorFor(_ capture: CaptureName?) -> NSColor {
-        return mapCapture(capture).color
+        mapCapture(capture).color
     }
 
     /// Returns the correct font with attributes (bold and italics) for a given capture name.

--- a/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/Mock.swift
+++ b/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/Mock.swift
@@ -97,7 +97,9 @@ enum Mock {
             numbers: EditorTheme.Attribute(color: .systemYellow),
             strings: EditorTheme.Attribute(color: .systemRed),
             characters: EditorTheme.Attribute(color: .systemRed),
-            comments: EditorTheme.Attribute(color: .systemGreen)
+            comments: EditorTheme.Attribute(color: .systemGreen),
+            operators: EditorTheme.Attribute(color: .systemBrown),
+            functions: EditorTheme.Attribute(color: .systemIndigo)
         )
     }
 

--- a/TablePro/Theme/ThemeEngine.swift
+++ b/TablePro/Theme/ThemeEngine.swift
@@ -292,6 +292,8 @@ internal final class ThemeEngine {
         let numberAttr = EditorTheme.Attribute(color: srgb(c.number))
         let variableAttr = EditorTheme.Attribute(color: srgb(c.null))
         let typeAttr = EditorTheme.Attribute(color: srgb(c.type))
+        let operatorAttr = EditorTheme.Attribute(color: srgb(c.operator))
+        let functionAttr = EditorTheme.Attribute(color: srgb(c.function))
 
         let lineHighlight: NSColor = highlightCurrentLine ? c.currentLineHighlight : .clear
         let statementHighlight: NSColor = highlightCurrentStatement ? resolvedStatementHighlight(c) : .clear
@@ -313,7 +315,9 @@ internal final class ThemeEngine {
             numbers: numberAttr,
             strings: stringAttr,
             characters: stringAttr,
-            comments: commentAttr
+            comments: commentAttr,
+            operators: operatorAttr,
+            functions: functionAttr
         )
     }
 

--- a/TableProTests/Editor/PasteHighlightCancelTests.swift
+++ b/TableProTests/Editor/PasteHighlightCancelTests.swift
@@ -187,7 +187,9 @@ struct PasteHighlightCancelTests {
             numbers: EditorTheme.Attribute(color: Self.numbers),
             strings: EditorTheme.Attribute(color: .systemRed),
             characters: EditorTheme.Attribute(color: .systemRed),
-            comments: EditorTheme.Attribute(color: .systemGreen)
+            comments: EditorTheme.Attribute(color: .systemGreen),
+            operators: EditorTheme.Attribute(color: .systemBrown),
+            functions: EditorTheme.Attribute(color: .systemIndigo)
         )
         let controller = TextViewController(
             string: Self.document,

--- a/TableProTests/Views/Editor/EditorControllerFixture.swift
+++ b/TableProTests/Views/Editor/EditorControllerFixture.swift
@@ -60,7 +60,9 @@ internal enum EditorControllerFixture {
             numbers: EditorTheme.Attribute(color: .systemYellow),
             strings: EditorTheme.Attribute(color: .systemRed),
             characters: EditorTheme.Attribute(color: .systemRed),
-            comments: EditorTheme.Attribute(color: .systemGreen)
+            comments: EditorTheme.Attribute(color: .systemGreen),
+            operators: EditorTheme.Attribute(color: .systemBrown),
+            functions: EditorTheme.Attribute(color: .systemIndigo)
         )
     }
 }

--- a/TableProTests/Views/Editor/MinimapHitTestTests.swift
+++ b/TableProTests/Views/Editor/MinimapHitTestTests.swift
@@ -46,7 +46,9 @@ struct MinimapHitTestTests {
                 numbers: EditorTheme.Attribute(color: .systemYellow),
                 strings: EditorTheme.Attribute(color: .systemRed),
                 characters: EditorTheme.Attribute(color: .systemRed),
-                comments: EditorTheme.Attribute(color: .systemGreen)
+                comments: EditorTheme.Attribute(color: .systemGreen),
+                operators: EditorTheme.Attribute(color: .systemBrown),
+                functions: EditorTheme.Attribute(color: .systemIndigo)
             )
             let configuration = SourceEditorConfiguration(
                 appearance: .init(

--- a/TableProTests/Views/Editor/SyntaxHighlightingTests.swift
+++ b/TableProTests/Views/Editor/SyntaxHighlightingTests.swift
@@ -1,0 +1,280 @@
+//
+//  SyntaxHighlightingTests.swift
+//  TableProTests
+//
+//  The grammars' capture names and the editor's `CaptureName` vocabulary are two hand-maintained lists that must
+//  agree. When they drifted, `TreeSitterClient` dropped every capture it could not name and the token kept the plain
+//  text colour, which reads as "this editor does not highlight that word" rather than as a defect (#2634).
+//
+
+import AppKit
+import CodeEditLanguages
+@testable import CodeEditSourceEditor
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Editor syntax highlighting")
+struct SyntaxHighlightingTests {
+    private static let bundledLanguageNames = ["sql", "json", "javascript", "jsx", "bash"]
+
+    private static func language(named name: String) -> CodeLanguage? {
+        switch name {
+        case "sql": .sql
+        case "json": .json
+        case "javascript": .javascript
+        case "jsx": .jsx
+        case "bash": .bash
+        default: nil
+        }
+    }
+
+    private static let sql = """
+    SELECT CAST(total AS INT), 42, NULL, 'abc'
+    FROM orders o
+    WHERE o.status IN ('a') AND o.total = 3
+    GROUP BY o.status
+    ORDER BY total DESC;
+    """
+
+    private static let json = """
+    {"active": true, "count": 7, "note": "x"}
+    """
+
+    // MARK: - The two lists must agree
+
+    @Test("Every bundled grammar's highlight query compiles", arguments: bundledLanguageNames)
+    func bundledQueryCompiles(name: String) throws {
+        let language = try #require(Self.language(named: name))
+        let query = TreeSitterModel.shared.query(for: language.id)
+        #expect(query != nil, "\(name) has no usable highlight query, so that editor shows no highlighting at all")
+    }
+
+    @Test("Every capture a bundled highlights query emits carries a colour or is deliberately unstyled")
+    func everyCaptureNameResolves() throws {
+        for name in Self.bundledLanguageNames {
+            let language = try #require(Self.language(named: name))
+            for url in try Self.highlightQueryURLs(for: language) {
+                for capture in try Self.captureNames(in: url) {
+                    let resolved = CaptureName.fromString(capture) != nil
+                    let deliberate = CaptureName.unstyledGrammarCaptures.contains(capture)
+                    #expect(
+                        resolved || deliberate,
+                        "\(name) emits @\(capture), which carries no colour and is not in unstyledGrammarCaptures"
+                    )
+                }
+            }
+        }
+    }
+
+    @Test("Deliberately unstyled captures stay unstyled", arguments: CaptureName.unstyledGrammarCaptures.sorted())
+    func unstyledCapturesResolveToNothing(capture: String) {
+        #expect(CaptureName.fromString(capture) == nil)
+    }
+
+    // MARK: - Capture resolution
+
+    @Test(
+        "Grammar capture names resolve to the editor's vocabulary",
+        arguments: [
+            ("keyword.operator", CaptureName.keyword),
+            ("attribute", .keyword),
+            ("storageclass", .keyword),
+            ("type.qualifier", .keyword),
+            ("type.builtin", .type),
+            ("function.call", .function),
+            ("function.builtin", .function),
+            ("function.method", .method),
+            ("constant", .constant),
+            ("constant.builtin", .constant),
+            ("operator", .operator),
+            ("string.special.key", .string),
+        ]
+    )
+    func grammarCaptureResolves(capture: String, expected: CaptureName) {
+        #expect(CaptureName.fromString(capture) == expected)
+    }
+
+    @Test("An unknown capture name carries no colour")
+    func unknownCaptureIsNil() {
+        #expect(CaptureName.fromString("keyword.operator.something") == nil)
+        #expect(CaptureName.fromString(nil) == nil)
+    }
+
+    @Test("A repeat capture spells itself without Swift's backticks")
+    func repeatSpellsItselfPlainly() {
+        #expect(CaptureName.repeat.stringValue == "repeat")
+        #expect(CaptureName.fromString(CaptureName.repeat.stringValue) == .repeat)
+    }
+
+    // MARK: - The colours a reader actually sees
+
+    @Test("SQL word tokens take their theme colour")
+    func sqlWordTokenColors() throws {
+        let palette = Palette.test
+        let expected: [(String, NSColor)] = [
+            ("SELECT", palette.keyword),
+            ("IN", palette.keyword),
+            ("AND", palette.keyword),
+            ("BY", palette.keyword),
+            ("DESC", palette.keyword),
+            ("INT", palette.type),
+            ("CAST", palette.function),
+            ("42", palette.number),
+            ("NULL", palette.value),
+            ("orders", palette.type),
+        ]
+
+        let highlighted = try Self.highlight(Self.sql, language: .sql)
+        for (token, color) in expected {
+            let range = try Self.range(ofWord: token, in: Self.sql)
+            #expect(Self.color(at: range, in: highlighted) == color, "\(token)")
+        }
+    }
+
+    @Test("SQL string literals and symbolic operators take their own colours")
+    func sqlLiteralAndOperatorColors() throws {
+        let highlighted = try Self.highlight(Self.sql, language: .sql)
+        let quoted = (Self.sql as NSString).range(of: "'abc'")
+        #expect(Self.color(at: quoted, in: highlighted) == Palette.test.string)
+
+        let equals = (Self.sql as NSString).range(of: "=")
+        #expect(Self.color(at: equals, in: highlighted) == Palette.test.operatorColor)
+    }
+
+    @Test("SQL brackets stay at the plain text colour")
+    func sqlBracketsAreUnstyled() throws {
+        let highlighted = try Self.highlight(Self.sql, language: .sql)
+        let bracket = (Self.sql as NSString).range(of: "(")
+        #expect(Self.color(at: bracket, in: highlighted) == nil)
+    }
+
+    @Test("JSON literals and keys take their theme colour")
+    func jsonTokenColors() throws {
+        let highlighted = try Self.highlight(Self.json, language: .json)
+        #expect(Self.color(at: try Self.range(ofWord: "true", in: Self.json), in: highlighted) == Palette.test.value)
+        #expect(Self.color(at: try Self.range(ofWord: "7", in: Self.json), in: highlighted) == Palette.test.number)
+
+        let key = (Self.json as NSString).range(of: "\"active\"")
+        #expect(Self.color(at: key, in: highlighted) == Palette.test.string)
+    }
+
+    // MARK: - The theme's own wiring
+
+    @MainActor
+    @Test("The theme's operator and function colours reach the editor")
+    func themeCarriesOperatorAndFunctionColors() {
+        let colors = ThemeEngine.shared.colors.editor
+        let theme = ThemeEngine.shared.makeEditorTheme()
+
+        #expect(Self.sameColor(theme.operators.color, colors.operator))
+        #expect(Self.sameColor(theme.functions.color, colors.function))
+    }
+
+    // MARK: - Helpers
+
+    struct Palette {
+        let text: NSColor
+        let keyword: NSColor
+        let type: NSColor
+        let number: NSColor
+        let string: NSColor
+        let comment: NSColor
+        let variable: NSColor
+        let value: NSColor
+        let operatorColor: NSColor
+        let function: NSColor
+
+        static var test: Palette {
+            Palette(
+                text: .systemGray,
+                keyword: .systemBlue,
+                type: .systemTeal,
+                number: .systemPurple,
+                string: .systemRed,
+                comment: .systemGreen,
+                variable: .systemOrange,
+                value: .systemYellow,
+                operatorColor: .systemBrown,
+                function: .systemIndigo
+            )
+        }
+
+        var editorTheme: EditorTheme {
+            EditorTheme(
+                text: .init(color: text),
+                insertionPoint: text,
+                invisibles: .init(color: text),
+                background: .white,
+                lineHighlight: .white,
+                selection: .white,
+                keywords: .init(color: keyword),
+                commands: .init(color: keyword),
+                types: .init(color: type),
+                attributes: .init(color: variable),
+                variables: .init(color: variable),
+                values: .init(color: value),
+                numbers: .init(color: number),
+                strings: .init(color: string),
+                characters: .init(color: string),
+                comments: .init(color: comment),
+                operators: .init(color: operatorColor),
+                functions: .init(color: function)
+            )
+        }
+    }
+
+    private static func highlight(_ source: String, language: CodeLanguage) throws -> NSAttributedString {
+        let highlighted = TreeSitterClient.quickHighlight(
+            string: source,
+            theme: Palette.test.editorTheme,
+            font: .monospacedSystemFont(ofSize: 13, weight: .regular),
+            language: language
+        )
+        return try #require(highlighted)
+    }
+
+    private static func color(at range: NSRange, in string: NSAttributedString) -> NSColor? {
+        guard range.location != NSNotFound, range.length > 0 else { return nil }
+        return string.attribute(.foregroundColor, at: range.location, effectiveRange: nil) as? NSColor
+    }
+
+    private static func range(ofWord word: String, in source: String) throws -> NSRange {
+        let pattern = "\\b\(NSRegularExpression.escapedPattern(for: word))\\b"
+        let expression = try NSRegularExpression(pattern: pattern)
+        let match = expression.firstMatch(in: source, range: NSRange(location: 0, length: (source as NSString).length))
+        return try #require(match?.range, "\(word) does not appear in the sample")
+    }
+
+    private static func highlightQueryURLs(for language: CodeLanguage) throws -> [URL] {
+        let primary = try #require(language.queryURL)
+        let directory = primary.deletingLastPathComponent()
+        let additional = (language.additionalHighlights ?? [])
+            .filter { $0.hasPrefix("highlights") }
+            .map { directory.appendingPathComponent("\($0).scm") }
+        return additional + [primary]
+    }
+
+    private static func captureNames(in url: URL) throws -> Set<String> {
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        let expression = try NSRegularExpression(pattern: "@([A-Za-z_][A-Za-z0-9_.]*)")
+        var names: Set<String> = []
+        for line in contents.components(separatedBy: .newlines) {
+            let code = line.components(separatedBy: ";").first ?? line
+            let scope = NSRange(location: 0, length: (code as NSString).length)
+            for match in expression.matches(in: code, range: scope) {
+                let name = (code as NSString).substring(with: match.range(at: 1))
+                guard !name.hasPrefix("_") else { continue }
+                names.insert(name)
+            }
+        }
+        return names
+    }
+
+    private static func sameColor(_ lhs: NSColor, _ rhs: NSColor) -> Bool {
+        guard let left = lhs.usingColorSpace(.sRGB), let right = rhs.usingColorSpace(.sRGB) else { return false }
+        return abs(left.redComponent - right.redComponent) < 0.001
+            && abs(left.greenComponent - right.greenComponent) < 0.001
+            && abs(left.blueComponent - right.blueComponent) < 0.001
+    }
+}

--- a/TableProTests/Views/Editor/SyntaxHighlightingTests.swift
+++ b/TableProTests/Views/Editor/SyntaxHighlightingTests.swift
@@ -11,6 +11,7 @@ import AppKit
 import CodeEditLanguages
 @testable import CodeEditSourceEditor
 import Foundation
+import SwiftTreeSitter
 @testable import TablePro
 import Testing
 
@@ -48,6 +49,18 @@ struct SyntaxHighlightingTests {
         let language = try #require(Self.language(named: name))
         let query = TreeSitterModel.shared.query(for: language.id)
         #expect(query != nil, "\(name) has no usable highlight query, so that editor shows no highlighting at all")
+    }
+
+    @Test("Every query file a bundled grammar ships compiles", arguments: bundledLanguageNames)
+    func everyShippedQueryFileCompiles(name: String) throws {
+        let language = try #require(Self.language(named: name))
+        let parserLanguage = try #require(language.language)
+
+        for url in try Self.shippedQueryURLs(for: language) {
+            #expect(throws: Never.self, "\(name)/\(url.lastPathComponent) does not compile") {
+                try parserLanguage.query(contentsOf: url)
+            }
+        }
     }
 
     @Test("Every capture a bundled highlights query emits carries a colour or is deliberately unstyled")
@@ -244,6 +257,12 @@ struct SyntaxHighlightingTests {
         let expression = try NSRegularExpression(pattern: pattern)
         let match = expression.firstMatch(in: source, range: NSRange(location: 0, length: (source as NSString).length))
         return try #require(match?.range, "\(word) does not appear in the sample")
+    }
+
+    private static func shippedQueryURLs(for language: CodeLanguage) throws -> [URL] {
+        let directory = try #require(language.queryURL).deletingLastPathComponent()
+        let contents = try FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+        return contents.filter { $0.pathExtension == "scm" }.sorted { $0.lastPathComponent < $1.lastPathComponent }
     }
 
     private static func highlightQueryURLs(for language: CodeLanguage) throws -> [URL] {


### PR DESCRIPTION
Fixes #2634.

`IN` and `AND` were one of six SQL token classes the editor silently refused to colour, and the same cause left the MongoDB and Elasticsearch editors with no highlighting at all.

## Root cause

`CaptureName.fromString` is a closed 21-string whitelist that predates the dotted capture names every bundled tree-sitter grammar emits. `TreeSitterClient+Highlight.swift:105` and `TreeSitterClient+Temporary.swift:44` both drop a capture the whitelist cannot name, so the token keeps the plain text attributes and simply looks unhighlighted. The grammars' capture names and the editor's vocabulary are two hand-maintained lists that must agree, and nothing forced them to.

Two more defects of the same class sat underneath it:

- **The SQL query's own pattern order.** `(literal) @string` sits at capture index 4 and wins the lower-index-wins dedupe against `@number` (7), `@float` (8) and `@type.builtin` (16), so every numeric literal and every `NULL`, `TRUE` and `FALSE` rendered in the String colour. The `#match?` predicates meant to separate them are nvim **Lua** patterns (`^[-+]?%d+$`); SwiftTreeSitter compiles `#match?` into `NSRegularExpression`, where `%d` is a literal `%` followed by `d` and never matches.
- **The JavaScript queries do not compile.** `CodeLanguage.javascript` declares `highlights: ["injections"]`, so `TreeSitterModel.queryFor` concatenates `injections.scm` + `highlights.scm` and `try?`s the result. `injections.scm` referenced `(glimmer_template)`, a node the vendored parser does not have, and `highlights.scm` used `(function`, which this parser calls `function_expression`. `TreeSitterModel.shared.query(for: .javascript)` returned nil, so the MQL and Query DSL editors had no highlighting whatsoever. `locals.scm` and `tags.scm` failed on the same renamed node; nothing loads them today, so they were inert, but they shipped broken.

`ThemeEngine.makeEditorTheme()` also never read `syntax.operator` or `syntax.function`, and `EditorTheme` had no attribute that could carry them, so the Operator and Function pickers in **Settings > Appearance** changed the preview card and nothing else.

## Measured

A harness linking the vendored `CodeEditLanguages` and replicating `highlightsFromCursor` exactly, over
`SELECT CAST(total AS INT), 42, NULL, 'abc' FROM orders o WHERE o.status IN ('a') AND o.total = 3 GROUP BY o.status ORDER BY total DESC;`

| | before | after |
|---|---|---|
| `IN` `AND` `BY` | plain text | keyword |
| `DESC` | plain text | keyword |
| `INT` | plain text | type |
| `CAST` | plain text | function |
| `orders` | type | type |
| `42` `3` | **string** | number |
| `NULL` | **string** | NULL |
| `'abc'` | string | string |
| `=` | plain text | operator |
| `(` `)` `,` `;` | plain text | plain text (unchanged, deliberate) |

JSON gains `true`/`false`/`null` in the NULL colour, matching what `JSONRowColors` already paints in the inspector's tree mode. Bash gains `|`, `>` and command flags. JavaScript gains all highlighting, from none.

## The fix

- A guard test compiles every `.scm` a bundled grammar ships, not only the ones a `CodeLanguage` loads, so a query file cannot ship broken again.
- `CaptureName` gains `operator` and `constant`, plus a `grammarAlias` table mapping the nvim-treesitter names the bundled grammars emit onto this editor's vocabulary. Names deliberately left uncoloured are listed in `unstyledGrammarCaptures` next to it rather than being invisible.
- `EditorTheme` gains `operators` and `functions`; `.function`/`.method` move off `variables`, which TablePro fills with the NULL colour.
- `ThemeEngine.makeEditorTheme()` passes `syntax.operator` and `syntax.function`, so both pickers now do what their labels say.
- `tree-sitter-sql/highlights.scm`: ICU regex for the two predicates, and `@number`, `@float` and a new `@constant.builtin` block hoisted above `(literal) @string`; `@function.call` hoisted above `@type`.
- `tree-sitter-javascript`: eleven `(function` renamed to `(function_expression` across `highlights`, `locals` and `tags`, and the Ember `glimmer_template` pattern removed from `injections`.

## Deliberately not doing

`@field` stays uncoloured, so column identifiers keep the plain text colour: of TablePlus, DataGrip, Postico, Sequel Ace and VS Code, only DataGrip colours them. `@punctuation.*` stays uncoloured for the same reason and because it costs a dense viewport 440 extra highlight ranges (1560 against 1120). `@spell` and `@embedded` mark a range for another tool and sit on a range something else already colours.

## Chose an alias table over a fallback rule

The first draft resolved a dotted name by stripping trailing components, which is neovim's documented rule and what these `.scm` files were written against. The Phase 2 critique showed why it is worse here: with the new guard test, an unknown capture fails CI loudly, whereas a stripping loop would silently resolve it to something plausible and possibly wrong. `type.qualifier` is the example: stripping gives `type`, but `UNIQUE` and `CASCADE` read as keywords.

## Verified

- `build` PASS
- `test` (13 suites: the new one plus every suite owning `EditorTheme`, `ThemeEngine` or the editor fixture) PASS, 127 cases, 0 failures
- `lint` 0 violations across the seven changed Swift files
- Re-verified after merging `main` at v0.72.0
- Before/after harness output above, from the shipping query files and the shipping resolution

No docs change: **Settings > Appearance** already documents Operator and Function as syntax colours, and this makes that true. The `sql-editor` page's images are still the "Screenshot coming soon" placeholders, so nothing there goes stale.

## Before / after

The change is entirely colour inside the editor, so the table above is the exact per-token record, taken from the shipping query files through the shipping resolution path. A rendered light and dark pair of the same sample went to the author to drag in here; `gh` cannot upload an image to a pull request.

Reading the sample in Default Light, before against after: `IN`, `AND`, `ON`, `NOT`, `BY`, `DESC` and `UNIQUE` go from black to the keyword blue; `INT`, `VARCHAR`, `JSONB` and `TIMESTAMP` from black to the type teal; `CAST` and `count` from black to the function teal; `42`, `3.5`, `100` and `255` from the string red to the number purple; `NULL` and `TRUE` from the string red to the NULL orange. Quoted literals, table names and aliases are unchanged.



https://claude.ai/code/session_016cKgYoccE88XFeVPuBLRak
