### PR TITLE
fix(datagrid): keep the cell selection Select All builds, and take a mount's observers off with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Cell selection cleared by Select All. (#2667)
+- Scroll and accessibility observers left registered every time a data grid was rebuilt. (#2667)
 - Grid row and cell selection lost on switching editor tabs, result view modes, or moving a tab to a new window. (#2667)
 - Connection and database choosers opening between the two toolbar capsules instead of under the one that was pressed.
 - Raw DuckDB driver text in place of the name of the app holding a locked database file. (#2518)

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -638,6 +638,19 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         }
     }
 
+    /// Registered for the life of the coordinator, so it has to come off when the grid goes.
+    ///
+    /// `NotificationCenter` retains a block observer's closure, and a coordinator is built fresh on
+    /// every mount, so an entry left behind at teardown is never fired again and never reclaimed.
+    /// The closure captures `self` weakly, so this leaks the registration rather than the grid.
+    func detachAccessibilityActivationObserver() {
+        guard let accessibilityActivationObserver else { return }
+        NotificationCenter.default.removeObserver(accessibilityActivationObserver)
+        self.accessibilityActivationObserver = nil
+    }
+
+    var hasAccessibilityActivationObserver: Bool { accessibilityActivationObserver != nil }
+
     /// Whether this row is one an assistive client can be reading right now.
     ///
     /// Walking the accessibility tree makes `NSTableView` prepare every row of the page, not the
@@ -680,10 +693,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         settingsCancellable = nil
         themeCancellable?.cancel()
         themeCancellable = nil
-        if let accessibilityActivationObserver {
-            NotificationCenter.default.removeObserver(accessibilityActivationObserver)
-        }
-        accessibilityActivationObserver = nil
+        detachAccessibilityActivationObserver()
         visualIndex.clear()
         displayCache.removeAll()
         columnDisplayFormats = []

--- a/TablePro/Views/Results/DataGridView.swift
+++ b/TablePro/Views/Results/DataGridView.swift
@@ -581,6 +581,13 @@ struct DataGridView: NSViewRepresentable {
         coordinator.recordScrollAnchor()
         coordinator.captureSelectionForTeardown()
         coordinator.flushPendingColumnLayoutPersistence()
+        /// The mount's own registrations, taken off with it. `NotificationCenter` retains a block
+        /// observer's closure and a coordinator is built fresh per mount, so anything left here is
+        /// never fired again and never reclaimed: three scroll observers and the accessibility
+        /// activation observer per tab switch and per result-mode toggle, for the life of the
+        /// process. `releaseData()` already did this, but it only runs on session teardown.
+        coordinator.detachScrollObservers()
+        coordinator.detachAccessibilityActivationObserver()
         coordinator.settingsCancellable = nil
         coordinator.themeCancellable = nil
     }

--- a/TablePro/Views/Results/KeyHandlingTableView.swift
+++ b/TablePro/Views/Results/KeyHandlingTableView.swift
@@ -310,7 +310,14 @@ final class KeyHandlingTableView: NSTableView {
             return
         }
         gridSelection?.selectAll(totalRows: totalRows, totalColumns: totalColumns)
-        selectRowIndexes(IndexSet(integersIn: 0..<totalRows), byExtendingSelection: false)
+        /// Marked programmatic, exactly as `selectRowsIntersectingSelection` marks the same
+        /// build-then-write shape. An unmarked write reads back as a gesture, and
+        /// `tableViewSelectionDidChange` answers a gesture that arrives over a live cell selection
+        /// by clearing it, so Cmd+A used to destroy the rectangle it had just built: Copy then took
+        /// the row path instead of the cell path, and Escape had nothing to cancel.
+        withProgrammaticRowSelection {
+            selectRowIndexes(IndexSet(integersIn: 0..<totalRows), byExtendingSelection: false)
+        }
     }
 
     private func focusedDataCell() -> (row: Int, columnIndex: Int)? {

--- a/TableProTests/Views/Results/DataGridMountTeardownTests.swift
+++ b/TableProTests/Views/Results/DataGridMountTeardownTests.swift
@@ -1,0 +1,98 @@
+//
+//  DataGridMountTeardownTests.swift
+//  TableProTests
+//
+//  A coordinator is built fresh on every mount, and the editor mounts the grid as `.id(tab.id)`,
+//  so anything the mount registers has to come off with it. `NotificationCenter` retains a block
+//  observer's closure, so a registration left behind is never fired again and never reclaimed.
+//
+
+import AppKit
+import Foundation
+import SwiftUI
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@MainActor
+private final class StubLayoutPersister: ColumnLayoutPersisting {
+    func load(for key: ColumnLayoutTableKey) -> ColumnLayoutState? { nil }
+    func save(_ layout: ColumnLayoutState, for key: ColumnLayoutTableKey) {}
+    func clear(for key: ColumnLayoutTableKey) {}
+}
+
+@Suite("DataGridView mount teardown")
+@MainActor
+struct DataGridMountTeardownTests {
+    private func makeCoordinator() -> TableViewCoordinator {
+        TableViewCoordinator(
+            changeManager: AnyChangeManager(DataChangeManager()),
+            isEditable: true,
+            selectedRowIndices: .constant([]),
+            delegate: nil,
+            layoutPersister: StubLayoutPersister()
+        )
+    }
+
+    private func makeScrollView(for coordinator: TableViewCoordinator) -> NSScrollView {
+        let tableView = KeyHandlingTableView()
+        tableView.coordinator = coordinator
+        tableView.delegate = coordinator
+        tableView.dataSource = coordinator
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        scrollView.documentView = tableView
+        coordinator.tableView = tableView
+        return scrollView
+    }
+
+    @Test("unmounting the grid takes its scroll observers off the notification centre")
+    func dismantleDetachesScrollObservers() {
+        let coordinator = makeCoordinator()
+        let scrollView = makeScrollView(for: coordinator)
+        coordinator.attachScrollObservers(scrollView: scrollView)
+        #expect(coordinator.scrollObservers.count == 3)
+
+        DataGridView.dismantleNSView(scrollView, coordinator: coordinator)
+
+        #expect(coordinator.scrollObservers.isEmpty)
+    }
+
+    @Test("unmounting the grid takes its accessibility activation observer off too")
+    func dismantleDetachesAccessibilityObserver() {
+        let coordinator = makeCoordinator()
+        let scrollView = makeScrollView(for: coordinator)
+        #expect(coordinator.hasAccessibilityActivationObserver)
+
+        DataGridView.dismantleNSView(scrollView, coordinator: coordinator)
+
+        #expect(!coordinator.hasAccessibilityActivationObserver)
+    }
+
+    /// The count is what the leak was: three registrations per mount, and the editor remounts the
+    /// grid on every tab switch and every result-mode toggle.
+    @Test("mounting and unmounting repeatedly leaves nothing registered")
+    func repeatedMountsLeaveNothingBehind() {
+        for _ in 0..<5 {
+            let coordinator = makeCoordinator()
+            let scrollView = makeScrollView(for: coordinator)
+            coordinator.attachScrollObservers(scrollView: scrollView)
+            DataGridView.dismantleNSView(scrollView, coordinator: coordinator)
+            #expect(coordinator.scrollObservers.isEmpty)
+            #expect(!coordinator.hasAccessibilityActivationObserver)
+        }
+    }
+
+    @Test("detaching twice is harmless, so teardown and session release can both run")
+    func detachIsIdempotent() {
+        let coordinator = makeCoordinator()
+        let scrollView = makeScrollView(for: coordinator)
+        coordinator.attachScrollObservers(scrollView: scrollView)
+
+        DataGridView.dismantleNSView(scrollView, coordinator: coordinator)
+        coordinator.detachScrollObservers()
+        coordinator.detachAccessibilityActivationObserver()
+
+        #expect(coordinator.scrollObservers.isEmpty)
+        #expect(!coordinator.hasAccessibilityActivationObserver)
+    }
+}

--- a/TableProTests/Views/Results/SelectAllCellSelectionTests.swift
+++ b/TableProTests/Views/Results/SelectAllCellSelectionTests.swift
@@ -1,0 +1,138 @@
+//
+//  SelectAllCellSelectionTests.swift
+//  TableProTests
+//
+//  Cmd+A builds a cell rectangle over the whole grid and then selects every row. The row write has
+//  to be marked programmatic: `tableViewSelectionDidChange` answers an unmarked write over a live
+//  cell selection by clearing it, so Cmd+A used to destroy the rectangle it had just built.
+//
+
+import AppKit
+import Foundation
+import SwiftUI
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@MainActor
+private final class StubSelectAllPersister: ColumnLayoutPersisting {
+    func load(for key: ColumnLayoutTableKey) -> ColumnLayoutState? { nil }
+    func save(_ layout: ColumnLayoutState, for key: ColumnLayoutTableKey) {}
+    func clear(for key: ColumnLayoutTableKey) {}
+}
+
+@MainActor
+private struct SelectAllGrid {
+    let tableView: KeyHandlingTableView
+    let coordinator: TableViewCoordinator
+    let rowCount: Int
+    let columnCount: Int
+
+    init(rowCount: Int = 8, dataColumns: Int = 4) {
+        self.rowCount = rowCount
+        self.columnCount = dataColumns
+        let columns = (0..<dataColumns).map { "col\($0)" }
+        let rows = (0..<rowCount).map { row in columns.map { PluginCellValue.text("\($0)-\(row)") } }
+        let tableRows = TableRows.from(
+            queryRows: rows,
+            columns: columns,
+            columnTypes: Array(repeating: ColumnType.text(rawType: nil), count: dataColumns)
+        )
+
+        coordinator = TableViewCoordinator(
+            changeManager: AnyChangeManager(DataChangeManager()),
+            isEditable: true,
+            selectedRowIndices: .constant([]),
+            delegate: nil,
+            layoutPersister: StubSelectAllPersister()
+        )
+        coordinator.tableRowsProvider = { tableRows }
+
+        tableView = KeyHandlingTableView()
+        tableView.coordinator = coordinator
+        tableView.delegate = coordinator
+        tableView.dataSource = coordinator
+        tableView.rowHeight = 22
+        tableView.allowsMultipleSelection = true
+
+        let rowNumberColumn = DataGridView.makeRowNumberColumn()
+        tableView.addTableColumn(rowNumberColumn)
+
+        coordinator.tableView = tableView
+        coordinator.rebuildColumnMetadataCache(from: tableRows)
+        /// The pool is what attaches the data columns and what `presentsColumn` answers from, so a
+        /// harness that adds columns by hand presents none of them and `selectAll` falls through to
+        /// AppKit's own path, which selects every row and builds no cell rectangle at all.
+        coordinator.columnPool.reconcile(
+            tableView: tableView,
+            schema: coordinator.identitySchema,
+            columnTypes: Array(repeating: ColumnType.text(rawType: "TEXT"), count: dataColumns),
+            savedLayout: nil,
+            isEditable: true,
+            hiddenColumnNames: [],
+            firstClickSortDirection: .ascending,
+            widthCalculator: { _, _ in 100 }
+        )
+        coordinator.invalidateColumnIndexCache()
+        coordinator.updateCache()
+        tableView.reloadData()
+    }
+}
+
+@Suite("KeyHandlingTableView.selectAll")
+@MainActor
+struct SelectAllCellSelectionTests {
+    /// `selectAll` falls through to AppKit's own when the grid presents no data columns, and that
+    /// path selects every row too, so without this the suite would pass over a harness that never
+    /// exercised the cell selection at all.
+    @Test("the harness presents its data columns, so selectAll takes the grid's own path")
+    func harnessPresentsDataColumns() {
+        let grid = SelectAllGrid()
+
+        #expect(grid.coordinator.presentedColumnCount == grid.columnCount)
+    }
+
+    @Test("Command A leaves the cell rectangle it built in place")
+    func selectAllKeepsTheCellSelection() {
+        let grid = SelectAllGrid()
+
+        grid.tableView.selectAll(nil)
+
+        #expect(!grid.coordinator.selectionController.isEmpty)
+        #expect(
+            grid.coordinator.selectionController.selection.rectangles
+                == [GridRect(rows: 0...(grid.rowCount - 1), columns: 0...(grid.columnCount - 1))]
+        )
+    }
+
+    @Test("Command A still selects every row")
+    func selectAllSelectsEveryRow() {
+        let grid = SelectAllGrid()
+
+        grid.tableView.selectAll(nil)
+
+        #expect(grid.tableView.selectedRowIndexes == IndexSet(integersIn: 0..<grid.rowCount))
+    }
+
+    /// Escape reads the cell selection to decide whether it has anything to cancel, so it is the
+    /// user-visible proof that the rectangle survived rather than an assertion about internals.
+    @Test("Escape after Command A has a cell selection to cancel")
+    func escapeAfterSelectAllClearsTheCellSelection() {
+        let grid = SelectAllGrid()
+        grid.tableView.selectAll(nil)
+        #expect(!grid.coordinator.selectionController.isEmpty)
+
+        grid.tableView.cancelOperation(nil)
+
+        #expect(grid.coordinator.selectionController.isEmpty)
+    }
+
+    @Test("an empty grid falls through to the table view's own select all")
+    func emptyGridFallsThrough() {
+        let grid = SelectAllGrid(rowCount: 0)
+
+        grid.tableView.selectAll(nil)
+
+        #expect(grid.coordinator.selectionController.isEmpty)
+    }
+}


