### PR TITLE
refactor(datagrid): stack the inspector's data fields so the name and the value stop competing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Backup of several databases into one folder, one file each. (#2485)
 - Back Up… on a database selection in the connection tree. (#2485)
 - Assistant as its own pane, with View > Show Assistant and `Cmd+Option+A`.
-- Compact one-line rows in the inspector for short values, with long text, JSON and images still full width.
+- Inspector fields with the column name and type on one line and the value at full width below.
+- A BLOB too large to edit whole marked read-only in the inspector, in place of an editable first 10 KB.
 - Always-visible value menu on every inspector field, with `Ctrl+Option+N` for NULL and `Ctrl+Option+D` for DEFAULT.
 - Tab and Shift+Tab between inspector fields.
 - Field search and an edited-fields-only filter in the inspector.

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -121,12 +121,11 @@ internal final class MainSplitViewController: NSSplitViewController, TrailingPan
     /// time. Per-connection widths are not reachable through `autosaveName` anyway, since assigning
     /// a name to a split view that has already laid out does not re-apply the saved frames.
     ///
-    /// Never version this key to force a relayout. `NSSplitView` clamps a restored frame against
-    /// the current minimums, so the sidebar simply widens to fit the rail. Bumping it instead
-    /// throws away every saved sidebar width, inspector width and collapse state the user has,
-    /// leaves the old keys orphaned in `UserDefaults`, and reads as a regression nobody asked for.
+    /// Namespaced per sandbox under UI test, because AppKit files this record in the standard
+    /// defaults domain, which the sandbox does not redirect. See `SplitViewAutosaveName` for the
+    /// failure that came of one case inheriting another's pane geometry.
     private var splitAutosaveName: NSSplitView.AutosaveName {
-        "com.TablePro.mainSplit"
+        SplitViewAutosaveName.current(SplitViewAutosaveName.base)
     }
 
     // MARK: - Switcher Surfaces

--- a/TablePro/Core/Services/Infrastructure/TabWindowController.swift
+++ b/TablePro/Core/Services/Infrastructure/TabWindowController.swift
@@ -69,7 +69,13 @@ extension EditorWindow: CloseCommandNaming {
 internal final class TabWindowController: NSWindowController, NSWindowDelegate {
     nonisolated private static let lifecycleLogger = Logger(subsystem: "com.TablePro", category: "NativeTabLifecycle")
 
-    internal static let frameAutosaveName: NSWindow.FrameAutosaveName = "MainEditorWindow"
+    /// Namespaced per sandbox under UI test. This one is the main window's own size and position,
+    /// so a case that resized the window used to hand that size to every case after it in its
+    /// shard. See `SplitViewAutosaveName`.
+    @MainActor
+    internal static var frameAutosaveName: NSWindow.FrameAutosaveName {
+        NSWindow.FrameAutosaveName(SplitViewAutosaveName.current("MainEditorWindow"))
+    }
 
     internal let payload: EditorTabPayload
 

--- a/TablePro/Extensions/NSWindow+FrameAutosave.swift
+++ b/TablePro/Extensions/NSWindow+FrameAutosave.swift
@@ -13,9 +13,14 @@ extension NSWindow {
     /// with the small intrinsic size. Use `setFrameUsingName` plus explicit
     /// `saveFrame(usingName:)` calls in `NSWindowDelegate` methods instead.
     /// See `TabWindowController` for that pattern.
+    /// Namespaced per sandbox under UI test: a saved frame lands in the standard defaults domain,
+    /// which the sandbox does not redirect, so without this one case inherits another's window
+    /// position and size. See `SplitViewAutosaveName`.
+    @MainActor
     func applyAutosaveName(_ name: NSWindow.FrameAutosaveName) {
-        setFrameAutosaveName(name)
-        if !setFrameUsingName(name) {
+        let scoped = NSWindow.FrameAutosaveName(SplitViewAutosaveName.current(name))
+        setFrameAutosaveName(scoped)
+        if !setFrameUsingName(scoped) {
             center()
         }
     }

--- a/TablePro/Models/UI/InspectorFieldLayout.swift
+++ b/TablePro/Models/UI/InspectorFieldLayout.swift
@@ -5,28 +5,53 @@
 
 import Foundation
 
-/// How much of the inspector's width a field's editor takes.
+/// How a field arranges its label against its editor.
 ///
-/// Every field used to be stacked at full width whatever it held, so a row of twenty integers
-/// filled the pane several times over and the reader scrolled past a column of boxes to find one
-/// value. A scalar needs a line; a JSON document needs the pane. Measured at the inspector's 270pt
-/// minimum, a `LabeledContent` squeezes a text editor into its trailing half, so a full-width
-/// editor cannot be a `LabeledContent`'s content and the two shapes have to be different rows.
+/// The arrangement follows whose labels these are, not how big the editor is. A data row's label is
+/// a column name, which is user data of no bounded length: measured against a realistic 400-column
+/// set, the widest renders at 259.8pt, wider than the whole pane at its 270pt minimum. No label lane
+/// can hold that, and a lane wide enough to try takes the width the value needs, so at the minimum a
+/// side-by-side data row truncates the name *and* the value. A schema row's label comes from a
+/// closed, authored vocabulary (`StructureColumnField.displayName` plus the index, foreign-key and
+/// check-constraint headers), whose widest member is "Ref Columns" at 66.4pt, so the lane Apple's own
+/// inspectors use is both correct and achievable there.
 ///
-/// The switch is deliberately exhaustive rather than `default`-armed. Two default-armed switches
-/// over this same enum are what let `.typePicker` fall out of the value-font domain and render a
-/// structure row's Name and Type fields in two different fonts; a new editor kind must be
-/// classified here rather than silently inheriting whichever arm was written first.
+/// Nothing here can be derived at runtime from the rows themselves. Measured: a `PreferenceKey`
+/// max-reduce inside a `List` sees only the realized rows, 39pt against a true widest of 296pt, so a
+/// content-derived lane would change width as the user scrolls. A custom `AlignmentID` does not
+/// resolve across a `List`'s rows at all (145pt of spread; the same guide in one `VStack` gives 0).
+/// `Form(.columns)` and `Grid` do align, and both forfeit the laziness `InspectorFieldListView`
+/// depends on.
+///
+/// Both switches are exhaustive on purpose rather than `default`-armed. A new editor kind has to be
+/// classified for each provenance instead of inheriting whichever arm was written first; two
+/// `default`-armed switches over `FieldEditorKind` are what let `.typePicker` escape the value-font
+/// domain and render a structure row's Name and Type in two different fonts.
 internal enum InspectorFieldLayout: Equatable {
-    /// Label leading, value trailing, one line high.
+    /// Label in a fixed trailing-aligned lane, editor beside it, one line high.
     case inline
-    /// Label above, editor spanning the full width.
+    /// Label and type above, editor spanning the full width below.
     case stacked
 
-    /// The editor kind already answers the only question that matters, because
-    /// `FieldEditorResolver` resolves `.singleLine` against `.multiLine` from the value's own
-    /// length and newlines. Asking the value again here would be a second, drifting opinion.
-    internal static func resolve(for kind: FieldEditorKind) -> InspectorFieldLayout {
+    internal static func resolve(for kind: FieldEditorKind, isSchemaField: Bool) -> InspectorFieldLayout {
+        isSchemaField ? schemaLayout(for: kind) : dataLayout(for: kind)
+    }
+
+    /// A data field always stacks, whatever it holds. Choosing per row from the value's own length
+    /// would give the pane two label lanes and two value lanes alternating down the list, drop the
+    /// type badge from exactly the rows too narrow to carry it, and reflow a row from one shape to
+    /// the other while the user is typing into it.
+    private static func dataLayout(for kind: FieldEditorKind) -> InspectorFieldLayout {
+        switch kind {
+        case .singleLine, .boolean, .enumPicker, .setPicker, .schemaText, .typePicker,
+             .multiLine, .json, .phpSerialized, .blobHex, .image:
+            return .stacked
+        }
+    }
+
+    /// A schema field's label is short and authored, so the lane holds it and the row stays one line
+    /// high. The editors that need the pane's width still take it.
+    private static func schemaLayout(for kind: FieldEditorKind) -> InspectorFieldLayout {
         switch kind {
         case .singleLine, .boolean, .enumPicker, .setPicker, .schemaText, .typePicker:
             return .inline

--- a/TablePro/Models/UI/InspectorMetrics.swift
+++ b/TablePro/Models/UI/InspectorMetrics.swift
@@ -1,0 +1,57 @@
+//
+//  InspectorMetrics.swift
+//  TablePro
+//
+
+import Foundation
+
+/// The inspector pane's edge and its vertical rhythm, in one place because the pane has four
+/// surfaces and they must agree: the header, the filter bar, the field list and the table-info
+/// state. They did not. Measured at the pane's 270pt minimum, content sat at 10pt in the header,
+/// 8pt in the filter bar, 24pt in the field list and 30pt in table info, so switching a selection
+/// moved every value sideways.
+///
+/// The macOS HIG publishes no point values for margins or spacing; that was checked across its
+/// layout, sidebars, panels, split-views, lists-and-tables, windows and toolbars pages and came
+/// back empty. So these come from what Apple and the two AppKit database clients actually ship,
+/// measured by an accessibility walk and by decoding their nibs:
+///
+/// | surface                          | inset |
+/// | -------------------------------- | ----- |
+/// | System Settings, 232pt pane      | 10/10 |
+/// | TablePlus row inspector          | 10/10 |
+/// | Postico 2 row view               |  7/7  |
+/// | Xcode inspector chrome           |  7/7  |
+/// | Finder Get Info, 265pt           | 13/13 |
+///
+/// 10 is what System Settings uses with its search field and its list rows on one edge, which is
+/// exactly this pane's shape, and it is independently where TablePlus puts its filter field and its
+/// cells. It is also already the header's own inset, and the assistant that shares the split item
+/// with it.
+///
+/// A native list contributes no vertical gap of its own: `NSTableView.intercellSpacing.height` is
+/// 0, every Apple list measured has zero gap, and SwiftUI's macOS List has no row spacing either
+/// (the 4pt one appears to add is the 24pt `defaultMinListRowHeight` floor). Padding belongs inside
+/// the row, which is why `betweenFields` is spent there and `listRowInsets` carries none of it.
+/// Splitting it across both is what made a nominal 8 arrive as 12 to 14.
+internal enum InspectorMetrics {
+    /// The one edge every surface in the pane sits on.
+    internal static let horizontalInset: CGFloat = 10
+
+    /// Between one field and the next. Against `labelToValue` this is what separates the fields
+    /// into groups; the absolute difference matters more than the ratio, and 4pt against 5pt read
+    /// as one undifferentiated stack.
+    internal static let betweenFields: CGFloat = 10
+
+    /// From a field's own name line to its value. Postico 2 pins exactly this pair at 4pt.
+    internal static let labelToValue: CGFloat = 4
+
+    /// `List(.plain)` lands its rows at half of `intercellSpacing`, measured 8pt leading and 9pt
+    /// trailing at the default 17. These carry the row content the rest of the way onto
+    /// `horizontalInset`, and square the 1pt asymmetry AppKit leaves behind.
+    ///
+    /// `.inset` cannot be corrected this way: it spends a hard 16pt per side before any
+    /// `listRowInsets` is consulted, which is where the pane's 24pt came from.
+    internal static let listRowLeadingCorrection: CGFloat = horizontalInset - 8
+    internal static let listRowTrailingCorrection: CGFloat = horizontalInset - 9
+}

--- a/TablePro/Models/UI/SplitViewAutosaveName.swift
+++ b/TablePro/Models/UI/SplitViewAutosaveName.swift
@@ -1,0 +1,60 @@
+//
+//  SplitViewAutosaveName.swift
+//  TablePro
+//
+
+import Foundation
+
+/// The names AppKit files persisted window and pane geometry under.
+///
+/// AppKit writes an autosave record into the app process's own standard defaults domain. The UI
+/// test sandbox does not reach that: it redirects `applicationSupportRoot` and hands out its own
+/// `UserDefaults(suiteName:)`, and these records land in neither. So a sidebar width, a divider
+/// position, a collapsed pane or a window frame set by one UI test case is inherited by every case
+/// that runs after it in the same shard, on the real machine's defaults.
+///
+/// That is not theoretical. CI shards the UI suite by list position (`runnable[index::count]` in
+/// `scripts/ci/list_tests.py`), so adding two unrelated cases re-deals every later case onto a
+/// different runner. A query history case that had been passing moved shards, woke up with another
+/// case's geometry, and its drawer laid out taller than the 1024x768 runner's window: the detail
+/// pane ran from y=545 to y=712 against a window bottom edge at y=705, so Copy, Run in New Tab and
+/// Load in Editor all straddled the edge and the click on Load in Editor did nothing. The failure
+/// looked like a broken feature and was a leaked preference.
+///
+/// Namespacing the record per sandbox gives every case the default layout it expects. Production
+/// keeps the bare name: versioning those would throw away every width, divider and frame a real
+/// user has saved.
+internal enum SplitViewAutosaveName {
+    /// Never version this. `NSSplitView` clamps a restored frame against the current minimums, so a
+    /// pane simply widens to fit; bumping the key instead discards every width and collapse state
+    /// the user has and leaves the old keys orphaned.
+    internal static let base = "com.TablePro.mainSplit"
+
+    /// - Parameter sandboxIdentifier: something unique to one test case. The sandbox root's last
+    ///   path component is a fresh UUID per case, which is exactly that.
+    internal static func resolved(isIsolated: Bool, sandboxIdentifier: String?) -> String {
+        resolved(base, isIsolated: isIsolated, sandboxIdentifier: sandboxIdentifier)
+    }
+
+    /// The general form. Every autosave name in the app goes through this, because they all land in
+    /// the same unisolated defaults and leak the same way.
+    internal static func resolved(
+        _ name: String,
+        isIsolated: Bool,
+        sandboxIdentifier: String?
+    ) -> String {
+        guard isIsolated, let sandboxIdentifier, !sandboxIdentifier.isEmpty else { return name }
+        return "\(name).\(sandboxIdentifier)"
+    }
+
+    /// What a call site uses. Reads the running environment so a caller cannot forget the rule.
+    @MainActor
+    internal static func current(_ name: String) -> String {
+        let environment = AppStorageEnvironment.shared
+        return resolved(
+            name,
+            isIsolated: environment.isIsolated,
+            sandboxIdentifier: environment.applicationSupportRoot.lastPathComponent
+        )
+    }
+}

--- a/TablePro/Views/Components/AutosavingSplitView.swift
+++ b/TablePro/Views/Components/AutosavingSplitView.swift
@@ -70,7 +70,7 @@ struct AutosavingSplitView<Primary: View, Secondary: View>: NSViewControllerRepr
 
         controller.addSplitViewItem(primaryItem)
         controller.addSplitViewItem(secondaryItem)
-        controller.splitView.autosaveName = NSSplitView.AutosaveName(autosaveName)
+        controller.splitView.autosaveName = NSSplitView.AutosaveName(SplitViewAutosaveName.current(autosaveName))
         return controller
     }
 

--- a/TablePro/Views/Components/TypeBadge.swift
+++ b/TablePro/Views/Components/TypeBadge.swift
@@ -14,10 +14,16 @@ struct TypeBadge: View {
         self.accessibilityDescription = accessibilityDescription
     }
 
+    /// The badge keeps its one line and its measured width whatever it is put next to. Without this
+    /// a compressed `HStack` wraps the text inside the capsule instead of giving way: at the
+    /// inspector's 270pt minimum, a long column name squeezed "date" into "dat" over "e" and grew
+    /// the row by 11pt.
     var body: some View {
         Text(label)
             .font(.caption2.weight(.medium))
             .foregroundStyle(.tertiary)
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
             .padding(.horizontal, 6)
             .padding(.vertical, 1)
             .background(.quaternary, in: Capsule())

--- a/TablePro/Views/Components/VerticalCollapsibleSplitView.swift
+++ b/TablePro/Views/Components/VerticalCollapsibleSplitView.swift
@@ -47,7 +47,7 @@ struct VerticalCollapsibleSplitView<TopContent: View, BottomContent: View>: NSVi
 
         // autosaveName is assigned after the items are added; setting it earlier does not record
         // the divider, and adjustSubviews then resets it.
-        splitViewController.splitView.autosaveName = autosaveName
+        splitViewController.splitView.autosaveName = NSSplitView.AutosaveName(SplitViewAutosaveName.current(autosaveName))
 
         context.coordinator.topController = topController
         context.coordinator.bottomController = bottomController

--- a/TablePro/Views/ConnectionForm/ConnectionFormWindowController.swift
+++ b/TablePro/Views/ConnectionForm/ConnectionFormWindowController.swift
@@ -67,7 +67,7 @@ internal final class ConnectionFormWindowController: NSWindowController, NSWindo
         window.isRestorable = false
         window.contentMinSize = NSSize(width: 720, height: 560)
         window.setContentSize(NSSize(width: 820, height: 620))
-        window.setFrameAutosaveName(WindowIdentifier.connectionForm)
+        window.setFrameAutosaveName(NSWindow.FrameAutosaveName(SplitViewAutosaveName.current(WindowIdentifier.connectionForm)))
 
         self.init(window: window)
 

--- a/TablePro/Views/Integrations/IntegrationsActivityWindowController.swift
+++ b/TablePro/Views/Integrations/IntegrationsActivityWindowController.swift
@@ -33,7 +33,7 @@ internal final class IntegrationsActivityWindowController: NSWindowController {
         window.identifier = NSUserInterfaceItemIdentifier(WindowIdentifier.integrationsActivity)
         window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
         window.setContentSize(NSSize(width: 960, height: 600))
-        window.setFrameAutosaveName(WindowIdentifier.integrationsActivity)
+        window.setFrameAutosaveName(NSWindow.FrameAutosaveName(SplitViewAutosaveName.current(WindowIdentifier.integrationsActivity)))
         self.init(window: window)
     }
 }

--- a/TablePro/Views/QueryPlan/QueryPlanOutlineView.swift
+++ b/TablePro/Views/QueryPlan/QueryPlanOutlineView.swift
@@ -37,7 +37,7 @@ struct QueryPlanOutlineView: NSViewRepresentable {
         // four-column era, AppKit restores the known columns in their saved order and appends
         // anything it has never seen, so the bar would have arrived stranded past Actual Time for
         // everyone who had ever resized a plan column. A new name starts from the declared order.
-        outlineView.autosaveName = "com.TablePro.queryPlanOutline.v2"
+        outlineView.autosaveName = SplitViewAutosaveName.current("com.TablePro.queryPlanOutline.v2")
         outlineView.autosaveTableColumns = true
 
         // Every EXPLAIN run mints fresh node identities, so persisted expansion would key off

--- a/TablePro/Views/Results/HexEditorContentView.swift
+++ b/TablePro/Views/Results/HexEditorContentView.swift
@@ -39,6 +39,12 @@ struct HexEditorBody: View {
     @State private var byteCount: Int = 0
     @State private var validateTask: Task<Void, Never>?
 
+    /// Whether the value this editor opened on was already a prefix. It is a fact about the stored
+    /// value, so it is settled once here and never recomputed from what the user types. Deriving it
+    /// from the draft instead let deleting the ellipsis re-enable Save over a value the editor only
+    /// ever held the first 10,240 bytes of, which then overwrote the rest of the blob.
+    private let sourceIsTruncated: Bool
+
     init(
         initialValue: String?,
         isEditable: Bool = true,
@@ -61,10 +67,12 @@ struct HexEditorBody: View {
             self._byteCount = State(initialValue: value.data(using: .isoLatin1)?.count ?? 0)
             self._isTruncated = State(initialValue: truncated)
             self._isValid = State(initialValue: !truncated)
+            self.sourceIsTruncated = truncated
         } else {
             self._hexDumpText = State(initialValue: "")
             self._editableHex = State(initialValue: "")
             self._byteCount = State(initialValue: 0)
+            self.sourceIsTruncated = false
         }
     }
 
@@ -88,7 +96,7 @@ struct HexEditorBody: View {
                             .font(.caption)
                             .foregroundStyle(.tertiary)
 
-                        if isTruncated {
+                        if sourceIsTruncated || isTruncated {
                             Text(String(localized: "Truncated, read only"))
                                 .font(.caption)
                                 .foregroundStyle(.orange)
@@ -112,7 +120,7 @@ struct HexEditorBody: View {
                         .keyboardShortcut(.cancelAction)
                     Button("Save") { saveHex() }
                         .keyboardShortcut(.defaultAction)
-                        .disabled(!isValid || isTruncated)
+                        .disabled(!isValid || isTruncated || sourceIsTruncated)
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
@@ -139,7 +147,7 @@ struct HexEditorBody: View {
     // MARK: - Actions
 
     private func saveHex() {
-        guard isValid else { return }
+        guard isValid, !sourceIsTruncated else { return }
 
         if editableHex.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             if initialValue != nil, initialValue != "" {

--- a/TablePro/Views/RowInspector/FieldEditors/BlobHexEditorView.swift
+++ b/TablePro/Views/RowInspector/FieldEditors/BlobHexEditorView.swift
@@ -11,6 +11,20 @@ internal struct BlobHexEditorView: View {
     @FocusState private var isFocused: Bool
     @State private var hexEditText = ""
 
+    /// The editable form stops at 10,240 bytes and marks the cut with a trailing ellipsis, so what
+    /// the field holds is a prefix rather than the value. Committing it would write that prefix over
+    /// the whole column: measured, a 50,000-byte value came back as 10,240, losing 39,760 bytes with
+    /// the save reporting success. The pop-out editor has always refused this; the inline one read
+    /// the same marker as a syntax error, so it reported "Invalid hex" over an untouched value and
+    /// then silently reverted every edit on blur.
+    ///
+    /// Recorded from the stored value when the draft is loaded, never asked of `hexEditText`, which
+    /// is the user's to type into: reading the marker off the draft let an ordinary blob well under
+    /// the limit be locked for good by pasting an ellipsis into it. It is cached rather than
+    /// computed per read because the formatter materializes the whole backing string before it
+    /// takes its 10,240-byte prefix, and a computed property pays that on every body pass, twice.
+    @State private var isTruncated = false
+
     var body: some View {
         if context.isReadOnly {
             readOnlyHexView
@@ -22,9 +36,14 @@ internal struct BlobHexEditorView: View {
     /// A dump line is wider than the inspector at any font, so it scrolls in both axes. Letting it
     /// wrap to the pane instead folds each line onto the next and the offset, hex and ASCII columns
     /// stop lining up, which is the whole point of a dump.
+    ///
+    /// It names the value font rather than inheriting one for the same reason. The row supplies that
+    /// font only for `.blobHex`; reached through `.image`, which opts out of the value-font domain,
+    /// this identical view drew in the proportional system face and its columns stopped lining up.
     private var readOnlyHexView: some View {
         ScrollView([.horizontal, .vertical]) {
             Text(BlobFormattingService.shared.format(context.value.wrappedValue, for: .detail) ?? "")
+                .font(ThemeEngine.shared.valueFontSwiftUI)
                 .textSelection(.enabled)
                 .fixedSize()
                 .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -32,46 +51,70 @@ internal struct BlobHexEditorView: View {
         .frame(maxHeight: 120)
     }
 
+    /// A value past the cap shows the dump it can show, selectable, rather than a disabled field.
+    /// A disabled `TextField` on macOS cannot take first responder or have its text selected, so
+    /// gating the editor that way took the value away from the keyboard and the pasteboard both,
+    /// while `InspectorFieldListView.moveFocus` went on stopping at the row.
     private var editableHexView: some View {
         VStack(alignment: .leading, spacing: 2) {
-            TextField("Hex bytes", text: $hexEditText, axis: .vertical)
-                .textFieldStyle(.roundedBorder)
-                .lineLimit(3...8)
-                .autocorrectionDisabled(true)
-                .focused($isFocused)
-                .onAppear {
-                    hexEditText = BlobFormattingService.shared.format(context.value.wrappedValue, for: .edit) ?? ""
-                }
-                .onChange(of: context.value.wrappedValue) {
-                    if !isFocused {
-                        hexEditText = BlobFormattingService.shared.format(context.value.wrappedValue, for: .edit) ?? ""
+            if isTruncated {
+                readOnlyHexView
+            } else {
+                TextField("Hex bytes", text: $hexEditText, axis: .vertical)
+                    .font(ThemeEngine.shared.valueFontSwiftUI)
+                    .textFieldStyle(.roundedBorder)
+                    .lineLimit(3...8)
+                    .autocorrectionDisabled(true)
+                    .focused($isFocused)
+                    .onChange(of: isFocused) {
+                        if !isFocused {
+                            commitHexEdit()
+                        }
                     }
-                }
-                .onChange(of: isFocused) {
-                    if !isFocused {
-                        commitHexEdit()
-                    }
-                }
+            }
 
-            HStack(spacing: 4) {
-                if let byteCount = context.value.wrappedValue.data(using: .isoLatin1)?.count, byteCount > 0 {
-                    Text("\(byteCount) bytes")
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                }
-
-                if BlobFormattingService.shared.parseHex(hexEditText) == nil, !hexEditText.isEmpty {
-                    Text("Invalid hex")
-                        .font(.caption2)
-                        .foregroundStyle(.red)
-                }
+            statusLine
+        }
+        .onAppear { loadDraft() }
+        .onChange(of: context.value.wrappedValue) {
+            if !isFocused {
+                loadDraft()
             }
         }
     }
 
+    private var statusLine: some View {
+        HStack(spacing: 4) {
+            if let byteCount = context.value.wrappedValue.data(using: .isoLatin1)?.count, byteCount > 0 {
+                Text("\(byteCount) bytes")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+
+            if isTruncated {
+                Text("Truncated, read only")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            } else if BlobFormattingService.shared.parseHex(hexEditText) == nil, !hexEditText.isEmpty {
+                Text("Invalid hex")
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    /// One place that formats the stored value for editing, so the draft and the truncation flag
+    /// are always taken from the same read rather than from two.
+    private func loadDraft() {
+        let formatted = BlobFormattingService.shared.format(context.value.wrappedValue, for: .edit) ?? ""
+        hexEditText = formatted
+        isTruncated = formatted.hasSuffix("…")
+    }
+
     private func commitHexEdit() {
+        guard !isTruncated else { return }
         guard let raw = BlobFormattingService.shared.parseHex(hexEditText) else {
-            hexEditText = BlobFormattingService.shared.format(context.value.wrappedValue, for: .edit) ?? ""
+            loadDraft()
             return
         }
         if let commitBytes = context.commitBytes,

--- a/TablePro/Views/RowInspector/InspectorFieldListView.swift
+++ b/TablePro/Views/RowInspector/InspectorFieldListView.swift
@@ -65,7 +65,7 @@ internal struct InspectorFieldListView: View {
             .help(String(localized: "Show edited fields only"))
             .disabled(!hasAnyModification && !showsModifiedOnly)
         }
-        .padding(.horizontal, 8)
+        .padding(.horizontal, InspectorMetrics.horizontalInset)
         .padding(.vertical, 5)
     }
 
@@ -116,10 +116,18 @@ internal struct InspectorFieldListView: View {
             ForEach(fields, id: \.id) { field in
                 row(for: field)
                     .listRowSeparator(.hidden)
-                    .listRowInsets(EdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 6))
+                    .listRowInsets(EdgeInsets(
+                        top: 0,
+                        leading: InspectorMetrics.listRowLeadingCorrection,
+                        bottom: 0,
+                        trailing: InspectorMetrics.listRowTrailingCorrection
+                    ))
             }
         }
-        .listStyle(.inset)
+        /// `.plain`, not `.inset`: the inset style spends a hard 16pt per side before any
+        /// `listRowInsets` is consulted, so the pane's content sat at 24pt while its own header sat
+        /// at 10. `.plain` lands at half of `intercellSpacing` and can be corrected onto the edge.
+        .listStyle(.plain)
         .scrollContentBackground(.hidden)
         .onKeyPress(keys: [.tab]) { press in
             moveFocus(within: fields, forward: !press.modifiers.contains(.shift))

--- a/TablePro/Views/RowInspector/InspectorFieldListView.swift
+++ b/TablePro/Views/RowInspector/InspectorFieldListView.swift
@@ -138,7 +138,7 @@ internal struct InspectorFieldListView: View {
         let editable = Self.isFieldEditable(field, kind: kind, rowIsEditable: isEditable)
         InspectorFieldRow(
             context: context(for: field, kind: kind, isEditable: editable),
-            layout: InspectorFieldLayout.resolve(for: kind),
+            layout: InspectorFieldLayout.resolve(for: kind, isSchemaField: field.isSchemaField),
             kind: kind,
             isModified: field.hasEdit || field.hasCommittedEdit,
             isPrimaryKey: field.isPrimaryKey,

--- a/TablePro/Views/RowInspector/InspectorFieldRow.swift
+++ b/TablePro/Views/RowInspector/InspectorFieldRow.swift
@@ -46,36 +46,34 @@ internal struct InspectorFieldRow: View {
 
     // MARK: - Layouts
 
+    /// A schema row: the label in a fixed trailing-aligned lane, the editor filling what is left.
+    /// The lane is a constant because the label vocabulary is closed and authored; its widest member
+    /// renders at 66.4pt, so 96 carries every one of them with room for a longer translation.
     private var inlineRow: some View {
-        HStack(spacing: 5) {
-            statusGlyphs
-            Text(context.columnName)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .layoutPriority(1)
-            Spacer(minLength: 6)
-            if context.showsTypeBadge {
-                TypeBadge(context.columnType.badgeLabel)
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            HStack(spacing: 3) {
+                statusGlyphs
+                fieldLabel
             }
+            .frame(width: Self.schemaLabelLaneWidth, alignment: .trailing)
             editor
-                .frame(maxWidth: Self.inlineEditorMaxWidth, alignment: .trailing)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            modifiedGlyph
             valueMenu
         }
-        .padding(.vertical, 2)
+        .padding(.vertical, 3)
     }
 
+    /// A data row: name and type on their own line, the value at full width beneath. Every value in
+    /// the pane then starts at the same x and gets the whole content width, against the 24 to 31pt a
+    /// long column name used to leave it.
     private var stackedRow: some View {
-        VStack(alignment: .leading, spacing: 3) {
-            HStack(spacing: 5) {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 4) {
                 statusGlyphs
-                Text(context.columnName)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
+                fieldLabel
                 Spacer(minLength: 4)
+                modifiedGlyph
                 if context.showsTypeBadge {
                     TypeBadge(context.columnType.badgeLabel)
                 }
@@ -96,7 +94,18 @@ internal struct InspectorFieldRow: View {
             }
             editor
         }
-        .padding(.vertical, 3)
+        .padding(.vertical, 2)
+    }
+
+    /// Carries the full name as a tooltip, which is what the HIG asks of a label it had to clip:
+    /// "consider using an expansion tooltip to show the full version of clipped or truncated text".
+    private var fieldLabel: some View {
+        Text(context.columnName)
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .help(context.columnName)
     }
 
     // MARK: - Header pieces
@@ -104,25 +113,35 @@ internal struct InspectorFieldRow: View {
     /// Drawn without accessibility of their own; the row's own label carries what they mean, so a
     /// reader is told which field is the primary key and which holds an unsaved edit. They were
     /// bare `Image` and `Circle` decoration before and said nothing at all.
+    ///
+    /// A row with neither takes no width for them, so its name sits at the same leading edge as the
+    /// value beneath it. Reserving the space on every row instead indented every name past its own
+    /// value by 18pt, which is the misalignment this layout exists to remove.
+    @ViewBuilder
     private var statusGlyphs: some View {
-        HStack(spacing: 3) {
+        if isPrimaryKey {
+            Image(systemName: "key.fill")
+                .foregroundStyle(.orange)
+                .font(.caption2)
+                .accessibilityHidden(true)
+        } else if isForeignKey {
+            Image(systemName: "arrow.up.forward")
+                .foregroundStyle(.secondary)
+                .font(.caption2)
+                .accessibilityHidden(true)
+        }
+    }
+
+    /// The unsaved-edit marker sits at the trailing end rather than in front of the name, so
+    /// recording an edit cannot shift the name it belongs to.
+    @ViewBuilder
+    private var modifiedGlyph: some View {
+        if isModified {
             Circle()
                 .fill(Color.accentColor)
                 .frame(width: 5, height: 5)
-                .opacity(isModified ? 1 : 0)
-            Group {
-                if isPrimaryKey {
-                    Image(systemName: "key.fill").foregroundStyle(.orange)
-                } else if isForeignKey {
-                    Image(systemName: "arrow.up.forward").foregroundStyle(.secondary)
-                } else {
-                    Color.clear
-                }
-            }
-            .font(.caption2)
-            .frame(width: 10)
+                .accessibilityHidden(true)
         }
-        .accessibilityHidden(true)
     }
 
     private var accessibilityLabel: String {
@@ -205,7 +224,13 @@ internal struct InspectorFieldRow: View {
     }
 
 
-    /// An inline value gives the label room to be read. Measured at the pane's 270pt minimum, a
-    /// wider share leaves a long column name showing three characters and an ellipsis.
-    private static let inlineEditorMaxWidth: CGFloat = 150
+    /// The lane a schema row's label sits in. The vocabulary is closed and authored, and its widest
+    /// member, "Ref Columns", renders at 66.4pt in `.subheadline`, so this carries every label with
+    /// 45% left over for a longer translation. A label that still overruns truncates in the middle
+    /// and keeps its tooltip rather than taking the width from its own value.
+    ///
+    /// It is a constant, not a measurement. A lane derived from the rows on screen would change
+    /// width as the user scrolls, because a `PreferenceKey` max-reduce inside a `List` only ever
+    /// sees the realized rows.
+    private static let schemaLabelLaneWidth: CGFloat = 96
 }

--- a/TablePro/Views/RowInspector/InspectorFieldRow.swift
+++ b/TablePro/Views/RowInspector/InspectorFieldRow.swift
@@ -61,14 +61,14 @@ internal struct InspectorFieldRow: View {
             modifiedGlyph
             valueMenu
         }
-        .padding(.vertical, 3)
+        .padding(.vertical, InspectorMetrics.betweenFields / 2)
     }
 
     /// A data row: name and type on their own line, the value at full width beneath. Every value in
     /// the pane then starts at the same x and gets the whole content width, against the 24 to 31pt a
     /// long column name used to leave it.
     private var stackedRow: some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: InspectorMetrics.labelToValue) {
             HStack(spacing: 4) {
                 statusGlyphs
                 fieldLabel
@@ -94,7 +94,7 @@ internal struct InspectorFieldRow: View {
             }
             editor
         }
-        .padding(.vertical, 2)
+        .padding(.vertical, InspectorMetrics.betweenFields / 2)
     }
 
     /// Carries the full name as a tooltip, which is what the HIG asks of a label it had to clip:

--- a/TablePro/Views/RowInspector/InspectorHeaderView.swift
+++ b/TablePro/Views/RowInspector/InspectorHeaderView.swift
@@ -39,7 +39,7 @@ internal struct InspectorHeaderView: View {
                 viewModePicker
             }
         }
-        .padding(.horizontal, 10)
+        .padding(.horizontal, InspectorMetrics.horizontalInset)
         .padding(.vertical, 6)
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/TablePro/Views/RowInspector/TableInfoView.swift
+++ b/TablePro/Views/RowInspector/TableInfoView.swift
@@ -7,70 +7,105 @@ import SwiftUI
 
 /// The table's own statistics, shown when the inspector has a table but no row selected.
 ///
-/// A `Form` is right here and wrong for the field list: this has a dozen rows of fixed shape, so
-/// eager layout costs nothing, and `.formStyle(.grouped)` gives the section headers and the value
-/// wrapping the platform draws for a settings-shaped list.
+/// Not a `Form`. `.formStyle(.grouped)` insets its content 30pt per side and there is no way to ask
+/// it for less: measured, that 30 holds at 250, 270, 300, 340, 420 and 600pt, so it is not a margin
+/// that gives way on a narrow pane. At the inspector's 270pt minimum it left a 116pt value column,
+/// which truncated the collation on every engine whose collation has a name (`utf8mb4_0900_ai_ci`
+/// needs 126pt, `SQL_Latin1_General_CP1_CI_AS` needs 196), and the previous author reached for a
+/// `.help` tooltip on that row rather than the width. It also disagreed with the field list beside
+/// it: selecting a row moved every value 20pt sideways.
 ///
-/// Its headers are title case. They were hand-written in capitals ("SIZE", "STATISTICS"), which is
-/// neither what `Form` draws nor what macOS has used since Big Sur.
+/// So the sections are drawn here, on `InspectorMetrics.horizontalInset` like everything else in
+/// the pane, and a value that still does not fit wraps rather than eliding. Wrapping is what
+/// Finder's Get Info does with a long value at this width, measured.
 internal struct TableInfoView: View {
     internal let metadata: TableMetadata
 
     var body: some View {
-        Form {
-            if AppSettingsManager.shared.general.showObjectComments,
-               let comment = metadata.comment, !comment.isEmpty {
-                Section(String(localized: "Comment")) {
-                    Text(comment)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .textSelection(.enabled)
-                }
-            }
-
-            Section(String(localized: "Size")) {
-                LabeledContent(String(localized: "Data"), value: TableMetadata.formatSize(metadata.dataSize))
-                LabeledContent(String(localized: "Indexes"), value: TableMetadata.formatSize(metadata.indexSize))
-                LabeledContent(String(localized: "Total"), value: TableMetadata.formatSize(metadata.totalSize))
-            }
-
-            if metadata.rowCount != nil || metadata.avgRowLength != nil {
-                Section(String(localized: "Statistics")) {
-                    if let rows = metadata.rowCount {
-                        LabeledContent(String(localized: "Rows"), value: rows.formatted(.number))
-                    }
-                    if let averageLength = metadata.avgRowLength {
-                        LabeledContent(
-                            String(localized: "Average Row"),
-                            value: TableMetadata.formatSize(averageLength)
-                        )
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                if AppSettingsManager.shared.general.showObjectComments,
+                   let comment = metadata.comment, !comment.isEmpty {
+                    section(String(localized: "Comment")) {
+                        Text(comment)
+                            .font(.subheadline)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
-            }
 
-            if metadata.engine != nil || metadata.collation != nil {
-                Section(String(localized: "Metadata")) {
-                    if let engine = metadata.engine {
-                        LabeledContent(String(localized: "Engine"), value: engine)
+                section(String(localized: "Size")) {
+                    row(String(localized: "Data"), TableMetadata.formatSize(metadata.dataSize))
+                    row(String(localized: "Indexes"), TableMetadata.formatSize(metadata.indexSize))
+                    row(String(localized: "Total"), TableMetadata.formatSize(metadata.totalSize))
+                }
+
+                if metadata.rowCount != nil || metadata.avgRowLength != nil {
+                    section(String(localized: "Statistics")) {
+                        if let rows = metadata.rowCount {
+                            row(String(localized: "Rows"), rows.formatted(.number))
+                        }
+                        if let averageLength = metadata.avgRowLength {
+                            row(String(localized: "Average Row"), TableMetadata.formatSize(averageLength))
+                        }
                     }
-                    if let collation = metadata.collation {
-                        LabeledContent(String(localized: "Collation"), value: collation)
-                            .help(collation)
+                }
+
+                if metadata.engine != nil || metadata.collation != nil {
+                    section(String(localized: "Metadata")) {
+                        if let engine = metadata.engine {
+                            row(String(localized: "Engine"), engine)
+                        }
+                        if let collation = metadata.collation {
+                            row(String(localized: "Collation"), collation)
+                        }
+                    }
+                }
+
+                if metadata.createTime != nil || metadata.updateTime != nil {
+                    section(String(localized: "Timestamps")) {
+                        if let created = metadata.createTime {
+                            row(String(localized: "Created"), Self.date(created))
+                        }
+                        if let updated = metadata.updateTime {
+                            row(String(localized: "Updated"), Self.date(updated))
+                        }
                     }
                 }
             }
-
-            if metadata.createTime != nil || metadata.updateTime != nil {
-                Section(String(localized: "Timestamps")) {
-                    if let created = metadata.createTime {
-                        LabeledContent(String(localized: "Created"), value: Self.date(created))
-                    }
-                    if let updated = metadata.updateTime {
-                        LabeledContent(String(localized: "Updated"), value: Self.date(updated))
-                    }
-                }
-            }
+            .padding(.horizontal, InspectorMetrics.horizontalInset)
+            .padding(.vertical, 12)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .formStyle(.grouped)
+    }
+
+    @ViewBuilder
+    private func section(_ title: String, @ViewBuilder content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: InspectorMetrics.labelToValue) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            content()
+        }
+    }
+
+    /// The label takes what it needs and the value takes the rest, wrapping when it has to. A fixed
+    /// label lane would be wrong here for the same reason it is wrong on a data field: these labels
+    /// are localized, so their widest member is not knowable from the English.
+    private func row(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(label)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Spacer(minLength: 8)
+            Text(value)
+                .font(.subheadline)
+                .multilineTextAlignment(.trailing)
+                .fixedSize(horizontal: false, vertical: true)
+                .textSelection(.enabled)
+        }
     }
 
     private static func date(_ value: Date) -> String {

--- a/TablePro/Views/ServerDashboard/ServerDashboardSplitView.swift
+++ b/TablePro/Views/ServerDashboard/ServerDashboardSplitView.swift
@@ -12,7 +12,7 @@ struct ServerDashboardSplitView: NSViewControllerRepresentable {
         let splitViewController = ResizeCursorSplitViewController()
         splitViewController.splitView.isVertical = false
         splitViewController.splitView.dividerStyle = .thin
-        splitViewController.splitView.autosaveName = "ServerDashboardSplit"
+        splitViewController.splitView.autosaveName = NSSplitView.AutosaveName(SplitViewAutosaveName.current("ServerDashboardSplit"))
 
         for panel in orderedPanels() {
             let item = makeItem(for: panel, coordinator: context.coordinator)

--- a/TablePro/Views/UsersRoles/PrivilegeScopeOutlineView.swift
+++ b/TablePro/Views/UsersRoles/PrivilegeScopeOutlineView.swift
@@ -26,7 +26,7 @@ struct PrivilegeScopeOutlineView: NSViewRepresentable {
         outlineView.usesAlternatingRowBackgroundColors = true
         outlineView.headerView = NSTableHeaderView()
         outlineView.allowsColumnResizing = true
-        outlineView.autosaveName = "com.TablePro.usersRoles.scopeOutline"
+        outlineView.autosaveName = SplitViewAutosaveName.current("com.TablePro.usersRoles.scopeOutline")
         outlineView.autosaveTableColumns = true
         outlineView.autosaveExpandedItems = false
         outlineView.setAccessibilityIdentifier("usersroles-scope-tree")

--- a/TableProTests/Models/InspectorFieldLayoutTests.swift
+++ b/TableProTests/Models/InspectorFieldLayoutTests.swift
@@ -10,49 +10,82 @@ import Testing
 @MainActor
 @Suite("Inspector field layout")
 struct InspectorFieldLayoutTests {
-    @Test("A scalar editor takes one line")
-    func scalarsAreInline() {
-        #expect(InspectorFieldLayout.resolve(for: .singleLine) == .inline)
-        #expect(InspectorFieldLayout.resolve(for: .boolean) == .inline)
-        #expect(InspectorFieldLayout.resolve(for: .schemaText) == .inline)
-        #expect(InspectorFieldLayout.resolve(for: .typePicker) == .inline)
-        #expect(InspectorFieldLayout.resolve(for: .enumPicker(values: ["a", "b"])) == .inline)
-        #expect(InspectorFieldLayout.resolve(for: .setPicker(values: ["a", "b"])) == .inline)
+    private static let everyKind: [FieldEditorKind] = [
+        .singleLine,
+        .boolean,
+        .schemaText,
+        .typePicker,
+        .enumPicker(values: ["a", "b"]),
+        .setPicker(values: ["a", "b"]),
+        .multiLine,
+        .json,
+        .phpSerialized,
+        .blobHex,
+        .image(.raster("public.png"))
+    ]
+
+    /// A column name is user data of no bounded length, so no label lane can hold every one of them
+    /// and a lane wide enough to try takes the width the value needs. Measured at the pane's 270pt
+    /// minimum, a side-by-side data row truncates the name *and* the value; stacking shows both.
+    @Test("Every data field stacks, whatever editor it resolves to")
+    func dataFieldsAlwaysStack() {
+        for kind in Self.everyKind {
+            #expect(
+                InspectorFieldLayout.resolve(for: kind, isSchemaField: false) == .stacked,
+                "\(kind) should stack on a data row"
+            )
+        }
     }
 
-    /// Measured at the pane's 270pt minimum: a `LabeledContent` squeezes a text editor into its
-    /// trailing half, so anything that needs room has to own the full width.
-    @Test("An editor that needs room spans the width")
-    func largeEditorsAreStacked() {
-        #expect(InspectorFieldLayout.resolve(for: .multiLine) == .stacked)
-        #expect(InspectorFieldLayout.resolve(for: .json) == .stacked)
-        #expect(InspectorFieldLayout.resolve(for: .phpSerialized) == .stacked)
-        #expect(InspectorFieldLayout.resolve(for: .blobHex) == .stacked)
-        #expect(InspectorFieldLayout.resolve(for: .image(.raster("public.png"))) == .stacked)
+    /// A schema label comes from a closed authored vocabulary whose widest member renders at 66.4pt,
+    /// so the lane holds it and the row stays one line high.
+    @Test("A schema scalar takes one line")
+    func schemaScalarsAreInline() {
+        #expect(InspectorFieldLayout.resolve(for: .singleLine, isSchemaField: true) == .inline)
+        #expect(InspectorFieldLayout.resolve(for: .boolean, isSchemaField: true) == .inline)
+        #expect(InspectorFieldLayout.resolve(for: .schemaText, isSchemaField: true) == .inline)
+        #expect(InspectorFieldLayout.resolve(for: .typePicker, isSchemaField: true) == .inline)
+        #expect(InspectorFieldLayout.resolve(for: .enumPicker(values: ["a"]), isSchemaField: true) == .inline)
+        #expect(InspectorFieldLayout.resolve(for: .setPicker(values: ["a"]), isSchemaField: true) == .inline)
     }
 
-    /// The editor kind already answers this, because `FieldEditorResolver` chooses `.singleLine`
-    /// against `.multiLine` from the value's own length and newlines. Asking the value again in the
-    /// layout would be a second opinion that could drift from the first.
-    @Test("A long value reaches the stacked layout through the editor it resolves to")
-    func aLongValueBecomesStackedThroughItsEditor() {
+    /// The editors that need the pane's width still take it, on a schema row as on a data row.
+    @Test("A schema editor that needs room spans the width")
+    func schemaLargeEditorsAreStacked() {
+        #expect(InspectorFieldLayout.resolve(for: .multiLine, isSchemaField: true) == .stacked)
+        #expect(InspectorFieldLayout.resolve(for: .json, isSchemaField: true) == .stacked)
+        #expect(InspectorFieldLayout.resolve(for: .phpSerialized, isSchemaField: true) == .stacked)
+        #expect(InspectorFieldLayout.resolve(for: .blobHex, isSchemaField: true) == .stacked)
+        #expect(InspectorFieldLayout.resolve(for: .image(.raster("public.png")), isSchemaField: true) == .stacked)
+    }
+
+    /// `.enumPicker` is the kind for a data row's ENUM column *and* for a structure row's dropdown
+    /// (On Delete, Unique, Nullable), so the editor kind alone cannot say which shape a row takes.
+    /// Resolving on the kind by itself is what put a structure dropdown and an ENUM value in the
+    /// same geometry.
+    @Test("One editor kind resolves differently by provenance")
+    func provenanceDecidesWhereTheKindIsShared() {
+        let dropdown = FieldEditorKind.enumPicker(values: ["CASCADE", "RESTRICT"])
+        #expect(InspectorFieldLayout.resolve(for: dropdown, isSchemaField: true) == .inline)
+        #expect(InspectorFieldLayout.resolve(for: dropdown, isSchemaField: false) == .stacked)
+    }
+
+    /// A long value still reaches its own editor through `FieldEditorResolver`; the layout no longer
+    /// asks the value a second time, so the two can never drift apart.
+    @Test("A long value resolves to the multi-line editor")
+    func aLongValueBecomesMultiLineThroughItsEditor() {
         let long = String(repeating: "x", count: FieldEditorResolver.multiLineValueThreshold + 1)
         let kind = FieldEditorResolver.resolve(for: .text(rawType: "TEXT"), isLongText: false, originalValue: long)
         #expect(kind == .multiLine)
-        #expect(InspectorFieldLayout.resolve(for: kind) == .stacked)
+        #expect(InspectorFieldLayout.resolve(for: kind, isSchemaField: false) == .stacked)
     }
 
-    @Test("A short value stays on one line")
-    func aShortValueStaysInline() {
+    /// A short data value gets the same shape as a long one. Choosing per row from the value's own
+    /// length would reflow a field from one shape to the other while the user typed into it.
+    @Test("A short data value keeps the same shape as a long one")
+    func aShortValueKeepsTheStackedShape() {
         let kind = FieldEditorResolver.resolve(for: .text(rawType: "TEXT"), isLongText: false, originalValue: "ok")
         #expect(kind == .singleLine)
-        #expect(InspectorFieldLayout.resolve(for: kind) == .inline)
-    }
-
-    /// A value with a newline in it cannot be shown on one line whatever its length.
-    @Test("A value with a newline is stacked")
-    func newlinesAreStacked() {
-        let kind = FieldEditorResolver.resolve(for: .text(rawType: "TEXT"), isLongText: false, originalValue: "a\nb")
-        #expect(InspectorFieldLayout.resolve(for: kind) == .stacked)
+        #expect(InspectorFieldLayout.resolve(for: kind, isSchemaField: false) == .stacked)
     }
 }

--- a/TableProTests/Models/InspectorMetricsTests.swift
+++ b/TableProTests/Models/InspectorMetricsTests.swift
@@ -1,0 +1,64 @@
+//
+//  InspectorMetricsTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Inspector metrics")
+struct InspectorMetricsTests {
+    /// Every surface in the pane sits on one edge. It did not: the header was 10, the filter bar 8,
+    /// the field list 24 and table info 30, so changing the selection moved every value sideways.
+    @Test("The row insets land the list on the pane's own edge")
+    func listRowInsetsReachTheSharedEdge() {
+        let plainLeading: CGFloat = 8
+        let plainTrailing: CGFloat = 9
+
+        #expect(plainLeading + InspectorMetrics.listRowLeadingCorrection == InspectorMetrics.horizontalInset)
+        #expect(plainTrailing + InspectorMetrics.listRowTrailingCorrection == InspectorMetrics.horizontalInset)
+    }
+
+    /// The corrections only work against `.plain`, whose inset is half of `intercellSpacing`.
+    /// `.inset` spends a hard 16pt per side first, which is where the 24 came from, so a correction
+    /// computed for `.plain` cannot be applied to it.
+    @Test("The corrections are small, because .plain starts close to the edge")
+    func correctionsAreSmall() {
+        #expect(InspectorMetrics.listRowLeadingCorrection >= 0)
+        #expect(InspectorMetrics.listRowTrailingCorrection >= 0)
+        #expect(InspectorMetrics.listRowLeadingCorrection < 8)
+        #expect(InspectorMetrics.listRowTrailingCorrection < 8)
+    }
+
+    /// The gap between two fields has to beat the gap inside one, by enough to see. The shipped
+    /// pane was 5pt against 2pt: the same 2.5x ratio, but only 3pt of actual difference, so the
+    /// fields read as one undifferentiated stack.
+    @Test("A field is separated from the next by more than its own label is from its value")
+    func fieldsGroupVisibly() {
+        #expect(InspectorMetrics.betweenFields > InspectorMetrics.labelToValue)
+        #expect(InspectorMetrics.betweenFields - InspectorMetrics.labelToValue >= 6)
+    }
+
+    /// The inset is a real margin, not a decoration. Apple's own inspectors at this width measure
+    /// 7 to 13, so anything outside that band is not a native number.
+    @Test("The inset sits in the band Apple's own inspectors use")
+    func insetIsNative() {
+        #expect(InspectorMetrics.horizontalInset >= 7)
+        #expect(InspectorMetrics.horizontalInset <= 13)
+    }
+
+    /// At the pane's 270pt minimum the value column is what is left after both margins. It was
+    /// 224pt. A 29-character `timestamptz` needs 233pt at the default Data Grid font, so the old
+    /// margin was the reason a stored timestamp could not be read whole.
+    @Test("The value column clears a full timestamp at the pane's minimum")
+    func valueColumnFitsATimestamp() {
+        let paneMinimum: CGFloat = 270
+        let content = paneMinimum - (InspectorMetrics.horizontalInset * 2)
+        let editorChrome: CGFloat = 12
+        let advanceAtDefaultGridFont: CGFloat = 8.036
+
+        #expect(content == 250)
+        #expect((content - editorChrome) / advanceAtDefaultGridFont >= 29)
+    }
+}

--- a/TableProTests/Models/SplitViewAutosaveNameTests.swift
+++ b/TableProTests/Models/SplitViewAutosaveNameTests.swift
@@ -1,0 +1,100 @@
+//
+//  SplitViewAutosaveNameTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Split view autosave name")
+struct SplitViewAutosaveNameTests {
+    /// A real user's saved widths and collapse states hang off this exact string. Versioning it
+    /// discards all of them, so production must keep the bare name whatever the sandbox does.
+    @Test("Production keeps the bare name")
+    func productionIsUnnamespaced() {
+        #expect(SplitViewAutosaveName.resolved(isIsolated: false, sandboxIdentifier: "ABC") == "com.TablePro.mainSplit")
+        #expect(SplitViewAutosaveName.resolved(isIsolated: false, sandboxIdentifier: nil) == "com.TablePro.mainSplit")
+    }
+
+    /// AppKit files the autosave record in the standard defaults domain, which the UI test sandbox
+    /// does not redirect, so without this every case inherits the pane geometry of whichever case
+    /// ran before it in its shard.
+    @Test("A sandboxed run gets its own record")
+    func isolationNamespacesTheRecord() {
+        let name = SplitViewAutosaveName.resolved(isIsolated: true, sandboxIdentifier: "ABC-123")
+
+        #expect(name == "com.TablePro.mainSplit.ABC-123")
+        #expect(name != SplitViewAutosaveName.base)
+    }
+
+    /// The whole point is that two cases cannot collide. The sandbox root's last path component is
+    /// a fresh UUID per case, which is what supplies the difference.
+    @Test("Two sandboxes never share a record")
+    func twoSandboxesDoNotCollide() {
+        let first = SplitViewAutosaveName.resolved(isIsolated: true, sandboxIdentifier: "case-one")
+        let second = SplitViewAutosaveName.resolved(isIsolated: true, sandboxIdentifier: "case-two")
+
+        #expect(first != second)
+    }
+
+    /// An empty identifier would namespace to a trailing dot shared by every case, which is the
+    /// collision this exists to prevent wearing a different name.
+    @Test("An empty identifier falls back rather than sharing a suffix")
+    func emptyIdentifierFallsBack() {
+        #expect(SplitViewAutosaveName.resolved(isIsolated: true, sandboxIdentifier: "") == SplitViewAutosaveName.base)
+        #expect(SplitViewAutosaveName.resolved(isIsolated: true, sandboxIdentifier: nil) == SplitViewAutosaveName.base)
+    }
+
+    /// Every autosave name in the app goes through the same helper, because they all land in the
+    /// same unisolated defaults: the window frames, the tab-content split dividers and the query
+    /// history drawer's own list/detail divider, which is the one that pushed a drawer's action bar
+    /// past the window's bottom edge.
+    @Test("The general form namespaces any name")
+    func anyNameIsNamespaced() {
+        let drawer = "com.TablePro.queryHistory.listDetail"
+        #expect(
+            SplitViewAutosaveName.resolved(drawer, isIsolated: true, sandboxIdentifier: "s1")
+                == "com.TablePro.queryHistory.listDetail.s1"
+        )
+        #expect(
+            SplitViewAutosaveName.resolved(drawer, isIsolated: false, sandboxIdentifier: "s1") == drawer
+        )
+        #expect(
+            SplitViewAutosaveName.resolved("TextViewerWindow", isIsolated: true, sandboxIdentifier: "s1")
+                != SplitViewAutosaveName.resolved("JSONViewerWindow", isIsolated: true, sandboxIdentifier: "s1")
+        )
+    }
+
+    /// The rule is only useful if the call sites actually use it. A new autosave name assigned
+    /// directly is a new leak, and this is what catches one.
+    @Test("Every autosave assignment goes through the helper")
+    func everyCallSiteIsNamespaced() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sites = [
+            "TablePro/Views/Components/AutosavingSplitView.swift",
+            "TablePro/Views/Components/VerticalCollapsibleSplitView.swift",
+            "TablePro/Views/ServerDashboard/ServerDashboardSplitView.swift",
+            "TablePro/Views/QueryPlan/QueryPlanOutlineView.swift",
+            "TablePro/Views/UsersRoles/PrivilegeScopeOutlineView.swift",
+            "TablePro/Views/ConnectionForm/ConnectionFormWindowController.swift",
+            "TablePro/Views/Integrations/IntegrationsActivityWindowController.swift",
+            "TablePro/Core/Services/Infrastructure/TabWindowController.swift",
+            "TablePro/Extensions/NSWindow+FrameAutosave.swift",
+            "TablePro/Core/Services/Infrastructure/MainSplitViewController.swift",
+        ]
+
+        var offenders: [String] = []
+        for site in sites {
+            let source = try String(contentsOf: root.appendingPathComponent(site), encoding: .utf8)
+            if !source.contains("SplitViewAutosaveName") {
+                offenders.append(site)
+            }
+        }
+
+        #expect(offenders.isEmpty, "These assign an autosave name without namespacing it: \(offenders)")
+    }
+}

--- a/TableProTests/Theme/ValueFontTests.swift
+++ b/TableProTests/Theme/ValueFontTests.swift
@@ -106,6 +106,10 @@ struct ValueFontTests {
             "TablePro/Views/Results/SvgViewerContentView.swift",
             "TablePro/Views/Results/CellImageWindowController.swift",
             "TablePro/Views/RowInspector/FieldEditors/ImageFieldView.swift",
+            /// Reached from `.blobHex`, which inherits the value font from the row, and from
+            /// `.image`, which does not, so it has to name the font itself or the same dump renders
+            /// monospaced down one route and proportional down the other.
+            "TablePro/Views/RowInspector/FieldEditors/BlobHexEditorView.swift",
             "TablePro/Views/Results/ForeignKeyPreviewView.swift",
             "TablePro/Views/Results/ArrayValueEditorView.swift",
             "TablePro/Views/Results/SetPopoverContentView.swift",

--- a/TableProTests/Views/Results/HexEditorTests.swift
+++ b/TableProTests/Views/Results/HexEditorTests.swift
@@ -291,6 +291,83 @@ struct HexEditorTests {
         #expect(hex!.hasSuffix("…"))
         #expect(BlobFormattingService.shared.parseHex(hex!) == nil)
     }
+
+    // MARK: - Truncation guard
+
+    /// What the guard exists to stop. Dropping the ellipsis the formatter appended leaves a string
+    /// that parses cleanly, so nothing downstream can tell it from a value the user actually typed:
+    /// it is a prefix, and committing it writes that prefix over the whole column.
+    @Test("A truncated edit string parses back to a prefix, not to the value")
+    func droppingTheEllipsisYieldsAPrefixThatStillParses() throws {
+        let original = String(repeating: "X", count: 50_000)
+        let truncated = try #require(original.formattedAsEditableHex())
+        #expect(truncated.hasSuffix("…"))
+
+        let withoutMarker = truncated.replacingOccurrences(of: " …", with: "")
+        let parsed = try #require(BlobFormattingService.shared.parseHex(withoutMarker))
+
+        #expect(parsed.count == 10_240)
+        #expect(parsed != original)
+        #expect(original.hasPrefix(parsed))
+    }
+
+    /// The inline inspector editor and the pop-out editor read the same formatter, so both have to
+    /// refuse a marked string. The pop-out has always disabled Save on it; the inline one treated
+    /// the marker as a syntax error, which reported "Invalid hex" over an untouched value and then
+    /// reverted every edit on blur instead of saying the value was too large to edit.
+    /// Both editors refuse to commit a value they only hold a prefix of, and both anchor that
+    /// refusal to the stored value rather than to the draft. Anchoring it to the draft is what makes
+    /// the guard defeatable: deleting the marker the formatter appended leaves a string that parses
+    /// cleanly, and the editor then writes 10,240 bytes over the whole blob.
+    @Test("The inline editor blocks a truncated commit and cannot be talked out of it")
+    func theInlineEditorGuardsTruncation() throws {
+        let inline = try source(of: "TablePro/Views/RowInspector/FieldEditors/BlobHexEditorView.swift")
+        #expect(inline.contains("guard !isTruncated else { return }"))
+        #expect(inline.contains("Truncated, read only"))
+
+        let loader = try #require(
+            inline.range(of: "private func loadDraft()"),
+            "BlobHexEditorView must load the draft and the flag from one read"
+        )
+        let body = inline[loader.lowerBound...].prefix(320)
+        #expect(body.contains("context.value.wrappedValue"))
+        #expect(body.contains("isTruncated = formatted.hasSuffix"))
+
+        /// The flag is never recomputed from what the user typed. It was, and pasting an ellipsis
+        /// into an ordinary blob then locked the field for good, because it went read-only and the
+        /// commit guard returned without restoring the text, so the marker could not be deleted.
+        let assignments = inline.components(separatedBy: "isTruncated =").dropFirst()
+        for assignment in assignments {
+            #expect(
+                !assignment.prefix(60).contains("hexEditText"),
+                "The truncation flag must not be assigned from the draft: \(assignment.prefix(60))"
+            )
+        }
+    }
+
+    /// The pop-out had the same defeatable guard: `validateHex` recomputed `isTruncated` from the
+    /// text view on every keystroke, so deleting the marker cleared it, re-enabled Save, and
+    /// committed the prefix over the full blob.
+    @Test("The pop-out editor anchors truncation to the value it opened on")
+    func thePopOutEditorGuardsTruncation() throws {
+        let popOut = try source(of: "TablePro/Views/Results/HexEditorContentView.swift")
+
+        #expect(popOut.contains("private let sourceIsTruncated: Bool"))
+        #expect(popOut.contains("guard isValid, !sourceIsTruncated else { return }"))
+        #expect(popOut.contains("|| sourceIsTruncated"))
+    }
+
+    private static let repositoryRoot: URL = {
+        var url = URL(fileURLWithPath: #filePath)
+        for _ in 0 ..< 4 {
+            url.deleteLastPathComponent()
+        }
+        return url
+    }()
+
+    private func source(of path: String) throws -> String {
+        try String(contentsOf: Self.repositoryRoot.appendingPathComponent(path), encoding: .utf8)
+    }
 }
 
 // swiftlint:enable force_unwrapping

--- a/TableProUITests/InspectorFieldAffordanceUITests.swift
+++ b/TableProUITests/InspectorFieldAffordanceUITests.swift
@@ -49,6 +49,64 @@ final class InspectorFieldAffordanceUITests: UITestCase {
         )
     }
 
+    /// A field's value sits below its name, not beside it, so neither has to give the other room.
+    /// Asserted as geometry rather than as text, because whether any particular value happens to be
+    /// elided depends on the pane's width and on the row the runner selected, while "the editor
+    /// starts below the name" is true of the stacked shape at every width and for every value.
+    ///
+    /// The shape this replaced put both on one line and settled the contest with `layoutPriority`
+    /// on the name, so a long column name left its value showing two characters and an ellipsis.
+    func testAFieldsValueIsBelowItsNameRatherThanBesideIt() throws {
+        let app = try launchWithSampleDatabase()
+        let window = try mainWindow(of: app)
+        _ = try openFirstTableRow(in: app, window: window)
+
+        let menu = window.descendants(matching: .any)["inspector-value-menu"].firstMatch
+        XCTAssertTrue(menu.waitToExist(timeout: 30), "The inspector must be showing a field")
+
+        let editor = window.textFields.firstMatch
+        XCTAssertTrue(editor.waitToExist(timeout: 15), "The inspector must be showing a field editor")
+
+        /// The menu sits at the trailing end of the name's line, so in the stacked shape its whole
+        /// height clears the editor beneath it. In the shape this replaced the two shared one line
+        /// and overlapped almost exactly, which is what let the name take the width from the value.
+        XCTAssertLessThanOrEqual(
+            menu.frame.maxY,
+            editor.frame.minY + 1,
+            """
+            The value menu belongs to the name's line and the editor to the line below it. \
+            Overlapping vertically means the row put the name and the value back on one line, \
+            where a long column name leaves its value showing two characters and an ellipsis. \
+            menu=\(menu.frame) editor=\(editor.frame)
+            """
+        )
+    }
+
+    /// The editor spans the row rather than sitting in a trailing lane, so every value in the pane
+    /// starts at the same x whatever its column is called.
+    func testEveryFieldEditorStartsAtTheSameLeadingEdge() throws {
+        let app = try launchWithSampleDatabase()
+        let window = try mainWindow(of: app)
+        _ = try openFirstTableRow(in: app, window: window)
+
+        let menu = window.descendants(matching: .any)["inspector-value-menu"].firstMatch
+        XCTAssertTrue(menu.waitToExist(timeout: 30), "The inspector must be showing a field")
+
+        let editors = window.textFields.allElementsBoundByIndex.filter { $0.frame.width > 0 }
+        try XCTSkipIf(editors.count < 2, "This row shows fewer than two text editors")
+
+        let leadingEdges = Set(editors.map { $0.frame.minX.rounded() })
+        XCTAssertEqual(
+            leadingEdges.count,
+            1,
+            """
+            Every field editor starts at one x. More than one means the rows are negotiating \
+            their widths separately again, which is what left nine consecutive values starting \
+            at nine different positions. edges=\(leadingEdges.sorted())
+            """
+        )
+    }
+
     // MARK: - Helpers
 
     /// A row is as wide as the grid and a column is published as its sibling, so XCUITest reads

--- a/docs/features/json-viewer.mdx
+++ b/docs/features/json-viewer.mdx
@@ -94,7 +94,7 @@ A value that refuses to open in one mode still opens in another.
 
 ## Row details inspector
 
-**View > Show Inspector** (`Cmd+Option+I`), or the toolbar button at the trailing end, opens it. A field's editor follows its content, with no **Display As** step, and the first match wins.
+**View > Show Inspector** (`Cmd+Option+I`), or the toolbar button at the trailing end, opens it. Each field carries its column name and type on one line, with the value on the line beneath, so the value gets the row's full width however long the column name is. A field's editor follows its content, with no **Display As** step, and the first match wins.
 
 | Content | Editor |
 | --- | --- |
@@ -104,14 +104,16 @@ A value that refuses to open in one mode still opens in another.
 | An enum, set, or boolean column | Picker |
 | A blob column | Hex editor |
 | A `TEXT` variant, `CLOB` or `NTEXT` column, or any value with a line break or over 80 characters | Scrolling text box |
-| Anything else | One-line field |
+| Anything else | Single-line field |
 
 <Frame caption="Row details inspector with per-field editors">
   <img className="block dark:hidden" src="/images/row-details-inspector.png" alt="Row details inspector" />
   <img className="hidden dark:block" src="/images/row-details-inspector-dark.png" alt="Row details inspector" />
 </Frame>
 
-The length test reads the stored value, so a long value pasted into a one-line field stays on one line until you save and reselect the row.
+The length test reads the stored value, so a long value pasted into a single-line field stays on one line until you save and reselect the row.
+
+The hex editor shows the first 10 KB of a blob. Past that it reads **Truncated, read only** and refuses edits, rather than saving back the part it could show.
 
 The text box and the JSON editor each carry a drag handle under them, with separate remembered heights that survive a relaunch.
 


### PR DESCRIPTION
## The problem

At the inspector's 270pt minimum, a field row asked one 256pt line to hold four things that each want to grow: the column name, the type badge, the value editor and the value menu. It settled that contest with `.layoutPriority(1)` on the name and `maxWidth: 150` with **no** `minWidth` on the editor, so the name always won and the value took what was left.

On `public.analytics_events` that meant `connection_succeeded_at` rendered its value as `NU…`, `machine_id` as `78ad8172e…`, `created_at` as `2026-02-13…`. The type badge, having no `lineLimit`, wrapped inside its own capsule to `dat` over `e` and grew those rows by 11pt. And because every row negotiated inside its own `HStack`, no value column existed: nine consecutive fields started their values at nine different x positions.

## Root cause

`InspectorFieldLayout.resolve(for:)` chose the row's **arrangement** from the **editor's size class**. Those are different questions. The arrangement has to follow whose labels these are:

- A **data** row's label is a column name, which is user data of no bounded length. Measured against a realistic 400-column set, the widest renders at **259.8pt**, wider than the whole pane at its minimum.
- A **schema** row's label comes from a closed authored vocabulary (`StructureColumnField.displayName` plus the index, foreign-key and check-constraint headers), whose widest member, "Ref Columns", is **66.4pt**.

One geometry cannot serve both, which is why the enum could not express the fix. This is a refactor, not a patch.

## What changed

A data field now puts its name and type on one line and its value at full width beneath, so every value in the pane starts at the same x and gets the whole content width. A schema field keeps a one-line row, with its label in a fixed 96pt trailing-aligned lane, which is the shape Apple's own inspectors use and which is achievable there because the vocabulary is closed.

`TypeBadge` gains `.lineLimit(1)` and `.fixedSize(horizontal:vertical:)`, which fixes the wrap at its cause and also covers `JSONTreeView` and `PhpTreeView`, which share the component.

The status glyphs no longer reserve width on every row. A row with no key and no foreign key takes none, so its name sits at the same leading edge as its own value; only a key column is indented, where the indent means something. The unsaved-edit dot moved to the trailing end so recording an edit cannot shift the name it belongs to.

Both switches in `InspectorFieldLayout` stay exhaustive over `FieldEditorKind`, so a new editor kind must be classified for each provenance rather than inheriting whichever arm was written first. Threading `isSchemaField` is not optional: `.enumPicker` is the kind for a data row's ENUM column *and* for a structure row's On Delete dropdown, so the kind alone cannot say which shape a row takes.

## Why stacked rather than an aligned two-lane row

The two-lane inline row is the shape Apple's inspectors use, and it was the leading alternative. Rendered at the 270pt minimum with the same data, it truncates **both** halves: labels come out as `connec…eded_at` and `first_qu…uted_at` while values still read `2026-02-13 08:41…`. Truncating both is strictly worse than truncating neither. Apple's labels are authored strings sized for their lane; a column name is not.

Measured against Apple's own inspectors for the underlying principle: Finder's Get Info at 265pt wraps its long `Size:` value to a second line rather than eliding it, and Xcode's File Inspector gives Full Path three lines. More vertical space, not an ellipsis, is the native answer to a value that does not fit. The label-line-above shape itself follows TablePlus, whose `RowDetailTextCell` puts the name and type on one line and the value in an `NSTextView` of the full width beneath, and Postico, which does the same.

Density was the real cost and the one thing three reviewers pushed back on. A stacked row is 44pt against an inline row's 25pt, but across a realistic column set a mixed layout only saves **16-19%**, because the long rows have to stack in either design. What mixing costs instead is the thing this PR exists to fix: two label columns and two value columns alternating down the pane, the type badge dropped from exactly the rows too narrow to carry it, and a row that reflows from one shape to the other while the user is typing into it, since its shape would depend on the value's current length.

## Also in this PR

Both are in the code this change rewrites, and both were found while investigating it.

**A hex dump rendered in the proportional system font.** `InspectorFieldRow.valueFont(for:)` returns `nil` for `.image`, and `ImageFieldView`'s Hex branch renders `BlobHexEditorView`, which named no font. So the identical dump drew monospaced under `.blobHex` and proportional under `.image`, and its offset, hex and ASCII columns stopped lining up. `BlobHexEditorView` now names `ThemeEngine.shared.valueFontSwiftUI` itself, which covers both routes, and is added to the path list in `ValueFontTests.standaloneValueViewsResolveTheValueFont`.

**A BLOB over 10 KB lost the rest of itself on save.** `formattedAsEditableHex` stops at 10,240 bytes and marks the cut with a trailing ellipsis. The inline editor never checked for that marker, so it read it as a syntax error: an untouched value showed a permanent "Invalid hex", every edit was silently reverted on blur, and deleting the ellipsis let the commit write the prefix over the whole column. Measured on a 50,000-byte value: 10,240 bytes committed, **39,760 lost**, with the save reporting success.

Past the cap the field now shows its dump read-only and says so. It renders a selectable view rather than a disabled `TextField`, because a disabled text field on macOS can neither take first responder nor have its text selected, which would have put the value out of reach of the keyboard and the pasteboard while `InspectorFieldListView.moveFocus` went on stopping at the row.

The pop-out editor turned out to have the same bug, found by the code review: `validateHex` recomputed its `isTruncated` from the text view on every keystroke, so deleting the marker cleared the flag, re-enabled **Save**, and committed the prefix. Both editors now anchor truncation to the value they opened on rather than to the draft the user is typing into, which is the only version of the guard that cannot be talked out of.

## Verified

Run in a dedicated worktree, because another session was mid-refactor in the shared checkout.

- `verify.sh build`: PASS
- `verify.sh test` over the eight suites that own the changed types: PASS, 109 executed, 109 passed, 0 failed
- `verify.sh uitest InspectorFieldAffordanceUITests`: PASS, 10 executed, 10 passed, 0 failed
- `swiftlint lint --strict` on the app, and on the four changed test files by explicit path, since `included: [TablePro]` never reaches the test targets: clean
- `docs/scripts/check-writing-style.sh` and `check-docs-against-source.py`: both pass

The two new UI tests assert the shape as geometry rather than as text, because whether a given value is elided depends on the pane's width and on which row the runner selected, while "the editor begins below the name" holds at every width for every value.

Both were checked against the old layout to prove they guard something. Reverted to the shipped row they fail, and the failure message is the report restated as a measurement:

```
XCTAssertEqual failed: ("9") is not equal to ("1")
edges=[1585.0, 1593.0, 1602.0, 1605.0, 1607.0, 1608.0, 1612.0, 1618.0, 1619.0]
```

Nine editors, nine different leading edges. After the change there is one. The three pre-existing tests in that suite pass on both sides, so the two new ones are the only thing that moved.

The measurements quoted above come from compiled `swiftc` + `ImageRenderer` harnesses rather than from inspection. The harness reproduces the reported bug pixel for pixel, `dat`/`e` wrap included, which is what makes its verdict on the alternatives worth anything.

## The CI failure this branch exposed, and the leak behind it

`QueryHistoryActionsUITests/testLoadInEditorFillsTheTabInFrontInsteadOfOpeningAnother` went red on this branch and stayed red on a rerun, while passing on the merge base. It is not the inspector: `TypeBadge` reaches only the inspector and the JSON and PHP trees, never `HistoryDetailPane`, and the editor a field builds is chosen by `FieldEditorContent` from the editor kind, which this change never touches. Two independent review lanes reached the same conclusion.

The element tree XCTest captured at the failure says what actually happened. The window is `{{0,31},{1024,674}}`, so its bottom edge is y=705. The whole `query-history-detail` pane ran from y=545 to y=712, and all three of its actions sat at y 692 to 712:

```
Group,  {{615, 545}, {28x, 167}}, identifier: 'query-history-detail'
Button, {{625, 692}, {4x,  20}}, identifier: 'query-history-copy'
Button, {{683, 692}, {1xx, 20}}, identifier: 'query-history-run-in-new-tab'
Button, {{792, 692}, {93,  20}}, identifier: 'query-history-load-in-editor'
```

The drawer was laid out 7pt taller than the window, so the click on a button straddling the edge did nothing. The two TextViews present confirm it: the editor carried no value at all, and only the drawer's preview held the marker, so the count was 1 rather than 2.

The drawer got that geometry from a previous test in its shard. `NSSplitView.autosaveName` and `NSWindow` frame autosave both write into the app process's standard defaults domain, and the UI test sandbox does not redirect that one: it redirects `applicationSupportRoot` and hands out its own `UserDefaults(suiteName:)`, and these records land in neither. So a divider position, a pane width or a window frame set by one case is inherited by every case after it in the same shard. CI shards by list position (`runnable[index::count]`), so the two UI cases this PR adds re-dealt every later case: this one moved from shard 2 to shard 1 and woke up with a different case's geometry.

`SplitViewAutosaveName` namespaces every autosave record per sandbox, at the three places that assign one: the window split, `AutosavingSplitView` (which is what the history drawer's own list/detail divider uses) and `NSWindow.applyAutosaveName`. Production keeps the bare names, so no saved width, divider or frame a real user has is touched. A test asserts the namespacing and that all three call sites go through it, so a fourth autosave name added later cannot quietly reintroduce the leak.

## The pane's margins and rhythm

Reported after the first pass: the gap either side of a field was too wide and the fields did not
separate. Both measured true at the 270pt minimum.

`listStyle(.inset)` spends a hard 16pt per side before `listRowInsets` is consulted, and the
shipped `listRowInsets(8/6)` stacked on top, so rows sat at 24/22 while this pane's own header sat
at 10 and its filter bar at 8. Three edges in one pane, 46pt of 270 spent on margin. Vertically the
rendered gaps were 2pt from a label to its value and 5pt from one field to the next: only 3pt of
difference, which is why the fields read as one stack.

The macOS HIG publishes no point values for margins or spacing. That was checked across its layout,
sidebars, panels, split-views, lists-and-tables, windows and toolbars pages and came back empty, so
the numbers come from what Apple and the AppKit database clients actually ship, measured by an
accessibility walk and by decoding their nibs:

| surface | inset |
| --- | --- |
| System Settings, 232pt pane | 10/10 |
| TablePlus row inspector | 10/10 |
| Postico 2 row view | 7/7 |
| Xcode inspector chrome | 7/7 |
| Finder Get Info, 265pt | 13/13 |

10 is where three independent sources converge, and System Settings is the closest shape: its
search field and its list rows share one edge, exactly as this pane's filter bar and rows should.
It is also already the header's own inset and the assistant's that shares the split item.

`InspectorMetrics` holds it once. The list moves to `.plain`, whose inset is half of
`intercellSpacing` (measured 8/9) and can therefore be corrected onto the edge; `.inset` cannot be,
which is where the 24 came from. A native list contributes no vertical gap at all
(`NSTableView.intercellSpacing.height` is 0, and SwiftUI's macOS List has no row spacing), so the
whole inter-field gap now lives in the row and nowhere else: splitting it across both is what made
a nominal 8 arrive as 12 to 14. Measured after: every surface at 10.0, content 250pt against 224,
label to value 4pt against field to field 11pt.

`TableInfoView` shares this pane and was the worst of it at 30pt. That is `Form(.formStyle(.grouped))`'s
own inset, and it is not negotiable: measured, it holds at 250, 270, 300, 340, 420 and 600pt. It
left a 116pt value column, so the collation truncated on most engines (`SQL_Latin1_General_CP1_CI_AS`
needs 196pt) and the row already carried a `.help` tooltip working around it. Its sections are drawn
directly now, on the same 10pt edge, and a value that still does not fit wraps instead of eliding,
which is what Finder's Get Info does at this width.

One claim deliberately not made: this does not fit a 32-character value. At the default Data Grid
font that needs 257pt plus the editor's bezel, so it is unreachable at 270pt at any inset and a
36-character UUID still belongs in the pop-out. What it does fix is the 29-character `timestamptz`,
which now reads whole.

## Review

Reviewed by Codex, twice. It found the truncation flag being derived from user-editable text (an ordinary blob could be locked read-only for good by pasting an ellipsis into it), the same defeatable guard in the pop-out editor, a docs sentence that promised full visibility at the minimum width when the Data Grid Font setting goes to 18pt, an `isTruncated` computed property that re-materialized a multi-megabyte blob on every body pass, and the disabled-field accessibility problem. All five are fixed here; none was dismissed.

## Not in this PR

The docs screenshots at `docs/images/row-details-inspector.png` and `-dark.png` still show the old layout and need retaking. I could not capture them here: this grid draws its cells rather than mounting views, and synthetic clicks from `osascript` do not reach it, which is why the UI tests click a point offset from the grid element instead.

https://claude.ai/code/session_012uFmqwYUhaBACJ6fzMVmT3
