### PR TITLE
fix(tabs): stop undone edits and another tab's find term surviving a tab switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Undone cell edits coming back after switching tabs. (#2667)
+- Find bar showing another tab's search term, over this tab's match count. (#2667)
 - Grid row and cell selection lost on switching editor tabs, result view modes, or moving a tab to a new window. (#2667)
 - Connection and database choosers opening between the two toolbar capsules instead of under the one that was pressed.
 - Raw DuckDB driver text in place of the name of the app holding a locked database file. (#2518)

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -760,6 +760,13 @@ struct MainEditorContentView: View {
                                     &+ resolvedRows.rows.count,
                                 onSearchAllRows: { coordinator.findCoordinator.escalateToAllRows() }
                             )
+                            /// Per tab, like the grid below it. The field text lives in the view's
+                            /// own `@State`, seeded once from `onAppear`, and the grid's find tint
+                            /// lives on a coordinator that `.id(tabId)` rebuilds from nothing. With
+                            /// find open on both tabs this view kept its identity across a switch,
+                            /// so neither was re-seeded: the field showed the other tab's term next
+                            /// to this tab's match count, and the grid came back untinted. (#2667)
+                            .id(tab.id)
                             Divider()
                         }
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
@@ -36,10 +36,15 @@ extension MainContentCoordinator {
         if let oldId = oldTabId,
            let oldIndex = tabManager.tabs.firstIndex(where: { $0.id == oldId })
         {
-            if changeManager.hasChanges {
-                let savedState = changeManager.saveState()
-                tabManager.mutate(at: oldIndex) { $0.pendingChanges = savedState }
-            }
+            /// Written whether or not there are changes, because an empty snapshot is the correct
+            /// answer once the reader has undone their edits and the tab is still holding the one a
+            /// previous switch saved. Gated on `hasChanges`, the undo was never recorded: switching
+            /// back restored the edit the reader had just taken back, and the tab went on reporting
+            /// unsaved work. Nothing has repointed the change manager at this point, so it still
+            /// describes the tab being left: every other `configureForTable` caller is either the
+            /// incoming block below or guarded to the selected tab.
+            let savedState = changeManager.saveState()
+            tabManager.mutate(at: oldIndex) { $0.pendingChanges = savedState }
             // One editor serves every query tab, so `cursorPositions` describes the outgoing tab
             // only until the switch completes. Persistence writes the live caret for the selected
             // tab alone, so a caret not captured here is gone once the editor has consumed the

--- a/TableProTests/Views/Main/MainContentCoordinatorTabSwitchTests.swift
+++ b/TableProTests/Views/Main/MainContentCoordinatorTabSwitchTests.swift
@@ -368,6 +368,49 @@ struct MainContentCoordinatorTabSwitchTests {
         #expect(tabManager.tabs[oldIndex].pendingChanges.hasChanges == true)
     }
 
+    /// The write used to be gated on `changeManager.hasChanges`, so an undo left the snapshot a
+    /// previous switch had saved sitting on the tab. Switching back restored the edit the reader had
+    /// just taken back, and the tab went on reporting unsaved work until it was closed.
+    @Test("Switching clears a snapshot the reader has undone")
+    func undoneChangesClearTheOutgoingSnapshot() throws {
+        let (coordinator, tabManager) = makeCoordinator()
+        let oldId = addQueryTab(to: tabManager, title: "Old")
+        let newId = addQueryTab(to: tabManager, title: "New")
+        seedRows(coordinator, for: oldId)
+        seedRows(coordinator, for: newId)
+
+        coordinator.changeManager.configureForTable(
+            tableName: "users",
+            columns: ["id", "name"],
+            primaryKeyColumns: ["id"],
+            databaseType: .mysql,
+            generatedColumns: [],
+            triggerReload: false
+        )
+        coordinator.changeManager.recordCellChange(
+            rowIndex: 0,
+            columnIndex: 1,
+            columnName: "name",
+            oldValue: "Alice",
+            newValue: "Bob",
+            originalRow: ["1", "Alice"]
+        )
+        coordinator.handleTabChange(from: oldId, to: newId, tabs: tabManager.tabs)
+        let afterFirstSwitch = try #require(tabManager.tabs.first { $0.id == oldId })
+        #expect(afterFirstSwitch.pendingChanges.hasChanges == true)
+
+        tabManager.selectedTabId = oldId
+        coordinator.handleTabChange(from: newId, to: oldId, tabs: tabManager.tabs)
+        coordinator.changeManager.clearChanges()
+        #expect(coordinator.changeManager.hasChanges == false)
+
+        tabManager.selectedTabId = newId
+        coordinator.handleTabChange(from: oldId, to: newId, tabs: tabManager.tabs)
+
+        let afterUndo = try #require(tabManager.tabs.first { $0.id == oldId })
+        #expect(afterUndo.pendingChanges.hasChanges == false)
+    }
+
     @Test("Hiding a column persists into the active tab's column layout")
     func hidingColumnPersistsToActiveTab() {
         let (coordinator, tabManager) = makeCoordinator()

--- a/TableProUITests/FindBarTabSwitchUITests.swift
+++ b/TableProUITests/FindBarTabSwitchUITests.swift
@@ -1,0 +1,112 @@
+//
+//  FindBarTabSwitchUITests.swift
+//  TableProUITests
+//
+//  The find bar holds its field text in the view's own `@State`, seeded once from `onAppear`. With
+//  find open on both tabs the view kept its identity across a tab switch, so nothing re-seeded it
+//  and the field showed the other tab's term. (#2667)
+//
+
+import XCTest
+
+final class FindBarTabSwitchUITests: UITestCase {
+    func testTheFindTermDoesNotFollowTheReaderToAnotherTab() throws {
+        let app = try launchWithSampleDatabase()
+        let window = try mainWindow(of: app)
+
+        let grid = window.tables.matching(identifier: "data-grid").firstMatch
+        XCTAssertTrue(grid.waitToExist(timeout: 30), "The sample table must produce a grid")
+        XCTAssertTrue(waitForClickableRows(in: grid), "The rows must be in before find can match any")
+
+        openFind(in: app)
+        let field = findField(in: window)
+        XCTAssertTrue(field.waitToExist(timeout: 15), "Command F must open the find bar")
+        field.click()
+        app.typeText("alice")
+        XCTAssertTrue(
+            waitForPredicate(timeout: 15) { Self.text(of: field) == "alice" },
+            "The first tab's term must reach its field, got \(Self.text(of: field))"
+        )
+
+        /// A second table tab, with find open too. That is the case the fix is about: when the
+        /// incoming tab has no find bar the view is destroyed anyway and the term reseeds itself.
+        openSecondTableTab(in: app, window: window)
+        XCTAssertTrue(waitForClickableRows(in: grid), "The second tab must load its rows")
+        openFind(in: app)
+        let secondField = findField(in: window)
+        XCTAssertTrue(secondField.waitToExist(timeout: 15), "The second tab must offer its own find bar")
+        secondField.click()
+        app.typeText("berlin")
+        XCTAssertTrue(
+            waitForPredicate(timeout: 15) { Self.text(of: secondField) == "berlin" },
+            "The second tab's term must reach its field, got \(Self.text(of: secondField))"
+        )
+
+        showPreviousTab(in: app)
+
+        let returned = findField(in: window)
+        XCTAssertTrue(returned.waitToExist(timeout: 15), "The first tab must come back with its find bar")
+        XCTAssertTrue(
+            waitForPredicate(timeout: 15) { Self.text(returned) == "alice" },
+            "Returning to the first tab must show its own term, not the other tab's. Got "
+                + Self.text(of: returned)
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func text(of element: XCUIElement) -> String {
+        guard element.exists else { return "<no field>" }
+        return (element.value as? String) ?? ""
+    }
+
+    private static func text(_ element: XCUIElement) -> String { text(of: element) }
+
+    private func findField(in window: XCUIElement) -> XCUIElement {
+        window.searchFields["find-in-results-field"].firstMatch
+    }
+
+    private func openFind(in app: XCUIApplication) {
+        app.typeKey("f", modifierFlags: .command)
+    }
+
+    private func mainWindow(of app: XCUIApplication) throws -> XCUIElement {
+        let window = app.windows.matching(NSPredicate(format: "identifier != %@", "welcome")).firstMatch
+        XCTAssertTrue(window.waitToExist(timeout: 60), "The sample database produced no window")
+        return window
+    }
+
+    /// A second table tab, through the tree's own "Open in New Tab". A double-click would not do:
+    /// without active work in the current tab, opening a table replaces it rather than adding one,
+    /// and this test needs both tabs to exist at once.
+    ///
+    /// The tree draws its rows as hosted cells, so the name arrives as the static text's `value`
+    /// rather than as a label, and the rows report as disabled. Matching on `value` finds them and a
+    /// coordinate click reaches them.
+    private func openSecondTableTab(in app: XCUIApplication, window: XCUIElement) {
+        XCTAssertTrue(
+            waitForPredicate(timeout: 30) { window.outlines.firstMatch.outlineRows.count > 1 },
+            "The object browser must list the sample database's tables"
+        )
+        let row = window.outlines.firstMatch.staticTexts
+            .matching(NSPredicate(format: "value == %@", "Table: Album"))
+            .firstMatch
+        XCTAssertTrue(row.waitToExist(timeout: 20), "The object browser must list a second table")
+        row.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).rightClick()
+
+        let item = app.menuItems["Open in New Tab"].firstMatch
+        XCTAssertTrue(item.waitToExist(timeout: 15), "The tree menu must offer Open in New Tab")
+        item.click()
+    }
+
+    /// The menu item rather than its key equivalent, which is user-rebindable. `firstMatch` because
+    /// the title is published more than once once AppKit's own window-tab machinery is involved.
+    private func showPreviousTab(in app: XCUIApplication) {
+        let menuBar = app.menuBars.firstMatch
+        XCTAssertTrue(menuBar.waitToExist(timeout: 20), "The app must publish its menu bar")
+        menuBar.menuBarItems["Window"].click()
+        let item = menuBar.menuItems["Show Previous Tab"].firstMatch
+        XCTAssertTrue(item.waitToExist(timeout: 10), "The Window menu must offer Show Previous Tab")
+        item.click()
+    }
+}


### PR DESCRIPTION
Two verified defects found by the collateral hunt during #2667. Both are per-tab state that a tab switch fails to re-point, which is why they are together; they are otherwise independent, and independent of the selection fix in #2679.

## Undone edits came back

`handleTabChange` wrote the outgoing tab's change snapshot only under `if changeManager.hasChanges`, while the incoming restore was unconditional. So an undo was never recorded:

1. Edit a cell in tab A, switch to B. A holds a snapshot with the edit.
2. Switch back to A. The edit is restored and shown.
3. Cmd+Z. The cell reverts and `hasChanges` goes false.
4. Switch to B. The guard skips the write, so A still holds the snapshot from step 1.
5. Switch back to A. The edit is back, and the tab reports unsaved work.

`saveState()` is a plain snapshot of `pending`, so on an empty manager it returns a snapshot with `hasChanges == false`, which is the correct value to write over the stale one. The write is now unconditional.

The risk worth naming is whether the change manager still describes the tab being *left* at that point, because writing an empty snapshot over real edits would be much worse than the bug. It does, and this was checked rather than assumed: there are four callers of `configureForTable`/`restoreState`, and every one of them is either `handleTabChange`'s own incoming block, which runs after this write, or guarded by `selectedTabId == tabId` (`QueryExecutionCoordinator+Helpers.swift:288`, `MainContentCoordinator+TableRowsMutation.swift:119`, `MainContentView+EventHandlers.swift:75` which also skips while `isHandlingTabSwitch`). `handleTabChange` runs synchronously from the `onChange`, so nothing can interleave between the selection changing and this write.

## The find bar showed the other tab's search term

`FindBarView` keeps its field text in `@State`, seeded once from `onAppear`, and it was mounted with no `.id()`. When the incoming tab has no find bar the view is destroyed anyway and the term reseeds itself, which is why this looked fine most of the time. With find open on **both** tabs the view kept its identity across the switch and nothing reseeded it:

- Tab A, Cmd+F, "alice". Tab B, Cmd+F, "berlin". Back to A: the field reads "berlin" while the counter beside it reports A's matches for "alice", and typing one more character replaces A's search with "berlin" plus that key.

The grid's find highlight is the same root cause seen from the other end. `DataGridView` is `.id(tabId)`, so a tab switch rebuilds `TableViewCoordinator` and its `currentFindMatch` starts nil; the only thing that re-applies the tint is `runSearch()`, reached through `onAppear` to `onChange(term)` to the debounce. When that chain does not run, tab A comes back untinted under a counter still claiming a match.

`.id(tab.id)` on the find bar, matching the grid directly below it, restores both.

One consequence worth flagging for review: `focusOnAppear` now fires on every switch into a find-open tab, so the find field takes focus on return. That is already what happens in the common case where the other tab had no find bar, so this makes the behaviour consistent rather than new.

## Tests

- `MainContentCoordinatorTabSwitchTests.undoneChangesClearTheOutgoingSnapshot` (new): edit, switch, return, clear, switch again, assert the tab's snapshot is clean. 101 cases pass across that suite plus `TabCloseProtectionTests`, `MainContentCoordinatorGridSelectionTests`, `MainContentCoordinatorSelectionResetTests`, `MainContentCoordinatorLazyLoadTests` and `RecentlyClosedTabStoreTests`.
- `FindBarTabSwitchUITests` (new): drives the exact repro, both tabs with find open, and asserts the field comes back reading "alice". It opens the second tab through the tree's "Open in New Tab" rather than a double-click, because without active work in the current tab a double-click replaces it instead of adding one, and this test needs both tabs to exist at once.

Both were confirmed as real guards by reverting each fix in turn: without `.id(tab.id)` the UI test fails, and with it, it passes.

## Verification

- `build` PASS
- `test` PASS, 101 cases
- `uitest FindBarTabSwitchUITests` PASS
- `swiftlint --strict` clean for this change. Two `legacy_swiftui_aspect_ratio` errors remain in `ImportFromAppSourcePicker.swift` and `SupportView.swift`; both are pre-existing on `main` and untouched here.

https://claude.ai/code/session_01STT2h6Y53XJah8xPXAH42L
