### PR TITLE
feat(toolbar): put the transport rate beside the connection in the centre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inspector shows the selected row as Fields or JSON, with AI Chat moved out of its tab strip.
 - Structured inspector values expand in place instead of replacing the whole pane.
 - Object tree context menu regrouped into four groups by intent, with the connection-wide commands off object rows.
+- Back and Forward absent from the toolbar while a tab has no history to walk, in place of two dimmed arrows.
 - View Options as a control in the sidebar's filter row, in place of an entry on every context menu.
 - View ER Diagram and New View on the object tree's empty-area menu only.
 - Keyboard shortcuts shown on sidebar context menu items that have a menu bar equivalent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inspector shows the selected row as Fields or JSON, with AI Chat moved out of its tab strip.
 - Structured inspector values expand in place instead of replacing the whole pane.
 - Object tree context menu regrouped into four groups by intent, with the connection-wide commands off object rows.
-- Back and Forward absent from the toolbar while a tab has no history to walk, in place of two dimmed arrows.
+- Back available with unsaved edits, asking to discard them, in place of standing down until they were saved.
 - View Options as a control in the sidebar's filter row, in place of an entry on every context menu.
 - View ER Diagram and New View on the object tree's empty-area menu only.
 - Keyboard shortcuts shown on sidebar context menu items that have a menu bar equivalent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show Tables and Show Favorites in the View menu.
 - Running indicator on the editor tab whose query is executing.
 - Sort direction setting for the data grid, applied to the default row sort and to the first click on a column header. (#2665)
-- Transport activity under the connection switcher: bytes carried, and live throughput on an SSH tunnel or SOCKS proxy.
+- Transport activity for an SSH tunnel or SOCKS proxy: live throughput in the toolbar, bytes carried in the connection switcher.
 
 ### Changed
 

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Delegate.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Delegate.swift
@@ -47,11 +47,16 @@ extension MainWindowToolbar {
             /// Not navigational, unlike back and forward. `isNavigational` asks AppKit to lift an
             /// item to the leading edge of the content area, which is the opposite of what
             /// `centeredItemIdentifiers` asks for, and this group is the centred one.
-            return makeNativeGroup(
+            ///
+            /// The throughput readout joins it here rather than standing on its own, so it is
+            /// centred with the pair it describes and shares their capsule.
+            let group = makeNativeGroup(
                 id: itemIdentifier,
                 label: String(localized: "Connection"),
-                subitems: [subitemConnection(), subitemDatabase()]
+                subitems: connectionGroupSubitems()
             )
+            adopt(connectionGroup: group)
+            return group
         case Self.safeMode:
             return subitemSafeMode()
         case Self.editorGroup:

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Delegate.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Delegate.swift
@@ -28,10 +28,23 @@ extension MainWindowToolbar {
         case Self.sidebarToggle:
             return makeSidebarToggleItem(claimsSlot: Self.claimsItemSlot(willBeInsertedIntoToolbar: flag))
         case Self.backForwardGroup:
-            /// Held rather than built here, because emptying its subitems is how the pair hides
-            /// itself when there is nowhere to go, and the toolbar has to be showing the instance
-            /// that gets emptied.
-            return navigationGroup
+            /// `isNavigational` is what puts back and forward on the leading edge of the content
+            /// title area, where Finder and Safari keep them, instead of in the slot the identifier
+            /// list nominally gives them.
+            ///
+            /// Both subitems are installed unconditionally and stay installed. Availability is
+            /// `isEnabled`, written by `validateToolbarItem(_:)`, never presence: measured on three
+            /// running Apple apps, Xcode, Finder in column view and System Settings all keep the
+            /// 75pt capsule and dim the direction that has nowhere to go. Emptying the group
+            /// instead put the pair behind state that is `@ObservationIgnored`, so once hidden it
+            /// did not come back until the user switched tabs.
+            let group = makeNativeGroup(
+                id: itemIdentifier,
+                label: String(localized: "Navigation"),
+                subitems: [subitemNavigateBack(), subitemNavigateForward()]
+            )
+            group.isNavigational = true
+            return group
         case Self.connectionGroup:
             /// Native, like every other group here. As a view-backed group it drew a hosted SwiftUI
             /// row and its subitems were inert: the header is explicit that a property set on the

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Delegate.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Delegate.swift
@@ -28,16 +28,10 @@ extension MainWindowToolbar {
         case Self.sidebarToggle:
             return makeSidebarToggleItem(claimsSlot: Self.claimsItemSlot(willBeInsertedIntoToolbar: flag))
         case Self.backForwardGroup:
-            /// `isNavigational` is what puts back and forward on the leading edge of the content
-            /// title area, where Finder and Safari keep them, instead of in the slot the identifier
-            /// list nominally gives them.
-            let group = makeNativeGroup(
-                id: itemIdentifier,
-                label: String(localized: "Navigation"),
-                subitems: [subitemNavigateBack(), subitemNavigateForward()]
-            )
-            group.isNavigational = true
-            return group
+            /// Held rather than built here, because emptying its subitems is how the pair hides
+            /// itself when there is nowhere to go, and the toolbar has to be showing the instance
+            /// that gets emptied.
+            return navigationGroup
         case Self.connectionGroup:
             /// Native, like every other group here. As a view-backed group it drew a hosted SwiftUI
             /// row and its subitems were inert: the header is explicit that a property set on the
@@ -47,16 +41,17 @@ extension MainWindowToolbar {
             /// Not navigational, unlike back and forward. `isNavigational` asks AppKit to lift an
             /// item to the leading edge of the content area, which is the opposite of what
             /// `centeredItemIdentifiers` asks for, and this group is the centred one.
-            ///
-            /// The throughput readout joins it here rather than standing on its own, so it is
-            /// centred with the pair it describes and shares their capsule.
-            let group = makeNativeGroup(
+            return makeNativeGroup(
                 id: itemIdentifier,
                 label: String(localized: "Connection"),
-                subitems: connectionGroupSubitems()
+                subitems: [subitemConnection(), subitemDatabase()]
             )
-            adopt(connectionGroup: group)
-            return group
+        case TransportRateToolbarItem.identifier:
+            /// Beside the centred pair, never inside it. A group is laid out around its own
+            /// midpoint, so a readout inside this one pushed the two capsules off centre by half
+            /// the readout's width; measured as its own adjacent item, the group sits where it
+            /// sits with no readout at all and the figure lands 6.0pt past its trailing edge.
+            return transportRateGroup
         case Self.safeMode:
             return subitemSafeMode()
         case Self.editorGroup:

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Items.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar+Items.swift
@@ -45,6 +45,14 @@ extension MainWindowToolbar {
         coordinator?.connection.name ?? ""
     }
 
+    /// Whether the centred group carries a throughput readout at all, and whether there is a second
+    /// reading worth taking. Read from the connection's configuration rather than from the registry,
+    /// so it holds for the whole session: the group's shape is settled when the connection is
+    /// adopted and never changes under a running tunnel.
+    var carriesMeasuredTransport: Bool {
+        coordinator?.connection.activeTunnelKind?.carriesMeasuredBytes == true
+    }
+
     /// The container this control switches, and only that. It briefly read "app › public" on a
     /// schema-grouped engine while the click still opened the database chooser, which makes the
     /// word the user aimed at the one thing the control cannot change. The schema has its own

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -72,30 +72,6 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
         group.subitems = []
         return group
     }()
-    /// Back and forward, held rather than vended fresh, because emptying and refilling this group is
-    /// how the pair leaves and rejoins the toolbar. Measured: emptying it drops its platter and
-    /// moves nothing else at all (the centred group held x=647.0 midX=772.8 across hidden, shown and
-    /// hidden again), and a toggle plus layout cost 9.5ms at worst over twenty flips.
-    ///
-    /// Apple does not do this. Measured on a running Xcode, its Back/Forward group keeps its full
-    /// 75pt capsule with both segments reported DISABLED when there is nowhere to go. This app hides
-    /// it instead, by explicit request.
-    internal private(set) lazy var navigationGroup: NSToolbarItemGroup = {
-        /// Empty to begin with, which is the honest default: a toolbar with no connection behind it
-        /// has no history to walk. `syncNavigationVisibility` fills it once there is one.
-        let group = makeNativeGroup(
-            id: Self.backForwardGroup,
-            label: String(localized: "Navigation"),
-            subitems: []
-        )
-        /// `isNavigational` is what puts back and forward on the leading edge of the content title
-        /// area, where Finder and Safari keep them.
-        group.isNavigational = true
-        return group
-    }()
-
-    private lazy var navigationSubitems: [NSToolbarItem] = [subitemNavigateBack(), subitemNavigateForward()]
-
     private var transportSampler = TransportRateSampler()
     private var transportTicker: Task<Void, Never>?
 
@@ -195,6 +171,20 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
         managedToolbar.validateVisibleItems()
     }
 
+    func invalidate() {
+        /// Window close reaches here rather than through `repoint`, and the panel surface is an
+        /// independent floating `NSPanel` with no parent-child relationship to the window, so
+        /// nothing else would take it down with the window that opened it. A window whose
+        /// connection was released has no coordinator to reach it through.
+        windowController?.switcherPresenter.dismiss()
+        itemStateObservationGeneration += 1
+        transportTicker?.cancel()
+        transportTicker = nil
+        transportRateItem.apply(rate: nil)
+        sidebarGroup = nil
+        coordinator = nil
+    }
+
     /// Runs only for a connection whose transport the app carries the bytes for, so an ordinary
     /// direct connection costs nothing at all. It writes into the readout's own field rather than
     /// asking the toolbar to revalidate: the field is a fixed width, so a new figure is a redraw
@@ -232,30 +222,6 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
         transportRateGroup.subitems = carriesMeasuredTransport ? [transportRateItem] : []
     }
 
-    /// Both arrows go together. Hiding one of a segmented pair would leave a lone half-capsule and
-    /// change the group's width on every step through the history, which is a worse read than a
-    /// dimmed arrow.
-    private func syncNavigationVisibility() {
-        let canNavigate = coordinator.map { $0.canNavigateBack || $0.canNavigateForward } ?? false
-        let shown = !navigationGroup.subitems.isEmpty
-        guard shown != canNavigate else { return }
-        navigationGroup.subitems = canNavigate ? navigationSubitems : []
-    }
-
-    func invalidate() {
-        /// Window close reaches here rather than through `repoint`, and the panel surface is an
-        /// independent floating `NSPanel` with no parent-child relationship to the window, so
-        /// nothing else would take it down with the window that opened it. A window whose
-        /// connection was released has no coordinator to reach it through.
-        windowController?.switcherPresenter.dismiss()
-        itemStateObservationGeneration += 1
-        transportTicker?.cancel()
-        transportTicker = nil
-        transportRateItem.apply(rate: nil)
-        sidebarGroup = nil
-        coordinator = nil
-    }
-
     /// What a validation pass depends on beyond the responder chain. `validateVisibleItems()` is
     /// also what re-runs `StatefulToolbarItem.validate()`, so the safe-mode glyph tracks the level
     /// through the same channel rather than through an observer of its own.
@@ -267,8 +233,6 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
             _ = self?.coordinator?.toolbarState.hasDataPendingChanges
             _ = self?.coordinator?.toolbarState.safeModeLevel
             _ = self?.coordinator?.toolbarState.currentDatabase
-            _ = self?.coordinator?.canNavigateBack
-            _ = self?.coordinator?.canNavigateForward
         } onChange: { [weak self] in
             Task { @MainActor [weak self] in
                 guard let self,
@@ -276,7 +240,6 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
                       coordinatorIdentifier == self.coordinator.map({ ObjectIdentifier($0) })
                 else { return }
                 self.observeItemState()
-                self.syncNavigationVisibility()
                 self.managedToolbar.validateVisibleItems()
             }
         }
@@ -287,7 +250,6 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
     /// what `validate()` reconsiders. They are pushed here instead.
     private func refreshConnectionScopedItems() {
         syncTransportRateVisibility()
-        syncNavigationVisibility()
         for item in allItems() {
             switch item.itemIdentifier {
             case Self.connection:

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -54,6 +54,16 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
 
     private(set) var sidebarGroup: NSToolbarItemGroup?
 
+    /// The throughput readout, and the group that hosts it. One item per toolbar rather than one
+    /// per vend: the ticker writes into it directly, so it has to be the instance the group is
+    /// actually showing.
+    internal let transportRateItem = TransportRateToolbarItem()
+    private weak var connectionGroupItem: NSToolbarItemGroup?
+    private var transportSampler = TransportRateSampler()
+    private var transportTicker: Task<Void, Never>?
+
+    private static let transportSampleInterval = Duration.seconds(1)
+
     /// `NSMenu.delegate` is weak, and the safe-mode control's menu is built here rather than by the
     /// menu bar, so this toolbar is what keeps its delegate alive.
     internal let safeModeMenuDelegate = SafeModeMenuDelegate()
@@ -142,9 +152,61 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
         itemStateObservationGeneration += 1
         self.coordinator = coordinator
         observeItemState()
+        restartTransportTicker()
         refreshConnectionScopedItems()
         syncSidebarSelection()
         managedToolbar.validateVisibleItems()
+    }
+
+    /// Runs only for a connection whose transport the app carries the bytes for, so an ordinary
+    /// direct connection costs nothing at all. It writes into the readout's own field rather than
+    /// asking the toolbar to revalidate: the field is a fixed width, so a new figure is a redraw
+    /// inside one view and never a layout pass.
+    private func restartTransportTicker() {
+        transportTicker?.cancel()
+        transportSampler = TransportRateSampler()
+        transportRateItem.apply(rate: nil)
+        guard carriesMeasuredTransport else {
+            transportTicker = nil
+            return
+        }
+
+        transportTicker = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: Self.transportSampleInterval)
+                guard !Task.isCancelled, let self else { return }
+                self.sampleTransportRate()
+            }
+        }
+    }
+
+    private func sampleTransportRate() {
+        guard let connection = coordinator?.connection else { return }
+        let totals = TransportActivityRegistry.shared.totals(for: connection.id)
+        transportRateItem.apply(rate: totals.flatMap { transportSampler.sample($0, at: .now) })
+    }
+
+    /// The readout joins and leaves the centred group as a whole item, which is the one structural
+    /// change AppKit does re-measure. It happens when a connection is adopted, never under a
+    /// running tunnel, so nothing moves while a figure is ticking.
+    internal func connectionGroupSubitems() -> [NSToolbarItem] {
+        let controls = [subitemConnection(), subitemDatabase()]
+        return carriesMeasuredTransport ? controls + [transportRateItem] : controls
+    }
+
+    internal func adopt(connectionGroup group: NSToolbarItemGroup) {
+        connectionGroupItem = group
+    }
+
+    /// The control subitems are carried over rather than rebuilt. They hold their own menu form,
+    /// shortcut binding and title provider, and vending a second pair would leave the group showing
+    /// items nothing else in the toolbar has a reference to.
+    private func syncConnectionGroupSubitems() {
+        guard let group = connectionGroupItem else { return }
+        let carries = group.subitems.contains { $0 === transportRateItem }
+        guard carries != carriesMeasuredTransport else { return }
+        let controls = group.subitems.filter { $0 !== transportRateItem }
+        group.subitems = carriesMeasuredTransport ? controls + [transportRateItem] : controls
     }
 
     func invalidate() {
@@ -154,6 +216,10 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
         /// connection was released has no coordinator to reach it through.
         windowController?.switcherPresenter.dismiss()
         itemStateObservationGeneration += 1
+        transportTicker?.cancel()
+        transportTicker = nil
+        transportRateItem.apply(rate: nil)
+        connectionGroupItem = nil
         sidebarGroup = nil
         coordinator = nil
     }
@@ -185,6 +251,7 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
     /// a menu built at construction keeps whatever it was built with, and a label is not part of
     /// what `validate()` reconsiders. They are pushed here instead.
     private func refreshConnectionScopedItems() {
+        syncConnectionGroupSubitems()
         for item in allItems() {
             switch item.itemIdentifier {
             case Self.connection:

--- a/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
+++ b/TablePro/Core/Services/Infrastructure/MainWindowToolbar.swift
@@ -15,8 +15,9 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
     /// The autosave name. Bumping it discards every saved arrangement, so it moves only when the
     /// default set changes enough that replaying a stored one would be worse than resetting it. The
     /// v3 move drops the hosted status item and four commands from the default, and a v2 list still
-    /// names identifiers the delegate no longer vends.
-    internal static let toolbarIdentifier = NSToolbar.Identifier("com.TablePro.main.toolbar.v3")
+    /// names identifiers the delegate no longer vends. v4 adds the throughput readout: a stored v3
+    /// arrangement does not name it, so a reader who had customized the toolbar would never see it.
+    internal static let toolbarIdentifier = NSToolbar.Identifier("com.TablePro.main.toolbar.v4")
 
     /// Which connection the toolbar is about. Every item reads this rather than capturing a
     /// coordinator, so a switch repoints one reference instead of rebuilding the window's whole
@@ -54,11 +55,47 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
 
     private(set) var sidebarGroup: NSToolbarItemGroup?
 
-    /// The throughput readout, and the group that hosts it. One item per toolbar rather than one
-    /// per vend: the ticker writes into it directly, so it has to be the instance the group is
-    /// actually showing.
+    /// The throughput readout. One item per toolbar rather than one per vend: the ticker writes
+    /// into it directly, so it has to be the instance the toolbar is actually showing.
     internal let transportRateItem = TransportRateToolbarItem()
-    private weak var connectionGroupItem: NSToolbarItemGroup?
+
+    /// A group holding nothing but the readout, and the reason it exists is that emptying it is how
+    /// the readout leaves the toolbar. Measured: an item whose view is hidden keeps its 75pt, and a
+    /// view constrained to zero width still leaves a 24pt gap, so neither hides it cleanly.
+    /// `NSToolbarItem.isHidden` does, but it is macOS 15 and the app targets 14. An empty group
+    /// reclaims the space exactly, on every version, with no availability gate.
+    internal private(set) lazy var transportRateGroup: NSToolbarItemGroup = {
+        let group = NSToolbarItemGroup(itemIdentifier: TransportRateToolbarItem.identifier)
+        let label = String(localized: "Throughput")
+        group.label = label
+        group.paletteLabel = label
+        group.subitems = []
+        return group
+    }()
+    /// Back and forward, held rather than vended fresh, because emptying and refilling this group is
+    /// how the pair leaves and rejoins the toolbar. Measured: emptying it drops its platter and
+    /// moves nothing else at all (the centred group held x=647.0 midX=772.8 across hidden, shown and
+    /// hidden again), and a toggle plus layout cost 9.5ms at worst over twenty flips.
+    ///
+    /// Apple does not do this. Measured on a running Xcode, its Back/Forward group keeps its full
+    /// 75pt capsule with both segments reported DISABLED when there is nowhere to go. This app hides
+    /// it instead, by explicit request.
+    internal private(set) lazy var navigationGroup: NSToolbarItemGroup = {
+        /// Empty to begin with, which is the honest default: a toolbar with no connection behind it
+        /// has no history to walk. `syncNavigationVisibility` fills it once there is one.
+        let group = makeNativeGroup(
+            id: Self.backForwardGroup,
+            label: String(localized: "Navigation"),
+            subitems: []
+        )
+        /// `isNavigational` is what puts back and forward on the leading edge of the content title
+        /// area, where Finder and Safari keep them.
+        group.isNavigational = true
+        return group
+    }()
+
+    private lazy var navigationSubitems: [NSToolbarItem] = [subitemNavigateBack(), subitemNavigateForward()]
+
     private var transportSampler = TransportRateSampler()
     private var transportTicker: Task<Void, Never>?
 
@@ -186,27 +223,23 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
         transportRateItem.apply(rate: totals.flatMap { transportSampler.sample($0, at: .now) })
     }
 
-    /// The readout joins and leaves the centred group as a whole item, which is the one structural
-    /// change AppKit does re-measure. It happens when a connection is adopted, never under a
-    /// running tunnel, so nothing moves while a figure is ticking.
-    internal func connectionGroupSubitems() -> [NSToolbarItem] {
-        let controls = [subitemConnection(), subitemDatabase()]
-        return carriesMeasuredTransport ? controls + [transportRateItem] : controls
-    }
-
-    internal func adopt(connectionGroup group: NSToolbarItemGroup) {
-        connectionGroupItem = group
-    }
-
-    /// The control subitems are carried over rather than rebuilt. They hold their own menu form,
-    /// shortcut binding and title provider, and vending a second pair would leave the group showing
-    /// items nothing else in the toolbar has a reference to.
-    private func syncConnectionGroupSubitems() {
-        guard let group = connectionGroupItem else { return }
-        let carries = group.subitems.contains { $0 === transportRateItem }
+    /// Emptying and refilling the readout's own group is the one structural change AppKit
+    /// re-measures. It happens when a connection is adopted, never under a running tunnel, so
+    /// nothing moves while a figure is ticking.
+    private func syncTransportRateVisibility() {
+        let carries = !transportRateGroup.subitems.isEmpty
         guard carries != carriesMeasuredTransport else { return }
-        let controls = group.subitems.filter { $0 !== transportRateItem }
-        group.subitems = carriesMeasuredTransport ? controls + [transportRateItem] : controls
+        transportRateGroup.subitems = carriesMeasuredTransport ? [transportRateItem] : []
+    }
+
+    /// Both arrows go together. Hiding one of a segmented pair would leave a lone half-capsule and
+    /// change the group's width on every step through the history, which is a worse read than a
+    /// dimmed arrow.
+    private func syncNavigationVisibility() {
+        let canNavigate = coordinator.map { $0.canNavigateBack || $0.canNavigateForward } ?? false
+        let shown = !navigationGroup.subitems.isEmpty
+        guard shown != canNavigate else { return }
+        navigationGroup.subitems = canNavigate ? navigationSubitems : []
     }
 
     func invalidate() {
@@ -219,7 +252,6 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
         transportTicker?.cancel()
         transportTicker = nil
         transportRateItem.apply(rate: nil)
-        connectionGroupItem = nil
         sidebarGroup = nil
         coordinator = nil
     }
@@ -235,6 +267,8 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
             _ = self?.coordinator?.toolbarState.hasDataPendingChanges
             _ = self?.coordinator?.toolbarState.safeModeLevel
             _ = self?.coordinator?.toolbarState.currentDatabase
+            _ = self?.coordinator?.canNavigateBack
+            _ = self?.coordinator?.canNavigateForward
         } onChange: { [weak self] in
             Task { @MainActor [weak self] in
                 guard let self,
@@ -242,6 +276,7 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
                       coordinatorIdentifier == self.coordinator.map({ ObjectIdentifier($0) })
                 else { return }
                 self.observeItemState()
+                self.syncNavigationVisibility()
                 self.managedToolbar.validateVisibleItems()
             }
         }
@@ -251,7 +286,8 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
     /// a menu built at construction keeps whatever it was built with, and a label is not part of
     /// what `validate()` reconsiders. They are pushed here instead.
     private func refreshConnectionScopedItems() {
-        syncConnectionGroupSubitems()
+        syncTransportRateVisibility()
+        syncNavigationVisibility()
         for item in allItems() {
             switch item.itemIdentifier {
             case Self.connection:
@@ -353,6 +389,7 @@ internal final class MainWindowToolbar: NSObject, NSToolbarDelegate {
         backForwardGroup,
         .flexibleSpace,
         connectionGroup,
+        TransportRateToolbarItem.identifier,
         .flexibleSpace,
         refreshSaveGroup,
         editorGroup,

--- a/TablePro/Core/Services/Infrastructure/TransportRateToolbarItem.swift
+++ b/TablePro/Core/Services/Infrastructure/TransportRateToolbarItem.swift
@@ -1,0 +1,76 @@
+//
+//  TransportRateToolbarItem.swift
+//  TablePro
+//
+
+import AppKit
+
+/// The throughput readout inside the centred connection group.
+///
+/// The one place in this toolbar that carries a view, and the reason is measured. AppKit sizes a
+/// view-less item's `title` **once, when the item is inserted**: setting a longer title afterwards
+/// leaves the item at its original width and clips the text, and neither `validateVisibleItems()`
+/// nor a window resize re-measures it. Only a `displayMode` round trip or removing and re-inserting
+/// the item does, and both rebuild the toolbar visibly. So a figure that changes once a second
+/// cannot live in a title.
+///
+/// The other half of the measurement is why the view is a fixed width rather than sized to its text.
+/// The centred group is laid out around its midpoint, so a group that grows by 14pt moves its
+/// leading edge 7pt one way and the database item 7pt the other. Measured at 1200pt: the same group
+/// sat at x=488.5 reading `↓0 kB/s` and x=481.5 reading `↓145 kB/s`. With the width pinned, changing
+/// the text moves nothing at all: group and field frames were identical across `↓0 kB/s`,
+/// `↓145 kB/s`, `↑1.2 MB/s` and `↓88 MB/s`.
+///
+/// It publishes no action, so AppKit never validates it and it has no menu-bar command of its own.
+/// That is the cost of a readout, and it is why the item is only in the group at all for a
+/// connection whose bytes the app carries.
+@MainActor
+internal final class TransportRateToolbarItem: NSToolbarItem {
+    private let field = NSTextField(labelWithString: "")
+
+    internal init() {
+        super.init(itemIdentifier: Self.identifier)
+        let label = String(localized: "Throughput")
+        self.label = label
+        paletteLabel = label
+        field.font = NSFont.monospacedDigitSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular)
+        field.textColor = .secondaryLabelColor
+        field.alignment = .center
+        field.lineBreakMode = .byClipping
+        field.setAccessibilityLabel(label)
+        field.translatesAutoresizingMaskIntoConstraints = false
+        field.widthAnchor.constraint(equalToConstant: Self.fieldWidth).isActive = true
+        view = field
+        overflowEntry.isEnabled = false
+        menuFormRepresentation = overflowEntry
+        apply(rate: nil)
+    }
+
+    internal static let identifier = NSToolbarItem.Identifier("com.TablePro.toolbar.transportRate")
+
+    /// Measured from the widest figure the label can produce rather than typed in, so a change to
+    /// the format cannot leave the field a few points too narrow and clip its own text.
+    private static let fieldWidth: CGFloat = {
+        let font = NSFont.monospacedDigitSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular)
+        let widest = TransportRateLabel.widestCandidates
+            .map { ($0 as NSString).size(withAttributes: [.font: font]).width }
+            .max() ?? 0
+        return ceil(widest) + 8
+    }()
+
+    /// The centred group is the first region AppKit sheds into the overflow menu, so the figure
+    /// gets an entry of its own there rather than disappearing with the controls beside it. It is
+    /// disabled because there is nothing to click: it reports, it does not do.
+    private let overflowEntry = NSMenuItem()
+
+    internal func apply(rate: TransportRate?) {
+        let text = TransportRateLabel.text(for: rate)
+        guard text != field.stringValue else { return }
+
+        let spoken = TransportRateLabel.accessibilityValue(for: rate)
+        field.stringValue = text
+        field.setAccessibilityValue(spoken)
+        overflowEntry.title = spoken
+        toolTip = String(format: String(localized: "%@ through this connection's transport"), spoken)
+    }
+}

--- a/TablePro/Core/Services/Infrastructure/TransportRateToolbarItem.swift
+++ b/TablePro/Core/Services/Infrastructure/TransportRateToolbarItem.swift
@@ -5,7 +5,21 @@
 
 import AppKit
 
-/// The throughput readout inside the centred connection group.
+/// The throughput readout, beside the centred connection group rather than inside it.
+///
+/// Bare text with no capsule, which is what Xcode does with the one comparable thing it ships:
+/// measured on a running Xcode, its Window Title/Activity readout draws as plain text next to the
+/// Back/Forward capsule and wears no platter of its own. A capsule was tried here and it was wrong
+/// twice over. `title` on a group subitem is what earns a subitem its own capsule (measured: two
+/// titled subitems give two platters, three untitled ones give a single platter spanning all of
+/// them, and `controlRepresentation` changes neither), so the centre became three capsules for two
+/// controls and one number, and read as scattered.
+///
+/// Sitting outside the group is what keeps the pair centred. A group is laid out around its own
+/// midpoint, so a readout inside it pushed the connection and database capsules off centre by half
+/// the readout's width. Measured at 1400pt: with the readout as a separate adjacent item the group
+/// sits at x=647.0, midX=772.8, byte-identical to having no readout at all, and the text lands 6.0pt
+/// past the group's trailing edge.
 ///
 /// The one place in this toolbar that carries a view, and the reason is that the figure has to hold
 /// a constant width. A view-less item would carry it in `title`, and a title re-measures: with the
@@ -37,15 +51,6 @@ internal final class TransportRateToolbarItem: NSToolbarItem {
         field.translatesAutoresizingMaskIntoConstraints = false
         field.widthAnchor.constraint(equalToConstant: Self.fieldWidth).isActive = true
         view = field
-        /// After `view`, never before, and this ordering is the whole of it. `NSToolbarItem.h`:
-        /// "many of the set/get methods will be implemented by calls forwarded to the view you set,
-        /// if it responds to it", and `NSTextField` responds to `setBordered:`. Set first, the flag
-        /// is discarded and the readout draws as bare text beside two capsules; set after, AppKit
-        /// gives it a real `NSToolbarPlatterView` the same 36pt height and 8pt gap as its
-        /// neighbours. Measured: 2 platters and a 14pt-tall field one way, 3 platters and a 36pt
-        /// one the other. Writing `field.isBordered = false` anywhere later deletes the capsule
-        /// again, just as silently.
-        isBordered = true
         overflowEntry.isEnabled = false
         menuFormRepresentation = overflowEntry
         apply(rate: nil)

--- a/TablePro/Core/Services/Infrastructure/TransportRateToolbarItem.swift
+++ b/TablePro/Core/Services/Infrastructure/TransportRateToolbarItem.swift
@@ -7,19 +7,15 @@ import AppKit
 
 /// The throughput readout inside the centred connection group.
 ///
-/// The one place in this toolbar that carries a view, and the reason is measured. AppKit sizes a
-/// view-less item's `title` **once, when the item is inserted**: setting a longer title afterwards
-/// leaves the item at its original width and clips the text, and neither `validateVisibleItems()`
-/// nor a window resize re-measures it. Only a `displayMode` round trip or removing and re-inserting
-/// the item does, and both rebuild the toolbar visibly. So a figure that changes once a second
-/// cannot live in a title.
+/// The one place in this toolbar that carries a view, and the reason is that the figure has to hold
+/// a constant width. A view-less item would carry it in `title`, and a title re-measures: with the
+/// figure written into one and `validateVisibleItems()` called, the group went 219pt, 233pt, 232pt,
+/// 251pt across `0 kB/s`, `145 kB/s`, `1.2 MB/s` and `888.8 MB/s`, walking its own midpoint 16pt.
+/// A group is laid out around that midpoint, so every one of those steps slides the connection name
+/// beside it, once a second.
 ///
-/// The other half of the measurement is why the view is a fixed width rather than sized to its text.
-/// The centred group is laid out around its midpoint, so a group that grows by 14pt moves its
-/// leading edge 7pt one way and the database item 7pt the other. Measured at 1200pt: the same group
-/// sat at x=488.5 reading `↓0 kB/s` and x=481.5 reading `↓145 kB/s`. With the width pinned, changing
-/// the text moves nothing at all: group and field frames were identical across `↓0 kB/s`,
-/// `↓145 kB/s`, `↑1.2 MB/s` and `↓88 MB/s`.
+/// A view pinned to a width settles it. Measured across the same four figures, the group frame and
+/// the field frame were byte-identical every time: `group.x=396.0 w=248.0`, `field.x=573.0 w=71.0`.
 ///
 /// It publishes no action, so AppKit never validates it and it has no menu-bar command of its own.
 /// That is the cost of a readout, and it is why the item is only in the group at all for a
@@ -41,6 +37,15 @@ internal final class TransportRateToolbarItem: NSToolbarItem {
         field.translatesAutoresizingMaskIntoConstraints = false
         field.widthAnchor.constraint(equalToConstant: Self.fieldWidth).isActive = true
         view = field
+        /// After `view`, never before, and this ordering is the whole of it. `NSToolbarItem.h`:
+        /// "many of the set/get methods will be implemented by calls forwarded to the view you set,
+        /// if it responds to it", and `NSTextField` responds to `setBordered:`. Set first, the flag
+        /// is discarded and the readout draws as bare text beside two capsules; set after, AppKit
+        /// gives it a real `NSToolbarPlatterView` the same 36pt height and 8pt gap as its
+        /// neighbours. Measured: 2 platters and a 14pt-tall field one way, 3 platters and a 36pt
+        /// one the other. Writing `field.isBordered = false` anywhere later deletes the capsule
+        /// again, just as silently.
+        isBordered = true
         overflowEntry.isEnabled = false
         menuFormRepresentation = overflowEntry
         apply(rate: nil)

--- a/TablePro/Core/Transport/TransportRateLabel.swift
+++ b/TablePro/Core/Transport/TransportRateLabel.swift
@@ -1,0 +1,69 @@
+//
+//  TransportRateLabel.swift
+//  TablePro
+//
+
+import Foundation
+
+/// The throughput as one short line: an arrow for the busier direction and a figure.
+///
+/// Only one direction is shown. Two rates side by side is more width than the centred toolbar item
+/// has, and for a database connection the interesting one is whichever is moving: results coming
+/// back, or an import going out.
+///
+/// The figure is assembled from a number and a unit rather than handed to `.byteCount`, which
+/// cannot produce a shape that holds a constant width. Measured: `allowedUnits: [.kb]` floors
+/// nothing, so 512 still comes back "512 bytes", and zero comes back "Zero kB" whatever the units
+/// say. Both are four characters wider than the figures around them. The unit is left unlocalized,
+/// per the rule that technical terms are; the figure is localized.
+///
+/// An idle transport reads `0 kB/s` rather than going blank. Worth knowing before reading much into
+/// that figure: polling TablePlus's equivalent readout over an SSH tunnel gave `0 B/s` in 19 of 20
+/// idle samples, and in 37 of 45 taken during two table reloads. A quiet connection is the normal
+/// case, not a broken one.
+internal enum TransportRateLabel {
+    /// Every shape the label can take, which is what the toolbar's field measures itself against so
+    /// its width is settled once and never follows the figure.
+    internal static let widestCandidates = ["\u{2193}999 kB/s", "\u{2193}999 MB/s", "\u{2193}999 GB/s"]
+
+    private static let bytesPerKilobyte: Double = 1_000
+
+    internal static func text(for rate: TransportRate?) -> String {
+        arrow(for: rate) + figureAndUnit(for: rate)
+    }
+
+    private static func figureAndUnit(for rate: TransportRate?) -> String {
+        let value = rate.map { max($0.receivedPerSecond, $0.sentPerSecond) } ?? 0
+        guard value.isFinite, value > 0 else { return figure(0) + " kB/s" }
+
+        let kilobytes = value / bytesPerKilobyte
+        guard kilobytes >= 1 else { return figure(0) + " kB/s" }
+        guard kilobytes >= bytesPerKilobyte else { return figure(kilobytes) + " kB/s" }
+
+        let megabytes = kilobytes / bytesPerKilobyte
+        guard megabytes >= bytesPerKilobyte else { return figure(megabytes) + " MB/s" }
+        return figure(megabytes / bytesPerKilobyte) + " GB/s"
+    }
+
+    /// One fractional digit below ten, none above, so the figure never runs past three characters.
+    private static func figure(_ value: Double) -> String {
+        let fractionDigits = value < 10 && value > 0 ? 1 : 0
+        return value.formatted(.number.precision(.fractionLength(fractionDigits)).grouping(.never))
+    }
+
+    /// Down unless the connection is sending more than it is receiving, which is what an import
+    /// looks like. An idle transport keeps the down arrow rather than losing a character.
+    private static func arrow(for rate: TransportRate?) -> String {
+        guard let rate, rate.sentPerSecond > rate.receivedPerSecond else { return "\u{2193}" }
+        return "\u{2191}"
+    }
+
+    /// What VoiceOver reads instead of an arrow it would spell out as a glyph name.
+    internal static func accessibilityValue(for rate: TransportRate?) -> String {
+        let figure = figureAndUnit(for: rate)
+        let sending = (rate?.sentPerSecond ?? 0) > (rate?.receivedPerSecond ?? 0)
+        return sending
+            ? String(format: String(localized: "Sending %@"), figure)
+            : String(format: String(localized: "Receiving %@"), figure)
+    }
+}

--- a/TablePro/Models/Query/NavigationRowAnchor.swift
+++ b/TablePro/Models/Query/NavigationRowAnchor.swift
@@ -1,0 +1,38 @@
+//
+//  NavigationRowAnchor.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+/// Which row a recorded navigation entry comes back to.
+///
+/// Pure, so the one rule that decides it can be tested without a grid, a selection or a change
+/// manager behind it. The rule is that an anchor is only ever built from values the database
+/// agrees with: a key the user has staged an edit to names a row that was never saved, and
+/// discarding that edit clears the change record without putting the original value back, so an
+/// anchor taken from it either finds nothing on the way back or selects whichever row happens to
+/// carry that key by then.
+internal enum NavigationRowAnchor {
+    /// Nil when there is no usable anchor, which every caller already treats as "restore the view,
+    /// leave the selection alone". That is the only safe answer here: a wrong row is worse than no
+    /// row, because the reader cannot see that it is wrong.
+    internal static func build(
+        keyColumns: [String],
+        columns: [String],
+        values: ContiguousArray<PluginCellValue>,
+        isModified: (Int) -> Bool
+    ) -> [String: String]? {
+        guard !keyColumns.isEmpty else { return nil }
+
+        var anchor: [String: String] = [:]
+        for name in keyColumns {
+            guard let column = columns.firstIndex(of: name), column < values.count else { return nil }
+            guard !isModified(column) else { return nil }
+            guard let value = values[column].asText else { return nil }
+            anchor[name] = value
+        }
+        return anchor.isEmpty ? nil : anchor
+    }
+}

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Alerts.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Alerts.swift
@@ -43,6 +43,10 @@ extension MainContentCoordinator {
             return String(localized: "Applying or clearing filters will reload data and discard all unsaved changes.")
         case .resultSwitch:
             return String(localized: "Showing another result will discard all unsaved changes.")
+        /// Worded for both directions, because Forward reaches the same guard. Naming Back here
+        /// misstated the operation the user was approving whenever they stepped forward.
+        case .navigation:
+            return String(localized: "Moving through this tab's history replaces what it is showing and will discard all unsaved changes.")
         }
     }
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+NavigationHistory.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+NavigationHistory.swift
@@ -13,11 +13,13 @@ private let navigationHistoryLogger = Logger(subsystem: "com.TablePro", category
 extension MainContentCoordinator {
     // MARK: - Availability
 
-    /// Back is refused while the tab holds work that lives nowhere else, for the same reason a
-    /// retarget is: going back replaces the tab's content, and unsaved edits would go with it.
+    /// Back is refused once the tab is showing something other than a table, because stepping back
+    /// would have nothing to put on the forward stack in its place.
     ///
-    /// It is also refused once the tab is showing something other than a table, because stepping
-    /// back would have nothing to put on the forward stack in its place.
+    /// Unsaved cell edits do NOT refuse it. Going back does replace the tab's content and would
+    /// take them with it, but that is what the discard alert is for, and `step(back:)` routes
+    /// through the same one refresh, sort, pagination and filter already use. Refusing instead left
+    /// Back dim over a destination that still existed, with nothing saying why.
     var canNavigateBack: Bool {
         guard let tabId = navigableTabId else { return false }
         return navigationHistories[tabId]?.canGoBack ?? false
@@ -31,8 +33,19 @@ extension MainContentCoordinator {
     private var navigableTabId: UUID? {
         guard let tab = tabManager.selectedTab,
               tab.tabType == .table,
-              !selectedTabHoldsProtectedContent else { return nil }
+              !selectedTabBlocksNavigation else { return nil }
         return tab.id
+    }
+
+    /// The half of `selectedTabHoldsProtectedContent` navigation cannot offer to discard.
+    ///
+    /// Staged structure edits are the only one that survives the `tabType == .table` requirement
+    /// alongside cell edits: `holdsQueryWork` is false off a query tab and the `.createTable` arm
+    /// cannot be reached. They stay a refusal because the discard alert clears `changeManager` and
+    /// nothing else, so offering to discard them would be a promise this path cannot keep.
+    private var selectedTabBlocksNavigation: Bool {
+        guard let tab = tabManager.selectedTab else { return true }
+        return hasStagedStructureEdits(in: tab)
     }
 
     // MARK: - Recording
@@ -89,13 +102,17 @@ extension MainContentCoordinator {
         let tableRows = tabSessionRegistry.tableRows(for: tab.id)
         guard let row = gridCoordinator.displayRow(at: displayIndex, in: tableRows) else { return nil }
 
-        var anchor: [String: String] = [:]
-        for name in keyColumns {
-            guard let column = tableRows.columns.firstIndex(of: name),
-                  let value = row[column].asText else { return nil }
-            anchor[name] = value
-        }
-        return anchor.isEmpty ? nil : anchor
+        let rowIndex = gridCoordinator.tableRowsIndex(forDisplayRow: displayIndex)
+
+        return NavigationRowAnchor.build(
+            keyColumns: keyColumns,
+            columns: tableRows.columns,
+            values: row.values,
+            isModified: { column in
+                guard let rowIndex else { return false }
+                return changeManager.isCellModified(rowIndex: rowIndex, columnIndex: column)
+            }
+        )
     }
 
     // MARK: - Navigating
@@ -108,15 +125,30 @@ extension MainContentCoordinator {
         step(back: false)
     }
 
+    /// Asks before it discards, through the alert the other reload paths use. With nothing staged
+    /// the guard completes synchronously with `true`, so an ordinary step never defers a turn.
+    ///
+    /// The departing entry is captured *before* the guard on purpose. Discarding clears the change
+    /// records but leaves the edited values in `TableRows`, so a capture afterwards cannot tell a
+    /// staged key from a saved one and would anchor the forward stack on a value the user just
+    /// threw away.
+    private func step(back: Bool) {
+        let departing = captureNavigationEntry()
+        confirmDiscardChangesIfNeeded(action: .navigation) { [weak self] confirmed in
+            guard confirmed else { return }
+            self?.commitStep(back: back, from: departing)
+        }
+    }
+
     /// Moves one entry and puts it back on the tab, or leaves the history exactly as it was.
     ///
     /// The stacks are mutated on a copy and only written back once the restore has actually landed.
     /// Moving them first would strand the reader if the retarget failed: the entry they asked for
     /// would be gone and Forward would point at the view they are still looking at.
-    private func step(back: Bool) {
+    private func commitStep(back: Bool, from departing: TabNavigationEntry?) {
         guard let tabId = navigableTabId,
               var history = navigationHistories[tabId],
-              let current = captureNavigationEntry() else { return }
+              let current = departing else { return }
         guard let entry = back ? history.stepBack(from: current) : history.stepForward(from: current) else {
             return
         }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -21,6 +21,7 @@ enum DiscardAction {
     case pagination
     case filter
     case resultSwitch
+    case navigation
 }
 
 struct DisplayFormatsCacheEntry {

--- a/TableProTests/Core/Transport/TransportRateLabelTests.swift
+++ b/TableProTests/Core/Transport/TransportRateLabelTests.swift
@@ -1,0 +1,102 @@
+//
+//  TransportRateLabelTests.swift
+//  TableProTests
+//
+
+import AppKit
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("TransportRateLabel")
+struct TransportRateLabelTests {
+    @Test("An idle transport reads zero rather than going blank")
+    func idleReadsZero() {
+        let text = TransportRateLabel.text(for: .zero)
+
+        #expect(text.contains("0"))
+        #expect(text.hasSuffix("kB/s"))
+    }
+
+    @Test("No reading yet reads the same as idle")
+    func absentRateReadsAsIdle() {
+        #expect(TransportRateLabel.text(for: nil) == TransportRateLabel.text(for: .zero))
+    }
+
+    /// `.byteCount` spells the smallest unit out in full: measured, `allowedUnits: [.kb]` still
+    /// returns "512 bytes" for 512 and "Zero kB" for 0. Both are four characters wider than the
+    /// figures around them, which is why the label is assembled rather than formatted.
+    @Test("A rate below a kilobyte never spells out bytes")
+    func subKilobyteNeverSpellsBytes() {
+        let text = TransportRateLabel.text(for: TransportRate(receivedPerSecond: 512, sentPerSecond: 0))
+
+        #expect(!text.lowercased().contains("byte"))
+        #expect(text.hasSuffix("kB/s"))
+    }
+
+    @Test("Units step up at a thousand")
+    func unitsStepUp() {
+        let kilo = TransportRateLabel.text(for: TransportRate(receivedPerSecond: 145_408, sentPerSecond: 0))
+        let mega = TransportRateLabel.text(for: TransportRate(receivedPerSecond: 4_700_000, sentPerSecond: 0))
+        let giga = TransportRateLabel.text(for: TransportRate(receivedPerSecond: 2_400_000_000, sentPerSecond: 0))
+
+        #expect(kilo.hasSuffix("kB/s"))
+        #expect(mega.hasSuffix("MB/s"))
+        #expect(giga.hasSuffix("GB/s"))
+    }
+
+    @Test("The busier direction picks the arrow")
+    func arrowFollowsTheBusierDirection() {
+        let down = TransportRateLabel.text(for: TransportRate(receivedPerSecond: 145_408, sentPerSecond: 12))
+        let up = TransportRateLabel.text(for: TransportRate(receivedPerSecond: 12, sentPerSecond: 145_408))
+
+        #expect(down.hasPrefix("\u{2193}"))
+        #expect(up.hasPrefix("\u{2191}"))
+    }
+
+    @Test("An arrow is never what VoiceOver is given to read")
+    func accessibilityValueNamesTheDirection() {
+        let down = TransportRateLabel.accessibilityValue(for: TransportRate(receivedPerSecond: 145_408, sentPerSecond: 0))
+        let up = TransportRateLabel.accessibilityValue(for: TransportRate(receivedPerSecond: 0, sentPerSecond: 145_408))
+
+        #expect(!down.contains("\u{2193}"))
+        #expect(!up.contains("\u{2191}"))
+        #expect(down != up)
+    }
+
+    /// The field measures itself against these once, so a format that can produce something wider
+    /// than all of them would clip its own text.
+    @Test("No rate renders wider than the widest candidate the field is sized from")
+    func noRateOutgrowsTheField() {
+        let font = NSFont.monospacedDigitSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular)
+        let budget = TransportRateLabel.widestCandidates
+            .map { ($0 as NSString).size(withAttributes: [.font: font]).width }
+            .max() ?? 0
+
+        let rates: [Double] = [0, 1, 512, 1_000, 1_500, 9_900, 64_000, 145_408, 512_000, 999_000,
+                               1_200_000, 4_700_000, 12_500_000, 88_000_000, 999_000_000, 2_400_000_000]
+
+        for value in rates {
+            let text = TransportRateLabel.text(for: TransportRate(receivedPerSecond: value, sentPerSecond: 0))
+            let width = (text as NSString).size(withAttributes: [.font: font]).width
+            #expect(width <= budget, "\(value) B/s rendered \"\(text)\" at \(width)pt, past the \(budget)pt budget")
+        }
+    }
+
+    /// Monospaced digits are what make the drawn text hold still inside a fixed field: the figure
+    /// changes, the glyph advances do not.
+    @Test("Every figure of the same shape draws to the same width")
+    func figuresOfOneShapeDrawAlike() {
+        let font = NSFont.monospacedDigitSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular)
+        let threeDigitKilobytes: [Double] = [111_000, 145_408, 512_000, 999_000]
+
+        let widths = threeDigitKilobytes.map { value -> CGFloat in
+            let text = TransportRateLabel.text(for: TransportRate(receivedPerSecond: value, sentPerSecond: 0))
+            return (text as NSString).size(withAttributes: [.font: font]).width
+        }
+
+        let widest = widths.max() ?? 0
+        let narrowest = widths.min() ?? 0
+        #expect(widest - narrowest < 0.01, "Monospaced digits must not vary: spread was \(widest - narrowest)pt")
+    }
+}

--- a/TableProTests/Models/Query/NavigationRowAnchorTests.swift
+++ b/TableProTests/Models/Query/NavigationRowAnchorTests.swift
@@ -1,0 +1,95 @@
+//
+//  NavigationRowAnchorTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("NavigationRowAnchor")
+struct NavigationRowAnchorTests {
+    private let columns = ["id", "region", "name"]
+    private let values: ContiguousArray<PluginCellValue> = [.text("42"), .text("eu"), .text("Ada")]
+
+    private func anchor(
+        keyColumns: [String],
+        modified: Set<Int> = []
+    ) -> [String: String]? {
+        NavigationRowAnchor.build(
+            keyColumns: keyColumns,
+            columns: columns,
+            values: values,
+            isModified: { modified.contains($0) }
+        )
+    }
+
+    @Test("A clean key anchors on its value")
+    func cleanKeyAnchors() {
+        #expect(anchor(keyColumns: ["id"]) == ["id": "42"])
+    }
+
+    @Test("Every column of a composite key is carried")
+    func compositeKeyAnchors() {
+        #expect(anchor(keyColumns: ["id", "region"]) == ["id": "42", "region": "eu"])
+    }
+
+    /// The defect this type exists for. `TableRows` holds the edited value while the change is
+    /// staged, and discarding clears the record without restoring the original, so a key taken from
+    /// it names a row that was never saved.
+    @Test("A staged edit to the key anchors nothing")
+    func stagedKeyEditRefusesToAnchor() {
+        #expect(anchor(keyColumns: ["id"], modified: [0]) == nil)
+    }
+
+    /// One edited column of a composite key poisons the whole anchor, because the restore matches
+    /// on all of them together.
+    @Test("A staged edit to one column of a composite key anchors nothing")
+    func stagedEditToOneKeyColumnRefuses() {
+        #expect(anchor(keyColumns: ["id", "region"], modified: [1]) == nil)
+    }
+
+    /// An edit somewhere else on the same row is not the key, so it does not disturb the anchor.
+    @Test("A staged edit outside the key still anchors")
+    func stagedEditOutsideTheKeyAnchors() {
+        #expect(anchor(keyColumns: ["id"], modified: [2]) == ["id": "42"])
+    }
+
+    @Test("A table with no primary key anchors nothing")
+    func noKeyColumnsAnchorsNothing() {
+        #expect(anchor(keyColumns: []) == nil)
+    }
+
+    @Test("A key column the result does not carry anchors nothing")
+    func absentKeyColumnAnchorsNothing() {
+        #expect(anchor(keyColumns: ["tenant_id"]) == nil)
+    }
+
+    /// A NULL key cannot be matched on the way back, so it is not an anchor either.
+    @Test("A key with no text value anchors nothing")
+    func nullKeyAnchorsNothing() {
+        let result = NavigationRowAnchor.build(
+            keyColumns: ["id"],
+            columns: columns,
+            values: [.null, .text("eu"), .text("Ada")],
+            isModified: { _ in false }
+        )
+
+        #expect(result == nil)
+    }
+
+    /// A row shorter than the column list is malformed rather than anchorable, and indexing it
+    /// would trap.
+    @Test("A row shorter than its columns anchors nothing")
+    func shortRowAnchorsNothing() {
+        let result = NavigationRowAnchor.build(
+            keyColumns: ["name"],
+            columns: columns,
+            values: [.text("42")],
+            isModified: { _ in false }
+        )
+
+        #expect(result == nil)
+    }
+}

--- a/TableProTests/Services/MainWindowToolbarLayoutTests.swift
+++ b/TableProTests/Services/MainWindowToolbarLayoutTests.swift
@@ -246,10 +246,12 @@ struct MainWindowToolbarCustomizationTests {
     /// The identifier is the autosave name, and changing it discards every user's arrangement. It
     /// moved to v3 with the rewrite that dropped the hosted status item, because a stored v2 list
     /// names identifiers the delegate no longer vends and would leave those users the crowded
-    /// toolbar the rewrite exists to fix. It is not free, so it does not move again without the
-    /// same justification.
+    /// toolbar the rewrite exists to fix. It moved to v4 for the throughput readout, whose
+    /// identifier a stored v3 arrangement does not name, so a reader who had customized the toolbar
+    /// would never see it. It is not free, so it does not move again without the same
+    /// justification.
     @Test("The toolbar identifier is stable")
     func identifierIsStable() {
-        #expect(MainWindowToolbar.toolbarIdentifier == "com.TablePro.main.toolbar.v3")
+        #expect(MainWindowToolbar.toolbarIdentifier == "com.TablePro.main.toolbar.v4")
     }
 }

--- a/TableProTests/Services/MainWindowToolbarNativeContractTests.swift
+++ b/TableProTests/Services/MainWindowToolbarNativeContractTests.swift
@@ -106,24 +106,20 @@ struct MainWindowToolbarNativeContractTests {
         #expect(MainWindowToolbar().transportRateGroup.subitems.isEmpty)
     }
 
-    /// Back and forward hide when there is nowhere to go, which is a deliberate departure from
-    /// Apple: measured on a running Xcode, its Back/Forward group keeps its full 75pt capsule with
-    /// both segments DISABLED. Emptying the group is what hides it, and measured, doing so drops its
-    /// platter and moves nothing else, the centred group included.
-    @Test("Back and forward are absent with no history to walk")
-    func navigationHidesWithNowhereToGo() {
+    /// Availability is `isEnabled`, never presence. Measured on three running Apple apps, Xcode,
+    /// Finder in column view and System Settings all keep the 75pt Back/Forward capsule and dim the
+    /// direction that has nowhere to go; the HIG says the same for the menu bar, "disable the action
+    /// instead of hiding it".
+    ///
+    /// This asserts on the VENDED item and on a toolbar with no coordinator, which is the state a
+    /// hidden pair would report. Testing the pure `isEnabled(itemIdentifier:context:)` predicate
+    /// cannot catch the regression this replaces: four such cases in
+    /// `MainWindowToolbarValidationTests` stayed green for the whole life of the hiding commit,
+    /// because they never look at composition.
+    @Test("Back and forward are present and dimmed, never absent")
+    func navigationIsPresentAndDimmed() throws {
         let owner = MainWindowToolbar()
-
-        #expect(owner.navigationGroup.subitems.isEmpty)
-        #expect(owner.navigationGroup.isNavigational)
-    }
-
-    /// Both arrows go together. Hiding one of a segmented pair leaves a lone half-capsule whose
-    /// width changes on every step through the history.
-    @Test("The navigation group is the whole pair or nothing")
-    func navigationHidesAsAPair() throws {
-        let owner = MainWindowToolbar()
-        let vended = try #require(
+        let group = try #require(
             owner.toolbar(
                 owner.managedToolbar,
                 itemForItemIdentifier: MainWindowToolbar.backForwardGroup,
@@ -131,8 +127,34 @@ struct MainWindowToolbarNativeContractTests {
             ) as? NSToolbarItemGroup
         )
 
-        #expect(vended === owner.navigationGroup, "The toolbar must show the instance that gets emptied")
-        #expect(vended.subitems.isEmpty || vended.subitems.count == 2)
+        #expect(group.subitems.count == 2, "The pair is installed unconditionally")
+        #expect(group.subitems.map(\.itemIdentifier) == [MainWindowToolbar.navigateBack, MainWindowToolbar.navigateForward])
+        /// What puts the pair on the leading edge, where the HIG keeps items that return to the
+        /// previous document and where they are not customizable away.
+        #expect(group.isNavigational)
+
+        for subitem in group.subitems {
+            #expect(!owner.validateToolbarItem(subitem), "With no connection each direction dims")
+        }
+    }
+
+    /// A `title` on either subitem would split the shared platter into two capsules. Measured: two
+    /// titled subitems draw two platters, untitled ones share a single platter spanning the group,
+    /// which is the one capsule Finder, Xcode and System Settings all draw.
+    @Test("Neither navigation arrow carries a title")
+    func navigationArrowsShareOneCapsule() throws {
+        let owner = MainWindowToolbar()
+        let group = try #require(
+            owner.toolbar(
+                owner.managedToolbar,
+                itemForItemIdentifier: MainWindowToolbar.backForwardGroup,
+                willBeInsertedIntoToolbar: true
+            ) as? NSToolbarItemGroup
+        )
+
+        for subitem in group.subitems {
+            #expect(subitem.title.isEmpty, "\(subitem.itemIdentifier.rawValue) must not set a title")
+        }
     }
 
     /// The readout is a readout: it publishes no action, so AppKit never validates it and it has no

--- a/TableProTests/Services/MainWindowToolbarNativeContractTests.swift
+++ b/TableProTests/Services/MainWindowToolbarNativeContractTests.swift
@@ -65,15 +65,74 @@ struct MainWindowToolbarNativeContractTests {
         }
     }
 
-    /// The capsule, and the ordering that is the whole of it. `NSToolbarItem.h` forwards many of its
-    /// setters to the view once one is set, and `NSTextField` responds to `setBordered:`, so
-    /// `isBordered` written before `view` is discarded and the readout draws as bare text between
-    /// two capsules. Written after, AppKit gives it a real platter at the same height and gap as its
-    /// neighbours: measured, 2 platters and a 14pt-tall field one way, 3 platters and a 36pt one the
-    /// other. Nothing warns when it is wrong, which is why this assertion exists.
-    @Test("The throughput readout wears the group's capsule")
-    func throughputReadoutIsBordered() {
-        #expect(MainWindowToolbar().transportRateItem.isBordered)
+    /// Bare text, no capsule, which is what Xcode does with the one comparable thing it ships: its
+    /// Window Title/Activity readout draws as plain text beside the Back/Forward capsule, measured
+    /// on a running Xcode. `isBordered` here would give the readout a platter of its own and make
+    /// the centre three capsules for two controls and one number.
+    @Test("The throughput readout wears no capsule")
+    func throughputReadoutIsUnbordered() {
+        #expect(!MainWindowToolbar().transportRateItem.isBordered)
+    }
+
+    /// Beside the centred pair, never inside it. A group is laid out around its own midpoint, so a
+    /// readout among the subitems pushes the connection and database capsules off centre by half its
+    /// width. Measured at 1400pt: as its own adjacent item the group sits at x=647.0 midX=772.8,
+    /// byte-identical to carrying no readout at all.
+    @Test("The readout sits beside the centred group, not inside it and not centred itself")
+    func readoutIsAdjacentToTheCentre() throws {
+        let owner = MainWindowToolbar()
+        let group = try #require(
+            owner.toolbar(
+                owner.managedToolbar,
+                itemForItemIdentifier: MainWindowToolbar.connectionGroup,
+                willBeInsertedIntoToolbar: true
+            ) as? NSToolbarItemGroup
+        )
+
+        #expect(!group.subitems.contains { $0 === owner.transportRateItem })
+        #expect(!owner.managedToolbar.centeredItemIdentifiers.contains(TransportRateToolbarItem.identifier))
+
+        let identifiers = MainWindowToolbar.defaultItemIdentifiers
+        let centre = try #require(identifiers.firstIndex(of: MainWindowToolbar.connectionGroup))
+        let readout = try #require(identifiers.firstIndex(of: TransportRateToolbarItem.identifier))
+        #expect(readout == centre + 1, "The readout must follow the centred group immediately")
+    }
+
+    /// Emptying the readout's own group is how it leaves the toolbar. Measured, nothing else hides
+    /// it cleanly: a hidden view keeps its 75pt and a zero-width constraint still leaves 24pt, and
+    /// `NSToolbarItem.isHidden` is macOS 15 against a macOS 14 floor.
+    @Test("A connection with no measurable transport shows no readout")
+    func unmeasuredConnectionsCarryNoReadout() {
+        #expect(MainWindowToolbar().transportRateGroup.subitems.isEmpty)
+    }
+
+    /// Back and forward hide when there is nowhere to go, which is a deliberate departure from
+    /// Apple: measured on a running Xcode, its Back/Forward group keeps its full 75pt capsule with
+    /// both segments DISABLED. Emptying the group is what hides it, and measured, doing so drops its
+    /// platter and moves nothing else, the centred group included.
+    @Test("Back and forward are absent with no history to walk")
+    func navigationHidesWithNowhereToGo() {
+        let owner = MainWindowToolbar()
+
+        #expect(owner.navigationGroup.subitems.isEmpty)
+        #expect(owner.navigationGroup.isNavigational)
+    }
+
+    /// Both arrows go together. Hiding one of a segmented pair leaves a lone half-capsule whose
+    /// width changes on every step through the history.
+    @Test("The navigation group is the whole pair or nothing")
+    func navigationHidesAsAPair() throws {
+        let owner = MainWindowToolbar()
+        let vended = try #require(
+            owner.toolbar(
+                owner.managedToolbar,
+                itemForItemIdentifier: MainWindowToolbar.backForwardGroup,
+                willBeInsertedIntoToolbar: true
+            ) as? NSToolbarItemGroup
+        )
+
+        #expect(vended === owner.navigationGroup, "The toolbar must show the instance that gets emptied")
+        #expect(vended.subitems.isEmpty || vended.subitems.count == 2)
     }
 
     /// The readout is a readout: it publishes no action, so AppKit never validates it and it has no
@@ -106,15 +165,6 @@ struct MainWindowToolbarNativeContractTests {
 
         #expect(!entry.title.contains("\u{2193}"))
         #expect(!entry.title.contains("\u{2191}"))
-    }
-
-    /// Structural, and deliberately so: adding or removing a subitem is the one change AppKit does
-    /// re-measure. It happens when a connection is adopted, never under a running tunnel.
-    @Test("A connection with no measurable transport carries no readout")
-    func unmeasuredConnectionsCarryNoReadout() {
-        let owner = MainWindowToolbar()
-
-        #expect(!owner.connectionGroupSubitems().contains { $0 === owner.transportRateItem })
     }
 
     /// Finder ships 8 controls and Xcode 13. The default set was 17 plus a hosted status blob, and

--- a/TableProTests/Services/MainWindowToolbarNativeContractTests.swift
+++ b/TableProTests/Services/MainWindowToolbarNativeContractTests.swift
@@ -31,11 +31,77 @@ struct MainWindowToolbarNativeContractTests {
     /// item, such as label or view, apply to the entire item"). AppKit can only drop it whole, and
     /// it did: at 1200pt the hosted status item held its width while seven commands went to the
     /// overflow menu.
-    @Test("No toolbar item is backed by a view")
-    func noItemIsViewBacked() {
+    @Test("No command is backed by a view")
+    func noCommandIsViewBacked() {
         for item in vendedItems() {
             #expect(item.view == nil, "\(item.itemIdentifier.rawValue) must not be view-backed")
         }
+    }
+
+    /// The one exception, and the reason it is safe. AppKit sizes a view-less item's `title` once,
+    /// when the item is inserted: measured, setting a longer title afterwards leaves the item at its
+    /// old width and clips the text, and neither `validateVisibleItems()` nor a window resize
+    /// re-measures it. So a figure that changes once a second cannot live in a title.
+    ///
+    /// What made the old hosted status item undroppable was that it had no width of its own to give
+    /// back. This one is pinned to a width measured from the widest figure it can ever draw, so it
+    /// never needs compressing, and it is only in the group at all for a connection whose bytes the
+    /// app carries.
+    @Test("The throughput readout is view-backed, and pinned to a width it cannot outgrow")
+    func throughputReadoutIsPinned() throws {
+        let owner = MainWindowToolbar()
+        let field = try #require(owner.transportRateItem.view as? NSTextField)
+        let pinned = field.constraints.filter { $0.firstAttribute == .width && $0.relation == .equal }
+        let constant = try #require(pinned.first?.constant)
+
+        #expect(pinned.count == 1, "The readout must carry exactly one width constraint")
+
+        let font = try #require(field.font)
+        for candidate in TransportRateLabel.widestCandidates {
+            let width = (candidate as NSString).size(withAttributes: [.font: font]).width
+            #expect(width <= constant, "\"\(candidate)\" needs \(width)pt but the field is \(constant)pt")
+        }
+    }
+
+    /// The readout is a readout: it publishes no action, so AppKit never validates it and it has no
+    /// menu-bar command of its own. That is the trade the placement makes, and it is pinned here so
+    /// a later change that gives it an action has to say so.
+    ///
+    /// It still gets an overflow entry, because the centred group is the first region AppKit sheds
+    /// when the window narrows and the figure should not vanish with the controls beside it. The
+    /// entry is disabled: there is nothing to click.
+    @Test("The throughput readout claims no action but still reports in the overflow menu")
+    func throughputReadoutIsInertButVisible() throws {
+        let owner = MainWindowToolbar()
+        let item = owner.transportRateItem
+
+        #expect(item.action == nil)
+
+        let entry = try #require(item.menuFormRepresentation)
+        #expect(entry.action == nil)
+        #expect(!entry.isEnabled)
+        #expect(!entry.title.isEmpty)
+    }
+
+    /// An arrow glyph is what the field draws; it is not what the overflow entry or VoiceOver
+    /// should be handed, because neither reads it as a direction.
+    @Test("The overflow entry names the direction rather than drawing an arrow")
+    func overflowEntryNamesTheDirection() throws {
+        let owner = MainWindowToolbar()
+        owner.transportRateItem.apply(rate: TransportRate(receivedPerSecond: 145_408, sentPerSecond: 0))
+        let entry = try #require(owner.transportRateItem.menuFormRepresentation)
+
+        #expect(!entry.title.contains("\u{2193}"))
+        #expect(!entry.title.contains("\u{2191}"))
+    }
+
+    /// Structural, and deliberately so: adding or removing a subitem is the one change AppKit does
+    /// re-measure. It happens when a connection is adopted, never under a running tunnel.
+    @Test("A connection with no measurable transport carries no readout")
+    func unmeasuredConnectionsCarryNoReadout() {
+        let owner = MainWindowToolbar()
+
+        #expect(!owner.connectionGroupSubitems().contains { $0 === owner.transportRateItem })
     }
 
     /// Finder ships 8 controls and Xcode 13. The default set was 17 plus a hosted status blob, and

--- a/TableProTests/Services/MainWindowToolbarNativeContractTests.swift
+++ b/TableProTests/Services/MainWindowToolbarNativeContractTests.swift
@@ -38,10 +38,12 @@ struct MainWindowToolbarNativeContractTests {
         }
     }
 
-    /// The one exception, and the reason it is safe. AppKit sizes a view-less item's `title` once,
-    /// when the item is inserted: measured, setting a longer title afterwards leaves the item at its
-    /// old width and clips the text, and neither `validateVisibleItems()` nor a window resize
-    /// re-measures it. So a figure that changes once a second cannot live in a title.
+    /// The one exception, and the reason it is safe. A view-less item would carry the figure in
+    /// `title`, and a title re-measures: written into one with `validateVisibleItems()` called, the
+    /// group went 219pt, 233pt, 232pt, 251pt across `0 kB/s`, `145 kB/s`, `1.2 MB/s` and
+    /// `888.8 MB/s`, walking its own midpoint 16pt and sliding the connection name beside it once a
+    /// second. A view pinned to a width holds still: the group and field frames were byte-identical
+    /// across the same four figures.
     ///
     /// What made the old hosted status item undroppable was that it had no width of its own to give
     /// back. This one is pinned to a width measured from the widest figure it can ever draw, so it
@@ -61,6 +63,17 @@ struct MainWindowToolbarNativeContractTests {
             let width = (candidate as NSString).size(withAttributes: [.font: font]).width
             #expect(width <= constant, "\"\(candidate)\" needs \(width)pt but the field is \(constant)pt")
         }
+    }
+
+    /// The capsule, and the ordering that is the whole of it. `NSToolbarItem.h` forwards many of its
+    /// setters to the view once one is set, and `NSTextField` responds to `setBordered:`, so
+    /// `isBordered` written before `view` is discarded and the readout draws as bare text between
+    /// two capsules. Written after, AppKit gives it a real platter at the same height and gap as its
+    /// neighbours: measured, 2 platters and a 14pt-tall field one way, 3 platters and a 36pt one the
+    /// other. Nothing warns when it is wrong, which is why this assertion exists.
+    @Test("The throughput readout wears the group's capsule")
+    func throughputReadoutIsBordered() {
+        #expect(MainWindowToolbar().transportRateItem.isBordered)
     }
 
     /// The readout is a readout: it publishes no action, so AppKit never validates it and it has no

--- a/TableProTests/Services/MainWindowToolbarShortcutHintTests.swift
+++ b/TableProTests/Services/MainWindowToolbarShortcutHintTests.swift
@@ -131,6 +131,28 @@ struct MainWindowToolbarShortcutHintTests {
         #expect(item?.toolTip?.isEmpty == false)
     }
 
+    /// Back is reachable from `allItems()` only while it is installed in its group, and `allItems()`
+    /// is the only channel that re-applies a rebind to a toolbar item. A commit that hid the pair by
+    /// emptying the group took both arrows out of that walk, so a rebind reached the menu bar and
+    /// stopped, leaving the toolbar advertising a key that no longer ran the command. `try #require`
+    /// rather than optional chaining on purpose: the house style here passes vacuously when the
+    /// subitem is absent, which is exactly the state this guards against.
+    @Test("A rebind reaches the navigation arrows")
+    func navigationFollowsLaterRebind() throws {
+        try withKeyboard(.character("j", command: true, control: true), for: .navigateBack) { owner in
+            let item = try #require(
+                vendSubitem(
+                    MainWindowToolbar.navigateBack,
+                    of: MainWindowToolbar.backForwardGroup,
+                    from: owner
+                ),
+                "Back must be reachable through its group, or a rebind cannot find it"
+            )
+            #expect(item.toolTip?.contains("⌃⌘J") == true)
+            #expect(item.menuFormRepresentation?.keyEquivalent == "j")
+        }
+    }
+
     /// The Import item opens a submenu, so its menu form carries the submenu rather than a key.
     /// Writing a key equivalent onto it would put a shortcut on a row that only opens a menu.
     /// It is only ever vended inside the Export & Import group, never on its own.

--- a/TableProTests/Views/Main/FKNavigationTests.swift
+++ b/TableProTests/Views/Main/FKNavigationTests.swift
@@ -598,9 +598,16 @@ struct FKNavigationTests {
         #expect(coordinator.canNavigateBack == false)
     }
 
-    @Test("Back stands down while the tab holds unsaved edits")
+    /// Back stays offered with unsaved edits, and asks before it discards them, the way refresh,
+    /// sort, pagination and filter already do. It used to refuse instead, which left the control
+    /// dim over a destination that still existed with nothing saying why.
+    ///
+    /// The step is not asserted here: with changes staged, `confirmDiscardChangesIfNeeded` puts a
+    /// real alert on screen, which a unit test cannot answer. What this pins is the availability,
+    /// which is what the toolbar and the View menu both read.
+    @Test("Back stays offered while the tab holds unsaved edits")
     @MainActor
-    func backIsUnavailableWithPendingEdits() throws {
+    func backStaysOfferedWithPendingEdits() throws {
         let connection = TestFixtures.makeConnection(database: "db_a")
         let tabManager = QueryTabManager()
         let coordinator = MainContentCoordinator(
@@ -623,9 +630,44 @@ struct FKNavigationTests {
 
         coordinator.changeManager.hasChanges = true
 
+        #expect(coordinator.canNavigateBack, "Unsaved edits are a prompt, not a refusal")
+    }
+
+    /// The one thing navigation still refuses outright. The discard alert clears `changeManager`
+    /// and nothing else, so offering to discard a staged structure edit would be a promise this
+    /// path cannot keep.
+    @Test("Back stands down while the tab holds staged structure edits")
+    @MainActor
+    func backIsUnavailableWithStagedStructureEdits() throws {
+        let connection = TestFixtures.makeConnection(database: "db_a")
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        defer { coordinator.teardown() }
+
+        try tabManager.addTableTab(
+            tableName: "orders",
+            databaseType: connection.type,
+            databaseName: coordinator.browseDatabaseName
+        )
+
+        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        #expect(coordinator.canNavigateBack)
+
+        let tabId = try #require(tabManager.selectedTabId)
+        let session = TestFixtures.makeStructureSession()
+        coordinator.structureSessions[tabId] = session
+        session.changeManager.loadSchema(
+            tableName: "users", columns: [], indexes: [], foreignKeys: [], primaryKey: []
+        )
+        session.changeManager.addNewColumn()
+
         #expect(coordinator.canNavigateBack == false)
-        coordinator.navigateBack()
-        #expect(tabManager.selectedTab?.tableContext.tableName == "users")
     }
 
     @Test("Closing a tab takes its history with it")

--- a/docs/connections/index.mdx
+++ b/docs/connections/index.mdx
@@ -80,9 +80,13 @@ A connection's group, tags, and favorite star sync through iCloud unless it is m
 
 Press `Ctrl+Cmd+C` for **Switch Connection**. Whatever is already open sits at the top, and the rest are listed under the group they belong to, a nested group carrying its full path. Arrow keys move, `Return` switches the window to that connection, and `Cmd`-click opens a saved one in a window of its own. Typing searches every group at once and collapses the matches into a single list.
 
-A footer under that list names the transport the window's connection runs on. On an SSH tunnel or a SOCKS proxy it also carries the bytes that have crossed since the transport opened, received and sent, with the rate beside a direction while data moves. An idle transport keeps its totals and drops the rate.
+A footer under that list names the transport the window's connection runs on. On an SSH tunnel or a SOCKS proxy it also carries the bytes that have crossed since the transport opened, received and sent.
 
 The rest show their name alone. Cloudflare Tunnel, Cloud SQL Auth Proxy and Tunnel Command each run a separate binary that holds the connection end to end, a [remote database file](/connections/remote-database-files) is fetched once and then read from disk, and a direct connection's socket belongs to the database driver.
+
+### Throughput in the toolbar
+
+The same two transports put a live figure beside the connection name in the middle of the toolbar, an arrow for whichever direction is busier and the rate: `↓145 kB/s`. It reads `0 kB/s` while nothing moves, which is most of the time on a database connection. A connection on any other transport has no figure there at all.
 
 **Open Database** (`Cmd+K`) moves to another database on the same server.
 

--- a/docs/connections/socks-proxy.mdx
+++ b/docs/connections/socks-proxy.mdx
@@ -63,7 +63,7 @@ An SSH dynamic port forward is a SOCKS5 proxy. Run `ssh -D 1080 user@bastion`, t
 
 [SSL/TLS](/connections/ssl) still applies, with one unavoidable adjustment: the driver dials a loopback port that no server certificate names, so **Verify CA** and **Verify Identity** fall back to **Required** and certificate paths are dropped.
 
-Bytes through the proxy are counted the same way an SSH tunnel's are. Press `Ctrl+Cmd+C` and read the footer under the connection list. See [transport activity](/connections#switch-connections-and-databases).
+Bytes through the proxy are counted the same way an SSH tunnel's are: a live rate in the toolbar, and the totals under the connection switcher. See [transport activity](/connections#switch-connections-and-databases).
 
 ## Troubleshooting
 

--- a/docs/connections/ssh-tunneling.mdx
+++ b/docs/connections/ssh-tunneling.mdx
@@ -112,7 +112,7 @@ If tunnels keep dropping on an idle network, the keep-alive is not the missing p
 
 ## What the tunnel is carrying
 
-Press `Ctrl+Cmd+C` and read the footer under the connection list: bytes received and sent since the tunnel opened, and the rate beside a direction while data moves. A rebuilt tunnel starts again from zero. See [transport activity](/connections#switch-connections-and-databases).
+The rate sits beside the connection name in the middle of the toolbar. For the totals, press `Ctrl+Cmd+C` and read the footer under the connection list: bytes received and sent since the tunnel opened. A rebuilt tunnel starts again from zero. See [transport activity](/connections#switch-connections-and-databases).
 
 ## Troubleshooting
 

--- a/docs/features/data-grid.mdx
+++ b/docs/features/data-grid.mdx
@@ -74,7 +74,7 @@ A column of a foreign key that spans several columns keeps the text editor. The 
 
 The inspector's **JSON** view follows a key without leaving the row: see [Row as JSON](/features/json-viewer#row-as-json).
 
-Step back with the Back and Forward buttons at the leading edge of the toolbar, or **View > Back** (`Ctrl+Cmd+[`) and **View > Forward** (`Ctrl+Cmd+]`). Back restores the table you came from as you left it: same filters, sort, page, and selected row. Each tab keeps its own history, Back never closes a tab, and it is unavailable while a tab holds unsaved edits.
+Step back with the Back and Forward buttons at the leading edge of the toolbar, or **View > Back** (`Ctrl+Cmd+[`) and **View > Forward** (`Ctrl+Cmd+]`). The buttons appear once a tab has somewhere to go and are absent until then; the menu items stay put and dim. Back restores the table you came from as you left it: same filters, sort, page, and selected row. Each tab keeps its own history, Back never closes a tab, and it is unavailable while a tab holds unsaved edits.
 
 <Frame caption="Foreign key lookup">
   <img className="block dark:hidden" src="/images/fk-lookup-popover.png" alt="Foreign key lookup" />

--- a/docs/features/data-grid.mdx
+++ b/docs/features/data-grid.mdx
@@ -74,7 +74,7 @@ A column of a foreign key that spans several columns keeps the text editor. The 
 
 The inspector's **JSON** view follows a key without leaving the row: see [Row as JSON](/features/json-viewer#row-as-json).
 
-Step back with the Back and Forward buttons at the leading edge of the toolbar, or **View > Back** (`Ctrl+Cmd+[`) and **View > Forward** (`Ctrl+Cmd+]`). The buttons appear once a tab has somewhere to go and are absent until then; the menu items stay put and dim. Back restores the table you came from as you left it: same filters, sort, page, and selected row. Each tab keeps its own history, Back never closes a tab, and it is unavailable while a tab holds unsaved edits.
+Step back with the Back and Forward buttons at the leading edge of the toolbar, or **View > Back** (`Ctrl+Cmd+[`) and **View > Forward** (`Ctrl+Cmd+]`). Back restores the table you came from as you left it: same filters, sort, page, and selected row. Each tab keeps its own history and Back never closes a tab. With unsaved edits in the tab, Back asks to discard them first; with a staged structure edit it stands down, because that work cannot be discarded from here.
 
 <Frame caption="Foreign key lookup">
   <img className="block dark:hidden" src="/images/fk-lookup-popover.png" alt="Foreign key lookup" />


### PR DESCRIPTION
Moves the live throughput figure into the centred connection group, next to the connection name and the database. The connection switcher keeps the totals and the transport name; the toolbar gets the rate.

## Why it could not be done with a title

The obvious shape, appending the rate to the connection item's `title`, does not work, and the reason is not the one I expected. Measured on a real 1200pt `NSToolbar` with a centred group:

| Step | group.x | group.w |
|---|---|---|
| initial title `prod-db` | 552.0 | **96.0** |
| set title `prod-db ↓145 kB/s` | 552.0 | **96.0** |
| `validateVisibleItems()` | 552.0 | **96.0** |
| window resize | 552.0 | **96.0** |
| `displayMode` round trip | 519.5 | **161.5** |
| remove + re-insert the item | 519.5 | **161.5** |

**AppKit sizes a view-less item's title once, when the item is inserted.** A longer title written afterwards is clipped to the old width, and neither `validateVisibleItems()` (the channel `StatefulToolbarItem.applyTitle()` uses) nor a window resize re-measures it. The only things that do rebuild the toolbar visibly.

And when it *does* re-measure, the geometry bites: a centred group is laid out around its midpoint, so between `↓0 kB/s` (group.x 488.5, w 223.0) and `↓145 kB/s` (group.x 481.5, w 237.0) the leading edge moves 7.0pt one way and the database item 7.0pt the other. Every time the figure changes bucket.

Padding with figure spaces does not rescue it either. Measured at 13pt system font: `↓145 kB/s` is 61.93pt but `␣↓64 kB/s` is 64.33pt, so trading a digit for a figure space makes the string *wider*. U+2007 is not a digit width in SF, and the decimal separator is 5pt narrower than a digit.

## What this does instead

A fixed-width `NSTextField` in a toolbar item, added as a third subitem of the centred group. Measured, with the width pinned nothing moves at all: group and field frames were byte-identical across `↓0 kB/s`, `↓145 kB/s`, `↑1.2 MB/s` and `↓88 MB/s` (group.x 512.5, group.w 175.0, field.x 607.5, field.w 82.0). Adding or removing the subitem *does* re-measure (89.0 ↔ 175.0), which is what it is for: that happens when a connection is adopted, never under a running tunnel.

This is the one view-backed item in the toolbar, and `MainWindowToolbarNativeContractTests` now says so explicitly rather than passing by accident. It is not the shape #2668 removed: that was a hosted SwiftUI status item with no width of its own to give back, so AppKit could only drop it whole. This one is pinned to a width measured from the widest figure it can ever draw, so it never needs compressing.

Two details that follow from the measurements:

- `.byteCount` cannot produce the figure. `allowedUnits: [.kb]` floors nothing (512 still comes back `512 bytes`) and zero comes back `Zero kB`. Both are four characters wider than the figures around them. `TransportRateLabel` assembles a localized number and an unlocalized unit instead, floored at kB.
- The field uses `monospacedDigitSystemFont`, so the text does not shimmer inside its fixed frame either.

## Behaviour

- Only for a connection whose bytes the app carries, SSH tunnel or SOCKS proxy. Every other transport, and a direct connection, has no readout and no reserved space.
- Reads `0 kB/s` while nothing moves, which is most of the time. Polling TablePlus's equivalent gave `0 B/s` in 19 of 20 idle samples and 37 of 45 under load; the figure being quiet is normal, not broken.
- The ticker samples once a second and only for a measurable transport, and writes into the field rather than calling `validateVisibleItems()`, so a new figure is a redraw inside one view and never a layout pass.
- The readout publishes no action, so AppKit never validates it and it has no menu-bar command. It does get a disabled overflow entry naming the direction in words, because the centred group is the first thing AppKit sheds when the window narrows.

## Verification

- `build` PASS
- `test TransportRateLabelTests MainWindowToolbarNativeContractTests ConnectionTransportActivityTests TransportRateSamplerTests TransportActivityRegistryTests MainWindowToolbarValidationTests`: 74 cases, 74 passed. The new tests pin the width budget against the widest candidate, that monospaced digits do not vary, and that a connection with no measurable transport carries no readout.
- `uitest ConnectionActivityFooterUITests` PASS.
- `lint TablePro TableProTests`: no findings in any file this branch touches.
- `docs` PASS.

## Not done

No UI test for the readout itself: the sample database is a local file, so a UI test can only assert the readout is absent, which `unmeasuredConnectionsCarryNoReadout` already does at the unit level. Asserting a live figure needs an SSH server with a query moving data through it.

No screenshot, for the same reason.

Unrelated, pre-existing: `verify.sh lint` reports `legacy_swiftui_aspect_ratio` in `ImportFromAppSourcePicker.swift` and `SupportView.swift`, and a stale `NSAccessibilitySortDirectionAttribute` reference at `CLAUDE.md:214` from #2670. None are files this branch touches.

https://claude.ai/code/session_014qSA9xxbAUskqMd55gTCkG