### PR TITLE
fix(hig): name the controls whose only label is an SF Symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Icon-only controls with no VoiceOver name or tooltip in the date picker, row inspector and slash command settings.
 - Cost badge on every plan node of a query ending in `LIMIT`, where the share it reads could exceed 100%. (#2633)
 - Green "low cost" badge on plans that report no cost at all, such as SQLite and ClickHouse. (#2633)
 - Empty Cost, Rows and Actual Time columns in the EXPLAIN tree for engines that report none of them. (#2633)

--- a/TablePro/Views/Results/DateTimePickerContentView.swift
+++ b/TablePro/Views/Results/DateTimePickerContentView.swift
@@ -111,6 +111,8 @@ private struct CalendarMonthView: View {
                 Image(systemName: "chevron.left")
             }
             .buttonStyle(.borderless)
+            .accessibilityLabel(String(localized: "Previous Month"))
+            .help(String(localized: "Previous Month"))
 
             Spacer()
 
@@ -123,6 +125,8 @@ private struct CalendarMonthView: View {
                 Image(systemName: "chevron.right")
             }
             .buttonStyle(.borderless)
+            .accessibilityLabel(String(localized: "Next Month"))
+            .help(String(localized: "Next Month"))
         }
     }
 

--- a/TablePro/Views/RightSidebar/FieldEditors/FieldMenuView.swift
+++ b/TablePro/Views/RightSidebar/FieldEditors/FieldMenuView.swift
@@ -107,5 +107,7 @@ internal struct FieldMenuView: View {
         .buttonStyle(.plain)
         .menuIndicator(.hidden)
         .fixedSize()
+        .accessibilityLabel(String(localized: "Value Options"))
+        .help(String(localized: "Value Options"))
     }
 }

--- a/TablePro/Views/Settings/CustomSlashCommandsSection.swift
+++ b/TablePro/Views/Settings/CustomSlashCommandsSection.swift
@@ -108,6 +108,8 @@ struct CustomSlashCommandsSection: View {
                 Image(systemName: "trash")
             }
             .controlSize(.small)
+            .accessibilityLabel(String(format: String(localized: "Delete /%@"), command.name))
+            .help(String(localized: "Delete"))
         }
     }
 }

