### PR TITLE
fix(export): scope a table preselection to its container, and share the truncate rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Export and Transfer To preselecting a same-named table from another schema, or nothing at all.
+- Delete queuing a table drop from the menu bar with none of the confirmation the sidebar asks for.
+- Truncate Table offered from the menu bar for a view, which the server then refuses.
+- Truncate offered on a sidebar selection that mixes a table with a view.
 - Import sheet clearing a table without confirmation on a connection set to confirm destructive statements.
 - Empty destination table picker in the import sheet, with no message and no retry, when the table list could not be read.
 - Connection with two transports enabled reaching the database directly, with neither transport applied.

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController+MenuValidation.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController+MenuValidation.swift
@@ -40,6 +40,9 @@ struct MenuValidationContext: Equatable {
     /// grid's selection specifically, not the structure grid's.
     var hasDataGridRowSelection = false
     var hasTableSelection = false
+    /// Whether every selected object is one the engine can truncate. Separate from
+    /// `hasTableSelection` because a view is a perfectly good selection and a hopeless truncate.
+    var canTruncateSelectedTables = false
     /// Whether the window-level `paste:` fallback would actually paste. AppKit hands a disabled
     /// item its key equivalent regardless, so an item enabled over a handler that returns at its
     /// first guard swallows Command+V with no feedback.
@@ -178,7 +181,7 @@ extension MainSplitViewController: NSMenuItemValidation {
         case #selector(restorePreviousValues(_:)):
             return context.isConnected && context.canRestorePreviousValues && !context.isReadOnly
         case #selector(truncateTable(_:)):
-            return context.isConnected && context.hasTableSelection && !context.isReadOnly
+            return context.isConnected && context.canTruncateSelectedTables && !context.isReadOnly
         case #selector(performFind(_:)):
             return context.hasEditorForFind || (context.isConnected && context.canUseGridFindCommands)
         case #selector(findNext(_:)), #selector(findPrevious(_:)):
@@ -281,6 +284,7 @@ extension MainSplitViewController: NSMenuItemValidation {
             hasRowSelection: actions.hasRowSelection,
             hasDataGridRowSelection: actions.hasDataGridRowSelection,
             hasTableSelection: actions.hasTableSelection,
+            canTruncateSelectedTables: actions.canTruncateSelectedTables,
             canPasteRows: actions.canPasteRows,
             canCloseOtherTabs: actions.canCloseOtherTabs,
             canCloseTabsForOtherDatabases: actions.canCloseTabsForOtherDatabases,

--- a/TablePro/Models/Database/TableOperationEligibility.swift
+++ b/TablePro/Models/Database/TableOperationEligibility.swift
@@ -1,0 +1,42 @@
+//
+//  TableOperationEligibility.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+/// Which objects a table operation may be aimed at.
+///
+/// The sidebar's contextual menu and the menu bar both offer Truncate, and they used to decide
+/// eligibility separately: the sidebar hid the item for a view, while the menu bar's validator
+/// asked only whether anything was selected. So selecting a view and using the menu bar staged a
+/// `TRUNCATE` against it that the server then refused, failing the whole save.
+///
+/// It lives beside the models rather than beside the sidebar because the menu-bar validator in
+/// `Core/` has to reach it too, and a `Views/` file is the wrong dependency for that.
+enum TableOperationEligibility {
+    /// A kind whose rows the engine will not let you replace or remove in place. A view holds no
+    /// rows of its own, a foreign or external table proxies rows on another server, and a system
+    /// table belongs to the catalog.
+    static func isReadOnlyKind(_ type: TableInfo.TableType?) -> Bool {
+        switch type {
+        case .view, .materializedView, .foreignTable, .systemTable, .externalTable:
+            return true
+        case .table, .partitionedTable, .none:
+            return false
+        }
+    }
+
+    static func canTruncate(_ type: TableInfo.TableType?) -> Bool {
+        !isReadOnlyKind(type)
+    }
+
+    /// All or nothing over a selection, rather than truncating the eligible part of it. A command
+    /// that silently acts on some of what the user selected is worse than one that declines: the
+    /// rows it skipped look truncated until someone checks.
+    static func canTruncate(_ targets: some Collection<DatabaseTreeTableRef>) -> Bool {
+        guard !targets.isEmpty else { return false }
+        return targets.allSatisfy { canTruncate($0.table.type) }
+    }
+}

--- a/TablePro/Models/Database/TableOperationEligibility.swift
+++ b/TablePro/Models/Database/TableOperationEligibility.swift
@@ -8,13 +8,10 @@ import TableProPluginKit
 
 /// Which objects a table operation may be aimed at.
 ///
-/// The sidebar's contextual menu and the menu bar both offer Truncate, and they used to decide
-/// eligibility separately: the sidebar hid the item for a view, while the menu bar's validator
-/// asked only whether anything was selected. So selecting a view and using the menu bar staged a
-/// `TRUNCATE` against it that the server then refused, failing the whole save.
-///
-/// It lives beside the models rather than beside the sidebar because the menu-bar validator in
-/// `Core/` has to reach it too, and a `Views/` file is the wrong dependency for that.
+/// The single answer for both menus that offer Truncate. Deciding it in two places let them
+/// disagree, and the menu bar's copy asked only whether anything was selected, so it staged a
+/// `TRUNCATE` against a view. It sits beside the models because the menu-bar validator in `Core/`
+/// has to reach it and must not depend on a `Views/` file.
 enum TableOperationEligibility {
     /// A kind whose rows the engine will not let you replace or remove in place. A view holds no
     /// rows of its own, a foreign or external table proxies rows on another server, and a system

--- a/TablePro/Models/Export/ExportModels.swift
+++ b/TablePro/Models/Export/ExportModels.swift
@@ -11,21 +11,37 @@ import TableProPluginKit
 /// What the export dialog starts with selected: named tables inside the current
 /// container, or every table of whole databases or schemas.
 enum ExportPreselection: Equatable {
-    /// `schema` is the one the named tables live in, carried because a bare name does not identify
-    /// a table: `orders` exists in every schema on the server. Without it the dialog fell back to
-    /// whichever schema it considered current and ticked a same-named table somewhere else.
-    /// Nil where the engine has no schemas, or where a selection spans several and none can anchor it.
-    case tables(names: Set<String>, schema: String?)
+    /// `scope` is the container the named tables live in, carried because a bare name does not
+    /// identify a table: `orders` exists in every schema and every database on the server.
+    /// Nil where no single container holds them all, which falls back to the current one.
+    case tables(names: Set<String>, scope: DatabaseContainerRef?)
     case containers([DatabaseContainerRef])
 
-    /// Carries the schema only when every row agrees on one, the same unanimity rule
-    /// `scopedDatabase` applies to a container preselection.
-    static func tables(fromSidebarSelection refs: Set<DatabaseTreeTableRef>) -> ExportPreselection {
-        let names = Set(refs.map(\.table.name))
-        guard let first = refs.first, refs.allSatisfy({ $0.qualifyingSchema == first.qualifyingSchema }) else {
-            return .tables(names: names, schema: nil)
+    /// The container the export dialog will list this row under. An engine that groups by database
+    /// draws no schema rows at all, and several of those still report a schema per table, so a
+    /// schema-shaped scope would match nothing there.
+    static func scope(
+        for ref: DatabaseTreeTableRef,
+        grouping: GroupingStrategy
+    ) -> DatabaseContainerRef? {
+        guard grouping != .byDatabase, let schema = ref.qualifyingSchema else {
+            return ref.database.map { .database($0) }
         }
-        return .tables(names: names, schema: first.qualifyingSchema)
+        return .schema(database: ref.database, schema: schema)
+    }
+
+    /// Carries a scope only when every row agrees on one, the same unanimity rule `scopedDatabase`
+    /// applies to a container preselection.
+    static func tables(
+        fromSidebarSelection refs: Set<DatabaseTreeTableRef>,
+        grouping: GroupingStrategy
+    ) -> ExportPreselection {
+        let names = Set(refs.map(\.table.name))
+        let scopes = refs.map { scope(for: $0, grouping: grouping) }
+        guard let first = scopes.first, scopes.allSatisfy({ $0 == first }) else {
+            return .tables(names: names, scope: nil)
+        }
+        return .tables(names: names, scope: first)
     }
 
     /// `container` is the ref the dialog is listing, not its bare name. Matching on the name alone
@@ -41,16 +57,16 @@ enum ExportPreselection: Equatable {
         isCurrentContainer: Bool
     ) -> Bool {
         switch self {
-        case .tables(let names, let schema):
+        case .tables(let names, let scope):
             guard kind == .table || kind == .view || kind == .materializedView || kind == .foreignTable else {
                 return false
             }
             guard names.contains(object) else { return false }
-            /// A named schema answers for itself. `isCurrentContainer` cannot: it is computed from
+            /// A named scope answers for itself. `isCurrentContainer` cannot: it is computed from
             /// the engine's static default schema name, which is "" on the five engines that hang
             /// tables off schemas, so it is false for every section on those.
-            guard let schema else { return isCurrentContainer }
-            return container.kind == .schema && container.schema == schema
+            guard let scope else { return isCurrentContainer }
+            return scope.covers(container)
         case .containers(let refs):
             return refs.contains { $0.covers(container) }
         }
@@ -61,11 +77,18 @@ enum ExportPreselection: Equatable {
         return names.first
     }
 
+    /// Whether a table preselection's scope reaches the given container. An unscoped preselection
+    /// reaches everything, which is the behaviour it had before it carried one.
+    func scope(covers container: DatabaseContainerRef) -> Bool {
+        guard case .tables(_, let scope) = self, let scope else { return true }
+        return scope.covers(container)
+    }
+
     /// The schema the dialog should open expanded, so the section holding a preselected table is
     /// the one on screen. Ticking the right row inside a collapsed section reads as nothing selected.
     var scopedSchema: String? {
-        guard case .tables(_, let schema) = self else { return nil }
-        return schema
+        guard case .tables(_, let scope) = self, scope?.kind == .schema else { return nil }
+        return scope?.schema
     }
 
     var containerNames: [String] {

--- a/TablePro/Models/Export/ExportModels.swift
+++ b/TablePro/Models/Export/ExportModels.swift
@@ -11,8 +11,22 @@ import TableProPluginKit
 /// What the export dialog starts with selected: named tables inside the current
 /// container, or every table of whole databases or schemas.
 enum ExportPreselection: Equatable {
-    case tables(Set<String>)
+    /// `schema` is the one the named tables live in, carried because a bare name does not identify
+    /// a table: `orders` exists in every schema on the server. Without it the dialog fell back to
+    /// whichever schema it considered current and ticked a same-named table somewhere else.
+    /// Nil where the engine has no schemas, or where a selection spans several and none can anchor it.
+    case tables(names: Set<String>, schema: String?)
     case containers([DatabaseContainerRef])
+
+    /// Carries the schema only when every row agrees on one, the same unanimity rule
+    /// `scopedDatabase` applies to a container preselection.
+    static func tables(fromSidebarSelection refs: Set<DatabaseTreeTableRef>) -> ExportPreselection {
+        let names = Set(refs.map(\.table.name))
+        guard let first = refs.first, refs.allSatisfy({ $0.qualifyingSchema == first.qualifyingSchema }) else {
+            return .tables(names: names, schema: nil)
+        }
+        return .tables(names: names, schema: first.qualifyingSchema)
+    }
 
     /// `container` is the ref the dialog is listing, not its bare name. Matching on the name alone
     /// compared a database name against schema names, so a preselected database selected nothing on
@@ -27,19 +41,31 @@ enum ExportPreselection: Equatable {
         isCurrentContainer: Bool
     ) -> Bool {
         switch self {
-        case .tables(let names):
+        case .tables(let names, let schema):
             guard kind == .table || kind == .view || kind == .materializedView || kind == .foreignTable else {
                 return false
             }
-            return isCurrentContainer && names.contains(object)
+            guard names.contains(object) else { return false }
+            /// A named schema answers for itself. `isCurrentContainer` cannot: it is computed from
+            /// the engine's static default schema name, which is "" on the five engines that hang
+            /// tables off schemas, so it is false for every section on those.
+            guard let schema else { return isCurrentContainer }
+            return container.kind == .schema && container.schema == schema
         case .containers(let refs):
             return refs.contains { $0.covers(container) }
         }
     }
 
     var singleTableName: String? {
-        guard case .tables(let names) = self, names.count == 1 else { return nil }
+        guard case .tables(let names, _) = self, names.count == 1 else { return nil }
         return names.first
+    }
+
+    /// The schema the dialog should open expanded, so the section holding a preselected table is
+    /// the one on screen. Ticking the right row inside a collapsed section reads as nothing selected.
+    var scopedSchema: String? {
+        guard case .tables(_, let schema) = self else { return nil }
+        return schema
     }
 
     var containerNames: [String] {

--- a/TablePro/ViewModels/SidebarViewModel.swift
+++ b/TablePro/ViewModels/SidebarViewModel.swift
@@ -4,10 +4,12 @@
 //
 
 import Observation
+import os
 import SwiftUI
 
 @MainActor @Observable
 final class SidebarViewModel {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "SidebarViewModel")
     private static var registry: [UUID: SidebarViewModel] = [:]
     private static let searchDebounceNanoseconds: UInt64 = 150_000_000
 
@@ -278,6 +280,12 @@ final class SidebarViewModel {
     func batchToggleTruncate(refs: [DatabaseTreeTableRef]? = nil) {
         let targets = refs ?? Array(selectedTables)
         guard !targets.isEmpty else { return }
+        /// The last gate before the queue, refusing the whole batch the way both menus now do
+        /// rather than truncating the part of a selection that happens to qualify.
+        guard TableOperationEligibility.canTruncate(targets) else {
+            Self.logger.warning("Refused to stage a truncate against an object that holds no rows of its own")
+            return
+        }
 
         guard !targets.allSatisfy({ pendingTruncates.contains($0) }) else {
             unstage(targets, from: &pendingTruncatesBinding.wrappedValue)

--- a/TablePro/Views/Export/ExportDialog.swift
+++ b/TablePro/Views/Export/ExportDialog.swift
@@ -88,7 +88,7 @@ struct ExportDialog: View {
         if case .tables(_, let preselection) = mode {
             return preselection
         }
-        return .tables(names: [], schema: nil)
+        return .tables(names: [], scope: nil)
     }
 
     // MARK: - Body
@@ -652,6 +652,11 @@ struct ExportDialog: View {
         /// failed load would leave them on screen looking like that database's contents.
         guard preselection.scopedDatabase == nil else { return }
         let dbName = connection.database
+        /// The preload can only build a database-shaped container, so a preselection scoped to a
+        /// schema is evaluated against the wrong one here and records every row unselected. The
+        /// snapshot it leaves is keyed by bare container name, so a database and a schema that
+        /// share one, `app` and `app`, then restore that stale answer over the real preselection.
+        guard preselection.scope(covers: .database(dbName)) else { return }
         let objectItems = sidebarTables.map { table in
             let kind = PluginExportObjectKind.from(tableType: table.type.rawValue)
             return ExportObjectItem(
@@ -1156,6 +1161,6 @@ struct ExportDialog: View {
 
     return ExportDialog(
         isPresented: .constant(true),
-        mode: .tables(connection: connection, preselection: .tables(names: ["users"], schema: nil))
+        mode: .tables(connection: connection, preselection: .tables(names: ["users"], scope: nil))
     )
 }

--- a/TablePro/Views/Export/ExportDialog.swift
+++ b/TablePro/Views/Export/ExportDialog.swift
@@ -88,7 +88,7 @@ struct ExportDialog: View {
         if case .tables(_, let preselection) = mode {
             return preselection
         }
-        return .tables([])
+        return .tables(names: [], schema: nil)
     }
 
     // MARK: - Body
@@ -734,7 +734,13 @@ struct ExportDialog: View {
                         items.append(ExportDatabaseItem(
                             name: schema,
                             objects: objectItems,
-                            isExpanded: isDefaultSchema || preselection.containerNames.contains(schema)
+                            /// The preselected table's own schema opens too. `isDefaultSchema` cannot
+                            /// carry that: it is "" on the five engines that hang tables off schemas,
+                            /// so every section stayed shut and a correctly ticked row read as nothing
+                            /// selected.
+                            isExpanded: isDefaultSchema
+                                || preselection.containerNames.contains(schema)
+                                || preselection.scopedSchema == schema
                         ))
                     }
                 }
@@ -1150,6 +1156,6 @@ struct ExportDialog: View {
 
     return ExportDialog(
         isPresented: .constant(true),
-        mode: .tables(connection: connection, preselection: .tables(["users"]))
+        mode: .tables(connection: connection, preselection: .tables(names: ["users"], schema: nil))
     )
 }

--- a/TablePro/Views/Export/TableTransferSheet.swift
+++ b/TablePro/Views/Export/TableTransferSheet.swift
@@ -19,6 +19,9 @@ struct TableTransferSheet: View {
     @Binding var isPresented: Bool
     let sourceConnection: DatabaseConnection
     let preselectedTables: Set<String>
+    /// The schema the preselected rows came from. Without it the sheet listed whichever schema the
+    /// session happened to be browsing and matched the bare names against that one instead.
+    var preselectedSchema: String?
 
     @State private var service = TableTransferService()
     @State private var destinationConnectionId: UUID?
@@ -393,10 +396,16 @@ struct TableTransferSheet: View {
         }
     }
 
+    /// An explicit schema wins over the session's current one in `resolvedScope`, which is what
+    /// makes the sheet list the rows the user actually right-clicked.
     private var sourceScope: DatabaseScope {
         DatabaseManager.shared.resolvedScope(
-            database: sourceConnection.database, schema: nil, for: sourceConnection.id
-        ) ?? DatabaseScope(connectionId: sourceConnection.id, database: sourceConnection.database, schema: nil)
+            database: sourceConnection.database, schema: preselectedSchema, for: sourceConnection.id
+        ) ?? DatabaseScope(
+            connectionId: sourceConnection.id,
+            database: sourceConnection.database,
+            schema: preselectedSchema
+        )
     }
 
     /// The database the user picked, not wherever the destination connection was last parked. Both

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarActions.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarActions.swift
@@ -165,10 +165,10 @@ extension MainContentCoordinator {
 
     // MARK: - Export/Import
 
-    /// The schema travels with the names because a bare name does not identify a table. Without it
-    /// the dialog resolved `orders` against whichever schema it considered current.
-    func openExportDialog(preselectedTableNames: Set<String>? = nil, schema: String? = nil) {
-        exportPreselection = preselectedTableNames.map { .tables(names: $0, schema: schema) }
+    /// The scope travels with the names because a bare name does not identify a table. Without it
+    /// the dialog resolved `orders` against whichever container it considered current.
+    func openExportDialog(preselectedTableNames: Set<String>? = nil, scope: DatabaseContainerRef? = nil) {
+        exportPreselection = preselectedTableNames.map { .tables(names: $0, scope: scope) }
         activeSheet = .exportDialog
     }
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarActions.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarActions.swift
@@ -165,8 +165,10 @@ extension MainContentCoordinator {
 
     // MARK: - Export/Import
 
-    func openExportDialog(preselectedTableNames: Set<String>? = nil) {
-        exportPreselection = preselectedTableNames.map { .tables($0) }
+    /// The schema travels with the names because a bare name does not identify a table. Without it
+    /// the dialog resolved `orders` against whichever schema it considered current.
+    func openExportDialog(preselectedTableNames: Set<String>? = nil, schema: String? = nil) {
+        exportPreselection = preselectedTableNames.map { .tables(names: $0, schema: schema) }
         activeSheet = .exportDialog
     }
 
@@ -179,8 +181,8 @@ extension MainContentCoordinator {
     /// Copies rows into another open connection. The tables the user right-clicked travel with the
     /// request rather than being read back from the object browser, which may have moved on by the
     /// time the sheet appears.
-    func openTableTransferSheet(preselectedTableNames: Set<String> = []) {
-        activeSheet = .transferTables(tables: preselectedTableNames)
+    func openTableTransferSheet(preselectedTableNames: Set<String> = [], schema: String? = nil) {
+        activeSheet = .transferTables(tables: preselectedTableNames, schema: schema)
     }
 
     func openExportQueryResultsDialog() {

--- a/TablePro/Views/Main/Extensions/MainContentView+TransferSheets.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+TransferSheets.swift
@@ -19,7 +19,7 @@ extension MainContentView {
                 mode: .tables(
                     connection: exportConnection,
                     preselection: coordinator.exportPreselection
-                        ?? .tables(Set(coordinator.windowSidebarState.selectedTables.map(\.table.name)))
+                        ?? .tables(fromSidebarSelection: coordinator.windowSidebarState.selectedTables)
                 ),
                 sidebarTables: tables
             )
@@ -78,8 +78,8 @@ extension MainContentView {
                     formatId: formatId
                 )
             }
-        case .transferTables(let tables):
-            transferSheet(tables: tables, dismiss: dismissBinding)
+        case .transferTables(let tables, let schema):
+            transferSheet(tables: tables, schema: schema, dismiss: dismissBinding)
         case .backupDatabase(let databases):
             BackupDatabaseFlow(
                 isPresented: dismissBinding,

--- a/TablePro/Views/Main/Extensions/MainContentView+TransferSheets.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+TransferSheets.swift
@@ -19,7 +19,10 @@ extension MainContentView {
                 mode: .tables(
                     connection: exportConnection,
                     preselection: coordinator.exportPreselection
-                        ?? .tables(fromSidebarSelection: coordinator.windowSidebarState.selectedTables)
+                        ?? .tables(
+                            fromSidebarSelection: coordinator.windowSidebarState.selectedTables,
+                            grouping: PluginManager.shared.databaseGroupingStrategy(for: connection.type)
+                        )
                 ),
                 sidebarTables: tables
             )

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -234,22 +234,10 @@ final class MainContentCommandActions {
         if !indices.isEmpty {
             coordinator?.deleteSelectedRows(indices: indices)
         } else if !fromDataGrid, !selectedTables.wrappedValue.isEmpty {
-            // Only toggle table deletion when the call did NOT originate from
-            // the data grid (e.g., from the app menu Cmd+Delete with no rows selected)
-            var updatedDeletes = pendingDeletes.wrappedValue
-            var updatedTruncates = pendingTruncates.wrappedValue
-
-            for ref in selectedTables.wrappedValue {
-                updatedTruncates.remove(ref)
-                if updatedDeletes.contains(ref) {
-                    updatedDeletes.remove(ref)
-                } else {
-                    updatedDeletes.insert(ref)
-                }
-            }
-
-            pendingTruncates.wrappedValue = updatedTruncates
-            pendingDeletes.wrappedValue = updatedDeletes
+            /// Through the sidebar's own path rather than a second copy of it. Staging the queue
+            /// here directly skipped the confirmation `batchToggleDelete` raises, so Delete from
+            /// the menu bar queued a drop with no dialog while the sidebar's Delete asked first.
+            coordinator?.sidebarViewModel?.batchToggleDelete(refs: Array(selectedTables.wrappedValue))
         }
     }
 
@@ -493,6 +481,12 @@ final class MainContentCommandActions {
 
     var hasTableSelection: Bool {
         !selectedTables.wrappedValue.isEmpty
+    }
+
+    /// A selection can be perfectly valid and still hold nothing truncatable, so the menu bar asks
+    /// this rather than `hasTableSelection`, which is what let it stage a `TRUNCATE` on a view.
+    var canTruncateSelectedTables: Bool {
+        TableOperationEligibility.canTruncate(selectedTables.wrappedValue)
     }
 
     /// The one selected object, or nil when the selection is empty or spans several.
@@ -871,7 +865,7 @@ final class MainContentCommandActions {
     }
 
     func truncateTables() {
-        guard !(selectedTables.wrappedValue.isEmpty) else { return }
+        guard canTruncateSelectedTables else { return }
         coordinator?.sidebarViewModel?.batchToggleTruncate()
     }
 

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -53,7 +53,7 @@ enum ActiveSheet: Identifiable {
     case exportQueryResults
     /// The tables the user right-clicked travel with the request, because the object browser may be
     /// pointed somewhere else by the time the sheet appears.
-    case transferTables(tables: Set<String>)
+    case transferTables(tables: Set<String>, schema: String?)
     /// The databases the user right-clicked travel with the request, so the sheet opens on them
     /// rather than on wherever the object browser happens to point. Empty means the browse database.
     case backupDatabase(databases: Set<String>)
@@ -81,7 +81,8 @@ enum ActiveSheet: Identifiable {
         case .importDialog(let formatId): "importDialog-\(formatId)"
         case .rowImport(let formatId): "rowImport-\(formatId)"
         case .exportQueryResults: "exportQueryResults"
-        case .transferTables(let tables): "transferTables-\(tables.sorted().joined(separator: ","))"
+        case .transferTables(let tables, let schema):
+            "transferTables-\(schema ?? "")-\(tables.sorted().joined(separator: ","))"
         case .backupDatabase: "backupDatabase"
         case .restoreDatabase(let fileURL): "restoreDatabase-\(fileURL.path)"
         case .serverSideExport(let table): "serverSideExport-\(table ?? "")"

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -162,11 +162,12 @@ struct MainContentView: View {
     /// The transfer sheet is built here rather than inline, because `sheetContent(for:)` is one
     /// switch over every sheet the window can present and is already at the function length limit.
     @ViewBuilder
-    func transferSheet(tables: Set<String>, dismiss: Binding<Bool>) -> some View {
+    func transferSheet(tables: Set<String>, schema: String?, dismiss: Binding<Bool>) -> some View {
         TableTransferSheet(
             isPresented: dismiss,
             sourceConnection: connectionWithCurrentDatabase,
-            preselectedTables: tables
+            preselectedTables: tables,
+            preselectedSchema: schema
         )
     }
 

--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Commands.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Commands.swift
@@ -47,9 +47,10 @@ extension DatabaseTreeOutlineCoordinator {
             ClipboardService.shared.writeText(names.joined(separator: ","))
         case .exportTables(let names, let ref):
             activateThen(ref) { [weak self] in
-                self?.mainCoordinator?.openExportDialog(
+                guard let self else { return }
+                self.mainCoordinator?.openExportDialog(
                     preselectedTableNames: names,
-                    schema: ref.qualifyingSchema
+                    scope: self.exportScope(for: ref)
                 )
             }
         case .transferTables(let names, let ref):
@@ -158,6 +159,13 @@ extension DatabaseTreeOutlineCoordinator {
         case .toggleObjectIcons, .toggleObjectComments, .setRowSize:
             _ = SidebarViewOptionsMenu.apply(command)
         }
+    }
+
+    private func exportScope(for ref: DatabaseTreeTableRef) -> DatabaseContainerRef? {
+        ExportPreselection.scope(
+            for: ref,
+            grouping: PluginManager.shared.databaseGroupingStrategy(for: databaseType)
+        )
     }
 
     /// A command that opens or edits an object has to reach the database that object lives in

--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Commands.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Commands.swift
@@ -47,11 +47,17 @@ extension DatabaseTreeOutlineCoordinator {
             ClipboardService.shared.writeText(names.joined(separator: ","))
         case .exportTables(let names, let ref):
             activateThen(ref) { [weak self] in
-                self?.mainCoordinator?.openExportDialog(preselectedTableNames: names)
+                self?.mainCoordinator?.openExportDialog(
+                    preselectedTableNames: names,
+                    schema: ref.qualifyingSchema
+                )
             }
         case .transferTables(let names, let ref):
             activateThen(ref) { [weak self] in
-                self?.mainCoordinator?.openTableTransferSheet(preselectedTableNames: names)
+                self?.mainCoordinator?.openTableTransferSheet(
+                    preselectedTableNames: names,
+                    schema: ref.qualifyingSchema
+                )
             }
         case .importTables(let formatId, let ref):
             activateThen(ref) { [weak self] in

--- a/TablePro/Views/Sidebar/Menu/DatabaseTreeMenuSpec.swift
+++ b/TablePro/Views/Sidebar/Menu/DatabaseTreeMenuSpec.swift
@@ -116,7 +116,11 @@ internal enum DatabaseTreeMenuSpec {
         targets: [DatabaseTreeTableRef],
         context: DatabaseTreeMenuContext
     ) -> [DatabaseTreeMenuItem] {
-        let names = Set(targets.map(\.table.name))
+        /// Narrowed to the clicked row's own schema as well as its database, which is what Copy To
+        /// already did alone. A bare name does not identify a table, so a selection spanning two
+        /// schemas handed the dialog names it resolved against one of them.
+        let sameScope = targets.filter { $0.qualifyingSchema == ref.qualifyingSchema }
+        let names = Set(sameScope.map(\.table.name))
         var items: [DatabaseTreeMenuItem] = [
             .command(String(localized: "Export…"), .exportTables(names: names, ref: ref))
         ]
@@ -126,10 +130,6 @@ internal enum DatabaseTreeMenuSpec {
         }
         items.append(.command(String(localized: "Transfer To…"), .transferTables(names: names, ref: ref)))
         if context.canCopyObjects {
-            /// Narrowed to the clicked row's own schema as well as its database. A copy names one
-            /// source scope, so a selection spanning two schemas would read one of them and either
-            /// drop the other's tables from the plan or map a same-named one to the wrong table.
-            let sameScope = targets.filter { $0.qualifyingSchema == ref.qualifyingSchema }
             items.append(.command(
                 String(localized: "Copy To…"),
                 .copyObjectsTo(objects: copySelections(for: sameScope), ref: ref)
@@ -163,7 +163,7 @@ internal enum DatabaseTreeMenuSpec {
         if ObjectRenameEligibility.canRename(table: ref.table, context: context.renameEligibility) {
             items.append(.command(String(localized: "Rename"), .beginRenameTable(ref: ref, isRecentRow: isRecentRow)))
         }
-        if SidebarContextMenuLogic.truncateVisible(clickedTable: ref.table) {
+        if SidebarContextMenuLogic.truncateVisible(targets: targets) {
             items.append(.command(String(localized: "Truncate"), .truncateTables(targets: targets, ref: ref)))
         }
         items.append(.command(

--- a/TablePro/Views/Sidebar/SidebarContextMenu.swift
+++ b/TablePro/Views/Sidebar/SidebarContextMenu.swift
@@ -12,12 +12,7 @@ enum SidebarContextMenuLogic {
     }
 
     static func isReadOnlyKind(_ type: TableInfo.TableType?) -> Bool {
-        switch type {
-        case .view, .materializedView, .foreignTable, .systemTable, .externalTable:
-            return true
-        case .table, .partitionedTable, .none:
-            return false
-        }
+        TableOperationEligibility.isReadOnlyKind(type)
     }
 
     static func importVisible(clickedTable: TableInfo?, supportsImport: Bool) -> Bool {
@@ -25,8 +20,11 @@ enum SidebarContextMenuLogic {
         return !isReadOnlyKind(clickedTable?.type)
     }
 
-    static func truncateVisible(clickedTable: TableInfo?) -> Bool {
-        !isReadOnlyKind(clickedTable?.type)
+    /// Asked of every row the command would act on, not just the one under the pointer. Right
+    /// clicking a table inside a selection that also held a view offered Truncate and staged it
+    /// for the view as well.
+    static func truncateVisible(targets: some Collection<DatabaseTreeTableRef>) -> Bool {
+        TableOperationEligibility.canTruncate(targets)
     }
 
     static func deleteLabel(for type: TableInfo.TableType?) -> String {

--- a/TableProTests/Core/Menu/MainMenuBuilderTests.swift
+++ b/TableProTests/Core/Menu/MainMenuBuilderTests.swift
@@ -370,10 +370,25 @@ struct MainMenuValidationTests {
         context.isCurrentTabEditable = true
         context.isCurrentTabSchemaResolved = true
         context.hasTableSelection = true
+        context.canTruncateSelectedTables = true
         context.isReadOnly = true
         #expect(!enabled(#selector(MainSplitViewController.addRow(_:)), context))
         #expect(!enabled(#selector(MainSplitViewController.truncateTable(_:)), context))
         #expect(!enabled(#selector(MainSplitViewController.createNewTable(_:)), context))
+    }
+
+    /// A view is a valid selection and a hopeless truncate. The menu bar used to ask only whether
+    /// anything was selected, so it offered Truncate Table for one and the server refused the save.
+    @Test("Truncate Table is disabled for a selection holding nothing truncatable")
+    func truncateNeedsATruncatableSelection() {
+        var context = MenuValidationContext()
+        context.isConnected = true
+        context.hasTableSelection = true
+        context.canTruncateSelectedTables = false
+        #expect(!enabled(#selector(MainSplitViewController.truncateTable(_:)), context))
+
+        context.canTruncateSelectedTables = true
+        #expect(enabled(#selector(MainSplitViewController.truncateTable(_:)), context))
     }
 
     @Test("Cancel Query tracks execution, not connection")
@@ -433,6 +448,7 @@ struct MainMenuValidationTests {
         context.isCurrentTabEditable = true
         context.isCurrentTabSchemaResolved = true
         context.hasTableSelection = true
+        context.canTruncateSelectedTables = true
         context.canShowTableStructure = true
         context.canEditViewDefinition = true
         context.hasMaintenanceOperations = true

--- a/TableProTests/Models/Database/TableOperationEligibilityTests.swift
+++ b/TableProTests/Models/Database/TableOperationEligibilityTests.swift
@@ -1,0 +1,59 @@
+//
+//  TableOperationEligibilityTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+@Suite("Table operation eligibility")
+struct TableOperationEligibilityTests {
+    private func ref(_ name: String, _ type: TableInfo.TableType) -> DatabaseTreeTableRef {
+        DatabaseTreeTableRef(
+            database: "app",
+            schema: "public",
+            table: TableInfo(name: name, type: type, rowCount: nil, schema: "public")
+        )
+    }
+
+    @Test("A table and a partitioned table can be truncated")
+    func writableKindsQualify() {
+        #expect(TableOperationEligibility.canTruncate(TableInfo.TableType.table))
+        #expect(TableOperationEligibility.canTruncate(TableInfo.TableType.partitionedTable))
+    }
+
+    /// A view holds no rows of its own, a foreign or external table proxies rows on another server,
+    /// and a system table belongs to the catalog. The server refuses a TRUNCATE against all of them.
+    @Test("A view, materialized view, foreign, system and external table cannot")
+    func readOnlyKindsDoNot() {
+        for type in [
+            TableInfo.TableType.view,
+            .materializedView,
+            .foreignTable,
+            .systemTable,
+            .externalTable,
+        ] {
+            #expect(!TableOperationEligibility.canTruncate(type), "\(type) should not be truncatable")
+        }
+    }
+
+    @Test("An empty selection cannot be truncated")
+    func emptySelectionDoesNotQualify() {
+        #expect(!TableOperationEligibility.canTruncate([DatabaseTreeTableRef]()))
+    }
+
+    @Test("A selection of tables alone can be truncated")
+    func allTablesQualify() {
+        #expect(TableOperationEligibility.canTruncate([ref("orders", .table), ref("users", .table)]))
+    }
+
+    /// All or nothing. Truncating the eligible part of a selection would leave the rest looking
+    /// emptied until someone checked.
+    @Test("A selection mixing a table and a view cannot be truncated at all")
+    func mixedSelectionDoesNotQualify() {
+        #expect(!TableOperationEligibility.canTruncate([ref("orders", .table), ref("summary", .view)]))
+    }
+}

--- a/TableProTests/Models/Export/ExportPreselectionTests.swift
+++ b/TableProTests/Models/Export/ExportPreselectionTests.swift
@@ -13,10 +13,77 @@ import Testing
 struct ExportPreselectionTests {
     @Test("Named tables only select inside the current container")
     func namedTablesStayInCurrentContainer() {
-        let preselection = ExportPreselection.tables(["users"])
+        let preselection = ExportPreselection.tables(names: ["users"], schema: nil)
 
         #expect(preselection.selects(object: "users", kind: .table, inContainer: .database("sales"), isCurrentContainer: true))
         #expect(!preselection.selects(object: "users", kind: .table, inContainer: .database("analytics"), isCurrentContainer: false))
+    }
+
+    /// The reported bug: `orders` in both `public` and `reporting`, exporting the `reporting` one.
+    /// Before this, the dialog matched the bare name against whichever schema it called current.
+    @Test("A schema-scoped table preselection selects only its own schema")
+    func schemaScopedTablesStayInTheirSchema() {
+        let preselection = ExportPreselection.tables(names: ["orders"], schema: "reporting")
+
+        #expect(preselection.selects(
+            object: "orders", kind: .table,
+            inContainer: .schema(database: "app", schema: "reporting"), isCurrentContainer: false
+        ))
+        #expect(!preselection.selects(
+            object: "orders", kind: .table,
+            inContainer: .schema(database: "app", schema: "public"), isCurrentContainer: true
+        ))
+    }
+
+    /// `isCurrentContainer` is computed from the engine's static default schema name, which is ""
+    /// on the five engines that hang tables off schemas, so it answers false everywhere on those.
+    /// A named schema is what makes the preselection reachable there at all.
+    @Test("A named schema selects even where nothing is the current container")
+    func namedSchemaWorksWithoutACurrentContainer() {
+        let preselection = ExportPreselection.tables(names: ["orders"], schema: "SALES")
+
+        #expect(preselection.selects(
+            object: "orders", kind: .table,
+            inContainer: .schema(database: "app", schema: "SALES"), isCurrentContainer: false
+        ))
+    }
+
+    @Test("A table preselection with no schema keeps the old current-container rule")
+    func unscopedTablesFallBackToCurrentContainer() {
+        let preselection = ExportPreselection.tables(names: ["users"], schema: nil)
+
+        #expect(preselection.selects(
+            object: "users", kind: .table,
+            inContainer: .schema(database: "app", schema: "public"), isCurrentContainer: true
+        ))
+    }
+
+    @Test("A sidebar selection carries its schema only when every row agrees")
+    func sidebarSelectionCarriesAgreedSchema() {
+        #expect(ExportPreselection.tables(fromSidebarSelection: [
+            Self.ref("orders", schema: "reporting"),
+            Self.ref("totals", schema: "reporting"),
+        ]).scopedSchema == "reporting")
+
+        #expect(ExportPreselection.tables(fromSidebarSelection: [
+            Self.ref("orders", schema: "reporting"),
+            Self.ref("users", schema: "public"),
+        ]).scopedSchema == nil)
+    }
+
+    /// The section holding the preselected table opens, or a correctly ticked row sits inside a
+    /// collapsed section and reads as nothing selected.
+    @Test("A container preselection exposes no schema scope")
+    func containerPreselectionHasNoSchemaScope() {
+        #expect(ExportPreselection.containers([.database("sales")]).scopedSchema == nil)
+    }
+
+    private static func ref(_ name: String, schema: String?) -> DatabaseTreeTableRef {
+        DatabaseTreeTableRef(
+            database: "app",
+            schema: schema,
+            table: TableInfo(name: name, type: .table, rowCount: nil, schema: schema)
+        )
     }
 
     @Test("A container preselection selects every table it holds")
@@ -44,8 +111,8 @@ struct ExportPreselectionTests {
 
     @Test("A single table names the export file")
     func singleTableNamesTheFile() {
-        #expect(ExportPreselection.tables(["users"]).singleTableName == "users")
-        #expect(ExportPreselection.tables(["users", "orders"]).singleTableName == nil)
+        #expect(ExportPreselection.tables(names: ["users"], schema: nil).singleTableName == "users")
+        #expect(ExportPreselection.tables(names: ["users", "orders"], schema: nil).singleTableName == nil)
         #expect(ExportPreselection.containers([.database("sales")]).singleTableName == nil)
     }
 
@@ -139,7 +206,7 @@ struct ExportPreselectionTests {
         #expect(ExportPreselection.containers([
             .database("app"), .database("analytics"),
         ]).scopedDatabase == nil)
-        #expect(ExportPreselection.tables(["users"]).scopedDatabase == nil)
+        #expect(ExportPreselection.tables(names: ["users"], schema: nil).scopedDatabase == nil)
     }
 
     @Test("Container names are exposed for expansion and file naming")
@@ -147,6 +214,6 @@ struct ExportPreselectionTests {
         let preselection = ExportPreselection.containers([.database("sales"), .database("analytics")])
 
         #expect(preselection.containerNames == ["sales", "analytics"])
-        #expect(ExportPreselection.tables(["users"]).containerNames.isEmpty)
+        #expect(ExportPreselection.tables(names: ["users"], schema: nil).containerNames.isEmpty)
     }
 }

--- a/TableProTests/Models/Export/ExportPreselectionTests.swift
+++ b/TableProTests/Models/Export/ExportPreselectionTests.swift
@@ -13,7 +13,7 @@ import Testing
 struct ExportPreselectionTests {
     @Test("Named tables only select inside the current container")
     func namedTablesStayInCurrentContainer() {
-        let preselection = ExportPreselection.tables(names: ["users"], schema: nil)
+        let preselection = ExportPreselection.tables(names: ["users"], scope: nil)
 
         #expect(preselection.selects(object: "users", kind: .table, inContainer: .database("sales"), isCurrentContainer: true))
         #expect(!preselection.selects(object: "users", kind: .table, inContainer: .database("analytics"), isCurrentContainer: false))
@@ -23,7 +23,7 @@ struct ExportPreselectionTests {
     /// Before this, the dialog matched the bare name against whichever schema it called current.
     @Test("A schema-scoped table preselection selects only its own schema")
     func schemaScopedTablesStayInTheirSchema() {
-        let preselection = ExportPreselection.tables(names: ["orders"], schema: "reporting")
+        let preselection = ExportPreselection.tables(names: ["orders"], scope: .schema(database: "app", schema: "reporting"))
 
         #expect(preselection.selects(
             object: "orders", kind: .table,
@@ -40,7 +40,7 @@ struct ExportPreselectionTests {
     /// A named schema is what makes the preselection reachable there at all.
     @Test("A named schema selects even where nothing is the current container")
     func namedSchemaWorksWithoutACurrentContainer() {
-        let preselection = ExportPreselection.tables(names: ["orders"], schema: "SALES")
+        let preselection = ExportPreselection.tables(names: ["orders"], scope: .schema(database: "app", schema: "SALES"))
 
         #expect(preselection.selects(
             object: "orders", kind: .table,
@@ -50,7 +50,7 @@ struct ExportPreselectionTests {
 
     @Test("A table preselection with no schema keeps the old current-container rule")
     func unscopedTablesFallBackToCurrentContainer() {
-        let preselection = ExportPreselection.tables(names: ["users"], schema: nil)
+        let preselection = ExportPreselection.tables(names: ["users"], scope: nil)
 
         #expect(preselection.selects(
             object: "users", kind: .table,
@@ -58,17 +58,47 @@ struct ExportPreselectionTests {
         ))
     }
 
-    @Test("A sidebar selection carries its schema only when every row agrees")
-    func sidebarSelectionCarriesAgreedSchema() {
+    @Test("A sidebar selection carries its scope only when every row agrees")
+    func sidebarSelectionCarriesAgreedScope() {
         #expect(ExportPreselection.tables(fromSidebarSelection: [
             Self.ref("orders", schema: "reporting"),
             Self.ref("totals", schema: "reporting"),
-        ]).scopedSchema == "reporting")
+        ], grouping: .bySchema).scopedSchema == "reporting")
 
         #expect(ExportPreselection.tables(fromSidebarSelection: [
             Self.ref("orders", schema: "reporting"),
             Self.ref("users", schema: "public"),
-        ]).scopedSchema == nil)
+        ], grouping: .bySchema).scopedSchema == nil)
+    }
+
+    /// Cassandra reports its keyspace as a schema and Teradata writes the database into one, yet
+    /// both group by database, so the dialog lists no schema rows at all. Scoping those to a schema
+    /// matched nothing and lost the preselection entirely.
+    @Test("An engine that groups by database is scoped to the database, schema or not")
+    func byDatabaseEnginesScopeToTheDatabase() {
+        let ref = Self.ref("orders", schema: "keyspace_one")
+        let scope = ExportPreselection.scope(for: ref, grouping: .byDatabase)
+
+        #expect(scope == .database("app"))
+
+        let preselection = ExportPreselection.tables(names: ["orders"], scope: scope)
+        #expect(preselection.selects(
+            object: "orders", kind: .table,
+            inContainer: .database("app"), isCurrentContainer: false
+        ))
+        #expect(!preselection.selects(
+            object: "orders", kind: .table,
+            inContainer: .database("other"), isCurrentContainer: true
+        ))
+    }
+
+    @Test("A schema-grouped engine is scoped to the schema")
+    func schemaGroupedEnginesScopeToTheSchema() {
+        let ref = Self.ref("orders", schema: "reporting")
+        #expect(ExportPreselection.scope(for: ref, grouping: .bySchema)
+            == .schema(database: "app", schema: "reporting"))
+        #expect(ExportPreselection.scope(for: ref, grouping: .hierarchicalSchema)
+            == .schema(database: "app", schema: "reporting"))
     }
 
     /// The section holding the preselected table opens, or a correctly ticked row sits inside a
@@ -76,6 +106,7 @@ struct ExportPreselectionTests {
     @Test("A container preselection exposes no schema scope")
     func containerPreselectionHasNoSchemaScope() {
         #expect(ExportPreselection.containers([.database("sales")]).scopedSchema == nil)
+        #expect(ExportPreselection.tables(names: ["orders"], scope: .database("app")).scopedSchema == nil)
     }
 
     private static func ref(_ name: String, schema: String?) -> DatabaseTreeTableRef {
@@ -111,8 +142,8 @@ struct ExportPreselectionTests {
 
     @Test("A single table names the export file")
     func singleTableNamesTheFile() {
-        #expect(ExportPreselection.tables(names: ["users"], schema: nil).singleTableName == "users")
-        #expect(ExportPreselection.tables(names: ["users", "orders"], schema: nil).singleTableName == nil)
+        #expect(ExportPreselection.tables(names: ["users"], scope: nil).singleTableName == "users")
+        #expect(ExportPreselection.tables(names: ["users", "orders"], scope: nil).singleTableName == nil)
         #expect(ExportPreselection.containers([.database("sales")]).singleTableName == nil)
     }
 
@@ -206,7 +237,7 @@ struct ExportPreselectionTests {
         #expect(ExportPreselection.containers([
             .database("app"), .database("analytics"),
         ]).scopedDatabase == nil)
-        #expect(ExportPreselection.tables(names: ["users"], schema: nil).scopedDatabase == nil)
+        #expect(ExportPreselection.tables(names: ["users"], scope: nil).scopedDatabase == nil)
     }
 
     @Test("Container names are exposed for expansion and file naming")
@@ -214,6 +245,6 @@ struct ExportPreselectionTests {
         let preselection = ExportPreselection.containers([.database("sales"), .database("analytics")])
 
         #expect(preselection.containerNames == ["sales", "analytics"])
-        #expect(ExportPreselection.tables(names: ["users"], schema: nil).containerNames.isEmpty)
+        #expect(ExportPreselection.tables(names: ["users"], scope: nil).containerNames.isEmpty)
     }
 }

--- a/TableProTests/Models/ExportObjectTreeTests.swift
+++ b/TableProTests/Models/ExportObjectTreeTests.swift
@@ -242,7 +242,7 @@ struct ExportPreselectionKindTests {
     /// the kind check, selecting the `users` table would also tick a `users()` function.
     @Test("A table preselection never selects a routine of the same name")
     func tablePreselectionIgnoresRoutines() {
-        let preselection = ExportPreselection.tables(["users"])
+        let preselection = ExportPreselection.tables(names: ["users"], schema: nil)
         #expect(preselection.selects(
             object: "users", kind: .table, inContainer: .database("app"), isCurrentContainer: true))
         #expect(!preselection.selects(
@@ -253,7 +253,7 @@ struct ExportPreselectionKindTests {
 
     @Test("A table preselection covers views and foreign tables")
     func tablePreselectionCoversViewShapes() {
-        let preselection = ExportPreselection.tables(["users"])
+        let preselection = ExportPreselection.tables(names: ["users"], schema: nil)
         #expect(preselection.selects(
             object: "users", kind: .view, inContainer: .database("app"), isCurrentContainer: true))
         #expect(preselection.selects(

--- a/TableProTests/Models/ExportObjectTreeTests.swift
+++ b/TableProTests/Models/ExportObjectTreeTests.swift
@@ -242,7 +242,7 @@ struct ExportPreselectionKindTests {
     /// the kind check, selecting the `users` table would also tick a `users()` function.
     @Test("A table preselection never selects a routine of the same name")
     func tablePreselectionIgnoresRoutines() {
-        let preselection = ExportPreselection.tables(names: ["users"], schema: nil)
+        let preselection = ExportPreselection.tables(names: ["users"], scope: nil)
         #expect(preselection.selects(
             object: "users", kind: .table, inContainer: .database("app"), isCurrentContainer: true))
         #expect(!preselection.selects(
@@ -253,7 +253,7 @@ struct ExportPreselectionKindTests {
 
     @Test("A table preselection covers views and foreign tables")
     func tablePreselectionCoversViewShapes() {
-        let preselection = ExportPreselection.tables(names: ["users"], schema: nil)
+        let preselection = ExportPreselection.tables(names: ["users"], scope: nil)
         #expect(preselection.selects(
             object: "users", kind: .view, inContainer: .database("app"), isCurrentContainer: true))
         #expect(preselection.selects(

--- a/TableProTests/Views/Sidebar/DatabaseTreeMenuSpecTests.swift
+++ b/TableProTests/Views/Sidebar/DatabaseTreeMenuSpecTests.swift
@@ -557,6 +557,44 @@ struct DatabaseTreeMenuSpecTests {
         #expect(commands(sections[sections.count - 1].items) == [.removeRecent(ref), .clearRecents])
     }
 
+    /// A bare name does not identify a table: `orders` exists in every schema. Export and Transfer
+    /// used to hand the dialog every same-database name, which it then resolved against whichever
+    /// schema it considered current, so exporting `reporting.orders` ticked `public.orders`.
+    @Test("Export and Transfer carry only the clicked row's schema")
+    func exportAndTransferStayInTheClickedSchema() {
+        let clicked = DatabaseTreeTableRef(
+            database: "app", schema: "reporting",
+            table: TableInfo(name: "orders", type: .table, rowCount: nil, schema: "reporting")
+        )
+        let elsewhere = DatabaseTreeTableRef(
+            database: "app", schema: "public",
+            table: TableInfo(name: "users", type: .table, rowCount: nil, schema: "public")
+        )
+        let issued = commands(DatabaseTreeMenuSpec.sections(
+            for: context(clicked: .table(clicked), selectedTables: [clicked, elsewhere])
+        ))
+
+        #expect(issued.contains(.exportTables(names: ["orders"], ref: clicked)))
+        #expect(issued.contains(.transferTables(names: ["orders"], ref: clicked)))
+        #expect(!issued.contains { command in
+            if case .exportTables(let names, _) = command { return names.contains("users") }
+            return false
+        })
+    }
+
+    /// Truncate is offered from the whole target list, not the clicked row alone, so a selection
+    /// that also holds a view withdraws it rather than staging a TRUNCATE the server refuses.
+    @Test("Truncate is withheld when the selection also holds a view")
+    func truncateWithheldForMixedSelection() {
+        let table = tableRef("orders")
+        let view = tableRef("summary", type: .view)
+        let issued = commands(DatabaseTreeMenuSpec.sections(
+            for: context(clicked: .table(table), selectedTables: [table, view])
+        ))
+
+        #expect(!issued.contains { if case .truncateTables = $0 { return true } else { return false } })
+    }
+
     /// The HIG asks for about three groups. A table row carried five, one of them seven unrelated
     /// commands, because a flat item list gave the spec no reason to count.
     @Test("No menu carries more than four groups")

--- a/TableProTests/Views/SidebarContextMenuLogicTests.swift
+++ b/TableProTests/Views/SidebarContextMenuLogicTests.swift
@@ -68,31 +68,31 @@ struct SidebarContextMenuLogicTests {
     @Test("Truncate visible for table")
     func truncateVisibleForTable() {
         let table = TestFixtures.makeTableInfo(name: "t", type: .table)
-        #expect(SidebarContextMenuLogic.truncateVisible(clickedTable: table))
+        #expect(SidebarContextMenuLogic.truncateVisible(targets: [Self.ref(table)]))
     }
 
     @Test("Truncate hidden for view")
     func truncateHiddenForView() {
         let view = TestFixtures.makeTableInfo(name: "v", type: .view)
-        #expect(!SidebarContextMenuLogic.truncateVisible(clickedTable: view))
+        #expect(!SidebarContextMenuLogic.truncateVisible(targets: [Self.ref(view)]))
     }
 
     @Test("Truncate hidden for materialized view")
     func truncateHiddenForMaterializedView() {
         let mv = TestFixtures.makeTableInfo(name: "mv", type: .materializedView)
-        #expect(!SidebarContextMenuLogic.truncateVisible(clickedTable: mv))
+        #expect(!SidebarContextMenuLogic.truncateVisible(targets: [Self.ref(mv)]))
     }
 
     @Test("Truncate hidden for foreign table")
     func truncateHiddenForForeignTable() {
         let ft = TestFixtures.makeTableInfo(name: "ft", type: .foreignTable)
-        #expect(!SidebarContextMenuLogic.truncateVisible(clickedTable: ft))
+        #expect(!SidebarContextMenuLogic.truncateVisible(targets: [Self.ref(ft)]))
     }
 
     @Test("Truncate hidden for system table")
     func truncateHiddenForSystemTable() {
         let sys = TestFixtures.makeTableInfo(name: "s", type: .systemTable)
-        #expect(!SidebarContextMenuLogic.truncateVisible(clickedTable: sys))
+        #expect(!SidebarContextMenuLogic.truncateVisible(targets: [Self.ref(sys)]))
     }
 
     // MARK: - Delete Label per Kind
@@ -176,7 +176,7 @@ struct SidebarContextMenuLogicTests {
     @Test("Truncate is hidden for an external table")
     func truncateHiddenForExternalTable() {
         let table = TableInfo(name: "customers", type: .externalTable, rowCount: nil)
-        #expect(!SidebarContextMenuLogic.truncateVisible(clickedTable: table))
+        #expect(!SidebarContextMenuLogic.truncateVisible(targets: [Self.ref(table)]))
     }
 
     @Test("External table drop label names the object kind")
@@ -184,4 +184,20 @@ struct SidebarContextMenuLogicTests {
         #expect(SidebarContextMenuLogic.deleteLabel(for: .externalTable) == "Drop External Table")
     }
 
+    /// The predicate now answers for every row a Truncate would act on, so the tests build refs.
+    private static func ref(_ table: TableInfo) -> DatabaseTreeTableRef {
+        DatabaseTreeTableRef(database: "app", schema: "public", table: table)
+    }
+
+    @Test("Truncate is hidden when a selection mixes a table with a view")
+    func truncateHiddenForMixedSelection() {
+        let table = TableInfo(name: "orders", type: .table, rowCount: nil)
+        let view = TableInfo(name: "summary", type: .view, rowCount: nil)
+        #expect(!SidebarContextMenuLogic.truncateVisible(targets: [Self.ref(table), Self.ref(view)]))
+    }
+
+    @Test("Truncate is hidden for an empty selection")
+    func truncateHiddenForEmptySelection() {
+        #expect(!SidebarContextMenuLogic.truncateVisible(targets: [DatabaseTreeTableRef]()))
+    }
 }


### PR DESCRIPTION
Two defects found while investigating the sidebar context menu in #2653, reported there and fixed here.

## Export and Transfer To picked the wrong table

On PostgreSQL with `orders` in both `public` and `reporting`, right-clicking `reporting.orders` and choosing **Export…** opened the dialog with `public.orders` ticked instead. If `public` had no `orders`, it opened with nothing ticked and said nothing.

Two causes compounded:

1. `ExportDialog` computed `isCurrentContainer` from the engine's **static** default schema name, never the connection's active schema. `ExportPreselection.tables` carried only bare names and matched on that flag, so it could never select outside the literal default schema. On the five engines that hang tables off schemas that name is `""`, so it matched nothing at all there.
2. The sidebar dropped the schema before dispatch. `Copy To…` in the same function already narrowed by `qualifyingSchema` and passed it through; Export and Transfer did not.

A bare name does not identify a table, so the preselection now carries the container it came from. `selects` asks `scope.covers(container)`, and the section holding the preselected table opens rather than staying collapsed behind a section that matched by default-schema name.

`TableTransferSheet` had the mirror defect: `sourceScope` passed `schema: nil`, so it fetched whichever schema the session happened to be browsing and matched bare names against that one. It now takes the row's schema, which `resolvedScope` prefers over the ambient one.

## Truncate and Delete disagreed between the two menus

The sidebar hides **Truncate** for a view, materialized view, foreign, system or external table. The menu bar's validator asked only `hasTableSelection && !isReadOnly`, with no object-kind test. So selecting a view and using **Database > Truncate Table** staged a `TRUNCATE` the sidebar itself refuses to offer, and the server then refused the whole save.

Worse, **Delete** from the menu bar routed through `deleteSelectedRows()`, which re-implemented the pending-set toggle inline instead of calling `batchToggleDelete`. That is the call that raises `TableOperationAlert`. The sidebar's Delete asks for confirmation with cascade and foreign-key options; the menu bar's staged the drop with no dialog at all.

Both menus now consult one `TableOperationEligibility`, and the menu bar's Delete goes through the same `batchToggleDelete` the sidebar uses. The predicate lives beside the models because the validator in `Core/` has to reach it and must not depend on a `Views/` file.

It also fixes a second defect inside the sidebar: `truncateVisible` tested only the clicked row, so right-clicking a table inside a selection that also held a view offered Truncate and staged it for the view too. It now answers for every row the command would act on, all or nothing, because truncating the eligible part of a selection would leave the rest looking emptied until someone checked.

## Review pass

Codex reviewed the first commit and found a regression I introduced, fixed in `24a398f16`.

Scoping the preselection to a bare schema string broke engines that group by database. `databaseGroupingStrategy` defaults to `.byDatabase`, and neither Cassandra nor Teradata declares otherwise, yet Cassandra reports its keyspace as a schema and Teradata writes the database into one. Their table refs carry a non-nil `qualifyingSchema` while the dialog lists `.database` containers, so a schema-shaped scope matched nothing and lost the preselection entirely. The scope is now a full `DatabaseContainerRef` chosen from the grouping strategy, and `ExportPreselection.scope(for:grouping:)` is the single place that decision is made. Pinned by a test using Cassandra's exact shape.

It also caught that the sidebar preload keys its row snapshots by bare container name, so a database and a schema both called `app` collide: the preload evaluated the row against `.database("app")`, recorded it unselected, and `loadDatabaseItems` then restored that stale answer over the real preselection. The preload now bails when its container is not one the scope covers, which is the same guard already above it for a database-scoped preselection.

I did not take its third point, that the rationale comments should go. `CLAUDE.md` bans comments describing what code does or explaining callers; these state why an invariant exists, which is the house style throughout this codebase and in `CLAUDE.md`'s own Invariants section. I compressed the most narrative one.

## Verified

- `verify.sh build`: PASS
- `verify.sh test ExportPreselectionTests ExportPreselectionKindTests ExportOutlineTreeTests SidebarContextMenuLogicTests DatabaseTreeMenuSpecTests TableOperationEligibilityTests MainMenuBuilderTests`: PASS, 115 of 115
- `verify.sh lint`: PASS, 0 violations

New tests cover the reported cross-schema case, a named scope selecting where nothing is the current container, the by-database engines Codex caught, unanimity when a selection spans schemas, the eligibility predicate across every table kind and the mixed table-plus-view selection, the menu bar's new Truncate gate, and that Export and Transfer carry only the clicked row's schema.

No UI automation. Both flows need a live server with two schemas holding a same-named table, which `TableProUITests` cannot stand up deterministically. The behaviour is pinned at the predicate and preselection level instead.

https://claude.ai/code/session_01HysxXUgegonhNukMzHFuX5
