### PR TITLE
fix(export): hold a typed new-table name to the engine's own name rules

### DIFF
--- a/TablePro/Core/Services/Export/NewTableNaming.swift
+++ b/TablePro/Core/Services/Export/NewTableNaming.swift
@@ -8,6 +8,8 @@ import Foundation
 enum NewTableNameProblem: Equatable {
     case blank
     case nameTaken
+    case reservedPrefix(String)
+    case tooLong(maximumBytes: Int)
 }
 
 /// How an engine treats a table name written without quotes, and what it refuses outright.
@@ -86,12 +88,27 @@ enum NewTableNaming {
         return disambiguating(fitted, style: style, avoiding: existingKeys)
     }
 
+    /// The engine's rules apply to whatever is in the field, not just to what was proposed: the
+    /// suggestion is only a starting point and the user is free to type a name the server will
+    /// refuse. Catching that here is the whole point of the check, since the alternative is the
+    /// driver's own error after the sheet has dismissed.
+    ///
     /// `existingNames` is `nil` when the table list never loaded. A collision cannot be ruled out
     /// then, and it must not be ruled in either: reporting one name as taken because the catalog
     /// is unreachable would block an import the engine would have accepted.
-    static func problem(with name: String, existingNames: Set<String>?) -> NewTableNameProblem? {
+    static func problem(
+        with name: String,
+        style: NewTableNameStyle,
+        existingNames: Set<String>?
+    ) -> NewTableNameProblem? {
         let trimmed = name.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return .blank }
+        if let reserved = style.reservedPrefix, trimmed.lowercased().hasPrefix(reserved.lowercased()) {
+            return .reservedPrefix(reserved)
+        }
+        if trimmed.utf8.count > style.maximumByteLength {
+            return .tooLong(maximumBytes: style.maximumByteLength)
+        }
         guard let existingNames else { return nil }
         return existingNames.contains(trimmed.lowercased()) ? .nameTaken : nil
     }

