### PR TITLE
refactor(sidebar): drop the contextual-menu destructive flag AppKit never renders

### DIFF
--- a/TablePro/Views/Sidebar/Menu/DatabaseTreeMenuSpec.swift
+++ b/TablePro/Views/Sidebar/Menu/DatabaseTreeMenuSpec.swift
@@ -377,7 +377,7 @@ internal enum DatabaseTreeMenuSpec {
             .submenu(title: FavoriteDatabaseMenu.submenuTitle(for: state), items: environmentItems)
         ]
         if state.hasFavorite {
-            items.append(.destructive(FavoriteDatabaseMenu.removeTitle, .removeFavoriteDatabases(databases)))
+            items.append(.command(FavoriteDatabaseMenu.removeTitle, .removeFavoriteDatabases(databases)))
         }
         return items
     }

--- a/TablePro/Views/Sidebar/Menu/FavoritesMenuSpec.swift
+++ b/TablePro/Views/Sidebar/Menu/FavoritesMenuSpec.swift
@@ -75,7 +75,7 @@ internal enum FavoritesMenuSpec {
             }
         ))
         items.append(.separator)
-        items.append(.destructive(FavoriteDatabaseMenu.removeTitle, .removeDatabaseFavorite(entry)))
+        items.append(.command(FavoriteDatabaseMenu.removeTitle, .removeDatabaseFavorite(entry)))
         return items
     }
 
@@ -84,7 +84,7 @@ internal enum FavoritesMenuSpec {
             .command(String(localized: "Open Table"), .openTable(table)),
             .command(String(localized: "Show ER Diagram"), .showERDiagram),
             .separator,
-            .destructive(String(localized: "Remove from Favorites"), .removeTableFavorite(table))
+            .command(String(localized: "Remove from Favorites"), .removeTableFavorite(table))
         ]
     }
 
@@ -123,7 +123,7 @@ internal enum FavoritesMenuSpec {
             items.append(moveTo)
         }
         items.append(.separator)
-        items.append(.destructive(String(localized: "Delete"), .deleteFavorite(favorite)))
+        items.append(.command(String(localized: "Delete"), .deleteFavorite(favorite)))
         return items
     }
 
@@ -156,7 +156,7 @@ internal enum FavoritesMenuSpec {
             .command(String(localized: "Copy Query"), .copyLinkedFavoriteQuery(favorite)),
             .command(String(localized: "Show in Finder"), .revealLinkedFavorite(favorite)),
             .separator,
-            .destructive(String(localized: "Move File to Trash"), .trashLinkedFavorite(favorite))
+            .command(String(localized: "Move File to Trash"), .trashLinkedFavorite(favorite))
         ]
     }
 
@@ -173,7 +173,7 @@ internal enum FavoritesMenuSpec {
             .separator,
             .command(String(localized: "Add Another SQL Folder…"), .addLinkedFolder),
             .separator,
-            .destructive(String(localized: "Remove from Sidebar"), .removeLinkedFolder(folder))
+            .command(String(localized: "Remove from Sidebar"), .removeLinkedFolder(folder))
         ]
     }
 
@@ -183,7 +183,7 @@ internal enum FavoritesMenuSpec {
             .command(String(localized: "New Favorite…"), .newFavorite(folderId: folder.id)),
             .command(String(localized: "New Subfolder"), .newFolder(parentId: folder.id)),
             .separator,
-            .destructive(String(localized: "Delete Folder"), .deleteFolder(folder))
+            .command(String(localized: "Delete Folder"), .deleteFolder(folder))
         ]
     }
 

--- a/TablePro/Views/Sidebar/Menu/SidebarMenuItem.swift
+++ b/TablePro/Views/Sidebar/Menu/SidebarMenuItem.swift
@@ -21,32 +21,30 @@ internal enum SidebarMenuItem<Command: Equatable>: Equatable {
     case submenu(title: String, items: [SidebarMenuItem<Command>])
 }
 
+/// No destructive flag. AppKit gives `NSMenuItem` no destructive role, on any SDK up to macOS 26,
+/// and Apple's own menus do not colour one: Finder's Move to Trash and Mail's Delete are ordinary
+/// items. Hand-rolling red through `attributedTitle` would invent a convention the platform does not
+/// have. A destructive item is set apart by sitting last in its group, behind a separator, which is
+/// what every spec here already does.
 internal struct SidebarMenuEntry<Command: Equatable>: Equatable {
     internal let title: String
     internal let command: Command
     internal var isOn: Bool?
-    internal var isDestructive: Bool
 
     internal init(
         title: String,
         command: Command,
-        isOn: Bool? = nil,
-        isDestructive: Bool = false
+        isOn: Bool? = nil
     ) {
         self.title = title
         self.command = command
         self.isOn = isOn
-        self.isDestructive = isDestructive
     }
 }
 
 internal extension SidebarMenuItem {
     static func command(_ title: String, _ command: Command) -> SidebarMenuItem<Command> {
         .command(SidebarMenuEntry(title: title, command: command))
-    }
-
-    static func destructive(_ title: String, _ command: Command) -> SidebarMenuItem<Command> {
-        .command(SidebarMenuEntry(title: title, command: command, isDestructive: true))
     }
 
     /// A menu is assembled by appending groups, so a group that turns out to be empty leaves a


### PR DESCRIPTION
Found during a HIG audit of the sidebar surface.

`SidebarMenuEntry.isDestructive` was set at seven call sites (`FavoritesMenuSpec` six, `DatabaseTreeMenuSpec` one) and read at none. `SidebarMenuBuilder.makeCommandItem` builds the `NSMenuItem` from title, target, `representedObject`, `isEnabled` and `state`, and never looks at the flag, so Delete, Move File to Trash and Remove from Sidebar have always rendered exactly like Open Table. No test asserted it either.

## Why removed rather than wired up

AppKit gives `NSMenuItem` no destructive role. Checked the macOS 26 SDK: `NSAlert`, `NSButton` and `NSTableViewRowAction` each declare one, `NSMenuItem.h` and `NSMenu.h` declare nothing. Apple does not colour these items either, in Finder (Move to Trash), Mail (Delete) or Notes.

Painting them red through `attributedTitle` would invent a convention the platform does not have, against the native-only principle in CLAUDE.md. The repo already avoids it: its one `attributedTitle` (`EnumMenuPicker`) styles the font, not the colour.

The signal the flag was reaching for is already carried by ordering. Every site sat last in its group behind a separator, which is how macOS sets a destructive item apart.

## Verification

- `xcodebuild build`, exit 0
- 108 tests passed, 0 failed, across `DatabaseTreeMenuSpecTests`, `FavoritesMenuSpecTests`, `SidebarMenuTargetTests`, `SidebarContextMenuLogicTests`, `FavoriteDatabaseMenuTests`
- `swiftlint lint --strict`, exit 0

Built and tested in an isolated worktree off `origin/main`, because the main checkout is carrying another branch in progress.

No CHANGELOG entry: the flag was never read, so nothing a user can see changes.

https://claude.ai/code/session_01KuMgrPwNLr7oPY63t8WWs9