### PR TITLE
fix(toolbar): anchor each centre switcher to the capsule that opens it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Connection and database choosers opening between the two toolbar capsules instead of under the one that was pressed.
 - Raw DuckDB driver text in place of the name of the app holding a locked database file. (#2518)
 - DuckDB instance and its worker threads leaked by every failed remote connection attempt.
 - MySQL statement replayed outside the transaction it was run in after the server dropped the connection.

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController+DatabaseMenuActions.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController+DatabaseMenuActions.swift
@@ -22,7 +22,7 @@ extension MainSplitViewController {
         view.window?.makeFirstResponder(nil)
         switcherPresenter.present(
             from: view.window,
-            anchoredTo: MainWindowToolbar.connectionGroup,
+            anchoredTo: MainWindowToolbar.connection,
             subject: .connection,
             contentSize: ConnectionSwitcherPopover.contentSize
         ) { dismiss in

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -1359,14 +1359,13 @@ final class MainContentCommandActions {
         coordinator?.switcherPresenter?.dismiss()
     }
 
-    /// Anchored to the connection group rather than to the Database subitem inside it. Measured:
-    /// `NSToolbar.items` holds groups only, never their subitems, and a native group's subitems
-    /// carry no view, so the subitem cannot resolve as an anchor and the presenter would fall back
-    /// to its floating panel.
+    /// Anchored to the Database subitem, which is the capsule the user pressed. The group is two
+    /// capsules wide, so anchoring to it points the chooser at the seam between them; the presenter
+    /// falls back to the group by itself once AppKit clips it into the overflow menu.
     private func presentDatabaseSwitcher(on coordinator: MainContentCoordinator, target: ContainerSwitchTarget?) {
         coordinator.switcherPresenter?.present(
             from: coordinator.contentWindow,
-            anchoredTo: MainWindowToolbar.connectionGroup,
+            anchoredTo: MainWindowToolbar.database,
             subject: .container(target),
             contentSize: DatabaseSwitcherPopover.contentSize
         ) { dismiss in

--- a/TablePro/Views/Toolbar/ToolbarSwitcherPresenter.swift
+++ b/TablePro/Views/Toolbar/ToolbarSwitcherPresenter.swift
@@ -134,6 +134,37 @@ internal final class ToolbarSwitcherPresenter {
         _ identifier: NSToolbarItem.Identifier
     ) -> NSToolbarItem? {
         guard let toolbar = window?.toolbar, toolbar.isVisible else { return nil }
-        return toolbar.items.first { $0.itemIdentifier == identifier }
+        return anchor(identifier, in: toolbar.items, visible: toolbar.visibleItems ?? [])
+    }
+
+    /// The anchor for an identifier that may name a subitem of a group rather than an item the
+    /// toolbar carries directly.
+    ///
+    /// The connection and the container are two subitems of one centred native group, and anchoring
+    /// both choosers to the group put each of them on the seam between the two capsules rather than
+    /// under the one it belongs to. Measured on a 1200pt window: the group's midpoint is 600.0, the
+    /// Connection capsule's is 543.2 and the Container capsule's is 671.8, and a popover anchored to
+    /// the group lands at 600.0 for both. A subitem does resolve as an anchor and lands on its own
+    /// capsule to within a point, even though `NSToolbar.items` lists groups only and a native
+    /// group's subitems carry no `view`.
+    ///
+    /// It resolves only while the group is on screen. Once AppKit clips the group into the overflow
+    /// menu its subitems have no view and `NSPopover.show(relativeTo:)` raises
+    /// `NSInvalidArgumentException` ("view has no window"), which Swift cannot catch; measured, that
+    /// is exactly the width at which `visibleItems` stops naming the group. The group keeps working
+    /// there, because AppKit presents a clipped item from another affordance in the window itself,
+    /// so an overflowed group is the fallback rather than the floating panel.
+    internal static func anchor(
+        _ identifier: NSToolbarItem.Identifier,
+        in items: [NSToolbarItem],
+        visible: [NSToolbarItem]
+    ) -> NSToolbarItem? {
+        if let item = items.first(where: { $0.itemIdentifier == identifier }) { return item }
+        let groups = items.compactMap { $0 as? NSToolbarItemGroup }
+        guard let group = groups.first(where: { group in
+            group.subitems.contains { $0.itemIdentifier == identifier }
+        }) else { return nil }
+        guard visible.contains(where: { $0.itemIdentifier == group.itemIdentifier }) else { return group }
+        return group.subitems.first { $0.itemIdentifier == identifier }
     }
 }

--- a/TableProTests/Services/ToolbarSwitcherAnchorTests.swift
+++ b/TableProTests/Services/ToolbarSwitcherAnchorTests.swift
@@ -19,9 +19,17 @@ struct ToolbarSwitcherAnchorTests {
 
     private final class Delegate: NSObject, NSToolbarDelegate {
         var identifiers: [NSToolbarItem.Identifier]
+        let groupIdentifier: NSToolbarItem.Identifier
+        let subitemIdentifiers: [NSToolbarItem.Identifier]
 
-        init(identifiers: [NSToolbarItem.Identifier]) {
+        init(
+            identifiers: [NSToolbarItem.Identifier],
+            groupIdentifier: NSToolbarItem.Identifier,
+            subitemIdentifiers: [NSToolbarItem.Identifier]
+        ) {
             self.identifiers = identifiers
+            self.groupIdentifier = groupIdentifier
+            self.subitemIdentifiers = subitemIdentifiers
         }
 
         func toolbar(
@@ -29,7 +37,12 @@ struct ToolbarSwitcherAnchorTests {
             itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
             willBeInsertedIntoToolbar flag: Bool
         ) -> NSToolbarItem? {
-            NSToolbarItem(itemIdentifier: itemIdentifier)
+            guard itemIdentifier == groupIdentifier else {
+                return NSToolbarItem(itemIdentifier: itemIdentifier)
+            }
+            let group = NSToolbarItemGroup(itemIdentifier: itemIdentifier)
+            group.subitems = subitemIdentifiers.map { NSToolbarItem(itemIdentifier: $0) }
+            return group
         }
 
         func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
@@ -51,7 +64,11 @@ struct ToolbarSwitcherAnchorTests {
             backing: .buffered,
             defer: true
         )
-        let delegate = Delegate(identifiers: identifiers)
+        let delegate = Delegate(
+            identifiers: identifiers,
+            groupIdentifier: Self.groupIdentifier,
+            subitemIdentifiers: [Self.leadingIdentifier, Self.trailingIdentifier]
+        )
         let toolbar = NSToolbar(identifier: "com.TablePro.tests.toolbar")
         toolbar.delegate = delegate
         window.toolbar = toolbar
@@ -111,5 +128,76 @@ struct ToolbarSwitcherAnchorTests {
     @Test("No window has no anchor")
     func noWindowHasNoAnchor() {
         #expect(ToolbarSwitcherPresenter.anchor(in: nil, Self.identifier) == nil)
+    }
+
+    // MARK: - Group subitems
+
+    private static let groupIdentifier = NSToolbarItem.Identifier("com.TablePro.tests.anchor.group")
+    private static let leadingIdentifier = NSToolbarItem.Identifier("com.TablePro.tests.anchor.leading")
+    private static let trailingIdentifier = NSToolbarItem.Identifier("com.TablePro.tests.anchor.trailing")
+
+    private func makeGroup() -> NSToolbarItemGroup {
+        let group = NSToolbarItemGroup(itemIdentifier: Self.groupIdentifier)
+        group.subitems = [
+            NSToolbarItem(itemIdentifier: Self.leadingIdentifier),
+            NSToolbarItem(itemIdentifier: Self.trailingIdentifier),
+        ]
+        return group
+    }
+
+    /// The centred pair are subitems of one group, and the group is two capsules wide. Anchoring
+    /// both choosers to the group put each of them on the seam between the capsules: measured on a
+    /// 1200pt window, the group's midpoint is 600.0 while the two capsules sit at 543.2 and 671.8.
+    @Test("A subitem of a visible group is the anchor, not the group")
+    func resolvesSubitemOfVisibleGroup() {
+        let group = makeGroup()
+
+        let anchor = ToolbarSwitcherPresenter.anchor(Self.trailingIdentifier, in: [group], visible: [group])
+
+        #expect(anchor?.itemIdentifier == Self.trailingIdentifier)
+    }
+
+    /// A subitem of a clipped group has no view, and `NSPopover.show(relativeTo:)` raises
+    /// `NSInvalidArgumentException` for one, which Swift cannot catch. The group still resolves,
+    /// because AppKit presents a clipped item from another affordance in the window itself.
+    @Test("A subitem of an overflowed group falls back to the group")
+    func fallsBackToOverflowedGroup() {
+        let group = makeGroup()
+
+        let anchor = ToolbarSwitcherPresenter.anchor(Self.leadingIdentifier, in: [group], visible: [])
+
+        #expect(anchor?.itemIdentifier == Self.groupIdentifier)
+    }
+
+    /// What Customize Toolbar leaves behind for the centred pair: neither subitem is an allowed
+    /// identifier of its own, so removing the group takes both choosers' anchors with it.
+    @Test("A subitem of a group the toolbar does not carry has no anchor")
+    func missingGroupHasNoAnchor() {
+        #expect(ToolbarSwitcherPresenter.anchor(Self.leadingIdentifier, in: [], visible: []) == nil)
+    }
+
+    /// The toolbar's own item wins without consulting the visible list, which is what keeps a
+    /// clipped top-level item resolving.
+    @Test("A top-level item resolves even when it is not visible")
+    func resolvesOverflowedTopLevelItem() {
+        let item = NSToolbarItem(itemIdentifier: Self.identifier)
+
+        let anchor = ToolbarSwitcherPresenter.anchor(Self.identifier, in: [item], visible: [])
+
+        #expect(anchor?.itemIdentifier == Self.identifier)
+    }
+
+    /// The whole path both switchers take: an identifier that names no item of the toolbar still
+    /// reaches the capsule it belongs to.
+    @Test("The window lookup resolves a subitem of the toolbar's group")
+    func windowLookupResolvesSubitem() {
+        let (window, delegate) = makeWindow(containing: [Self.groupIdentifier])
+        withExtendedLifetime(delegate) {
+            #expect(window.toolbar?.items.contains { $0.itemIdentifier == Self.leadingIdentifier } == false)
+
+            let anchor = ToolbarSwitcherPresenter.anchor(in: window, Self.leadingIdentifier)
+
+            #expect(anchor?.itemIdentifier == Self.leadingIdentifier)
+        }
     }
 }


### PR DESCRIPTION
The connection chooser and the container chooser both anchored to `MainWindowToolbar.connectionGroup`, which is the whole centred group: two capsules wide. So both popovers opened on the seam between Connection and Database rather than under the one the user pressed.

## Measured

A compiled `NSToolbar` harness, group of two bordered subitems, `centeredItemIdentifiers = [group]`, window 1200pt:

| anchor | popover midX | capsule midX |
| --- | --- | --- |
| group | 600.0 | - |
| Connection subitem | 543.0 | 543.2 |
| Database subitem | 671.0 | 671.8 |

A subitem does resolve as a popover anchor and lands on its own capsule to within a point. The code did not do that because of a claim in its own comment: `NSToolbar.items` holds groups only and a native group's subitems carry no `view`, so the subitem "cannot" anchor. The first half is true, the conclusion is not; `NSPopover.show(relativeTo:)` does not go through `toolbar.items`.

There is a real trap, though. Once AppKit clips the group into the overflow menu its subitems have no view, and the same call raises `NSInvalidArgumentException` ("view has no window"), which Swift cannot catch. Sweeping the window width: `toolbar.visibleItems` names the group down to 640pt and stops at 600pt, and the throw begins at exactly the same width. The group itself keeps working there, because AppKit presents a clipped item from another affordance in the window.

## Change

`ToolbarSwitcherPresenter.anchor` now resolves an identifier that may name a subitem: the toolbar's own item first, then the subitem while its group is in `visibleItems`, then the group once it is not, then nil so a removed group still falls back to the floating panel. Switch Connection anchors to `MainWindowToolbar.connection`, the container and schema choosers to `MainWindowToolbar.database`.

`CompareEndpointToolbarController` shares the same resolver but its identifiers are top-level, so its behaviour is unchanged.

## Tests

Five cases in `ToolbarSwitcherAnchorTests`, over a resolver seam that takes items and visible items rather than a live toolbar: subitem of a visible group, fallback to an overflowed group, group absent from the toolbar (what Customize Toolbar leaves behind, since neither subitem is an allowed identifier of its own), a clipped top-level item, and the window lookup end to end. `visibleItems` names a group even for a window never ordered front, measured, so the visible branch is reachable from a unit test.

10/10 pass, `swiftlint --strict` clean on the touched files, app builds.

https://claude.ai/code/session_01DT51WAbwXF3AxSReQxNhnD