--- a/TablePro/Views/Import/RowImportSheet.swift
+++ b/TablePro/Views/Import/RowImportSheet.swift
@@ -120,8 +120,13 @@ struct RowImportSheet: View {
     /// the catalog is.
     private var newTableNameProblem: NewTableNameProblem? {
         let trimmed = newTableName.trimmingCharacters(in: .whitespaces)
-        guard createdTables[trimmed] == nil else { return nil }
-        return NewTableNaming.problem(with: newTableName, existingNames: catalogNameKeys)
+        let problem = NewTableNaming.problem(
+            with: newTableName,
+            style: NewTableNameStyle.forDatabaseType(connection.type),
+            existingNames: catalogNameKeys
+        )
+        guard problem == .nameTaken, createdTables[trimmed] != nil else { return problem }
+        return nil
     }
 
     var body: some View {
@@ -580,6 +585,16 @@ struct RowImportSheet: View {
                     return String(
                         format: String(localized: "A table named %@ already exists."),
                         newTableName.trimmingCharacters(in: .whitespaces)
+                    )
+                case .reservedPrefix(let prefix):
+                    return String(
+                        format: String(localized: "This database keeps names beginning with %@ for itself."),
+                        prefix
+                    )
+                case .tooLong(let maximumBytes):
+                    return String(
+                        format: String(localized: "This database allows at most %lld bytes in a table name."),
+                        Int64(maximumBytes)
                     )
                 }
             }

--- a/TableProTests/Core/Services/NewTableNamingTests.swift
+++ b/TableProTests/Core/Services/NewTableNamingTests.swift
@@ -196,19 +196,19 @@ struct NewTableNamingTests {
 
     @Test("An empty or whitespace name is blank")
     func blankNameIsReported() {
-        #expect(NewTableNaming.problem(with: "", existingNames: []) == .blank)
-        #expect(NewTableNaming.problem(with: "   ", existingNames: []) == .blank)
+        #expect(NewTableNaming.problem(with: "", style: postgres, existingNames: []) == .blank)
+        #expect(NewTableNaming.problem(with: "   ", style: postgres, existingNames: []) == .blank)
     }
 
     @Test("A free name has no problem")
     func freeNameHasNoProblem() {
-        #expect(NewTableNaming.problem(with: "orders", existingNames: ["users"]) == nil)
+        #expect(NewTableNaming.problem(with: "orders", style: postgres, existingNames: ["users"]) == nil)
     }
 
     @Test("A taken name is reported, whatever its case")
     func takenNameIsReported() {
-        #expect(NewTableNaming.problem(with: "users", existingNames: ["users"]) == .nameTaken)
-        #expect(NewTableNaming.problem(with: " Users ", existingNames: ["users"]) == .nameTaken)
+        #expect(NewTableNaming.problem(with: "users", style: postgres, existingNames: ["users"]) == .nameTaken)
+        #expect(NewTableNaming.problem(with: " Users ", style: postgres, existingNames: ["users"]) == .nameTaken)
     }
 
     /// The whole point of the optional: an unreachable catalog is an empty list, and calling every
@@ -216,7 +216,38 @@ struct NewTableNamingTests {
     /// not call a name taken either, which would block an import the engine would have accepted.
     @Test("An unknown catalog reports no collision and still catches a blank name")
     func unknownCatalogReportsNoCollision() {
-        #expect(NewTableNaming.problem(with: "users", existingNames: nil) == nil)
-        #expect(NewTableNaming.problem(with: "", existingNames: nil) == .blank)
+        #expect(NewTableNaming.problem(with: "users", style: postgres, existingNames: nil) == nil)
+        #expect(NewTableNaming.problem(with: "", style: postgres, existingNames: nil) == .blank)
+    }
+
+    /// The engine's rules bind whatever the user types, not just what was proposed. A name typed
+    /// over the proposal used to reach `CREATE TABLE` unchecked and fail there.
+    @Test("A typed name carrying the reserved prefix is refused")
+    func typedReservedPrefixIsRefused() {
+        let sqlite = NewTableNameStyle.forDatabaseType(.sqlite)
+        #expect(
+            NewTableNaming.problem(with: "sqlite_master", style: sqlite, existingNames: [])
+                == .reservedPrefix("sqlite_")
+        )
+        #expect(NewTableNaming.problem(with: "sqlite_master", style: postgres, existingNames: []) == nil)
+    }
+
+    @Test("A typed name past the engine's limit is refused")
+    func typedOverlongNameIsRefused() {
+        let oracle = NewTableNameStyle.forDatabaseType(.oracle)
+        let name = String(repeating: "a", count: 31)
+        #expect(NewTableNaming.problem(with: name, style: oracle, existingNames: []) == .tooLong(maximumBytes: 30))
+        #expect(NewTableNaming.problem(with: name, style: postgres, existingNames: []) == nil)
+    }
+
+    /// The limits are in bytes, so a multi-byte name hits them sooner than its character count says.
+    @Test("Length is judged in bytes, not characters")
+    func lengthIsJudgedInBytes() {
+        let oracle = NewTableNameStyle.forDatabaseType(.oracle)
+        #expect(
+            NewTableNaming.problem(with: String(repeating: "销", count: 11), style: oracle, existingNames: [])
+                == .tooLong(maximumBytes: 30)
+        )
+        #expect(NewTableNaming.problem(with: String(repeating: "销", count: 10), style: oracle, existingNames: []) == nil)
     }
 }

--- a/docs/features/import-export.mdx
+++ b/docs/features/import-export.mdx
@@ -292,7 +292,7 @@ The sheet accepts an array of objects `[{…}, {…}]`, newline-delimited JSON s
 - **Existing table**: map each JSON field to a column. Fields auto-match by name; switch one off to skip it. A column with no matching field keeps its default or NULL.
 - **New table**: the name field opens on a name derived from the file, already selected, so one keystroke replaces it. Review the inferred columns underneath. Name, type, primary key, nullable flag, and default are all editable before the table is created.
 
