### PR TITLE
fix: the two things that made macOS Tests red on main

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -341,8 +341,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: scripts/ci/summarize-xcresult.sh TestResults.xcresult "Unit tests"
 
+      # The bundle is evidence about the run, not the run's verdict, so a failure to upload it
+      # must not decide whether the suite passed. GitHub's own artifact endpoint answered
+      # ENOTFOUND on run 34056832569 and turned a green suite red, which failed the gate on main.
       - name: Upload test results
         if: ${{ !cancelled() }}
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: macos-test-results
@@ -422,8 +426,11 @@ jobs:
         if: ${{ !cancelled() }}
         run: scripts/ci/summarize-xcresult.sh UITestResults.xcresult "UI tests ${{ matrix.shard }}/${{ matrix.of }}"
 
+      # Diagnostic, exactly as in the unit job above: an upload that cannot reach GitHub says
+      # nothing about the tests and must not fail the shard.
       - name: Upload UI test results
         if: ${{ !cancelled() }}
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: macos-ui-test-results-${{ matrix.shard }}

--- a/TableProUITests/ForeignKeyPickerUITests.swift
+++ b/TableProUITests/ForeignKeyPickerUITests.swift
@@ -72,7 +72,7 @@ final class ForeignKeyPickerUITests: UITestCase {
         let grid = window.tables.matching(identifier: "data-grid").firstMatch
         XCTAssertTrue(grid.waitToExist(timeout: 30), "Album produced no data grid")
         XCTAssertTrue(
-            waitForPredicate(timeout: 30) { !grid.tableRows.allElementsBoundByIndex.isEmpty },
+            waitForClickableRows(in: grid),
             "Album must load rows before a cell can be edited"
         )
         return grid

--- a/TableProUITests/InspectorFieldAffordanceUITests.swift
+++ b/TableProUITests/InspectorFieldAffordanceUITests.swift
@@ -71,11 +71,6 @@ final class InspectorFieldAffordanceUITests: UITestCase {
         )
 
         gridPoint(in: grid, of: window, dy: 70).click()
-        XCTAssertTrue(
-            waitForPredicate(timeout: 10) { grid.tableRows.allElementsBoundByIndex.contains { $0.isSelected } },
-            "The click must select a row, or the inspector has nothing to draw fields for"
-        )
-
         showInspector(in: app)
         return grid
     }

