### PR TITLE
fix(datagrid): confirm before a value filter re-points pending cell edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Unsaved cell edits following the row that took their place after a per-column value filter changed. (#2667)
 - Grid row and cell selection lost on switching editor tabs, result view modes, or moving a tab to a new window. (#2667)
 - Connection and database choosers opening between the two toolbar capsules instead of under the one that was pressed.
 - Raw DuckDB driver text in place of the name of the app holding a locked database file. (#2518)

--- a/TablePro/Views/Main/Child/DataTabGridDelegate.swift
+++ b/TablePro/Views/Main/Child/DataTabGridDelegate.swift
@@ -31,6 +31,19 @@ final class DataTabGridDelegate: DataGridViewDelegate {
         onSortStateChanged?(state)
     }
 
+    /// The same gate sort, pagination and the WHERE filter go through. `confirmDiscardChangesIfNeeded`
+    /// answers immediately when there is nothing to lose, so an unedited result never sees an alert.
+    func dataGridConfirmDisplayOrderChange(then apply: @escaping () -> Void) {
+        guard let coordinator else {
+            apply()
+            return
+        }
+        coordinator.confirmDiscardChangesIfNeeded(action: .displayOrder) { confirmed in
+            guard confirmed else { return }
+            apply()
+        }
+    }
+
     func dataGridDisplayOrderChanged() {
         coordinator?.gridDisplayRevision &+= 1
     }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Alerts.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Alerts.swift
@@ -47,6 +47,11 @@ extension MainContentCoordinator {
         /// misstated the operation the user was approving whenever they stepped forward.
         case .navigation:
             return String(localized: "Moving through this tab's history replaces what it is showing and will discard all unsaved changes.")
+        /// No mention of reloading, unlike sort and the WHERE filter: a value filter narrows the
+        /// rows already loaded and never re-queries. What it does change is which row each display
+        /// position names, which is what the edits are recorded against.
+        case .displayOrder:
+            return String(localized: "Changing which rows are shown will discard all unsaved changes.")
         }
     }
 

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -22,6 +22,7 @@ enum DiscardAction {
     case filter
     case resultSwitch
     case navigation
+    case displayOrder
 }
 
 struct DisplayFormatsCacheEntry {

--- a/TablePro/Views/Results/DataGridViewDelegate.swift
+++ b/TablePro/Views/Results/DataGridViewDelegate.swift
@@ -20,6 +20,13 @@ protocol DataGridViewDelegate: AnyObject {
     func dataGridUndoInsert(at index: Int)
     func dataGridMoveRow(from source: Int, to destination: Int)
     func dataGridSortStateChanged(_ state: SortState)
+    /// Asks the owner to approve a change that re-points the display order before it happens.
+    ///
+    /// A pending cell edit is recorded against a display row, so anything that changes which row
+    /// a position names re-points it: the tint moves and a later edit at that position merges
+    /// into another row's change. Sort, pagination and the WHERE filter already confirm; a grid
+    /// with no owner has no edits to lose and runs the work directly.
+    func dataGridConfirmDisplayOrderChange(then apply: @escaping () -> Void)
     func dataGridFilterColumn(_ columnName: String)
     func dataGridNavigateFK(value: String, fkInfo: ForeignKeyInfo, openInNewTab: Bool)
     func dataGridShowRowAsJSON()
@@ -56,6 +63,7 @@ extension DataGridViewDelegate {
     func dataGridUndoInsert(at index: Int) {}
     func dataGridMoveRow(from source: Int, to destination: Int) {}
     func dataGridSortStateChanged(_ state: SortState) {}
+    func dataGridConfirmDisplayOrderChange(then apply: @escaping () -> Void) { apply() }
     func dataGridFilterColumn(_ columnName: String) {}
     func dataGridNavigateFK(value: String, fkInfo: ForeignKeyInfo, openInNewTab: Bool) {}
     func dataGridShowRowAsJSON() {}

--- a/TablePro/Views/Results/Extensions/DataGridView+Sort.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Sort.swift
@@ -395,8 +395,12 @@ extension TableViewCoordinator {
         )
         let remappedValueFilters = updateDisplayFormats(formats)
 
+        /// A remap moves the same rows to different positions, so it re-points a pending edit
+        /// exactly as an outright filter change does and takes the same confirmation.
         if remappedValueFilters {
-            reloadAfterValueFilterChange()
+            confirmDisplayOrderChange { [weak self] in
+                self?.reloadAfterValueFilterChange()
+            }
             return
         }
 

--- a/TablePro/Views/Results/Extensions/DataGridView+ValueFilter.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+ValueFilter.swift
@@ -67,19 +67,38 @@ extension TableViewCoordinator {
         valueFilterState = state
     }
 
+    /// Confirmed before the state moves, not after: the alert's whole purpose is to let the reader
+    /// keep edits that this change would re-point, so the filter must not be written until they
+    /// have said yes.
     func applyValueFilter(_ filter: ColumnValueFilter?, columnName: String, forColumn dataIndex: Int) {
-        if let filter {
-            valueFilterState.set(filter, columnName: columnName, forColumn: dataIndex)
-        } else {
-            valueFilterState.clear(column: dataIndex)
+        confirmDisplayOrderChange { [weak self] in
+            guard let self else { return }
+            if let filter {
+                self.valueFilterState.set(filter, columnName: columnName, forColumn: dataIndex)
+            } else {
+                self.valueFilterState.clear(column: dataIndex)
+            }
+            self.reloadAfterValueFilterChange()
         }
-        reloadAfterValueFilterChange()
     }
 
     func clearAllValueFilters() {
         guard valueFilterState.isActive else { return }
-        valueFilterState.clearAll()
-        reloadAfterValueFilterChange()
+        confirmDisplayOrderChange { [weak self] in
+            guard let self else { return }
+            self.valueFilterState.clearAll()
+            self.reloadAfterValueFilterChange()
+        }
+    }
+
+    /// A grid with no owner has no pending edits to lose, and the protocol default runs the work
+    /// directly, so the structure, create-table and inspector grids are unaffected.
+    func confirmDisplayOrderChange(_ apply: @escaping () -> Void) {
+        guard let delegate else {
+            apply()
+            return
+        }
+        delegate.dataGridConfirmDisplayOrderChange(then: apply)
     }
 
     func reloadAfterValueFilterChange() {

--- a/TableProTests/Views/Results/ValueFilterChangeGuardTests.swift
+++ b/TableProTests/Views/Results/ValueFilterChangeGuardTests.swift
@@ -1,0 +1,152 @@
+//
+//  ValueFilterChangeGuardTests.swift
+//  TableProTests
+//
+//  A pending cell edit is recorded against a display row, so anything that changes which row a
+//  position names re-points it. Sort, pagination and the WHERE filter already confirm before doing
+//  that; the per-column value filter did not. (#2667)
+//
+
+import AppKit
+import SwiftUI
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+@MainActor
+private final class GuardPersister: ColumnLayoutPersisting {
+    func load(for key: ColumnLayoutTableKey) -> ColumnLayoutState? { nil }
+    func save(_ layout: ColumnLayoutState, for key: ColumnLayoutTableKey) {}
+    func clear(for key: ColumnLayoutTableKey) {}
+}
+
+/// Holds the work instead of running it, standing in for a reader who has not answered the alert.
+@MainActor
+private final class DeferringDelegate: DataGridViewDelegate {
+    private(set) var askedCount = 0
+    private var pending: (() -> Void)?
+
+    func dataGridConfirmDisplayOrderChange(then apply: @escaping () -> Void) {
+        askedCount += 1
+        pending = apply
+    }
+
+    func confirm() {
+        let work = pending
+        pending = nil
+        work?()
+    }
+
+    func discard() {
+        pending = nil
+    }
+}
+
+@Suite("Value filter change guard")
+@MainActor
+struct ValueFilterChangeGuardTests {
+    private func makeCoordinator(delegate: (any DataGridViewDelegate)? = nil) -> TableViewCoordinator {
+        let coordinator = TableViewCoordinator(
+            changeManager: AnyChangeManager(DataChangeManager()),
+            isEditable: true,
+            selectedRowIndices: .constant([]),
+            delegate: delegate,
+            layoutPersister: GuardPersister()
+        )
+        let rows: ContiguousArray<Row> = [
+            Row(id: .existing(0), values: [.text("active"), .text("a")]),
+            Row(id: .existing(1), values: [.text("inactive"), .text("b")]),
+            Row(id: .existing(2), values: [.text("active"), .text("c")]),
+        ]
+        var captured = TableRows(
+            rows: rows,
+            columns: ["status", "name"],
+            columnTypes: [.text(rawType: nil), .text(rawType: nil)]
+        )
+        coordinator.tableRowsProvider = { captured }
+        coordinator.tableRowsMutator = { mutation in mutation(&captured) }
+        coordinator.updateCache()
+        return coordinator
+    }
+
+    private func onlyActive() -> ColumnValueFilter {
+        ColumnValueFilter(selectedValues: ["active"], includesNull: false)
+    }
+
+    /// The structure, create-table and inspector grids own no pending edits and take the protocol
+    /// default, so they must keep applying a filter with no round trip at all.
+    @Test("a grid with no owner applies its filter directly")
+    func ownerlessGridAppliesImmediately() {
+        let coordinator = makeCoordinator()
+
+        coordinator.applyValueFilter(onlyActive(), columnName: "status", forColumn: 0)
+
+        #expect(coordinator.valueFilterState.isActive)
+        #expect(coordinator.valueFilteredIDs?.count == 2)
+    }
+
+    @Test("a grid with an owner asks before it narrows anything")
+    func ownedGridAsksFirst() {
+        let delegate = DeferringDelegate()
+        let coordinator = makeCoordinator(delegate: delegate)
+
+        coordinator.applyValueFilter(onlyActive(), columnName: "status", forColumn: 0)
+
+        #expect(delegate.askedCount == 1)
+        /// Nothing moved yet. The filter is written inside the approved work, not before it, or the
+        /// reader would be answering an alert about a change that had already happened.
+        #expect(!coordinator.valueFilterState.isActive)
+        #expect(coordinator.valueFilteredIDs == nil)
+    }
+
+    @Test("approving the change applies the filter")
+    func approvingApplies() {
+        let delegate = DeferringDelegate()
+        let coordinator = makeCoordinator(delegate: delegate)
+        coordinator.applyValueFilter(onlyActive(), columnName: "status", forColumn: 0)
+
+        delegate.confirm()
+
+        #expect(coordinator.valueFilterState.isActive)
+        #expect(coordinator.valueFilteredIDs?.count == 2)
+    }
+
+    @Test("declining the change leaves the rows as they were")
+    func decliningLeavesRowsAlone() {
+        let delegate = DeferringDelegate()
+        let coordinator = makeCoordinator(delegate: delegate)
+
+        coordinator.applyValueFilter(onlyActive(), columnName: "status", forColumn: 0)
+        delegate.discard()
+
+        #expect(!coordinator.valueFilterState.isActive)
+        #expect(coordinator.valueFilteredIDs == nil)
+    }
+
+    @Test("clearing every filter asks as well")
+    func clearingAsksFirst() {
+        let delegate = DeferringDelegate()
+        let coordinator = makeCoordinator(delegate: delegate)
+        coordinator.applyValueFilter(onlyActive(), columnName: "status", forColumn: 0)
+        delegate.confirm()
+        #expect(coordinator.valueFilterState.isActive)
+
+        coordinator.clearAllValueFilters()
+        #expect(delegate.askedCount == 2)
+        #expect(coordinator.valueFilterState.isActive)
+
+        delegate.confirm()
+        #expect(!coordinator.valueFilterState.isActive)
+    }
+
+    @Test("clearing when nothing is filtered asks nothing")
+    func clearingWithNoFilterAsksNothing() {
+        let delegate = DeferringDelegate()
+        let coordinator = makeCoordinator(delegate: delegate)
+
+        coordinator.clearAllValueFilters()
+
+        #expect(delegate.askedCount == 0)
+    }
+}


### PR DESCRIPTION
The last of the verified defects found by the collateral hunt during #2667, and the only one that can put a value on the wrong row.

## What happens

A pending cell edit is recorded against a **display** row. `DataGridView+CellCommit.swift` calls `recordCellChange(rowIndex: row, ...)` with the display index, and computes the storage index separately for the buffer write; `RowChange.rowIndex` is the only positional key a change carries, and every `PendingChanges` lookup takes that same index.

The per-column value filter changes which row each display position names, and it did so with no guard at all:

1. Editable table tab, ten rows with ids 1 to 10, no filter.
2. Edit display row 2, which is id 3. A `RowChange` is recorded at `rowIndex: 2` with `originalRow` = id 3.
3. Open a column's value filter and exclude a value that hides display rows 0 and 1.
4. Display row 2 now names id 6. The modified tint moves onto id 6.
5. Edit that row. `recordCellChange(rowIndex: 2, ...)` merges into the change record belonging to id 3.

Step 5 is the part that matters. The write itself builds its `WHERE` from `change.originalRow` (`RowWriteOperationBuilder.swift:70,121`), so the first edit still targets id 3 correctly. But the second edit merges into id 3's record and is then written against id 3's pre-image, so a value the reader typed into id 6 is saved onto id 3. Steps 1 to 4 alone are a visual defect; step 5 is a wrong-row write.

Sort, pagination and the WHERE filter all already route through `confirmDiscardChangesIfNeeded` for exactly this reason (`FilterCoordinator.swift`, `PaginationCoordinator.swift`, `MainContentCoordinator.handleSortStateChanged`). The value filter was the one display-order change that did not.

## The fix

A new `dataGridConfirmDisplayOrderChange(then:)` on `DataGridViewDelegate`, defaulting to running the work directly, and `DataTabGridDelegate` implements it against the existing `confirmDiscardChangesIfNeeded(action: .displayOrder)`. `confirmDiscardChangesIfNeeded` answers immediately when there is nothing to lose, so an unedited result never sees an alert.

Three call sites go through it, not two. `applyValueFilter` and `clearAllValueFilters` are the obvious ones; `setDisplayFormat` is the third, and it was easy to miss: when a format change remaps an active filter it calls `reloadAfterValueFilterChange()` directly (`DataGridView+Sort.swift:399`), which moves the same rows to different positions and re-points a pending edit exactly the same way.

The filter state is written **inside** the approved closure, not before it. Confirming after the fact would mean the reader was answering an alert about a change that had already happened.

Named for what it guards, a change to the display order, rather than for the value filter, because `setDisplayFormat` is also a caller.

## Scope, and what this deliberately does not do

The grids that take the protocol default are unaffected: structure, create-table and inspector. The real reason is not that they have no value filter (the header menu offers "Filter Values…" to any coordinator-backed grid) but that `StructureChangeManager.recordCellChange` is a no-op, because structure edits are tracked by entity id rather than by display position. So there is nothing there to re-point.

Two alternatives were considered and rejected:

- **Re-key `PendingChanges` by `RowID`.** This is the root-cause fix and it is genuinely better, but the positional key runs through `SQLStatementGenerator`, `RowWriteOperationBuilder`, `RewindPlanner` and `RowVisualIndex`, and the undo stack captures `rowIndex` in its closures too, so a remap that did not also re-key undo would leave undo pointing at the wrong rows. That is a much larger change than this defect justifies, and it is worth doing on its own terms rather than inside a bug fix.
- **Blocking the filter outright while edits are pending.** No precedent: every sibling operation confirms and discards rather than refusing.

So this discards all pending edits on a value-filter change, including for rows the new filter keeps visible. That matches what sort, pagination and the WHERE filter already do, and it is the conservative half of the trade: the alternative silently keeps edits whose positions have moved.

## Tests

`ValueFilterChangeGuardTests` (new), with a delegate that holds the work instead of running it, standing in for a reader who has not answered:

- a grid with no owner applies its filter directly, so the ownerless grids keep working
- an owned grid asks first, and nothing has moved before the answer
- approving applies; declining leaves the rows alone
- clearing every filter asks as well, and clearing when nothing is filtered asks nothing

## Verification

- `build` PASS
- `test` PASS, 55 cases over `ValueFilterChangeGuardTests`, `TableViewCoordinatorValueFilterTests`, `GridValueFilterStateTests`, `DataGridSelectionTests`, `CommandActionsDispatchTests`, `CoordinatorColumnVisibilityTests`. The pre-existing value-filter suite passes unmodified, which is the check that the ownerless path still applies immediately.
- `swiftlint --strict` clean for this change. Two `legacy_swiftui_aspect_ratio` errors remain in `ImportFromAppSourcePicker.swift` and `SupportView.swift`; both are pre-existing on `main` and untouched here.

No UI test: the flow ends in a modal alert, and a unit test that holds the closure covers the ordering question that actually matters here.

## Known gap

`reloadAfterRowMutationWithValueFilter` (`DataGridCoordinator.swift`) also reorders rows, on insert and delete while a filter is active, and is not gated by this change. It is a narrower case, since those paths already adjust the pending changes themselves, but it is the next place to look if this class of defect reappears.

https://claude.ai/code/session_01STT2h6Y53XJah8xPXAH42L