-The proposed name drops the extension, turns spaces and punctuation into underscores, and lowercases the result. Letters from any script are kept as they are. On Oracle the name comes through in upper case instead, and is cut to 30 bytes rather than 63. A name an existing table or view already holds gains a numeric suffix, so re-importing `users.csv` next to a `users` table proposes `users_2`. Type a name that is already taken and the sheet says so, with **Import** off until it changes.
+The proposed name drops the extension, turns spaces and punctuation into underscores, and lowercases the result. Letters from any script are kept as they are. On Oracle the name comes through in upper case instead, and is cut to 30 bytes rather than 63. A name an existing table or view already holds gains a numeric suffix, so re-importing `users.csv` next to a `users` table proposes `users_2`. Whatever you type over it is held to the same rules: a name already taken, one longer than the engine allows, or one starting with a prefix the engine keeps for itself is reported in the sheet, with **Import** off until it changes.
 
 Rows insert through parameterized statements, so a JSON value is never concatenated into SQL. Nested objects and arrays are stored as JSON text.
 


### PR DESCRIPTION
Follow-up to #2654, from an adversarial review of that change.

#2654 proposes a new table's name from the file being imported, and shapes the proposal to the
engine: SQLite's reserved `sqlite_` prefix is broken up, and the name is cut to the engine's byte
limit. Those rules only ever ran over the **proposal**. The field is editable, so a name typed over
it went to `CREATE TABLE` unchecked and failed there, which is the exact behaviour #2654 exists to
remove.

Type `sqlite_master` on a SQLite connection, or a 40-character name on Oracle, and **Import** was
enabled and the import failed on the driver's error after the sheet had dismissed.

## What changed

`NewTableNaming.problem(with:style:existingNames:)` now takes the engine style and checks the name
in the field, not just the one it generated:

- `.reservedPrefix` when the name starts with a prefix the engine keeps for itself. Measured against
  the vendored SQLite: `CREATE TABLE "sqlite_master"` fails with `object name reserved for internal
  use` quoted, unquoted, and in any case.
- `.tooLong` when the name is past the engine's limit, counted in **bytes**. Oracle caps at 30 bytes
  until the server is 12.2 or later, so eleven CJK characters already exceed it while ten do not.

Both render through the sheet's existing `validationMessage`, so **Import** dims with the reason
beside it rather than the import failing later.

## Not changed, and why

The same review raised four other points. They describe behaviour that predates #2654 rather than
anything it introduced, so they are reported rather than folded in here:

- `CREATE`, the retry's `DELETE`, and the row `INSERT`s are not qualified by one captured schema.
  `PluginCreateTableDefinition` carries no schema field and `ImportDataSinkAdapter` omits
  `schemaName`; both resolve through the session's current schema today.
- The retry path clears a table it believes it created, keyed on an in-memory name-to-DDL map.
  #2654 made that path safer, not riskier, by putting its `DELETE` behind the execution gate the
  sibling `CREATE TABLE` already used.
- A catalog list fetched when the sheet opened cannot be authoritative for `CREATE`. A preflight
  check can never close that race; translating a duplicate-object failure back into the inline
  `.nameTaken` state would need per-engine error-code mapping.
- Swift's `lowercased()` is not the same equality any engine uses for identifiers. A missed
  collision falls back to the driver's error, which is the pre-#2654 behaviour.

## Verification

| Step | Result |
| --- | --- |
| `verify.sh build` | PASS |
| `verify.sh test NewTableNamingTests NewTableImportPlannerTests TransferAlertWindowOwnershipTests` | PASS, 36 cases |
| `verify.sh lint` (3 paths) | PASS, 0 violations |
| `verify.sh docs` | PASS |

Rebased onto `main` after #2654 merged, and rebuilt against it.

Three tests added: a typed reserved prefix, a typed over-limit name, and length judged in bytes
rather than characters. No UI automation, for the reason given in #2654: the flow opens an
`NSOpenPanel` first and nothing in the repo drives one deterministically.

https://claude.ai/code/session_01CxdJojLJYkn88VregtYPQo
