### PR TITLE
feat(mcp): give connection approval its own setting, durable grants and an honest prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Server-side `INSERT … SELECT` when a copy's two sides are one connection. (#1491)
 - Tunnel Command pane, with presets for `kubectl port-forward` and `aws ssm start-session` and a custom command line. (#2520)
 - Bar chart column in the EXPLAIN tree, with a Metric menu for self cost, self time and row counts. (#2633)
+- Approval setting for MCP connection access, with the list of approved connections and a Forget action. (#2640)
 
 ### Fixed
 
@@ -29,6 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JavaScript `locals` and `tags` queries that no longer compiled against the bundled parser.
 - JSON `true`, `false` and `null` unhighlighted in the row inspector and the JSON viewer.
 - Operator and Function theme colours with no effect on the editor.
+- MCP access prompt with no setting to turn it off, reachable only from the AI tab and hidden entirely with AI features off. (#2640)
+- MCP access prompt discarding an answer given more than 30 seconds after it appeared. (#2640)
+- MCP access prompt returning every 30 minutes, and after each rotation of the bundled bridge's credential. (#2640)
+- Repeated MCP access prompts when a client retried a call the user had just denied. (#2640)
+- Destructive-operation consent reaching an elicitation-capable MCP client as an internal error instead of a prompt.
+- `ai_policy` in `list_connections` reporting `askEachTime` whatever the app-wide default was.
 
 ## [0.72.0] - 2026-09-04
 

--- a/TablePro/Core/AI/ClaudeAgent/ClaudeAgentMCPBridge.swift
+++ b/TablePro/Core/AI/ClaudeAgent/ClaudeAgentMCPBridge.swift
@@ -37,7 +37,8 @@ struct ClaudeAgentMCPBridge: ClaudeAgentMCPBridging {
             name: Self.tokenName,
             permissions: permissions,
             connectionAccess: connectionAccess,
-            expiresAt: Date.now.addingTimeInterval(Self.tokenLifetime)
+            expiresAt: Date.now.addingTimeInterval(Self.tokenLifetime),
+            isBridgeCredential: false
         ) else { return nil }
 
         guard let configPath = Self.writeConfig(endpoint: endpoint, token: generated.plaintext) else {

--- a/TablePro/Core/MCP/Auth/MCPBearerTokenAuthenticator.swift
+++ b/TablePro/Core/MCP/Auth/MCPBearerTokenAuthenticator.swift
@@ -9,6 +9,7 @@ public struct MCPValidatedToken: Sendable, Equatable {
     public let connectionAccess: ConnectionAccess
     public let issuedAt: Date
     public let expiresAt: Date?
+    public let isBridgeCredential: Bool
 
     public init(
         tokenId: UUID,
@@ -16,12 +17,14 @@ public struct MCPValidatedToken: Sendable, Equatable {
         scopes: Set<MCPScope>,
         connectionAccess: ConnectionAccess,
         issuedAt: Date,
-        expiresAt: Date?
+        expiresAt: Date?,
+        isBridgeCredential: Bool = false
     ) {
         self.tokenId = tokenId
         self.label = label
         self.scopes = scopes
         self.connectionAccess = connectionAccess
+        self.isBridgeCredential = isBridgeCredential
         self.issuedAt = issuedAt
         self.expiresAt = expiresAt
     }
@@ -56,7 +59,8 @@ internal extension MCPTokenStore {
             scopes: authToken.permissions.scopes,
             connectionAccess: authToken.connectionAccess,
             issuedAt: authToken.createdAt,
-            expiresAt: authToken.expiresAt
+            expiresAt: authToken.expiresAt,
+            isBridgeCredential: authToken.isBridgeCredential
         )
         return .success(validated)
     }
@@ -136,7 +140,8 @@ public actor MCPBearerTokenAuthenticator: MCPAuthenticator {
                 metadata: MCPPrincipalMetadata(
                     label: validated.label,
                     issuedAt: validated.issuedAt,
-                    expiresAt: validated.expiresAt
+                    expiresAt: validated.expiresAt,
+                    isBridgeCredential: validated.isBridgeCredential
                 )
             )
             MCPAuditLogger.logAuthSuccess(

--- a/TablePro/Core/MCP/Auth/MCPPrincipal.swift
+++ b/TablePro/Core/MCP/Auth/MCPPrincipal.swift
@@ -4,11 +4,13 @@ public struct MCPPrincipalMetadata: Sendable, Equatable {
     public let label: String?
     public let issuedAt: Date
     public let expiresAt: Date?
+    public let isBridgeCredential: Bool
 
-    public init(label: String?, issuedAt: Date, expiresAt: Date?) {
+    public init(label: String?, issuedAt: Date, expiresAt: Date?, isBridgeCredential: Bool = false) {
         self.label = label
         self.issuedAt = issuedAt
         self.expiresAt = expiresAt
+        self.isBridgeCredential = isBridgeCredential
     }
 }
 

--- a/TablePro/Core/MCP/Identity/MCPApprovalLedger.swift
+++ b/TablePro/Core/MCP/Identity/MCPApprovalLedger.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+/// Remembers which connections a client may reach.
+///
+/// Two tiers, because they answer to different lifetimes. A durable grant is a decision the user
+/// made and belongs to a `MCPGrantSubject`, so it survives the server teardown that any settings
+/// edit triggers, and a relaunch. A session approval is what a caller with no durable identity gets
+/// instead: an anonymous loopback caller cannot be told apart from the next one, so remembering its
+/// answer past this session would approve a process the user never saw.
 public actor MCPApprovalLedger {
     public struct Key: Sendable, Equatable, Hashable {
         public let principalKey: String
@@ -11,16 +18,37 @@ public actor MCPApprovalLedger {
         }
     }
 
+    /// Long enough that a model retrying a refused call gives up before the user is asked twice,
+    /// short enough that a user who meant to allow it can simply ask the client to try again.
+    static let denialCoolOff: TimeInterval = 60
+
     private let ttl: Duration
     private let clock: any MCPClock
+    private let store: any MCPApprovalStoring
     private var approvals: [Key: Date] = [:]
+    private var denials: [Key: Date] = [:]
 
     public init(ttl: Duration = .seconds(1_800), clock: any MCPClock = MCPSystemClock()) {
+        self.init(ttl: ttl, clock: clock, store: MCPApprovalStore.shared)
+    }
+
+    init(
+        ttl: Duration = .seconds(1_800),
+        clock: any MCPClock = MCPSystemClock(),
+        store: any MCPApprovalStoring
+    ) {
         self.ttl = ttl
         self.clock = clock
+        self.store = store
     }
 
     public func isApproved(principal: MCPPrincipal, connectionId: UUID) async -> Bool {
+        if let subject = principal.grantSubject {
+            let granted = await store.grants().contains {
+                $0.subject == subject.storageKey && $0.connectionId == connectionId
+            }
+            if granted { return true }
+        }
         let now = await clock.now()
         prune(now: now)
         let key = Key(principalKey: principal.ledgerKey, connectionId: connectionId)
@@ -28,38 +56,118 @@ public actor MCPApprovalLedger {
         return expiresAt > now
     }
 
-    public func record(principal: MCPPrincipal, connectionId: UUID, approved: Bool) async {
+    /// `remember` is the user's setting speaking. At Ask Every Time nothing is written, so the next
+    /// call asks again; anything else would make the level a lie.
+    public func record(
+        principal: MCPPrincipal,
+        connectionId: UUID,
+        approved: Bool,
+        remember: Bool = true
+    ) async {
         let now = await clock.now()
         prune(now: now)
         let key = Key(principalKey: principal.ledgerKey, connectionId: connectionId)
         guard approved else {
             approvals.removeValue(forKey: key)
+            if let subject = principal.grantSubject {
+                await store.revoke(subject: subject.storageKey, connectionId: connectionId)
+            }
+            await recordDenial(principal: principal, connectionId: connectionId, now: now)
+            return
+        }
+        guard remember else { return }
+        if let subject = principal.grantSubject {
+            await store.record(
+                MCPConnectionGrant(subject: subject.storageKey, connectionId: connectionId, grantedAt: now)
+            )
             return
         }
         approvals[key] = now.addingTimeInterval(Self.seconds(of: ttl))
     }
 
-    public func clear(tokenId: UUID?) async {
-        guard let tokenId else {
+    /// How long a refusal stands before the client may raise the question with the user again.
+    ///
+    /// A caller with no durable identity still gets one, in memory: without it an unauthenticated
+    /// local process that retries a refused call raises a fresh focus-stealing alert every time,
+    /// which is the whole reason the cool-off exists.
+    public func denialExpiry(principal: MCPPrincipal, connectionId: UUID) async -> Date? {
+        let now = await clock.now()
+        guard let subject = principal.grantSubject else {
+            let key = Key(principalKey: principal.ledgerKey, connectionId: connectionId)
+            denials = denials.filter { $0.value > now }
+            return denials[key]
+        }
+        return await store.denial(subject: subject.storageKey, connectionId: connectionId, now: now)
+    }
+
+    /// Drops the approvals a revoked token was carrying. Rotating the bridge credential is not a
+    /// revocation: the bridge re-mints itself roughly every 45 minutes and deletes the token it
+    /// replaces, so treating that as the user withdrawing consent re-asks them all day.
+    func clear(subject: MCPGrantSubject?) async {
+        guard let subject else {
             approvals = approvals.filter { !$0.key.principalKey.hasPrefix("anon:") }
             return
         }
-        let principalKey = tokenId.uuidString
-        approvals = approvals.filter { $0.key.principalKey != principalKey }
+        await store.revokeAll(subject: subject.storageKey)
+        if case .token(let tokenId) = subject {
+            approvals = approvals.filter { $0.key.principalKey != tokenId.uuidString }
+        }
     }
 
-    public func clearAll() async {
+    public func revoke(subject: String, connectionId: UUID) async {
+        await store.revoke(subject: subject, connectionId: connectionId)
+        approvals = approvals.filter {
+            !($0.key.principalKey == subject && $0.key.connectionId == connectionId)
+        }
+    }
+
+    /// Ends the session's own approvals. Durable grants are untouched, because a server restart is
+    /// not the user changing their mind.
+    public func clearSessionApprovals() async {
         approvals.removeAll()
+        denials.removeAll()
+    }
+
+    public func forgetEveryGrant() async {
+        approvals.removeAll()
+        denials.removeAll()
+        await store.revokeEverything()
+    }
+
+    func grants() async -> [MCPConnectionGrant] {
+        await store.grants()
     }
 
     public func approvedConnectionIds(principal: MCPPrincipal) async -> Set<UUID> {
         let now = await clock.now()
         prune(now: now)
         let principalKey = principal.ledgerKey
-        return Set(
+        var ids = Set(
             approvals
                 .filter { $0.key.principalKey == principalKey && $0.value > now }
                 .map(\.key.connectionId)
+        )
+        if let subject = principal.grantSubject {
+            let durable = await store.grants()
+                .filter { $0.subject == subject.storageKey }
+                .map(\.connectionId)
+            ids.formUnion(durable)
+        }
+        return ids
+    }
+
+    private func recordDenial(principal: MCPPrincipal, connectionId: UUID, now: Date) async {
+        let expiresAt = now.addingTimeInterval(Self.denialCoolOff)
+        guard let subject = principal.grantSubject else {
+            denials[Key(principalKey: principal.ledgerKey, connectionId: connectionId)] = expiresAt
+            return
+        }
+        await store.record(
+            MCPConnectionDenial(
+                subject: subject.storageKey,
+                connectionId: connectionId,
+                expiresAt: expiresAt
+            )
         )
     }
 

--- a/TablePro/Core/MCP/Identity/MCPGrantSubject.swift
+++ b/TablePro/Core/MCP/Identity/MCPGrantSubject.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// The identity a remembered MCP approval is filed under.
+///
+/// Deliberately not `MCPPrincipal.ledgerKey`. The bundled stdio bridge re-mints its credential with
+/// a fresh UUID roughly every 45 minutes and deletes the previous one, and that delete notifies the
+/// revocation observers, so a grant filed under the token id is both orphaned and actively revoked
+/// before the hour is out. The bridge is one client however often its credential turns over.
+///
+/// The bridge is recognised by a flag its own mint sets on the token record, never by the token's
+/// name: a pairing request carries the client name it wants, so a name test would let any caller
+/// ask to be the bridge and inherit every grant the bridge had earned.
+enum MCPGrantSubject: Sendable, Equatable {
+    case bridge
+    case token(UUID)
+
+    var storageKey: String {
+        switch self {
+        case .bridge: return "bridge"
+        case .token(let id): return id.uuidString
+        }
+    }
+}
+
+extension MCPPrincipal {
+    /// The subject a durable grant belongs to, or nil when this caller may not earn one.
+    ///
+    /// An anonymous loopback caller collapses to a single shared identity with nothing to
+    /// distinguish one local process from the next, so remembering its answer would silently
+    /// approve every future unauthenticated caller. It keeps the session-only approval it has today.
+    var grantSubject: MCPGrantSubject? {
+        if metadata.isBridgeCredential { return .bridge }
+        guard let tokenId else { return nil }
+        return .token(tokenId)
+    }
+}

--- a/TablePro/Core/MCP/Lifecycle/MCPServerManager.swift
+++ b/TablePro/Core/MCP/Lifecycle/MCPServerManager.swift
@@ -112,6 +112,24 @@ internal final class MCPServerManager {
         }
     }
 
+    /// Grants outlive the composition that recorded them, so the settings pane reads them through a
+    /// policy built on demand when the server is not running.
+    internal func connectionGrants() async -> [MCPConnectionGrant] {
+        await approvalPolicy().grants()
+    }
+
+    internal func forgetGrant(subject: String, connectionId: UUID) async {
+        await approvalPolicy().revokeGrant(subject: subject, connectionId: connectionId)
+    }
+
+    internal func forgetEveryGrant() async {
+        await approvalPolicy().forgetEveryGrant()
+    }
+
+    private func approvalPolicy() -> MCPAuthPolicy {
+        composition?.authPolicy ?? MCPAuthPolicy()
+    }
+
     internal func disconnectClient(_ clientId: String) async {
         guard let composition else { return }
         let entries = await composition.activityLedger.snapshot(now: Date())
@@ -248,7 +266,8 @@ internal final class MCPServerManager {
                 name: MCPTokenStore.stdioBridgeTokenName,
                 permissions: MCPTokenStore.bridgeTokenPermissions,
                 connectionAccess: .all,
-                expiresAt: expiresAt
+                expiresAt: expiresAt,
+                isBridgeCredential: true
             )
             return BridgeCredential(
                 tokenId: generated.token.id,
@@ -347,20 +366,29 @@ internal final class MCPServerManager {
         store: MCPTokenStore,
         generation: Int
     ) async {
-        revocationObserverId = await store.addRevocationObserver { [weak self] rawTokenId in
+        revocationObserverId = await store.addRevocationObserver { [weak self] rawTokenId, wasBridge in
             guard let tokenId = UUID(uuidString: rawTokenId), let self else { return }
-            await self.handleTokenRevoked(tokenId: tokenId, dispatcher: built.dispatcher, generation: generation)
+            await self.handleTokenRevoked(
+                tokenId: tokenId,
+                wasBridgeCredential: wasBridge,
+                dispatcher: built.dispatcher,
+                generation: generation
+            )
         }
     }
 
     private func handleTokenRevoked(
         tokenId: UUID,
+        wasBridgeCredential: Bool,
         dispatcher: MCPProtocolDispatcher,
         generation: Int
     ) async {
         guard isCurrent(generation) else { return }
         let cancelled = await dispatcher.cancelInflight(matchingTokenId: tokenId)
-        await composition?.authPolicy.clearApprovals(tokenId: tokenId)
+        await composition?.authPolicy.clearApprovals(
+            tokenId: tokenId,
+            wasBridgeCredential: wasBridgeCredential
+        )
         guard cancelled > 0 else { return }
         Self.logger.info(
             "Token \(tokenId.uuidString, privacy: .public) revoked: cancelled \(cancelled, privacy: .public) request(s)"

--- a/TablePro/Core/MCP/MCPApprovalPresenter.swift
+++ b/TablePro/Core/MCP/MCPApprovalPresenter.swift
@@ -1,0 +1,63 @@
+import AppKit
+import Foundation
+
+/// How long an Allow lasts, so the prompt can say so rather than guess.
+enum MCPApprovalMemory: Sendable, Equatable {
+    case thisRequestOnly
+    case thisSession
+    case untilRevoked
+}
+
+struct MCPApprovalRequest: Sendable {
+    let connectionName: String
+    let databaseType: String
+    let clientLabel: String?
+    let memory: MCPApprovalMemory
+}
+
+protocol MCPApprovalPresenting: Sendable {
+    func requestApproval(_ request: MCPApprovalRequest) async -> Bool
+}
+
+/// The native prompt, and the only one: a client that could answer this question in its own
+/// interface could also answer it without asking anyone.
+///
+/// It carries no deadline. The previous shape raced the alert against a 30 second sleep inside a
+/// task group, which could not work: the group cannot propagate the timeout until the uncancellable
+/// modal returns, so the request stayed blocked for as long as the alert was up and the user's
+/// eventual Allow was thrown away and replaced with a timeout error. Whoever sent the request owns
+/// its timeout, which is what the MCP lifecycle says, and an answer is recorded whenever it arrives
+/// so that stepping away costs at most the one call.
+struct MCPApprovalAlertPresenter: MCPApprovalPresenting {
+    func requestApproval(_ request: MCPApprovalRequest) async -> Bool {
+        await AlertHelper.runApprovalModal(
+            title: String(localized: "MCP Access Request"),
+            message: Self.message(for: request),
+            confirm: String(localized: "Allow"),
+            cancel: String(localized: "Deny")
+        )
+    }
+
+    static func message(for request: MCPApprovalRequest) -> String {
+        let client = request.clientLabel ?? String(localized: "An MCP client")
+        let opening = String(
+            format: String(localized: "%@ wants to access '%@' (%@)."),
+            client,
+            request.connectionName,
+            request.databaseType
+        )
+        let pointer = String(localized: "Change this in Settings > Integrations.")
+        return opening + "\n\n" + Self.consequence(of: request.memory) + " " + pointer
+    }
+
+    private static func consequence(of memory: MCPApprovalMemory) -> String {
+        switch memory {
+        case .thisRequestOnly:
+            return String(localized: "Allowing covers this request only.")
+        case .thisSession:
+            return String(localized: "Allowing is remembered until TablePro quits.")
+        case .untilRevoked:
+            return String(localized: "Allowing is remembered for this client until you revoke it.")
+        }
+    }
+}

--- a/TablePro/Core/MCP/MCPAuthPolicy.swift
+++ b/TablePro/Core/MCP/MCPAuthPolicy.swift
@@ -33,6 +33,8 @@ public actor MCPAuthPolicy {
     private let connectionIdsProvider: MCPConnectionIdsProvider
     private let approvalLedger: MCPApprovalLedger
     private let historyRecorder: QueryHistoryRecording
+    private let approvalSetting: MCPConnectionApprovalReading
+    private let presenter: any MCPApprovalPresenting
     private let approvalDedup = OnceTask<ApprovalKey, Bool>()
 
     public init() {
@@ -43,12 +45,16 @@ public actor MCPAuthPolicy {
         connectionResolver: @escaping MCPConnectionSnapshotResolver,
         connectionIdsProvider: @escaping MCPConnectionIdsProvider = MCPAuthPolicy.defaultConnectionIdsProvider,
         approvalLedger: MCPApprovalLedger = MCPApprovalLedger(),
-        historyRecorder: QueryHistoryRecording = QueryHistoryManager.shared
+        historyRecorder: QueryHistoryRecording = QueryHistoryManager.shared,
+        approvalSetting: MCPConnectionApprovalReading = MCPSettingsApprovalReader(),
+        presenter: any MCPApprovalPresenting = MCPApprovalAlertPresenter()
     ) {
         self.connectionResolver = connectionResolver
         self.connectionIdsProvider = connectionIdsProvider
         self.approvalLedger = approvalLedger
         self.historyRecorder = historyRecorder
+        self.approvalSetting = approvalSetting
+        self.presenter = presenter
     }
 
     private struct ApprovalKey: Hashable, Sendable {
@@ -104,12 +110,18 @@ public actor MCPAuthPolicy {
             return .denied(reason: writeReason)
         }
 
-        guard snapshot.policy == .askEachTime else { return .allowed }
-        let alreadyApproved = await approvalLedger.isApproved(
-            principal: principal,
-            connectionId: connectionId
-        )
-        guard !alreadyApproved else { return .allowed }
+        guard snapshot.policy != .alwaysAllow else { return .allowed }
+
+        let approval = await approvalSetting.connectionApproval()
+        guard approval.asksBeforeReachingAConnection else { return .allowed }
+
+        if approval.remembersAnswer {
+            let alreadyApproved = await approvalLedger.isApproved(
+                principal: principal,
+                connectionId: connectionId
+            )
+            guard !alreadyApproved else { return .allowed }
+        }
 
         return .requiresUserApproval(
             reason: String(
@@ -168,34 +180,97 @@ public actor MCPAuthPolicy {
             guard let connectionId else {
                 throw DatabaseAccessError.forbidden(reason)
             }
-            let approved = try await runApprovalDedup(
-                principal: principal,
-                connectionId: connectionId,
-                reason: reason
-            )
-            await approvalLedger.record(
-                principal: principal,
-                connectionId: connectionId,
-                approved: approved
-            )
-            guard approved else {
-                throw DatabaseAccessError.forbidden(
-                    String(localized: "User denied MCP access to this connection")
-                )
-            }
+            try await requireApproval(principal: principal, connectionId: connectionId)
         }
+    }
+
+    /// A refusal stands for a cool-off period. Without one a model that retries a refused call, or
+    /// that had several calls planned against the same connection, raises a fresh focus-stealing
+    /// alert for each attempt with nothing remembering that the user just said no.
+    private func requireApproval(principal: MCPPrincipal, connectionId: UUID) async throws {
+        if await approvalLedger.denialExpiry(principal: principal, connectionId: connectionId) != nil {
+            throw DatabaseAccessError.forbidden(
+                String(localized: "User denied MCP access to this connection")
+            )
+        }
+
+        guard let snapshot = await connectionResolver(connectionId) else {
+            throw DatabaseAccessError.forbidden(String(localized: "Connection not found"))
+        }
+
+        let approved = await collectApproval(
+            principal: principal,
+            connectionId: connectionId,
+            snapshot: snapshot
+        )
+
+        await approvalLedger.record(
+            principal: principal,
+            connectionId: connectionId,
+            approved: approved,
+            remember: await approvalSetting.connectionApproval().remembersAnswer
+        )
+        guard approved else {
+            throw DatabaseAccessError.forbidden(
+                String(localized: "User denied MCP access to this connection")
+            )
+        }
+    }
+
+    /// Whether a client may reach a connection at all is the one question the client may not answer
+    /// about itself, so this never routes through elicitation. A client declares `elicitation` in
+    /// its own `_meta` on every request, so a caller that wanted the gate open would simply claim
+    /// the capability and post its own acceptance, and under the remembering level that self-answer
+    /// would become a durable grant. Statement consent can be elicited because Safe Mode still
+    /// strips `confirmationPreCleared` from anything but an admin-scoped token; there is no second
+    /// gate behind this one.
+    private func collectApproval(
+        principal: MCPPrincipal,
+        connectionId: UUID,
+        snapshot: MCPConnectionAuthSnapshot
+    ) async -> Bool {
+        let approval = await approvalSetting.connectionApproval()
+
+        return await runApprovalDedup(
+            principal: principal,
+            connectionId: connectionId,
+            request: MCPApprovalRequest(
+                connectionName: snapshot.name,
+                databaseType: snapshot.databaseType,
+                clientLabel: principal.auditLabel,
+                memory: Self.memory(of: approval, for: principal)
+            )
+        )
     }
 
     func recordApproval(principal: MCPPrincipal, connectionId: UUID) async {
         await approvalLedger.record(principal: principal, connectionId: connectionId, approved: true)
     }
 
-    func clearApprovals(tokenId: UUID?) async {
-        await approvalLedger.clear(tokenId: tokenId)
+    /// Called when a token is revoked. The bundled bridge re-mints its credential roughly every
+    /// 45 minutes and deletes the one it replaces, which reaches here as a revocation; treating that
+    /// as the user withdrawing consent is what made the prompt come back all day, so the caller
+    /// passes the token's name and the bridge's own rotation is skipped.
+    func clearApprovals(tokenId: UUID?, wasBridgeCredential: Bool = false) async {
+        guard !wasBridgeCredential else { return }
+        await approvalLedger.clear(subject: tokenId.map { .token($0) })
     }
 
+    /// Ends this session's approvals. A grant the user chose to remember is not one of them.
     func clearAllApprovals() async {
-        await approvalLedger.clearAll()
+        await approvalLedger.clearSessionApprovals()
+    }
+
+    func forgetEveryGrant() async {
+        await approvalLedger.forgetEveryGrant()
+    }
+
+    func revokeGrant(subject: String, connectionId: UUID) async {
+        await approvalLedger.revoke(subject: subject, connectionId: connectionId)
+    }
+
+    func grants() async -> [MCPConnectionGrant] {
+        await approvalLedger.grants()
     }
 
     /// The MCP surface never pre-clears Safe Mode on the client's word alone. `confirmationPreCleared`
@@ -292,6 +367,16 @@ public actor MCPAuthPolicy {
         )
     }
 
+    /// A caller with no durable identity keeps its answer only for this session, so the prompt says
+    /// that rather than promising a grant the ledger will not file.
+    private static func memory(
+        of approval: MCPConnectionApproval,
+        for principal: MCPPrincipal
+    ) -> MCPApprovalMemory {
+        guard approval.remembersAnswer else { return .thisRequestOnly }
+        return principal.grantSubject == nil ? .thisSession : .untilRevoked
+    }
+
     private static func adminScopeDenial(principal: MCPPrincipal, tool: MCPToolName) -> AuthDecision? {
         guard MCPToolName.requiresAdminScope.contains(tool) else { return nil }
         guard !principal.has(.admin) || principal.isAnonymous else { return nil }
@@ -321,36 +406,14 @@ public actor MCPAuthPolicy {
     private func runApprovalDedup(
         principal: MCPPrincipal,
         connectionId: UUID,
-        reason: String
-    ) async throws -> Bool {
+        request: MCPApprovalRequest
+    ) async -> Bool {
         let key = ApprovalKey(principalKey: principal.ledgerKey, connectionId: connectionId)
-        return try await approvalDedup.execute(key: key) {
-            try await Self.promptApproval(reason: reason)
+        let presenter = presenter
+        let approved = try? await approvalDedup.execute(key: key) {
+            await presenter.requestApproval(request)
         }
-    }
-
-    private static func promptApproval(reason: String) async throws -> Bool {
-        try await withThrowingTaskGroup(of: Bool.self) { group in
-            defer { group.cancelAll() }
-            group.addTask {
-                await AlertHelper.runApprovalModal(
-                    title: String(localized: "MCP Access Request"),
-                    message: reason,
-                    confirm: String(localized: "Allow"),
-                    cancel: String(localized: "Deny")
-                )
-            }
-            group.addTask {
-                try await Task.sleep(for: .seconds(30))
-                throw DatabaseAccessError.timeout(
-                    String(localized: "User approval timed out after 30 seconds")
-                )
-            }
-            guard let result = try await group.next() else {
-                throw DatabaseAccessError.dataSourceError("No result from approval prompt")
-            }
-            return result
-        }
+        return approved ?? false
     }
 
     private func denialForWriteIntent(

--- a/TablePro/Core/MCP/MCPConnectionApprovalReading.swift
+++ b/TablePro/Core/MCP/MCPConnectionApprovalReading.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Reads the user's MCP approval setting.
+///
+/// A seam rather than a direct `AppSettingsManager` read, because the auth policy is an actor and
+/// its tests must be able to state the policy without standing up main-actor settings.
+protocol MCPConnectionApprovalReading: Sendable {
+    func connectionApproval() async -> MCPConnectionApproval
+}
+
+struct MCPSettingsApprovalReader: MCPConnectionApprovalReading {
+    func connectionApproval() async -> MCPConnectionApproval {
+        await MainActor.run { AppSettingsManager.shared.mcp.connectionApproval }
+    }
+}
+
+struct MCPFixedApprovalReader: MCPConnectionApprovalReading {
+    let approval: MCPConnectionApproval
+
+    init(_ approval: MCPConnectionApproval) {
+        self.approval = approval
+    }
+
+    func connectionApproval() async -> MCPConnectionApproval {
+        approval
+    }
+}

--- a/TablePro/Core/MCP/MCPConnectionBridge.swift
+++ b/TablePro/Core/MCP/MCPConnectionBridge.swift
@@ -23,13 +23,13 @@ public actor MCPConnectionBridge {
     }
 
     private func listConnections(access: ConnectionAccess) async -> JsonValue {
-        let (connections, activeSessions) = await MainActor.run {
+        let (connections, activeSessions, defaultPolicy) = await MainActor.run {
             let defaultPolicy = AppSettingsManager.shared.ai.defaultConnectionPolicy
             let conns = ConnectionStorage.shared.loadConnections()
                 .filter { $0.externalAccess != .blocked }
                 .filter { ($0.aiPolicy ?? defaultPolicy) != .never }
                 .filter { access.allows($0.id) }
-            return (conns, DatabaseManager.shared.activeSessions)
+            return (conns, DatabaseManager.shared.activeSessions, defaultPolicy)
         }
 
         let items: [JsonValue] = connections
@@ -40,7 +40,7 @@ public actor MCPConnectionBridge {
             }
             .map { conn in
                 let session = activeSessions[conn.id]
-                let policy = conn.aiPolicy ?? AIConnectionPolicy.askEachTime
+                let policy = conn.aiPolicy ?? defaultPolicy
                 return .object([
                     "id": .string(conn.id.uuidString),
                     "name": .string(conn.name),

--- a/TablePro/Core/MCP/MCPPairingService.swift
+++ b/TablePro/Core/MCP/MCPPairingService.swift
@@ -163,7 +163,8 @@ final class MCPPairingService {
             name: request.clientName,
             permissions: approval.grantedPermissions,
             connectionAccess: connectionAccess,
-            expiresAt: approval.expiresAt
+            expiresAt: approval.expiresAt,
+            isBridgeCredential: false
         )
 
         let code = UUID().uuidString

--- a/TablePro/Core/MCP/MCPTokenStore.swift
+++ b/TablePro/Core/MCP/MCPTokenStore.swift
@@ -48,6 +48,9 @@ struct MCPAuthToken: Codable, Identifiable, Sendable {
     var lastUsedAt: Date?
     let expiresAt: Date?
     var isActive: Bool
+    /// Set only by the bundled bridge's own mint. Never derived from the token's name, which a
+    /// pairing request supplies and could therefore claim.
+    let isBridgeCredential: Bool
 
     var isExpired: Bool {
         guard let expiresAt else { return false }
@@ -67,7 +70,8 @@ struct MCPAuthToken: Codable, Identifiable, Sendable {
         createdAt: Date,
         lastUsedAt: Date?,
         expiresAt: Date?,
-        isActive: Bool
+        isActive: Bool,
+        isBridgeCredential: Bool = false
     ) {
         self.id = id
         self.name = name
@@ -80,6 +84,7 @@ struct MCPAuthToken: Codable, Identifiable, Sendable {
         self.lastUsedAt = lastUsedAt
         self.expiresAt = expiresAt
         self.isActive = isActive
+        self.isBridgeCredential = isBridgeCredential
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -94,6 +99,7 @@ struct MCPAuthToken: Codable, Identifiable, Sendable {
         case lastUsedAt
         case expiresAt
         case isActive
+        case isBridgeCredential
     }
 
     init(from decoder: Decoder) throws {
@@ -109,6 +115,7 @@ struct MCPAuthToken: Codable, Identifiable, Sendable {
         self.expiresAt = try container.decodeIfPresent(Date.self, forKey: .expiresAt)
         self.isActive = try container.decode(Bool.self, forKey: .isActive)
         self.connectionAccess = try container.decodeIfPresent(ConnectionAccess.self, forKey: .connectionAccess) ?? .all
+        self.isBridgeCredential = try container.decodeIfPresent(Bool.self, forKey: .isBridgeCredential) ?? false
     }
 
     func encode(to encoder: Encoder) throws {
@@ -123,6 +130,7 @@ struct MCPAuthToken: Codable, Identifiable, Sendable {
         try container.encode(createdAt, forKey: .createdAt)
         try container.encodeIfPresent(lastUsedAt, forKey: .lastUsedAt)
         try container.encodeIfPresent(expiresAt, forKey: .expiresAt)
+        try container.encode(isBridgeCredential, forKey: .isBridgeCredential)
         try container.encode(isActive, forKey: .isActive)
     }
 }
@@ -170,7 +178,7 @@ actor MCPTokenStore {
     private var lastSavedAt: ContinuousClock.Instant = .now
     private static let saveCooldown: Duration = .seconds(60)
 
-    private var revocationObservers: [UUID: @Sendable (String) async -> Void] = [:]
+    private var revocationObservers: [UUID: @Sendable (String, Bool) async -> Void] = [:]
 
     init(credentialStore: any MCPTokenCredentialStoring = MCPTokenKeychainStore()) {
         self.credentialStore = credentialStore
@@ -179,7 +187,7 @@ actor MCPTokenStore {
     }
 
     @discardableResult
-    func addRevocationObserver(_ handler: @escaping @Sendable (String) async -> Void) -> UUID {
+    func addRevocationObserver(_ handler: @escaping @Sendable (String, Bool) async -> Void) -> UUID {
         let id = UUID()
         revocationObservers[id] = handler
         return id
@@ -189,12 +197,19 @@ actor MCPTokenStore {
         revocationObservers.removeValue(forKey: id)
     }
 
+    /// The bridge's reserved name carries no privilege, and nothing but the bridge's own mint may
+    /// claim it: a pairing request supplies its client name, so a caller could otherwise ask to be
+    /// called the bridge and inherit every grant the bridge had earned.
     func generate(
         name: String,
         permissions: TokenPermissions,
         connectionAccess: ConnectionAccess,
-        expiresAt: Date?
+        expiresAt: Date?,
+        isBridgeCredential: Bool
     ) throws -> (token: MCPAuthToken, plaintext: String) {
+        let name = (!isBridgeCredential && name == Self.stdioBridgeTokenName)
+            ? name + " (client)"
+            : name
         let plaintext = "tp_" + Self.base64UrlEncode(try Self.randomBytes(count: 32))
         let saltBase64 = try Self.randomBytes(count: 16).base64EncodedString()
         let hash = Self.computeHash(salt: saltBase64, plaintext: plaintext)
@@ -210,7 +225,8 @@ actor MCPTokenStore {
             createdAt: Date.now,
             lastUsedAt: nil,
             expiresAt: expiresAt,
-            isActive: true
+            isActive: true,
+            isBridgeCredential: isBridgeCredential
         )
 
         tokens.append(token)
@@ -243,8 +259,9 @@ actor MCPTokenStore {
 
         tokens[index].isActive = false
         let revokedName = tokens[index].name
+        let wasBridge = tokens[index].isBridgeCredential
         save()
-        notifyRevocationObservers(tokenId: tokenId)
+        notifyRevocationObservers(tokenId: tokenId, wasBridgeCredential: wasBridge)
 
         Self.logger.info("Revoked MCP token '\(revokedName, privacy: .public)'")
         MCPAuditLogger.logTokenRevoked(tokenId: tokenId, tokenName: revokedName)
@@ -257,18 +274,19 @@ actor MCPTokenStore {
         }
 
         let name = tokens[index].name
+        let wasBridge = tokens[index].isBridgeCredential
         tokens.remove(at: index)
         save()
-        notifyRevocationObservers(tokenId: tokenId)
+        notifyRevocationObservers(tokenId: tokenId, wasBridgeCredential: wasBridge)
 
         Self.logger.info("Deleted MCP token '\(name, privacy: .public)'")
     }
 
-    private func notifyRevocationObservers(tokenId: UUID) {
+    private func notifyRevocationObservers(tokenId: UUID, wasBridgeCredential: Bool) {
         let observers = Array(revocationObservers.values)
         let key = tokenId.uuidString
         for observer in observers {
-            Task { await observer(key) }
+            Task { await observer(key, wasBridgeCredential) }
         }
     }
 
@@ -287,9 +305,12 @@ actor MCPTokenStore {
     func loadFromDisk() {
         tokens = readCredentialStore() ?? migrateLegacyFileIfPresent()
 
-        let staleCount = tokens.filter { $0.name == Self.stdioBridgeTokenName }.count
+        let isStaleBridge: (MCPAuthToken) -> Bool = {
+            $0.isBridgeCredential || $0.name == Self.stdioBridgeTokenName
+        }
+        let staleCount = tokens.filter(isStaleBridge).count
         guard staleCount > 0 else { return }
-        tokens.removeAll { $0.name == Self.stdioBridgeTokenName }
+        tokens.removeAll(where: isStaleBridge)
         save()
         Self.logger.info("Cleaned up \(staleCount) stale bridge token(s)")
     }

--- a/TablePro/Core/MCP/Protocol/Extensions/MCPProtocolDispatcher+Requests.swift
+++ b/TablePro/Core/MCP/Protocol/Extensions/MCPProtocolDispatcher+Requests.swift
@@ -200,6 +200,8 @@ extension MCPProtocolDispatcher {
             let outcome: MCPHandlerOutcome
             do {
                 outcome = .success(try await handler.handle(params: params, context: context))
+            } catch let signal as MCPInputRequired where signal.isValid {
+                outcome = .success(signal.asResult)
             } catch let error as MCPProtocolError {
                 outcome = .failure(error)
             } catch is CancellationError {

--- a/TablePro/Core/Storage/AppSettingsManager.swift
+++ b/TablePro/Core/Storage/AppSettingsManager.swift
@@ -181,7 +181,7 @@ final class AppSettingsManager {
         if mcpServerManager.tokenStore == nil {
             await tokenStore.loadFromDisk()
         }
-        let existing = await tokenStore.list().filter { $0.name != MCPTokenStore.stdioBridgeTokenName }
+        let existing = await tokenStore.list().filter { !$0.isBridgeCredential }
         guard existing.isEmpty else {
             mcp.requireAuthentication = value
             return nil
@@ -192,7 +192,8 @@ final class AppSettingsManager {
             name: defaultName,
             permissions: .readWrite,
             connectionAccess: .all,
-            expiresAt: nil
+            expiresAt: nil,
+            isBridgeCredential: false
         )
         mcp.requireAuthentication = value
         return result

--- a/TablePro/Core/Storage/MCPApprovalStore.swift
+++ b/TablePro/Core/Storage/MCPApprovalStore.swift
@@ -1,0 +1,151 @@
+//
+//  MCPApprovalStore.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+struct MCPConnectionGrant: Codable, Hashable, Sendable, Identifiable {
+    let subject: String
+    let connectionId: UUID
+    let grantedAt: Date
+
+    var id: String { subject + "|" + connectionId.uuidString }
+}
+
+struct MCPConnectionDenial: Codable, Hashable, Sendable {
+    let subject: String
+    let connectionId: UUID
+    let expiresAt: Date
+}
+
+protocol MCPApprovalStoring: Sendable {
+    func grants() async -> [MCPConnectionGrant]
+    func record(_ grant: MCPConnectionGrant) async
+    func revoke(subject: String, connectionId: UUID) async
+    func revokeAll(subject: String) async
+    func revokeEverything() async
+
+    func denial(subject: String, connectionId: UUID, now: Date) async -> Date?
+    func record(_ denial: MCPConnectionDenial) async
+}
+
+/// Durable, revocable MCP connection grants, device-local.
+///
+/// A grant is a security decision the user made, so it outlives the session that earned it: the
+/// server is torn down and rebuilt whenever the port or the authentication toggle changes, and the
+/// app is relaunched far more often than that. It is never synced, for the same reason MCP tokens
+/// are not.
+actor MCPApprovalStore: MCPApprovalStoring {
+    static let shared = MCPApprovalStore()
+
+    private static let logger = Logger(subsystem: "com.TablePro", category: "MCPApprovalStore")
+    private static let grantsKey = "com.TablePro.mcp.connectionGrants"
+    private static let denialsKey = "com.TablePro.mcp.connectionDenials"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func grants() -> [MCPConnectionGrant] {
+        decode([MCPConnectionGrant].self, forKey: Self.grantsKey)
+    }
+
+    func record(_ grant: MCPConnectionGrant) {
+        var updated = grants().filter { $0.id != grant.id }
+        updated.append(grant)
+        encode(updated, forKey: Self.grantsKey)
+        Self.logger.info("Remembered an MCP connection grant for \(grant.subject, privacy: .public)")
+    }
+
+    func revoke(subject: String, connectionId: UUID) {
+        encode(
+            grants().filter { !($0.subject == subject && $0.connectionId == connectionId) },
+            forKey: Self.grantsKey
+        )
+    }
+
+    func revokeAll(subject: String) {
+        encode(grants().filter { $0.subject != subject }, forKey: Self.grantsKey)
+    }
+
+    func revokeEverything() {
+        defaults.removeObject(forKey: Self.grantsKey)
+    }
+
+    func denial(subject: String, connectionId: UUID, now: Date) -> Date? {
+        let surviving = decode([MCPConnectionDenial].self, forKey: Self.denialsKey)
+            .filter { $0.expiresAt > now }
+        encode(surviving, forKey: Self.denialsKey)
+        return surviving.first { $0.subject == subject && $0.connectionId == connectionId }?.expiresAt
+    }
+
+    func record(_ denial: MCPConnectionDenial) {
+        var updated = decode([MCPConnectionDenial].self, forKey: Self.denialsKey)
+            .filter { !($0.subject == denial.subject && $0.connectionId == denial.connectionId) }
+        updated.append(denial)
+        encode(updated, forKey: Self.denialsKey)
+    }
+
+    private func decode<T: Decodable>(_ type: [T].Type, forKey key: String) -> [T] {
+        guard let data = defaults.data(forKey: key),
+              let decoded = try? JSONDecoder().decode(type, from: data)
+        else { return [] }
+        return decoded
+    }
+
+    private func encode(_ value: some Encodable & Collection, forKey key: String) {
+        guard !value.isEmpty else {
+            defaults.removeObject(forKey: key)
+            return
+        }
+        guard let data = try? JSONEncoder().encode(value) else {
+            Self.logger.error("Failed to encode MCP approvals for \(key, privacy: .public)")
+            return
+        }
+        defaults.set(data, forKey: key)
+    }
+}
+
+/// Keeps grants for its own lifetime and never writes them anywhere. For tests, and for any path
+/// that must not leave a decision on disk.
+actor MCPInMemoryApprovalStore: MCPApprovalStoring {
+    private var storedGrants: [MCPConnectionGrant] = []
+    private var storedDenials: [MCPConnectionDenial] = []
+
+    init() {}
+
+    func grants() -> [MCPConnectionGrant] {
+        storedGrants
+    }
+
+    func record(_ grant: MCPConnectionGrant) {
+        storedGrants.removeAll { $0.id == grant.id }
+        storedGrants.append(grant)
+    }
+
+    func revoke(subject: String, connectionId: UUID) {
+        storedGrants.removeAll { $0.subject == subject && $0.connectionId == connectionId }
+    }
+
+    func revokeAll(subject: String) {
+        storedGrants.removeAll { $0.subject == subject }
+    }
+
+    func revokeEverything() {
+        storedGrants.removeAll()
+    }
+
+    func denial(subject: String, connectionId: UUID, now: Date) -> Date? {
+        storedDenials.removeAll { $0.expiresAt <= now }
+        return storedDenials.first { $0.subject == subject && $0.connectionId == connectionId }?.expiresAt
+    }
+
+    func record(_ denial: MCPConnectionDenial) {
+        storedDenials.removeAll { $0.subject == denial.subject && $0.connectionId == denial.connectionId }
+        storedDenials.append(denial)
+    }
+}

--- a/TablePro/Models/Settings/MCPConnectionApproval.swift
+++ b/TablePro/Models/Settings/MCPConnectionApproval.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// How the MCP server asks before a client may reach a saved connection.
+///
+/// This is MCP's own decision and is deliberately not `AIConnectionPolicy`. That policy answers a
+/// different question, whether a connection's schema may be sent to a model provider, and the
+/// connection form describes it as governing in-app AI agents. Both of its controls disappear when
+/// AI features are off, which left the MCP prompt with no control at all.
+///
+/// `alwaysApprove` is the permissive end. `AIConnectionPolicy.never` is the restrictive end of the
+/// other policy and still denies here, so the two spellings of "never" never meet.
+enum MCPConnectionApproval: String, Codable, CaseIterable, Identifiable, Sendable {
+    case everyTime
+    case oncePerConnection
+    case alwaysApprove
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .everyTime: return String(localized: "Ask Every Time")
+        case .oncePerConnection: return String(localized: "Ask Once for Each Connection")
+        case .alwaysApprove: return String(localized: "Never Ask")
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .everyTime:
+            return String(localized: "Every call that reaches a connection asks first.")
+        case .oncePerConnection:
+            return String(localized: "The first call asks. The answer is remembered for that client until you revoke it.")
+        case .alwaysApprove:
+            return String(localized: "Connections are reached without asking.")
+        }
+    }
+
+    var remembersAnswer: Bool {
+        self == .oncePerConnection
+    }
+
+    var asksBeforeReachingAConnection: Bool {
+        self != .alwaysApprove
+    }
+}

--- a/TablePro/Models/Settings/MCPSettings.swift
+++ b/TablePro/Models/Settings/MCPSettings.swift
@@ -8,6 +8,7 @@ struct MCPSettings: Codable, Equatable {
     var queryTimeoutSeconds: Int
     var logQueriesInHistory: Bool
     var requireAuthentication: Bool
+    var connectionApproval: MCPConnectionApproval
 
     static let `default` = MCPSettings(
         enabled: false,
@@ -16,7 +17,8 @@ struct MCPSettings: Codable, Equatable {
         maxRowLimit: 10_000,
         queryTimeoutSeconds: 30,
         logQueriesInHistory: true,
-        requireAuthentication: true
+        requireAuthentication: true,
+        connectionApproval: .oncePerConnection
     )
 
     init(
@@ -26,7 +28,8 @@ struct MCPSettings: Codable, Equatable {
         maxRowLimit: Int = 10_000,
         queryTimeoutSeconds: Int = 30,
         logQueriesInHistory: Bool = true,
-        requireAuthentication: Bool = true
+        requireAuthentication: Bool = true,
+        connectionApproval: MCPConnectionApproval = .oncePerConnection
     ) {
         self.enabled = enabled
         self.port = port
@@ -35,6 +38,7 @@ struct MCPSettings: Codable, Equatable {
         self.queryTimeoutSeconds = queryTimeoutSeconds
         self.logQueriesInHistory = logQueriesInHistory
         self.requireAuthentication = requireAuthentication
+        self.connectionApproval = connectionApproval
     }
 
     init(from decoder: Decoder) throws {
@@ -47,6 +51,9 @@ struct MCPSettings: Codable, Equatable {
         queryTimeoutSeconds = try container.decodeIfPresent(Int.self, forKey: .queryTimeoutSeconds) ?? 30
         logQueriesInHistory = try container.decodeIfPresent(Bool.self, forKey: .logQueriesInHistory) ?? true
         requireAuthentication = try container.decodeIfPresent(Bool.self, forKey: .requireAuthentication) ?? true
+        connectionApproval = try container.decodeIfPresent(
+            MCPConnectionApproval.self, forKey: .connectionApproval
+        ) ?? .oncePerConnection
 
         maxRowLimit = validatedMaxRowLimit
         defaultRowLimit = validatedDefaultRowLimit

--- a/TablePro/Views/Integrations/IntegrationsActivityLogPane.swift
+++ b/TablePro/Views/Integrations/IntegrationsActivityLogPane.swift
@@ -213,7 +213,7 @@ struct IntegrationsActivityLogPane: View {
         }
 
         if let store = MCPServerManager.shared.tokenStore {
-            tokens = await store.list().filter { $0.name != MCPTokenStore.stdioBridgeTokenName }
+            tokens = await store.list().filter { !$0.isBridgeCredential }
         }
         connections = ConnectionStorage.shared.loadConnections()
 

--- a/TablePro/Views/Settings/Sections/MCPGrantListView.swift
+++ b/TablePro/Views/Settings/Sections/MCPGrantListView.swift
@@ -1,0 +1,61 @@
+//
+//  MCPGrantListView.swift
+//  TablePro
+//
+
+import SwiftUI
+
+/// The approvals the user has already given, so a remembered answer stays visible and revocable.
+struct MCPGrantListView: View {
+    @State private var grants: [MCPConnectionGrant] = []
+    @State private var connectionNames: [UUID: String] = [:]
+
+    var body: some View {
+        Group {
+            if grants.isEmpty {
+                Text("No connections are approved yet.")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(grants) { grant in
+                    LabeledContent(name(for: grant)) {
+                        Button(String(localized: "Forget")) {
+                            forget(grant)
+                        }
+                    }
+                }
+
+                Button(String(localized: "Forget All"), role: .destructive) {
+                    forgetAll()
+                }
+            }
+        }
+        .task { await refresh() }
+    }
+
+    private func name(for grant: MCPConnectionGrant) -> String {
+        connectionNames[grant.connectionId] ?? String(localized: "Deleted connection")
+    }
+
+    private func forget(_ grant: MCPConnectionGrant) {
+        Task {
+            await MCPServerManager.shared.forgetGrant(subject: grant.subject, connectionId: grant.connectionId)
+            await refresh()
+        }
+    }
+
+    private func forgetAll() {
+        Task {
+            await MCPServerManager.shared.forgetEveryGrant()
+            await refresh()
+        }
+    }
+
+    private func refresh() async {
+        grants = await MCPServerManager.shared.connectionGrants()
+            .sorted { $0.grantedAt > $1.grantedAt }
+        connectionNames = Dictionary(
+            ConnectionStorage.shared.loadConnections().map { ($0.id, $0.name) },
+            uniquingKeysWith: { first, _ in first }
+        )
+    }
+}

--- a/TablePro/Views/Settings/Sections/MCPSection.swift
+++ b/TablePro/Views/Settings/Sections/MCPSection.swift
@@ -55,14 +55,33 @@ struct MCPSection: View {
 
         if settings.enabled {
             configurationSection
+            connectionAccessSection
             authenticationSection
             helpSection
+        }
+    }
 
-            Section {
-                Text(String(localized: "AI access policies are configured per-connection in each connection's settings."))
-                    .foregroundStyle(.secondary)
-                    .font(.callout)
+    private var connectionAccessSection: some View {
+        Section {
+            Picker(String(localized: "Approval"), selection: $settings.connectionApproval) {
+                ForEach(MCPConnectionApproval.allCases) { approval in
+                    Text(approval.displayName).tag(approval)
+                }
             }
+            .pickerStyle(.menu)
+
+            Text(settings.connectionApproval.explanation)
+                .foregroundStyle(.secondary)
+                .font(.callout)
+
+            MCPGrantListView()
+        } header: {
+            Text("Connection Access")
+        } footer: {
+            // swiftlint:disable:next line_length
+            Text("Approval is separate from what a client may reach. A connection blocked for external clients stays blocked, a read-only one stays read only, and Safe Mode still confirms destructive statements.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 
@@ -150,7 +169,8 @@ struct MCPSection: View {
                 name: name,
                 permissions: permissions,
                 connectionAccess: access,
-                expiresAt: expiresAt
+                expiresAt: expiresAt,
+                isBridgeCredential: false
             ) else { return }
             revealedToken = result.token
             revealedPlaintext = result.plaintext
@@ -162,7 +182,7 @@ struct MCPSection: View {
 
     private func refreshTokens() async {
         guard let store = MCPServerManager.shared.tokenStore else { return }
-        tokenList = await store.list().filter { $0.name != MCPTokenStore.stdioBridgeTokenName }
+        tokenList = await store.list().filter { !$0.isBridgeCredential }
     }
 }
 

--- a/TableProTests/Core/MCP/Helpers/MCPProtocolTestStubs.swift
+++ b/TableProTests/Core/MCP/Helpers/MCPProtocolTestStubs.swift
@@ -257,6 +257,7 @@ enum StubHandlerBehavior: Sendable {
     case waitForCancellation
     case blockUntilReleased(ReleaseGate)
     case emitProgressThenComplete(Double)
+    case requiringInput(MCPInputRequired)
 }
 
 protocol StubHandlerIdentity: Sendable {
@@ -334,6 +335,8 @@ struct StubHandler<Identity: StubHandlerIdentity>: MCPMethodHandler {
         case .emitProgressThenComplete(let progress):
             await context.progress.emit(progress: progress)
             return .complete(["ok": .bool(true)])
+        case .requiringInput(let signal):
+            throw signal
         }
     }
 }

--- a/TableProTests/Core/MCP/Helpers/RecordingApprovalPresenter.swift
+++ b/TableProTests/Core/MCP/Helpers/RecordingApprovalPresenter.swift
@@ -1,0 +1,28 @@
+import Foundation
+@testable import TablePro
+
+/// Stands in for the native alert so a test can state the user's answer.
+///
+/// Nothing in a test may reach the real presenter: `NSAlert.runModal()` blocks its thread until a
+/// human dismisses it, which on CI means the job dies on the timeout rather than failing.
+actor RecordingApprovalPresenter: MCPApprovalPresenting {
+    private let answer: Bool
+    private var requests: [MCPApprovalRequest] = []
+
+    init(answer: Bool) {
+        self.answer = answer
+    }
+
+    func requestApproval(_ request: MCPApprovalRequest) async -> Bool {
+        requests.append(request)
+        return answer
+    }
+
+    var askedCount: Int {
+        requests.count
+    }
+
+    var lastRequest: MCPApprovalRequest? {
+        requests.last
+    }
+}

--- a/TableProTests/Core/MCP/Identity/MCPIdentityLedgerTests.swift
+++ b/TableProTests/Core/MCP/Identity/MCPIdentityLedgerTests.swift
@@ -28,7 +28,7 @@ struct MCPIdentityLedgerTests {
 
     @Test("An approval is scoped to the token that earned it")
     func approvalDoesNotLeakAcrossTokens() async {
-        let ledger = MCPApprovalLedger(clock: MCPTestClock())
+        let ledger = MCPApprovalLedger(clock: MCPTestClock(), store: MCPInMemoryApprovalStore())
         let connectionId = UUID()
         let first = principal(tokenId: UUID(), fingerprint: "first")
         let second = principal(tokenId: UUID(), fingerprint: "second")
@@ -41,7 +41,7 @@ struct MCPIdentityLedgerTests {
 
     @Test("An approval is scoped to the connection it was given for")
     func approvalDoesNotLeakAcrossConnections() async {
-        let ledger = MCPApprovalLedger(clock: MCPTestClock())
+        let ledger = MCPApprovalLedger(clock: MCPTestClock(), store: MCPInMemoryApprovalStore())
         let approved = UUID()
         let other = UUID()
         let subject = principal(tokenId: UUID())
@@ -53,12 +53,12 @@ struct MCPIdentityLedgerTests {
         #expect(await ledger.approvedConnectionIds(principal: subject) == [approved])
     }
 
-    @Test("An approval expires once its lifetime elapses")
-    func approvalExpires() async {
+    @Test("An anonymous caller's approval expires once its lifetime elapses")
+    func anonymousApprovalExpires() async {
         let clock = MCPTestClock()
-        let ledger = MCPApprovalLedger(ttl: .seconds(60), clock: clock)
+        let ledger = MCPApprovalLedger(ttl: .seconds(60), clock: clock, store: MCPInMemoryApprovalStore())
         let connectionId = UUID()
-        let subject = principal(tokenId: UUID())
+        let subject = principal(tokenId: nil, fingerprint: "anon")
 
         await ledger.record(principal: subject, connectionId: connectionId, approved: true)
         await clock.advance(by: .seconds(59))
@@ -69,12 +69,12 @@ struct MCPIdentityLedgerTests {
         #expect(await ledger.approvedConnectionIds(principal: subject).isEmpty)
     }
 
-    @Test("The default approval lifetime is half an hour")
-    func defaultApprovalLifetime() async {
+    @Test("The default lifetime of an anonymous approval is half an hour")
+    func defaultAnonymousApprovalLifetime() async {
         let clock = MCPTestClock()
-        let ledger = MCPApprovalLedger(clock: clock)
+        let ledger = MCPApprovalLedger(clock: clock, store: MCPInMemoryApprovalStore())
         let connectionId = UUID()
-        let subject = principal(tokenId: UUID())
+        let subject = principal(tokenId: nil, fingerprint: "anon")
 
         await ledger.record(principal: subject, connectionId: connectionId, approved: true)
         await clock.advance(by: .seconds(1_799))
@@ -84,9 +84,34 @@ struct MCPIdentityLedgerTests {
         #expect(await ledger.isApproved(principal: subject, connectionId: connectionId) == false)
     }
 
+    @Test("An issued token's grant does not expire on a timer")
+    func issuedTokenGrantDoesNotExpire() async {
+        let clock = MCPTestClock()
+        let ledger = MCPApprovalLedger(ttl: .seconds(60), clock: clock, store: MCPInMemoryApprovalStore())
+        let connectionId = UUID()
+        let subject = principal(tokenId: UUID())
+
+        await ledger.record(principal: subject, connectionId: connectionId, approved: true)
+        await clock.advance(by: .seconds(100_000))
+
+        #expect(await ledger.isApproved(principal: subject, connectionId: connectionId) == true)
+        #expect(await ledger.approvedConnectionIds(principal: subject) == [connectionId])
+    }
+
+    @Test("A grant is not remembered when the caller asked for it not to be")
+    func recordWithoutRememberingIsNotKept() async {
+        let ledger = MCPApprovalLedger(clock: MCPTestClock(), store: MCPInMemoryApprovalStore())
+        let connectionId = UUID()
+        let subject = principal(tokenId: UUID())
+
+        await ledger.record(principal: subject, connectionId: connectionId, approved: true, remember: false)
+
+        #expect(await ledger.isApproved(principal: subject, connectionId: connectionId) == false)
+    }
+
     @Test("Revoking a token drops only that token's approvals")
     func clearByTokenId() async {
-        let ledger = MCPApprovalLedger(clock: MCPTestClock())
+        let ledger = MCPApprovalLedger(clock: MCPTestClock(), store: MCPInMemoryApprovalStore())
         let connectionId = UUID()
         let revokedId = UUID()
         let revoked = principal(tokenId: revokedId, fingerprint: "revoked")
@@ -94,7 +119,7 @@ struct MCPIdentityLedgerTests {
 
         await ledger.record(principal: revoked, connectionId: connectionId, approved: true)
         await ledger.record(principal: survivor, connectionId: connectionId, approved: true)
-        await ledger.clear(tokenId: revokedId)
+        await ledger.clear(subject: .token(revokedId))
 
         #expect(await ledger.isApproved(principal: revoked, connectionId: connectionId) == false)
         #expect(await ledger.isApproved(principal: survivor, connectionId: connectionId) == true)
@@ -102,14 +127,14 @@ struct MCPIdentityLedgerTests {
 
     @Test("Clearing with no token id drops the anonymous approvals and leaves the issued ones")
     func clearWithoutTokenIdDropsAnonymousApprovals() async {
-        let ledger = MCPApprovalLedger(clock: MCPTestClock())
+        let ledger = MCPApprovalLedger(clock: MCPTestClock(), store: MCPInMemoryApprovalStore())
         let connectionId = UUID()
         let anonymous = principal(tokenId: nil, fingerprint: MCPPrincipal.anonymousFingerprint)
         let issued = principal(tokenId: UUID(), fingerprint: "issued")
 
         await ledger.record(principal: anonymous, connectionId: connectionId, approved: true)
         await ledger.record(principal: issued, connectionId: connectionId, approved: true)
-        await ledger.clear(tokenId: nil)
+        await ledger.clear(subject: nil)
 
         #expect(await ledger.isApproved(principal: anonymous, connectionId: connectionId) == false)
         #expect(await ledger.isApproved(principal: issued, connectionId: connectionId) == true)
@@ -117,7 +142,7 @@ struct MCPIdentityLedgerTests {
 
     @Test("Two anonymous callers are two callers")
     func anonymousPrincipalsAreKeyedByFingerprint() async {
-        let ledger = MCPApprovalLedger(clock: MCPTestClock())
+        let ledger = MCPApprovalLedger(clock: MCPTestClock(), store: MCPInMemoryApprovalStore())
         let connectionId = UUID()
         let first = principal(tokenId: nil, fingerprint: "first")
         let second = principal(tokenId: nil, fingerprint: "second")
@@ -131,7 +156,7 @@ struct MCPIdentityLedgerTests {
 
     @Test("A denial removes any standing approval")
     func denialRemovesApproval() async {
-        let ledger = MCPApprovalLedger(clock: MCPTestClock())
+        let ledger = MCPApprovalLedger(clock: MCPTestClock(), store: MCPInMemoryApprovalStore())
         let connectionId = UUID()
         let subject = principal(tokenId: UUID())
 
@@ -143,14 +168,14 @@ struct MCPIdentityLedgerTests {
 
     @Test("Clearing everything leaves no approval standing")
     func clearAllDropsEveryApproval() async {
-        let ledger = MCPApprovalLedger(clock: MCPTestClock())
+        let ledger = MCPApprovalLedger(clock: MCPTestClock(), store: MCPInMemoryApprovalStore())
         let connectionId = UUID()
         let anonymous = principal(tokenId: nil, fingerprint: "anon")
         let issued = principal(tokenId: UUID())
 
         await ledger.record(principal: anonymous, connectionId: connectionId, approved: true)
         await ledger.record(principal: issued, connectionId: connectionId, approved: true)
-        await ledger.clearAll()
+        await ledger.forgetEveryGrant()
 
         #expect(await ledger.isApproved(principal: anonymous, connectionId: connectionId) == false)
         #expect(await ledger.isApproved(principal: issued, connectionId: connectionId) == false)

--- a/TableProTests/Core/MCP/MCPAuthPolicyTests.swift
+++ b/TableProTests/Core/MCP/MCPAuthPolicyTests.swift
@@ -34,13 +34,17 @@ struct MCPAuthPolicyTests {
 
     private func makePolicy(
         _ snapshot: MCPConnectionAuthSnapshot?,
-        ledger: MCPApprovalLedger = MCPApprovalLedger(clock: MCPTestClock()),
-        connectionIds: Set<UUID> = []
+        ledger: MCPApprovalLedger = MCPApprovalLedger(clock: MCPTestClock(), store: MCPInMemoryApprovalStore()),
+        connectionIds: Set<UUID> = [],
+        approval: MCPConnectionApproval = .oncePerConnection,
+        presenter: any MCPApprovalPresenting = RecordingApprovalPresenter(answer: false)
     ) -> MCPAuthPolicy {
         MCPAuthPolicy(
             connectionResolver: { _ in snapshot },
             connectionIdsProvider: { connectionIds },
-            approvalLedger: ledger
+            approvalLedger: ledger,
+            approvalSetting: MCPFixedApprovalReader(approval),
+            presenter: presenter
         )
     }
 
@@ -51,7 +55,7 @@ struct MCPAuthPolicyTests {
         MCPAuthPolicy(
             connectionResolver: resolver,
             connectionIdsProvider: { connectionIds },
-            approvalLedger: MCPApprovalLedger(clock: MCPTestClock())
+            approvalLedger: MCPApprovalLedger(clock: MCPTestClock(), store: MCPInMemoryApprovalStore())
         )
     }
 
@@ -362,7 +366,7 @@ struct MCPAuthPolicyTests {
 
     @Test("Revoking a token clears the approvals it was carrying and leaves the others alone")
     func clearingApprovalsFollowsTheToken() async throws {
-        let ledger = MCPApprovalLedger(clock: MCPTestClock())
+        let ledger = MCPApprovalLedger(clock: MCPTestClock(), store: MCPInMemoryApprovalStore())
         let policy = makePolicy(makeSnapshot(policy: .askEachTime), ledger: ledger)
         let revoked = makePrincipal(fingerprint: "revoked")
         let survivor = makePrincipal(fingerprint: "survivor")
@@ -392,12 +396,12 @@ struct MCPAuthPolicyTests {
         }
     }
 
-    @Test("An approval expires on its own")
-    func approvalExpires() async throws {
+    @Test("A token's approval stands until it is revoked, not until a timer runs out")
+    func approvalDoesNotExpireOnATimer() async throws {
         let clock = MCPTestClock()
         let policy = makePolicy(
             makeSnapshot(policy: .askEachTime),
-            ledger: MCPApprovalLedger(ttl: .seconds(1_800), clock: clock)
+            ledger: MCPApprovalLedger(ttl: .seconds(1_800), clock: clock, store: MCPInMemoryApprovalStore())
         )
         let principal = makePrincipal()
         await policy.recordApproval(principal: principal, connectionId: connectionA)
@@ -410,19 +414,19 @@ struct MCPAuthPolicyTests {
             connectionId: connectionA
         )
 
-        guard case .requiresUserApproval = decision else {
-            Issue.record("Expected an expired approval to be asked again, got \(decision)")
+        guard case .allowed = decision else {
+            Issue.record("Expected a granted connection to stay granted, got \(decision)")
             return
         }
     }
 
-    @Test("Clearing every approval asks each token again")
-    func clearingAllApprovals() async throws {
+    @Test("Forgetting every grant asks each token again")
+    func forgettingEveryGrant() async throws {
         let policy = makePolicy(makeSnapshot(policy: .askEachTime))
         let principal = makePrincipal()
         await policy.recordApproval(principal: principal, connectionId: connectionA)
 
-        await policy.clearAllApprovals()
+        await policy.forgetEveryGrant()
 
         let decision = try await policy.authorize(
             principal: principal,

--- a/TableProTests/Core/MCP/MCPConnectionApprovalTests.swift
+++ b/TableProTests/Core/MCP/MCPConnectionApprovalTests.swift
@@ -1,0 +1,433 @@
+//
+//  MCPConnectionApprovalTests.swift
+//  TableProTests
+//
+//  Whether an MCP client is asked before it reaches a connection is MCP's own setting, not the AI
+//  tab's. What a client may do once it is there is unchanged: a connection blocked for external
+//  clients, one whose AI policy is Never, and Safe Mode all still refuse, whatever the approval
+//  setting says.
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("MCP connection approval")
+struct MCPConnectionApprovalTests {
+    private let connectionA = UUID()
+
+    private func makeSnapshot(
+        externalAccess: ExternalAccessLevel = .readWrite,
+        policy: AIConnectionPolicy = .askEachTime
+    ) -> MCPConnectionAuthSnapshot {
+        MCPConnectionAuthSnapshot(
+            policy: policy,
+            externalAccess: externalAccess,
+            name: "Test Connection",
+            databaseType: DatabaseType.postgresql.rawValue
+        )
+    }
+
+    private func makePrincipal(
+        tokenId: UUID? = UUID(),
+        label: String = "token",
+        fingerprint: String = "fp",
+        isBridge: Bool = false
+    ) -> MCPPrincipal {
+        MCPPrincipal(
+            tokenFingerprint: fingerprint,
+            tokenId: tokenId,
+            scopes: MCPScope.fullAccessSet,
+            connectionAccess: .all,
+            metadata: MCPPrincipalMetadata(
+                label: label,
+                issuedAt: .distantPast,
+                expiresAt: nil,
+                isBridgeCredential: isBridge
+            )
+        )
+    }
+
+    private func makePolicy(
+        approval: MCPConnectionApproval,
+        snapshot: MCPConnectionAuthSnapshot? = nil,
+        presenter: any MCPApprovalPresenting = RecordingApprovalPresenter(answer: true),
+        store: any MCPApprovalStoring = MCPInMemoryApprovalStore()
+    ) -> MCPAuthPolicy {
+        MCPAuthPolicy(
+            connectionResolver: { _ in snapshot ?? self.makeSnapshot() },
+            connectionIdsProvider: { [] },
+            approvalLedger: MCPApprovalLedger(clock: MCPTestClock(), store: store),
+            approvalSetting: MCPFixedApprovalReader(approval),
+            presenter: presenter
+        )
+    }
+
+    @Test("Never Ask reaches the connection without a prompt")
+    func neverAskSkipsThePrompt() async throws {
+        let presenter = RecordingApprovalPresenter(answer: false)
+        let policy = makePolicy(approval: .alwaysApprove, presenter: presenter)
+
+        let decision = try await policy.authorize(
+            principal: makePrincipal(),
+            tool: "list_tables",
+            connectionId: connectionA
+        )
+
+        guard case .allowed = decision else {
+            Issue.record("Expected Never Ask to allow without asking, got \(decision)")
+            return
+        }
+        #expect(await presenter.askedCount == 0)
+    }
+
+    @Test("Asking is still required at the two asking levels")
+    func askingLevelsStillAsk() async throws {
+        for approval in [MCPConnectionApproval.everyTime, .oncePerConnection] {
+            let policy = makePolicy(approval: approval)
+
+            let decision = try await policy.authorize(
+                principal: makePrincipal(),
+                tool: "list_tables",
+                connectionId: connectionA
+            )
+
+            guard case .requiresUserApproval = decision else {
+                Issue.record("Expected \(approval) to ask, got \(decision)")
+                return
+            }
+        }
+    }
+
+    @Test("Never Ask does not open a connection the user blocked for external clients")
+    func neverAskDoesNotOverrideBlocked() async throws {
+        let policy = makePolicy(
+            approval: .alwaysApprove,
+            snapshot: makeSnapshot(externalAccess: .blocked)
+        )
+
+        let decision = try await policy.authorize(
+            principal: makePrincipal(),
+            tool: "list_tables",
+            connectionId: connectionA
+        )
+
+        guard case .denied = decision else {
+            Issue.record("Expected a blocked connection to stay blocked, got \(decision)")
+            return
+        }
+    }
+
+    @Test("Never Ask does not open a connection whose AI policy is Never")
+    func neverAskDoesNotOverrideNeverPolicy() async throws {
+        let policy = makePolicy(approval: .alwaysApprove, snapshot: makeSnapshot(policy: .never))
+
+        let decision = try await policy.authorize(
+            principal: makePrincipal(),
+            tool: "list_tables",
+            connectionId: connectionA
+        )
+
+        guard case .denied = decision else {
+            Issue.record("Expected an AI policy of Never to keep denying, got \(decision)")
+            return
+        }
+    }
+
+    @Test("A connection set to Always Allow is reached without asking whatever the level")
+    func perConnectionAlwaysAllowWins() async throws {
+        let presenter = RecordingApprovalPresenter(answer: false)
+        let policy = makePolicy(
+            approval: .everyTime,
+            snapshot: makeSnapshot(policy: .alwaysAllow),
+            presenter: presenter
+        )
+
+        let decision = try await policy.authorize(
+            principal: makePrincipal(),
+            tool: "list_tables",
+            connectionId: connectionA
+        )
+
+        guard case .allowed = decision else {
+            Issue.record("Expected a per-connection Always Allow to win, got \(decision)")
+            return
+        }
+        #expect(await presenter.askedCount == 0)
+    }
+
+    @Test("Ask Once remembers the answer, and the next call does not ask")
+    func askOnceRemembers() async throws {
+        let presenter = RecordingApprovalPresenter(answer: true)
+        let store = MCPApprovalStore(defaults: Self.scratchDefaults())
+        let policy = makePolicy(approval: .oncePerConnection, presenter: presenter, store: store)
+        let principal = makePrincipal()
+
+        try await policy.resolveAndAuthorize(
+            principal: principal, tool: "list_tables", connectionId: connectionA
+        )
+        try await policy.resolveAndAuthorize(
+            principal: principal, tool: "list_tables", connectionId: connectionA
+        )
+
+        #expect(await presenter.askedCount == 1)
+    }
+
+    @Test("Ask Every Time asks again on the next call")
+    func everyTimeAsksAgain() async throws {
+        let presenter = RecordingApprovalPresenter(answer: true)
+        let store = MCPApprovalStore(defaults: Self.scratchDefaults())
+        let policy = makePolicy(approval: .everyTime, presenter: presenter, store: store)
+        let principal = makePrincipal()
+
+        try await policy.resolveAndAuthorize(
+            principal: principal, tool: "list_tables", connectionId: connectionA
+        )
+        try await policy.resolveAndAuthorize(
+            principal: principal, tool: "list_tables", connectionId: connectionA
+        )
+
+        #expect(await presenter.askedCount == 2)
+    }
+
+    @Test("The prompt says whether the answer will be remembered")
+    func promptExplainsWhatAllowMeans() async throws {
+        let remembering = RecordingApprovalPresenter(answer: true)
+        try await makePolicy(approval: .oncePerConnection, presenter: remembering)
+            .resolveAndAuthorize(principal: makePrincipal(), tool: "list_tables", connectionId: connectionA)
+        #expect(await remembering.lastRequest?.memory == .untilRevoked)
+
+        let onceOnly = RecordingApprovalPresenter(answer: true)
+        try await makePolicy(approval: .everyTime, presenter: onceOnly)
+            .resolveAndAuthorize(principal: makePrincipal(), tool: "list_tables", connectionId: connectionA)
+        #expect(await onceOnly.lastRequest?.memory == .thisRequestOnly)
+    }
+
+    @Test("A refusal stands for a cool-off instead of raising a fresh prompt on the retry")
+    func denialIsRememberedBriefly() async throws {
+        let presenter = RecordingApprovalPresenter(answer: false)
+        let store = MCPApprovalStore(defaults: Self.scratchDefaults())
+        let policy = makePolicy(approval: .oncePerConnection, presenter: presenter, store: store)
+        let principal = makePrincipal()
+
+        for _ in 0..<3 {
+            await #expect(throws: DatabaseAccessError.self) {
+                try await policy.resolveAndAuthorize(
+                    principal: principal, tool: "list_tables", connectionId: connectionA
+                )
+            }
+        }
+
+        #expect(await presenter.askedCount == 1)
+    }
+
+    @Test("The bundled bridge keeps its grant when its credential rotates")
+    func bridgeGrantSurvivesCredentialRotation() async throws {
+        let store = MCPApprovalStore(defaults: Self.scratchDefaults())
+        let presenter = RecordingApprovalPresenter(answer: true)
+        let policy = makePolicy(approval: .oncePerConnection, presenter: presenter, store: store)
+
+        let firstCredential = makePrincipal(
+            tokenId: UUID(),
+            label: MCPTokenStore.stdioBridgeTokenName,
+            fingerprint: "bridge-1",
+            isBridge: true
+        )
+        try await policy.resolveAndAuthorize(
+            principal: firstCredential, tool: "list_tables", connectionId: connectionA
+        )
+
+        await policy.clearApprovals(tokenId: firstCredential.tokenId, wasBridgeCredential: true)
+
+        let rotated = makePrincipal(
+            tokenId: UUID(),
+            label: MCPTokenStore.stdioBridgeTokenName,
+            fingerprint: "bridge-2",
+            isBridge: true
+        )
+        try await policy.resolveAndAuthorize(
+            principal: rotated, tool: "list_tables", connectionId: connectionA
+        )
+
+        #expect(await presenter.askedCount == 1)
+    }
+
+    @Test("Revoking a token the user issued drops the grant it was carrying")
+    func revokingAnIssuedTokenDropsItsGrant() async throws {
+        let store = MCPApprovalStore(defaults: Self.scratchDefaults())
+        let presenter = RecordingApprovalPresenter(answer: true)
+        let policy = makePolicy(approval: .oncePerConnection, presenter: presenter, store: store)
+        let principal = makePrincipal(label: "Laptop token")
+
+        try await policy.resolveAndAuthorize(
+            principal: principal, tool: "list_tables", connectionId: connectionA
+        )
+        await policy.clearApprovals(tokenId: principal.tokenId)
+        try await policy.resolveAndAuthorize(
+            principal: principal, tool: "list_tables", connectionId: connectionA
+        )
+
+        #expect(await presenter.askedCount == 2)
+    }
+
+    @Test("A remembered grant survives the teardown a settings change triggers")
+    func grantSurvivesServerTeardown() async throws {
+        let store = MCPApprovalStore(defaults: Self.scratchDefaults())
+        let presenter = RecordingApprovalPresenter(answer: true)
+        let policy = makePolicy(approval: .oncePerConnection, presenter: presenter, store: store)
+        let principal = makePrincipal()
+
+        try await policy.resolveAndAuthorize(
+            principal: principal, tool: "list_tables", connectionId: connectionA
+        )
+        await policy.clearAllApprovals()
+        try await policy.resolveAndAuthorize(
+            principal: principal, tool: "list_tables", connectionId: connectionA
+        )
+
+        #expect(await presenter.askedCount == 1)
+    }
+
+    @Test("An anonymous caller's approval is never written to disk")
+    func anonymousApprovalIsNotPersisted() async throws {
+        let store = MCPApprovalStore(defaults: Self.scratchDefaults())
+        let presenter = RecordingApprovalPresenter(answer: true)
+        let policy = makePolicy(approval: .oncePerConnection, presenter: presenter, store: store)
+
+        try await policy.resolveAndAuthorize(
+            principal: .anonymousLoopback, tool: "list_tables", connectionId: connectionA
+        )
+
+        #expect(await store.grants().isEmpty)
+    }
+
+    @Test("Forgetting a grant makes the next call ask again")
+    func forgettingAGrantAsksAgain() async throws {
+        let store = MCPApprovalStore(defaults: Self.scratchDefaults())
+        let presenter = RecordingApprovalPresenter(answer: true)
+        let policy = makePolicy(approval: .oncePerConnection, presenter: presenter, store: store)
+        let principal = makePrincipal()
+
+        try await policy.resolveAndAuthorize(
+            principal: principal, tool: "list_tables", connectionId: connectionA
+        )
+        let grants = await policy.grants()
+        let subject = try #require(grants.first?.subject)
+        await policy.revokeGrant(subject: subject, connectionId: connectionA)
+
+        try await policy.resolveAndAuthorize(
+            principal: principal, tool: "list_tables", connectionId: connectionA
+        )
+
+        #expect(await presenter.askedCount == 2)
+    }
+
+    @Test("A token that merely calls itself the bridge inherits none of the bridge's grants")
+    func aTokenNamedLikeTheBridgeInheritsNothing() async throws {
+        let store = MCPApprovalStore(defaults: Self.scratchDefaults())
+        let presenter = RecordingApprovalPresenter(answer: true)
+        let policy = makePolicy(approval: .oncePerConnection, presenter: presenter, store: store)
+
+        let bridge = makePrincipal(label: MCPTokenStore.stdioBridgeTokenName, fingerprint: "real", isBridge: true)
+        try await policy.resolveAndAuthorize(
+            principal: bridge, tool: "list_tables", connectionId: connectionA
+        )
+
+        let impostor = makePrincipal(
+            label: MCPTokenStore.stdioBridgeTokenName,
+            fingerprint: "impostor",
+            isBridge: false
+        )
+        try await policy.resolveAndAuthorize(
+            principal: impostor, tool: "list_tables", connectionId: connectionA
+        )
+
+        #expect(await presenter.askedCount == 2)
+    }
+
+    @Test("Ask Every Time asks again even for a connection that already carries a grant")
+    func everyTimeIgnoresAnExistingGrant() async throws {
+        let store = MCPApprovalStore(defaults: Self.scratchDefaults())
+        let principal = makePrincipal()
+
+        let remembering = RecordingApprovalPresenter(answer: true)
+        let granting = makePolicy(approval: .oncePerConnection, presenter: remembering, store: store)
+        try await granting.resolveAndAuthorize(
+            principal: principal, tool: "list_tables", connectionId: connectionA
+        )
+        #expect(await granting.grants().count == 1)
+
+        let strict = RecordingApprovalPresenter(answer: true)
+        let tightened = makePolicy(approval: .everyTime, presenter: strict, store: store)
+        try await tightened.resolveAndAuthorize(
+            principal: principal, tool: "list_tables", connectionId: connectionA
+        )
+
+        #expect(await strict.askedCount == 1)
+    }
+
+    @Test("A denial withdraws a grant the user had already given")
+    func denialWithdrawsAnExistingGrant() async throws {
+        let store = MCPApprovalStore(defaults: Self.scratchDefaults())
+        let principal = makePrincipal()
+
+        let allowing = makePolicy(
+            approval: .oncePerConnection,
+            presenter: RecordingApprovalPresenter(answer: true),
+            store: store
+        )
+        try await allowing.resolveAndAuthorize(
+            principal: principal, tool: "list_tables", connectionId: connectionA
+        )
+        #expect(await allowing.grants().count == 1)
+
+        let denying = makePolicy(
+            approval: .everyTime,
+            presenter: RecordingApprovalPresenter(answer: false),
+            store: store
+        )
+        await #expect(throws: DatabaseAccessError.self) {
+            try await denying.resolveAndAuthorize(
+                principal: principal, tool: "list_tables", connectionId: connectionA
+            )
+        }
+
+        #expect(await denying.grants().isEmpty)
+    }
+
+    @Test("An anonymous caller is told its approval lasts only for the session")
+    func anonymousPromptSaysSessionOnly() async throws {
+        let presenter = RecordingApprovalPresenter(answer: true)
+        let policy = makePolicy(approval: .oncePerConnection, presenter: presenter)
+
+        try await policy.resolveAndAuthorize(
+            principal: .anonymousLoopback, tool: "list_tables", connectionId: connectionA
+        )
+
+        #expect(await presenter.lastRequest?.memory == .thisSession)
+    }
+
+    @Test("An anonymous caller's refusal also stands for a cool-off")
+    func anonymousDenialIsRememberedBriefly() async throws {
+        let presenter = RecordingApprovalPresenter(answer: false)
+        let policy = makePolicy(approval: .oncePerConnection, presenter: presenter)
+
+        for _ in 0..<3 {
+            await #expect(throws: DatabaseAccessError.self) {
+                try await policy.resolveAndAuthorize(
+                    principal: .anonymousLoopback, tool: "list_tables", connectionId: connectionA
+                )
+            }
+        }
+
+        #expect(await presenter.askedCount == 1)
+    }
+
+    private static func scratchDefaults() -> UserDefaults {
+        let suite = "com.TablePro.tests.mcpApprovals." + UUID().uuidString
+        let defaults = UserDefaults(suiteName: suite) ?? .standard
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+}

--- a/TableProTests/Core/MCP/MCPSettingsTests.swift
+++ b/TableProTests/Core/MCP/MCPSettingsTests.swift
@@ -46,7 +46,8 @@ struct MCPSettingsTests {
             "maxRowLimit",
             "queryTimeoutSeconds",
             "logQueriesInHistory",
-            "requireAuthentication"
+            "requireAuthentication",
+            "connectionApproval"
         ])
         #expect(decoded == MCPSettings.default)
     }
@@ -59,6 +60,42 @@ struct MCPSettingsTests {
         for banned in ["allowRemoteConnections", "host", "bindAddress", "tls", "useTLS", "certificatePath"] {
             #expect(fields[banned] == nil)
         }
+    }
+
+    @Test("Connection approval defaults to asking once for each connection")
+    func defaultApprovalAsksOnce() throws {
+        #expect(MCPSettings.default.connectionApproval == .oncePerConnection)
+        #expect(MCPSettings().connectionApproval == .oncePerConnection)
+        let decoded = try JSONDecoder().decode(MCPSettings.self, from: Data("{}".utf8))
+        #expect(decoded.connectionApproval == .oncePerConnection)
+    }
+
+    @Test("A settings blob written before the approval setting existed keeps asking")
+    func decodesLegacyBlobAsAsking() throws {
+        let json = Data(#"{"enabled": true, "requireAuthentication": true}"#.utf8)
+        let decoded = try JSONDecoder().decode(MCPSettings.self, from: json)
+        #expect(decoded.connectionApproval == .oncePerConnection)
+        #expect(decoded.connectionApproval.asksBeforeReachingAConnection)
+    }
+
+    @Test("Each stored approval level round trips")
+    func decodesEachApprovalLevel() throws {
+        for level in MCPConnectionApproval.allCases {
+            let json = Data(#"{"connectionApproval": "\#(level.rawValue)"}"#.utf8)
+            let decoded = try JSONDecoder().decode(MCPSettings.self, from: json)
+            #expect(decoded.connectionApproval == level)
+        }
+    }
+
+    @Test("Only the permissive level stops asking, and only it forgets the answer")
+    func approvalLevelSemantics() {
+        #expect(MCPConnectionApproval.everyTime.asksBeforeReachingAConnection)
+        #expect(MCPConnectionApproval.oncePerConnection.asksBeforeReachingAConnection)
+        #expect(!MCPConnectionApproval.alwaysApprove.asksBeforeReachingAConnection)
+
+        #expect(!MCPConnectionApproval.everyTime.remembersAnswer)
+        #expect(MCPConnectionApproval.oncePerConnection.remembersAnswer)
+        #expect(!MCPConnectionApproval.alwaysApprove.remembersAnswer)
     }
 
     @Test("A stored port outside the valid range falls back to the default")

--- a/TableProTests/Core/MCP/MCPTokenStoreTests.swift
+++ b/TableProTests/Core/MCP/MCPTokenStoreTests.swift
@@ -126,7 +126,8 @@ struct MCPTokenStoreTests {
             name: "scoped",
             permissions: .readOnly,
             connectionAccess: .limited(allowed),
-            expiresAt: expiry
+            expiresAt: expiry,
+            isBridgeCredential: false
         )
 
         #expect(result.token.connectionAccess == .limited(allowed))
@@ -152,8 +153,10 @@ struct MCPTokenStoreTests {
 
         #expect(signature.contains("connectionAccess: ConnectionAccess"))
         #expect(signature.contains("expiresAt: Date?"))
+        #expect(signature.contains("isBridgeCredential: Bool"))
         #expect(signature.contains("connectionAccess: ConnectionAccess = ") == false)
         #expect(signature.contains("expiresAt: Date? = ") == false)
+        #expect(signature.contains("isBridgeCredential: Bool = ") == false)
         #expect(signature.contains("=") == false)
     }
 
@@ -165,13 +168,15 @@ struct MCPTokenStoreTests {
             name: "token-1",
             permissions: .readOnly,
             connectionAccess: .all,
-            expiresAt: nil
+            expiresAt: nil,
+            isBridgeCredential: false
         )
         let second = try await store.generate(
             name: "token-2",
             permissions: .readOnly,
             connectionAccess: .all,
-            expiresAt: nil
+            expiresAt: nil,
+            isBridgeCredential: false
         )
 
         #expect(first.plaintext != second.plaintext)
@@ -189,7 +194,8 @@ struct MCPTokenStoreTests {
             name: "persisted",
             permissions: .readOnly,
             connectionAccess: .all,
-            expiresAt: nil
+            expiresAt: nil,
+            isBridgeCredential: false
         )
 
         let text = credentials.storedText
@@ -205,7 +211,8 @@ struct MCPTokenStoreTests {
             name: "valid",
             permissions: .readOnly,
             connectionAccess: .all,
-            expiresAt: nil
+            expiresAt: nil,
+            isBridgeCredential: false
         )
 
         #expect(await store.validate(bearerToken: result.plaintext)?.id == result.token.id)
@@ -220,7 +227,8 @@ struct MCPTokenStoreTests {
             name: "expired",
             permissions: .readOnly,
             connectionAccess: .all,
-            expiresAt: Date.now.addingTimeInterval(-1)
+            expiresAt: Date.now.addingTimeInterval(-1),
+            isBridgeCredential: false
         )
 
         #expect(await store.validate(bearerToken: result.plaintext) == nil)
@@ -234,7 +242,8 @@ struct MCPTokenStoreTests {
             name: "revoked",
             permissions: .readWrite,
             connectionAccess: .all,
-            expiresAt: nil
+            expiresAt: nil,
+            isBridgeCredential: false
         )
 
         await store.revoke(tokenId: result.token.id)
@@ -251,7 +260,8 @@ struct MCPTokenStoreTests {
             name: "used",
             permissions: .readOnly,
             connectionAccess: .all,
-            expiresAt: nil
+            expiresAt: nil,
+            isBridgeCredential: false
         )
 
         _ = await store.validate(bearerToken: result.plaintext)
@@ -266,10 +276,11 @@ struct MCPTokenStoreTests {
             name: "observed",
             permissions: .readOnly,
             connectionAccess: .all,
-            expiresAt: nil
+            expiresAt: nil,
+            isBridgeCredential: false
         )
         let recorder = RevocationRecorder()
-        await store.addRevocationObserver { key in
+        await store.addRevocationObserver { key, _ in
             await recorder.append(key)
         }
 
@@ -286,7 +297,8 @@ struct MCPTokenStoreTests {
             name: "temporary",
             permissions: .readOnly,
             connectionAccess: .all,
-            expiresAt: nil
+            expiresAt: nil,
+            isBridgeCredential: false
         )
 
         await store.delete(tokenId: result.token.id)
@@ -302,14 +314,16 @@ struct MCPTokenStoreTests {
             name: "Claude",
             permissions: .readWrite,
             connectionAccess: .all,
-            expiresAt: nil
+            expiresAt: nil,
+            isBridgeCredential: false
         )
 
         let impostor = try await store.generate(
             name: "Claude",
             permissions: .readOnly,
             connectionAccess: .all,
-            expiresAt: nil
+            expiresAt: nil,
+            isBridgeCredential: false
         )
 
         #expect(impostor.token.id != standing.token.id)
@@ -326,7 +340,8 @@ struct MCPTokenStoreTests {
             name: "persisted",
             permissions: .fullAccess,
             connectionAccess: .limited([UUID()]),
-            expiresAt: nil
+            expiresAt: nil,
+            isBridgeCredential: false
         )
 
         let reader = makeStore(credentials)
@@ -347,13 +362,15 @@ struct MCPTokenStoreTests {
             name: MCPTokenStore.stdioBridgeTokenName,
             permissions: MCPTokenStore.bridgeTokenPermissions,
             connectionAccess: .all,
-            expiresAt: Date.now.addingTimeInterval(3_600)
+            expiresAt: Date.now.addingTimeInterval(3_600),
+            isBridgeCredential: true
         )
         let survivor = try await writer.generate(
             name: "user token",
             permissions: .readOnly,
             connectionAccess: .all,
-            expiresAt: nil
+            expiresAt: nil,
+            isBridgeCredential: false
         )
 
         let reader = makeStore(credentials)

--- a/TableProTests/Core/MCP/Protocol/MCPProtocolDispatcherTests.swift
+++ b/TableProTests/Core/MCP/Protocol/MCPProtocolDispatcherTests.swift
@@ -533,6 +533,32 @@ final class MCPProtocolDispatcherTests: XCTestCase {
         _ = await run
     }
 
+    func testAnInputRequiredSignalReachesTheClientAsAnInputRequiredResult() async throws {
+        let signal = MCPInputRequired(
+            inputRequests: [
+                MCPElicitationRequest.approval(
+                    key: "approve_connection",
+                    message: "Allow this client to access 'Sales' (PostgreSQL)?",
+                    detail: "PostgreSQL"
+                )
+            ],
+            requestState: "sealed-state"
+        )
+        let sink = try await dispatch(
+            MCPProtocolTestSupport.makeModernRequest(method: StubToolsCallHandler.method),
+            handlers: [StubToolsCallHandler(behavior: .requiringInput(signal))]
+        )
+
+        let envelope = try await sink.errorEnvelope()
+        XCTAssertNil(envelope, "A consent question is not a failure")
+
+        let resultValue = try await sink.successResult()
+        let result = try XCTUnwrap(resultValue)
+        XCTAssertEqual(result["resultType"]?.stringValue, "input_required")
+        XCTAssertEqual(result["requestState"]?.stringValue, "sealed-state")
+        XCTAssertNotNil(result["inputRequests"]?["approve_connection"])
+    }
+
     private func dispatch(
         _ message: JsonRpcMessage,
         handlers: [any MCPMethodHandler],

--- a/docs/connections/connection-form.mdx
+++ b/docs/connections/connection-form.mdx
@@ -48,7 +48,7 @@ SQLite, DuckDB, and Beancount replace the host section with a file path picker.
 |-------|-------------|
 | **Startup Commands** | SQL to run after every connect. See [Startup commands](#startup-commands) |
 | **Pre-Connect Script** | Shell script run before connecting. A non-zero exit aborts the connect |
-| **AI Policy** | Per-connection override for the in-app AI agents |
+| **AI Policy** | Per-connection override for the in-app AI agents. **Never** also refuses external clients |
 | **External Clients** | **Blocked**, **Read Only** (the default), or **Read & Write** for MCP clients such as Raycast, Cursor, and Claude Desktop, and for [AppleScript](/external-api/applescript). A token's own scope cannot raise it. See [External API](/external-api) |
 | **Local only** | Keeps this connection off iCloud Sync. See [iCloud Sync](/features/icloud-sync) |
 | Plugin fields | Driver-specific options, such as MongoDB's `replicaSet` |

--- a/docs/customization/settings.mdx
+++ b/docs/customization/settings.mdx
@@ -95,6 +95,7 @@ What a fresh install ships with, so one glance down this column says what you ch
 | Integrations | Query timeout | 30 seconds |
 | Integrations | Log MCP queries in history | On |
 | Integrations | Require authentication | On |
+| Integrations | Approval | Ask Once for Each Connection |
 | Sync | Sync this Mac with iCloud | Off |
 | Sync | Passwords (keychain sync) | Off |
 

--- a/docs/external-api/mcp-tools.mdx
+++ b/docs/external-api/mcp-tools.mdx
@@ -36,7 +36,7 @@ Fourteen tools need `tools:write`: `connect`, `disconnect`, `switch_database`, `
 Past the scope, a call clears three more gates:
 
 1. **Connection allowlist.** A token limited to named connections gets `-33007` for anything else.
-2. **Connection policy.** **External Clients** set to **Blocked** hides the connection: `list_connections` omits it and any tool that names it is refused. An AI policy of **Never** does the same. **Ask Each Time** shows an approval dialog on the first call that touches the connection, and the answer is remembered for that token until it is revoked.
+2. **Connection policy.** **External Clients** set to **Blocked** hides the connection: `list_connections` omits it and any tool that names it is refused. An AI policy of **Never** does the same. Otherwise the first call that touches a connection asks the user, as often as **Settings > Integrations > Approval** says. That question is always a dialog on the user's Mac, never an elicitation: a client that could answer it could also grant itself the connection. It has no deadline, so the client owns the timeout, and a refusal stands for 60 seconds before the question can be put again.
 3. **Safe Mode.** A write goes through the connection's Safe Mode, which may ask the user to confirm it or to authenticate. See [Approvals](/external-api/mcp-protocol#approvals-and-input-required).
 
 `confirm_destructive_operation` needs `admin` as well, so it takes a Full Access token, and **Read Only** refuses it outright whatever the token carries. No token skips the user's approval.

--- a/docs/features/mcp.mdx
+++ b/docs/features/mcp.mdx
@@ -40,6 +40,33 @@ Click **Connect a Client…** and pick **Claude Code**, **Claude Desktop**, **Cu
 
 For VS Code, Cline, Continue, Windsurf, Antigravity, Goose, the HTTP transport, and a client that connects but lists no tools, see [MCP Clients](/external-api/mcp-clients).
 
+## Connection access
+
+The first time a client reaches one of your connections, TablePro asks. **Approval** under
+**Connection Access** decides how often it asks after that.
+
+| Approval | What happens |
+|---|---|
+| **Ask Every Time** | Every call that names a connection asks first |
+| **Ask Once for Each Connection** | The first call asks, and the answer is kept until you revoke it. The default |
+| **Never Ask** | Connections are reached without asking |
+
+Leave it at **Ask Once for Each Connection** unless a client runs unattended, in which case **Never
+Ask** stops the prompt from waiting for someone who is not there. Approvals already given are listed
+underneath, each with **Forget**.
+
+Approval decides only whether you are asked. It grants nothing: a connection **Blocked** for
+external clients stays blocked, a **Read Only** one stays read only, a connection whose AI policy is
+**Never** is refused, and [Safe Mode](/features/safe-mode#external-clients) still confirms
+destructive statements. **Never Ask** is not a way to skip any of those.
+
+The question always arrives as a dialog on your Mac, never through the client. A client that could
+answer it in its own interface could also answer it without asking you, and this is the gate that
+decides whether it reaches the connection at all.
+
+Nothing here times out. Whoever sent the request decides how long to wait for you, and an answer
+counts whenever you give it.
+
 ## Authentication
 
 **Require authentication** is on by default. Turning it on for the first time with no tokens yet generates a full-access "Default token" and shows the plaintext once, so copy it then. Create, scope, allowlist, expire and revoke tokens in the same section, described in [Tokens](/external-api/tokens).

--- a/docs/security/privacy.mdx
+++ b/docs/security/privacy.mdx
@@ -94,7 +94,7 @@ It is off by default, but it starts on demand: the bundled bridge and the pairin
 1. **Require authentication**, on by default. With it on, a request that arrives without an `Authorization` header is refused. Turn it off and a loopback caller with no header is allowed instead, capped at `tools:read` and `resources:read` however much it asks for.
 2. The token's scope and its connection allowlist.
 3. The connection's **External Clients** level: **Blocked**, **Read Only** (the default for a new connection), or **Read & Write**. The effective permission is the lower of that and the token's scope.
-4. The connection's **AI Policy** and its [Safe Mode](/features/safe-mode) level, which still apply to statements a client sends.
+4. The connection's **AI Policy** of **Never**, its [Safe Mode](/features/safe-mode) level, and the **Approval** setting under **Settings > Integrations**, which decides how often a client is asked before it reaches a connection.
 
 Loopback-only describes where the server binds, not everything that can reach it. The server returns CORS headers for two remote origins, `claude.ai` and `app.cursor.com`, so a page you have open there can call your local server from your own browser. The four gates above are what stands between such a call and your data, which is the reason to leave **Require authentication** on.
 


### PR DESCRIPTION
Fixes #2640.

## The problem

The MCP connection gate owned no policy, no consent surface and no durable grant of its own.

It read the AI chat's `AIConnectionPolicy`, whose only two controls are **Settings > AI > Privacy** and the connection form's **AI Policy** picker. Both are hidden when *Enable AI Features* is off (`AISettingsView.swift:25`, `ConnectionAdvancedView.swift:71`), so with AI off there was no control anywhere while the prompt still fired on every connection. The connection form's own footer said "AI Policy controls in-app AI agents. External Clients controls Raycast, Cursor, Claude Desktop, other MCP clients", which the code contradicted.

Two further defects made it worse, both measured rather than reasoned:

**The 30-second timeout could not do its job.** `promptApproval` raced an app-modal `NSAlert` against `Task.sleep(30s)` in a `withThrowingTaskGroup`. The group cannot propagate the timeout until the uncancellable modal child returns, so the request stayed blocked for the whole life of the alert and the user's eventual **Allow** was discarded and replaced with a timeout error. A probe reproducing the exact shape:

```
modal=3.0s timeout=0.3s -> threw TimedOut() after 3.00s
modal=0.3s timeout=3.0s -> returned true after 0.31s
```

Measured against the running app, a default-configuration `get_connection_status` from Claude Code returned `Timeout: tools/call exceeded the handler deadline` and nothing else. Claude Code waits 10 minutes (`MCP_TOOL_TIMEOUT`), so TablePro was the one giving up.

**The answer did not stick.** The grant lived in memory with a 30-minute TTL, and the bundled stdio bridge re-mints its credential every ~45 minutes with a fresh `UUID` and deletes the old one, which fired the revocation observer and cleared the grant. So the reporter's client re-prompted forever whatever they answered. `docs/external-api/mcp-tools.mdx` promised the opposite: "remembered for that token until it is revoked".

## The fix

**MCP owns its consent policy.** `MCPSettings.connectionApproval` (`Ask Every Time` / `Ask Once for Each Connection`, the default / `Never Ask`) in **Settings > Integrations**, with the list of approved connections and **Forget** / **Forget All**. Device-local, so no CloudKit schema deploy. `AIConnectionPolicy` keeps exactly its allow and deny powers: `.never` still denies and still hides the connection, `.alwaysAllow` still skips the prompt. AI-chat egress consent is untouched.

**Approval grants nothing.** External Clients **Blocked**, **Read Only**, the token's scopes and allowlist, and Safe Mode all still refuse under **Never Ask**, each covered by a test.

**Grants are durable and revocable**, filed under a stable client subject so the bridge's credential rotation no longer loses them, and no longer wiped by the teardown any settings edit triggers.

**The prompt stops being a trap.** The race is gone, a late Allow is honoured, and the client owns the timeout as the MCP lifecycle spec says. A refusal stands for 60 seconds so a retrying model cannot machine-gun modals. An injectable presenter means no test can raise a real modal.

## Security review changed the design

An adversarial review found three defects in the first draft, all fixed here:

1. **Client self-approval (HIGH).** The draft routed the approval through MCP elicitation. A client declares `elicitation` in its own `_meta` per request, so any client could have claimed the capability, posted its own acceptance, and turned that self-answer into a durable grant. The connection boundary is the one question a client may not answer about itself, so it is now always the native prompt. Statement consent can still be elicited because Safe Mode strips `confirmationPreCleared` from anything but an admin token; there is no second gate behind this one.
2. **Forgeable grant subject (HIGH).** The draft keyed the bridge identity on the token's *name*, which `tablepro://pair?client=…` supplies. A paired token named `__stdio_bridge__` would have inherited every grant the bridge earned, and was hidden from the token list. The bridge is now identified by an `isBridgeCredential` flag its own mint sets on the token record; the name is reserved, and the token-list filters key on the flag.
3. **"Ask Every Time" ignored existing grants (MEDIUM).** Tightening the setting left a client with a standing grant reaching the connection silently. The ledger is now consulted only at levels that remember answers.

A correctness review then found the denial cool-off skipped anonymous loopback callers (the no-auth mode), and that the prompt promised "this request only" while an anonymous approval was in fact kept for the session. Both fixed.

## Also fixed

- `MCPInputRequired` never reached the client: `asResult` had no production caller and the dispatcher turned the signal into `-32603 handler failed`. Every destructive-operation consent that the docs promise "through your elicitation prompt" was broken for elicitation-capable clients.
- `list_connections` reported `ai_policy` from a hardcoded `askEachTime` instead of the app default, so the field disagreed with what was enforced.

## Verification

- `build` PASS
- `test` PASS, 214 of 214 across the 14 suites owning the changed types
- `lint TablePro TableProTests` 0 violations
- `docs` PASS

No `TableProUITests` coverage: the flow's decisive step is an app-modal `NSAlert` raised by a background server, which XCUITest cannot drive deterministically from the app under test. The Settings picker and the grant list are covered by unit tests through the injectable presenter and store instead.


https://claude.ai/code/session_01LikBUDFCMFdFRg1iZ9WWcw
