### PR TITLE
fix(hig): gate the six animations that ignored Reduce Motion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Animations that played through the Reduce Motion setting when removing a jump host or copying DDL or a query plan.
 - Cost badge on every plan node of a query ending in `LIMIT`, where the share it reads could exceed 100%. (#2633)
 - Green "low cost" badge on plans that report no cost at all, such as SQLite and ClickHouse. (#2633)
 - Empty Cost, Rows and Actual Time columns in the EXPLAIN tree for engines that report none of them. (#2633)

--- a/TablePro/Views/Connection/ConnectionSSHTunnelView.swift
+++ b/TablePro/Views/Connection/ConnectionSSHTunnelView.swift
@@ -338,7 +338,7 @@ struct ConnectionSSHTunnelView: View {
                                 Spacer()
                                 Button {
                                     let idToRemove = jumpHost.id
-                                    withAnimation { sshState.jumpHosts.removeAll { $0.id == idToRemove } }
+                                    withMotion { sshState.jumpHosts.removeAll { $0.id == idToRemove } }
                                 } label: {
                                     Image(systemName: "minus.circle.fill")
                                         .frame(width: 24, height: 24)

--- a/TablePro/Views/Connection/SSHProfileEditorView.swift
+++ b/TablePro/Views/Connection/SSHProfileEditorView.swift
@@ -282,7 +282,7 @@ struct SSHProfileEditorView: View {
                             Spacer()
                             Button {
                                 let idToRemove = jumpHost.id
-                                withAnimation { jumpHosts.removeAll { $0.id == idToRemove } }
+                                withMotion { jumpHosts.removeAll { $0.id == idToRemove } }
                             } label: {
                                 Image(systemName: "minus.circle.fill")
                                     .frame(width: 24, height: 24)

--- a/TablePro/Views/QueryPlan/QueryPlanResultView.swift
+++ b/TablePro/Views/QueryPlan/QueryPlanResultView.swift
@@ -345,12 +345,12 @@ struct QueryPlanResultView: View {
 
     private func copyText() {
         ClipboardService.shared.writeText(rawText)
-        withAnimation { showCopyConfirmation = true }
+        withMotion { showCopyConfirmation = true }
         copyResetTask?.cancel()
         copyResetTask = Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(1_500))
             guard !Task.isCancelled else { return }
-            withAnimation { showCopyConfirmation = false }
+            withMotion { showCopyConfirmation = false }
         }
     }
 

--- a/TablePro/Views/Structure/TableStructureView+Schema.swift
+++ b/TablePro/Views/Structure/TableStructureView+Schema.swift
@@ -166,7 +166,7 @@ extension TableStructureView {
     private func copyDDL() {
         ClipboardService.shared.writeText(ddlStatement)
 
-        withAnimation {
+        withMotion {
             showCopyConfirmation = true
         }
 
@@ -174,7 +174,7 @@ extension TableStructureView {
         copyResetTask = Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(1_500))
             guard !Task.isCancelled else { return }
-            withAnimation {
+            withMotion {
                 showCopyConfirmation = false
             }
         }

--- a/TableProTests/Views/ReduceMotionGateTests.swift
+++ b/TableProTests/Views/ReduceMotionGateTests.swift
@@ -1,0 +1,64 @@
+//
+//  ReduceMotionGateTests.swift
+//  TableProTests
+//
+//  Reduce Motion is a system accessibility setting, and `withAnimation` captures its animation at
+//  the call, so a call site that does not read the setting animates regardless of it. `withMotion`
+//  is the gate. The data grid already gated its row insert and remove through `rowAnimation`, which
+//  is what makes the six that did not a slip rather than a decision: two jump host removals, and
+//  both copy confirmations in the plan view and the structure editor.
+//
+
+import Foundation
+import Testing
+
+@Suite("Reduce Motion gate")
+struct ReduceMotionGateTests {
+    private static let repositoryRoot: URL = {
+        var url = URL(fileURLWithPath: #filePath)
+        for _ in 0 ..< 3 {
+            url.deleteLastPathComponent()
+        }
+        return url
+    }()
+
+    @Test("Every animated call site reads the Reduce Motion setting")
+    func animationsAreGated() throws {
+        let appRoot = Self.repositoryRoot.appendingPathComponent("TablePro")
+        let enumerator = try #require(
+            FileManager.default.enumerator(at: appRoot, includingPropertiesForKeys: nil)
+        )
+
+        var offenders: [String] = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            /// The gate itself is the one place allowed to call the ungated function.
+            guard url.lastPathComponent != "MotionAccessibility.swift" else { continue }
+            offenders += Self.offenders(in: url, root: Self.repositoryRoot)
+        }
+
+        #expect(
+            offenders.isEmpty,
+            "These call sites animate against Reduce Motion, use withMotion: \(offenders.sorted())"
+        )
+    }
+
+    private static func offenders(in url: URL, root: URL) -> [String] {
+        guard let source = try? String(contentsOf: url, encoding: .utf8) else { return [] }
+        let relativePath = url.path.replacingOccurrences(of: root.path + "/", with: "")
+
+        var offenders: [String] = []
+        for (index, line) in source.components(separatedBy: .newlines).enumerated() {
+            guard !line.trimmingCharacters(in: .whitespaces).hasPrefix("//") else { continue }
+            var searchStart = line.startIndex
+            while let found = line.range(of: "withAnimation", range: searchStart ..< line.endIndex) {
+                searchStart = found.upperBound
+                let rest = line[found.upperBound...]
+                /// `NSTableView.insertRows(at:withAnimation:)` spells its parameter the same way and
+                /// gates separately, and `withAnimation(nil)` is already the reduced behaviour.
+                guard !rest.hasPrefix(":"), !rest.hasPrefix("(nil)") else { continue }
+                offenders.append("\(relativePath):\(index + 1)")
+            }
+        }
+        return offenders
+    }
+}


### PR DESCRIPTION
Third finding from the HIG audit, after #2637 and #2641.

`withAnimation` captures its animation at the call, so a call site that never reads Reduce Motion animates whatever the user set. `withMotion` is the gate the app already has, and the data grid already used it: `DataGridCoordinator.rowAnimation` drops the row insert and remove animations when the setting is on. Six call sites did not.

- Removing an SSH jump host, in both the profile editor and the connection form tunnel pane
- The copy confirmation in the query plan view, appearing and dismissing
- The copy confirmation in the structure editor DDL tab, appearing and dismissing

That the grid gates and these do not is what makes it a slip rather than a decision.

`withMotion` defaults to `.default`, which is what a bare `withAnimation { }` already used, so nothing changes for a user who has Reduce Motion off.

## The guard

`ReduceMotionGateTests` scans `TablePro` for `withAnimation` and fails on any that is not gated. Two spellings are allowed and both are explained where they are skipped: `NSTableView.insertRows(at:withAnimation:)` names its parameter identically and gates separately, and `withAnimation(nil)` is already the reduced behaviour. `MotionAccessibility.swift` is the one file allowed to call the ungated function, since it is the gate.

Verified against `origin/main`: the guard reports exactly these six sites before the fix and none after.

## Verification

- `xcodebuild build`, exit 0
- `ReduceMotionGateTests` passes
- `swiftlint lint --strict`, exit 0

Built and tested in an isolated worktree off `origin/main`, because the main checkout is carrying another branch in progress.

https://claude.ai/code/session_01KuMgrPwNLr7oPY63t8WWs9