### PR TITLE
refactor(connections): drop the dotenv entry flag nothing reads

### DIFF
--- a/TablePro/Core/Services/ProjectImport/DotenvParser+Interpolation.swift
+++ b/TablePro/Core/Services/ProjectImport/DotenvParser+Interpolation.swift
@@ -20,7 +20,6 @@ extension DotenvParser {
             return DotenvEntry(
                 key: assignment.key,
                 value: assignment.rawValue,
-                isSingleQuoted: true,
                 hasUnresolvedReference: false
             )
         }
@@ -54,7 +53,6 @@ extension DotenvParser {
         return DotenvEntry(
             key: assignment.key,
             value: value,
-            isSingleQuoted: false,
             hasUnresolvedReference: unresolved
         )
     }

--- a/TablePro/Core/Services/ProjectImport/DotenvParser.swift
+++ b/TablePro/Core/Services/ProjectImport/DotenvParser.swift
@@ -5,10 +5,12 @@
 
 import Foundation
 
+/// No quoting flag. Single quotes decide one thing, that the value is taken literally, and `resolve`
+/// answers that from the assignment's own quoting before an entry exists. Carrying it here as well
+/// would be a second copy of a question already settled.
 struct DotenvEntry: Sendable {
     let key: String
     let value: String
-    let isSingleQuoted: Bool
     let hasUnresolvedReference: Bool
 }
 


### PR DESCRIPTION
Fourth finding from the HIG and architecture audit, same class as #2637.

`DotenvEntry.isSingleQuoted` was set at both construction sites in `resolve` and read nowhere, in the app or in the tests.

Worth being explicit that the parser behaviour was already right, because this flag is the one a dotenv parser would normally use. Single quotes mean the value is literal, no `${VAR}` interpolation, and `resolve` enforces that on its first line, from `assignment.quoting`, before any entry is built. The flag was a second copy of a question already settled, not the thing answering it. Nothing about quoting or interpolation changes here.

## Verification

- `xcodebuild build`, exit 0
- 42 tests passed, 0 failed, across `DotenvParserTests` and `DotenvConnectionExtractorTests`
- `swiftlint lint --strict`, exit 0

No CHANGELOG entry: the field was never read, so nothing a user can see changes.

Built and tested in an isolated worktree off `origin/main`, because the main checkout is carrying another branch in progress.

https://claude.ai/code/session_01KuMgrPwNLr7oPY63t8WWs9