--- a/TableProTests/Views/IconOnlyControlLabelTests.swift
+++ b/TableProTests/Views/IconOnlyControlLabelTests.swift
@@ -1,0 +1,100 @@
+//
+//  IconOnlyControlLabelTests.swift
+//  TableProTests
+//
+//  A control whose whole label is an SF Symbol has no name for VoiceOver to read and no tooltip for
+//  a sighted user to discover it by, so the symbol name is all anyone gets. Four shipped that way:
+//  the row inspector's value menu, the delete button on a custom slash command, and both month
+//  chevrons in the date picker, whose own day cells were labelled correctly.
+//
+
+import Foundation
+import Testing
+
+@Suite("Icon-only control labels")
+struct IconOnlyControlLabelTests {
+    private static let labelMarker = "} label: {"
+
+    private static let repositoryRoot: URL = {
+        var url = URL(fileURLWithPath: #filePath)
+        for _ in 0 ..< 3 {
+            url.deleteLastPathComponent()
+        }
+        return url
+    }()
+
+    /// Any one of these gives the control a name. `accessibilityHidden` and `accessibilityElement`
+    /// count because they hand the naming to an ancestor that speaks for the whole subtree, which is
+    /// what an editor tab does.
+    private static let namingModifiers = [
+        ".help(",
+        "accessibilityLabel",
+        "accessibilityHidden",
+        "accessibilityElement"
+    ]
+
+    @Test("Every SwiftUI control labelled only by an SF Symbol carries a name")
+    func iconOnlyControlsAreNamed() throws {
+        let viewsRoot = Self.repositoryRoot.appendingPathComponent("TablePro/Views")
+        let enumerator = try #require(
+            FileManager.default.enumerator(at: viewsRoot, includingPropertiesForKeys: nil)
+        )
+
+        var inspected = 0
+        var offenders: [String] = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            let result = Self.scan(url, root: Self.repositoryRoot)
+            inspected += result.inspected
+            offenders += result.offenders
+        }
+
+        /// Guards the scanner itself. Brace matching that closes early finds no label block at all,
+        /// which reads as a clean run rather than as the broken scan it is.
+        #expect(inspected > 40, "Expected to find icon-only controls to check, found \(inspected)")
+        #expect(
+            offenders.isEmpty,
+            "These controls show only an SF Symbol and need .help() or .accessibilityLabel(): \(offenders.sorted())"
+        )
+    }
+
+    private static func scan(_ url: URL, root: URL) -> (inspected: Int, offenders: [String]) {
+        guard let source = try? String(contentsOf: url, encoding: .utf8) else { return (0, []) }
+        let lines = source.components(separatedBy: .newlines)
+        let relativePath = url.path.replacingOccurrences(of: root.path + "/", with: "")
+
+        var inspected = 0
+        var offenders: [String] = []
+        for (index, line) in lines.enumerated() where line.contains(labelMarker) {
+            let (block, end) = labelBlock(lines, from: index)
+            guard block.contains("Image(systemName:") else { continue }
+            /// A symbol beside its own text is decoration, and the text is already the name.
+            guard !block.contains("Text("), !block.contains("Label(") else { continue }
+
+            inspected += 1
+            let chain = lines[end ..< min(end + 18, lines.count)].joined(separator: "\n")
+            guard !namingModifiers.contains(where: chain.contains) else { continue }
+            offenders.append("\(relativePath):\(index + 1)")
+        }
+        return (inspected, offenders)
+    }
+
+    /// The label closure, brace matched. The opening line has to be measured from its `{` alone: the
+    /// marker carries the previous closure's `}` too, and counting that balances the line to zero, so
+    /// every block reads as one line long and no control is ever inspected.
+    private static func labelBlock(_ lines: [String], from start: Int) -> (block: String, end: Int) {
+        var depth = 0
+        var collected: [String] = []
+        for index in start ..< lines.count {
+            let line = lines[index]
+            var measured = line
+            if index == start, let range = line.range(of: labelMarker) {
+                measured = String(line[range.lowerBound...].dropFirst("} label: ".count))
+            }
+            collected.append(line)
+            depth += measured.filter { $0 == "{" }.count
+            depth -= measured.filter { $0 == "}" }.count
+            if depth <= 0 { return (collected.joined(separator: "\n"), index) }
+        }
+        return (collected.joined(separator: "\n"), lines.count - 1)
+    }
+}


### PR DESCRIPTION
Second finding from the HIG audit, after #2637.

Four controls carried an SF Symbol and nothing else: no `Text`, no `.help()`, no `.accessibilityLabel()`. VoiceOver had only the symbol name to read, and hovering showed no tooltip.

- The row inspector value menu, a bare `chevron.down` with `.menuIndicator(.hidden)`
- Delete on a custom slash command, a bare `trash` sitting beside a labelled Edit button
- Both month arrows in the date picker, whose own day cells are labelled correctly, which is what makes these an oversight rather than a choice

## The guard

`IconOnlyControlLabelTests` scans `TablePro/Views` the way `EllipsisConventionTests` scans the strings catalog. It brace matches each `} label: {` block, keeps the ones holding an `Image(systemName:)` with no `Text` or `Label` beside it, and fails when the attached chain names none of `.help(`, `accessibilityLabel`, `accessibilityHidden` or `accessibilityElement`. The last two count because they hand naming to an ancestor that speaks for the whole subtree, which is what an editor tab does.

Brace matching earns its own assertion. Measuring the opening line whole counts the marker s leading `}` as well as its `{`, which balances to zero, ends every block after one line and finds no controls at all: a broken scan that reads as a clean run. The test fails under 40 inspected; it currently inspects 69.

Verified against `origin/main`: the guard reports exactly these four sites before the fix and none after.

## Verification

- `xcodebuild build`, exit 0
- `IconOnlyControlLabelTests` passes, 69 controls inspected
- `swiftlint lint --strict`, exit 0

Built and tested in an isolated worktree off `origin/main`, because the main checkout is carrying another branch in progress.

https://claude.ai/code/session_01KuMgrPwNLr7oPY63t8WWs9