### PR TITLE
feat(connections): show what a connection's transport is carrying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Field search and an edited-fields-only filter in the inspector.
 - Table and row position at the top of the inspector.
 - Sort direction setting for the data grid, applied to the default row sort and to the first click on a column header. (#2665)
+- Transport activity under the connection switcher: bytes carried, and live throughput on an SSH tunnel or SOCKS proxy.
 
 ### Changed
 

--- a/TablePro/Core/SOCKS/SOCKSProxyManager.swift
+++ b/TablePro/Core/SOCKS/SOCKSProxyManager.swift
@@ -47,6 +47,11 @@ actor SOCKSProxyManager: TunnelManaging {
         let listener: NWListener
         let localPort: Int
         var relays: [UUID: RelayPair] = [:]
+
+        /// Shared by every relay pair the listener accepts, so the readout describes the proxy
+        /// rather than one of the sockets through it. Held here, which is what makes the totals
+        /// vanish with the tunnel the registry only points at weakly.
+        let byteCounter = TransportByteCounter()
     }
 
     private var tunnels: [UUID: TunnelState] = [:]
@@ -98,7 +103,9 @@ actor SOCKSProxyManager: TunnelManaging {
         }
 
         let localPort = try await Self.startListener(listener)
-        tunnels[connectionId] = TunnelState(listener: listener, localPort: localPort)
+        let state = TunnelState(listener: listener, localPort: localPort)
+        tunnels[connectionId] = state
+        TransportActivityRegistry.shared.register(state.byteCounter, for: connectionId)
         updateAppNapState()
         Self.logger.info("SOCKS proxy tunnel ready for \(connectionId.uuidString, privacy: .public) on 127.0.0.1:\(localPort)")
         return localPort
@@ -160,7 +167,7 @@ actor SOCKSProxyManager: TunnelManaging {
         targetHost: String,
         targetPort: Int
     ) {
-        guard tunnels[connectionId] != nil else {
+        guard let byteCounter = tunnels[connectionId]?.byteCounter else {
             inbound.cancel()
             return
         }
@@ -179,7 +186,7 @@ actor SOCKSProxyManager: TunnelManaging {
         }
         inbound.start(queue: Self.networkQueue)
 
-        Task { [connectTimeout] in
+        Task { [connectTimeout, byteCounter] in
             do {
                 try await Self.waitUntilReady(outbound, timeout: connectTimeout, proxyHost: config.host, proxyPort: config.port)
                 outbound.stateUpdateHandler = { [weak self] state in
@@ -199,8 +206,8 @@ actor SOCKSProxyManager: TunnelManaging {
                     guard bothFinished else { return }
                     Task { await self?.removeRelay(connectionId: connectionId, relayId: relayId) }
                 }
-                Self.pump(inbound, into: outbound, onFinished: onDirectionFinished)
-                Self.pump(outbound, into: inbound, onFinished: onDirectionFinished)
+                Self.pump(inbound, into: outbound, record: byteCounter.recordSent, onFinished: onDirectionFinished)
+                Self.pump(outbound, into: inbound, record: byteCounter.recordReceived, onFinished: onDirectionFinished)
             } catch {
                 Self.logger.warning("SOCKS relay setup failed for \(connectionId.uuidString, privacy: .public): \(error.localizedDescription)")
                 await self.removeRelay(connectionId: connectionId, relayId: relayId)
@@ -367,13 +374,19 @@ actor SOCKSProxyManager: TunnelManaging {
         }
     }
 
+    /// `record` is what makes one call of this recursion a direction: the pair that carries the
+    /// client's bytes towards the proxy passes `recordSent`, the pair coming back passes
+    /// `recordReceived`. The connection ids are not in scope here, and threading one in would name
+    /// the tunnel rather than the direction, which is the half the caller already knows.
     private static func pump(
         _ source: NWConnection,
         into destination: NWConnection,
+        record: @escaping @Sendable (Int) -> Void,
         onFinished: @escaping @Sendable () -> Void
     ) {
         source.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { data, _, isComplete, error in
             if let data, !data.isEmpty {
+                record(data.count)
                 destination.send(content: data, completion: .contentProcessed { sendError in
                     guard sendError == nil else {
                         source.cancel()
@@ -386,7 +399,7 @@ actor SOCKSProxyManager: TunnelManaging {
                         onFinished()
                         return
                     }
-                    pump(source, into: destination, onFinished: onFinished)
+                    pump(source, into: destination, record: record, onFinished: onFinished)
                 })
                 return
             }
@@ -401,7 +414,7 @@ actor SOCKSProxyManager: TunnelManaging {
                 onFinished()
                 return
             }
-            pump(source, into: destination, onFinished: onFinished)
+            pump(source, into: destination, record: record, onFinished: onFinished)
         }
     }
 }

--- a/TablePro/Core/SSH/LibSSH2Tunnel.swift
+++ b/TablePro/Core/SSH/LibSSH2Tunnel.swift
@@ -46,6 +46,11 @@ internal final class LibSSH2Tunnel: @unchecked Sendable {
 
     private let forwardFailure = SSHForwardFailureRecorder()
 
+    /// Shared by every client relay this tunnel serves, so the readout describes the tunnel rather
+    /// than whichever socket the driver happens to be using. Owned here and registered weakly, so
+    /// the totals disappear with the tunnel instead of outliving it.
+    private let byteCounter = TransportByteCounter()
+
     struct JumpHop {
         let session: OpaquePointer    // LIBSSH2_SESSION*
         let socket: Int32             // TCP or socketpair fd
@@ -93,6 +98,7 @@ internal final class LibSSH2Tunnel: @unchecked Sendable {
             label: "com.TablePro.ssh.accept.\(connectionId.uuidString)",
             qos: .utility
         )
+        TransportActivityRegistry.shared.register(byteCounter, for: connectionId)
     }
 
     var isRunning: Bool {
@@ -392,7 +398,8 @@ internal final class LibSSH2Tunnel: @unchecked Sendable {
             transportFD: socketFD,
             channelIO: LibSSH2ChannelIO(channel: channel, session: session, sessionQueue: sessionQueue),
             bufferSize: Self.relayBufferSize,
-            isActive: { [weak self] in self?.isRunning ?? false }
+            isActive: { [weak self] in self?.isRunning ?? false },
+            byteCounter: byteCounter
         )
 
         let startedAt = Date()

--- a/TablePro/Core/SSH/SSHChannelRelay.swift
+++ b/TablePro/Core/SSH/SSHChannelRelay.swift
@@ -51,6 +51,11 @@ internal struct SSHChannelRelay {
     let bufferSize: Int
     let isActive: () -> Bool
 
+    /// Counts what crosses this relay, for the connection activity readout. Absent for a jump hop,
+    /// whose relay carries the same payload a second time on its way to the next hop: counting both
+    /// would report every byte twice for a connection that goes through a bastion.
+    var byteCounter: TransportByteCounter?
+
     private static let pollTimeoutMs: Int32 = 500
     private static let writeWaitTimeoutMs: Int32 = 1_000
 
@@ -116,6 +121,7 @@ internal struct SSHChannelRelay {
     private func pumpChannelToLocal(_ buffer: UnsafeMutablePointer<CChar>, transportReadable: Bool) -> PumpOutcome {
         switch channelIO.read(into: buffer, count: bufferSize) {
         case .bytes(let count):
+            byteCounter?.recordReceived(count)
             var totalSent = 0
             while totalSent < count {
                 let sent = send(localFD, buffer.advanced(by: totalSent), count - totalSent, 0)
@@ -134,6 +140,7 @@ internal struct SSHChannelRelay {
     private func pumpLocalToChannel(_ buffer: UnsafeMutablePointer<CChar>) -> PumpOutcome {
         let localRead = recv(localFD, buffer, bufferSize, 0)
         if localRead <= 0 { return .localClosed }
+        byteCounter?.recordSent(localRead)
 
         var totalWritten = 0
         while totalWritten < Int(localRead) {

--- a/TablePro/Core/Services/Formatting/ByteSizeFormatting.swift
+++ b/TablePro/Core/Services/Formatting/ByteSizeFormatting.swift
@@ -21,6 +21,14 @@ internal enum ByteSizeFormatting {
         string(bytes: Int64(clamping: bytes))
     }
 
+    /// A throughput figure, rendered as the size per second: "142 KB/s". Rounded to whole bytes
+    /// first, because the size formatter takes an integer and a rate never arrives as one.
+    internal static func string(bytesPerSecond: Double) -> String {
+        let rounded = bytesPerSecond.rounded()
+        guard rounded.isFinite, rounded >= 0, rounded < Double(Int64.max) else { return "" }
+        return String(format: String(localized: "%@/s"), string(bytes: Int64(rounded)))
+    }
+
     /// Returns the input unchanged when it is not a number, because several servers report
     /// these values as opaque strings. `Double` parses "inf", "nan" and values past `Int64.max`,
     /// all of which trap on conversion, so a server reporting one of those has to fall through to

--- a/TablePro/Core/Transport/ConnectionTransportActivity.swift
+++ b/TablePro/Core/Transport/ConnectionTransportActivity.swift
@@ -1,0 +1,56 @@
+//
+//  ConnectionTransportActivity.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Everything the connection activity readout says about one connection, resolved in one place so
+/// the view has nothing left to decide.
+struct ConnectionTransportActivity: Equatable {
+    let transportName: String
+    let totals: TransportByteTotals?
+    let rate: TransportRate?
+
+    /// Whether a figure exists at all. False both for a transport whose bytes the app never sees
+    /// and for a measurable one that has not opened yet, which the readout treats the same way:
+    /// it names the transport and shows no number, rather than showing a zero that reads as a
+    /// connection carrying nothing.
+    var isMeasured: Bool {
+        totals != nil
+    }
+
+    /// Shown only while something is moving. An idle rate is "0 B/s", which says a connection is
+    /// broken rather than quiet, and the totals beside it already carry the honest answer.
+    var displayedRate: TransportRate? {
+        guard let rate, !rate.isIdle else { return nil }
+        return rate
+    }
+}
+
+enum ConnectionTransportActivityResolver {
+    /// A connection whose transport the app cannot count is resolved with `totals` nil whatever the
+    /// registry holds, so a stale entry from an earlier transport on the same connection id can
+    /// never be attributed to this one.
+    static func resolve(
+        tunnelKind: ConnectionTunnelKind?,
+        totals: TransportByteTotals?,
+        rate: TransportRate?
+    ) -> ConnectionTransportActivity {
+        guard let tunnelKind else {
+            return ConnectionTransportActivity(
+                transportName: ConnectionTunnelKind.directDisplayName,
+                totals: nil,
+                rate: nil
+            )
+        }
+        guard tunnelKind.carriesMeasuredBytes else {
+            return ConnectionTransportActivity(transportName: tunnelKind.displayName, totals: nil, rate: nil)
+        }
+        return ConnectionTransportActivity(
+            transportName: tunnelKind.displayName,
+            totals: totals,
+            rate: totals == nil ? nil : rate
+        )
+    }
+}

--- a/TablePro/Core/Transport/TransportActivityRegistry.swift
+++ b/TablePro/Core/Transport/TransportActivityRegistry.swift
@@ -1,0 +1,48 @@
+//
+//  TransportActivityRegistry.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+/// The one place that answers what a connection's transport is carrying.
+///
+/// A transport is built by its own manager, on its own actor, and the surface that reports it is on
+/// the main actor, so asking each manager in turn would mean an actor hop per transport per sample.
+/// The registry is a plain lock-guarded table instead, which the readout can read synchronously
+/// while it is on screen.
+///
+/// Entries are held weakly, and the transport itself owns its counter. That is what makes teardown
+/// impossible to get wrong: a tunnel that dies, is closed, or is replaced by a reconnect takes its
+/// counter with it and the entry becomes absent on its own. An explicit `unregister` would have to
+/// be called from every one of those paths, and the one that was missed would report a dead
+/// tunnel's totals as the live connection's.
+final class TransportActivityRegistry: Sendable {
+    static let shared = TransportActivityRegistry()
+
+    private struct Entry {
+        weak var counter: TransportByteCounter?
+    }
+
+    private let entries = OSAllocatedUnfairLock(initialState: [UUID: Entry]())
+
+    init() {}
+
+    /// Registering is also when the table is swept, so an entry whose transport has gone costs one
+    /// dictionary slot until the next transport opens rather than until the app quits.
+    func register(_ counter: TransportByteCounter, for connectionId: UUID) {
+        entries.withLock { table in
+            table = table.filter { $0.value.counter != nil }
+            table[connectionId] = Entry(counter: counter)
+        }
+    }
+
+    func totals(for connectionId: UUID) -> TransportByteTotals? {
+        entries.withLock { $0[connectionId]?.counter?.totals }
+    }
+
+    var measuredConnectionIds: Set<UUID> {
+        entries.withLock { Set($0.filter { $0.value.counter != nil }.keys) }
+    }
+}

--- a/TablePro/Core/Transport/TransportByteCounter.swift
+++ b/TablePro/Core/Transport/TransportByteCounter.swift
@@ -1,0 +1,46 @@
+//
+//  TransportByteCounter.swift
+//  TablePro
+//
+
+import Foundation
+import os
+
+/// Bytes a connection's transport has carried since it was opened, in each direction.
+///
+/// Totals rather than a rate, because a total is the only figure that stays true whatever the
+/// sampling interval is. The rate is derived from two of these by `TransportRateSampler`, which
+/// divides by the interval it actually measured rather than by the one it asked for.
+struct TransportByteTotals: Equatable, Sendable {
+    var received: UInt64
+    var sent: UInt64
+
+    static let zero = TransportByteTotals(received: 0, sent: 0)
+}
+
+/// Accumulates the bytes crossing one connection's transport.
+///
+/// A tunnel serves every client socket the driver opens, each on its own task of a concurrent
+/// queue, so the counter is shared and has to be safe against concurrent increments. The lock is
+/// the same primitive `LibSSH2Tunnel` already holds its client tasks behind, and the increment is
+/// the whole cost: the byte count is already a plain `Int` in the caller's hand the instant the
+/// read returns, so nothing here reads the clock or makes a syscall.
+final class TransportByteCounter: Sendable {
+    private let state = OSAllocatedUnfairLock(initialState: TransportByteTotals.zero)
+
+    init() {}
+
+    var totals: TransportByteTotals {
+        state.withLock { $0 }
+    }
+
+    func recordReceived(_ count: Int) {
+        guard count > 0 else { return }
+        state.withLock { $0.received &+= UInt64(count) }
+    }
+
+    func recordSent(_ count: Int) {
+        guard count > 0 else { return }
+        state.withLock { $0.sent &+= UInt64(count) }
+    }
+}

--- a/TablePro/Core/Transport/TransportRateSampler.swift
+++ b/TablePro/Core/Transport/TransportRateSampler.swift
@@ -1,0 +1,60 @@
+//
+//  TransportRateSampler.swift
+//  TablePro
+//
+
+import Foundation
+
+struct TransportRate: Equatable, Sendable {
+    let receivedPerSecond: Double
+    let sentPerSecond: Double
+
+    static let zero = TransportRate(receivedPerSecond: 0, sentPerSecond: 0)
+
+    /// Below a byte a second in both directions there is nothing to report, and a rate that rounds
+    /// to "0 B/s" is worse than no rate at all: it reads as a broken connection rather than an idle
+    /// one. The readout shows the totals in that case, which stay true whether or not anything is
+    /// moving right now.
+    var isIdle: Bool {
+        receivedPerSecond < 1 && sentPerSecond < 1
+    }
+}
+
+/// Turns two readings of a `TransportByteCounter` into a rate.
+///
+/// It divides by the interval it actually measured rather than the one the caller asked for, so a
+/// sampler the run loop kept waiting reports the rate over the time that really passed. Holding the
+/// baseline here rather than in the view is what lets the arithmetic be tested without a clock.
+struct TransportRateSampler {
+    private var previousTotals: TransportByteTotals?
+    private var previousInstant: ContinuousClock.Instant?
+
+    init() {}
+
+    /// Returns nil for the first reading, which has nothing to be measured against, and for a
+    /// counter that went backwards, which means a reconnect installed a fresh transport. Both
+    /// re-baseline, so the next reading measures against the new one instead of reporting the whole
+    /// of a new tunnel's traffic as one interval's worth.
+    mutating func sample(_ totals: TransportByteTotals, at instant: ContinuousClock.Instant) -> TransportRate? {
+        defer {
+            previousTotals = totals
+            previousInstant = instant
+        }
+
+        guard let previousTotals, let previousInstant else { return nil }
+        guard totals.received >= previousTotals.received, totals.sent >= previousTotals.sent else { return nil }
+
+        let elapsed = Self.seconds(previousInstant.duration(to: instant))
+        guard elapsed > 0 else { return nil }
+
+        return TransportRate(
+            receivedPerSecond: Double(totals.received - previousTotals.received) / elapsed,
+            sentPerSecond: Double(totals.sent - previousTotals.sent) / elapsed
+        )
+    }
+
+    private static func seconds(_ duration: Duration) -> Double {
+        let components = duration.components
+        return Double(components.seconds) + Double(components.attoseconds) / 1e18
+    }
+}

--- a/TablePro/Models/Connection/ConnectionTunnelKind.swift
+++ b/TablePro/Models/Connection/ConnectionTunnelKind.swift
@@ -61,6 +61,22 @@ enum ConnectionTunnelKind: String, CaseIterable, Sendable {
         }
     }
 
+    /// Whether TablePro's own Swift code carries this transport's bytes, and can therefore count
+    /// them for the connection activity readout.
+    ///
+    /// The three subprocess transports run someone else's binary, which owns its socket from end to
+    /// end; TablePro reads their standard error for a readiness line and never sees a payload byte.
+    /// Remote Database File measures nothing per query by construction: it fetches the file once and
+    /// the driver then reads a local copy, so there is no wire traffic left to describe. A direct
+    /// connection has no case here at all, and is handled as the absence of one: its socket belongs
+    /// to the driver's own C library, inside the plugin.
+    var carriesMeasuredBytes: Bool {
+        switch self {
+        case .ssh, .socksProxy: return true
+        case .cloudflare, .cloudSQLProxy, .tunnelCommand, .remoteFile: return false
+        }
+    }
+
     /// The connection form's label for reaching the database with no transport in between.
     static var directDisplayName: String {
         String(localized: "Direct")

--- a/TablePro/Views/Toolbar/ConnectionActivityFooter.swift
+++ b/TablePro/Views/Toolbar/ConnectionActivityFooter.swift
@@ -1,0 +1,145 @@
+//
+//  ConnectionActivityFooter.swift
+//  TablePro
+//
+
+import SwiftUI
+
+/// What the connection the window is on is carrying, under the list of connections it could switch
+/// to. Totals first with the rate parenthetical beside the direction it belongs to, which is the
+/// shape Safari's downloads popover uses: a total stays true whatever the sampling interval is, and
+/// a rate that is only shown while something moves never reads as a broken connection.
+///
+/// The sampling runs on this view's own `task`, so nothing computes a rate while the popover is
+/// closed. The counters underneath keep running, but they are one increment on a byte count the
+/// transport already had in hand.
+struct ConnectionActivityFooter: View {
+    let connection: DatabaseConnection?
+
+    @State private var sampler = TransportRateSampler()
+    @State private var activity: ConnectionTransportActivity?
+
+    private static let sampleInterval = Duration.seconds(1)
+
+    /// The sampling task hangs off an `if`/`else`, never a `Group`: a modifier on a `Group` is
+    /// applied to each of its children, so an empty one carries the task nowhere and the first
+    /// reading is never taken.
+    var body: some View {
+        content
+            .task(id: connection?.id) {
+                await sampleUntilCancelled()
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let activity {
+            row(activity)
+        } else {
+            Color.clear.frame(height: 0)
+        }
+    }
+
+    private func row(_ activity: ConnectionTransportActivity) -> some View {
+        HStack(spacing: 8) {
+            Text(activity.transportName)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .accessibilityIdentifier("connection-activity-transport")
+
+            Spacer(minLength: 8)
+
+            if let totals = activity.totals {
+                direction(
+                    symbol: "arrow.down",
+                    label: String(localized: "Received"),
+                    bytes: totals.received,
+                    bytesPerSecond: activity.displayedRate?.receivedPerSecond
+                )
+                direction(
+                    symbol: "arrow.up",
+                    label: String(localized: "Sent"),
+                    bytes: totals.sent,
+                    bytesPerSecond: activity.displayedRate?.sentPerSecond
+                )
+            }
+        }
+        .font(.caption)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .help(helpText(activity))
+    }
+
+    /// Tabular figures, so a rate that changes every second does not shuffle the text beside it.
+    /// Postico shipped that same fix for its elapsed-time readout.
+    private func direction(symbol: String, label: String, bytes: UInt64, bytesPerSecond: Double?) -> some View {
+        HStack(spacing: 3) {
+            Image(systemName: symbol)
+                .imageScale(.small)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel(label)
+
+            Text(ByteSizeFormatting.string(bytes: bytes))
+
+            if let bytesPerSecond {
+                Text(ByteSizeFormatting.string(bytesPerSecond: bytesPerSecond))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .monospacedDigit()
+        .lineLimit(1)
+    }
+
+    private func helpText(_ activity: ConnectionTransportActivity) -> String {
+        guard activity.isMeasured else {
+            return String(localized: "Throughput is measured for SSH tunnels and SOCKS proxies, the transports TablePro carries the bytes for itself.")
+        }
+        return String(localized: "Bytes carried since the transport opened.")
+    }
+
+    private func sampleUntilCancelled() async {
+        guard let connection else {
+            activity = nil
+            return
+        }
+
+        sampler = TransportRateSampler()
+        publish(resolve(connection, totals: totals(of: connection), rate: nil))
+
+        /// A transport whose bytes the app never sees has one reading and no second one to take,
+        /// so the loop would wake every second to resolve the same row forever.
+        guard connection.activeTunnelKind?.carriesMeasuredBytes == true else { return }
+
+        while !Task.isCancelled {
+            try? await Task.sleep(for: Self.sampleInterval)
+            guard !Task.isCancelled else { return }
+
+            let totals = totals(of: connection)
+            let rate = totals.flatMap { sampler.sample($0, at: .now) }
+            publish(resolve(connection, totals: totals, rate: rate))
+        }
+    }
+
+    /// An idle transport resolves to the same row every second, and writing it back rebuilds the
+    /// footer each time for no change on screen.
+    private func publish(_ next: ConnectionTransportActivity) {
+        guard next != activity else { return }
+        activity = next
+    }
+
+    private func totals(of connection: DatabaseConnection) -> TransportByteTotals? {
+        TransportActivityRegistry.shared.totals(for: connection.id)
+    }
+
+    private func resolve(
+        _ connection: DatabaseConnection,
+        totals: TransportByteTotals?,
+        rate: TransportRate?
+    ) -> ConnectionTransportActivity {
+        ConnectionTransportActivityResolver.resolve(
+            tunnelKind: connection.activeTunnelKind,
+            totals: totals,
+            rate: rate
+        )
+    }
+}

--- a/TablePro/Views/Toolbar/ConnectionSwitcherPopover.swift
+++ b/TablePro/Views/Toolbar/ConnectionSwitcherPopover.swift
@@ -61,6 +61,13 @@ struct ConnectionSwitcherPopover: View {
         DatabaseManager.shared.lastActiveSessionId
     }
 
+    /// The connection the window that opened this popover is on, which is the one the activity
+    /// footer describes. Absent while the window is between connections, where the footer draws
+    /// nothing rather than a row about no transport.
+    private var currentConnection: DatabaseConnection? {
+        currentSessionId.flatMap { activeSessions[$0]?.connection }
+    }
+
     private var sortedSessions: [ConnectionSession] {
         Array(activeSessions.values).sorted { $0.lastActiveAt > $1.lastActiveAt }
     }
@@ -122,6 +129,10 @@ struct ConnectionSwitcherPopover: View {
             Divider()
 
             content
+
+            Divider()
+
+            ConnectionActivityFooter(connection: currentConnection)
 
             Divider()
 

--- a/TableProTests/Core/SSH/SSHChannelRelayTests.swift
+++ b/TableProTests/Core/SSH/SSHChannelRelayTests.swift
@@ -139,6 +139,65 @@ struct SSHChannelRelayTests {
         #expect(io.written == payload)
     }
 
+    @Test("Channel data counts as received")
+    func countsChannelDataAsReceived() {
+        let local = SocketPair()
+        let transport = SocketPair()
+        defer { local.close(); transport.close() }
+
+        let payload = Data("hello".utf8)
+        var dummy: UInt8 = 1
+        _ = Darwin.send(transport.b, &dummy, 1, 0)
+
+        let counter = TransportByteCounter()
+        let io = FakeChannelIO(actions: [.data(payload)], fallback: .closed)
+        let result = runRelay(localFD: local.a, transportFD: transport.a, io: io, byteCounter: counter)
+
+        #expect(result == .channelClosed)
+        #expect(counter.totals == TransportByteTotals(received: UInt64(payload.count), sent: 0))
+    }
+
+    @Test("Local data counts as sent")
+    func countsLocalDataAsSent() {
+        let local = SocketPair()
+        let transport = SocketPair()
+        defer { local.close(); transport.close() }
+
+        let payload = Data("world".utf8)
+        payload.withUnsafeBytes { raw in
+            _ = Darwin.send(local.b, raw.baseAddress, raw.count, 0)
+        }
+
+        let counter = TransportByteCounter()
+        let io = FakeChannelIO(fallback: .wouldBlock)
+        let result = runRelay(
+            localFD: local.a,
+            transportFD: transport.a,
+            io: io,
+            isActive: io.activeUntilWritten(payload.count),
+            byteCounter: counter
+        )
+
+        #expect(result == .cancelled)
+        #expect(counter.totals == TransportByteTotals(received: 0, sent: UInt64(payload.count)))
+    }
+
+    @Test("A relay with no counter still runs")
+    func runsWithoutACounter() {
+        let local = SocketPair()
+        let transport = SocketPair()
+        defer { local.close(); transport.close() }
+
+        let payload = Data("hello".utf8)
+        var dummy: UInt8 = 1
+        _ = Darwin.send(transport.b, &dummy, 1, 0)
+
+        let io = FakeChannelIO(actions: [.data(payload)], fallback: .closed)
+        let result = runRelay(localFD: local.a, transportFD: transport.a, io: io)
+
+        #expect(result == .channelClosed)
+    }
+
     @Test("Concurrent relays sharing one transport each receive their own channel data")
     func concurrentRelaysShareTransport() {
         let transport = SocketPair()
@@ -188,6 +247,7 @@ struct SSHChannelRelayTests {
         transportFD: Int32,
         io: FakeChannelIO,
         isActive: @escaping @Sendable () -> Bool = { true },
+        byteCounter: TransportByteCounter? = nil,
         timeout: Double = 3
     ) -> RelayTermination? {
         let box = ResultBox()
@@ -197,7 +257,8 @@ struct SSHChannelRelayTests {
             transportFD: transportFD,
             io: io,
             isActive: isActive,
-            box: box
+            box: box,
+            byteCounter: byteCounter
         ) { semaphore.signal() }
         _ = semaphore.wait(timeout: .now() + timeout)
         return box.value
@@ -214,6 +275,7 @@ internal func runRelayOnDedicatedThread(
     io: any SSHChannelIO,
     isActive: @escaping @Sendable () -> Bool,
     box: ResultBox,
+    byteCounter: TransportByteCounter? = nil,
     onFinish: @escaping @Sendable () -> Void
 ) {
     let thread = Thread {
@@ -222,7 +284,8 @@ internal func runRelayOnDedicatedThread(
             transportFD: transportFD,
             channelIO: io,
             bufferSize: 32_768,
-            isActive: isActive
+            isActive: isActive,
+            byteCounter: byteCounter
         )
         box.value = relay.run()
         onFinish()

--- a/TableProTests/Core/Services/Formatting/ByteSizeFormattingTests.swift
+++ b/TableProTests/Core/Services/Formatting/ByteSizeFormattingTests.swift
@@ -24,6 +24,29 @@ struct ByteSizeFormattingTests {
         #expect(ByteSizeFormatting.string(byteString: "unknown") == "unknown")
     }
 
+    @Test("A rate is the size for that many bytes, per second")
+    func ratesRenderPerSecond() {
+        let rate = ByteSizeFormatting.string(bytesPerSecond: 145_408)
+
+        #expect(rate.hasPrefix(ByteSizeFormatting.string(bytes: Int64(145_408))))
+        #expect(rate.hasSuffix("/s"))
+    }
+
+    @Test("A fractional rate rounds to whole bytes")
+    func ratesRound() {
+        #expect(ByteSizeFormatting.string(bytesPerSecond: 511.6) == ByteSizeFormatting.string(bytesPerSecond: 512))
+    }
+
+    /// A sampler dividing by an interval it measured can produce these, and `Int64(_:)` traps on
+    /// every one of them.
+    @Test("A rate that is not a finite non-negative number renders as nothing")
+    func unrepresentableRatesRenderEmpty() {
+        #expect(ByteSizeFormatting.string(bytesPerSecond: .infinity).isEmpty)
+        #expect(ByteSizeFormatting.string(bytesPerSecond: .nan).isEmpty)
+        #expect(ByteSizeFormatting.string(bytesPerSecond: -1).isEmpty)
+        #expect(ByteSizeFormatting.string(bytesPerSecond: Double(Int64.max)).isEmpty)
+    }
+
     @Test("Durations grow units as they get longer")
     func durationsGrowUnits() {
         let seconds = DurationFormatting.string(seconds: 5)

--- a/TableProTests/Core/Transport/ConnectionTransportActivityTests.swift
+++ b/TableProTests/Core/Transport/ConnectionTransportActivityTests.swift
@@ -1,0 +1,98 @@
+//
+//  ConnectionTransportActivityTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("ConnectionTransportActivity")
+struct ConnectionTransportActivityTests {
+    private let totals = TransportByteTotals(received: 4_096, sent: 1_024)
+
+    @Test("A connection with no transport reads as Direct and carries no figure")
+    func directIsNamedAndUnmeasured() {
+        let activity = ConnectionTransportActivityResolver.resolve(tunnelKind: nil, totals: totals, rate: .zero)
+
+        #expect(activity.transportName == ConnectionTunnelKind.directDisplayName)
+        #expect(activity.totals == nil)
+        #expect(!activity.isMeasured)
+    }
+
+    @Test("An SSH tunnel carries its totals")
+    func sshIsMeasured() {
+        let activity = ConnectionTransportActivityResolver.resolve(tunnelKind: .ssh, totals: totals, rate: nil)
+
+        #expect(activity.transportName == ConnectionTunnelKind.ssh.displayName)
+        #expect(activity.totals == totals)
+        #expect(activity.isMeasured)
+    }
+
+    @Test("A SOCKS proxy carries its totals")
+    func socksIsMeasured() {
+        let activity = ConnectionTransportActivityResolver.resolve(tunnelKind: .socksProxy, totals: totals, rate: nil)
+
+        #expect(activity.totals == totals)
+        #expect(activity.isMeasured)
+    }
+
+    /// The registry is keyed by connection id, and a connection can be reconfigured from SSH to
+    /// Cloudflare without changing that id. Resolving from the kind rather than from whatever the
+    /// table happens to hold is what stops the earlier transport's totals being reported as this
+    /// one's.
+    @Test("A transport the app cannot count shows no figure even when the registry holds one")
+    func subprocessTransportsNeverReportTotals() {
+        for kind in [ConnectionTunnelKind.cloudflare, .cloudSQLProxy, .tunnelCommand, .remoteFile] {
+            let activity = ConnectionTransportActivityResolver.resolve(
+                tunnelKind: kind,
+                totals: totals,
+                rate: TransportRate(receivedPerSecond: 900, sentPerSecond: 100)
+            )
+
+            #expect(activity.transportName == kind.displayName)
+            #expect(activity.totals == nil)
+            #expect(activity.displayedRate == nil)
+            #expect(!activity.isMeasured)
+        }
+    }
+
+    @Test("A measurable transport that has not opened yet shows no figure")
+    func measurableButAbsentCounter() {
+        let activity = ConnectionTransportActivityResolver.resolve(
+            tunnelKind: .ssh,
+            totals: nil,
+            rate: TransportRate(receivedPerSecond: 900, sentPerSecond: 100)
+        )
+
+        #expect(!activity.isMeasured)
+        #expect(activity.displayedRate == nil)
+    }
+
+    /// "0 B/s" reads as a broken connection rather than a quiet one, and the totals beside it
+    /// already carry the honest answer.
+    @Test("An idle rate is withheld while the totals stay")
+    func idleRateIsWithheld() {
+        let activity = ConnectionTransportActivityResolver.resolve(tunnelKind: .ssh, totals: totals, rate: .zero)
+
+        #expect(activity.totals == totals)
+        #expect(activity.displayedRate == nil)
+    }
+
+    @Test("A moving rate is shown")
+    func movingRateIsShown() {
+        let rate = TransportRate(receivedPerSecond: 145_408, sentPerSecond: 2)
+        let activity = ConnectionTransportActivityResolver.resolve(tunnelKind: .ssh, totals: totals, rate: rate)
+
+        #expect(activity.displayedRate == rate)
+    }
+
+    /// Exhaustive on purpose: a transport added without deciding this reports a number it cannot
+    /// measure, or hides one it can.
+    @Test("Every tunnel kind declares whether its bytes are measured")
+    func everyKindDeclaresMeasurability() {
+        let measured = ConnectionTunnelKind.allCases.filter(\.carriesMeasuredBytes)
+
+        #expect(Set(measured) == Set([.ssh, .socksProxy]))
+    }
+}

--- a/TableProTests/Core/Transport/TransportActivityRegistryTests.swift
+++ b/TableProTests/Core/Transport/TransportActivityRegistryTests.swift
@@ -1,0 +1,110 @@
+//
+//  TransportActivityRegistryTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("TransportActivityRegistry")
+struct TransportActivityRegistryTests {
+    @Test("A counter reports its totals through the registry")
+    func readsBackTheTotals() {
+        let registry = TransportActivityRegistry()
+        let connectionId = UUID()
+        let counter = TransportByteCounter()
+        registry.register(counter, for: connectionId)
+
+        counter.recordReceived(4_096)
+        counter.recordSent(1_024)
+
+        #expect(registry.totals(for: connectionId) == TransportByteTotals(received: 4_096, sent: 1_024))
+    }
+
+    @Test("A connection with no transport has no totals")
+    func unknownConnectionHasNothing() {
+        #expect(TransportActivityRegistry().totals(for: UUID()) == nil)
+    }
+
+    /// The transport owns its counter and the registry only points at it, so teardown needs no call
+    /// of its own. An explicit unregister would have to be made from tunnel close, tunnel death and
+    /// reconnect alike, and the one that was missed would report a dead tunnel's totals as the live
+    /// connection's.
+    @Test("Totals disappear when the transport that owned the counter goes")
+    func releasingTheCounterClearsTheEntry() {
+        let registry = TransportActivityRegistry()
+        let connectionId = UUID()
+
+        do {
+            let counter = TransportByteCounter()
+            registry.register(counter, for: connectionId)
+            counter.recordReceived(512)
+            #expect(registry.totals(for: connectionId) != nil)
+        }
+
+        #expect(registry.totals(for: connectionId) == nil)
+        #expect(!registry.measuredConnectionIds.contains(connectionId))
+    }
+
+    @Test("Registering again replaces the previous transport's counter")
+    func reconnectReplacesTheCounter() {
+        let registry = TransportActivityRegistry()
+        let connectionId = UUID()
+
+        let first = TransportByteCounter()
+        registry.register(first, for: connectionId)
+        first.recordReceived(9_000)
+
+        let second = TransportByteCounter()
+        registry.register(second, for: connectionId)
+        second.recordReceived(10)
+
+        #expect(registry.totals(for: connectionId) == TransportByteTotals(received: 10, sent: 0))
+    }
+
+    @Test("Two connections keep separate totals")
+    func connectionsAreIndependent() {
+        let registry = TransportActivityRegistry()
+        let first = UUID()
+        let second = UUID()
+        let firstCounter = TransportByteCounter()
+        let secondCounter = TransportByteCounter()
+        registry.register(firstCounter, for: first)
+        registry.register(secondCounter, for: second)
+
+        firstCounter.recordReceived(100)
+        secondCounter.recordSent(200)
+
+        #expect(registry.totals(for: first) == TransportByteTotals(received: 100, sent: 0))
+        #expect(registry.totals(for: second) == TransportByteTotals(received: 0, sent: 200))
+    }
+
+    @Test("A non-positive count is not recorded")
+    func ignoresEmptyReads() {
+        let counter = TransportByteCounter()
+        counter.recordReceived(0)
+        counter.recordSent(-1)
+
+        #expect(counter.totals == .zero)
+    }
+
+    /// One tunnel serves every client socket the driver opens, each relayed on its own task of a
+    /// concurrent queue, so the increments genuinely race.
+    @Test("Concurrent increments from many relays all land")
+    func concurrentIncrementsAllLand() {
+        let counter = TransportByteCounter()
+        let relays = 8
+        let perRelay = 1_000
+
+        DispatchQueue.concurrentPerform(iterations: relays) { _ in
+            for _ in 0..<perRelay {
+                counter.recordReceived(4)
+                counter.recordSent(1)
+            }
+        }
+
+        #expect(counter.totals.received == UInt64(relays * perRelay * 4))
+        #expect(counter.totals.sent == UInt64(relays * perRelay))
+    }
+}

--- a/TableProTests/Core/Transport/TransportRateSamplerTests.swift
+++ b/TableProTests/Core/Transport/TransportRateSamplerTests.swift
@@ -1,0 +1,107 @@
+//
+//  TransportRateSamplerTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("TransportRateSampler")
+struct TransportRateSamplerTests {
+    private let start = ContinuousClock.now
+
+    @Test("The first reading has nothing to measure against")
+    func firstReadingHasNoRate() {
+        var sampler = TransportRateSampler()
+
+        #expect(sampler.sample(TransportByteTotals(received: 1_000, sent: 500), at: start) == nil)
+    }
+
+    @Test("A rate is the delta over the interval that actually elapsed")
+    func measuresOverTheElapsedInterval() {
+        var sampler = TransportRateSampler()
+        _ = sampler.sample(TransportByteTotals(received: 1_000, sent: 500), at: start)
+
+        let rate = sampler.sample(
+            TransportByteTotals(received: 5_000, sent: 700),
+            at: start.advanced(by: .seconds(2))
+        )
+
+        #expect(rate?.receivedPerSecond == 2_000)
+        #expect(rate?.sentPerSecond == 100)
+    }
+
+    /// A sampler the run loop kept waiting must divide by the time that passed, not by the one it
+    /// asked for, or a late sample overstates the rate by exactly how late it was.
+    @Test("A late sample reports the rate over its own longer interval")
+    func lateSampleDividesByItsOwnInterval() {
+        var sampler = TransportRateSampler()
+        _ = sampler.sample(.zero, at: start)
+
+        let rate = sampler.sample(
+            TransportByteTotals(received: 8_000, sent: 0),
+            at: start.advanced(by: .seconds(4))
+        )
+
+        #expect(rate?.receivedPerSecond == 2_000)
+    }
+
+    @Test("Sub-second intervals scale up")
+    func subSecondInterval() {
+        var sampler = TransportRateSampler()
+        _ = sampler.sample(.zero, at: start)
+
+        let rate = sampler.sample(
+            TransportByteTotals(received: 250, sent: 0),
+            at: start.advanced(by: .milliseconds(500))
+        )
+
+        #expect(rate?.receivedPerSecond == 500)
+    }
+
+    /// A reconnect installs a fresh transport with a counter at zero. Measuring against the dead
+    /// one's totals would make the next reading negative, and the one after it report a whole new
+    /// tunnel's traffic as a single interval's worth.
+    @Test("A counter that went backwards re-baselines instead of reporting a rate")
+    func rebaselinesAfterAReset() {
+        var sampler = TransportRateSampler()
+        _ = sampler.sample(TransportByteTotals(received: 10_000, sent: 4_000), at: start)
+
+        let afterReset = sampler.sample(.zero, at: start.advanced(by: .seconds(1)))
+        #expect(afterReset == nil)
+
+        let next = sampler.sample(
+            TransportByteTotals(received: 300, sent: 0),
+            at: start.advanced(by: .seconds(2))
+        )
+        #expect(next?.receivedPerSecond == 300)
+    }
+
+    @Test("Two readings at the same instant report no rate")
+    func zeroElapsedReportsNothing() {
+        var sampler = TransportRateSampler()
+        _ = sampler.sample(.zero, at: start)
+
+        #expect(sampler.sample(TransportByteTotals(received: 100, sent: 0), at: start) == nil)
+    }
+
+    @Test("An unchanged counter reports an idle rate")
+    func unchangedCounterIsIdle() {
+        var sampler = TransportRateSampler()
+        let totals = TransportByteTotals(received: 9_000, sent: 3_000)
+        _ = sampler.sample(totals, at: start)
+
+        let rate = sampler.sample(totals, at: start.advanced(by: .seconds(1)))
+
+        #expect(rate == .zero)
+        #expect(rate?.isIdle == true)
+    }
+
+    @Test("A rate under a byte a second counts as idle")
+    func slowTrickleIsIdle() {
+        #expect(TransportRate(receivedPerSecond: 0.4, sentPerSecond: 0.9).isIdle)
+        #expect(!TransportRate(receivedPerSecond: 1, sentPerSecond: 0).isIdle)
+        #expect(!TransportRate(receivedPerSecond: 0, sentPerSecond: 42).isIdle)
+    }
+}

--- a/TableProUITests/ConnectionActivityFooterUITests.swift
+++ b/TableProUITests/ConnectionActivityFooterUITests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+/// The connection switcher's footer names the transport the window is on. The sample database is a
+/// local file with no transport in front of it, so the deterministic assertion is the one this test
+/// makes: the footer is there, and it reads Direct.
+///
+/// A tunnelled connection is not covered here, because a byte count needs a live SSH server and a
+/// query moving data through it. `SSHChannelRelayTests`, `TransportRateSamplerTests` and
+/// `ConnectionTransportActivityTests` cover the counting, the rate and the per-transport choice.
+final class ConnectionActivityFooterUITests: UITestCase {
+    func testTheSwitcherNamesTheTransportTheWindowIsOn() throws {
+        let app = try launchWithSampleDatabase()
+
+        app.typeKey("c", modifierFlags: [.command, .control])
+
+        let field = app.searchFields.matching(
+            NSPredicate(format: "placeholderValue BEGINSWITH[c] %@", "Search connections")
+        ).firstMatch
+        XCTAssertTrue(field.waitToExist(timeout: 15), "The connection switcher never opened")
+
+        let transport = app.staticTexts["connection-activity-transport"]
+        XCTAssertTrue(transport.waitToExist(timeout: 10), "The switcher must carry a transport footer")
+        XCTAssertEqual(
+            transport.value as? String,
+            "Direct",
+            "A connection with no tunnel must read as Direct"
+        )
+
+        app.typeKey(.escape, modifierFlags: [])
+        XCTAssertTrue(field.waitForNonExistence(timeout: 10), "Escape must dismiss the switcher")
+    }
+}

--- a/docs/connections/index.mdx
+++ b/docs/connections/index.mdx
@@ -80,6 +80,10 @@ A connection's group, tags, and favorite star sync through iCloud unless it is m
 
 Press `Ctrl+Cmd+C` for **Switch Connection**. Whatever is already open sits at the top, and the rest are listed under the group they belong to, a nested group carrying its full path. Arrow keys move, `Return` switches the window to that connection, and `Cmd`-click opens a saved one in a window of its own. Typing searches every group at once and collapses the matches into a single list.
 
+A footer under that list names the transport the window's connection runs on. On an SSH tunnel or a SOCKS proxy it also carries the bytes that have crossed since the transport opened, received and sent, with the rate beside a direction while data moves. An idle transport keeps its totals and drops the rate.
+
+The rest show their name alone. Cloudflare Tunnel, Cloud SQL Auth Proxy and Tunnel Command each run a separate binary that holds the connection end to end, a [remote database file](/connections/remote-database-files) is fetched once and then read from disk, and a direct connection's socket belongs to the database driver.
+
 **Open Database** (`Cmd+K`) moves to another database on the same server.
 
 <Frame caption="Database switcher in toolbar">

--- a/docs/connections/socks-proxy.mdx
+++ b/docs/connections/socks-proxy.mdx
@@ -63,6 +63,8 @@ An SSH dynamic port forward is a SOCKS5 proxy. Run `ssh -D 1080 user@bastion`, t
 
 [SSL/TLS](/connections/ssl) still applies, with one unavoidable adjustment: the driver dials a loopback port that no server certificate names, so **Verify CA** and **Verify Identity** fall back to **Required** and certificate paths are dropped.
 
+Bytes through the proxy are counted the same way an SSH tunnel's are. Press `Ctrl+Cmd+C` and read the footer under the connection list. See [transport activity](/connections#switch-connections-and-databases).
+
 ## Troubleshooting
 
 ### Timed out connecting through the SOCKS proxy

--- a/docs/connections/ssh-tunneling.mdx
+++ b/docs/connections/ssh-tunneling.mdx
@@ -110,6 +110,10 @@ A keep-alive goes out every 30 seconds. When one fails the session drops to conn
 
 If tunnels keep dropping on an idle network, the keep-alive is not the missing piece: check the server's `ClientAliveInterval` and the idle timeouts on any firewall or load balancer in between.
 
+## What the tunnel is carrying
+
+Press `Ctrl+Cmd+C` and read the footer under the connection list: bytes received and sent since the tunnel opened, and the rate beside a direction while data moves. A rebuilt tunnel starts again from zero. See [transport activity](/connections#switch-connections-and-databases).
+
 ## Troubleshooting
 
 ### "The SSH server could not reach …"


### PR DESCRIPTION
## What this adds

A footer under the connection switcher (`Ctrl+Cmd+C`) naming the transport the window's connection runs on, and for an SSH tunnel or a SOCKS proxy the bytes it has carried since it opened, received and sent, with the rate beside a direction while data moves.

## Why a popover and not the toolbar

The ask was for this in the centred toolbar item. Research measured the case against it and the user picked the popover once it was presented:

- **TablePlus ships exactly this readout, and it does not work.** Polled live against an SSH-tunnelled PostgreSQL 18.6: `0 B/s` in 19 of 20 idle samples, and in 37 of 45 samples during two forced table reloads. The non-zero bursts swung 353 B/s to 32 KB/s inside 400ms. Its item is not centred either (left edge pinned at x=773 at every window width) and the whole group vanishes into the overflow menu at 700pt.
- **Apple shows a rate in one place**: Safari's downloads popover off a trailing button, for a bounded transfer with an ETA, and the rate disappears on completion. Activity Monitor's rates are in a bottom bar. Finder's copy window shows bytes and an ETA and no rate. Xcode has zero `/sec` strings in DVTKit, IDEKit, IDEFoundation or DVTFoundation.
- **The HIG reserves the centre for controls** and guarantees it collapses into the overflow menu first, and a pure readout publishes no action, so it can be neither validated nor mirrored as a menu command.

So the number lives where Safari puts it: disclosed, off the control the user already clicks, and absent rather than zero when there is nothing to report.

## How the bytes are counted

`TransportByteCounter` is a lock-guarded pair of totals. The increment is the whole cost: the byte count is already a plain `Int` in the caller's hand the instant the read returns, and nothing in the hot path reads a clock or makes a syscall.

- `SSHChannelRelay` counts in `pumpChannelToLocal` and `pumpLocalToChannel`. `LibSSH2Tunnel` owns one counter shared by every client relay. A jump hop's relay gets no counter, so a bastion connection is not counted twice.
- `SOCKSProxyManager.pump` takes a `record` closure, which is what makes one call of that recursion a direction.

`TransportActivityRegistry` holds counters **weakly**, and the transport owns its own. That is why there is no `unregister` call anywhere: a tunnel that closes, dies, or is replaced by a reconnect takes its counter with it and the entry goes absent on its own. An explicit teardown call would have to be made from all four of those paths, and the one that was missed would report a dead tunnel's totals as the live connection's.

`TransportRateSampler` divides by the interval it actually measured, not the one it asked for, and re-baselines when a counter goes backwards so a reconnect's first reading is not reported as one second's worth of a whole new tunnel.

## Which transports report a number

`ConnectionTunnelKind.carriesMeasuredBytes` decides it, exhaustively, so a transport added later has to answer. SSH Tunnel and SOCKS Proxy do. Cloudflare Tunnel, Cloud SQL Auth Proxy and Tunnel Command each run a separate binary that owns the socket end to end. A remote database file is fetched once and then read from disk. A direct connection's socket belongs to the driver's C library, inside the plugin.

The resolver reads the figure from the kind, never from whatever the registry happens to hold, so a connection reconfigured from SSH to Cloudflare without changing its id cannot show the old transport's totals.

## Two SwiftUI details worth knowing

- The sampling task hangs off an `if`/`else`, **not** a `Group`. A modifier on a `Group` is applied to each of its children, so an empty one carried the task nowhere and no reading was ever taken. That is what the first version of the UI test caught.
- An idle transport resolves to the same row every second, so the footer only writes state when the value changed. Without that, the row rebuilt once a second and XCUITest lost the element between `waitToExist` and reading its value.

## Verification

- `build` PASS
- `test TransportRateSamplerTests ConnectionTransportActivityTests TransportActivityRegistryTests ByteSizeFormattingTests SSHChannelRelayTests`: 42 cases, 42 passed. Includes two new relay tests asserting the direction each pump counts, and a registry test that the totals go when the owning transport is released.
- `uitest ConnectionActivityFooterUITests` PASS. The sample database is a local file, so the deterministic assertion is that the footer exists and reads Direct. A tunnelled connection is not covered: a byte count needs a live SSH server with a query moving data through it.
- `lint TablePro TableProTests TableProUITests`: 0 violations.
- `docs` PASS.

## Not done

No screenshot. This adds a footer row to an existing popover rather than a new screen, and that popover has no shot on the page today; capturing one needs a live tunnel carrying traffic.

Unrelated: `verify.sh lint` reports `CLAUDE.md:214` referencing `NSAccessibilitySortDirectionAttribute`, which is in no Swift source. It came in with #2670 and no CI workflow runs that check.

https://claude.ai/code/session_014qSA9xxbAUskqMd55gTCkG