### PR TITLE
test: fix the three tests that are red on main

### DIFF
--- a/TableProTests/Core/Execution/TabExecutionSettleGuardTests.swift
+++ b/TableProTests/Core/Execution/TabExecutionSettleGuardTests.swift
@@ -10,7 +10,7 @@
 //
 //  The scan is keyed on the receiver, not on the bare method name: `MCPHandlerOutcomeGate.settle`
 //  is an unrelated resume-once continuation that returns nothing, so there is no answer to consume
-//  there. `registryIsOnlyReachedThroughTheScannedPropertyName` keeps that narrowing fail-closed.
+//  there. `everyMutableRegistryUsesTheScannedPropertyName` keeps that narrowing fail-closed.
 //
 
 import Foundation
@@ -32,15 +32,19 @@ struct TabExecutionSettleGuardTests {
         )
     }
 
-    @Test("The registry is only reached through the property name the guard scans")
-    func registryIsOnlyReachedThroughTheScannedPropertyName() throws {
+    /// `settle` is `mutating`, so it can only run on a registry the compiler lets it mutate: a `var`
+    /// or an `inout` parameter. An immutable binding is inert whatever it is called, which is what
+    /// lets `ExecutionReadout` hold the registry as `let execution` and ask it for the busy bit.
+    @Test("Every registry a settle can run on is named tabExecution")
+    func everyMutableRegistryUsesTheScannedPropertyName() throws {
         let references = try Self.registryReferences()
         #expect(!references.isEmpty)
+        let escaping = references.filter { $0.isMutable && !$0.text.contains("var tabExecution") }
         #expect(
-            references.allSatisfy { $0.text.contains("var tabExecution") },
+            escaping.isEmpty,
             """
-            The settle guard scans for `tabExecution.settle(`. A registry reached under another \
-            name escapes it, so widen the scan: \(references.map(\.description).sorted())
+            The settle guard scans for `tabExecution.settle(`. A registry that can be mutated under \
+            another name escapes it, so widen the scan: \(escaping.map(\.description).sorted())
             """
         )
     }
@@ -83,6 +87,11 @@ struct TabExecutionSettleGuardTests {
                 || trimmed.hasPrefix("return ")
                 || trimmed.hasPrefix("while ")
                 || trimmed.contains(" = ")
+        }
+
+        /// Whether a `mutating` member is reachable through the binding this line declares.
+        var isMutable: Bool {
+            text.contains("var ") || text.contains("inout ")
         }
 
         var description: String { "\(file):\(line)" }

