### PR TITLE
refactor(sidebar): group the object tree context menu and move its globals out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tab moves focus out of Startup Commands and Pre-Connect Script instead of inserting a tab.
 - SQL export writes a materialized view's indexes once the view exists. (#2492)
 - Backup Dump as one sheet with scope, format and destination, in place of a picker with a save panel over it. (#2485)
+- Object tree context menu regrouped into four groups by intent, with the connection-wide commands off object rows.
+- View Options as a control in the sidebar's filter row, in place of an entry on every context menu.
+- View ER Diagram and New View on the object tree's empty-area menu only.
+- Keyboard shortcuts shown on sidebar context menu items that have a menu bar equivalent.
 
 ### Fixed
 
 - Connection with two transports enabled reaching the database directly, with neither transport applied.
+- Object list unchanged after toggling Show object icons or Show object comments in Settings.
 - Delete Connection missing from the connection editor since 0.39.0.
 - Continue dimmed after filtering the database chooser down to one driver.
 - Down arrow not reaching the list from the database chooser's search field.

--- a/TablePro/Core/Services/Infrastructure/SidebarContainerViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/SidebarContainerViewController.swift
@@ -45,7 +45,6 @@ internal final class SidebarContainerViewController: NSViewController {
         searchField.delegate = self
         searchField.setAccessibilityIdentifier("sidebar-filter")
         searchField.setAccessibilityLabel(String(localized: "Filter"))
-        view.addSubview(searchField)
 
         viewOptionsButton.isHidden = true
         viewOptionsButton.setContentHuggingPriority(.required, for: .horizontal)
@@ -127,6 +126,10 @@ internal final class SidebarContainerViewController: NSViewController {
             return
         }
         searchField.isHidden = false
+        /// Set here rather than left to the observation task, which runs on the next main-actor
+        /// turn: the button would show over the favorites filter for a turn on the way in, and
+        /// linger for a turn on the way out, with the stack view re-laying the row each time.
+        viewOptionsButton.isHidden = state.selectedSidebarTab != .tables
         observationTask = Task { @MainActor [weak self] in
             guard let self else { return }
             while !Task.isCancelled {

--- a/TablePro/Core/Services/Infrastructure/SidebarContainerViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/SidebarContainerViewController.swift
@@ -9,6 +9,10 @@ import SwiftUI
 @MainActor
 internal final class SidebarContainerViewController: NSViewController {
     private let searchField = NSSearchField()
+    /// Sidebar chrome, like the field it shares a row with, so it survives a connection switch and
+    /// writes settings that are not scoped to one. Hidden on the Favorites tab, whose list draws
+    /// none of what these options settle.
+    private let viewOptionsButton = SidebarViewOptionsButton()
     /// The filter field is window chrome and stays put; only the object list below it belongs to a
     /// connection, so that is the part the window swaps.
     private let listHost = WorkspacePaneHost()
@@ -43,6 +47,20 @@ internal final class SidebarContainerViewController: NSViewController {
         searchField.setAccessibilityLabel(String(localized: "Filter"))
         view.addSubview(searchField)
 
+        viewOptionsButton.isHidden = true
+        viewOptionsButton.setContentHuggingPriority(.required, for: .horizontal)
+
+        /// A stack view rather than two anchored controls, so hiding the button on the Favorites
+        /// tab takes its width with it: `detachesHiddenViews` removes a hidden arranged subview
+        /// from the layout, where a hidden anchored one would keep its gap beside the field.
+        let filterRow = NSStackView(views: [searchField, viewOptionsButton])
+        filterRow.translatesAutoresizingMaskIntoConstraints = false
+        filterRow.orientation = .horizontal
+        filterRow.alignment = .centerY
+        filterRow.spacing = 6
+        filterRow.detachesHiddenViews = true
+        view.addSubview(filterRow)
+
         addChild(listHost)
         let hostingView = listHost.view
         hostingView.translatesAutoresizingMaskIntoConstraints = false
@@ -51,17 +69,17 @@ internal final class SidebarContainerViewController: NSViewController {
 
         /// The insets are a margin, not an invariant, so they yield rather than break when the
         /// window narrows the sidebar to the workspace rail and leaves this view no width at all.
-        let searchLeading = searchField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10)
-        let searchTrailing = searchField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -10)
-        searchLeading.priority = .defaultHigh
-        searchTrailing.priority = .defaultHigh
+        let rowLeading = filterRow.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10)
+        let rowTrailing = filterRow.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -10)
+        rowLeading.priority = .defaultHigh
+        rowTrailing.priority = .defaultHigh
 
         NSLayoutConstraint.activate([
-            searchField.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 5),
-            searchLeading,
-            searchTrailing,
+            filterRow.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 5),
+            rowLeading,
+            rowTrailing,
 
-            hostingView.topAnchor.constraint(equalTo: searchField.bottomAnchor, constant: 5),
+            hostingView.topAnchor.constraint(equalTo: filterRow.bottomAnchor, constant: 5),
             hostingView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             hostingView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             hostingView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
@@ -105,6 +123,7 @@ internal final class SidebarContainerViewController: NSViewController {
         self.sidebarState = state
         guard let state else {
             searchField.isHidden = true
+            viewOptionsButton.isHidden = true
             return
         }
         searchField.isHidden = false
@@ -146,9 +165,11 @@ internal final class SidebarContainerViewController: NSViewController {
         case .tables:
             activeText = state.searchText
             placeholder = String(localized: "Filter")
+            viewOptionsButton.isHidden = false
         case .favorites:
             activeText = state.favoritesSearchText
             placeholder = String(localized: "Filter favorites")
+            viewOptionsButton.isHidden = true
         }
 
         if searchField.stringValue != activeText {

--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Commands.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Commands.swift
@@ -149,12 +149,8 @@ extension DatabaseTreeOutlineCoordinator {
             ClipboardService.shared.writeText(key)
         case .openRedisKey(let key, let keyType):
             mainCoordinator?.openRedisKey(key, keyType: keyType)
-        case .toggleObjectIcons:
-            AppSettingsManager.shared.general.showObjectIcons.toggle()
-        case .toggleObjectComments:
-            AppSettingsManager.shared.general.showObjectComments.toggle()
-        case .setRowSize(let size):
-            AppSettingsManager.shared.general.sidebarRowSize = size
+        case .toggleObjectIcons, .toggleObjectComments, .setRowSize:
+            _ = SidebarViewOptionsMenu.apply(command)
         }
     }
 

--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Commands.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Commands.swift
@@ -151,10 +151,8 @@ extension DatabaseTreeOutlineCoordinator {
             mainCoordinator?.openRedisKey(key, keyType: keyType)
         case .toggleObjectIcons:
             AppSettingsManager.shared.general.showObjectIcons.toggle()
-            refreshVisibleRows()
         case .toggleObjectComments:
             AppSettingsManager.shared.general.showObjectComments.toggle()
-            refreshVisibleRows()
         case .setRowSize(let size):
             AppSettingsManager.shared.general.sidebarRowSize = size
         }

--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Menu.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Menu.swift
@@ -16,7 +16,7 @@ extension DatabaseTreeOutlineCoordinator: NSMenuDelegate {
     internal func menuNeedsUpdate(_ menu: NSMenu) {
         SidebarMenuBuilder.fill(
             menu,
-            with: DatabaseTreeMenuSpec.items(for: menuContext()),
+            with: DatabaseTreeMenuSpec.sections(for: menuContext()),
             target: self,
             action: #selector(performMenuCommand(_:))
         )

--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator.swift
@@ -107,6 +107,26 @@ final class DatabaseTreeOutlineCoordinator: NSObject, NSTextFieldDelegate {
             }
         }
         favoritesObservers.withLockUnchecked { $0.append(databaseObserver) }
+        observeObjectListAppearance()
+    }
+
+    /// The rows repaint from the setting rather than from the command that wrote it, so the same
+    /// change arrives whether it came from the View Options control in the filter row, the
+    /// empty-area menu, or Settings. Toggling Show Object Icons in Settings used to repaint
+    /// nothing, because only the contextual menu's own handler called `refreshVisibleRows`.
+    ///
+    /// Re-arms itself, because `withObservationTracking` fires once per registration.
+    private func observeObjectListAppearance() {
+        withObservationTracking {
+            _ = AppSettingsManager.shared.general.showObjectIcons
+            _ = AppSettingsManager.shared.general.showObjectComments
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                self.refreshVisibleRows()
+                self.observeObjectListAppearance()
+            }
+        }
     }
 
     deinit {

--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator.swift
@@ -64,6 +64,7 @@ final class DatabaseTreeOutlineCoordinator: NSObject, NSTextFieldDelegate {
     private var favoriteTables: Set<FavoriteTablesStorage.FavoriteEntry> = []
     private var favoriteDatabases: Set<FavoriteDatabaseEntry> = []
     private let favoritesObservers = OSAllocatedUnfairLock<[any NSObjectProtocol]>(uncheckedState: [])
+    private var observedAppearance = DatabaseTreeOutlineCoordinator.objectListAppearance()
 
     init(
         favoriteTablesStorage: FavoriteTablesStorage = .shared,
@@ -116,17 +117,38 @@ final class DatabaseTreeOutlineCoordinator: NSObject, NSTextFieldDelegate {
     /// nothing, because only the contextual menu's own handler called `refreshVisibleRows`.
     ///
     /// Re-arms itself, because `withObservationTracking` fires once per registration.
+    ///
+    /// The macro registers access on the stored `general` property rather than on the two fields
+    /// read inside it, so this wakes on every `GeneralSettings` write, the query timeout and the
+    /// sync write-back included. `refreshVisibleRows` reconfigures every row of every open window,
+    /// so the two values are compared before it runs.
     private func observeObjectListAppearance() {
         withObservationTracking {
-            _ = AppSettingsManager.shared.general.showObjectIcons
-            _ = AppSettingsManager.shared.general.showObjectComments
+            _ = AppSettingsManager.shared.general
         } onChange: { [weak self] in
             Task { @MainActor in
                 guard let self else { return }
-                self.refreshVisibleRows()
+                let appearance = Self.objectListAppearance()
+                if appearance != self.observedAppearance {
+                    self.observedAppearance = appearance
+                    self.refreshVisibleRows()
+                }
                 self.observeObjectListAppearance()
             }
         }
+    }
+
+    private static func objectListAppearance() -> ObjectListAppearance {
+        let settings = AppSettingsManager.shared.general
+        return ObjectListAppearance(
+            showsIcons: settings.showObjectIcons,
+            showsComments: settings.showObjectComments
+        )
+    }
+
+    internal struct ObjectListAppearance: Equatable {
+        internal let showsIcons: Bool
+        internal let showsComments: Bool
     }
 
     deinit {

--- a/TablePro/Views/Sidebar/FavoritesOutlineCoordinator.swift
+++ b/TablePro/Views/Sidebar/FavoritesOutlineCoordinator.swift
@@ -328,7 +328,7 @@ internal final class FavoritesOutlineCoordinator<Row: View>: NSObject, NSOutline
         )
         SidebarMenuBuilder.fill(
             menu,
-            with: FavoritesMenuSpec.items(for: context),
+            with: FavoritesMenuSpec.sections(for: context),
             target: self,
             action: #selector(performFavoritesMenuCommand(_:))
         )

--- a/TablePro/Views/Sidebar/Menu/DatabaseTreeMenuContext.swift
+++ b/TablePro/Views/Sidebar/Menu/DatabaseTreeMenuContext.swift
@@ -1,0 +1,54 @@
+//
+//  DatabaseTreeMenuContext.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+/// Everything the object tree's contextual menu depends on, as values.
+///
+/// `clicked` is nil for a right-click in the empty area below the last row, which `NSOutlineView`
+/// reports as `clickedRow == -1`. That case used to produce no menu at all.
+internal struct DatabaseTreeMenuContext {
+    internal let clicked: DatabaseTreeNode.Kind?
+    internal let selectedTables: Set<DatabaseTreeTableRef>
+    internal let selectedContainers: [DatabaseContainerRef]
+    internal let activeDatabase: String?
+    internal let activeSchema: String?
+    /// Whether this engine can open a second connection to another database on the server, which
+    /// is what lets the export dialog scope itself to a database other than the active one.
+    internal let canReachOtherDatabases: Bool
+    internal let systemSchemas: Set<String>
+    internal let isReadOnly: Bool
+    internal let supportsImport: Bool
+    internal let importFormats: [ImportFormatOption]
+    internal let maintenanceOperations: [String]
+    internal let dropEligibility: ContainerDropEligibility.Context
+    internal let renameEligibility: ObjectRenameEligibility.Context
+    internal let containerEntityName: String
+    internal let containerEntityNamePlural: String
+    internal let schemaEntityName: String
+    internal let schemaEntityNamePlural: String
+    internal let objectKindTitles: [SidebarObjectKind: String]
+    internal let isFavorite: Bool
+    /// Keyed per database rather than resolved for the clicked row alone, because a right-click
+    /// inside a multi-selection acts on the whole selection and those databases need not share a tag.
+    internal var favoriteDatabaseEnvironments: [String: FavoriteDatabaseEnvironment] = [:]
+    internal let showObjectIcons: Bool
+    internal let showObjectComments: Bool
+    internal let rowSize: SidebarRowSizePreference
+    internal var canFilterDatabases: Bool = false
+    internal var hasDatabaseFilter: Bool = false
+    /// Copying reads the source and writes somewhere else, so it needs a driver that reports
+    /// structure and a target that is not this connection's read-only self.
+    internal var canCopyObjects: Bool = false
+    /// Duplicating means creating a database, which is the same test the New Database command uses.
+    internal var canDuplicateDatabase: Bool = false
+
+    /// Whether this connection has a dump tool at all. Backing up writes nothing to the database,
+    /// so safe mode does not gate it, which is the same rule File > Backup Dump follows.
+    internal var canBackUp: Bool = false
+    /// Whether the driver can offer a CREATE TYPE template. Read-only mode still hides the item.
+    internal var canCreateType: Bool = false
+}

--- a/TablePro/Views/Sidebar/Menu/DatabaseTreeMenuSpec.swift
+++ b/TablePro/Views/Sidebar/Menu/DatabaseTreeMenuSpec.swift
@@ -6,113 +6,63 @@
 import Foundation
 import TableProPluginKit
 
-/// Everything the object tree's contextual menu depends on, as values.
-///
-/// `clicked` is nil for a right-click in the empty area below the last row, which `NSOutlineView`
-/// reports as `clickedRow == -1`. That case used to produce no menu at all.
-internal struct DatabaseTreeMenuContext {
-    internal let clicked: DatabaseTreeNode.Kind?
-    internal let selectedTables: Set<DatabaseTreeTableRef>
-    internal let selectedContainers: [DatabaseContainerRef]
-    internal let activeDatabase: String?
-    internal let activeSchema: String?
-    /// Whether this engine can open a second connection to another database on the server, which
-    /// is what lets the export dialog scope itself to a database other than the active one.
-    internal let canReachOtherDatabases: Bool
-    internal let systemSchemas: Set<String>
-    internal let isReadOnly: Bool
-    internal let supportsImport: Bool
-    internal let importFormats: [ImportFormatOption]
-    internal let maintenanceOperations: [String]
-    internal let dropEligibility: ContainerDropEligibility.Context
-    internal let renameEligibility: ObjectRenameEligibility.Context
-    internal let containerEntityName: String
-    internal let containerEntityNamePlural: String
-    internal let schemaEntityName: String
-    internal let schemaEntityNamePlural: String
-    internal let objectKindTitles: [SidebarObjectKind: String]
-    internal let isFavorite: Bool
-    /// Keyed per database rather than resolved for the clicked row alone, because a right-click
-    /// inside a multi-selection acts on the whole selection and those databases need not share a tag.
-    internal var favoriteDatabaseEnvironments: [String: FavoriteDatabaseEnvironment] = [:]
-    internal let showObjectIcons: Bool
-    internal let showObjectComments: Bool
-    internal let rowSize: SidebarRowSizePreference
-    internal var canFilterDatabases: Bool = false
-    internal var hasDatabaseFilter: Bool = false
-    /// Copying reads the source and writes somewhere else, so it needs a driver that reports
-    /// structure and a target that is not this connection's read-only self.
-    internal var canCopyObjects: Bool = false
-    /// Duplicating means creating a database, which is the same test the New Database command uses.
-    internal var canDuplicateDatabase: Bool = false
-
-    /// Whether this connection has a dump tool at all. Backing up writes nothing to the database,
-    /// so safe mode does not gate it, which is the same rule File > Backup Dump follows.
-    internal var canBackUp: Bool = false
-    /// Whether the driver can offer a CREATE TYPE template. Read-only mode still hides the item.
-    internal var canCreateType: Bool = false
-}
-
 internal enum DatabaseTreeMenuSpec {
-    /// Every menu ends with View Options, including a row's. It used to hang off row menus only,
-    /// which put it out of reach whenever the list was empty, loading or failed.
-    internal static func items(for context: DatabaseTreeMenuContext) -> [DatabaseTreeMenuItem] {
-        let rows = rawItems(for: context)
-        let viewOptions = DatabaseTreeMenuItem.submenu(
-            title: String(localized: "View Options"),
-            items: viewOptionItems(context)
-        )
-        guard !rows.contains(viewOptions) else {
-            return DatabaseTreeMenuItem.collapsingSeparators(rows)
-        }
-        return DatabaseTreeMenuItem.collapsingSeparators(rows + [.separator, viewOptions])
-    }
-
-    private static func rawItems(for context: DatabaseTreeMenuContext) -> [DatabaseTreeMenuItem] {
-        guard let clicked = context.clicked else { return backgroundItems(context) }
+    /// A menu is a list of groups, and every group here is one intent: reach the object, note it,
+    /// move its data, change it. The HIG asks for a small number of items in about three groups and
+    /// for commands relevant to the clicked object only, so nothing connection-wide belongs on a
+    /// row. View Options used to be appended to every menu including every object row, and View ER
+    /// Diagram sat in the middle of a table row's clipboard and export commands; both now live on
+    /// the empty-area menu, where the thing they act on is the sidebar rather than an object.
+    internal static func sections(for context: DatabaseTreeMenuContext) -> [DatabaseTreeMenuSection] {
+        guard let clicked = context.clicked else { return backgroundSections(context) }
         switch clicked {
         case .recentTable(let ref):
-            return tableItems(ref, context: context, isRecentRow: true) + [
-                .separator,
-                .command(String(localized: "Remove from Recent"), .removeRecent(ref)),
-                .command(String(localized: "Clear Recent Tables"), .clearRecents)
+            return tableSections(ref, context: context, isRecentRow: true) + [
+                DatabaseTreeMenuSection([
+                    .command(String(localized: "Remove from Recent"), .removeRecent(ref)),
+                    .command(String(localized: "Clear Recent Tables"), .clearRecents)
+                ])
             ]
         case .table(let ref):
-            return tableItems(ref, context: context)
+            return tableSections(ref, context: context)
         case .database(let metadata):
-            return containerItems(.database(metadata.name, isSystem: metadata.isSystemDatabase), context: context)
+            return containerSections(.database(metadata.name, isSystem: metadata.isSystemDatabase), context: context)
         case .schema(let database, let schema):
-            return containerItems(
+            return containerSections(
                 .schema(database: database, schema: schema, isSystem: context.systemSchemas.contains(schema)),
                 context: context
             )
         case .routine(let ref):
-            return routineItems(ref)
+            return routineSections(ref)
         case .trigger(let ref):
-            return triggerItems(ref)
+            return triggerSections(ref)
         case .userType(let ref):
-            return userTypeItems(ref)
+            return userTypeSections(ref)
         case .objectKindSection(let kind):
-            return objectKindItems(kind, context: context)
+            return objectKindSections(kind, context: context)
         case .containerObjectKindSection(let group):
-            return [.command(String(localized: "Refresh"), .refreshContainerObjectKind(group))]
-                + createTypeItems(kind: group.kind, database: group.database, schema: group.schema, context: context)
+            return [
+                DatabaseTreeMenuSection([.command(String(localized: "Refresh"), .refreshContainerObjectKind(group))]),
+                DatabaseTreeMenuSection(
+                    createTypeItems(kind: group.kind, database: group.database, schema: group.schema, context: context)
+                )
+            ]
         case .hierarchicalSchemaSection(let schema):
-            return hierarchicalSchemaItems(schema, context: context)
+            return hierarchicalSchemaSections(schema, context: context)
         case .redisNode(let node):
-            return redisItems(node)
+            return redisSections(node)
         case .status, .recentSection, .redisKeysSection:
-            return backgroundItems(context)
+            return backgroundSections(context)
         }
     }
 
     // MARK: - Objects
 
-    private static func tableItems(
+    private static func tableSections(
         _ ref: DatabaseTreeTableRef,
         context: DatabaseTreeMenuContext,
         isRecentRow: Bool = false
-    ) -> [DatabaseTreeMenuItem] {
+    ) -> [DatabaseTreeMenuSection] {
         /// Narrowed to the clicked row's own database, because a queued Truncate or Drop is
         /// applied by one save against one database. A tree selection can span two of them, and
         /// the second database's tables would then either run in the first or refuse the whole
@@ -120,7 +70,18 @@ internal enum DatabaseTreeMenuSpec {
         let targets = SidebarMenuTarget
             .resolve(clicked: ref, selection: Array(context.selectedTables))
             .filter { $0.database == ref.database }
-        let names = targets.map(\.table.name).sorted()
+        return [
+            DatabaseTreeMenuSection(openItems(ref, context: context)),
+            DatabaseTreeMenuSection(noteItems(ref, targets: targets, context: context)),
+            DatabaseTreeMenuSection(dataItems(ref, targets: targets, context: context)),
+            DatabaseTreeMenuSection(writeItems(ref, targets: targets, context: context, isRecentRow: isRecentRow))
+        ]
+    }
+
+    private static func openItems(
+        _ ref: DatabaseTreeTableRef,
+        context: DatabaseTreeMenuContext
+    ) -> [DatabaseTreeMenuItem] {
         var items: [DatabaseTreeMenuItem] = [
             .command(String(localized: "Open in New Tab"), .openInNewTab(ref)),
             .command(String(localized: "Show Structure"), .showStructure(ref))
@@ -128,18 +89,42 @@ internal enum DatabaseTreeMenuSpec {
         if SidebarContextMenuLogic.isView(clickedTable: ref.table), !context.isReadOnly {
             items.append(.command(String(localized: "Edit View Definition"), .editViewDefinition(ref)))
         }
-        items.append(.separator)
-        items.append(.command(
-            context.isFavorite
-                ? String(localized: "Remove from Favorites")
-                : String(localized: "Add to Favorites"),
-            .toggleFavorite(ref)
-        ))
-        items.append(.separator)
-        items.append(.command(copyNamesTitle(count: names.count), .copyTableNames(names)))
-        items.append(.command(String(localized: "Export…"), .exportTables(names: Set(names), ref: ref)))
-        items.append(.command(
-            String(localized: "Transfer To…"), .transferTables(names: Set(names), ref: ref)))
+        return items
+    }
+
+    private static func noteItems(
+        _ ref: DatabaseTreeTableRef,
+        targets: [DatabaseTreeTableRef],
+        context: DatabaseTreeMenuContext
+    ) -> [DatabaseTreeMenuItem] {
+        let names = targets.map(\.table.name).sorted()
+        return [
+            .command(copyNamesTitle(count: names.count), .copyTableNames(names)),
+            .command(
+                context.isFavorite
+                    ? String(localized: "Remove from Favorites")
+                    : String(localized: "Add to Favorites"),
+                .toggleFavorite(ref)
+            )
+        ]
+    }
+
+    /// Everything that moves the object's data somewhere else, in the order the work usually runs:
+    /// out of the table, into it, across to another connection, across to another database.
+    private static func dataItems(
+        _ ref: DatabaseTreeTableRef,
+        targets: [DatabaseTreeTableRef],
+        context: DatabaseTreeMenuContext
+    ) -> [DatabaseTreeMenuItem] {
+        let names = Set(targets.map(\.table.name))
+        var items: [DatabaseTreeMenuItem] = [
+            .command(String(localized: "Export…"), .exportTables(names: names, ref: ref))
+        ]
+        if !context.isReadOnly,
+           SidebarContextMenuLogic.importVisible(clickedTable: ref.table, supportsImport: context.supportsImport) {
+            items += importItems(context.importFormats, ref: ref)
+        }
+        items.append(.command(String(localized: "Transfer To…"), .transferTables(names: names, ref: ref)))
         if context.canCopyObjects {
             /// Narrowed to the clicked row's own schema as well as its database. A copy names one
             /// source scope, so a selection spanning two schemas would read one of them and either
@@ -150,13 +135,6 @@ internal enum DatabaseTreeMenuSpec {
                 .copyObjectsTo(objects: copySelections(for: sameScope), ref: ref)
             ))
         }
-        items.append(.command(String(localized: "View ER Diagram"), .showERDiagram))
-
-        if !context.isReadOnly,
-           SidebarContextMenuLogic.importVisible(clickedTable: ref.table, supportsImport: context.supportsImport) {
-            items += importItems(context.importFormats, ref: ref)
-        }
-
         if SidebarContextMenuLogic.maintenanceGroupEnabled(
             isReadOnly: context.isReadOnly,
             hasSelection: true,
@@ -169,13 +147,22 @@ internal enum DatabaseTreeMenuSpec {
                 }
             ))
         }
+        return items
+    }
 
-        guard !context.isReadOnly else { return items }
-        items.append(.separator)
+    /// Destructive last, behind its own separator, which is the only way macOS sets one apart:
+    /// `NSMenuItem` has no destructive role and Apple does not colour Finder's Move to Trash.
+    private static func writeItems(
+        _ ref: DatabaseTreeTableRef,
+        targets: [DatabaseTreeTableRef],
+        context: DatabaseTreeMenuContext,
+        isRecentRow: Bool
+    ) -> [DatabaseTreeMenuItem] {
+        guard !context.isReadOnly else { return [] }
+        var items: [DatabaseTreeMenuItem] = []
         if ObjectRenameEligibility.canRename(table: ref.table, context: context.renameEligibility) {
             items.append(.command(String(localized: "Rename"), .beginRenameTable(ref: ref, isRecentRow: isRecentRow)))
         }
-        items.append(.command(String(localized: "Create New View…"), .createView))
         if SidebarContextMenuLogic.truncateVisible(clickedTable: ref.table) {
             items.append(.command(String(localized: "Truncate"), .truncateTables(targets: targets, ref: ref)))
         }
@@ -202,41 +189,44 @@ internal enum DatabaseTreeMenuSpec {
         )]
     }
 
-    private static func routineItems(_ ref: DatabaseTreeRoutineRef) -> [DatabaseTreeMenuItem] {
-        var items: [DatabaseTreeMenuItem] = [.command(String(localized: "Copy Name"), .copyText(ref.routine.name))]
+    private static func routineSections(_ ref: DatabaseTreeRoutineRef) -> [DatabaseTreeMenuSection] {
+        var copies: [DatabaseTreeMenuItem] = [.command(String(localized: "Copy Name"), .copyText(ref.routine.name))]
         if let signature = ref.routine.argumentSignature, !signature.isEmpty {
-            items.append(.command(
+            copies.append(.command(
                 String(localized: "Copy with Signature"),
                 .copyText(RoutineDisplayLabel.copyableSignature(for: ref.routine))
             ))
         }
-        items.append(.separator)
-        items.append(.command(String(localized: "Show DDL"), .showObjectSource(ref.objectRef)))
-        return items
+        return [
+            DatabaseTreeMenuSection(copies),
+            DatabaseTreeMenuSection([.command(String(localized: "Show DDL"), .showObjectSource(ref.objectRef))])
+        ]
     }
 
-    private static func triggerItems(_ ref: DatabaseTreeTriggerRef) -> [DatabaseTreeMenuItem] {
-        var items: [DatabaseTreeMenuItem] = [.command(String(localized: "Copy Name"), .copyText(ref.trigger.name))]
+    private static func triggerSections(_ ref: DatabaseTreeTriggerRef) -> [DatabaseTreeMenuSection] {
+        var copies: [DatabaseTreeMenuItem] = [.command(String(localized: "Copy Name"), .copyText(ref.trigger.name))]
         if let table = ref.trigger.table, !table.isEmpty {
-            items.append(.command(String(localized: "Copy Table Name"), .copyText(table)))
+            copies.append(.command(String(localized: "Copy Table Name"), .copyText(table)))
         }
-        items.append(.separator)
-        items.append(.command(String(localized: "Show DDL"), .showObjectSource(ref.objectRef)))
-        return items
+        return [
+            DatabaseTreeMenuSection(copies),
+            DatabaseTreeMenuSection([.command(String(localized: "Show DDL"), .showObjectSource(ref.objectRef))])
+        ]
     }
 
-    private static func userTypeItems(_ ref: DatabaseTreeUserTypeRef) -> [DatabaseTreeMenuItem] {
-        var items: [DatabaseTreeMenuItem] = [.command(String(localized: "Copy Name"), .copyText(ref.type.name))]
+    private static func userTypeSections(_ ref: DatabaseTreeUserTypeRef) -> [DatabaseTreeMenuSection] {
+        var copies: [DatabaseTreeMenuItem] = [.command(String(localized: "Copy Name"), .copyText(ref.type.name))]
         if ref.type.qualifiedName != ref.type.name {
-            items.append(.command(String(localized: "Copy Qualified Name"), .copyText(ref.type.qualifiedName)))
+            copies.append(.command(String(localized: "Copy Qualified Name"), .copyText(ref.type.qualifiedName)))
         }
-        items.append(.separator)
-        items.append(.command(String(localized: "Show Definition"), .showObjectSource(ref.objectRef)))
-        return items
+        return [
+            DatabaseTreeMenuSection(copies),
+            DatabaseTreeMenuSection([.command(String(localized: "Show Definition"), .showObjectSource(ref.objectRef))])
+        ]
     }
 
     /// Only the Types section offers it, and only where the engine can hand over a template. It is
-    /// omitted rather than disabled in read-only mode, the way Create New View is on a table row.
+    /// omitted rather than disabled in read-only mode, the way New View is on the empty-area menu.
     private static func createTypeItems(
         kind: SidebarObjectKind,
         database: String?,
@@ -244,28 +234,29 @@ internal enum DatabaseTreeMenuSpec {
         context: DatabaseTreeMenuContext
     ) -> [DatabaseTreeMenuItem] {
         guard kind == .type, context.canCreateType, !context.isReadOnly else { return [] }
-        return [
-            .separator,
-            .command(String(localized: "Create New Type…"), .createType(database: database, schema: schema))
-        ]
+        return [.command(String(localized: "New Type…"), .createType(database: database, schema: schema))]
     }
 
-    private static func redisItems(_ node: RedisKeyNode) -> [DatabaseTreeMenuItem] {
+    private static func redisSections(_ node: RedisKeyNode) -> [DatabaseTreeMenuSection] {
         switch node {
         case .namespace(_, let fullPrefix, _, _):
-            return [.command(String(localized: "Copy Namespace Prefix"), .copyRedisNamespacePrefix(fullPrefix))]
+            return [DatabaseTreeMenuSection([
+                .command(String(localized: "Copy Namespace Prefix"), .copyRedisNamespacePrefix(fullPrefix))
+            ])]
         case .key(_, let fullKey, let keyType):
             return [
-                .command(String(localized: "Copy Key"), .copyRedisKey(fullKey)),
-                .command(String(localized: "Open in New Tab"), .openRedisKey(key: fullKey, keyType: keyType))
+                DatabaseTreeMenuSection([
+                    .command(String(localized: "Open in New Tab"), .openRedisKey(key: fullKey, keyType: keyType))
+                ]),
+                DatabaseTreeMenuSection([.command(String(localized: "Copy Key"), .copyRedisKey(fullKey))])
             ]
         }
     }
 
-    private static func objectKindItems(
+    private static func objectKindSections(
         _ kind: SidebarObjectKind,
         context: DatabaseTreeMenuContext
-    ) -> [DatabaseTreeMenuItem] {
+    ) -> [DatabaseTreeMenuSection] {
         var items: [DatabaseTreeMenuItem] = []
         if kind == .table {
             let title = context.objectKindTitles[kind] ?? kind.pluralDisplayName
@@ -275,79 +266,87 @@ internal enum DatabaseTreeMenuSpec {
             ))
         }
         items.append(.command(String(localized: "Refresh"), .refreshObjectKind(kind)))
-        items += createTypeItems(
-            kind: kind, database: context.activeDatabase, schema: context.activeSchema, context: context
-        )
-        return items
+        return [
+            DatabaseTreeMenuSection(items),
+            DatabaseTreeMenuSection(createTypeItems(
+                kind: kind, database: context.activeDatabase, schema: context.activeSchema, context: context
+            ))
+        ]
     }
 
     /// An engine whose tree hangs tables off schemas draws no database rows at all, so its schemas
     /// arrive here rather than as `.schema`. Without this the rename an engine declares and
     /// implements is unreachable on Snowflake and Trino, which are the two that do.
-    private static func hierarchicalSchemaItems(
+    private static func hierarchicalSchemaSections(
         _ schema: String,
         context: DatabaseTreeMenuContext
-    ) -> [DatabaseTreeMenuItem] {
-        var items: [DatabaseTreeMenuItem] = [
-            .command(String(localized: "Refresh"), .refreshHierarchicalSchema(schema))
-        ]
+    ) -> [DatabaseTreeMenuSection] {
         let ref = DatabaseContainerRef.schema(
             database: context.activeDatabase,
             schema: schema,
             isSystem: context.systemSchemas.contains(schema)
         )
-        /// Oracle, Snowflake, Trino, Dameng and BigQuery draw their schemas here rather than as
-        /// container rows, and several of them need a schema-scoped source, so leaving Copy To on
-        /// the container path alone put it out of reach on exactly the engines that require it.
-        items += copyItems(ref, context: context)
-        guard let renameable = ObjectRenameEligibility.renameable([ref], context: context.renameEligibility)
-        else { return items }
-        items.append(.separator)
-        items.append(.command(renameTitle(for: renameable, context: context), .renameContainer(renameable)))
-        return items
+        var writes: [DatabaseTreeMenuItem] = []
+        if let renameable = ObjectRenameEligibility.renameable([ref], context: context.renameEligibility) {
+            writes.append(.command(renameTitle(for: renameable, context: context), .renameContainer(renameable)))
+        }
+        return [
+            DatabaseTreeMenuSection([.command(String(localized: "Refresh"), .refreshHierarchicalSchema(schema))]),
+            /// Oracle, Snowflake, Trino, Dameng and BigQuery draw their schemas here rather than as
+            /// container rows, and several of them need a schema-scoped source, so leaving Copy To
+            /// on the container path alone put it out of reach on exactly the engines that require it.
+            DatabaseTreeMenuSection(copyItems(ref, context: context)),
+            DatabaseTreeMenuSection(writes)
+        ]
     }
 
     // MARK: - Containers
 
-    private static func containerItems(
+    private static func containerSections(
         _ clicked: DatabaseContainerRef,
         context: DatabaseTreeMenuContext
-    ) -> [DatabaseTreeMenuItem] {
+    ) -> [DatabaseTreeMenuSection] {
         let targets = SidebarMenuTarget.resolveContainers(clicked: clicked, selection: context.selectedContainers)
-        let droppable = ContainerDropEligibility.droppable(targets, context: context.dropEligibility)
-        var items: [DatabaseTreeMenuItem] = []
-
+        var open: [DatabaseTreeMenuItem] = []
         /// Omitted rather than disabled: a menu item that can never fire in this state is noise, and
         /// the HIG prefers removing an item that does not apply over showing it greyed out.
         if targets.count == 1, !isActive(clicked, context: context) {
-            items.append(.command(useAsActiveTitle(for: clicked, context: context), .useAsActive(clicked)))
+            open.append(.command(useAsActiveTitle(for: clicked, context: context), .useAsActive(clicked)))
         }
-        items.append(.command(String(localized: "Refresh"), .refreshContainers(targets)))
-        items.append(.command(copyNamesTitle(count: targets.count), .copyContainerNames(targets)))
+        open.append(.command(String(localized: "Refresh"), .refreshContainers(targets)))
 
+        var note: [DatabaseTreeMenuItem] = [.command(copyNamesTitle(count: targets.count), .copyContainerNames(targets))]
         let favoriteDatabases = targets.filter { $0.kind == .database }.compactMap(\.database)
         if !favoriteDatabases.isEmpty {
-            let favoriteItems = favoriteDatabaseItems(
+            note += favoriteDatabaseItems(
                 databases: favoriteDatabases,
                 state: FavoriteDatabaseSelectionState(
                     environments: favoriteDatabases.map { context.favoriteDatabaseEnvironments[$0] }
                 )
             )
-            if !favoriteItems.isEmpty {
-                items.append(.separator)
-                items += favoriteItems
-            }
         }
 
+        return [
+            DatabaseTreeMenuSection(open),
+            DatabaseTreeMenuSection(note),
+            DatabaseTreeMenuSection(containerDataItems(clicked, targets: targets, context: context)),
+            DatabaseTreeMenuSection(containerWriteItems(targets: targets, context: context))
+        ]
+    }
+
+    private static func containerDataItems(
+        _ clicked: DatabaseContainerRef,
+        targets: [DatabaseContainerRef],
+        context: DatabaseTreeMenuContext
+    ) -> [DatabaseTreeMenuItem] {
+        var items: [DatabaseTreeMenuItem] = []
         if ExportPreselection.canPreselect(
             containers: targets,
             activeDatabase: context.activeDatabase,
             canReachOtherDatabases: context.canReachOtherDatabases
         ) {
-            items.append(.separator)
             items.append(.command(String(localized: "Export…"), .exportContainers(targets)))
         }
-
         /// Offered on a multi-selection where Export is not: `ExportPreselection.canPreselect`
         /// requires every container to share one database, and backing several databases up into
         /// one folder is the whole point of the command.
@@ -360,12 +359,18 @@ internal enum DatabaseTreeMenuSpec {
         if targets.count == 1 {
             items += copyItems(clicked, context: context)
         }
-        let renameable = ObjectRenameEligibility.renameable(targets, context: context.renameEligibility)
-        guard renameable != nil || !droppable.isEmpty else { return items }
-        items.append(.separator)
-        if let renameable {
+        return items
+    }
+
+    private static func containerWriteItems(
+        targets: [DatabaseContainerRef],
+        context: DatabaseTreeMenuContext
+    ) -> [DatabaseTreeMenuItem] {
+        var items: [DatabaseTreeMenuItem] = []
+        if let renameable = ObjectRenameEligibility.renameable(targets, context: context.renameEligibility) {
             items.append(.command(renameTitle(for: renameable, context: context), .renameContainer(renameable)))
         }
+        let droppable = ContainerDropEligibility.droppable(targets, context: context.dropEligibility)
         if !droppable.isEmpty {
             items.append(.command(dropTitle(for: droppable, context: context), .dropContainers(droppable)))
         }
@@ -414,8 +419,7 @@ internal enum DatabaseTreeMenuSpec {
         if clicked.kind == .database, context.canDuplicateDatabase, !clicked.isSystem {
             items.append(.command(String(localized: "Duplicate Database…"), .duplicateDatabase(clicked)))
         }
-        guard !items.isEmpty else { return [] }
-        return [.separator] + items
+        return items
     }
 
     /// A table row's copy carries the whole selection the menu resolved, so right-clicking inside a
@@ -492,49 +496,30 @@ internal enum DatabaseTreeMenuSpec {
 
     /// The menu for the empty area below the last row, and for the rows that stand for nothing.
     /// It has to produce at least one item: a menu that updates to nothing still shows an empty frame.
-    private static func backgroundItems(_ context: DatabaseTreeMenuContext) -> [DatabaseTreeMenuItem] {
-        var items: [DatabaseTreeMenuItem] = []
+    ///
+    /// This is where everything scoped to the connection or the sidebar lives, rather than on an
+    /// object row: creating an object names no existing one, the diagram is the whole schema, the
+    /// database filter and View Options are the sidebar's own state.
+    private static func backgroundSections(_ context: DatabaseTreeMenuContext) -> [DatabaseTreeMenuSection] {
+        var creation: [DatabaseTreeMenuItem] = []
         if !context.isReadOnly {
-            items.append(.command(String(localized: "New Table…"), .createTable))
-            items.append(.command(String(localized: "New View…"), .createView))
-            items.append(.separator)
+            creation.append(.command(String(localized: "New Table…"), .createTable))
+            creation.append(.command(String(localized: "New View…"), .createView))
         }
-        items.append(.command(String(localized: "View ER Diagram"), .showERDiagram))
+        var filters: [DatabaseTreeMenuItem] = []
         if context.canFilterDatabases {
-            items.append(.separator)
-            items.append(.command(String(localized: "Filter Databases…"), .filterDatabases))
+            filters.append(.command(String(localized: "Filter Databases…"), .filterDatabases))
             if context.hasDatabaseFilter {
-                items.append(.command(String(localized: "Show All Databases"), .showAllDatabases))
+                filters.append(.command(String(localized: "Show All Databases"), .showAllDatabases))
             }
         }
-        items.append(.separator)
-        items.append(.submenu(title: String(localized: "View Options"), items: viewOptionItems(context)))
-        return items
-    }
-
-    /// Reachable from every menu, including the empty-area one, because it was previously nested in
-    /// a row's menu and so disappeared entirely whenever the sidebar was empty, loading or failed.
-    internal static func viewOptionItems(_ context: DatabaseTreeMenuContext) -> [DatabaseTreeMenuItem] {
-        var items: [DatabaseTreeMenuItem] = [
-            .command(SidebarMenuEntry(
-                title: String(localized: "Icons"),
-                command: .toggleObjectIcons,
-                isOn: context.showObjectIcons
-            )),
-            .command(SidebarMenuEntry(
-                title: String(localized: "Comments"),
-                command: .toggleObjectComments,
-                isOn: context.showObjectComments
-            )),
-            .separator
+        return [
+            DatabaseTreeMenuSection(creation),
+            DatabaseTreeMenuSection([.command(String(localized: "View ER Diagram"), .showERDiagram)]),
+            DatabaseTreeMenuSection(filters),
+            DatabaseTreeMenuSection([
+                .submenu(title: SidebarViewOptionsMenu.title, sections: SidebarViewOptionsMenu.sections(context))
+            ])
         ]
-        items += SidebarRowSizePreference.allCases.map { size in
-            .command(SidebarMenuEntry(
-                title: size.title,
-                command: .setRowSize(size),
-                isOn: context.rowSize == size
-            ))
-        }
-        return items
     }
 }

--- a/TablePro/Views/Sidebar/Menu/FavoritesMenuSpec.swift
+++ b/TablePro/Views/Sidebar/Menu/FavoritesMenuSpec.swift
@@ -29,30 +29,26 @@ internal struct FavoritesMenuContext {
 }
 
 internal enum FavoritesMenuSpec {
-    internal static func items(for context: FavoritesMenuContext) -> [FavoritesMenuItem] {
-        SidebarMenuItem.collapsingSeparators(rawItems(for: context))
-    }
-
-    private static func rawItems(for context: FavoritesMenuContext) -> [FavoritesMenuItem] {
-        guard let clicked = context.clicked else { return backgroundItems(context) }
+    internal static func sections(for context: FavoritesMenuContext) -> [FavoritesMenuSection] {
+        guard let clicked = context.clicked else { return backgroundSections(context) }
         switch clicked {
         case .databaseEnvironment:
-            return backgroundItems(context)
+            return backgroundSections(context)
         case .database(let entry):
-            return databaseItems(entry, context: context)
+            return databaseSections(entry, context: context)
         case .table(let table):
-            return tableItems(table)
+            return tableSections(table)
         case .query(let node):
-            return queryItems(node, context: context)
+            return querySections(node, context: context)
         case .header, .teamQuery:
-            return backgroundItems(context)
+            return backgroundSections(context)
         }
     }
 
-    private static func databaseItems(
+    private static func databaseSections(
         _ entry: FavoriteDatabaseEntry,
         context: FavoritesMenuContext
-    ) -> [FavoritesMenuItem] {
+    ) -> [FavoritesMenuSection] {
         var items: [FavoritesMenuItem] = []
         if entry.database != context.activeDatabase {
             items.append(.command(
@@ -74,57 +70,67 @@ internal enum FavoritesMenuSpec {
                 ))
             }
         ))
-        items.append(.separator)
-        items.append(.command(FavoriteDatabaseMenu.removeTitle, .removeDatabaseFavorite(entry)))
-        return items
-    }
-
-    private static func tableItems(_ table: TableInfo) -> [FavoritesMenuItem] {
-        [
-            .command(String(localized: "Open Table"), .openTable(table)),
-            .command(String(localized: "Show ER Diagram"), .showERDiagram),
-            .separator,
-            .command(String(localized: "Remove from Favorites"), .removeTableFavorite(table))
+        return [
+            FavoritesMenuSection(items),
+            FavoritesMenuSection([
+                .command(FavoriteDatabaseMenu.removeTitle, .removeDatabaseFavorite(entry))
+            ])
         ]
     }
 
-    private static func queryItems(
+    /// Spelled as the Database menu and the object tree spell it. It read "Show ER Diagram" here
+    /// and "View ER Diagram" everywhere else, which is one command reading as two.
+    private static func tableSections(_ table: TableInfo) -> [FavoritesMenuSection] {
+        [
+            FavoritesMenuSection([
+                .command(String(localized: "Open Table"), .openTable(table)),
+                .command(String(localized: "View ER Diagram"), .showERDiagram)
+            ]),
+            FavoritesMenuSection([
+                .command(String(localized: "Remove from Favorites"), .removeTableFavorite(table))
+            ])
+        ]
+    }
+
+    private static func querySections(
         _ node: FavoriteNode,
         context: FavoritesMenuContext
-    ) -> [FavoritesMenuItem] {
+    ) -> [FavoritesMenuSection] {
         switch node.content {
         case .favorite(let favorite):
-            return favoriteItems(favorite, context: context)
+            return favoriteSections(favorite, context: context)
         case .linkedFavorite(let linked):
-            return linkedFavoriteItems(linked)
+            return linkedFavoriteSections(linked)
         case .folder(let folder):
-            return folderItems(folder)
+            return folderSections(folder)
         case .linkedFolder(let folder):
-            return linkedFolderItems(folder)
+            return linkedFolderSections(folder)
         case .linkedSubfolder:
             /// A subfolder mirrors a directory, so it owns no command of its own. It still gets the
             /// background menu rather than an empty frame.
-            return backgroundItems(context)
+            return backgroundSections(context)
         }
     }
 
-    private static func favoriteItems(
+    private static func favoriteSections(
         _ favorite: SQLFavorite,
         context: FavoritesMenuContext
-    ) -> [FavoritesMenuItem] {
-        var items: [FavoritesMenuItem] = [
-            .command(String(localized: "Insert in Editor"), .insertFavorite(favorite)),
-            .command(String(localized: "Run in New Tab"), .runFavoriteInNewTab(favorite)),
-            .separator,
+    ) -> [FavoritesMenuSection] {
+        var edits: [FavoritesMenuItem] = [
             .command(String(localized: "Copy Query"), .copyText(favorite.query)),
             .command(String(localized: "Edit…"), .editFavorite(favorite))
         ]
         if let moveTo = moveToSubmenu(favorite, folders: context.allFolders) {
-            items.append(moveTo)
+            edits.append(moveTo)
         }
-        items.append(.separator)
-        items.append(.command(String(localized: "Delete"), .deleteFavorite(favorite)))
-        return items
+        return [
+            FavoritesMenuSection([
+                .command(String(localized: "Insert in Editor"), .insertFavorite(favorite)),
+                .command(String(localized: "Run in New Tab"), .runFavoriteInNewTab(favorite))
+            ]),
+            FavoritesMenuSection(edits),
+            FavoritesMenuSection([.command(String(localized: "Delete"), .deleteFavorite(favorite))])
+        ]
     }
 
     private static func moveToSubmenu(
@@ -132,79 +138,89 @@ internal enum FavoritesMenuSpec {
         folders: [SQLFavoriteFolder]
     ) -> FavoritesMenuItem? {
         guard !folders.isEmpty else { return nil }
-        var nested: [FavoritesMenuItem] = []
+        var root: [FavoritesMenuItem] = []
         if favorite.folderId != nil {
-            nested.append(.command(
+            root.append(.command(
                 String(localized: "Root Level"),
                 .moveFavorite(id: favorite.id, toFolder: nil)
             ))
-            nested.append(.separator)
         }
-        nested += folders
+        let targets: [FavoritesMenuItem] = folders
             .filter { $0.id != favorite.folderId }
             .map { .command($0.name, .moveFavorite(id: favorite.id, toFolder: $0.id)) }
-        guard nested.contains(where: { if case .command = $0 { return true } else { return false } })
-        else { return nil }
-        return .submenu(title: String(localized: "Move to"), items: SidebarMenuItem.collapsingSeparators(nested))
+        guard !root.isEmpty || !targets.isEmpty else { return nil }
+        return .submenu(
+            title: String(localized: "Move to"),
+            sections: [FavoritesMenuSection(root), FavoritesMenuSection(targets)]
+        )
     }
 
-    private static func linkedFavoriteItems(_ favorite: LinkedSQLFavorite) -> [FavoritesMenuItem] {
+    private static func linkedFavoriteSections(_ favorite: LinkedSQLFavorite) -> [FavoritesMenuSection] {
         [
-            .command(String(localized: "Open in Editor"), .openLinkedFavorite(favorite)),
-            .command(String(localized: "Edit Metadata…"), .editLinkedMetadata(favorite)),
-            .separator,
-            .command(String(localized: "Copy Query"), .copyLinkedFavoriteQuery(favorite)),
-            .command(String(localized: "Show in Finder"), .revealLinkedFavorite(favorite)),
-            .separator,
-            .command(String(localized: "Move File to Trash"), .trashLinkedFavorite(favorite))
+            FavoritesMenuSection([
+                .command(String(localized: "Open in Editor"), .openLinkedFavorite(favorite)),
+                .command(String(localized: "Edit Metadata…"), .editLinkedMetadata(favorite))
+            ]),
+            FavoritesMenuSection([
+                .command(String(localized: "Copy Query"), .copyLinkedFavoriteQuery(favorite)),
+                .command(String(localized: "Show in Finder"), .revealLinkedFavorite(favorite))
+            ]),
+            FavoritesMenuSection([
+                .command(String(localized: "Move File to Trash"), .trashLinkedFavorite(favorite))
+            ])
         ]
     }
 
-    private static func linkedFolderItems(_ folder: LinkedSQLFolder) -> [FavoritesMenuItem] {
+    private static func linkedFolderSections(_ folder: LinkedSQLFolder) -> [FavoritesMenuSection] {
         [
-            .command(String(localized: "Show in Finder"), .revealLinkedFolder(folder)),
-            .command(String(localized: "Copy Path"), .copyText(folder.expandedURL.path)),
-            .separator,
-            .command(
-                folder.isEnabled ? String(localized: "Disable") : String(localized: "Enable"),
-                .setLinkedFolderEnabled(folder, !folder.isEnabled)
-            ),
-            .command(String(localized: "Reload"), .reloadLinkedFolders),
-            .separator,
-            .command(String(localized: "Add Another SQL Folder…"), .addLinkedFolder),
-            .separator,
-            .command(String(localized: "Remove from Sidebar"), .removeLinkedFolder(folder))
+            FavoritesMenuSection([
+                .command(String(localized: "Show in Finder"), .revealLinkedFolder(folder)),
+                .command(String(localized: "Copy Path"), .copyText(folder.expandedURL.path))
+            ]),
+            FavoritesMenuSection([
+                .command(
+                    folder.isEnabled ? String(localized: "Disable") : String(localized: "Enable"),
+                    .setLinkedFolderEnabled(folder, !folder.isEnabled)
+                ),
+                .command(String(localized: "Reload"), .reloadLinkedFolders),
+                .command(String(localized: "Add Another SQL Folder…"), .addLinkedFolder)
+            ]),
+            FavoritesMenuSection([
+                .command(String(localized: "Remove from Sidebar"), .removeLinkedFolder(folder))
+            ])
         ]
     }
 
-    private static func folderItems(_ folder: SQLFavoriteFolder) -> [FavoritesMenuItem] {
+    private static func folderSections(_ folder: SQLFavoriteFolder) -> [FavoritesMenuSection] {
         [
-            .command(String(localized: "Rename"), .renameFolder(folder)),
-            .command(String(localized: "New Favorite…"), .newFavorite(folderId: folder.id)),
-            .command(String(localized: "New Subfolder"), .newFolder(parentId: folder.id)),
-            .separator,
-            .command(String(localized: "Delete Folder"), .deleteFolder(folder))
+            FavoritesMenuSection([
+                .command(String(localized: "New Favorite…"), .newFavorite(folderId: folder.id)),
+                .command(String(localized: "New Subfolder"), .newFolder(parentId: folder.id))
+            ]),
+            FavoritesMenuSection([.command(String(localized: "Rename"), .renameFolder(folder))]),
+            FavoritesMenuSection([.command(String(localized: "Delete Folder"), .deleteFolder(folder))])
         ]
     }
 
     /// The empty area below the last row, a header, and a Team Library row all land here. It is the
     /// same list the bottom bar's plus button used to carry, which is where those commands go now
     /// that the sidebar has no bottom bar.
-    internal static func backgroundItems(_ context: FavoritesMenuContext) -> [FavoritesMenuItem] {
-        var items: [FavoritesMenuItem] = [
-            .command(String(localized: "New Query"), .newQuery),
-            .separator,
-            .command(String(localized: "New Favorite…"), .newFavorite(folderId: nil)),
-            .command(String(localized: "New Folder"), .newFolder(parentId: nil)),
-            .separator,
-            .command(String(localized: "Add Linked SQL Folder…"), .addLinkedFolder)
+    internal static func backgroundSections(_ context: FavoritesMenuContext) -> [FavoritesMenuSection] {
+        var team: [FavoritesMenuItem] = []
+        if context.teamLibraryAvailable {
+            team.append(.command(
+                String(localized: "Publish Saved Queries to Team…"),
+                .publishSavedQueriesToTeam
+            ))
+        }
+        return [
+            FavoritesMenuSection([.command(String(localized: "New Query"), .newQuery)]),
+            FavoritesMenuSection([
+                .command(String(localized: "New Favorite…"), .newFavorite(folderId: nil)),
+                .command(String(localized: "New Folder"), .newFolder(parentId: nil)),
+                .command(String(localized: "Add Linked SQL Folder…"), .addLinkedFolder)
+            ]),
+            FavoritesMenuSection(team)
         ]
-        guard context.teamLibraryAvailable else { return items }
-        items.append(.separator)
-        items.append(.command(
-            String(localized: "Publish Saved Queries to Team…"),
-            .publishSavedQueriesToTeam
-        ))
-        return items
     }
 }

--- a/TablePro/Views/Sidebar/Menu/SidebarMenuBuilder.swift
+++ b/TablePro/Views/Sidebar/Menu/SidebarMenuBuilder.swift
@@ -11,50 +11,63 @@ import AppKit
 /// pure function of values.
 @MainActor
 internal enum SidebarMenuBuilder {
-    internal static func fill<Command: Equatable>(
+    internal static func fill<Command: Equatable & SidebarMenuShortcutProviding>(
         _ menu: NSMenu,
-        with items: [SidebarMenuItem<Command>],
+        with sections: [SidebarMenuSection<Command>],
         target: AnyObject,
-        action: Selector
+        action: Selector,
+        keyboard: KeyboardSettings = AppSettingsManager.shared.keyboard
     ) {
         menu.removeAllItems()
         /// `autoenablesItems` defaults to true, and validation runs after `menuNeedsUpdate`, so
         /// every item would be greyed out unless a validator answers for it. The spec decides what
         /// exists instead of what is dimmed, so nothing here needs validating.
         menu.autoenablesItems = false
-        for item in items {
-            menu.addItem(makeItem(item, target: target, action: action))
+        for (index, section) in sections.nonEmptySections().enumerated() {
+            if index > 0 {
+                menu.addItem(.separator())
+            }
+            for item in section.items {
+                menu.addItem(makeItem(item, target: target, action: action, keyboard: keyboard))
+            }
         }
     }
 
-    private static func makeItem<Command: Equatable>(
+    private static func makeItem<Command: Equatable & SidebarMenuShortcutProviding>(
         _ item: SidebarMenuItem<Command>,
         target: AnyObject,
-        action: Selector
+        action: Selector,
+        keyboard: KeyboardSettings
     ) -> NSMenuItem {
         switch item {
-        case .separator:
-            return .separator()
         case .command(let entry):
-            return makeCommandItem(entry, target: target, action: action)
-        case .submenu(let title, let items):
+            return makeCommandItem(entry, target: target, action: action, keyboard: keyboard)
+        case .submenu(let title, let sections):
             let container = NSMenuItem(title: title, action: nil, keyEquivalent: "")
             let submenu = NSMenu(title: title)
-            fill(submenu, with: items, target: target, action: action)
+            fill(submenu, with: sections, target: target, action: action, keyboard: keyboard)
             container.submenu = submenu
             return container
         }
     }
 
-    private static func makeCommandItem<Command: Equatable>(
+    /// The key equivalent is resolved rather than spelled, so a rebind in Settings moves this item
+    /// and its menu-bar twin together. Measured on macOS 27: a key equivalent on a contextual menu
+    /// item is display-only, because `NSView.performKeyEquivalent` never consults the view's own
+    /// menu, so this claims nothing the menu bar already owns and blanks nothing.
+    private static func makeCommandItem<Command: Equatable & SidebarMenuShortcutProviding>(
         _ entry: SidebarMenuEntry<Command>,
         target: AnyObject,
-        action: Selector
+        action: Selector,
+        keyboard: KeyboardSettings
     ) -> NSMenuItem {
         let item = NSMenuItem(title: entry.title, action: action, keyEquivalent: "")
         item.target = target
         item.representedObject = SidebarMenuCommandBox(entry.command)
         item.isEnabled = true
+        if let shortcut = entry.command.shortcutAction {
+            MenuItemFactory.apply(shortcut: shortcut, keyboard: keyboard, to: item)
+        }
         if let isOn = entry.isOn {
             item.state = isOn ? .on : .off
         }

--- a/TablePro/Views/Sidebar/Menu/SidebarMenuBuilder.swift
+++ b/TablePro/Views/Sidebar/Menu/SidebarMenuBuilder.swift
@@ -23,12 +23,27 @@ internal enum SidebarMenuBuilder {
         /// every item would be greyed out unless a validator answers for it. The spec decides what
         /// exists instead of what is dimmed, so nothing here needs validating.
         menu.autoenablesItems = false
+        fill(menu, with: sections, target: target, action: action, keyboard: keyboard, isTopLevel: true)
+    }
+
+    private static func fill<Command: Equatable & SidebarMenuShortcutProviding>(
+        _ menu: NSMenu,
+        with sections: [SidebarMenuSection<Command>],
+        target: AnyObject,
+        action: Selector,
+        keyboard: KeyboardSettings,
+        isTopLevel: Bool
+    ) {
+        menu.removeAllItems()
+        menu.autoenablesItems = false
         for (index, section) in sections.nonEmptySections().enumerated() {
             if index > 0 {
                 menu.addItem(.separator())
             }
             for item in section.items {
-                menu.addItem(makeItem(item, target: target, action: action, keyboard: keyboard))
+                menu.addItem(makeItem(
+                    item, target: target, action: action, keyboard: keyboard, isTopLevel: isTopLevel
+                ))
             }
         }
     }
@@ -37,15 +52,18 @@ internal enum SidebarMenuBuilder {
         _ item: SidebarMenuItem<Command>,
         target: AnyObject,
         action: Selector,
-        keyboard: KeyboardSettings
+        keyboard: KeyboardSettings,
+        isTopLevel: Bool
     ) -> NSMenuItem {
         switch item {
         case .command(let entry):
-            return makeCommandItem(entry, target: target, action: action, keyboard: keyboard)
+            return makeCommandItem(
+                entry, target: target, action: action, keyboard: keyboard, showsShortcut: isTopLevel
+            )
         case .submenu(let title, let sections):
             let container = NSMenuItem(title: title, action: nil, keyEquivalent: "")
             let submenu = NSMenu(title: title)
-            fill(submenu, with: sections, target: target, action: action, keyboard: keyboard)
+            fill(submenu, with: sections, target: target, action: action, keyboard: keyboard, isTopLevel: false)
             container.submenu = submenu
             return container
         }
@@ -55,17 +73,22 @@ internal enum SidebarMenuBuilder {
     /// and its menu-bar twin together. Measured on macOS 27: a key equivalent on a contextual menu
     /// item is display-only, because `NSView.performKeyEquivalent` never consults the view's own
     /// menu, so this claims nothing the menu bar already owns and blanks nothing.
+    ///
+    /// A shortcut names one command, so it is shown once, on the top-level item. A submenu's leaves
+    /// are variants of the command its container stands for: Import's four format items all carry
+    /// `.importTables`, and stamping the shortcut on each showed one binding four times over.
     private static func makeCommandItem<Command: Equatable & SidebarMenuShortcutProviding>(
         _ entry: SidebarMenuEntry<Command>,
         target: AnyObject,
         action: Selector,
-        keyboard: KeyboardSettings
+        keyboard: KeyboardSettings,
+        showsShortcut: Bool
     ) -> NSMenuItem {
         let item = NSMenuItem(title: entry.title, action: action, keyEquivalent: "")
         item.target = target
         item.representedObject = SidebarMenuCommandBox(entry.command)
         item.isEnabled = true
-        if let shortcut = entry.command.shortcutAction {
+        if showsShortcut, let shortcut = entry.command.shortcutAction {
             MenuItemFactory.apply(shortcut: shortcut, keyboard: keyboard, to: item)
         }
         if let isOn = entry.isOn {

--- a/TablePro/Views/Sidebar/Menu/SidebarMenuItem.swift
+++ b/TablePro/Views/Sidebar/Menu/SidebarMenuItem.swift
@@ -13,12 +13,14 @@ import Foundation
 /// outline view means the items have to be `NSMenuItem`s, and describing them as values first keeps
 /// every decision about which items exist, in what order, testable without a window.
 ///
+/// There is deliberately no `separator` case. A menu is a list of `SidebarMenuSection`s and the
+/// builder rules between them, so a stray separator is unrepresentable rather than swept up.
+///
 /// Generic over the command so both sidebar lists share one model and one builder while keeping
 /// their own, closed, vocabularies.
 internal enum SidebarMenuItem<Command: Equatable>: Equatable {
-    case separator
     case command(SidebarMenuEntry<Command>)
-    case submenu(title: String, items: [SidebarMenuItem<Command>])
+    case submenu(title: String, sections: [SidebarMenuSection<Command>])
 }
 
 /// No destructive flag. AppKit gives `NSMenuItem` no destructive role, on any SDK up to macOS 26,
@@ -47,21 +49,8 @@ internal extension SidebarMenuItem {
         .command(SidebarMenuEntry(title: title, command: command))
     }
 
-    /// A menu is assembled by appending groups, so a group that turns out to be empty leaves a
-    /// separator with nothing on one side of it. SwiftUI's `Divider()` collapsed those on its own;
-    /// an imperative builder has to.
-    static func collapsingSeparators(_ items: [SidebarMenuItem<Command>]) -> [SidebarMenuItem<Command>] {
-        var result: [SidebarMenuItem<Command>] = []
-        for item in items {
-            guard item == .separator else {
-                result.append(item)
-                continue
-            }
-            guard let last = result.last, last != .separator else { continue }
-            result.append(item)
-        }
-        while result.last == .separator { result.removeLast() }
-        return result
+    static func submenu(title: String, items: [SidebarMenuItem<Command>]) -> SidebarMenuItem<Command> {
+        .submenu(title: title, sections: [SidebarMenuSection(items)])
     }
 }
 

--- a/TablePro/Views/Sidebar/Menu/SidebarMenuSection.swift
+++ b/TablePro/Views/Sidebar/Menu/SidebarMenuSection.swift
@@ -1,0 +1,41 @@
+//
+//  SidebarMenuSection.swift
+//  TablePro
+//
+
+import Foundation
+
+/// One separator-delimited group of a sidebar contextual menu.
+///
+/// A group used to be an emergent property of append order: the item model carried a `.separator`
+/// case, a spec built one flat array, and a helper swept up the leading, trailing and doubled
+/// separators that shape made representable. Nothing could state how many groups a menu had, so
+/// nothing could hold it to the HIG's "no more than about three groups", and the object tree's
+/// table row drifted to five groups with seven unrelated commands in one of them.
+///
+/// Making the group the unit the spec returns puts that back under the type system: a separator is
+/// no longer something a spec can emit, so it can no longer be emitted in the wrong place, and a
+/// test can assert the group count directly.
+internal struct SidebarMenuSection<Command: Equatable>: Equatable {
+    internal let items: [SidebarMenuItem<Command>]
+
+    internal init(_ items: [SidebarMenuItem<Command>]) {
+        self.items = items
+    }
+
+    internal var isEmpty: Bool {
+        items.isEmpty
+    }
+}
+
+internal extension Array {
+    /// An empty section contributes no separator, which is what makes a spec free to build a group
+    /// out of items that may all turn out to be unavailable.
+    func nonEmptySections<Command>() -> [SidebarMenuSection<Command>]
+        where Element == SidebarMenuSection<Command> {
+        filter { !$0.isEmpty }
+    }
+}
+
+internal typealias DatabaseTreeMenuSection = SidebarMenuSection<SidebarMenuCommand>
+internal typealias FavoritesMenuSection = SidebarMenuSection<FavoritesMenuCommand>

--- a/TablePro/Views/Sidebar/Menu/SidebarMenuShortcut.swift
+++ b/TablePro/Views/Sidebar/Menu/SidebarMenuShortcut.swift
@@ -1,0 +1,50 @@
+//
+//  SidebarMenuShortcut.swift
+//  TablePro
+//
+
+import Foundation
+
+/// The shortcut a sidebar contextual command shares with its menu-bar twin, if it has one.
+///
+/// The binding itself is never spelled here. A command names a `ShortcutAction` and the builder
+/// resolves it through the same `MenuItemFactory.apply(shortcut:keyboard:to:)` the menu bar uses,
+/// so both menus read one `KeyboardSettings` and a rebind in Settings moves them together. Spelling
+/// a key equivalent in the sidebar instead would be a second copy of a binding nothing forces to
+/// agree with the first.
+///
+/// A command with no menu-bar twin, or a twin the menu bar never gave a `ShortcutAction`, answers
+/// nil and shows no shortcut. That is the honest result: an invented binding here would be a
+/// shortcut the menu bar does not have.
+internal protocol SidebarMenuShortcutProviding {
+    var shortcutAction: ShortcutAction? { get }
+}
+
+extension SidebarMenuCommand: SidebarMenuShortcutProviding {
+    /// Only the commands whose menu-bar twin actually carries a `ShortcutAction` today: Database >
+    /// Refresh, Database > Truncate Table, File > Import Data and File > Export. Drop is left out
+    /// deliberately, because the menu bar's Delete is the data grid's row delete and pointing the
+    /// sidebar's object drop at it would show a shortcut that deletes something else.
+    internal var shortcutAction: ShortcutAction? {
+        switch self {
+        case .refreshContainers, .refreshObjectKind, .refreshContainerObjectKind, .refreshHierarchicalSchema:
+            return .refresh
+        case .truncateTables:
+            return .truncateTable
+        case .importTables:
+            return .importData
+        case .exportTables, .exportContainers:
+            return .export
+        default:
+            return nil
+        }
+    }
+}
+
+extension FavoritesMenuCommand: SidebarMenuShortcutProviding {
+    /// The Favorites list shares no command with the menu bar that carries a binding. Declared all
+    /// the same so one builder serves both menus.
+    internal var shortcutAction: ShortcutAction? {
+        nil
+    }
+}

--- a/TablePro/Views/Sidebar/Menu/SidebarViewOptionsMenu.swift
+++ b/TablePro/Views/Sidebar/Menu/SidebarViewOptionsMenu.swift
@@ -55,6 +55,25 @@ internal enum SidebarViewOptionsMenu {
         ]
     }
 
+    /// Applied here rather than by each menu that offers these, so a fourth option added above
+    /// cannot work from the empty-area menu and do nothing from the filter row's control.
+    /// Returns false for a command that is not one of these, which is what lets the object tree's
+    /// own dispatch hand every command to this first.
+    @MainActor
+    internal static func apply(_ command: SidebarMenuCommand) -> Bool {
+        switch command {
+        case .toggleObjectIcons:
+            AppSettingsManager.shared.general.showObjectIcons.toggle()
+        case .toggleObjectComments:
+            AppSettingsManager.shared.general.showObjectComments.toggle()
+        case .setRowSize(let size):
+            AppSettingsManager.shared.general.sidebarRowSize = size
+        default:
+            return false
+        }
+        return true
+    }
+
     /// The control in the filter row is sidebar chrome that outlives a connection switch, so it
     /// reads the settings directly rather than through whichever tree happens to be mounted.
     @MainActor

--- a/TablePro/Views/Sidebar/Menu/SidebarViewOptionsMenu.swift
+++ b/TablePro/Views/Sidebar/Menu/SidebarViewOptionsMenu.swift
@@ -1,0 +1,69 @@
+//
+//  SidebarViewOptionsMenu.swift
+//  TablePro
+//
+
+import Foundation
+
+/// How the object list draws itself: icons, comments and row height.
+///
+/// These settle the sidebar, not the clicked object, so they are not on an object row's contextual
+/// menu. The HIG asks a contextual menu to carry commands relevant to the item the pointer is over,
+/// and this was appended to every menu the object tree produced, including every table, view,
+/// routine, trigger and Redis key. It now has one home the pointer can always reach, the control in
+/// the sidebar's filter row, and one fallback on the empty-area menu.
+///
+/// Both read this, so the two can never list different options or report a different state.
+internal enum SidebarViewOptionsMenu {
+    internal static var title: String {
+        String(localized: "View Options")
+    }
+
+    internal static func sections(_ context: DatabaseTreeMenuContext) -> [DatabaseTreeMenuSection] {
+        sections(
+            showObjectIcons: context.showObjectIcons,
+            showObjectComments: context.showObjectComments,
+            rowSize: context.rowSize
+        )
+    }
+
+    internal static func sections(
+        showObjectIcons: Bool,
+        showObjectComments: Bool,
+        rowSize: SidebarRowSizePreference
+    ) -> [DatabaseTreeMenuSection] {
+        [
+            DatabaseTreeMenuSection([
+                .command(SidebarMenuEntry(
+                    title: String(localized: "Icons"),
+                    command: .toggleObjectIcons,
+                    isOn: showObjectIcons
+                )),
+                .command(SidebarMenuEntry(
+                    title: String(localized: "Comments"),
+                    command: .toggleObjectComments,
+                    isOn: showObjectComments
+                ))
+            ]),
+            DatabaseTreeMenuSection(SidebarRowSizePreference.allCases.map { size in
+                .command(SidebarMenuEntry(
+                    title: size.title,
+                    command: .setRowSize(size),
+                    isOn: rowSize == size
+                ))
+            })
+        ]
+    }
+
+    /// The control in the filter row is sidebar chrome that outlives a connection switch, so it
+    /// reads the settings directly rather than through whichever tree happens to be mounted.
+    @MainActor
+    internal static func currentSections() -> [DatabaseTreeMenuSection] {
+        let settings = AppSettingsManager.shared.general
+        return sections(
+            showObjectIcons: settings.showObjectIcons,
+            showObjectComments: settings.showObjectComments,
+            rowSize: settings.sidebarRowSize
+        )
+    }
+}

--- a/TablePro/Views/Sidebar/SidebarContextMenu.swift
+++ b/TablePro/Views/Sidebar/SidebarContextMenu.swift
@@ -7,20 +7,8 @@ import SwiftUI
 import TableProPluginKit
 
 enum SidebarContextMenuLogic {
-    static func hasSelection(selectedTables: Set<TableInfo>, clickedTable: TableInfo?) -> Bool {
-        !selectedTables.isEmpty || clickedTable != nil
-    }
-
     static func isView(clickedTable: TableInfo?) -> Bool {
         clickedTable?.type == .view
-    }
-
-    /// AppKit's rule for a contextual menu over a list: a click inside the selection acts on the
-    /// whole selection, a click outside it acts on the row under the pointer and nothing else.
-    static func contextTargets(clickedTable: TableInfo?, selectedTables: Set<TableInfo>) -> [String] {
-        guard let clickedTable else { return selectedTables.map(\.name).sorted() }
-        guard selectedTables.contains(clickedTable) else { return [clickedTable.name] }
-        return selectedTables.map(\.name).sorted()
     }
 
     static func isReadOnlyKind(_ type: TableInfo.TableType?) -> Bool {

--- a/TablePro/Views/Sidebar/SidebarViewOptionsButton.swift
+++ b/TablePro/Views/Sidebar/SidebarViewOptionsButton.swift
@@ -1,0 +1,79 @@
+//
+//  SidebarViewOptionsButton.swift
+//  TablePro
+//
+
+import AppKit
+
+/// The View Options control in the sidebar's filter row.
+///
+/// `NSPopUpButton` in pull-down mode rather than a plain `NSButton` carrying a menu: a button's
+/// `menu` opens on a secondary click only, and driving a menu from a button's action would give up
+/// the keyboard activation and the menu-button accessibility role the pull-down has for free.
+///
+/// Measured on macOS 27: an `NSPopUpButton` ignores its own `image`, because the cell draws from the
+/// menu, so the symbol goes on the item in the pull-down's label slot at index 0. That item is the
+/// label and never appears among the choices.
+@MainActor
+internal final class SidebarViewOptionsButton: NSPopUpButton {
+    private let labelItem: NSMenuItem = {
+        let item = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        item.image = NSImage(systemSymbolName: "ellipsis.circle", accessibilityDescription: nil)
+        return item
+    }()
+
+    internal init() {
+        super.init(frame: .zero, pullsDown: true)
+        translatesAutoresizingMaskIntoConstraints = false
+        isBordered = false
+        imagePosition = .imageOnly
+        (cell as? NSPopUpButtonCell)?.arrowPosition = .noArrow
+        setAccessibilityIdentifier("sidebar-view-options")
+        setAccessibilityLabel(String(localized: "View Options"))
+        toolTip = String(localized: "View Options")
+        let options = NSMenu()
+        options.delegate = self
+        menu = options
+        rebuild(options)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("SidebarViewOptionsButton does not support NSCoder init")
+    }
+
+    private func rebuild(_ menu: NSMenu) {
+        SidebarMenuBuilder.fill(
+            menu,
+            with: SidebarViewOptionsMenu.currentSections(),
+            target: self,
+            action: #selector(performViewOption(_:))
+        )
+        menu.insertItem(labelItem, at: 0)
+    }
+
+    /// These settle how every object list draws, not this connection's, so the control writes the
+    /// setting and nothing else. Each mounted tree repaints from its own observation of the same
+    /// setting, which is what lets the same change arrive from here, from the empty-area menu and
+    /// from Settings without three separate notifications.
+    @objc
+    private func performViewOption(_ sender: NSMenuItem) {
+        guard let box = sender.representedObject as? SidebarMenuCommandBox<SidebarMenuCommand> else { return }
+        switch box.command {
+        case .toggleObjectIcons:
+            AppSettingsManager.shared.general.showObjectIcons.toggle()
+        case .toggleObjectComments:
+            AppSettingsManager.shared.general.showObjectComments.toggle()
+        case .setRowSize(let size):
+            AppSettingsManager.shared.general.sidebarRowSize = size
+        default:
+            return
+        }
+    }
+}
+
+extension SidebarViewOptionsButton: NSMenuDelegate {
+    internal func menuNeedsUpdate(_ menu: NSMenu) {
+        rebuild(menu)
+    }
+}

--- a/TablePro/Views/Sidebar/SidebarViewOptionsButton.swift
+++ b/TablePro/Views/Sidebar/SidebarViewOptionsButton.swift
@@ -59,16 +59,7 @@ internal final class SidebarViewOptionsButton: NSPopUpButton {
     @objc
     private func performViewOption(_ sender: NSMenuItem) {
         guard let box = sender.representedObject as? SidebarMenuCommandBox<SidebarMenuCommand> else { return }
-        switch box.command {
-        case .toggleObjectIcons:
-            AppSettingsManager.shared.general.showObjectIcons.toggle()
-        case .toggleObjectComments:
-            AppSettingsManager.shared.general.showObjectComments.toggle()
-        case .setRowSize(let size):
-            AppSettingsManager.shared.general.sidebarRowSize = size
-        default:
-            return
-        }
+        _ = SidebarViewOptionsMenu.apply(box.command)
     }
 }
 

--- a/TableProTests/Views/Sidebar/DatabaseTreeMenuSpecTests.swift
+++ b/TableProTests/Views/Sidebar/DatabaseTreeMenuSpecTests.swift
@@ -82,24 +82,35 @@ struct DatabaseTreeMenuSpecTests {
         )
     }
 
+    private func commands(_ sections: [DatabaseTreeMenuSection]) -> [SidebarMenuCommand] {
+        commands(sections.flatMap(\.items))
+    }
+
     private func commands(_ items: [DatabaseTreeMenuItem]) -> [SidebarMenuCommand] {
         items.flatMap { item -> [SidebarMenuCommand] in
             switch item {
-            case .separator: return []
             case .command(let entry): return [entry.command]
             case .submenu(_, let nested): return commands(nested)
             }
         }
     }
 
+    private func titles(_ sections: [DatabaseTreeMenuSection]) -> [String] {
+        titles(sections.flatMap(\.items))
+    }
+
     private func titles(_ items: [DatabaseTreeMenuItem]) -> [String] {
-        items.compactMap { item in
+        items.map { item in
             switch item {
             case .command(let entry): return entry.title
             case .submenu(let title, _): return title
-            case .separator: return nil
             }
         }
+    }
+
+    /// The items a user actually sees at the top level of one menu, submenu contents excluded.
+    private func topLevelTitles(_ sections: [DatabaseTreeMenuSection]) -> [String] {
+        titles(sections.flatMap(\.items))
     }
 
     // MARK: - The empty area
@@ -108,7 +119,7 @@ struct DatabaseTreeMenuSpecTests {
     /// Options unreachable whenever the sidebar was empty, loading or failed.
     @Test("Right-clicking the empty area still gives a menu")
     func emptyAreaHasAMenu() {
-        let items = DatabaseTreeMenuSpec.items(for: context(clicked: nil))
+        let items = DatabaseTreeMenuSpec.sections(for: context(clicked: nil))
 
         #expect(!items.isEmpty)
         #expect(titles(items).contains(String(localized: "View Options")))
@@ -116,7 +127,7 @@ struct DatabaseTreeMenuSpecTests {
 
     @Test("A status row falls back to the empty-area menu rather than showing nothing")
     func statusRowUsesTheBackgroundMenu() {
-        let items = DatabaseTreeMenuSpec.items(for: context(clicked: .status(.loading)))
+        let items = DatabaseTreeMenuSpec.sections(for: context(clicked: .status(.loading)))
 
         #expect(titles(items).contains(String(localized: "View Options")))
     }
@@ -125,7 +136,7 @@ struct DatabaseTreeMenuSpecTests {
     /// critical, so the background menu is now their only sidebar-local home.
     @Test("Creating objects is reachable from the empty area")
     func emptyAreaOffersCreation() {
-        let issued = commands(DatabaseTreeMenuSpec.items(for: context(clicked: nil)))
+        let issued = commands(DatabaseTreeMenuSpec.sections(for: context(clicked: nil)))
 
         #expect(issued.contains(.createTable))
         #expect(issued.contains(.createView))
@@ -133,7 +144,7 @@ struct DatabaseTreeMenuSpecTests {
 
     @Test("Read-only hides creation from the empty area too")
     func readOnlyEmptyAreaHidesCreation() {
-        let issued = commands(DatabaseTreeMenuSpec.items(for: context(clicked: nil, isReadOnly: true)))
+        let issued = commands(DatabaseTreeMenuSpec.sections(for: context(clicked: nil, isReadOnly: true)))
 
         #expect(!issued.contains(.createTable))
         #expect(!issued.contains(.createView))
@@ -142,7 +153,7 @@ struct DatabaseTreeMenuSpecTests {
     @Test("A nested object group refresh carries its database and schema")
     func nestedObjectGroupRefreshIsScoped() {
         let group = DatabaseTreeObjectGroup(database: "archive", schema: "audit", kind: .view)
-        let issued = commands(DatabaseTreeMenuSpec.items(
+        let issued = commands(DatabaseTreeMenuSpec.sections(
             for: context(clicked: .containerObjectKindSection(group))
         ))
 
@@ -156,13 +167,13 @@ struct DatabaseTreeMenuSpecTests {
     @Test("Exporting another database is offered only where the dialog can reach it")
     func exportOfferedOnlyWhereReachable() {
         let target = DatabaseContainerRef.database("analytics")
-        let reachable = commands(DatabaseTreeMenuSpec.items(for: context(
+        let reachable = commands(DatabaseTreeMenuSpec.sections(for: context(
             clicked: .database(DatabaseMetadata.minimal(name: "analytics")),
             selectedContainers: [target],
             activeDatabase: "app",
             canReachOtherDatabases: true
         )))
-        let unreachable = commands(DatabaseTreeMenuSpec.items(for: context(
+        let unreachable = commands(DatabaseTreeMenuSpec.sections(for: context(
             clicked: .database(DatabaseMetadata.minimal(name: "analytics")),
             selectedContainers: [target],
             activeDatabase: "app",
@@ -175,8 +186,8 @@ struct DatabaseTreeMenuSpecTests {
 
     @Test("The database filter is offered only where a database list exists")
     func filterOnlyWhereADatabaseListExists() {
-        let tree = commands(DatabaseTreeMenuSpec.items(for: context(clicked: nil, canFilterDatabases: true)))
-        let flat = commands(DatabaseTreeMenuSpec.items(for: context(clicked: nil, canFilterDatabases: false)))
+        let tree = commands(DatabaseTreeMenuSpec.sections(for: context(clicked: nil, canFilterDatabases: true)))
+        let flat = commands(DatabaseTreeMenuSpec.sections(for: context(clicked: nil, canFilterDatabases: false)))
 
         #expect(tree.contains(.filterDatabases))
         #expect(!flat.contains(.filterDatabases))
@@ -184,10 +195,10 @@ struct DatabaseTreeMenuSpecTests {
 
     @Test("Show All Databases appears only when a filter is actually on")
     func showAllOnlyWhenFiltered() {
-        let filtered = commands(DatabaseTreeMenuSpec.items(
+        let filtered = commands(DatabaseTreeMenuSpec.sections(
             for: context(clicked: nil, canFilterDatabases: true, hasDatabaseFilter: true)
         ))
-        let unfiltered = commands(DatabaseTreeMenuSpec.items(
+        let unfiltered = commands(DatabaseTreeMenuSpec.sections(
             for: context(clicked: nil, canFilterDatabases: true, hasDatabaseFilter: false)
         ))
 
@@ -197,7 +208,7 @@ struct DatabaseTreeMenuSpecTests {
 
     @Test("View Options reports the settings it is toggling")
     func viewOptionsCarryTheirState() {
-        let items = DatabaseTreeMenuSpec.viewOptionItems(context(clicked: nil))
+        let items = SidebarViewOptionsMenu.sections(context(clicked: nil)).flatMap(\.items)
         let icons = items.compactMap { item -> SidebarMenuEntry<SidebarMenuCommand>? in
             guard case .command(let entry) = item, entry.command == .toggleObjectIcons else { return nil }
             return entry
@@ -211,7 +222,7 @@ struct DatabaseTreeMenuSpecTests {
     @Test("A table menu acts on the clicked table when it is outside the selection")
     func clickedTableOutsideSelectionActsOnItself() {
         let clicked = tableRef("orders")
-        let items = DatabaseTreeMenuSpec.items(
+        let items = DatabaseTreeMenuSpec.sections(
             for: context(clicked: .table(clicked), selectedTables: [tableRef("users")])
         )
 
@@ -221,7 +232,7 @@ struct DatabaseTreeMenuSpecTests {
     @Test("A table menu acts on the whole selection when the clicked row is inside it")
     func clickedTableInsideSelectionActsOnAllOfIt() {
         let clicked = tableRef("orders")
-        let items = DatabaseTreeMenuSpec.items(
+        let items = DatabaseTreeMenuSpec.sections(
             for: context(
                 clicked: .table(clicked),
                 selectedTables: [clicked, tableRef("users")]
@@ -234,7 +245,7 @@ struct DatabaseTreeMenuSpecTests {
     @Test("Read-only hides the destructive items rather than dimming them")
     func readOnlyOmitsWrites() {
         let clicked = tableRef("orders")
-        let items = DatabaseTreeMenuSpec.items(for: context(clicked: .table(clicked), isReadOnly: true))
+        let items = DatabaseTreeMenuSpec.sections(for: context(clicked: .table(clicked), isReadOnly: true))
         let issued = commands(items)
 
         #expect(!issued.contains(.truncateTables(targets: [clicked], ref: clicked)))
@@ -253,7 +264,7 @@ struct DatabaseTreeMenuSpecTests {
             schema: "public",
             table: TableInfo(name: "orders", type: .table, rowCount: nil, schema: "public")
         )
-        let issued = commands(DatabaseTreeMenuSpec.items(for: context(clicked: .table(elsewhere))))
+        let issued = commands(DatabaseTreeMenuSpec.sections(for: context(clicked: .table(elsewhere))))
 
         #expect(issued.contains(.truncateTables(targets: [elsewhere], ref: elsewhere)))
         #expect(issued.contains(.dropTables(targets: [elsewhere], ref: elsewhere)))
@@ -271,7 +282,7 @@ struct DatabaseTreeMenuSpecTests {
             schema: "public",
             table: TableInfo(name: "orders", type: .table, rowCount: nil, schema: "public")
         )
-        let issued = commands(DatabaseTreeMenuSpec.items(
+        let issued = commands(DatabaseTreeMenuSpec.sections(
             for: context(clicked: .table(clicked), selectedTables: [clicked, elsewhere])
         ))
 
@@ -282,7 +293,7 @@ struct DatabaseTreeMenuSpecTests {
     @Test("A table row offers Rename where the engine can do it")
     func tableOffersRename() {
         let clicked = tableRef("orders")
-        let issued = commands(DatabaseTreeMenuSpec.items(for: context(clicked: .table(clicked))))
+        let issued = commands(DatabaseTreeMenuSpec.sections(for: context(clicked: .table(clicked))))
 
         #expect(issued.contains(.beginRenameTable(ref: clicked, isRecentRow: false)))
     }
@@ -292,7 +303,7 @@ struct DatabaseTreeMenuSpecTests {
     @Test("Rename carries no ellipsis")
     func renameHasNoEllipsis() {
         let clicked = tableRef("orders")
-        let items = DatabaseTreeMenuSpec.items(for: context(clicked: .table(clicked)))
+        let items = DatabaseTreeMenuSpec.sections(for: context(clicked: .table(clicked)))
 
         #expect(titles(items).contains(String(localized: "Rename")))
     }
@@ -302,7 +313,7 @@ struct DatabaseTreeMenuSpecTests {
     @Test("An engine that cannot rename a table omits the item")
     func engineWithoutRenameOmitsTheItem() {
         let clicked = tableRef("orders")
-        let issued = commands(DatabaseTreeMenuSpec.items(
+        let issued = commands(DatabaseTreeMenuSpec.sections(
             for: context(clicked: .table(clicked), supportsRename: false)
         ))
 
@@ -312,7 +323,7 @@ struct DatabaseTreeMenuSpecTests {
     @Test("Read-only safe mode hides Rename with the other writes")
     func readOnlyOmitsRename() {
         let clicked = tableRef("orders")
-        let issued = commands(DatabaseTreeMenuSpec.items(
+        let issued = commands(DatabaseTreeMenuSpec.sections(
             for: context(clicked: .table(clicked), isReadOnly: true)
         ))
 
@@ -325,7 +336,7 @@ struct DatabaseTreeMenuSpecTests {
     @Test("Rename from a Recent row says so, so the editor lands on the clicked row")
     func renameFromARecentRowCarriesThatRow() {
         let clicked = tableRef("orders")
-        let issued = commands(DatabaseTreeMenuSpec.items(for: context(clicked: .recentTable(clicked))))
+        let issued = commands(DatabaseTreeMenuSpec.sections(for: context(clicked: .recentTable(clicked))))
 
         #expect(issued.contains(.beginRenameTable(ref: clicked, isRecentRow: true)))
         #expect(!issued.contains(.beginRenameTable(ref: clicked, isRecentRow: false)))
@@ -336,7 +347,7 @@ struct DatabaseTreeMenuSpecTests {
     /// this the command has no row to be raised from.
     @Test("A hierarchical schema row offers Rename")
     func hierarchicalSchemaOffersRename() {
-        let issued = commands(DatabaseTreeMenuSpec.items(
+        let issued = commands(DatabaseTreeMenuSpec.sections(
             for: context(clicked: .hierarchicalSchemaSection(schema: "reporting"))
         ))
         let expected = DatabaseContainerRef.schema(database: "app", schema: "reporting", isSystem: false)
@@ -346,7 +357,7 @@ struct DatabaseTreeMenuSpecTests {
 
     @Test("A hierarchical schema row omits Rename where the engine has none")
     func hierarchicalSchemaWithoutRenameOmitsIt() {
-        let issued = commands(DatabaseTreeMenuSpec.items(
+        let issued = commands(DatabaseTreeMenuSpec.sections(
             for: context(clicked: .hierarchicalSchemaSection(schema: "reporting"), supportsRename: false)
         ))
 
@@ -356,8 +367,8 @@ struct DatabaseTreeMenuSpecTests {
     @Test("The favourite item names the action it will take")
     func favouriteItemFlipsItsTitle() {
         let clicked = tableRef("orders")
-        let add = DatabaseTreeMenuSpec.items(for: context(clicked: .table(clicked), isFavorite: false))
-        let remove = DatabaseTreeMenuSpec.items(for: context(clicked: .table(clicked), isFavorite: true))
+        let add = DatabaseTreeMenuSpec.sections(for: context(clicked: .table(clicked), isFavorite: false))
+        let remove = DatabaseTreeMenuSpec.sections(for: context(clicked: .table(clicked), isFavorite: true))
 
         #expect(titles(add).contains(String(localized: "Add to Favorites")))
         #expect(titles(remove).contains(String(localized: "Remove from Favorites")))
@@ -368,9 +379,9 @@ struct DatabaseTreeMenuSpecTests {
         let view = tableRef("active_users", type: .view)
         let table = tableRef("users")
 
-        #expect(commands(DatabaseTreeMenuSpec.items(for: context(clicked: .table(view))))
+        #expect(commands(DatabaseTreeMenuSpec.sections(for: context(clicked: .table(view))))
             .contains(.editViewDefinition(view)))
-        #expect(!commands(DatabaseTreeMenuSpec.items(for: context(clicked: .table(table))))
+        #expect(!commands(DatabaseTreeMenuSpec.sections(for: context(clicked: .table(table))))
             .contains(.editViewDefinition(table)))
     }
 
@@ -378,7 +389,7 @@ struct DatabaseTreeMenuSpecTests {
 
     @Test("Use as Active is omitted for the container already in use")
     func activeContainerHasNoUseAsActive() {
-        let items = DatabaseTreeMenuSpec.items(
+        let items = DatabaseTreeMenuSpec.sections(
             for: context(clicked: .schema(database: "app", schema: "public"))
         )
 
@@ -390,7 +401,7 @@ struct DatabaseTreeMenuSpecTests {
 
     @Test("Use as Active is offered for a container that is not in use")
     func inactiveContainerOffersUseAsActive() {
-        let items = DatabaseTreeMenuSpec.items(
+        let items = DatabaseTreeMenuSpec.sections(
             for: context(clicked: .schema(database: "app", schema: "billing"))
         )
 
@@ -403,7 +414,7 @@ struct DatabaseTreeMenuSpecTests {
     @Test("An unfavorited database offers every environment under Add to Favorites")
     func databaseCanBeFavoritedWithEnvironment() {
         let database = DatabaseMetadata.minimal(name: "analytics", isSystem: false)
-        let items = DatabaseTreeMenuSpec.items(for: context(clicked: .database(database)))
+        let items = DatabaseTreeMenuSpec.sections(for: context(clicked: .database(database)))
         let issued = commands(items)
 
         #expect(titles(items).contains(String(localized: "Add to Favorites")))
@@ -416,7 +427,7 @@ struct DatabaseTreeMenuSpecTests {
     @Test("A favorite database can change environment or be removed")
     func favoriteDatabaseMenuReflectsState() {
         let database = DatabaseMetadata.minimal(name: "analytics", isSystem: false)
-        let items = DatabaseTreeMenuSpec.items(for: context(
+        let items = DatabaseTreeMenuSpec.sections(for: context(
             clicked: .database(database),
             favoriteDatabaseEnvironments: ["analytics": .production]
         ))
@@ -433,7 +444,7 @@ struct DatabaseTreeMenuSpecTests {
     @Test("A multi-database selection still offers the favorite items, for every database")
     func favoriteItemsSurviveMultiSelection() {
         let clicked = DatabaseMetadata.minimal(name: "analytics", isSystem: false)
-        let items = DatabaseTreeMenuSpec.items(for: context(
+        let items = DatabaseTreeMenuSpec.sections(for: context(
             clicked: .database(clicked),
             selectedContainers: [
                 .database("analytics", isSystem: false),
@@ -453,7 +464,7 @@ struct DatabaseTreeMenuSpecTests {
     @Test("A mixed selection offers Add to Favorites with no environment checked")
     func mixedSelectionOffersAdd() {
         let clicked = DatabaseMetadata.minimal(name: "analytics", isSystem: false)
-        let items = DatabaseTreeMenuSpec.items(for: context(
+        let items = DatabaseTreeMenuSpec.sections(for: context(
             clicked: .database(clicked),
             selectedContainers: [
                 .database("analytics", isSystem: false),
@@ -470,7 +481,7 @@ struct DatabaseTreeMenuSpecTests {
     /// that names nothing is unreachable.
     @Test("A schema row offers no favorite items")
     func schemaRowOffersNoFavoriteItems() {
-        let items = DatabaseTreeMenuSpec.items(
+        let items = DatabaseTreeMenuSpec.sections(
             for: context(clicked: .schema(database: "app", schema: "public"))
         )
 
@@ -480,27 +491,129 @@ struct DatabaseTreeMenuSpecTests {
 
     // MARK: - Shape
 
-    @Test("A menu never opens or closes on a separator, and never doubles one")
-    func separatorsAreCollapsed() {
-        let kinds: [DatabaseTreeNode.Kind?] = [
-            nil,
+    /// The pointer is over an object, so the menu carries commands about that object. View Options
+    /// settles how the sidebar draws and View ER Diagram is the whole schema; both used to sit on
+    /// every row, View Options on literally every menu the spec produced.
+    @Test("No object row offers a command scoped to the sidebar or the connection")
+    func objectRowsCarryNoGlobalCommands() {
+        let rows: [DatabaseTreeNode.Kind] = [
             .table(tableRef("orders")),
+            .table(tableRef("summary", type: .view)),
             .recentTable(tableRef("orders")),
-            .schema(database: "app", schema: "billing"),
+            .routine(DatabaseTreeRoutineRef(
+                database: "app", schema: "public",
+                routine: RoutineInfo(name: "do_thing", kind: .function, schema: "public")
+            )),
+            .userType(userTypeRef("mood")),
+            .redisNode(.key(name: "k", fullKey: "ns:k", keyType: "string")),
             .database(DatabaseMetadata.minimal(name: "app", isSystem: false)),
-            .objectKindSection(.table),
-            .status(.loading)
+            .schema(database: "app", schema: "billing")
         ]
 
-        for kind in kinds {
-            let items = DatabaseTreeMenuSpec.items(for: context(clicked: kind, isReadOnly: false))
-            #expect(items.first != .separator)
-            #expect(items.last != .separator)
-            for (previous, next) in zip(items, items.dropFirst()) {
-                #expect(!(previous == .separator && next == .separator))
+        for row in rows {
+            let issued = commands(DatabaseTreeMenuSpec.sections(for: context(clicked: row)))
+            #expect(!issued.contains(.showERDiagram), "\(row) offered View ER Diagram")
+            #expect(!issued.contains(.toggleObjectIcons), "\(row) offered View Options")
+            #expect(!issued.contains(.toggleObjectComments), "\(row) offered View Options")
+            #expect(!issued.contains { if case .setRowSize = $0 { return true } else { return false } })
+        }
+    }
+
+    /// Creation names no existing object, so it belongs where the pointer is over none. It used to
+    /// sit in a table row's last group, beside Truncate and Delete.
+    @Test("Creating a view is offered from the empty area and never from a row")
+    func createViewIsNotOnAnObjectRow() {
+        #expect(commands(DatabaseTreeMenuSpec.sections(for: context(clicked: nil))).contains(.createView))
+        #expect(!commands(DatabaseTreeMenuSpec.sections(for: context(clicked: .table(tableRef("orders")))))
+            .contains(.createView))
+    }
+
+    @Test("A table row is four groups of open, note, move and change")
+    func tableRowGroupsByIntent() {
+        let ref = tableRef("orders")
+        let sections = DatabaseTreeMenuSpec.sections(for: context(clicked: .table(ref)))
+            .nonEmptySections()
+
+        #expect(sections.count == 4)
+        #expect(commands(sections[0].items) == [.openInNewTab(ref), .showStructure(ref)])
+        #expect(commands(sections[1].items) == [.copyTableNames(["orders"]), .toggleFavorite(ref)])
+        #expect(commands(sections[3].items).last == .dropTables(targets: [ref], ref: ref))
+    }
+
+    /// Destructive last in its own group is the only way macOS sets one apart: `NSMenuItem` has no
+    /// destructive role and Apple does not colour Finder's Move to Trash.
+    @Test("Truncate and Delete are the last group and nothing follows them")
+    func destructiveCommandsCloseTheMenu() {
+        let ref = tableRef("orders")
+        let sections = DatabaseTreeMenuSpec.sections(for: context(clicked: .table(ref)))
+            .nonEmptySections()
+        let last = commands(sections[sections.count - 1].items)
+
+        #expect(last.contains(.truncateTables(targets: [ref], ref: ref)))
+        #expect(last.last == .dropTables(targets: [ref], ref: ref))
+    }
+
+    @Test("A recent row keeps its own group after the table's four")
+    func recentRowAddsItsOwnGroup() {
+        let ref = tableRef("orders")
+        let sections = DatabaseTreeMenuSpec.sections(for: context(clicked: .recentTable(ref)))
+            .nonEmptySections()
+
+        #expect(commands(sections[sections.count - 1].items) == [.removeRecent(ref), .clearRecents])
+    }
+
+    /// The HIG asks for about three groups. A table row carried five, one of them seven unrelated
+    /// commands, because a flat item list gave the spec no reason to count.
+    @Test("No menu carries more than four groups")
+    func menusStayWithinFourGroups() {
+        for kind in Self.everyKind {
+            /// A recent row is a table row plus the two commands that manage the recent list
+            /// itself, which belong neither with the table's own commands nor beside Delete.
+            let allowance = if case .recentTable = kind { 5 } else { 4 }
+            let sections = DatabaseTreeMenuSpec.sections(for: context(clicked: kind, isReadOnly: false))
+                .nonEmptySections()
+            #expect(
+                sections.count <= allowance,
+                "\(String(describing: kind)) produced \(sections.count) groups"
+            )
+        }
+    }
+
+    /// One level is the HIG's hard rule for submenus; the five-item guidance is per group, which is
+    /// why View Options splits its toggles from its row sizes rather than listing six in a row.
+    @Test("Every submenu is one level deep with at most five items in a group")
+    func submenusStayShallow() {
+        for kind in Self.everyKind {
+            let sections = DatabaseTreeMenuSpec.sections(for: context(clicked: kind, isReadOnly: false))
+            for item in sections.flatMap(\.items) {
+                guard case .submenu(let title, let nested) = item else { continue }
+                for group in nested {
+                    #expect(group.items.count <= 5, "\(title) has a group of \(group.items.count)")
+                    #expect(!group.items.contains {
+                        if case .submenu = $0 { return true } else { return false }
+                    }, "\(title) nests a second level")
+                }
             }
         }
     }
+
+    private static let sampleRef = DatabaseTreeTableRef(
+        database: "app",
+        schema: "public",
+        table: TableInfo(name: "orders", type: .table, rowCount: nil, schema: "public")
+    )
+
+    private static let everyKind: [DatabaseTreeNode.Kind?] = [
+        nil,
+        .table(DatabaseTreeMenuSpecTests.sampleRef),
+        .recentTable(DatabaseTreeMenuSpecTests.sampleRef),
+        .schema(database: "app", schema: "billing"),
+        .database(DatabaseMetadata.minimal(name: "app", isSystem: false)),
+        .objectKindSection(.table),
+        .objectKindSection(.type),
+        .hierarchicalSchemaSection(schema: "billing"),
+        .status(.loading)
+    ]
 
     @Test("Every menu produces at least one item, so none opens as an empty frame")
     func everyMenuHasContent() {
@@ -518,7 +631,7 @@ struct DatabaseTreeMenuSpecTests {
         ]
 
         for kind in kinds {
-            #expect(!DatabaseTreeMenuSpec.items(for: context(clicked: kind, isReadOnly: true)).isEmpty)
+            #expect(!DatabaseTreeMenuSpec.sections(for: context(clicked: kind, isReadOnly: true)).isEmpty)
         }
     }
 
@@ -534,7 +647,7 @@ struct DatabaseTreeMenuSpecTests {
     @Test("A type row copies its name, its qualified name, and shows its definition")
     func typeRowItems() {
         let ref = userTypeRef("mood")
-        let issued = commands(DatabaseTreeMenuSpec.items(for: context(clicked: .userType(ref))))
+        let issued = commands(DatabaseTreeMenuSpec.sections(for: context(clicked: .userType(ref))))
 
         #expect(issued.contains(.copyText("mood")))
         #expect(issued.contains(.copyText("public.mood")))
@@ -544,14 +657,14 @@ struct DatabaseTreeMenuSpecTests {
     @Test("A type with no schema offers no qualified copy")
     func bareTypeRowHasNoQualifiedCopy() {
         let ref = userTypeRef("mood", schema: nil)
-        let issued = commands(DatabaseTreeMenuSpec.items(for: context(clicked: .userType(ref))))
+        let issued = commands(DatabaseTreeMenuSpec.sections(for: context(clicked: .userType(ref))))
 
         #expect(issued.filter { if case .copyText = $0 { return true } else { return false } }.count == 1)
     }
 
     @Test("The Types section offers Create New Type when the driver has a template and writes are allowed")
     func typesSectionOffersCreate() {
-        let flat = commands(DatabaseTreeMenuSpec.items(
+        let flat = commands(DatabaseTreeMenuSpec.sections(
             for: context(clicked: .objectKindSection(.type), activeSchema: "sales", canCreateType: true)
         ))
         #expect(flat.contains(.createType(database: "app", schema: "sales")))
@@ -559,7 +672,7 @@ struct DatabaseTreeMenuSpecTests {
         /// A tree lists every database, so the section names its own rather than the browsed one:
         /// PostgreSQL cannot reach another database by qualifying the type name.
         let group = DatabaseTreeObjectGroup(database: "warehouse", schema: "billing", kind: .type)
-        let tree = commands(DatabaseTreeMenuSpec.items(
+        let tree = commands(DatabaseTreeMenuSpec.sections(
             for: context(clicked: .containerObjectKindSection(group), canCreateType: true)
         ))
         #expect(tree.contains(.createType(database: "warehouse", schema: "billing")))
@@ -568,15 +681,15 @@ struct DatabaseTreeMenuSpecTests {
 
     @Test("Create New Type is omitted in read-only mode, without a template, and on other sections")
     func createTypeIsOmittedWhereItCannotRun() {
-        let readOnly = commands(DatabaseTreeMenuSpec.items(
+        let readOnly = commands(DatabaseTreeMenuSpec.sections(
             for: context(clicked: .objectKindSection(.type), isReadOnly: true, canCreateType: true)
         ))
         #expect(!readOnly.contains { if case .createType = $0 { return true } else { return false } })
 
-        let noTemplate = commands(DatabaseTreeMenuSpec.items(for: context(clicked: .objectKindSection(.type))))
+        let noTemplate = commands(DatabaseTreeMenuSpec.sections(for: context(clicked: .objectKindSection(.type))))
         #expect(!noTemplate.contains { if case .createType = $0 { return true } else { return false } })
 
-        let functions = commands(DatabaseTreeMenuSpec.items(
+        let functions = commands(DatabaseTreeMenuSpec.sections(
             for: context(clicked: .objectKindSection(.function), canCreateType: true)
         ))
         #expect(!functions.contains { if case .createType = $0 { return true } else { return false } })
@@ -591,7 +704,7 @@ struct DatabaseTreeMenuSpecTests {
     @Test("A table row offers Copy To")
     func tableOffersCopyTo() {
         let ref = tableRef("orders")
-        let issued = commands(DatabaseTreeMenuSpec.items(
+        let issued = commands(DatabaseTreeMenuSpec.sections(
             for: context(clicked: .table(ref), selectedTables: [ref])
         ))
 
@@ -607,7 +720,7 @@ struct DatabaseTreeMenuSpecTests {
     func copyToCarriesTheSelection() {
         let orders = tableRef("orders")
         let customers = tableRef("customers")
-        let issued = commands(DatabaseTreeMenuSpec.items(
+        let issued = commands(DatabaseTreeMenuSpec.sections(
             for: context(clicked: .table(orders), selectedTables: [orders, customers])
         ))
 
@@ -623,7 +736,7 @@ struct DatabaseTreeMenuSpecTests {
     @Test("A view row is offered as a view rather than as a table")
     func viewIsOfferedAsAView() {
         let ref = tableRef("active_users", type: .view)
-        let issued = commands(DatabaseTreeMenuSpec.items(
+        let issued = commands(DatabaseTreeMenuSpec.sections(
             for: context(clicked: .table(ref), selectedTables: [ref])
         ))
 
@@ -636,10 +749,10 @@ struct DatabaseTreeMenuSpecTests {
     @Test("An engine that cannot copy offers neither command")
     func ineligibleEngineHidesCopying() {
         let ref = tableRef("orders")
-        let tableCommands = commands(DatabaseTreeMenuSpec.items(for: context(
+        let tableCommands = commands(DatabaseTreeMenuSpec.sections(for: context(
             clicked: .table(ref), selectedTables: [ref], canCopyObjects: false
         )))
-        let databaseCommands = commands(DatabaseTreeMenuSpec.items(for: context(
+        let databaseCommands = commands(DatabaseTreeMenuSpec.sections(for: context(
             clicked: databaseKind("app"),
             selectedContainers: [.database("app")],
             canCopyObjects: false,
@@ -653,7 +766,7 @@ struct DatabaseTreeMenuSpecTests {
 
     @Test("A database row offers Copy To and Duplicate Database")
     func databaseOffersCopyAndDuplicate() {
-        let issued = commands(DatabaseTreeMenuSpec.items(for: context(
+        let issued = commands(DatabaseTreeMenuSpec.sections(for: context(
             clicked: databaseKind("app"), selectedContainers: [.database("app")]
         )))
 
@@ -664,7 +777,7 @@ struct DatabaseTreeMenuSpecTests {
     /// `CREATE DATABASE information_schema` is not a thing anyone wants offered.
     @Test("A system database is not offered for duplication")
     func systemDatabaseIsNotDuplicated() {
-        let issued = commands(DatabaseTreeMenuSpec.items(for: context(
+        let issued = commands(DatabaseTreeMenuSpec.sections(for: context(
             clicked: databaseKind("information_schema", isSystem: true),
             selectedContainers: [.database("information_schema", isSystem: true)]
         )))
@@ -677,7 +790,7 @@ struct DatabaseTreeMenuSpecTests {
     @Test("A schema row offers Copy To but not Duplicate Database")
     func schemaOffersCopyOnly() {
         let schema = DatabaseContainerRef.schema(database: "app", schema: "sales")
-        let issued = commands(DatabaseTreeMenuSpec.items(for: context(
+        let issued = commands(DatabaseTreeMenuSpec.sections(for: context(
             clicked: .schema(database: "app", schema: "sales"), selectedContainers: [schema]
         )))
 
@@ -689,7 +802,7 @@ struct DatabaseTreeMenuSpecTests {
     /// target each.
     @Test("A multi-container selection offers neither copy command")
     func multipleContainersHideCopying() {
-        let issued = commands(DatabaseTreeMenuSpec.items(for: context(
+        let issued = commands(DatabaseTreeMenuSpec.sections(for: context(
             clicked: databaseKind("app"),
             selectedContainers: [.database("app"), .database("archive")]
         )))

--- a/TableProTests/Views/Sidebar/DatabaseTreeMenuSpecTests.swift
+++ b/TableProTests/Views/Sidebar/DatabaseTreeMenuSpecTests.swift
@@ -108,11 +108,6 @@ struct DatabaseTreeMenuSpecTests {
         }
     }
 
-    /// The items a user actually sees at the top level of one menu, submenu contents excluded.
-    private func topLevelTitles(_ sections: [DatabaseTreeMenuSection]) -> [String] {
-        titles(sections.flatMap(\.items))
-    }
-
     // MARK: - The empty area
 
     /// A right-click below the last row used to produce nothing at all, which also made View

--- a/TableProTests/Views/Sidebar/FavoritesMenuSpecTests.swift
+++ b/TableProTests/Views/Sidebar/FavoritesMenuSpecTests.swift
@@ -23,10 +23,13 @@ struct FavoritesMenuSpecTests {
         )
     }
 
+    private func commands(_ sections: [FavoritesMenuSection]) -> [FavoritesMenuCommand] {
+        commands(sections.flatMap(\.items))
+    }
+
     private func commands(_ items: [FavoritesMenuItem]) -> [FavoritesMenuCommand] {
         items.flatMap { item -> [FavoritesMenuCommand] in
             switch item {
-            case .separator: return []
             case .command(let entry): return [entry.command]
             case .submenu(_, let nested): return commands(nested)
             }
@@ -74,12 +77,14 @@ struct FavoritesMenuSpecTests {
         ]
 
         for kind in kinds {
-            #expect(!FavoritesMenuSpec.items(for: context(clicked: kind)).isEmpty)
+            #expect(!FavoritesMenuSpec.sections(for: context(clicked: kind)).isEmpty)
         }
     }
 
-    @Test("A menu never opens or closes on a separator, and never doubles one")
-    func separatorsAreCollapsed() {
+    /// The HIG asks for about three groups. Placing the separators is the builder's job now, so
+    /// what this can still get wrong is the number of groups it asks for.
+    @Test("No menu carries more than four groups")
+    func menusStayWithinFourGroups() {
         let kinds: [FavoritesOutlineNode.Kind?] = [
             nil,
             .database(database()),
@@ -89,19 +94,15 @@ struct FavoritesMenuSpecTests {
         ]
 
         for kind in kinds {
-            let items = FavoritesMenuSpec.items(for: context(clicked: kind))
-            #expect(items.first != .separator)
-            #expect(items.last != .separator)
-            for (previous, next) in zip(items, items.dropFirst()) {
-                #expect(!(previous == .separator && next == .separator))
-            }
+            let sections = FavoritesMenuSpec.sections(for: context(clicked: kind)).nonEmptySections()
+            #expect(sections.count <= 4, "\(String(describing: kind)) produced \(sections.count) groups")
         }
     }
 
     /// These moved out of the bar at the bottom of the sidebar.
     @Test("The empty area carries the commands the bottom bar used to")
     func backgroundOffersCreation() {
-        let issued = commands(FavoritesMenuSpec.items(for: context(clicked: nil)))
+        let issued = commands(FavoritesMenuSpec.sections(for: context(clicked: nil)))
 
         #expect(issued.contains(.newQuery))
         #expect(issued.contains(.newFavorite(folderId: nil)))
@@ -111,8 +112,8 @@ struct FavoritesMenuSpecTests {
 
     @Test("Publishing to the team appears only when the licence allows it")
     func teamPublishIsGated() {
-        let with = commands(FavoritesMenuSpec.items(for: context(clicked: nil, teamLibraryAvailable: true)))
-        let without = commands(FavoritesMenuSpec.items(for: context(clicked: nil, teamLibraryAvailable: false)))
+        let with = commands(FavoritesMenuSpec.sections(for: context(clicked: nil, teamLibraryAvailable: true)))
+        let without = commands(FavoritesMenuSpec.sections(for: context(clicked: nil, teamLibraryAvailable: false)))
 
         #expect(with.contains(.publishSavedQueriesToTeam))
         #expect(!without.contains(.publishSavedQueriesToTeam))
@@ -121,7 +122,7 @@ struct FavoritesMenuSpecTests {
     @Test("A database favorite can switch, change environment, or be removed")
     func databaseFavoriteCommands() {
         let entry = database()
-        let issued = commands(FavoritesMenuSpec.items(for: FavoritesMenuContext(
+        let issued = commands(FavoritesMenuSpec.sections(for: FavoritesMenuContext(
             clicked: .database(entry),
             databaseEntityName: "Database",
             activeDatabase: "other"
@@ -135,7 +136,7 @@ struct FavoritesMenuSpecTests {
     @Test("The active database omits a redundant switch command")
     func activeDatabaseOmitsSwitch() {
         let entry = database()
-        let issued = commands(FavoritesMenuSpec.items(for: FavoritesMenuContext(
+        let issued = commands(FavoritesMenuSpec.sections(for: FavoritesMenuContext(
             clicked: .database(entry),
             databaseEntityName: "Database",
             activeDatabase: entry.database
@@ -148,7 +149,7 @@ struct FavoritesMenuSpecTests {
     func moveToSkipsTheCurrentFolder() {
         let home = SQLFavoriteFolder(name: "Home")
         let other = SQLFavoriteFolder(name: "Other")
-        let issued = commands(FavoritesMenuSpec.items(
+        let issued = commands(FavoritesMenuSpec.sections(
             for: context(clicked: .query(.favorite(favorite(folderId: home.id))), allFolders: [home, other])
         ))
 
@@ -159,7 +160,7 @@ struct FavoritesMenuSpecTests {
     @Test("A favourite in a folder can be moved back to the root")
     func rootLevelOfferedFromInsideAFolder() {
         let home = SQLFavoriteFolder(name: "Home")
-        let issued = commands(FavoritesMenuSpec.items(
+        let issued = commands(FavoritesMenuSpec.sections(
             for: context(clicked: .query(.favorite(favorite(folderId: home.id))), allFolders: [home])
         ))
 
@@ -169,7 +170,7 @@ struct FavoritesMenuSpecTests {
     @Test("A favourite already at the root is not offered Root Level again")
     func rootLevelOnlyWhenInAFolder() {
         let folder = SQLFavoriteFolder(name: "Home")
-        let issued = commands(FavoritesMenuSpec.items(
+        let issued = commands(FavoritesMenuSpec.sections(
             for: context(clicked: .query(.favorite(favorite(folderId: nil))), allFolders: [folder])
         ))
 
@@ -179,11 +180,11 @@ struct FavoritesMenuSpecTests {
     @Test("A linked folder offers Enable when it is disabled and Disable when it is not")
     func linkedFolderTogglesByState() {
         var folder = LinkedSQLFolder(path: "~/queries")
-        let enabled = commands(FavoritesMenuSpec.items(
+        let enabled = commands(FavoritesMenuSpec.sections(
             for: context(clicked: .query(.linkedFolder(folder, children: [])))
         ))
         folder.isEnabled = false
-        let disabled = commands(FavoritesMenuSpec.items(
+        let disabled = commands(FavoritesMenuSpec.sections(
             for: context(clicked: .query(.linkedFolder(folder, children: [])))
         ))
 

--- a/TableProTests/Views/Sidebar/SidebarMenuBuilderTests.swift
+++ b/TableProTests/Views/Sidebar/SidebarMenuBuilderTests.swift
@@ -1,0 +1,121 @@
+//
+//  SidebarMenuBuilderTests.swift
+//  TableProTests
+//
+
+import AppKit
+import Testing
+
+@testable import TablePro
+
+@Suite("Sidebar menu builder")
+@MainActor
+struct SidebarMenuBuilderTests {
+    private func build(_ sections: [DatabaseTreeMenuSection]) -> NSMenu {
+        let menu = NSMenu()
+        SidebarMenuBuilder.fill(
+            menu,
+            with: sections,
+            target: NSObject(),
+            action: #selector(NSObject.description as () -> String),
+            keyboard: KeyboardSettings.default
+        )
+        return menu
+    }
+
+    /// The separator is the builder's to place now, so this is where the shape is guaranteed. The
+    /// spec used to emit separators itself and a helper swept up the strays that made possible.
+    @Test("A separator falls between groups and never opens, closes or doubles")
+    func separatorsFallBetweenGroups() {
+        let menu = build([
+            DatabaseTreeMenuSection([.command("A", .createTable)]),
+            DatabaseTreeMenuSection([]),
+            DatabaseTreeMenuSection([.command("B", .createView)]),
+        ])
+
+        #expect(menu.items.map(\.isSeparatorItem) == [false, true, false])
+    }
+
+    @Test("An empty group contributes no separator")
+    func emptyGroupsAreDropped() {
+        let menu = build([
+            DatabaseTreeMenuSection([]),
+            DatabaseTreeMenuSection([.command("only", .createTable)]),
+            DatabaseTreeMenuSection([]),
+        ])
+
+        #expect(menu.items.count == 1)
+        #expect(!menu.items[0].isSeparatorItem)
+    }
+
+    @Test("A menu of nothing but empty groups builds nothing")
+    func allEmptyBuildsNothing() {
+        #expect(build([DatabaseTreeMenuSection([]), DatabaseTreeMenuSection([])]).items.isEmpty)
+    }
+
+    /// Resolved through `MenuItemFactory` from the same `KeyboardSettings` the menu bar reads, so a
+    /// rebind moves both. Spelling a key equivalent here instead would be a second copy of the
+    /// binding that nothing forces to agree with the first.
+    @Test("A command shares the key equivalent its menu-bar twin resolves to")
+    func shortcutsMatchTheMenuBar() {
+        let keyboard = KeyboardSettings.default
+        let ref = DatabaseTreeTableRef(
+            database: "app",
+            schema: "public",
+            table: TableInfo(name: "orders", type: .table, rowCount: nil, schema: "public")
+        )
+        let menu = build([DatabaseTreeMenuSection([
+            .command("Truncate", .truncateTables(targets: [ref], ref: ref))
+        ])])
+
+        let expected = keyboard.menuKeyEquivalent(for: .truncateTable)
+        #expect(menu.items[0].keyEquivalent == (expected?.characters ?? ""))
+        #expect(menu.items[0].keyEquivalentModifierMask == (expected?.modifiers ?? []))
+    }
+
+    /// A command the menu bar never bound shows no shortcut, rather than one invented here.
+    @Test("A command with no menu-bar binding shows no shortcut")
+    func unboundCommandsShowNothing() {
+        let menu = build([DatabaseTreeMenuSection([.command("Copy Name", .copyText("orders"))])])
+
+        #expect(menu.items[0].keyEquivalent.isEmpty)
+    }
+
+    /// The spec decides what exists rather than what is dimmed, which is the HIG's hide-don't-dim
+    /// rule, so nothing here is left for a validator to answer for.
+    @Test("Every built item is enabled and the menu does not autoenable")
+    func itemsAreEnabledAndNotAutoenabled() {
+        let menu = build([DatabaseTreeMenuSection([.command("A", .createTable)])])
+
+        #expect(!menu.autoenablesItems)
+        #expect(menu.items[0].isEnabled)
+    }
+
+    @Test("A submenu is built from its own groups")
+    func submenusCarryTheirOwnGroups() {
+        let menu = build([DatabaseTreeMenuSection([
+            .submenu(title: "View Options", sections: [
+                DatabaseTreeMenuSection([.command("Icons", .toggleObjectIcons)]),
+                DatabaseTreeMenuSection([.command("Small", .setRowSize(.small))]),
+            ])
+        ])])
+
+        let submenu = try? #require(menu.items[0].submenu)
+        #expect(submenu?.items.map(\.isSeparatorItem) == [false, true, false])
+    }
+
+    /// One source, so the control in the filter row and the empty-area menu can never list
+    /// different options or report a different state.
+    @Test("The filter row's control and the empty-area menu show the same options")
+    func viewOptionsHaveOneSource() {
+        let fromSettings = SidebarViewOptionsMenu.currentSections()
+        let settings = AppSettingsManager.shared.general
+        let fromContext = SidebarViewOptionsMenu.sections(
+            showObjectIcons: settings.showObjectIcons,
+            showObjectComments: settings.showObjectComments,
+            rowSize: settings.sidebarRowSize
+        )
+
+        #expect(fromSettings == fromContext)
+    }
+}

--- a/TableProTests/Views/Sidebar/SidebarMenuBuilderTests.swift
+++ b/TableProTests/Views/Sidebar/SidebarMenuBuilderTests.swift
@@ -73,6 +73,26 @@ struct SidebarMenuBuilderTests {
         #expect(menu.items[0].keyEquivalentModifierMask == (expected?.modifiers ?? []))
     }
 
+    /// A shortcut names one command, so it is shown once. Import's format items all carry
+    /// `.importTables`, and stamping the binding on each showed one shortcut four times over.
+    @Test("A submenu's items show no shortcut, even when the command has one")
+    func submenuItemsShowNoShortcut() {
+        let ref = DatabaseTreeTableRef(
+            database: "app",
+            schema: "public",
+            table: TableInfo(name: "orders", type: .table, rowCount: nil, schema: "public")
+        )
+        let menu = build([DatabaseTreeMenuSection([
+            .submenu(title: "Import", items: [
+                .command("CSV", .importTables(formatId: "csv", ref: ref)),
+                .command("JSON", .importTables(formatId: "json", ref: ref)),
+            ])
+        ])])
+
+        let nested = try? #require(menu.items[0].submenu)
+        #expect(nested?.items.allSatisfy { $0.keyEquivalent.isEmpty } == true)
+    }
+
     /// A command the menu bar never bound shows no shortcut, rather than one invented here.
     @Test("A command with no menu-bar binding shows no shortcut")
     func unboundCommandsShowNothing() {

--- a/TableProTests/Views/SidebarContextMenuLogicTests.swift
+++ b/TableProTests/Views/SidebarContextMenuLogicTests.swift
@@ -12,32 +12,6 @@ import Testing
 
 @Suite("SidebarContextMenuLogicTests")
 struct SidebarContextMenuLogicTests {
-    // MARK: - hasSelection
-
-    @Test("hasSelection false when empty selection and no clicked table")
-    func hasSelectionEmpty() {
-        #expect(!SidebarContextMenuLogic.hasSelection(selectedTables: [], clickedTable: nil))
-    }
-
-    @Test("hasSelection true when clicked table exists")
-    func hasSelectionClickedOnly() {
-        let table = TestFixtures.makeTableInfo(name: "users")
-        #expect(SidebarContextMenuLogic.hasSelection(selectedTables: [], clickedTable: table))
-    }
-
-    @Test("hasSelection true when selection exists")
-    func hasSelectionSelectedOnly() {
-        let table = TestFixtures.makeTableInfo(name: "users")
-        #expect(SidebarContextMenuLogic.hasSelection(selectedTables: [table], clickedTable: nil))
-    }
-
-    @Test("hasSelection true when both exist")
-    func hasSelectionBoth() {
-        let t1 = TestFixtures.makeTableInfo(name: "users")
-        let t2 = TestFixtures.makeTableInfo(name: "orders")
-        #expect(SidebarContextMenuLogic.hasSelection(selectedTables: [t1], clickedTable: t2))
-    }
-
     // MARK: - isView
 
     @Test("isView true for view type")
@@ -148,33 +122,6 @@ struct SidebarContextMenuLogicTests {
         #expect(SidebarContextMenuLogic.deleteLabel(for: nil) == "Delete")
     }
 
-    // MARK: - Disabled State Combinations
-
-    @Test("Copy name disabled with no selection")
-    func copyNameDisabledNoSelection() {
-        let hasSelection = SidebarContextMenuLogic.hasSelection(selectedTables: [], clickedTable: nil)
-        #expect(!hasSelection)
-    }
-
-    @Test("Copy name enabled with selection")
-    func copyNameEnabledWithSelection() {
-        let table = TestFixtures.makeTableInfo(name: "users")
-        let hasSelection = SidebarContextMenuLogic.hasSelection(selectedTables: [table], clickedTable: nil)
-        #expect(hasSelection)
-    }
-
-    @Test("Show structure disabled when clicked table is nil")
-    func showStructureDisabledNilTable() {
-        let clickedTable: TableInfo? = nil
-        #expect(clickedTable == nil)
-    }
-
-    @Test("Show structure enabled when clicked table exists")
-    func showStructureEnabledWithTable() {
-        let clickedTable: TableInfo? = TestFixtures.makeTableInfo(name: "users")
-        #expect(clickedTable != nil)
-    }
-
     // MARK: - Maintenance group disabled rule
 
     @Test("Maintenance group enabled with selection, writable, and supported ops")
@@ -237,51 +184,4 @@ struct SidebarContextMenuLogicTests {
         #expect(SidebarContextMenuLogic.deleteLabel(for: .externalTable) == "Drop External Table")
     }
 
-    // MARK: - contextTargets
-
-    @Test("Clicking outside the selection targets only the clicked row")
-    func contextTargetsClickOutsideSelection() {
-        let selected = TestFixtures.makeTableInfo(name: "users")
-        let clicked = TestFixtures.makeTableInfo(name: "orders")
-        let targets = SidebarContextMenuLogic.contextTargets(
-            clickedTable: clicked,
-            selectedTables: [selected]
-        )
-        #expect(targets == ["orders"])
-    }
-
-    @Test("Clicking inside the selection targets the whole selection")
-    func contextTargetsClickInsideSelection() {
-        let users = TestFixtures.makeTableInfo(name: "users")
-        let orders = TestFixtures.makeTableInfo(name: "orders")
-        let targets = SidebarContextMenuLogic.contextTargets(
-            clickedTable: users,
-            selectedTables: [users, orders]
-        )
-        #expect(targets == ["orders", "users"])
-    }
-
-    @Test("Clicking with no selection targets the clicked row")
-    func contextTargetsNoSelection() {
-        let clicked = TestFixtures.makeTableInfo(name: "users")
-        #expect(SidebarContextMenuLogic.contextTargets(clickedTable: clicked, selectedTables: []) == ["users"])
-    }
-
-    @Test("No clicked row falls back to the selection")
-    func contextTargetsNoClickedRow() {
-        let users = TestFixtures.makeTableInfo(name: "users")
-        let orders = TestFixtures.makeTableInfo(name: "orders")
-        let targets = SidebarContextMenuLogic.contextTargets(
-            clickedTable: nil,
-            selectedTables: [users, orders]
-        )
-        #expect(targets == ["orders", "users"])
-    }
-
-    @Test("A clicked row of a different kind is not treated as selected")
-    func contextTargetsMatchesOnIdentity() {
-        let table = TestFixtures.makeTableInfo(name: "users", type: .table)
-        let view = TestFixtures.makeTableInfo(name: "users", type: .view)
-        #expect(SidebarContextMenuLogic.contextTargets(clickedTable: view, selectedTables: [table]) == ["users"])
-    }
 }

--- a/docs/customization/general-settings.mdx
+++ b/docs/customization/general-settings.mdx
@@ -30,7 +30,7 @@ System (the default), English, Tiếng Việt, 简体中文, 繁體中文, 한�
 | **Row size** | Match System | Match System follows **Sidebar icon size** in **System Settings > Appearance**. Small, Medium, or Large overrides it to fit more objects on screen |
 | **Default layout for new connections** | List | List or Tree, on servers with a database tree. Switch the connection you are in from the **View** menu |
 
-Icons, comments, and row size are also under **View Options** in the sidebar's right-click menu, which every sidebar menu ends with.
+Icons, comments, and row size are also under **View Options**, the button beside the sidebar's filter field. Right-clicking the empty space below the object list reaches the same options.
 
 ## Query timeout
 

--- a/docs/databases/mysql.mdx
+++ b/docs/databases/mysql.mdx
@@ -64,7 +64,7 @@ Opening a URL connects directly. See [Connection URL Reference](/connections/url
 
 The sidebar lists every accessible database with each table's structure and DDL. Switch databases with `Cmd+K`. A tab keeps the database it was opened on; MySQL switches database in place, so that tab runs on the same connection rather than a second one.
 
-Table and column comments show in the UI: dimmed after a table's name in the sidebar, and in the grid header tooltip. Right-click the sidebar and choose **View Options > Comments** to turn that off.
+Table and column comments show in the UI: dimmed after a table's name in the sidebar, and in the grid header tooltip. Turn that off under **View Options**, the button beside the sidebar’s filter field.
 
 ## SSL/TLS
 

--- a/docs/features/er-diagram.mdx
+++ b/docs/features/er-diagram.mdx
@@ -3,7 +3,7 @@ title: ER Diagram
 description: View table relationships as an interactive entity-relationship diagram
 ---
 
-Right-click a table in the sidebar and choose **View ER Diagram**, or use **Database > View ER Diagram**. What opens is the current schema, drawn entirely from the foreign keys the driver reports: tables outside that schema are left out, and a foreign key pointing at one of them is not drawn.
+Right-click the empty space below the sidebar’s object list and choose **View ER Diagram**, or use **Database > View ER Diagram**. What opens is the current schema, drawn entirely from the foreign keys the driver reports: tables outside that schema are left out, and a foreign key pointing at one of them is not drawn.
 
 <Frame caption="ER diagram showing tables and foreign key relationships">
   <img

--- a/docs/features/favorites.mdx
+++ b/docs/features/favorites.mdx
@@ -32,7 +32,7 @@ Database favorites belong to the connection, and go when you delete it. A droppe
 
 Hover a table row and click the star at its trailing edge, or right-click and choose **Add to Favorites**. A pinned row keeps its star, filled and yellow.
 
-Pinned tables sit under **Tables** in the Favorites tab. Double-click, or press `Return`, to open one. Its right-click menu has **Open Table**, **Show ER Diagram**, and **Remove from Favorites**; `Delete` removes the selection.
+Pinned tables sit under **Tables** in the Favorites tab. Double-click, or press `Return`, to open one. Its right-click menu has **Open Table**, **View ER Diagram**, and **Remove from Favorites**; `Delete` removes the selection.
 
 Table favorites are scoped to the connection, database, and schema, and sync through [iCloud](/features/icloud-sync). One whose table is missing from the database you are browsing is hidden rather than shown broken.
 

--- a/docs/features/table-operations.mdx
+++ b/docs/features/table-operations.mdx
@@ -7,7 +7,7 @@ Dropping a table cannot be undone, and **Cascade** in the confirmation dialog wi
 
 ## Create a table or view
 
-**Database > New Table…** opens the visual structure editor (see [Table Structure](/features/table-structure)). **Database > New View…** opens a query tab holding a `CREATE VIEW` template for the engine. Both are also on the sidebar's right-click menu over empty space, and both are dimmed while [safe mode](/features/safe-mode) blocks writes.
+**Database > New Table…** opens the visual structure editor (see [Table Structure](/features/table-structure)). **Database > New View…** opens a query tab holding a `CREATE VIEW` template for the engine. Both are also on the sidebar's right-click menu over empty space, where [safe mode](/features/safe-mode) removes them rather than dimming them.
 
 ## Drop and truncate
 
@@ -82,7 +82,7 @@ PostgreSQL VACUUM carries FULL (rewrites the table and blocks access), ANALYZE, 
 
 Views carry an eye icon in the sidebar; materialized views and foreign tables get their own. All three are read-only kinds, so their menus drop **Truncate** and **Import**, and the drop item reads **Drop View**, **Drop Materialized View**, or **Drop Foreign Table**. Dropping removes the definition only, and the data in the underlying tables stays.
 
-Right-click empty space and choose **Create New View…** to write a new one; right-click an existing view and choose **Edit View Definition** to open the current definition in a query tab. Either way, execute the statement to apply it.
+Right-click empty space and choose **New View…** to write a new one; right-click an existing view and choose **Edit View Definition** to open the current definition in a query tab. Either way, execute the statement to apply it.
 
 ## Databases and schemas
 

--- a/docs/features/user-defined-types.mdx
+++ b/docs/features/user-defined-types.mdx
@@ -50,7 +50,7 @@ PostgreSQL has no statement that removes a label or moves an existing one. To dr
 
 ## Creating a type
 
-Right-click the **Types** section and choose **Create New Type…**. A query tab opens with a `CREATE TYPE … AS ENUM` template addressed to that schema. Edit it, run it, then choose **Refresh** on the section.
+Right-click the **Types** section and choose **New Type…**. A query tab opens with a `CREATE TYPE … AS ENUM` template addressed to that schema. Edit it, run it, then choose **Refresh** on the section.
 
 ## Using a type in a column
 


### PR DESCRIPTION
## The problem

A table row's contextual menu in the object tree produced 15 items in 5 groups, one of which held 7 unrelated commands: clipboard, export, transfer, schema copy, a connection-wide diagram, import and maintenance. `View Options`, a sidebar display preference, was appended to **every** menu the spec produced, including every table, view, routine, trigger and Redis key. `Create New View…` sat in the destructive group beside Truncate and Delete.

## Root cause

`SidebarMenuItem` carried a `.separator` case, so a menu was a flat array in which a group was an emergent property of append order that nothing modelled. Three things followed, and all three shipped:

- Nothing could state how many groups a menu had, so nothing held it to the HIG's *"no more than about three groups"*.
- `items(for:)` could append `View Options` to every menu, because the model had no place to say a command is scoped to the sidebar rather than to the clicked object.
- A stray or doubled separator was representable, so `collapsingSeparators` existed to sweep them up.

## The fix

**A group is now a value.** `SidebarMenuSection` is what a spec returns, `.separator` is deleted, and `SidebarMenuBuilder` rules between non-empty sections. A stray separator is unrepresentable rather than swept up, `collapsingSeparators` is gone, and a test can assert the group count directly.

**A table row is four groups of 12 items**, one intent each: reach it, note it, move its data, change it. Destructive last behind its own separator, which is the only way macOS sets one apart (`NSMenuItem` has no destructive role and Apple does not colour Finder's Move to Trash).

```
Open in New Tab / Show Structure / [Edit View Definition]
Copy Name / Add to Favorites
Export… / Import ▸ / Transfer To… / Copy To… / Maintenance ▸
Rename / Truncate / Delete
```

**Connection-wide and sidebar-wide commands leave object rows.** `View ER Diagram` and `New View…` are on the empty-area menu, where the pointer is over no object. `View Options` becomes a control in the sidebar's filter row.

**View Options is an `NSPopUpButton` in pull-down mode**, not a plain button carrying a menu: a button's `menu` opens on secondary click only, and driving one from a button action gives up the keyboard activation and menu-button accessibility role the pull-down has for free. Measured on macOS 27: an `NSPopUpButton` ignores its own `image` because the cell draws from the menu, so the symbol goes on the item in the label slot at index 0. The filter row became an `NSStackView` so hiding the button on the Favorites tab takes its width with it.

**Shortcuts resolve through `MenuItemFactory.apply(shortcut:keyboard:to:)`**, the same function the menu bar uses against the same `KeyboardSettings`, so a rebind in Settings moves both and the two menus cannot drift. A command whose menu-bar twin has no `ShortcutAction` shows nothing rather than an invented binding; today that means Refresh, Truncate, Import and Export carry one.

Note for reviewers: Apple's HIG says *"Show keyboard shortcuts in your app's main menus, not in context menus... it is redundant."* Showing them is a deliberate product decision here, taken with that guideline in view. It is safe: measured with an AppKit harness, a key equivalent on a contextual menu item is display-only, because `NSView.performKeyEquivalent` never consults the view's own menu. `window.performKeyEquivalent` returns `false`, nothing is blanked, and no second claimant is created for a shortcut the menu bar owns.

## Review pass

A second review caught a real defect in the first commit and it is fixed in `8622d1f57`. `SidebarMenuBuilder` recursed into submenus applying the shortcut to every nested item, so on MySQL and PostgreSQL the **Import** submenu showed the same binding on all four format items. A shortcut is now shown once, on the top-level item, since a submenu's leaves are variants of the command its container stands for. Pinned by a regression test.

Four more docs pages that still described the old menu were updated in the same commit (`er-diagram`, `favorites`, `user-defined-types`, `mysql`). Also from that pass: the appearance observer woke on every `GeneralSettings` write, because `@Observable` registers access on the stored `general` property rather than on the fields read inside it, and each wake reconfigured every row of every open window; the two values are now compared before the refresh runs. The View Options button's visibility is set alongside the search field's rather than a main-actor turn later, which removed a one-turn flicker on workspace switch. The three view-options commands had two dispatch sites, one of which ended in `default: return`, so a fourth option would have worked from the menu and done nothing from the button; both now route through one `SidebarViewOptionsMenu.apply`.

## Also fixed

Toggling **Show object icons** or **Show object comments** in Settings repainted nothing in an open object tree: `refreshVisibleRows()` was only ever called from the contextual menu's own handler. The tree now observes the setting and repaints itself, so the same change arrives from the new control, the empty-area menu and Settings alike. That decoupling is what lets the filter-row control work at all, since it is sidebar chrome that outlives the per-connection coordinator.

Two dead helpers went with it: `SidebarContextMenuLogic.contextTargets` was a second, unused implementation of the clicked-versus-selection rule, documented as if authoritative while every live menu resolved through `SidebarMenuTarget`. Editing it changed nothing and its tests still passed.

## Verified

- `verify.sh build`: PASS
- `verify.sh test DatabaseTreeMenuSpecTests FavoritesMenuSpecTests SidebarContextMenuLogicTests SidebarMenuTargetTests SidebarMenuBuilderTests`: PASS, 101 of 101
- `verify.sh lint TablePro/Views/Sidebar …`: PASS, 0 violations
- `verify.sh docs`: PASS

New tests cover the group count per node kind, submenu depth and per-group size, the absence of connection-wide commands from every object row, the four-group table shape with destructive last, the recent row's extra group, and at the builder: separator placement, empty-group collapse, shortcut resolution against `KeyboardSettings`, and that an unbound command shows none.

No UI automation: the change is a contextual menu's contents, which `TableProUITests` cannot open and read deterministically. The shape is asserted at the spec and the built `NSMenu` instead, which is where the behaviour lives.

Screenshots are not included; capturing a contextual menu needs a live connection this branch was not built against. The exact item lists are pinned by the tests above.

https://claude.ai/code/session_01HysxXUgegonhNukMzHFuX5
