### PR TITLE
fix(ios): mark a memory-stopped query before cancelling it and hold the activity through its end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Query Live Activity still counting up on the iOS Lock Screen and Dynamic Island after the app was quit mid-query.
 - Stop leaving an iOS MySQL or Redis query running, with the spinner and the Live Activity stuck behind it.
-- A stopped or memory-stopped iOS query recorded in Query History as successful.
+- A stopped or memory-stopped iOS query recorded in Query History as successful, including a write that streamed no rows.
 - Query Live Activity marked interrupted while an iOS query longer than five minutes was still running.
 - Connection screen stuck on Connecting for good after a cancelled connect on iPhone and iPad.
 - Edited connection host, port or credentials ignored until relaunch on iPhone and iPad.

--- a/TableProMobile/TableProMobile/Platform/QueryActivityController.swift
+++ b/TableProMobile/TableProMobile/Platform/QueryActivityController.swift
@@ -40,6 +40,7 @@ final class QueryActivityController {
         let connectionId: UUID
         let handle: any LiveActivityHandle
         var lastUpdatedAt: Date
+        var isEnding = false
     }
 
     private let store: any LiveActivityStore
@@ -106,7 +107,7 @@ final class QueryActivityController {
     }
 
     func update(token: QueryExecutionToken?, rowsStreamed: Int) async {
-        guard let token, let execution = executions[token] else { return }
+        guard let token, let execution = executions[token], !execution.isEnding else { return }
         let instant = now()
         let rowsChanged = execution.handle.state.rowsStreamed != rowsStreamed
         let heartbeatDue = instant.timeIntervalSince(execution.lastUpdatedAt) >= Self.heartbeatInterval
@@ -123,18 +124,21 @@ final class QueryActivityController {
     }
 
     func end(token: QueryExecutionToken?, outcome: QueryActivityAttributes.Outcome) async {
-        guard let token, let execution = executions.removeValue(forKey: token) else { return }
+        guard let token, let execution = executions[token], !execution.isEnding else { return }
+        executions[token]?.isEnding = true
         await end(execution: execution, outcome: outcome)
+        executions.removeValue(forKey: token)
     }
 
     func endEverything(forConnection connectionId: UUID, outcome: QueryActivityAttributes.Outcome) async {
-        let matching = executions.filter { $0.value.connectionId == connectionId }
+        let matching = executions.filter { $0.value.connectionId == connectionId && !$0.value.isEnding }
         guard !matching.isEmpty else { return }
         for token in matching.keys {
-            executions.removeValue(forKey: token)
+            executions[token]?.isEnding = true
         }
-        for execution in matching.values {
+        for (token, execution) in matching {
             await end(execution: execution, outcome: outcome)
+            executions.removeValue(forKey: token)
         }
     }
 

--- a/TableProMobile/TableProMobile/ViewModels/QueryEditorViewModel.swift
+++ b/TableProMobile/TableProMobile/ViewModels/QueryEditorViewModel.swift
@@ -125,9 +125,8 @@ final class QueryEditorViewModel {
             case .warning, .critical:
                 guard case .running = self.phase else { return }
                 Self.logger.warning("Memory pressure: stopping query stream to stay within limits")
-                self.fetchTask?.cancel()
-                guard !self.buffer.isEmpty else { return }
                 self.buffer.markTruncated(.memoryPressure)
+                self.fetchTask?.cancel()
                 self.phase = .truncated(reason: .memoryPressure)
             }
         }

--- a/TableProMobile/TableProMobile/Views/QueryEditorView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryEditorView.swift
@@ -434,10 +434,10 @@ struct QueryEditorView: View {
         )
 
         guard !Task.isCancelled else {
+            recordHistory(query: trimmed, outcome: .stopped, errorMessage: QueryExecutionOutcome.stopped.historyMessage)
             isExecuting = false
             executionStartTime = nil
             await appState.queryActivities.end(token: token, outcome: .stopped)
-            recordHistory(query: trimmed, outcome: .stopped, errorMessage: QueryExecutionOutcome.stopped.historyMessage)
             return
         }
 
@@ -448,31 +448,24 @@ struct QueryEditorView: View {
         progressUpdater.cancel()
         let phase = viewModel.phase
         let outcome = QueryExecutionOutcome(phase: phase)
-        let elapsed = viewModel.executionTime
-        isExecuting = false
-        executionStartTime = nil
-
-        await appState.queryActivities.end(token: token, outcome: outcome.activityOutcome)
 
         if case .error(let err) = phase {
             appError = err
             hapticError.toggle()
             recordHistory(query: trimmed, outcome: outcome, errorMessage: err.localizedDescription)
-            return
-        }
-
-        executionTime = elapsed
-
-        guard outcome == .completed else {
+        } else {
+            executionTime = viewModel.executionTime
+            if outcome == .completed {
+                hapticSuccess.toggle()
+                IOSAnalyticsProvider.shared.markFirstQueryExecuted()
+            }
             recordHistory(query: trimmed, outcome: outcome, errorMessage: outcome.historyMessage)
-            return
         }
 
-        hapticSuccess.toggle()
+        isExecuting = false
+        executionStartTime = nil
 
-        IOSAnalyticsProvider.shared.markFirstQueryExecuted()
-
-        recordHistory(query: trimmed, outcome: outcome, errorMessage: nil)
+        await appState.queryActivities.end(token: token, outcome: outcome.activityOutcome)
     }
 
     private func recordHistory(query: String, outcome: QueryExecutionOutcome, errorMessage: String?) {

--- a/TableProMobile/TableProMobile/Views/QueryHistoryView.swift
+++ b/TableProMobile/TableProMobile/Views/QueryHistoryView.swift
@@ -17,7 +17,7 @@ struct QueryHistoryView: View {
                                 Image(systemName: "exclamationmark.circle.fill")
                                     .font(.footnote)
                                     .foregroundStyle(.red)
-                                    .accessibilityLabel(String(localized: "Failed"))
+                                    .accessibilityLabel(item.errorMessage ?? String(localized: "Failed"))
                             }
                             Text(verbatim: item.query)
                                 .font(.system(.footnote, design: .monospaced))

--- a/TableProMobile/TableProMobileTests/QueryActivityControllerTests.swift
+++ b/TableProMobile/TableProMobileTests/QueryActivityControllerTests.swift
@@ -10,6 +10,9 @@ private final class SpyLiveActivityHandle: LiveActivityHandle {
     private(set) var endedStates: [QueryActivityAttributes.ContentState] = []
     private(set) var updatedStaleDates: [Date?] = []
     weak var store: SpyLiveActivityStore?
+    var holdsEndUntilReleased = false
+    private(set) var isEndParked = false
+    private var endGate: CheckedContinuation<Void, Never>?
 
     init(id: String, state: QueryActivityAttributes.ContentState) {
         self.id = id
@@ -22,9 +25,21 @@ private final class SpyLiveActivityHandle: LiveActivityHandle {
     }
 
     func end(state: QueryActivityAttributes.ContentState) async {
+        if holdsEndUntilReleased {
+            await withCheckedContinuation {
+                endGate = $0
+                isEndParked = true
+            }
+        }
         self.state = state
         endedStates.append(state)
         store?.forget(self)
+    }
+
+    func releaseEnd() {
+        isEndParked = false
+        endGate?.resume()
+        endGate = nil
     }
 }
 
@@ -303,6 +318,33 @@ struct QueryActivityControllerTests {
         let final = store.requested.first?.endedStates.first
         #expect(final?.outcome == .stopped)
         #expect(final?.endedAt == referenceNow)
+    }
+
+    @Test
+    func aReapDuringAnInFlightEndDoesNotEndTheActivityTwice() async {
+        let store = SpyLiveActivityStore()
+        let controller = makeController(store: store)
+
+        let token = await controller.start(
+            connectionId: UUID(),
+            connectionName: "SIT",
+            query: "select 1",
+            startedAt: referenceNow
+        )
+        let handle = store.requested.first
+        handle?.holdsEndUntilReleased = true
+
+        let ending = Task { await controller.end(token: token, outcome: .completed) }
+        while handle?.isEndParked == false {
+            await Task.yield()
+        }
+        await controller.reapOrphans()
+        handle?.releaseEnd()
+        await ending.value
+
+        #expect(handle?.endedStates.count == 1)
+        #expect(handle?.endedStates.first?.outcome == .completed)
+        #expect(controller.ownedActivityIds.isEmpty)
     }
 
     @Test

--- a/TableProMobile/TableProMobileTests/QueryEditorViewModelTests.swift
+++ b/TableProMobile/TableProMobileTests/QueryEditorViewModelTests.swift
@@ -62,6 +62,31 @@ struct QueryEditorViewModelTests {
         #expect(QueryExecutionOutcome(phase: vm.phase) == .stopped)
     }
 
+    @Test("memory pressure before the first row still marks the run interrupted")
+    func pressureBeforeAnyRowIsNotASuccess() async {
+        let driver = MockDatabaseDriver()
+        let gate = QueryGate()
+        driver.beforeExecute = { await gate.wait() }
+        driver.scriptedExecuteResults = [
+            .success(QueryResult(columns: makeColumns(), rows: [], rowsAffected: 1, executionTime: 0))
+        ]
+
+        let vm = QueryEditorViewModel(windowCapacity: 100)
+        let run = Task { await vm.run(driver: driver, query: "UPDATE t SET a = 1") }
+        while !vm.isRunning {
+            await Task.yield()
+        }
+        await vm.handlePressure(.critical)
+        await gate.open()
+        await run.value
+
+        if case .truncated(let reason) = vm.phase, case .memoryPressure = reason {
+            #expect(QueryExecutionOutcome(phase: vm.phase) == .interrupted)
+        } else {
+            Issue.record("expected truncated(.memoryPressure) phase, got \(vm.phase)")
+        }
+    }
+
     @Test("stop on an idle view model changes nothing")
     func stopWhenIdleIsInert() {
         let vm = QueryEditorViewModel(windowCapacity: 100)


### PR DESCRIPTION
Follow-up to #2661. An adversarial review of that branch returned a no-ship verdict after it had already merged; these are the findings it raised. One of them means #2661 only half delivered a fix it claimed.

## A memory-stopped query was still recorded as successful

`handlePressure` cancelled the fetch task and then returned early when the row buffer was empty, before marking the truncation:

```swift
self.fetchTask?.cancel()
guard !self.buffer.isEmpty else { return }   // skips the mark
self.buffer.markTruncated(.memoryPressure)
```

Cancelling a continuation-based `AsyncThrowingStream` resumes the iterator with `nil` rather than throwing, so `run` exits its loop normally and `resolvePhase()` promotes a still-`.running` phase to `.finished`. The query then ends its Live Activity as completed, fires the success haptic, and writes `wasSuccessful: true`.

A long aggregate or a write commonly streams no rows at all, so the empty-buffer case is the common one, not the edge case. This is the same shape #2661 fixed for Stop, left in the sibling path: that fix pre-marks `.cancelled` before cancelling for exactly this reason. Memory pressure now does the same.

## A second run could overlap the first run's terminal writes

`executeQueryDirect` set `isExecuting = false` before awaiting the Live Activity teardown, so Run was enabled while the first execution still had error, history and haptic writes pending. Query A could fail, query B start and clear `appError`, and A then resume and install its stale error over B's result. `resultSection` prioritises `appError`, so B's successful result stayed hidden.

All durable and UI writes now happen before the execution slot is released. ActivityKit teardown is last, which also means query history is no longer written behind an `await` that a suspension could cut short.

## An activity lost ownership before its end completed

`end(token:)` removed the execution from the map and then awaited `handle.end`. Main-actor isolation does not span that suspension, so a concurrent `reapOrphans()` could see the activity as unowned and issue a competing `.interrupted` end against the intended outcome. Executions now carry an `isEnding` state and stay in `ownedActivityIds` until the terminal call returns; progress updates are rejected once ending starts.

Whether ActivityKit still enumerates an activity during its asynchronous end is not documented, so this is a guard against an inferred race rather than a measured one. It costs one flag and makes the controller's ownership invariant actually true.

## Query history accessibility

The history row's icon hardcoded an accessibility label of "Failed" for anything unsuccessful, so VoiceOver announced a stopped query as failed. It now reads the item's own message, "Stopped before the query finished."

## Not in this PR

The review also argued that collapsing `.failed`, `.stopped` and `.interrupted` into `wasSuccessful == false` is wrong, and it has a point worth recording: for MySQL and Redis, whose `cancelCurrentQuery()` are no-ops, a stopped write may still have committed server-side, so presenting it as a definite failure invites a duplicate retry. Deduplication in `QueryHistoryStorage` also keys on that Boolean, so a stopped and a failed attempt of the same query collapse into one.

Fixing it properly means a persisted outcome enum on `QueryHistoryItem` with backward-compatible decoding, distinct UI states, and new dedup. That is a query-history feature change rather than part of this defect, so it is left out deliberately.

## Verification

- iOS build and `QueryActivityControllerTests`, `QueryActivityContentStateDecodingTests`, `QueryExecutionOutcomeTests`, `QueryEditorViewModelTests`, `BackgroundReleaseCoordinatorTests`, `DataBrowserViewModelTests`.
- Two new regression tests: memory pressure applied before the first stream element, and a reap racing an in-flight end.
- SwiftLint `--strict` clean on every changed file. `TableProMobile` sits outside `.swiftlint.yml`'s `included:`, so the paths were passed explicitly.

No UI automation: the Lock Screen and Dynamic Island render outside the app process, so XCUITest cannot observe a Live Activity. The controller is covered through its injected store instead.

Building locally needs a workaround unrelated to this change: `oracle-nio`'s single `@TaskLocal` fails to expand under the Xcode 27 beta. CI pins Xcode 26.4.1, where it compiles. The workaround was applied to the DerivedData checkout only and reverted.

https://claude.ai/code/session_01DeXDeLTqEXdRgsPkvPkdPP
