### PR TITLE
fix(datagrid): restore the rows a discarded value-filter change was about to re-point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Edited values left on screen with nothing tracking them after discarding to change a value filter. (#2667)
+- Discard prompt on applying a value filter that changes nothing. (#2667)
 - Unsaved cell edits following the row that took their place after a per-column value filter changed. (#2667)
 - Undone cell edits coming back after switching tabs. (#2667)
 - Find bar showing another tab's search term, over this tab's match count. (#2667)

--- a/TablePro/Core/Coordinators/RowEditingCoordinator+Discard.swift
+++ b/TablePro/Core/Coordinators/RowEditingCoordinator+Discard.swift
@@ -51,6 +51,30 @@ extension RowEditingCoordinator {
         pendingTruncates: inout Set<DatabaseTreeTableRef>,
         pendingDeletes: inout Set<DatabaseTreeTableRef>
     ) {
+        restoreRowBufferToOriginals()
+
+        if let tableName = parent.tabManager.selectedTab?.tableContext.tableName {
+            parent.saveLastFilters(for: tableName)
+        }
+
+        pendingTruncates.removeAll()
+        pendingDeletes.removeAll()
+        parent.changeManager.clearChangesAndUndoHistory()
+
+        if let (_, index) = parent.tabManager.selectedTabAndIndex {
+            parent.tabManager.mutate(at: index) { $0.pendingChanges = TabChangeSnapshot() }
+        }
+
+        Task { [parent] in await parent.refreshTables() }
+    }
+
+    /// Puts the loaded rows back the way the server last reported them.
+    ///
+    /// An edit is written straight into the tab's `TableRows` as well as being recorded, so
+    /// clearing the change records alone leaves the edited values on screen with nothing tracking
+    /// them, and the next edit captures an unsaved value as its baseline. A discard that re-queries
+    /// replaces the buffer wholesale and needs none of this; one that does not has to undo it here.
+    func restoreRowBufferToOriginals() {
         let originalValues = parent.changeManager.getOriginalValues()
         var deltas: [Delta] = []
         if let (tab, _) = parent.tabManager.selectedTabAndIndex {
@@ -81,20 +105,6 @@ extension RowEditingCoordinator {
         for delta in deltas {
             parent.dataTabDelegate?.tableViewCoordinator?.applyDelta(delta)
         }
-
-        if let tableName = parent.tabManager.selectedTab?.tableContext.tableName {
-            parent.saveLastFilters(for: tableName)
-        }
-
-        pendingTruncates.removeAll()
-        pendingDeletes.removeAll()
-        parent.changeManager.clearChangesAndUndoHistory()
-
-        if let (_, index) = parent.tabManager.selectedTabAndIndex {
-            parent.tabManager.mutate(at: index) { $0.pendingChanges = TabChangeSnapshot() }
-        }
-
-        Task { [parent] in await parent.refreshTables() }
     }
 
     private func collectInsertedRowIDs(tabId: UUID, indices: Set<Int>) -> Set<RowID> {

--- a/TablePro/Views/Main/Child/DataTabGridDelegate.swift
+++ b/TablePro/Views/Main/Child/DataTabGridDelegate.swift
@@ -38,7 +38,7 @@ final class DataTabGridDelegate: DataGridViewDelegate {
             apply()
             return
         }
-        coordinator.confirmDiscardChangesIfNeeded(action: .displayOrder) { confirmed in
+        coordinator.confirmDiscardRestoringRowsIfNeeded(action: .displayOrder) { confirmed in
             guard confirmed else { return }
             apply()
         }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ChangeGuard.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ChangeGuard.swift
@@ -34,4 +34,38 @@ extension MainContentCoordinator {
             completion(confirmed)
         }
     }
+
+    /// The same gate, for an operation that does NOT re-query.
+    ///
+    /// An edit is written into the tab's loaded rows as well as being recorded, so every caller of
+    /// the plain gate above gets away with clearing only the records: sort, pagination, the WHERE
+    /// filter and refresh all re-run the query and replace the buffer. A per-column value filter
+    /// narrows the rows already loaded, so the edited values would stay on screen with nothing
+    /// tracking them, and the next edit would capture an unsaved value as its baseline. (#2667)
+    func confirmDiscardRestoringRowsIfNeeded(
+        action: DiscardAction,
+        completion: @escaping (Bool) -> Void
+    ) {
+        guard changeManager.hasChanges else {
+            completion(true)
+            return
+        }
+
+        guard !isShowingConfirmAlert else {
+            completion(false)
+            return
+        }
+
+        Task {
+            let confirmed = await confirmDiscardChanges(action: action, window: contentWindow)
+            if confirmed {
+                rowEditingCoordinator.restoreRowBufferToOriginals()
+                changeManager.clearChangesAndUndoHistory()
+                if let (_, index) = tabManager.selectedTabAndIndex {
+                    tabManager.mutate(at: index) { $0.pendingChanges = TabChangeSnapshot() }
+                }
+            }
+            completion(confirmed)
+        }
+    }
 }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TabSwitch.swift
@@ -36,15 +36,23 @@ extension MainContentCoordinator {
         if let oldId = oldTabId,
            let oldIndex = tabManager.tabs.firstIndex(where: { $0.id == oldId })
         {
-            /// Written whether or not there are changes, because an empty snapshot is the correct
-            /// answer once the reader has undone their edits and the tab is still holding the one a
-            /// previous switch saved. Gated on `hasChanges`, the undo was never recorded: switching
-            /// back restored the edit the reader had just taken back, and the tab went on reporting
-            /// unsaved work. Nothing has repointed the change manager at this point, so it still
-            /// describes the tab being left: every other `configureForTable` caller is either the
-            /// incoming block below or guarded to the selected tab.
-            let savedState = changeManager.saveState()
-            tabManager.mutate(at: oldIndex) { $0.pendingChanges = savedState }
+            /// The second half of the condition is the fix. Gated on `hasChanges` alone, an undo was
+            /// never recorded: the tab kept the snapshot a previous switch had saved, so switching
+            /// back restored the edit the reader had just taken back and the tab went on reporting
+            /// unsaved work. Writing the empty snapshot is what clears it.
+            ///
+            /// Still conditional, because `mutate` takes the element `inout` and so runs the array's
+            /// setter whether or not the block writes: an unconditional write would fire `tabs`'
+            /// `didSet` over every open tab on every switch, for nothing.
+            ///
+            /// Safe to take the snapshot from the change manager here because nothing has repointed
+            /// it yet: every other `configureForTable` and `restoreState` caller is either the
+            /// incoming block below or guarded to the selected tab, and this runs synchronously
+            /// from the selection change with no suspension in between.
+            if changeManager.hasChanges || tabManager.tabs[oldIndex].pendingChanges.hasChanges {
+                let savedState = changeManager.saveState()
+                tabManager.mutate(at: oldIndex) { $0.pendingChanges = savedState }
+            }
             // One editor serves every query tab, so `cursorPositions` describes the outgoing tab
             // only until the switch completes. Persistence writes the live caret for the selected
             // tab alone, so a caret not captured here is gone once the editor has consumed the

--- a/TablePro/Views/Results/Extensions/DataGridView+Sort.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Sort.swift
@@ -376,9 +376,25 @@ extension TableViewCoordinator {
         scheduleLayoutPersist()
     }
 
+    /// Gated whole, not just at the reload. `applyDisplayFormats` remaps the value filter and
+    /// rewrites the format array before it reports whether anything moved, so gating the reload
+    /// alone left a declined change half-applied: the state moved, the grid did not, and the next
+    /// unrelated update would have shown the reorder anyway.
+    ///
+    /// Only when a filter is active, because that is the only way a format change can renumber the
+    /// display at all. Without one this is a repaint, and repaints do not touch pending edits.
     @objc func setDisplayFormat(_ sender: NSMenuItem) {
         guard let info = sender.representedObject as? DisplayFormatMenuItem else { return }
+        guard valueFilterState.isActive else {
+            applyDisplayFormatSelection(info)
+            return
+        }
+        confirmDisplayOrderChange { [weak self] in
+            self?.applyDisplayFormatSelection(info)
+        }
+    }
 
+    private func applyDisplayFormatSelection(_ info: DisplayFormatMenuItem) {
         if let scope = tableScope {
             ValueDisplayFormatService.shared.setOverride(
                 info.format,
@@ -395,12 +411,8 @@ extension TableViewCoordinator {
         )
         let remappedValueFilters = updateDisplayFormats(formats)
 
-        /// A remap moves the same rows to different positions, so it re-points a pending edit
-        /// exactly as an outright filter change does and takes the same confirmation.
         if remappedValueFilters {
-            confirmDisplayOrderChange { [weak self] in
-                self?.reloadAfterValueFilterChange()
-            }
+            reloadAfterValueFilterChange()
             return
         }
 

--- a/TablePro/Views/Results/Extensions/DataGridView+ValueFilter.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+ValueFilter.swift
@@ -70,15 +70,32 @@ extension TableViewCoordinator {
     /// Confirmed before the state moves, not after: the alert's whole purpose is to let the reader
     /// keep edits that this change would re-point, so the filter must not be written until they
     /// have said yes.
-    func applyValueFilter(_ filter: ColumnValueFilter?, columnName: String, forColumn dataIndex: Int) {
+    func applyValueFilter(
+        _ filter: ColumnValueFilter?,
+        columnName: String,
+        forColumn dataIndex: Int,
+        onApplied: (() -> Void)? = nil
+    ) {
+        /// Nothing to confirm when the filter lands on the state it already had. Opening the popover
+        /// and pressing Apply without touching anything is an ordinary thing to do, and asking the
+        /// reader to discard their edits for a change that moves no row at all trains them to
+        /// dismiss the alert without reading it.
+        var candidate = valueFilterState
+        if let filter {
+            candidate.set(filter, columnName: columnName, forColumn: dataIndex)
+        } else {
+            candidate.clear(column: dataIndex)
+        }
+        guard candidate != valueFilterState else {
+            onApplied?()
+            return
+        }
+
         confirmDisplayOrderChange { [weak self] in
             guard let self else { return }
-            if let filter {
-                self.valueFilterState.set(filter, columnName: columnName, forColumn: dataIndex)
-            } else {
-                self.valueFilterState.clear(column: dataIndex)
-            }
+            self.valueFilterState = candidate
             self.reloadAfterValueFilterChange()
+            onApplied?()
         }
     }
 
@@ -135,9 +152,16 @@ extension TableViewCoordinator {
                 values: values,
                 loadedRowCount: loadedRowCount,
                 initialFilter: initialFilter,
+                /// Dismissed from inside the applied work, not beside it. The confirmation is a
+                /// sheet and resolves asynchronously, so closing here would put the popover away
+                /// before the reader had answered the alert it raised.
                 onApply: { filter in
-                    self?.applyValueFilter(filter, columnName: columnName, forColumn: dataIndex)
-                    dismiss()
+                    self?.applyValueFilter(
+                        filter,
+                        columnName: columnName,
+                        forColumn: dataIndex,
+                        onApplied: dismiss
+                    )
                 },
                 onCancel: dismiss
             )

--- a/TableProTests/Views/Results/ValueFilterChangeGuardTests.swift
+++ b/TableProTests/Views/Results/ValueFilterChangeGuardTests.swift
@@ -140,6 +140,66 @@ struct ValueFilterChangeGuardTests {
         #expect(!coordinator.valueFilterState.isActive)
     }
 
+    /// Opening the popover and pressing Apply without touching anything is ordinary, and it moves no
+    /// row, so it must not put a discard alert in the reader's way.
+    @Test("applying the filter it already has asks nothing and still dismisses")
+    func reapplyingTheSameFilterAsksNothing() {
+        let delegate = DeferringDelegate()
+        let coordinator = makeCoordinator(delegate: delegate)
+        coordinator.applyValueFilter(onlyActive(), columnName: "status", forColumn: 0)
+        delegate.confirm()
+        #expect(delegate.askedCount == 1)
+
+        var dismissed = false
+        coordinator.applyValueFilter(
+            onlyActive(),
+            columnName: "status",
+            forColumn: 0,
+            onApplied: { dismissed = true }
+        )
+
+        #expect(delegate.askedCount == 1)
+        #expect(dismissed)
+    }
+
+    /// The popover must not close while the reader still has an alert to answer, or Cancel leaves
+    /// them with no popover and no filter and no way to see what happened.
+    @Test("the popover is dismissed only once the change is applied")
+    func popoverDismissalWaitsForTheAnswer() {
+        let delegate = DeferringDelegate()
+        let coordinator = makeCoordinator(delegate: delegate)
+
+        var dismissed = false
+        coordinator.applyValueFilter(
+            onlyActive(),
+            columnName: "status",
+            forColumn: 0,
+            onApplied: { dismissed = true }
+        )
+        #expect(!dismissed)
+
+        delegate.confirm()
+        #expect(dismissed)
+    }
+
+    @Test("declining leaves the popover open")
+    func decliningLeavesThePopoverOpen() {
+        let delegate = DeferringDelegate()
+        let coordinator = makeCoordinator(delegate: delegate)
+
+        var dismissed = false
+        coordinator.applyValueFilter(
+            onlyActive(),
+            columnName: "status",
+            forColumn: 0,
+            onApplied: { dismissed = true }
+        )
+        delegate.discard()
+
+        #expect(!dismissed)
+        #expect(!coordinator.valueFilterState.isActive)
+    }
+
     @Test("clearing when nothing is filtered asks nothing")
     func clearingWithNoFilterAsksNothing() {
         let delegate = DeferringDelegate()


### PR DESCRIPTION
Follow-up to #2681, #2682 and #2683. Those three merged from the state they were reviewed in; this carries the review findings that landed after the merge, including one defect #2683 introduced.

## The defect #2683 introduced

`#2683` routed a value-filter change through `confirmDiscardChangesIfNeeded`, matching sort, pagination and the WHERE filter. That gate clears the change records and the undo history, and nothing else. Every existing caller gets away with that because **they all re-query**: sort issues a new `ORDER BY`, pagination fetches a page, the WHERE filter rebuilds and re-runs, refresh refetches. The buffer is replaced by fresh server rows, so the discarded edits go with it.

A per-column value filter does not re-query. It narrows the rows already loaded. So choosing Discard cleared the records while `recordCellEdit`'s writes stayed in the tab's `TableRows`: the edited values remained on screen with nothing tracking them, and the next edit to such a row would capture an unsaved value as its `originalRow`, which is the pre-image the `UPDATE`'s `WHERE` is built from. That statement would then match nothing.

`RowEditingCoordinator+Discard` already knew how to do this properly, reverting the buffer through `getOriginalValues()` and removing inserted rows before clearing. That block is now extracted as `restoreRowBufferToOriginals()`, `handleDiscard` calls it, and a new `confirmDiscardRestoringRowsIfNeeded` uses it for operations that do not re-query. The plain gate is unchanged for its existing callers, which do not need it.

## The two fixes that missed the merge on #2683

Both were pushed to the branch after review but before the merge picked it up.

**The display-format path mutated before the gate.** `setDisplayFormat` called `updateDisplayFormats` unconditionally, and that persists the override, replaces `columnDisplayFormats`, invalidates the display cache and rewrites `valueFilterState` before reporting whether anything moved. Only the reload was gated, so Cancel left the change half-applied: the state moved, the grid did not, and the next unrelated update would have shown the reorder anyway. The whole operation is now behind the gate, and only when a value filter is active, since that is the only way a format change can renumber the display at all.

**The filter popover closed before the alert was answered.** `onApply` called `applyValueFilter` and then `dismiss()` synchronously, while the confirmation is a sheet that resolves asynchronously. The popover went away, then the alert appeared. Dismissal now happens from inside the applied work, so declining leaves the popover open.

## The fix that missed the merge on #2682

The outgoing snapshot write was made unconditional to record an undo. `mutate` takes the element `inout`, so the array's setter runs whether or not the block writes, firing `tabs`' `didSet` across every open tab on every switch. It is conditional again, on `changeManager.hasChanges || tabManager.tabs[oldIndex].pendingChanges.hasChanges`: the second half is what records the undo, the first keeps the common no-op switch free.

## Also here

Applying a value filter that resolves to the state it already had no longer prompts. Opening the popover and pressing Apply without touching anything is ordinary, moves no row, and asking someone to discard their edits for it teaches them to dismiss the alert unread.

## Tests

`ValueFilterChangeGuardTests` gains three cases: re-applying an unchanged filter asks nothing and still dismisses, the popover is dismissed only once the change applies, and declining leaves it open. 90 cases pass across that suite plus `TableViewCoordinatorValueFilterTests`, `MainContentCoordinatorTabSwitchTests`, `TabCloseProtectionTests`, `RowEditingCoordinatorCopyTests`, `HeaderSortCycleTests` and `GridValueFilterStateTests`.

`swiftlint --strict` clean for this change. Two `legacy_swiftui_aspect_ratio` errors remain in `ImportFromAppSourcePicker.swift` and `SupportView.swift`; both are pre-existing on `main` and untouched here.

## Still open, and deliberately not in here

The column visibility commands (`hideColumn`, `showAllColumns` and their siblings) re-query the whole table through `requeryWithColumnScope` with no discard confirmation at all, unlike sort, pagination and the WHERE filter. That is pre-existing and predates all of this work, but it is the same class of gap and is worth closing separately.

https://claude.ai/code/session_01STT2h6Y53XJah8xPXAH42L
