### PR TITLE
feat(export): propose the new table's name from the file being imported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Table name proposed from the file name when an import creates the table, with a warning when the name is taken.
 - Copy To across database engines, with every type approximation listed before the copy runs. (#1491)
 - Per-table `WHERE` and row limit in Copy To. (#1491)
 - Server-side `INSERT … SELECT` when a copy's two sides are one connection. (#1491)
@@ -41,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Import sheet clearing a table without confirmation on a connection set to confirm destructive statements.
+- Empty destination table picker in the import sheet, with no message and no retry, when the table list could not be read.
 - Connection with two transports enabled reaching the database directly, with neither transport applied.
 - Delete Connection missing from the connection editor since 0.39.0.
 - Continue dimmed after filtering the database chooser down to one driver.

--- a/TablePro/Core/Services/Export/NewTableNaming.swift
+++ b/TablePro/Core/Services/Export/NewTableNaming.swift
@@ -1,0 +1,179 @@
+//
+//  NewTableNaming.swift
+//  TablePro
+//
+
+import Foundation
+
+enum NewTableNameProblem: Equatable {
+    case blank
+    case nameTaken
+}
+
+/// How an engine treats a table name written without quotes, and what it refuses outright.
+///
+/// The import sheet always quotes the name it creates, so the casing only decides whether the table
+/// can be named without quotes in a query written later. The other two are harder rules: a name past
+/// the engine's limit is rejected, and PostgreSQL truncates it silently instead, which lands two
+/// imports in one table.
+struct NewTableNameStyle: Equatable {
+    enum Casing: Equatable {
+        case lower
+        case upper
+    }
+
+    let casing: Casing
+    let maximumByteLength: Int
+
+    /// A prefix the engine keeps for itself. Measured against the vendored SQLite: `CREATE TABLE
+    /// "sqlite_backup"` fails with "object name reserved for internal use" even quoted and whatever
+    /// its case, and `SQLitePlugin.fetchTables` hides those objects, so a collision check cannot
+    /// rescue the name either. A proposal carrying it could never be imported.
+    let reservedPrefix: String?
+
+    /// Oracle folds an unquoted identifier to upper case and caps it at 30 bytes until the server
+    /// runs 12.2 or later with `COMPATIBLE` raised. TablePro connects back to 11.1 and the login
+    /// never reports `COMPATIBLE`, so the shorter limit is the only one a suggestion can assume.
+    /// Snowflake folds to upper case too. Everything else folds to lower, and 63 bytes is
+    /// PostgreSQL's limit and under MySQL's.
+    static func forDatabaseType(_ databaseType: DatabaseType) -> NewTableNameStyle {
+        switch databaseType {
+        case .oracle:
+            return NewTableNameStyle(casing: .upper, maximumByteLength: 30, reservedPrefix: nil)
+        case .snowflake:
+            return NewTableNameStyle(casing: .upper, maximumByteLength: 63, reservedPrefix: nil)
+        case .sqlite, .libsql, .turso, .cloudflareD1:
+            return NewTableNameStyle(casing: .lower, maximumByteLength: 63, reservedPrefix: "sqlite_")
+        default:
+            return NewTableNameStyle(casing: .lower, maximumByteLength: 63, reservedPrefix: nil)
+        }
+    }
+}
+
+/// The name an import proposes for the table it is about to create, and what is wrong with the
+/// name the user left in the field.
+///
+/// A file name is not an identifier: APFS accepts every scalar but `/` and NUL, so a stem arrives
+/// holding spaces, punctuation, emoji and combining marks. Mapping the ones outside
+/// `CharacterSet.alphanumerics` onto `_` keeps letters and digits from every script, which matters
+/// because that set spans Unicode `L*` and `M*`: a Cyrillic or CJK file name survives as itself
+/// rather than being transliterated into something the user never wrote.
+enum NewTableNaming {
+    private static let fallbackStem = "imported_data"
+    private static let safetyPrefix = "t_"
+    private static let separator: Character = "_"
+
+    /// Names compare case-insensitively because the engines disagree about whether they should:
+    /// PostgreSQL folds an unquoted name, macOS MySQL compares one case-insensitively, and a
+    /// suggestion that differs from an existing table only in case is a collision on both.
+    static func comparisonKeys(for names: some Sequence<String>) -> Set<String> {
+        Set(names.map { $0.lowercased() })
+    }
+
+    static func suggestion(
+        forFileNamed fileName: String,
+        style: NewTableNameStyle,
+        avoiding existingKeys: Set<String>
+    ) -> String {
+        let stem = URL(fileURLWithPath: fileName).deletingPathExtension().lastPathComponent
+        let shaped = shaping(identifier(from: stem), style: style)
+        var fitted = truncating(shaped, toByteLength: style.maximumByteLength)
+        if fitted.isEmpty {
+            fitted = truncating(
+                shaping(fallbackStem, style: style), toByteLength: style.maximumByteLength
+            )
+        }
+        return disambiguating(fitted, style: style, avoiding: existingKeys)
+    }
+
+    /// `existingNames` is `nil` when the table list never loaded. A collision cannot be ruled out
+    /// then, and it must not be ruled in either: reporting one name as taken because the catalog
+    /// is unreachable would block an import the engine would have accepted.
+    static func problem(with name: String, existingNames: Set<String>?) -> NewTableNameProblem? {
+        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return .blank }
+        guard let existingNames else { return nil }
+        return existingNames.contains(trimmed.lowercased()) ? .nameTaken : nil
+    }
+
+    /// Runs of rejected scalars collapse onto one separator, and a run at either end produces
+    /// none, so `.hidden` yields `hidden` and `sales - 2024` yields `sales_2024`.
+    private static func identifier(from stem: String) -> String {
+        let allowed = CharacterSet.alphanumerics
+        var result = ""
+        var separatorPending = false
+        for scalar in stem.precomposedStringWithCanonicalMapping.unicodeScalars {
+            guard allowed.contains(scalar) else {
+                separatorPending = true
+                continue
+            }
+            if separatorPending, !result.isEmpty {
+                result.append(separator)
+            }
+            separatorPending = false
+            result.unicodeScalars.append(scalar)
+        }
+        return result
+    }
+
+    /// A stem that survives as nothing, one that survives as digits, and one carrying the engine's
+    /// own reserved prefix all need characters the file did not supply: no mainstream unquoted
+    /// identifier grammar admits a leading digit, and a reserved prefix is refused outright.
+    private static func shaping(_ identifier: String, style: NewTableNameStyle) -> String {
+        var name = identifier
+        if name.isEmpty {
+            name = fallbackStem
+        }
+        if let first = name.unicodeScalars.first, CharacterSet.decimalDigits.contains(first) {
+            name = safetyPrefix + name
+        }
+        if let reserved = style.reservedPrefix,
+           name.lowercased().hasPrefix(reserved.lowercased()) {
+            name = safetyPrefix + name
+        }
+        switch style.casing {
+        case .lower: return name.lowercased()
+        case .upper: return name.uppercased()
+        }
+    }
+
+    /// Cuts on a `Character` boundary while counting UTF-8 bytes, because the engines state their
+    /// limits in bytes and a multi-byte name would otherwise be cut mid-grapheme.
+    private static func truncating(_ name: String, toByteLength limit: Int) -> String {
+        guard name.utf8.count > limit else { return name }
+        var result = ""
+        var usedBytes = 0
+        for character in name {
+            let width = String(character).utf8.count
+            guard usedBytes + width <= limit else { break }
+            result.append(character)
+            usedBytes += width
+        }
+        return trimmingSeparators(result)
+    }
+
+    private static func trimmingSeparators(_ name: String) -> String {
+        var trimmed = Substring(name)
+        while trimmed.first == separator { trimmed = trimmed.dropFirst() }
+        while trimmed.last == separator { trimmed = trimmed.dropLast() }
+        return String(trimmed)
+    }
+
+    /// One more candidate than there are names guarantees a free one, so the walk is bounded by
+    /// the catalog rather than by a constant that a large schema could exhaust.
+    private static func disambiguating(
+        _ name: String,
+        style: NewTableNameStyle,
+        avoiding existingKeys: Set<String>
+    ) -> String {
+        guard existingKeys.contains(name.lowercased()) else { return name }
+        var candidate = name
+        for index in 2...(existingKeys.count + 2) {
+            let suffix = "\(separator)\(index)"
+            let room = max(1, style.maximumByteLength - suffix.utf8.count)
+            candidate = truncating(name, toByteLength: room) + suffix
+            if !existingKeys.contains(candidate.lowercased()) { return candidate }
+        }
+        return candidate
+    }
+}

--- a/TablePro/Models/Connection/DatabaseConnection.swift
+++ b/TablePro/Models/Connection/DatabaseConnection.swift
@@ -36,6 +36,7 @@ extension DatabaseType {
     static let redis = DatabaseType(rawValue: "Redis")
     static let mssql = DatabaseType(rawValue: "SQL Server")
     static let oracle = DatabaseType(rawValue: "Oracle")
+    static let snowflake = DatabaseType(rawValue: "Snowflake")
     static let dameng = DatabaseType(rawValue: "Dameng")
     static let clickhouse = DatabaseType(rawValue: "ClickHouse")
     static let duckdb = DatabaseType(rawValue: "DuckDB")

--- a/TablePro/Views/Import/RowImportSheet.swift
+++ b/TablePro/Views/Import/RowImportSheet.swift
@@ -46,15 +46,41 @@ struct RowImportSheet: View {
     }
 
     @State private var destination: Destination = .existingTable
-    @State private var availableTables: [TableInfo] = []
+
+    /// Every object the connection holds, not just the tables the destination picker offers. A
+    /// `CREATE TABLE` collides with a view, a materialized view or a foreign table under the same
+    /// name as surely as with a table, so the name check has to see all of them.
+    @State private var databaseObjects: [TableInfo] = []
+
+    /// Those names folded for comparison, and `nil` while the catalog is unknown. A read that
+    /// failed leaves an empty list, and taking that for "nothing is in the way" would propose a
+    /// name that already exists and then report it as free. Stored rather than computed because the
+    /// name check runs on every keystroke, and `body` would otherwise rebuild the set each time.
+    @State private var catalogNameKeys: Set<String>?
+    @State private var tableListError: String?
+
+    /// `loadTables()` is `@MainActor` but reentrant across its `await`, so two Try Again presses
+    /// would interleave and a late failure could clear the keys while the picker kept its rows.
+    /// Concurrent callers wait for the one in flight, per the schema-loading invariant.
+    @State private var isLoadingTables = false
     @State private var selectedTargetTable: String?
     @State private var targetColumns: [String] = []
     @State private var mappings: [FieldMapping] = []
     @State private var newTableName: String = ""
+
+    /// The last name this sheet proposed, so a second pass can tell its own guess from what
+    /// the user typed over it.
+    @State private var proposedTableName: String = ""
     @State private var newColumns: [NewColumn] = []
     @State private var newColumnsLoaded = false
     @State private var isLoadingContext = false
     @State private var loadError: String?
+
+    /// Moving focus here also selects the whole proposed name, measured rather than assumed:
+    /// SwiftUI hands the field editor a full selection when `@FocusState` lands on text already in
+    /// place, both on appear and when the field is revealed by the destination picker. So the first
+    /// keystroke replaces the proposal instead of appending to it, and no AppKit detour is needed.
+    @FocusState private var newTableNameFocused: Bool
 
     /// The plugin's own options are persistent and shared, and this sheet edits them in place.
     /// Without a snapshot, Cancel kept every change, so `Delete existing rows` stayed armed for
@@ -79,6 +105,24 @@ struct RowImportSheet: View {
     /// Avoids `NSApp.keyWindow`, which when a result is presented is the progress sheet being
     /// torn down in the same transaction, and AppKit ends a sheet's children with it (#2314).
     @State private var hostWindow: NSWindow?
+
+    // MARK: - Derived catalog state
+
+    /// Tables alone, because they are the only objects the existing-table branch can insert into.
+    private var availableTables: [TableInfo] {
+        databaseObjects.filter { $0.type == .table }
+    }
+
+    /// A table this sheet created is not in the way of this sheet: a failed import leaves its table
+    /// behind, and `NewTableImportPlanner` exists to reuse that one on the retry, so reporting the
+    /// name as taken would block the very attempt that mechanism exists to allow. Checked against
+    /// `createdTables` by key rather than folded into `catalogNameKeys`, which is rebuilt only when
+    /// the catalog is.
+    private var newTableNameProblem: NewTableNameProblem? {
+        let trimmed = newTableName.trimmingCharacters(in: .whitespaces)
+        guard createdTables[trimmed] == nil else { return nil }
+        return NewTableNaming.problem(with: newTableName, existingNames: catalogNameKeys)
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -112,8 +156,14 @@ struct RowImportSheet: View {
         .task {
             settingsSnapshot = PluginSettingsSnapshot(
                 plugins: [currentPlugin as? any SettablePluginDiscoverable].compactMap { $0 })
+            suggestNewTableName()
             await loadTables()
             await loadNewColumns()
+        }
+        .onChange(of: destination) { _, newValue in
+            guard newValue == .newTable else { return }
+            suggestNewTableName()
+            newTableNameFocused = true
         }
         .onChange(of: selectedTargetTable) { _, newValue in
             mappings = []
@@ -208,8 +258,37 @@ struct RowImportSheet: View {
                     Text("New table:")
                     TextField("", text: $newTableName, prompt: Text("table_name"))
                         .frame(maxWidth: 280)
+                        .focused($newTableNameFocused)
                 }
             }
+
+            if let tableListError {
+                GridRow {
+                    tableListErrorRow(tableListError)
+                        .gridCellColumns(2)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// The list is what both destinations are chosen against, so a failure to read it is worth
+    /// saying and worth being able to retry without losing the options already set in this sheet.
+    private func tableListErrorRow(_ message: String) -> some View {
+        HStack(spacing: 6) {
+            Label(
+                String(format: String(localized: "Could not read the table list. %@"), message),
+                systemImage: "exclamationmark.triangle"
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(2)
+            Button(String(localized: "Try Again")) {
+                Task { await loadTables() }
+            }
+            .buttonStyle(.link)
+            .font(.caption)
+            .disabled(isLoadingTables)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -493,6 +572,17 @@ struct RowImportSheet: View {
             }
             return nil
         case .newTable:
+            if let problem = newTableNameProblem {
+                switch problem {
+                case .blank:
+                    return String(localized: "Enter a name for the new table.")
+                case .nameTaken:
+                    return String(
+                        format: String(localized: "A table named %@ already exists."),
+                        newTableName.trimmingCharacters(in: .whitespaces)
+                    )
+                }
+            }
             let names = newColumns
                 .filter { $0.include }
                 .map { $0.name.trimmingCharacters(in: .whitespaces).lowercased() }
@@ -551,14 +641,50 @@ struct RowImportSheet: View {
 
     // MARK: - Loading
 
+    /// Both failures used to leave an empty list and say nothing, so the destination picker offered
+    /// "Select a table…" and nothing else with no way to tell an empty database from an unreachable
+    /// one, and no way to ask again.
     @MainActor
     private func loadTables() async {
-        guard let driver = DatabaseManager.shared.driver(for: connection.id) else { return }
+        guard !isLoadingTables else { return }
+        isLoadingTables = true
+        defer { isLoadingTables = false }
+        guard let driver = DatabaseManager.shared.driver(for: connection.id) else {
+            catalogNameKeys = nil
+            tableListError = String(localized: "This connection is not open.")
+            return
+        }
         do {
-            availableTables = try await driver.fetchTables().filter { $0.type == .table }
+            databaseObjects = try await driver.fetchTables()
+            catalogNameKeys = NewTableNaming.comparisonKeys(for: databaseObjects.map(\.name))
+            tableListError = nil
+            suggestNewTableName()
         } catch {
+            catalogNameKeys = nil
+            tableListError = error.localizedDescription
             Self.logger.warning("Failed to load tables: \(error.localizedDescription, privacy: .public)")
         }
+    }
+
+    /// Proposes a name straight away and again once the catalog arrives, because only the part that
+    /// avoids a name already in use needs the catalog. Waiting for it would leave the field empty
+    /// under a "name this table" warning while the list loaded, and empty for good if it failed.
+    ///
+    /// The second pass replaces this sheet's own earlier guess and nothing else: anything the user
+    /// typed differs from `proposedTableName` and is left alone. A table this sheet already created
+    /// is left out of the avoid-set for the same reason it is left out of the name check: a retry
+    /// is meant to land back on it, and stepping the name to `_2` would strand the first one.
+    @MainActor
+    private func suggestNewTableName() {
+        guard newTableName.isEmpty || newTableName == proposedTableName else { return }
+        let ours = NewTableNaming.comparisonKeys(for: createdTables.keys)
+        let suggestion = NewTableNaming.suggestion(
+            forFileNamed: fileURL.lastPathComponent,
+            style: NewTableNameStyle.forDatabaseType(connection.type),
+            avoiding: (catalogNameKeys ?? []).subtracting(ours)
+        )
+        proposedTableName = suggestion
+        newTableName = suggestion
     }
 
     /// `detectSourceFields` is synchronous and reads the file: the XLSX plugin materialises the
@@ -776,27 +902,40 @@ struct RowImportSheet: View {
             primaryKeyColumns: [],
             databaseType: connection.type
         )
-        _ = try await driver.execute(query: generator.deleteAllRowsStatement())
+        let sql = generator.deleteAllRowsStatement()
+        try await authorize(
+            sql: sql, kind: .destructiveQuery, description: String(localized: "Clear Table")
+        )
+        _ = try await driver.execute(query: sql)
     }
 
     private func createTable(sql: String) async throws {
         guard let driver = DatabaseManager.shared.driver(for: connection.id) else {
             throw DatabaseError.notConnected
         }
+        try await authorize(
+            sql: sql, kind: .schemaMutation, description: String(localized: "Create Table")
+        )
+        _ = try await driver.execute(query: sql)
+    }
+
+    /// Every statement this sheet issues on its own account goes through the gate. The retry path's
+    /// `DELETE FROM` used to skip it while the `CREATE TABLE` beside it did not, so a connection
+    /// set to confirm destructive statements emptied a table without asking.
+    private func authorize(sql: String, kind: OperationKind, description: String) async throws {
         let decision = await ExecutionGateProvider.shared.authorize(
             OperationRequest(
                 connectionId: connection.id,
                 databaseType: connection.type,
                 sql: sql,
-                kind: .schemaMutation,
+                kind: kind,
                 caller: .userInterface,
                 capabilities: .interactiveUser,
-                operationDescription: String(localized: "Create Table")
+                operationDescription: description
             )
         )
         guard case .authorized = decision else {
             throw PluginImportError.importFailed(decision.deniedReason ?? String(localized: "Operation not permitted"))
         }
-        _ = try await driver.execute(query: sql)
     }
 }

--- a/TableProTests/Core/Services/NewTableNamingTests.swift
+++ b/TableProTests/Core/Services/NewTableNamingTests.swift
@@ -1,0 +1,222 @@
+//
+//  NewTableNamingTests.swift
+//  TableProTests
+//
+
+@testable import TablePro
+import Testing
+
+/// A row import that creates its table used to open with an empty name field, so the name reached
+/// `CREATE TABLE` unchecked and the server was the first thing to judge it.
+@Suite("New table naming")
+struct NewTableNamingTests {
+    private let postgres = NewTableNameStyle.forDatabaseType(.postgresql)
+
+    private func suggestion(_ fileName: String, taken: [String] = []) -> String {
+        NewTableNaming.suggestion(
+            forFileNamed: fileName,
+            style: postgres,
+            avoiding: NewTableNaming.comparisonKeys(for: taken)
+        )
+    }
+
+    // MARK: - Shaping the file name
+
+    @Test("Punctuation and spaces collapse onto single separators")
+    func punctuationCollapses() {
+        #expect(suggestion("sales-2024 Q1.csv") == "sales_2024_q1")
+        #expect(suggestion("a  -  b.csv") == "a_b")
+    }
+
+    /// `CharacterSet.alphanumerics` spans Unicode `L*` and `M*`, so a name written in any script
+    /// survives as itself. Transliterating would hand the user a name their file never held.
+    @Test("Letters from every script survive")
+    func nonLatinSurvives() {
+        #expect(suggestion("销售数据.csv") == "销售数据")
+        #expect(suggestion("продажи.csv") == "продажи")
+        #expect(suggestion("naïve-café 2024.csv") == "naïve_café_2024")
+    }
+
+    /// APFS hands back decomposed text, so an accented name arrives as a letter plus a combining
+    /// mark. Without the NFC pass the two spellings are different table names.
+    @Test("Decomposed input normalizes to the composed spelling")
+    func decomposedInputNormalizes() {
+        #expect(suggestion("cafe\u{0301}.csv") == suggestion("caf\u{00E9}.csv"))
+    }
+
+    @Test("Emoji and symbols become separators")
+    func symbolsBecomeSeparators() {
+        #expect(suggestion("emoji🚀name.csv") == "emoji_name")
+    }
+
+    /// Only the last extension goes, so a dotfile keeps its stem instead of yielding nothing.
+    /// A leading dot is not an extension separator to Foundation, so a file named `.csv` has no
+    /// extension at all and its whole name is the stem, which shapes into a usable `csv`.
+    @Test("Only the final extension is dropped")
+    func onlyFinalExtensionDropped() {
+        #expect(suggestion(".hidden.csv") == "hidden")
+        #expect(suggestion("a.b.c.tsv") == "a_b_c")
+        #expect(suggestion("no_extension") == "no_extension")
+        #expect(suggestion(".csv") == "csv")
+    }
+
+    @Test("A stem that survives as nothing falls back to a usable name")
+    func emptyStemFallsBack() {
+        #expect(suggestion("---.csv") == "imported_data")
+        #expect(suggestion("🚀.csv") == "imported_data")
+    }
+
+    /// No mainstream unquoted identifier grammar admits a leading digit, and MySQL rejects an
+    /// all-digit one outright.
+    @Test("A leading digit gains a letter prefix")
+    func leadingDigitPrefixed() {
+        #expect(suggestion("2024.csv") == "t_2024")
+        #expect(suggestion("1st-quarter.csv") == "t_1st_quarter")
+        #expect(suggestion("q1-2024.csv") == "q1_2024")
+    }
+
+    // MARK: - Engine style
+
+    @Test("Oracle folds to upper case and caps the name at 30 bytes")
+    func oracleStyle() {
+        let style = NewTableNameStyle.forDatabaseType(.oracle)
+        #expect(style.casing == .upper)
+        #expect(style.maximumByteLength == 30)
+        let name = NewTableNaming.suggestion(forFileNamed: "sales-2024 Q1.csv", style: style, avoiding: [])
+        #expect(name == "SALES_2024_Q1")
+    }
+
+    @Test("Snowflake folds to upper case too")
+    func snowflakeStyle() {
+        let style = NewTableNameStyle.forDatabaseType(.snowflake)
+        #expect(style.casing == .upper)
+        let name = NewTableNaming.suggestion(forFileNamed: "Sales.csv", style: style, avoiding: [])
+        #expect(name == "SALES")
+    }
+
+    @Test("An unknown engine takes the lower case default")
+    func unknownEngineTakesDefault() {
+        let style = NewTableNameStyle.forDatabaseType(DatabaseType(rawValue: "SomeFuturePlugin"))
+        #expect(style.casing == .lower)
+        #expect(style.maximumByteLength == 63)
+        #expect(style.reservedPrefix == nil)
+    }
+
+    /// Measured against the vendored SQLite: `CREATE TABLE "sqlite_backup"` fails with "object name
+    /// reserved for internal use" quoted and unquoted, in any case, and `fetchTables` hides those
+    /// objects so no collision check would catch it. A proposal carrying the prefix could never run.
+    @Test("The SQLite family keeps its reserved prefix out of a proposal")
+    func sqliteReservedPrefixIsBrokenUp() {
+        for type in [DatabaseType.sqlite, .libsql, .turso, .cloudflareD1] {
+            let style = NewTableNameStyle.forDatabaseType(type)
+            #expect(style.reservedPrefix == "sqlite_")
+            let name = NewTableNaming.suggestion(
+                forFileNamed: "sqlite_backup.csv", style: style, avoiding: []
+            )
+            #expect(name == "t_sqlite_backup")
+        }
+    }
+
+    @Test("A name that merely resembles the reserved prefix is left alone")
+    func nearMissKeepsItsName() {
+        let style = NewTableNameStyle.forDatabaseType(.sqlite)
+        #expect(NewTableNaming.suggestion(forFileNamed: "sqlitex.csv", style: style, avoiding: []) == "sqlitex")
+    }
+
+    /// Engines outside the family have no such rule, so the prefix survives there.
+    @Test("Other engines keep a name starting with the SQLite prefix")
+    func otherEnginesKeepThePrefix() {
+        #expect(suggestion("sqlite_backup.csv") == "sqlite_backup")
+    }
+
+    // MARK: - Length
+
+    @Test("A long name is cut to the engine's byte limit")
+    func longNameTruncates() {
+        let name = suggestion(String(repeating: "a", count: 200) + ".csv")
+        #expect(name.utf8.count == 63)
+    }
+
+    /// The limits are stated in bytes, so a multi-byte name has to be measured in bytes and cut
+    /// between characters. A cut mid-scalar would not be a string at all.
+    @Test("A multi-byte name is measured in bytes and cut between characters")
+    func multiByteNameTruncatesOnBoundary() {
+        let name = suggestion(String(repeating: "销", count: 40) + ".csv")
+        #expect(name.utf8.count <= 63)
+        #expect(name.count == 21)
+        #expect(name.allSatisfy { $0 == "销" })
+    }
+
+    /// One grapheme can be wider than the whole cap, and cutting on a character boundary then
+    /// yields nothing. An empty proposal would open the sheet on a blank-name warning.
+    @Test("A single grapheme wider than the cap still proposes a usable name")
+    func oversizedGraphemeFallsBack() {
+        let grapheme = "a" + String(repeating: "\u{0301}", count: 40)
+        let name = suggestion(grapheme + ".csv")
+        #expect(!name.isEmpty)
+        #expect(name.utf8.count <= 63)
+    }
+
+    @Test("A cut that lands on a separator does not leave one trailing")
+    func truncationTrimsTrailingSeparator() {
+        let stem = String(repeating: "a", count: 62) + " tail"
+        #expect(suggestion(stem + ".csv") == String(repeating: "a", count: 62))
+    }
+
+    // MARK: - Collisions
+
+    @Test("A free name is proposed unchanged")
+    func freeNameIsProposedUnchanged() {
+        #expect(suggestion("users.csv", taken: ["orders"]) == "users")
+    }
+
+    @Test("A taken name is disambiguated with a suffix")
+    func takenNameGainsSuffix() {
+        #expect(suggestion("users.csv", taken: ["users"]) == "users_2")
+        #expect(suggestion("users.csv", taken: ["users", "users_2"]) == "users_3")
+    }
+
+    /// PostgreSQL folds an unquoted name and macOS MySQL compares one case-insensitively, so a
+    /// suggestion differing only in case is a collision on both.
+    @Test("Collisions compare case-insensitively")
+    func collisionIsCaseInsensitive() {
+        #expect(suggestion("Users.csv", taken: ["USERS"]) == "users_2")
+    }
+
+    @Test("A suffix keeps the whole name inside the byte limit")
+    func suffixFitsInsideTheLimit() {
+        let stem = String(repeating: "a", count: 100)
+        let taken = [String(repeating: "a", count: 63)]
+        let name = suggestion(stem + ".csv", taken: taken)
+        #expect(name.utf8.count <= 63)
+        #expect(name.hasSuffix("_2"))
+    }
+
+    // MARK: - Validating what the user typed
+
+    @Test("An empty or whitespace name is blank")
+    func blankNameIsReported() {
+        #expect(NewTableNaming.problem(with: "", existingNames: []) == .blank)
+        #expect(NewTableNaming.problem(with: "   ", existingNames: []) == .blank)
+    }
+
+    @Test("A free name has no problem")
+    func freeNameHasNoProblem() {
+        #expect(NewTableNaming.problem(with: "orders", existingNames: ["users"]) == nil)
+    }
+
+    @Test("A taken name is reported, whatever its case")
+    func takenNameIsReported() {
+        #expect(NewTableNaming.problem(with: "users", existingNames: ["users"]) == .nameTaken)
+        #expect(NewTableNaming.problem(with: " Users ", existingNames: ["users"]) == .nameTaken)
+    }
+
+    /// The whole point of the optional: an unreachable catalog is an empty list, and calling every
+    /// name free on that basis hands back the driver error this check exists to replace. It must
+    /// not call a name taken either, which would block an import the engine would have accepted.
+    @Test("An unknown catalog reports no collision and still catches a blank name")
+    func unknownCatalogReportsNoCollision() {
+        #expect(NewTableNaming.problem(with: "users", existingNames: nil) == nil)
+        #expect(NewTableNaming.problem(with: "", existingNames: nil) == .blank)
+    }
+}

--- a/docs/features/import-export.mdx
+++ b/docs/features/import-export.mdx
@@ -290,13 +290,16 @@ A server that rejects the statement stops the import with that error, so clear t
 The sheet accepts an array of objects `[{…}, {…}]`, newline-delimited JSON streamed a line at a time, and TablePro's own export shape `{ "table": [ {…} ] }`, so an export round-trips. Then choose a destination:
 
 - **Existing table**: map each JSON field to a column. Fields auto-match by name; switch one off to skip it. A column with no matching field keeps its default or NULL.
-- **New table**: name it and review the columns TablePro infers. Name, type, primary key, nullable flag, and default are all editable before the table is created.
+- **New table**: the name field opens on a name derived from the file, already selected, so one keystroke replaces it. Review the inferred columns underneath. Name, type, primary key, nullable flag, and default are all editable before the table is created.
+
+The proposed name drops the extension, turns spaces and punctuation into underscores, and lowercases the result. Letters from any script are kept as they are. On Oracle the name comes through in upper case instead, and is cut to 30 bytes rather than 63. A name an existing table or view already holds gains a numeric suffix, so re-importing `users.csv` next to a `users` table proposes `users_2`. Type a name that is already taken and the sheet says so, with **Import** off until it changes.
 
 Rows insert through parameterized statements, so a JSON value is never concatenated into SQL. Nested objects and arrays are stored as JSON text.
 
 ### Import XLSX
 
-Reads the first worksheet of an `.xlsx` workbook.
+Reads the first worksheet of an `.xlsx` workbook. The destinations and the proposed new-table name
+behave as they do for JSON.
 
 | Option | Default |
 |--------|---------|


### PR DESCRIPTION
Importing a CSV, TSV, JSON, NDJSON or XLSX file into a **New table** opened the sheet with an empty
name field and a grey `table_name` placeholder. The name had to be typed from scratch every time,
and nothing checked it, so a name that was already taken failed at `CREATE TABLE` with the driver's
own error after the sheet had already dismissed into the progress sheet.

## Root cause

The new-table branch had no naming logic at all. `newTableName` was `@State = ""` with nothing
computing a default, and `canImport` asked only that the trimmed name be non-empty. The sheet was
already fetching the connection's object list into `availableTables` for the *other* destination and
never consulted it here, so the first thing that judged the name was the server.

`loadTables()` made that worse than it looks. Both of its failure exits left an empty array and set
nothing the UI could see, so a name check built on it would have read "catalog unreachable" as
"nothing is in the way" and handed back exactly the error this change removes.

## What changed

`NewTableNaming` is a new pure type beside `NewTableImportPlanner`, which is where testable logic
for this sheet already lives (`RowImportSheet` is a SwiftUI view whose state is all private
`@State`, so nothing inside it is reachable from a test).

- The name is proposed from the file: last path component, one extension dropped, NFC normalized,
  every scalar outside `CharacterSet.alphanumerics` mapped to `_`, runs collapsed, ends trimmed,
  cased and length-capped for the engine, then made unique against the objects that already exist.
- `sales-2024 Q1.csv` proposes `sales_2024_q1`. A second import next to a `users` table proposes
  `users_2`. Typing a name that is taken reports it in the sheet and holds **Import** off.
- Focus moves to the field when the destination flips, which also selects the whole proposal, so one
  keystroke replaces it.
- `loadTables()` now keeps the full object list, so the check sees views and materialized views too,
  and reports its own failure with a **Try Again** instead of an empty picker and silence.

Letters are kept as they are rather than transliterated: `销售数据.csv` proposes `销售数据`, not
`xiao_shou_shu_ju`. The generated `CREATE TABLE` quotes the identifier on every engine, so legality
is never at risk, and rewriting a name the user's own file supplied is a worse default than keeping
it. Casing and length are per engine because those are not cosmetic: Oracle folds an unquoted
identifier to upper case and caps it at 30 bytes until the server is 12.2 or later with `COMPATIBLE`
raised, and TablePro connects back to 11.1.

## Two fixes that ship with it

**The retry path's `DELETE FROM` ran without the execution gate** that the `CREATE TABLE` twelve
lines below it went through, so a connection set to confirm destructive statements emptied a table
without asking. Both now go through one `authorize` helper. This is a Safe Mode bypass and worth
triaging on its own terms rather than as part of the feature.

**A failed table-list read was invisible.** The destination picker offered "Select a table…" and
nothing else, with no way to tell an empty database from an unreachable one and no way to ask again.

## Measured, not assumed

Two investigation findings were overturned by measuring them:

- `@FocusState` alone focuses **and selects** a prefilled SwiftUI `TextField` on this toolchain
  (`NSText.selectedRange {0, 13}` on a 13-character value), in `.onAppear` and when the field is
  revealed by a segmented picker. The recommendation had been an `NSViewRepresentable` plus AppKit
  `selectText(_:)` plus an `#available` split for macOS 15's `TextField(text:selection:)`. None of it
  is needed.
- `CharacterSet.alphanumerics` spans Unicode `L*` **and** `M*`, so it preserves CJK, Cyrillic,
  Arabic, accented Latin and the NFD combining marks APFS actually hands back. A stricter set would
  have turned every accented file name into `a_bc`.

Review findings acted on, each confirmed against the engine first: SQLite refuses any name starting
with `sqlite_` even quoted and in any case (`object name reserved for internal use`), and
`SQLitePlugin.fetchTables` hides those objects, so a proposal carrying that prefix could never be
imported; Snowflake folds unquoted identifiers to upper case like Oracle; `loadTables()` is
`@MainActor` but reentrant across its `await`, so two **Try Again** presses could interleave.

## Known limit

The collision check sees tables and views. Indexes and sequences share the table namespace on some
engines (`CREATE TABLE archive` fails against an index named `archive` on SQLite, measured), and
`fetchTables()` does not return them, so those still surface as the driver's error. That is the
behaviour this change inherits rather than introduces; covering it needs a per-engine catalog query.

## Verification

| Step | Result |
| --- | --- |
| `verify.sh build` | PASS |
| `verify.sh test NewTableNamingTests NewTableImportPlannerTests TransferAlertWindowOwnershipTests ImportTypeMapperTests` | PASS |
| `verify.sh lint` (4 paths) | PASS, 0 violations |
| `verify.sh docs` | PASS |

Built and tested on a worktree based directly on `main`.

No `TableProUITests` case. Reaching this sheet goes through an `NSOpenPanel`, no existing UI test in
the repo drives one, and a test that did would not run deterministically. The naming and collision
rules are covered by unit tests instead, which is why they live in a type outside the view.

No before/after screenshots: a second session is active in this checkout, and launching a second
`TablePro` process to drive the sheet would fail its test host. The visible change is the **New
table** row of the import sheet, where the name field opens filled and selected instead of empty.

https://claude.ai/code/session_01CxdJojLJYkn88VregtYPQo