### PR DESCRIPTION
Two verified defects found by the collateral hunt during #2667, both in the data grid's mount and selection lifecycle. Independent of each other and of the selection fix in #2679; grouped because they are the same file and the same review.

## Select All destroyed the cell selection it had just built

`KeyHandlingTableView.selectAll(_:)` builds the full-grid cell rectangle and then selects every row. The row write was a bare `selectRowIndexes`, so it read back as a gesture, and `tableViewSelectionDidChange` answers a gesture arriving over a live cell selection by clearing it. The rectangle was gone before Cmd+A returned.

What the user saw: Cmd+C took the whole-row path instead of the cell path, Escape had nothing to cancel and fell through to `super`, and the header's column indicators went dark.

The fix is the helper already in the same file, three functions away: `selectRowsIntersectingSelection()` does the identical build-then-write and wraps its write in `withProgrammaticRowSelection`. Cmd+A now does the same. `publishRowSelection` still runs unconditionally, so the row set still reaches the tab.

Reordering the two writes would also dodge the guard today, but only because `GridSelectionController.selectAll` happens not to touch `selectedRowIndexes`. Marking the write says what is meant and matches every other correct call site.

## A grid mount left its observers registered

`makeNSView` registers three `NotificationCenter` block observers through `attachScrollObservers` (live-scroll start and end, and the clip view's `boundsDidChange`), and the coordinator's `init` registers a fourth for accessibility activation. `dismantleNSView` removed neither.

`releaseData()` does remove them, but it only runs on session teardown, and `dismantleNSView` runs on every editor-tab switch and every result-mode toggle. `NotificationCenter` retains a block observer's closure and a coordinator is built fresh per mount, so each mount left four registrations that are never fired again and never reclaimed. Switching among ten tabs fifty times leaves about 2,000.

`dismantleNSView` now calls `detachScrollObservers()` and a new `detachAccessibilityActivationObserver()`, extracted from `releaseData()` so both paths share it. Both are idempotent, so a later `releaseData()` on the same coordinator is still fine.

This is a registration leak, not a coordinator leak: every one of those closures captures `self` weakly, so the coordinator itself was always free to deallocate. No `deinit` was added, because `TableViewCoordinator` is `@MainActor` and a `nonisolated deinit` cannot call these methods; `dismantleNSView` is the hook that matches the mount.

## Tests

`SelectAllCellSelectionTests` (new) and `DataGridMountTeardownTests` (new), plus the existing selection and gutter suites: 59 cases, all passing.

The Select All suite carries a guard case of its own, `harnessPresentsDataColumns`. `selectAll` falls through to AppKit's own implementation when the grid presents no data columns, and that path selects every row too, so a harness that never reconciled the column pool would have passed the row assertion while never exercising the cell selection at all. That is not hypothetical: the first draft of this suite did exactly that, and the guard is what caught it.

Confirmed as a real regression guard: with the `withProgrammaticRowSelection` wrapper reverted, `selectAllKeepsTheCellSelection` and `escapeAfterSelectAllClearsTheCellSelection` both fail; with it, all five pass.

## Verification

- `build` PASS
- `test` PASS, 59 cases over `SelectAllCellSelectionTests`, `DataGridMountTeardownTests`, `GridSelectionControllerTests`, `DataGridSelectionTests`, `PublishedRowSelectionTests`, `KeyHandlingTableViewCopyTests`, `DataGridRowGutterTests`, `TableViewCoordinatorRowCountCacheTests`, `FocusedColumnResolutionTests`
- `swiftlint --strict` clean for this change. Two `legacy_swiftui_aspect_ratio` errors remain in `ImportFromAppSourcePicker.swift` and `SupportView.swift`; both are pre-existing on `main` and untouched here.

## Noted, not fixed

`focusCell(row:column:)` has the same unmarked-write shape and can drop a multi-cell range while tabbing inside it. `applyFindMatch` and `beginEditing` also write unmarked, but there it is arguably intended: jumping to a match or starting an edit plausibly should replace a stale range. Left alone rather than folded in, since neither is this defect.

https://claude.ai/code/session_01STT2h6Y53XJah8xPXAH42L
