### PR TITLE
fix(mcp): report connection health from liveness, not the raw session status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Animations that played through the Reduce Motion setting when removing a jump host or copying DDL or a query plan.
 - Icon-only controls with no VoiceOver name or tooltip in the date picker, row inspector and slash command settings.
+- `is_connected` reported as true over MCP for a connection that had stopped answering.
 - Cost badge on every plan node of a query ending in `LIMIT`, where the share it reads could exceed 100%. (#2633)
 - Green "low cost" badge on plans that report no cost at all, such as SQLite and ClickHouse. (#2633)
 - Empty Cost, Rows and Actual Time columns in the EXPLAIN tree for engines that report none of them. (#2633)

--- a/TablePro/Core/MCP/MCPConnectionBridge.swift
+++ b/TablePro/Core/MCP/MCPConnectionBridge.swift
@@ -48,7 +48,7 @@ public actor MCPConnectionBridge {
                     "host": .string(conn.host),
                     "port": .int(conn.port),
                     "database": .string(session?.resolvedBrowseDatabase ?? conn.database),
-                    "is_connected": .bool(session?.status.isConnected ?? false),
+                    "is_connected": .bool(session?.reportedStatus.isConnected ?? false),
                     "ai_policy": .string(policy.rawValue),
                     "external_access": .string(conn.externalAccess.rawValue),
                     "safe_mode": .string(conn.safeModeLevel.rawValue)

--- a/TablePro/Core/MCP/Protocol/Tools/OpenConnectionWindowTool.swift
+++ b/TablePro/Core/MCP/Protocol/Tools/OpenConnectionWindowTool.swift
@@ -70,7 +70,7 @@ public struct OpenConnectionWindowTool: MCPToolImplementation {
         }
 
         let isConnected = await MainActor.run {
-            DatabaseManager.shared.activeSessions[connectionId]?.status.isConnected ?? false
+            DatabaseManager.shared.activeSessions[connectionId]?.reportedStatus.isConnected ?? false
         }
 
         var fields: [String: JsonValue] = [

--- a/TablePro/Core/MCP/Subscriptions/MCPSubscriptionRegistry.swift
+++ b/TablePro/Core/MCP/Subscriptions/MCPSubscriptionRegistry.swift
@@ -235,7 +235,7 @@ public enum MCPSubscriptionVisibility {
         for connection in ConnectionStorage.shared.loadConnections() {
             guard connection.externalAccess != .blocked else { continue }
             guard (connection.aiPolicy ?? defaultPolicy) != .never else { continue }
-            guard sessions[connection.id]?.status.isConnected == true else { continue }
+            guard sessions[connection.id]?.reportedStatus.isConnected == true else { continue }
             visible.insert(connection.id)
         }
         return visible

--- a/TableProTests/Core/MCP/MCPReportedStatusTests.swift
+++ b/TableProTests/Core/MCP/MCPReportedStatusTests.swift
@@ -1,0 +1,57 @@
+//
+//  MCPReportedStatusTests.swift
+//  TableProTests
+//
+//  `ConnectionSession.status` still reads `.connected` for a session whose driver stopped answering,
+//  because the driver handle is a handle rather than a live connection. `reportedStatus` is the one
+//  answer to "can this be believed", and CLAUDE.md's invariant is that everything reporting
+//  connection health goes through it. `ConnectionLivenessReportingTests` covers what the property
+//  does; this covers who asks it.
+//
+//  The MCP surface disagreed with itself. `get_connection_status` used `reportedStatus`, while
+//  `list_connections`, `open_connection_window` and the subscription visibility set used the raw
+//  status, so one tool called an unreachable connection connected and another called it an error.
+//
+
+import Foundation
+import Testing
+
+@Suite("MCP connection health reporting")
+struct MCPReportedStatusTests {
+    private static let repositoryRoot: URL = {
+        var url = URL(fileURLWithPath: #filePath)
+        for _ in 0 ..< 4 {
+            url.deleteLastPathComponent()
+        }
+        return url
+    }()
+
+    @Test("No MCP file reads a session's raw status to report health")
+    func mcpReportsThroughReportedStatus() throws {
+        let mcpRoot = Self.repositoryRoot.appendingPathComponent("TablePro/Core/MCP")
+        let enumerator = try #require(
+            FileManager.default.enumerator(at: mcpRoot, includingPropertiesForKeys: nil)
+        )
+
+        var scanned = 0
+        var offenders: [String] = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            guard let source = try? String(contentsOf: url, encoding: .utf8) else { continue }
+            scanned += 1
+            let relativePath = url.path
+                .replacingOccurrences(of: Self.repositoryRoot.path + "/", with: "")
+            for (index, line) in source.components(separatedBy: .newlines).enumerated() {
+                guard !line.trimmingCharacters(in: .whitespaces).hasPrefix("//") else { continue }
+                guard line.contains(".status.isConnected") else { continue }
+                offenders.append("\(relativePath):\(index + 1)")
+            }
+        }
+
+        /// A path that stops resolving would scan nothing and pass silently.
+        #expect(scanned > 20, "Expected to scan the MCP sources, scanned \(scanned) files")
+        #expect(
+            offenders.isEmpty,
+            "MCP reports connection health through reportedStatus, not status: \(offenders.sorted())"
+        )
+    }
+}

--- a/docs/external-api/mcp-tools.mdx
+++ b/docs/external-api/mcp-tools.mdx
@@ -47,7 +47,7 @@ Statements that read or write files, or that run server-side code, are refused o
 
 | Tool | Arguments | Returns |
 |------|-----------|---------|
-| `list_connections` | none | `connections[]` with `id`, `name`, `type`, `host`, `port`, `database`, `is_connected`, `ai_policy`, `external_access`, `safe_mode` |
+| `list_connections` | none | `connections[]` with `id`, `name`, `type`, `host`, `port`, `database`, `is_connected`, `ai_policy`, `external_access`, `safe_mode`. `is_connected` is false once a connection stops answering, before it is disconnected |
 | `connect` | `connection_id` | `status` (`connected`), `connection_id`, `current_database`, plus `current_schema` and `server_version` when known. Returns once the driver is up |
 | `disconnect` | `connection_id` | `status` (`disconnected`), `connection_id` |
 | `get_connection_status` | `connection_id` | `status` (`connected`, `connecting`, `disconnected`, `error`), `connection_id`, `current_database`, plus `current_schema`, `server_version`, `connected_at`, `last_active_at` and `error` when they apply |


### PR DESCRIPTION
Fifth finding from the HIG and architecture audit.

CLAUDE.md: "everything that reports connection health reads `ConnectionSession.reportedStatus`, never `status` directly, or the strip and the pane drift apart again." The MCP surface disagreed with itself.

`reportedStatus` returns `status` unchanged unless `liveness` is `.unreachable`, where it returns `.error`. An installed driver is a handle, not a live connection, so a session whose server stopped answering keeps `status == .connected` until something replaces the driver. `DatabaseAccessBridge.connectionStatus`, behind `get_connection_status`, already read `reportedStatus`. Three siblings did not:

- `list_connections`, whose `is_connected` said true for a connection the app had already given up on
- `open_connection_window`, same field, same answer
- `MCPSubscriptionVisibility.visibleConnectedConnectionIds`, which kept announcing it to subscribers

So an agent calling `get_connection_status` was told error while `list_connections` said connected, and an agent trusting the list routed a query into a dead handle.

## Security

No widening. All three sites read only `.isConnected` and discard the payload, so the `.error(message)` string never reaches a client through them. `visibleConnectedConnectionIds` is a visibility gate and the set gets strictly smaller; its `externalAccess != .blocked` and `aiPolicy != .never` guards are untouched. `is_connected` can now go false where it was true, never the reverse. Reviewed with the security-review skill: no findings.

## The guard

`MCPReportedStatusTests` fails on any `.status.isConnected` under `TablePro/Core/MCP`, and asserts it scanned the tree so a path that stops resolving cannot pass silently. The model behaviour itself is already covered by `ConnectionLivenessReportingTests`, so this only covers who asks.

## Verification

- `xcodebuild build`, exit 0
- 11 tests passed, 0 failed, across `MCPReportedStatusTests`, `ConnectionLivenessReportingTests` and `ListConnectionsToolTests`
- `swiftlint lint --strict`, exit 0
- `verify.sh docs`, PASS; `docs/external-api/mcp-tools.mdx` now states when `is_connected` goes false

https://claude.ai/code/session_01KuMgrPwNLr7oPY63t8WWs9