--- a/TableProUITests/CopyObjectsUITests.swift
+++ b/TableProUITests/CopyObjectsUITests.swift
@@ -32,10 +32,9 @@ final class CopyObjectsUITests: UITestCase {
         XCTAssertTrue(item.waitToExist(timeout: 10))
         item.click()
 
-        let objects = window.descendants(matching: .any)
-            .matching(identifier: "copy-objects-list").firstMatch
-        let target = window.descendants(matching: .any)
-            .matching(identifier: "copy-objects-target").firstMatch
+        let sheet = copyToSheet(of: window)
+        let objects = sheet.outlines.matching(identifier: "copy-objects-list").firstMatch
+        let target = sheet.buttons.matching(identifier: "copy-objects-target").firstMatch
         XCTAssertTrue(
             waitForPredicate(timeout: 20) { objects.exists || target.exists },
             "Copy To must open a sheet offering the objects and a target"
@@ -43,7 +42,7 @@ final class CopyObjectsUITests: UITestCase {
 
         /// Nothing has been written and nothing can be: the sheet is still on its first step, so
         /// Cancel is the whole interaction under test.
-        let cancel = window.buttons["Cancel"].firstMatch
+        let cancel = sheet.buttons["Cancel"].firstMatch
         if cancel.waitToExist(timeout: 10) {
             cancel.click()
         }
@@ -62,7 +61,7 @@ final class CopyObjectsUITests: UITestCase {
         XCTAssertTrue(item.waitToExist(timeout: 10))
         item.click()
 
-        let search = window.descendants(matching: .any)
+        let search = copyToSheet(of: window).searchFields
             .matching(identifier: "copy-objects-search").firstMatch
         XCTAssertTrue(search.waitToExist(timeout: 20), "The sheet must offer a search field")
         XCTAssertTrue(waitUntilHittable(search, timeout: 20))
@@ -90,10 +89,9 @@ final class CopyObjectsUITests: UITestCase {
     func testAPerTableFilterIsSetFromTheObjectListAndShownOnTheRow() throws {
         let app = try launchWithSampleDatabase()
         let window = try readyWindow(of: app)
-        try openCopyToSheet(onRow: "Album", in: window, of: app)
+        let sheet = try openCopyToSheet(onRow: "Album", in: window, of: app)
 
-        let funnel = window.descendants(matching: .any)
-            .matching(identifier: "copy-objects-row-filter-Album").firstMatch
+        let funnel = sheet.buttons.matching(identifier: "copy-objects-row-filter-Album").firstMatch
         XCTAssertTrue(funnel.waitToExist(timeout: 20), "A table row must offer a row filter")
         XCTAssertTrue(waitUntilHittable(funnel, timeout: 20))
         funnel.click()
@@ -108,8 +106,7 @@ final class CopyObjectsUITests: UITestCase {
         XCTAssertTrue(done.waitToExist(timeout: 10))
         done.click()
 
-        let summary = window.descendants(matching: .any)
-            .matching(identifier: "copy-objects-row-scope-Album").firstMatch
+        let summary = sheet.staticTexts.matching(identifier: "copy-objects-row-scope-Album").firstMatch
         XCTAssertTrue(
             waitForPredicate(timeout: 20) { summary.exists },
             "The row must show the filter it now carries"
@@ -128,10 +125,9 @@ final class CopyObjectsUITests: UITestCase {
     func testAFilterCarryingASecondStatementBlocksContinue() throws {
         let app = try launchWithSampleDatabase()
         let window = try readyWindow(of: app)
-        try openCopyToSheet(onRow: "Album", in: window, of: app)
+        let sheet = try openCopyToSheet(onRow: "Album", in: window, of: app)
 
-        let funnel = window.descendants(matching: .any)
-            .matching(identifier: "copy-objects-row-filter-Album").firstMatch
+        let funnel = sheet.buttons.matching(identifier: "copy-objects-row-filter-Album").firstMatch
         XCTAssertTrue(funnel.waitToExist(timeout: 20))
         XCTAssertTrue(waitUntilHittable(funnel, timeout: 20))
         funnel.click()
@@ -146,7 +142,7 @@ final class CopyObjectsUITests: UITestCase {
         XCTAssertTrue(done.waitToExist(timeout: 10))
         done.click()
 
-        let cont = window.buttons["Continue"].firstMatch
+        let cont = sheet.buttons["Continue"].firstMatch
         XCTAssertTrue(
             waitForPredicate(timeout: 20) { cont.exists && !cont.isEnabled },
             "Continue must stay unavailable while a filter holds a second statement"
@@ -157,18 +153,33 @@ final class CopyObjectsUITests: UITestCase {
 
     // MARK: - Helpers
 
+    @discardableResult
     private func openCopyToSheet(
         onRow name: String,
         in window: XCUIElement,
         of app: XCUIApplication
-    ) throws {
+    ) throws -> XCUIElement {
         openContextMenu(onRow: name, in: window, of: app)
         let item = contextMenuItem(copyToTitle, in: app)
         XCTAssertTrue(item.waitToExist(timeout: 10))
         item.click()
-        let list = window.descendants(matching: .any)
-            .matching(identifier: "copy-objects-list").firstMatch
+        let sheet = copyToSheet(of: window)
+        let list = sheet.outlines.matching(identifier: "copy-objects-list").firstMatch
         XCTAssertTrue(list.waitToExist(timeout: 20), "Copy To must open its object list")
+        return sheet
+    }
+
+    /// Every lookup inside the sheet starts here, and none of them walks the window.
+    ///
+    /// The window behind the sheet holds a data grid, and a grid answers its first accessibility
+    /// question by mounting a cell per row of the page: the sample opens on `Track`, so the window
+    /// publishes about 12,800 elements. A `descendants(matching: .any)` taken off the window walks
+    /// all of them, which measured 8.5 to 14.5 seconds per evaluation on the runner, so three polls
+    /// used up a twenty second wait and the suite reported a sheet that was open on screen as never
+    /// having opened. The sheet is a direct child of the window, so `children` resolves it without
+    /// touching the grid, and everything under it is a sixty element subtree.
+    private func copyToSheet(of window: XCUIElement) -> XCUIElement {
+        window.children(matching: .sheet).firstMatch
     }
 
     private func readyWindow(of app: XCUIApplication) throws -> XCUIElement {

--- a/TableProUITests/HeaderSortUITests.swift
+++ b/TableProUITests/HeaderSortUITests.swift
@@ -64,25 +64,37 @@ final class HeaderSortUITests: UITestCase {
 
     // MARK: - Helpers
 
-    /// Waits for the header to be hittable, not merely to exist.
+    /// The header is read for its geometry and clicked through a coordinate, never through the
+    /// element.
     ///
-    /// `waitToExist` polls `.exists` alone, while `click()` hit-tests once and throws
-    /// "Not hittable" if the view is not ready. The grid is still settling when the rows land:
-    /// the first accessibility question activates `DataGridCellAccessibilityView` and defers
-    /// `remountAccessibilityCells()` onto an async main-actor task, so a click posted straight after
-    /// `waitForClickableRows` can arrive mid-remount.
+    /// A column header is one more thing inside the grid that XCUITest will not click, alongside
+    /// the rows and cells `gridPoint` exists for. Measured on the runner and on a developer Mac:
+    /// the header element exists, reports `isEnabled` true and a correct frame inside the grid, and
+    /// nothing in the failure's own element tree or screen recording overlaps it, yet `isHittable`
+    /// stays false for a full thirty seconds. `waitUntilHittable` therefore waits out its timeout
+    /// on a header that is on screen, which is how this suite was merged red (#2670) and stayed
+    /// red. A coordinate taken off the grid clicks it every time, including the right-click that
+    /// raises the header menu.
+    ///
+    /// The offset is measured from the grid rather than assumed, because the column's position
+    /// moves with the row-number gutter's width and with the sidebar.
     private func clickHeader(in grid: XCUIElement, rightClick: Bool = false) throws {
         let header = grid.buttons
             .matching(NSPredicate(format: "label BEGINSWITH %@", "Column: \(Self.sortedColumn)"))
             .firstMatch
         XCTAssertTrue(
-            waitUntilHittable(header, timeout: 30),
-            "The grid must publish a clickable \(Self.sortedColumn) header"
+            header.waitToExist(timeout: 30),
+            "The grid must publish a \(Self.sortedColumn) header"
         )
+        let frame = header.frame
+        let origin = grid.frame.origin
+        XCTAssertTrue(frame.width > 0, "The \(Self.sortedColumn) header must be laid out")
+        let point = grid.coordinate(withNormalizedOffset: .zero)
+            .withOffset(CGVector(dx: frame.midX - origin.x, dy: frame.midY - origin.y))
         if rightClick {
-            header.rightClick()
+            point.rightClick()
         } else {
-            header.click()
+            point.click()
         }
     }
 


### PR DESCRIPTION
Three tests fail on `main` at 3496162cf. All three measure the harness rather than the app, and the app behaviour under them is correct.

## `Execution claim settle guard` (unit)

`TabExecutionSettleGuardTests` asserted that every line mentioning `TabExecutionRegistry` outside its own file spells the binding `var tabExecution`, so that the `tabExecution.settle(` scan is exhaustive. #2668 added `ExecutionReadout.execution: TabExecutionRegistry`, and the guard flagged it.

`settle` is `mutating`, so an immutable binding cannot reach it: the readout holds the registry to ask `isBusy`, and no `settle` can be written through it. The guard now requires the scanned name only of references a `mutating` member can run on, which is a `var` or an `inout` parameter. It stays fail-closed for both.

## `CopyObjectsUITests` (UI, 2 cases)

"Copy To must open its object list" failed on a sheet that was open on screen, and the element tree captured at the failure shows the list right there.

The sheet lookups were `window.descendants(matching: .any)`. The window behind the sheet holds a data grid, and a grid answers its first accessibility question by mounting a cell per row of the page: the sample opens on `Track`, so the window publishes about 12,800 elements. Measured from the failure's activity log, one such lookup cost 14.5s, then 9.6s, then 8.5s, so three polls used up a 20s wait.

The sheet is a direct child of the window, so `window.children(matching: .sheet)` resolves it without touching the grid, and every lookup inside it then runs against a 60-element subtree.

## `HeaderSortUITests` (UI)

"The grid must publish a clickable Name header" has failed on every run since the suite was added (#2670); it has never been green on CI. It reproduces on a developer Mac.

Measured: the header element exists, reports `isEnabled` true and a correct frame inside the grid (`(1116.5, 248.0, 234.0, 28.0)` against a grid at `(959.0, 247.0, 922.0, 685.0)`), and nothing in the element tree or the screen recording overlaps it, yet `isHittable` stays false for the full 30 second wait. A column header is one more thing inside the grid XCUITest will not click, alongside the rows and cells `gridPoint` already exists for.

The header is now read for its geometry and clicked through a coordinate taken off the grid. The whole cycle passes that way, ascending, descending, back to server order, and the right-click that raises Don't Sort.

## Verification

Run in a worktree off `3496162cf`:

- `verify.sh test TabExecutionSettleGuardTests` — 3 executed, 3 passed
- `verify.sh uitest HeaderSortUITests` — 2 executed, 2 passed (was 2 failed)
- `verify.sh uitest CopyObjectsUITests` — 10 executed, 10 passed
- `verify.sh lint` on the three files — 0 violations

No CHANGELOG entry: nothing user-facing changed.

## Not fixed here

`descendants(matching: .any)` rooted at the window or the app appears 47 more times across 20 UI suites, and every one of them pays the same cost whenever a grid is on screen. `ColumnJumpUITests` takes 135 seconds for that reason. Worth a sweep, but it is not what is red.

`verify.sh lint` also reports one stale doc symbol that predates this branch: `CLAUDE.md:214` names `NSAccessibilitySortDirectionAttribute`, which is in no Swift source and no SDK interface.

https://claude.ai/code/session_011tz9LQDhQ6AZ64PgKnDkkZ