### PR TITLE
fix(plugin-redis): authenticate as the ACL user typed, not the default user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cancel doing nothing while a backup's size estimate ran. (#2485)
 - Backup size estimate queueing behind a query tab's own work and joining its open transaction. (#2485)
 - A narrowed PostgreSQL dump matching nothing when a table name held a capital, a dot or a wildcard. (#2485)
+- Redis and Valkey ACL users without permission to run `PING` refused at connect and dropped by the health check.
+- Redis database index ignoring the `dbN` spelling the driver itself publishes.
+- A Sentinel that rejected the credentials reported as unreachable.
+- A Redis reconnect that failed leaving the connection marked live, so every later command reported it as not connected.
+
+### Security
+
+- Redis and Valkey connections signing in as the default user when a username was typed with an empty password.
+- Redis connections on iOS reported as successful without a single command reaching the server.
 
 ## [0.72.0] - 2026-09-04
 

--- a/Plugins/RedisDriverPlugin/HiredisSentinelTransport.swift
+++ b/Plugins/RedisDriverPlugin/HiredisSentinelTransport.swift
@@ -56,7 +56,12 @@ struct HiredisSentinelTransport: RedisSentinelTransport {
             sslConfig: sslConfig,
             connectTimeout: connectTimeout
         )
-        try await connection.connect()
+        do {
+            try await connection.connect()
+        } catch let error as RedisPluginError where error.refusedByServer {
+            logger.debug("Sentinel \(sentinel.identifier, privacy: .public) refused: \(error.message, privacy: .public)")
+            throw RedisSentinelError.refused(sentinel, detail: error.message)
+        }
         defer { connection.disconnect() }
 
         let reply = try await connection.executeCommand(command)

--- a/Plugins/RedisDriverPlugin/RedisAuthCommand.swift
+++ b/Plugins/RedisDriverPlugin/RedisAuthCommand.swift
@@ -4,18 +4,31 @@ nonisolated enum RedisAuthCommand {
     enum Failure: Equatable, Sendable {
         case rejectedCredentials
         case rejectedWithoutUsername
+        case rejectedWithoutPassword
         case serverHasNoPassword
         case usernameUnsupported
         case unrecognized
     }
 
+    /// A typed username is an identity, and an empty password does not cancel it.
+    ///
+    /// Redis defines the one-argument form as `AUTH default <password>`, so sending it for an ACL
+    /// user checks their password against `default` and fails. Skipping AUTH entirely is worse:
+    /// the server leaves the connection on `default`, every command runs with `default`'s
+    /// privileges, and the app reports a successful sign-in as the user who was never sent.
+    /// `AUTH <username> ""` is the wire form for a `nopass` ACL user and is rejected for every
+    /// other user, so it is both the correct request and an exact test of the identity.
     static func arguments(username: String?, password: String?) -> [String]? {
-        guard let password, !password.isEmpty else { return nil }
-        guard let username, !username.isEmpty else { return ["AUTH", password] }
-        return ["AUTH", username, password]
+        let user = username ?? ""
+        let secret = password ?? ""
+        if !user.isEmpty { return ["AUTH", user, secret] }
+        guard !secret.isEmpty else { return nil }
+        return ["AUTH", secret]
     }
 
-    static func failure(serverError: String, hadUsername: Bool) -> Failure {
+    /// `WRONGPASS` is the same reply for a wrong password, an empty one and an unknown user, so
+    /// what the client sent is the only thing that can tell the three apart.
+    static func failure(serverError: String, hadUsername: Bool, hadPassword: Bool) -> Failure {
         let text = serverError.lowercased()
         if text.contains("wrong number of arguments") { return .usernameUnsupported }
         if text.contains("without any password configured") || text.contains("no password is set") {
@@ -23,8 +36,25 @@ nonisolated enum RedisAuthCommand {
         }
         if text.contains("invalid password") { return .rejectedCredentials }
         if text.contains("wrongpass") {
-            return hadUsername ? .rejectedCredentials : .rejectedWithoutUsername
+            if !hadUsername { return .rejectedWithoutUsername }
+            if !hadPassword { return .rejectedWithoutPassword }
+            return .rejectedCredentials
         }
         return .unrecognized
+    }
+
+    static func hint(for failure: Failure) -> String? {
+        switch failure {
+        case .rejectedWithoutUsername:
+            return String(localized: "If this server uses Redis 6 or later ACL users, fill in the Username field.")
+        case .rejectedWithoutPassword:
+            return String(localized: "The Password field is empty. Fill it in, or clear Username to sign in as the default user.")
+        case .serverHasNoPassword:
+            return String(localized: "This server has no password set for the default user. Clear the Password field.")
+        case .usernameUnsupported:
+            return String(localized: "This server predates Redis 6 and takes no username. Clear the Username field.")
+        case .rejectedCredentials, .unrecognized:
+            return nil
+        }
     }
 }

--- a/Plugins/RedisDriverPlugin/RedisConnectProbe.swift
+++ b/Plugins/RedisDriverPlugin/RedisConnectProbe.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Whether a connection carries an identity, asked of the server rather than assumed.
+///
+/// A hiredis context that opened proves a reachable port and nothing else: an unauthenticated
+/// connection accepts the socket and refuses every command, so "connected" has to be a reply the
+/// server sent, not the absence of a transport error.
+///
+/// The reply cannot simply be tested for success. `PING`, `INFO` and `ACL WHOAMI` are all
+/// ACL-deniable, so a restricted user answers `NOPERM` to whichever one is used as the probe, and
+/// treating that as a failure locks out exactly the accounts ACLs exist to create. Measured
+/// against Redis 8.10.1: an unauthenticated session gets `NOAUTH` from every command, while a
+/// session bound to a user without `+ping` gets `NOPERM` and can still run what it is allowed.
+/// `NOPERM` is therefore the server confirming an identity, and `NOAUTH` is the only reply that
+/// says there is none.
+nonisolated enum RedisConnectProbe {
+    enum Outcome: Equatable, Sendable {
+        case established
+        case unauthenticated
+        case refused(String)
+    }
+
+    static let command = ["PING"]
+
+    static let unauthenticatedMessage = String(localized: "This server requires authentication.")
+    static let unauthenticatedHint = String(
+        localized: "Fill in Password, and Username too if the server uses Redis 6 ACL users."
+    )
+
+    static func outcome(errorMessage: String?) -> Outcome {
+        guard let errorMessage, !errorMessage.isEmpty else { return .established }
+        switch errorClass(of: errorMessage) {
+        case "NOAUTH": return .unauthenticated
+        case "NOPERM": return .established
+        default: return .refused(errorMessage)
+        }
+    }
+
+    /// RESP puts the error class in the first word, so the class is compared whole. A prefix test
+    /// would let a future `NOAUTHZ` read as `NOAUTH`.
+    private static func errorClass(of message: String) -> String {
+        String(message.prefix { !$0.isWhitespace }).uppercased()
+    }
+}
+
+nonisolated extension RedisConnectProbe.Outcome {
+    var failureMessage: String? {
+        switch self {
+        case .established:
+            return nil
+        case .unauthenticated:
+            return RedisConnectProbe.unauthenticatedMessage
+        case .refused(let serverError):
+            return String(format: String(localized: "PING failed: %@"), serverError)
+        }
+    }
+
+    var failureHint: String? {
+        switch self {
+        case .unauthenticated:
+            return RedisConnectProbe.unauthenticatedHint
+        case .established, .refused:
+            return nil
+        }
+    }
+}

--- a/Plugins/RedisDriverPlugin/RedisDatabaseIndex.swift
+++ b/Plugins/RedisDriverPlugin/RedisDatabaseIndex.swift
@@ -3,8 +3,18 @@ import Foundation
 nonisolated enum RedisDatabaseIndex {
     static let fieldName = "redisDatabase"
 
+    /// The driver names databases `db0` upward everywhere it shows one, and `switchDatabase`
+    /// reads that spelling back, so connecting has to accept it too. Taking only a bare integer
+    /// made a saved `db4` resolve to 0 and browse the wrong database with nothing said.
     static func resolve(additionalFields: [String: String], database: String) -> Int {
-        if let field = additionalFields[fieldName], let index = Int(field) { return index }
-        return Int(database) ?? 0
+        if let field = additionalFields[fieldName], let index = parse(field) { return index }
+        return parse(database) ?? 0
+    }
+
+    static func parse(_ value: String) -> Int? {
+        let trimmed = value.trimmingCharacters(in: .whitespaces)
+        if let index = Int(trimmed) { return index }
+        guard trimmed.lowercased().hasPrefix("db") else { return nil }
+        return Int(trimmed.dropFirst(2))
     }
 }

--- a/Plugins/RedisDriverPlugin/RedisPluginConnection.swift
+++ b/Plugins/RedisDriverPlugin/RedisPluginConnection.swift
@@ -138,17 +138,6 @@ final class RedisPluginConnection: RedisCommandChannel, @unchecked Sendable {
 
             try openContextSync(selectDatabase: database, reportingStage: report)
 
-            report(.preparingSession)
-            do {
-                let pingReply = try executeCommandSync(["PING"])
-                if case .error(let msg) = pingReply {
-                    throw RedisPluginError(code: 3, message: "PING failed: \(msg)")
-                }
-            } catch {
-                freeContextSync()
-                throw error
-            }
-
             let versionString = fetchServerVersionSync()
 
             stateLock.lock()
@@ -398,10 +387,10 @@ private extension RedisPluginConnection {
                 report(.negotiatingEncryption)
                 try connectSSL(ctx)
             }
-            if let password, !password.isEmpty {
-                report(.authenticating)
+            if !(try authenticateSync(reportingStage: report)) {
+                report(.preparingSession)
+                try probeSessionSync()
             }
-            try authenticateSync()
             if dbIndex != 0 {
                 let reply = try executeCommandSync(["SELECT", String(dbIndex)])
                 if case .error(let msg) = reply {
@@ -414,20 +403,55 @@ private extension RedisPluginConnection {
         }
     }
 
-    func authenticateSync() throws {
-        guard let authArgs = RedisAuthCommand.arguments(username: username, password: password) else { return }
+    /// Reports whether credentials were sent, which decides whether the session still needs
+    /// proving. A `+OK` to AUTH is the server naming the identity it bound and answering a round
+    /// trip in the same breath, so nothing more is needed. Sending nothing proves nothing, and
+    /// only a reply separates an open server from one that will refuse every command.
+    @discardableResult
+    func authenticateSync(reportingStage report: ConnectionStageReporter = { _ in }) throws -> Bool {
+        guard let authArgs = RedisAuthCommand.arguments(username: username, password: password) else { return false }
+        report(.authenticating)
         let reply = try executeCommandSync(authArgs)
-        if case .error(let msg) = reply {
-            throw RedisPluginError(code: 1, message: "AUTH failed: \(msg)")
-        }
+        guard case .error(let msg) = reply else { return true }
+        let failure = RedisAuthCommand.failure(
+            serverError: msg,
+            hadUsername: !(username ?? "").isEmpty,
+            hadPassword: !(password ?? "").isEmpty
+        )
+        throw RedisPluginError(
+            code: 1,
+            message: String(format: String(localized: "AUTH failed: %@"), msg),
+            detail: RedisAuthCommand.hint(for: failure),
+            refusedByServer: true
+        )
     }
 
+    /// Asks the server whether this connection holds any identity, for the case where nothing was
+    /// sent to give it one. Runs on every path that makes a connection usable, `reconnectSync`
+    /// included, so an unauthenticated session is never declared live.
+    func probeSessionSync() throws {
+        let reply = try executeCommandSync(RedisConnectProbe.command)
+        let outcome = RedisConnectProbe.outcome(errorMessage: reply.errorMessage)
+        guard let message = outcome.failureMessage else { return }
+        throw RedisPluginError(
+            code: 3,
+            message: message,
+            detail: outcome.failureHint,
+            refusedByServer: true
+        )
+    }
+
+    /// Freeing the context is what makes the connection unusable, so the flag that reports it
+    /// usable goes with it. A reconnect that frees the old context and then fails to open a new
+    /// one used to leave `isConnected` true over a nil context, and the cluster channel went on
+    /// handing that object out until the health monitor replaced it.
     func freeContextSync() {
         stateLock.lock()
         let handle = context
         let ssl = sslContext
         context = nil
         sslContext = nil
+        _isConnected = false
         stateLock.unlock()
         if let handle { redisFree(handle) }
         if let ssl { redisFreeSSLContext(ssl) }

--- a/Plugins/RedisDriverPlugin/RedisPluginDriver.swift
+++ b/Plugins/RedisDriverPlugin/RedisPluginDriver.swift
@@ -147,11 +147,23 @@ final class RedisPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         redisConnection = nil
     }
 
+    /// The health monitor asks this every 30 seconds, and a reconnect is what it does with a no.
+    /// So the only answer worth failing on is the one a reconnect fixes: the session no longer
+    /// holds an identity. Any reply at all, an error included, is the server answering on a live
+    /// socket, and reconnecting cannot talk a restricted user into `+ping` or hurry a busy script
+    /// along. A lost socket does not reach here; it throws out of `executeCommand`.
     func ping() async throws {
         guard let conn = redisConnection else {
             throw RedisPluginError.notConnected
         }
-        try await conn.run(["PING"])
+        let reply = try await conn.executeCommand(RedisConnectProbe.command)
+        if RedisConnectProbe.outcome(errorMessage: reply.errorMessage) == .unauthenticated {
+            throw RedisPluginError(
+                code: 3,
+                message: RedisConnectProbe.unauthenticatedMessage,
+                detail: RedisConnectProbe.unauthenticatedHint
+            )
+        }
         try await conn.verifyStillPrimary()
     }
 
@@ -369,12 +381,7 @@ final class RedisPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func switchDatabase(to database: String) async throws {
         guard let conn = redisConnection else { throw RedisPluginError.notConnected }
-        let dbIndex: Int
-        if let idx = Int(database) {
-            dbIndex = idx
-        } else if database.lowercased().hasPrefix("db"), let idx = Int(database.dropFirst(2)) {
-            dbIndex = idx
-        } else {
+        guard let dbIndex = RedisDatabaseIndex.parse(database) else {
             let template = String(localized: "%@ is not a Redis database index.")
             throw RedisPluginError(code: 0, message: String(format: template, database))
         }

--- a/Plugins/RedisDriverPlugin/RedisReply.swift
+++ b/Plugins/RedisDriverPlugin/RedisReply.swift
@@ -73,6 +73,17 @@ enum RedisReply {
 struct RedisPluginError: Error {
     let code: Int
     let message: String
+    let detail: String?
+    /// True when the server answered and said no. A node that rejects credentials is a
+    /// configuration problem, and reporting it as unreachable sends the user to the wrong field.
+    let refusedByServer: Bool
+
+    init(code: Int, message: String, detail: String? = nil, refusedByServer: Bool = false) {
+        self.code = code
+        self.message = message
+        self.detail = detail
+        self.refusedByServer = refusedByServer
+    }
 
     static let notConnected = RedisPluginError(code: 0, message: String(localized: "Not connected to Redis"))
     static let connectionFailed = RedisPluginError(code: 0, message: String(localized: "Failed to establish connection"))
@@ -85,6 +96,7 @@ struct RedisPluginError: Error {
 extension RedisPluginError: PluginDriverError {
     var pluginErrorMessage: String { message }
     var pluginErrorCode: Int? { code }
+    var pluginErrorDetail: String? { detail }
 }
 
 /// A connection-level failure that records which side of the exchange it happened on.

--- a/TableProMobile/TableProMobile/Drivers/RedisDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/RedisDriver.swift
@@ -351,6 +351,11 @@ nonisolated private enum RedisReplyValue: Sendable {
         case .array(let items): return "[\(items.compactMap(\.stringRepresentation).joined(separator: ", "))]"
         }
     }
+
+    var errorMessage: String? {
+        guard case .error(let message) = self else { return nil }
+        return message
+    }
 }
 
 nonisolated private func withOptionalCString<R>(_ string: String?, _ body: (UnsafePointer<CChar>?) throws -> R) rethrows -> R {
@@ -434,9 +439,16 @@ private actor RedisActor {
                         serverMessage: msg,
                         failure: RedisAuthCommand.failure(
                             serverError: msg,
-                            hadUsername: !(username ?? "").isEmpty
+                            hadUsername: !(username ?? "").isEmpty,
+                            hadPassword: !(password ?? "").isEmpty
                         )
                     )
+                }
+            } else {
+                let probe = try executeCommand(RedisConnectProbe.command)
+                let outcome = RedisConnectProbe.outcome(errorMessage: probe.errorMessage)
+                if outcome != .established {
+                    throw RedisError.sessionUnverified(outcome)
                 }
             }
 
@@ -581,6 +593,7 @@ private actor RedisActor {
 nonisolated enum RedisError: Error, LocalizedError {
     case connectionFailed(String)
     case authenticationFailed(serverMessage: String, failure: RedisAuthCommand.Failure)
+    case sessionUnverified(RedisConnectProbe.Outcome)
     case notConnected
     case queryFailed(String)
     case unsupported(String)
@@ -589,7 +602,7 @@ nonisolated enum RedisError: Error, LocalizedError {
         switch self {
         case .connectionFailed(let msg): return "Redis connection failed: \(msg)"
         case .authenticationFailed(let serverMessage, let failure):
-            guard let hint = Self.hint(for: failure) else {
+            guard let hint = RedisAuthCommand.hint(for: failure) else {
                 return String(format: String(localized: "Redis authentication failed: %@"), serverMessage)
             }
             return String(
@@ -597,22 +610,13 @@ nonisolated enum RedisError: Error, LocalizedError {
                 serverMessage,
                 hint
             )
+        case .sessionUnverified(let outcome):
+            let message = outcome.failureMessage ?? String(localized: "Redis connection failed")
+            guard let hint = outcome.failureHint else { return message }
+            return "\(message) \(hint)"
         case .notConnected: return "Not connected to Redis"
         case .queryFailed(let msg): return "Redis command failed: \(msg)"
         case .unsupported(let msg): return msg
-        }
-    }
-
-    private static func hint(for failure: RedisAuthCommand.Failure) -> String? {
-        switch failure {
-        case .rejectedWithoutUsername:
-            return String(localized: "If this server uses Redis 6 or later ACL users, fill in the Username field.")
-        case .serverHasNoPassword:
-            return String(localized: "This server has no password set for the default user. Clear the Password field.")
-        case .usernameUnsupported:
-            return String(localized: "This server predates Redis 6 and takes no username. Clear the Username field.")
-        case .rejectedCredentials, .unrecognized:
-            return nil
         }
     }
 }

--- a/TableProMobile/project.yml
+++ b/TableProMobile/project.yml
@@ -50,6 +50,7 @@ targets:
       - ../Plugins/MSSQLDriverPlugin/MSSQLLoginParameters.swift
       # Redis credential rules the iOS driver shares with the macOS plugin.
       - ../Plugins/RedisDriverPlugin/RedisAuthCommand.swift
+      - ../Plugins/RedisDriverPlugin/RedisConnectProbe.swift
       - ../Plugins/RedisDriverPlugin/RedisDatabaseIndex.swift
     configFiles:
       Debug: ../Configs/Version-iOS.xcconfig

--- a/TableProTests/Plugins/RedisAuthCommandTests.swift
+++ b/TableProTests/Plugins/RedisAuthCommandTests.swift
@@ -3,12 +3,17 @@ import Testing
 
 @Suite("Redis AUTH command")
 struct RedisAuthCommandTests {
-    @Test("no password sends no AUTH at all")
-    func noPassword() {
+    @Test("no credentials at all sends no AUTH")
+    func noCredentials() {
         #expect(RedisAuthCommand.arguments(username: nil, password: nil) == nil)
         #expect(RedisAuthCommand.arguments(username: nil, password: "") == nil)
-        #expect(RedisAuthCommand.arguments(username: "acl-user", password: nil) == nil)
-        #expect(RedisAuthCommand.arguments(username: "acl-user", password: "") == nil)
+        #expect(RedisAuthCommand.arguments(username: "", password: "") == nil)
+    }
+
+    @Test("a username with no password still authenticates as that user")
+    func usernameWithoutPassword() {
+        #expect(RedisAuthCommand.arguments(username: "acl-user", password: nil) == ["AUTH", "acl-user", ""])
+        #expect(RedisAuthCommand.arguments(username: "acl-user", password: "") == ["AUTH", "acl-user", ""])
     }
 
     @Test("password without a username uses the one-argument form")
@@ -39,16 +44,25 @@ struct RedisAuthCommandTests {
     func wrongPassWithoutUsername() {
         let serverError = "WRONGPASS invalid username-password pair or user is disabled."
         #expect(
-            RedisAuthCommand.failure(serverError: serverError, hadUsername: false)
+            RedisAuthCommand.failure(serverError: serverError, hadUsername: false, hadPassword: true)
                 == .rejectedWithoutUsername
         )
     }
 
-    @Test("WRONGPASS with a username stays an ordinary credential rejection")
+    @Test("WRONGPASS for a username sent with no password points at the empty Password field")
+    func wrongPassWithoutPassword() {
+        let serverError = "WRONGPASS invalid username-password pair or user is disabled."
+        #expect(
+            RedisAuthCommand.failure(serverError: serverError, hadUsername: true, hadPassword: false)
+                == .rejectedWithoutPassword
+        )
+    }
+
+    @Test("WRONGPASS with both fields filled stays an ordinary credential rejection")
     func wrongPassWithUsername() {
         let serverError = "WRONGPASS invalid username-password pair or user is disabled."
         #expect(
-            RedisAuthCommand.failure(serverError: serverError, hadUsername: true)
+            RedisAuthCommand.failure(serverError: serverError, hadUsername: true, hadPassword: true)
                 == .rejectedCredentials
         )
     }
@@ -56,27 +70,60 @@ struct RedisAuthCommandTests {
     @Test("a server with no password configured is reported as such")
     func serverHasNoPassword() {
         let modern = "ERR AUTH <password> called without any password configured for the default user."
-        #expect(RedisAuthCommand.failure(serverError: modern, hadUsername: false) == .serverHasNoPassword)
+        #expect(
+            RedisAuthCommand.failure(serverError: modern, hadUsername: false, hadPassword: true)
+                == .serverHasNoPassword
+        )
 
         let legacy = "ERR Client sent AUTH, but no password is set"
-        #expect(RedisAuthCommand.failure(serverError: legacy, hadUsername: false) == .serverHasNoPassword)
+        #expect(
+            RedisAuthCommand.failure(serverError: legacy, hadUsername: false, hadPassword: true)
+                == .serverHasNoPassword
+        )
     }
 
     @Test("a pre-ACL server's wrong-password reply never suggests an ACL username")
     func legacyInvalidPasswordCarriesNoUsernameHint() {
         let serverError = "ERR invalid password"
-        #expect(RedisAuthCommand.failure(serverError: serverError, hadUsername: false) == .rejectedCredentials)
-        #expect(RedisAuthCommand.failure(serverError: serverError, hadUsername: true) == .rejectedCredentials)
+        #expect(
+            RedisAuthCommand.failure(serverError: serverError, hadUsername: false, hadPassword: true)
+                == .rejectedCredentials
+        )
+        #expect(
+            RedisAuthCommand.failure(serverError: serverError, hadUsername: true, hadPassword: true)
+                == .rejectedCredentials
+        )
     }
 
     @Test("a pre-ACL server rejects the username form with an arity error")
     func usernameUnsupported() {
         let serverError = "ERR wrong number of arguments for 'auth' command"
-        #expect(RedisAuthCommand.failure(serverError: serverError, hadUsername: true) == .usernameUnsupported)
+        #expect(
+            RedisAuthCommand.failure(serverError: serverError, hadUsername: true, hadPassword: false)
+                == .usernameUnsupported
+        )
     }
 
     @Test("an unrelated error carries no hint")
     func unrecognized() {
-        #expect(RedisAuthCommand.failure(serverError: "LOADING dataset in memory", hadUsername: true) == .unrecognized)
+        #expect(
+            RedisAuthCommand.failure(serverError: "LOADING dataset in memory", hadUsername: true, hadPassword: true)
+                == .unrecognized
+        )
+        #expect(RedisAuthCommand.hint(for: .unrecognized) == nil)
+        #expect(RedisAuthCommand.hint(for: .rejectedCredentials) == nil)
+    }
+
+    @Test("every actionable failure names the field to change")
+    func actionableFailuresCarryAHint() {
+        let actionable: [RedisAuthCommand.Failure] = [
+            .rejectedWithoutUsername,
+            .rejectedWithoutPassword,
+            .serverHasNoPassword,
+            .usernameUnsupported,
+        ]
+        for failure in actionable {
+            #expect(RedisAuthCommand.hint(for: failure)?.isEmpty == false)
+        }
     }
 }

--- a/TableProTests/Plugins/RedisConnectProbeTests.swift
+++ b/TableProTests/Plugins/RedisConnectProbeTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+
+@Suite("Redis connect probe")
+struct RedisConnectProbeTests {
+    @Test("a reply with no error means the server bound the session")
+    func successEstablishes() {
+        #expect(RedisConnectProbe.outcome(errorMessage: nil) == .established)
+        #expect(RedisConnectProbe.outcome(errorMessage: "") == .established)
+    }
+
+    @Test("NOAUTH is the only reply that means no identity")
+    func noAuthIsFatal() {
+        #expect(RedisConnectProbe.outcome(errorMessage: "NOAUTH Authentication required.") == .unauthenticated)
+    }
+
+    @Test("NOPERM means authenticated but restricted, which is a usable session")
+    func noPermEstablishes() {
+        let denied = "NOPERM User dave has no permissions to run the 'ping' command"
+        #expect(RedisConnectProbe.outcome(errorMessage: denied) == .established)
+    }
+
+    @Test("any other error reply still fails the connection and carries the server text")
+    func otherErrorsRefuse() {
+        #expect(
+            RedisConnectProbe.outcome(errorMessage: "LOADING dataset in memory")
+                == .refused("LOADING dataset in memory")
+        )
+        #expect(RedisConnectProbe.outcome(errorMessage: "BUSY Redis is busy") == .refused("BUSY Redis is busy"))
+    }
+
+    @Test("the error class is matched whole, not as a prefix")
+    func errorClassIsDelimited() {
+        #expect(RedisConnectProbe.outcome(errorMessage: "NOAUTHZ something new") == .refused("NOAUTHZ something new"))
+        #expect(RedisConnectProbe.outcome(errorMessage: "NOPERMISSION something new") != .established)
+    }
+
+    @Test("the error class is matched case-insensitively")
+    func errorClassIsCaseInsensitive() {
+        #expect(RedisConnectProbe.outcome(errorMessage: "noauth Authentication required.") == .unauthenticated)
+    }
+
+    @Test("only a failing outcome carries a message, and only the unauthenticated one names a field")
+    func messagesMatchOutcomes() {
+        #expect(RedisConnectProbe.Outcome.established.failureMessage == nil)
+        #expect(RedisConnectProbe.Outcome.established.failureHint == nil)
+        #expect(RedisConnectProbe.Outcome.unauthenticated.failureMessage?.isEmpty == false)
+        #expect(RedisConnectProbe.Outcome.unauthenticated.failureHint?.isEmpty == false)
+
+        let refused = RedisConnectProbe.Outcome.refused("LOADING dataset in memory")
+        #expect(refused.failureMessage?.contains("LOADING dataset in memory") == true)
+        #expect(refused.failureHint == nil)
+    }
+
+    @Test("the probe asks for PING")
+    func probeCommand() {
+        #expect(RedisConnectProbe.command == ["PING"])
+    }
+}

--- a/TableProTests/Plugins/RedisDatabaseIndexTests.swift
+++ b/TableProTests/Plugins/RedisDatabaseIndexTests.swift
@@ -14,14 +14,27 @@ struct RedisDatabaseIndexTests {
         #expect(RedisDatabaseIndex.resolve(additionalFields: [:], database: "7") == 7)
     }
 
-    @Test("a non-numeric field falls back to the database name")
-    func nonNumericField() {
-        #expect(RedisDatabaseIndex.resolve(additionalFields: ["redisDatabase": "db2"], database: "5") == 5)
+    @Test("the dbN spelling the driver publishes resolves to that index")
+    func acceptsDbPrefix() {
+        #expect(RedisDatabaseIndex.resolve(additionalFields: [:], database: "db4") == 4)
+        #expect(RedisDatabaseIndex.resolve(additionalFields: [:], database: "DB4") == 4)
+        #expect(RedisDatabaseIndex.resolve(additionalFields: [:], database: " db4 ") == 4)
+        #expect(RedisDatabaseIndex.resolve(additionalFields: ["redisDatabase": "db2"], database: "5") == 2)
     }
 
     @Test("an unusable value resolves to database zero")
     func defaultsToZero() {
         #expect(RedisDatabaseIndex.resolve(additionalFields: [:], database: "") == 0)
+        #expect(RedisDatabaseIndex.resolve(additionalFields: [:], database: "cache") == 0)
         #expect(RedisDatabaseIndex.resolve(additionalFields: ["redisDatabase": ""], database: "db0") == 0)
+    }
+
+    @Test("parse rejects what is not an index so the switch can report it")
+    func parseRejectsNonIndexes() {
+        #expect(RedisDatabaseIndex.parse("db4") == 4)
+        #expect(RedisDatabaseIndex.parse("4") == 4)
+        #expect(RedisDatabaseIndex.parse("") == nil)
+        #expect(RedisDatabaseIndex.parse("cache") == nil)
+        #expect(RedisDatabaseIndex.parse("dbx") == nil)
     }
 }

--- a/docs/databases/redis.mdx
+++ b/docs/databases/redis.mdx
@@ -23,8 +23,8 @@ The sidebar splits keys into folders at every `:`, and each key gets a grid row 
 | **Connection Mode** | `Standalone` | `Sentinel` for a Sentinel-managed primary, `Cluster` for a sharded cluster |
 | **Host** | `localhost` | Standalone only |
 | **Port** | `6379` | Standalone only |
-| **Username** | - | Redis 6 ACL user, sent as `AUTH username password`. Leave empty for `requirepass` auth |
-| **Password** | - | Leave empty for local dev |
+| **Username** | - | Redis 6 ACL user, sent as `AUTH username password`. Empty signs in as `default` |
+| **Password** | - | Empty for a server with no `requirepass`, and for a `nopass` ACL user |
 | **Database Index** | `0` | 0-15 stepper, in the Advanced section |
 | **Key Separator** | `:` | What the sidebar splits key names on (Advanced) |
 
@@ -40,6 +40,14 @@ rediss://:password@host:6380/0
 ```
 
 `rediss://` connects with TLS. See [Connection URL Reference](/connections/urls).
+
+## Authentication
+
+The Username field selects a Redis 6 ACL user. Empty signs in as `default`, the identity a bare `requirepass` password belongs to.
+
+A username is sent as `AUTH username password` even when Password is empty, which is the form a `nopass` ACL user needs. Every other user rejects that form, so the connection either holds the identity typed into the form or fails.
+
+A `nopass` user accepts any password, so a leftover value in Password still signs in as that user.
 
 ## Connection modes
 
@@ -145,14 +153,32 @@ New connections default to **Disabled**. SNI is sent in every TLS mode.
 
 ## Troubleshooting
 
-**Connection refused**: check Redis is running (`brew services start redis`), the port matches `redis.conf`, and the `bind` directive covers the address you are using.
+### Connection refused
 
-**WRONGPASS invalid username-password pair or user is disabled.**: with Username empty, `AUTH password` is checked against the `default` user, and an ACL user's password fails that. Fill in Username to authenticate as that user.
+The server is not listening where the connection points. Check Redis is running (`brew services start redis`), the port matches `redis.conf`, and the `bind` directive covers the address you are using.
+
+### WRONGPASS invalid username-password pair or user is disabled.
+
+The server rejected the pair. With Username empty, `AUTH password` is checked against the `default` user, and an ACL user's password fails that: fill in Username to authenticate as that user. With Username filled and Password empty, the named user has a password and needs it, or the name does not exist on this server.
 
 One ACL trap produces the same error: `>password` sets a password, `#hash` sets a SHA-256 hash, and a 64-character hex string is valid for both, so `ACL SETUSER myuser on #<64-hex>` is accepted where `>` was meant. `ACL LIST` prints passwords as hashes, so a value copied from there is a hash, not a password.
 
-**Timeout**: verify host and port, check the network and firewall, and allow your IP on a cloud-hosted Redis.
+### This server requires authentication.
 
-**Sentinel or Cluster over SSH**: a tunnel forwards one local port to one remote address, and the addresses Sentinel and Cluster hand back are the server's own. Over a tunnel only the first host in the list is used, as a standalone node, so failover and shard routing are unavailable.
+The server answered `NOAUTH` to the first command, so the connection carries no identity. Check `requirepass` in `redis.conf` and whether the `default` user is `off` in `ACL LIST`. Fill in Password, and Username as well when the account is an ACL user.
 
-**Slow key list**: `KEYS` blocks the server on a large keyspace. Browse by namespace instead, and use `SCAN` in the CLI when you need a pattern. Check memory pressure with `INFO memory`.
+### ERR wrong number of arguments for 'auth' command
+
+The server predates Redis 6 and takes a password alone. Check its version with `INFO server`. Clear Username.
+
+### Timeout
+
+Nothing answered in time. Verify host and port, check the network and firewall, and allow your IP on a cloud-hosted Redis.
+
+### Sentinel or cluster mode over SSH
+
+A tunnel forwards one local port to one remote address, and the addresses Sentinel and Cluster hand back are the server's own. Over a tunnel only the first host in the list is used, as a standalone node, so failover and shard routing are unavailable.
+
+### Slow key list
+
+`KEYS` blocks the server on a large keyspace. Browse by namespace instead, and use `SCAN` in the CLI when you need a pattern. Check memory pressure with `INFO memory`.

--- a/project.yml
+++ b/project.yml
@@ -539,6 +539,7 @@ targets:
       - Plugins/RedisDriverPlugin/RedisClusterTopology.swift
       - Plugins/RedisDriverPlugin/RedisCommandParser.swift
       - Plugins/RedisDriverPlugin/RedisCommandRouting.swift
+      - Plugins/RedisDriverPlugin/RedisConnectProbe.swift
       - Plugins/RedisDriverPlugin/RedisConnectionMode.swift
       - Plugins/RedisDriverPlugin/RedisDatabaseIndex.swift
       - Plugins/RedisDriverPlugin/RedisKeySlot.swift

--- a/scripts/check-redis-auth-handshake.sh
+++ b/scripts/check-redis-auth-handshake.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+#
+# Checks the Redis/Valkey handshake facts the driver hard-codes against a real server.
+#
+# RedisAuthCommand and RedisConnectProbe encode three things the server owns: that the
+# one-argument AUTH form binds to `default`, that `AUTH <user> ""` is the wire form for a
+# nopass ACL user, and that a session with no identity answers NOAUTH while an authenticated
+# but restricted one answers NOPERM. Those are transcriptions, and nothing at runtime rechecks
+# them, so a server or hiredis bump can invalidate them silently.
+#
+# Usage: scripts/check-redis-auth-handshake.sh [redis-server-binary]
+#
+# Starts a throwaway server on a free port with a known ACL set, asserts the matrix, and stops.
+
+set -euo pipefail
+
+SERVER_BIN="${1:-$(command -v redis-server || command -v valkey-server || true)}"
+CLI_BIN="$(command -v redis-cli || command -v valkey-cli || true)"
+
+if [ -z "$SERVER_BIN" ] || [ -z "$CLI_BIN" ]; then
+    echo "Need redis-server (or valkey-server) and redis-cli on PATH." >&2
+    echo "Install with: brew install redis" >&2
+    exit 2
+fi
+
+# redis-cli reads REDISCLI_AUTH and authenticates before running the command, which would make
+# the "with no identity" cases answer as an authenticated session.
+unset REDISCLI_AUTH
+
+WORKDIR="$(mktemp -d)"
+SERVER_PID=""
+# Kill by PID, never by SHUTDOWN over the port: a resident Redis that happens to accept this
+# password would be stopped instead, taking its unsaved data with it.
+trap 'if [ -n "$SERVER_PID" ]; then kill "$SERVER_PID" 2>/dev/null || true; fi; rm -rf "$WORKDIR"' EXIT
+
+PORT=""
+for candidate in $(seq 7397 7457); do
+    if ! nc -z 127.0.0.1 "$candidate" 2>/dev/null; then
+        PORT="$candidate"
+        break
+    fi
+done
+
+if [ -z "$PORT" ]; then
+    echo "No free port between 7397 and 7457 to start a throwaway server on." >&2
+    exit 2
+fi
+
+cat > "$WORKDIR/redis.conf" <<EOF
+port $PORT
+bind 127.0.0.1
+save ""
+appendonly no
+dir $WORKDIR
+pidfile $WORKDIR/redis.pid
+requirepass defaultpass
+user alice on >alicepass ~* +@all
+user bob on nopass ~* +@all
+user carol on nopass ~cache:* +get +set
+EOF
+
+"$SERVER_BIN" "$WORKDIR/redis.conf" --daemonize yes
+for _ in $(seq 1 50); do
+    if [ -s "$WORKDIR/redis.pid" ]; then
+        SERVER_PID="$(cat "$WORKDIR/redis.pid")"
+    fi
+    if [ -n "$SERVER_PID" ] && "$CLI_BIN" -p "$PORT" -a defaultpass --no-auth-warning ping >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.1
+done
+
+if [ -z "$SERVER_PID" ]; then
+    echo "Throwaway server on port $PORT did not start." >&2
+    exit 2
+fi
+
+FAILURES=0
+
+expect() {
+    local label="$1" want="$2"
+    shift 2
+    local got
+    got="$("$CLI_BIN" -p "$PORT" "$@" 2>&1 | head -1)"
+    case "$got" in
+        "$want"*)
+            printf '  ok    %-52s -> %s\n' "$label" "$want"
+            ;;
+        *)
+            printf '  FAIL  %-52s\n        expected: %s\n        actual:   %s\n' "$label" "$want" "$got"
+            FAILURES=$((FAILURES + 1))
+            ;;
+    esac
+}
+
+echo "RedisAuthCommand.arguments: the wire forms the driver builds"
+expect "AUTH <default password>"          "OK"        AUTH defaultpass
+expect "AUTH default <default password>"  "OK"        AUTH default defaultpass
+expect "AUTH alice <alice password>"      "OK"        AUTH alice alicepass
+expect "AUTH <alice password>"            "WRONGPASS" AUTH alicepass
+expect "AUTH <unknown user> <password>"   "WRONGPASS" AUTH nosuchuser defaultpass
+expect 'AUTH bob "" (nopass ACL user)'    "OK"        AUTH bob ""
+expect 'AUTH alice "" (has a password)'   "WRONGPASS" AUTH alice ""
+expect 'AUTH <unknown user> ""'           "WRONGPASS" AUTH nosuchuser ""
+
+echo
+echo "RedisConnectProbe.outcome: the error classes it switches on"
+expect "PING with no identity"            "NOAUTH"    PING
+expect "INFO with no identity"            "NOAUTH"    INFO server
+expect "PING as a restricted ACL user"    "NOPERM"    --user carol --pass "" --no-auth-warning PING
+expect "ACL WHOAMI as a restricted user"  "NOPERM"    --user carol --pass "" --no-auth-warning ACL WHOAMI
+expect "PING as an unrestricted user"     "PONG"      --user alice --pass alicepass --no-auth-warning PING
+
+echo
+if [ "$FAILURES" -ne 0 ]; then
+    echo "$FAILURES handshake fact(s) no longer match the server."
+    echo "Plugins/RedisDriverPlugin/RedisAuthCommand.swift and RedisConnectProbe.swift need updating."
+    exit 1
+fi
+
+echo "All handshake facts still hold."


### PR DESCRIPTION
A user reported that TablePro signs in to Valkey with the wrong credentials and reports success, and that correct ACL username and password pairs do not work at all. Both halves are real, both are live on `main` today, and they come from one mechanism.

## Root cause

TablePro decided **whether to authenticate** from the password alone, and decided **whether the connection was usable** from a probe whose error replies it could not classify.

`RedisAuthCommand.arguments` opened with `guard let password, !password.isEmpty else { return nil }`, and that ran before the username was ever consulted. A typed ACL username with an empty password therefore sent no `AUTH` at all. Redis leaves such a connection on the `default` user, so the session ran with `default`'s privileges while the UI reported a successful sign-in as the user who was never sent.

Separately, `RedisPluginConnection` treated any error reply to its post-connect `PING` as fatal. `PING`, `INFO` and `ACL WHOAMI` are all ACL-deniable, so a correctly authenticated restricted user was refused with `PING failed: NOPERM …`. The 30-second health monitor ran the same unclassified check, so even a connection that got past the first one was dropped later.

The iOS driver ran no post-connect command at all: `AUTH` was conditional, `SELECT` was conditional, and the only unconditional call was `try? fetchServerVersion()`, whose `-NOAUTH` reply was discarded by a type guard. Test Connection could report success on a bare TCP socket. That is the reporter's screenshot exactly.

## The fix

`RedisAuthCommand.arguments` now sends `AUTH` whenever a username **or** a password is present, and returns nil only when both are empty. Measured against a real server: `AUTH bob ""` is `OK` for a `nopass` ACL user and `WRONGPASS` for every other user, so the two-argument form with an empty password is both the correct request and an exact test of the identity. This matches ioredis (the client behind RedisInsight) and `redis-cli`'s `cliAuth`.

`RedisConnectProbe` is a new pure type that classifies the probe reply three ways: `NOAUTH` means the connection carries no identity and is fatal; `NOPERM` means the server bound the session and only denied that one command, so it passes; anything else keeps the previous fatal behaviour, which leaves `-LOADING` and `-BUSY` failing exactly as before. `ACL WHOAMI` is not used as a gate, because it is ACL-deniable too.

The probe runs only when nothing was sent to give the connection an identity. `AUTH`'s `+OK` is the server naming the user it bound and answering a round trip in the same breath, so a connection that authenticated needs no second question. That also means a hardened server with `PING` renamed away now connects, where before it could not connect at all. The probe lives in `openContextSync`, so `reconnectSync`, cluster nodes, sentinel-discovered primaries and the metadata pool all get it.

`RedisPluginDriver.ping()` fails only on `NOAUTH`. A reconnect is what the health monitor does with a no, and that is the one condition a reconnect fixes: it cannot talk a restricted user into `+ping` or hurry a busy script along, and a lost socket throws out of `executeCommand` before any of this. So the health monitor no longer drops a restricted user 30 seconds after it connects.

Three smaller changes ride along because the primary fix is incomplete without them:

- macOS now calls `RedisAuthCommand.failure`. That classifier and its whole `Failure` enum had zero call sites under `Plugins/`; the only consumer was the iOS driver, so the "fill in the Username field" hint written for this exact bug was iOS-only. It renders through the existing `PluginDriverError.pluginErrorDetail`. `failure` also gained a `hadPassword` parameter, because `WRONGPASS` is the same reply for a wrong password, an empty one and an unknown user, and only the client knows which it sent. This matters now that the change converts silently-succeeding connections into hard failures.
- A Sentinel that rejects the credentials reported as unreachable, because the auth failure was a `RedisPluginError` and `RedisSentinelResolver` only routes `RedisSentinelError.refused` to its configuration-problem message. `RedisPluginError` carries a `refusedByServer` flag now.
- `RedisDatabaseIndex.resolve` accepts the `dbN` spelling. The driver publishes databases as `db0` upward and `switchDatabase` already parsed the prefix, so a saved `db4` resolved to 0 and browsed the wrong database with nothing said. Both now share one parser.
- `freeContextSync` clears `isConnected`. A reconnect frees the old context before opening a new one, so a reconnect that then failed left the flag true over a nil context, and `RedisClusterChannel.reusableConnection` went on handing that object out until the health monitor replaced it. Found by the Codex review; it predates this branch, but the branch adds a throw site to that path.

## Before and after

Measured with the real shipped `RedisPluginDriver`, compiled with `swiftc` against `Libs/libhiredis.a` and run against a throwaway `redis-server` whose `default` user is `nopass`, plus ACL users `alice` (password), `bob` (`nopass`), `carol` (`nopass`, `~cache:*` `+get` `+set`) and `dave` (password, no `+ping`):

| Connection | Before | After |
| --- | --- | --- |
| Username `q`, Password empty | connects, `ACL WHOAMI` says `default` | rejected, with the empty-password hint |
| Username `bob`, Password empty | connects as `default` | connects **as `bob`** |
| Username `dave`, correct password | `PING failed: NOPERM …` | connects, and stays healthy |
| Username `carol`, Password empty | connects as `default` | connects as `carol` |
| Username `alice`, correct password | connects as `alice` | unchanged |
| Both empty, `requirepass` server | `PING failed: NOAUTH …` | `This server requires authentication.` |
| Both empty, open server | connects as `default` | unchanged |
| Correct password, `PING` renamed away | `PING failed: ERR unknown command 'PING'` | connects, and stays healthy |

There is no new UI, and no screenshot is included: the only user-visible surface is the text in the connection editor's existing error field, and its before state would need the fix reverted and the app rebuilt to photograph. The driver-level transcript above is the exact evidence, and `scripts/check-redis-auth-handshake.sh` reproduces the server side of it on any machine.

## Deliberate behaviour change

A stray username against an open server now fails where it used to connect silently as `default`. That is the fix, not a regression, and it is reachable: `redis://user@host` yields a username with an empty password (`ConnectionURLParser.swift:475`). The failure names the field to change, which is why the hint work is in this PR rather than deferred. The same holds for a pre-Redis-6 server, where a username produces an arity error and the existing `.usernameUnsupported` hint says to clear the field. Retrying without the username was considered and rejected: connecting as somebody else is the bug.

## Verified

- `verify.sh build` PASS, `verify.sh build RedisDriver` PASS.
- `RedisAuthCommandTests RedisConnectProbeTests RedisDatabaseIndexTests` PASS, 26 cases.
- `RedisReplyErrorDetectionTests RedisReplyThrowTests RedisTransportFailureTests` PASS, 14 cases. These cover `RedisPluginError`, which gained two fields.
- `SwitchDatabaseTests SwitchDatabaseReconnectFailureTests MetadataConnectionPoolTests MetadataConnectionPoolPlanTests ConnectionURLParserTests` PASS, 118 cases.
- `verify.sh lint` PASS, 0 violations. `verify.sh docs` PASS. `shellcheck --severity=warning` clean on the new script.
- `scripts/check-redis-auth-handshake.sh` passes all 13 assertions against `redis-server` 8.10.1.
- `verify.sh plugins` fails locally on the known oracle-nio `@TaskLocal` macro defect, which predates this branch and stops the aggregate for any change under `Plugins/`. The Redis target alone builds clean, and CI runs the aggregate on its own toolchain.
- The iOS app build hits the same oracle-nio defect locally. The changed mobile driver typechecks clean under Swift 6 against the real `TableProCore` modules and the `CRedis` bridge, and `ios-tests.yml` builds and tests it in CI.

No `TableProUITests` automation: reproducing this needs a live Valkey with ACL users, which CI has no fixture for. The shared logic is covered by unit tests on all three pure types instead, and the wire facts they encode are covered by the committed script.

No PluginKit ABI change. Redis is a bundled plugin with a registry arm in `build-plugin.yml`, so this can be published to users on an already-shipped app.

## Review

A Codex review of the working tree raised four points and all four are fixed here: requiring `PING` after a successful `AUTH` (the probe is now conditional, which is a better design than the one I had); the reconnect path leaving `isConnected` true over a freed context; the check script's `SHUTDOWN` reaching a resident Redis that happened to accept the same password, now a PID-tracked kill on a port it verified was free; and `REDISCLI_AUTH` in the caller's environment silently authenticating the cases labelled "with no identity", now unset. A three-lens security review (auth bypass, injection and exposure, blast radius) returned no findings, and confirmed both platforms encode `AUTH` arguments length-prefixed so no credential can inject a second command, and that no new log or error path carries a credential.


https://claude.ai/code/session_01HRHCkJTkD9Xots9fV3oPxr