--- a/TableProUITests/InspectorFieldAffordanceUITests.swift
+++ b/TableProUITests/InspectorFieldAffordanceUITests.swift
@@ -57,10 +57,25 @@ final class InspectorFieldAffordanceUITests: UITestCase {
     /// the grid on the 1024x768 runner, and `dy` clears the 42pt header so the click does not open
     /// the column menu. The row is selected before the inspector opens, so the reveal cannot move
     /// the grid out from under the coordinate.
+    ///
+    /// The rows have to be in before the click, or it lands on empty grid and selects nothing: the
+    /// inspector then opens on its no-selection state, which draws no field and so no value menu,
+    /// and the failure reads as a missing menu rather than as a missed row. That is what made this
+    /// suite fail on a contended runner and pass on its retry.
     private func openFirstTableRow(in app: XCUIApplication, window: XCUIElement) throws -> XCUIElement {
         let grid = window.tables.matching(identifier: "data-grid").firstMatch
         XCTAssertTrue(grid.waitToExist(timeout: 30), "The sample table must produce a grid")
+        XCTAssertTrue(
+            waitForClickableRows(in: grid),
+            "The sample table must have its rows in before one of them can be clicked"
+        )
+
         gridPoint(in: grid, of: window, dy: 70).click()
+        XCTAssertTrue(
+            waitForPredicate(timeout: 10) { grid.tableRows.allElementsBoundByIndex.contains { $0.isSelected } },
+            "The click must select a row, or the inspector has nothing to draw fields for"
+        )
+
         showInspector(in: app)
         return grid
     }

--- a/TableProUITests/JSONRowInspectorUITests.swift
+++ b/TableProUITests/JSONRowInspectorUITests.swift
@@ -71,7 +71,7 @@ final class JSONRowInspectorUITests: UITestCase {
         let grid = window.tables.matching(identifier: "data-grid").firstMatch
         XCTAssertTrue(grid.waitToExist(timeout: 30), "Album produced no data grid")
         XCTAssertTrue(
-            waitForPredicate(timeout: 30) { !grid.tableRows.allElementsBoundByIndex.isEmpty },
+            waitForClickableRows(in: grid),
             "Album must load rows before a row can be inspected"
         )
         return grid

--- a/TableProUITests/Support/UITestCase.swift
+++ b/TableProUITests/Support/UITestCase.swift
@@ -226,6 +226,21 @@ internal class UITestCase: XCTestCase {
             .withOffset(CGVector(dx: max(80, clearOfBrowser), dy: dy))
     }
 
+    /// The preconditions a click taken off the grid actually has, which existence does not give.
+    ///
+    /// The grid enters the tree when its table view is mounted, which is before the query behind it
+    /// has returned. A click posted then lands on empty grid and selects nothing, and nothing fails
+    /// there: the suite goes on to wait out its own timeout for whatever the selection was supposed
+    /// to produce, and reports that as the missing thing. A grid that exists is also not laid out
+    /// yet, and a coordinate taken off an empty frame resolves to `(inf, inf)`, which posts at no
+    /// display at all and takes the runner down instead of failing.
+    internal func waitForClickableRows(in grid: XCUIElement, timeout: TimeInterval = 30) -> Bool {
+        waitForPredicate(timeout: timeout) {
+            grid.frame.width > 0 && grid.frame.height > 0
+                && !grid.tableRows.allElementsBoundByIndex.isEmpty
+        }
+    }
+
     /// The object browser draws its rows as hosted cells, so a row's name arrives as the static
     /// text's `value`, carrying the object kind the row reads out to VoiceOver, rather than as a
     /// label or an identifier. Matching on `value` is what finds them.

--- a/TableProUITests/Support/UITestCase.swift
+++ b/TableProUITests/Support/UITestCase.swift
@@ -234,10 +234,17 @@ internal class UITestCase: XCTestCase {
     /// to produce, and reports that as the missing thing. A grid that exists is also not laid out
     /// yet, and a coordinate taken off an empty frame resolves to `(inf, inf)`, which posts at no
     /// display at all and takes the runner down instead of failing.
+    ///
+    /// The question has to stop at the first row. `allElementsBoundByIndex` resolves the whole set,
+    /// and asking the grid for its rows is what activates `DataGridCellAccessibilityView`, so the
+    /// table view then prepares every row of the page and mounts a cell view for each: fine on
+    /// Album's 347 rows, and past XCUITest's own query budget on the `Track` table the sample opens
+    /// by default, where it fails the suite with "Timed out while evaluating UI query" rather than
+    /// with an assertion. `firstMatch` is what stops the traversal early.
     internal func waitForClickableRows(in grid: XCUIElement, timeout: TimeInterval = 30) -> Bool {
-        waitForPredicate(timeout: timeout) {
-            grid.frame.width > 0 && grid.frame.height > 0
-                && !grid.tableRows.allElementsBoundByIndex.isEmpty
+        let firstRow = grid.tableRows.firstMatch
+        return waitForPredicate(timeout: timeout) {
+            grid.frame.width > 0 && grid.frame.height > 0 && firstRow.exists
         }
     }
 


### PR DESCRIPTION
Run [34056832569](https://github.com/TableProApp/TablePro/actions/runs/34056832569) on `main` (869e63cd5) failed with two independent causes. Both are here.

## The flaky suite

`InspectorFieldAffordanceUITests.testTheValueMenuIsPresentWithoutHoveringAField` failed on its first attempt and passed on the retry:

```
XCTAssertTrue failed - Every inspector field draws its own value menu.
```

`openFirstTableRow` waited for the grid to *exist* and clicked immediately. The grid enters the accessibility tree when its table view is mounted, which is before the query behind it has returned, so on a contended runner the click landed on empty grid and selected nothing. The inspector then opened on its no-selection state, which draws no field and so no value menu, and the failure read as a missing menu rather than as a missed row.

The wait the click actually needs is now `UITestCase.waitForClickableRows(in:)`: a first row present, and a laid-out frame, which a coordinate taken off the grid also needs (an empty frame resolves to `(inf, inf)` and posts at no display at all).

**The question has to stop at the first row.** The first version of this asked `grid.tableRows.allElementsBoundByIndex`, which resolves the whole set, and asking the grid for its rows is what activates `DataGridCellAccessibilityView`: the table view then prepares every row of the page and mounts a cell view for each. That is fine on `Album`'s 347 rows and past XCUITest's own query budget on `Track`, the 3,503-row table `WelcomeViewModel+Sample` opens by default. It failed all three shards with `Failed to resolve query: Timed out while evaluating UI query` while `JSONRowInspectorUITests`, calling the same helper on `Album`, stayed green. `firstMatch` is what stops the traversal early.

`JSONRowInspectorUITests` and `ForeignKeyPickerUITests` carried the unbounded wait inline, minus the frame check. Both now call the shared one and get the bound with it.

## The artifact upload

The job that reported `failure` to the gate had a green `Run UI tests` step. What failed was `Upload UI test results`:

```
Failed to CreateArtifact: Unable to make request: ENOTFOUND
```

A result bundle is evidence about a run, not the run's verdict, so GitHub's artifact endpoint being unreachable turned a passing suite red and blocked the gate on `main`. Both diagnostic uploads are now `continue-on-error: true`. `Upload the built products` is left alone: the test jobs unpack it, so its failure is a real one.

## Verification

- `InspectorFieldAffordanceUITests`, `JSONRowInspectorUITests`, `ForeignKeyPickerUITests`: 7 of 7 pass. The two cheap affordance cases went from 51s to 12s each once the wait stopped enumerating `Track`.
- `swiftlint lint --strict TableProUITests`: 0 violations.
- `actionlint .github/workflows/macos-tests.yml`: clean.

No CHANGELOG entry: nothing here is user-facing.

https://claude.ai/code/session_01GKojw3udSpBimqV6HwHGH2