### PR TITLE
fix(datagrid): confirm before hiding or showing a column discards unsaved edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Unsaved cell edits discarded without asking when a column was hidden, shown or reset. (#2667)
 - Edited values left on screen with nothing tracking them after discarding to change a value filter. (#2667)
 - Discard prompt on applying a value filter that changes nothing. (#2667)
 - Unsaved cell edits following the row that took their place after a per-column value filter changed. (#2667)

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Alerts.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Alerts.swift
@@ -52,6 +52,10 @@ extension MainContentCoordinator {
         /// position names, which is what the edits are recorded against.
         case .displayOrder:
             return String(localized: "Changing which rows are shown will discard all unsaved changes.")
+        /// Named for the reload, like sort and the WHERE filter, because that is what costs the
+        /// edits: the table is fetched again with a different column list.
+        case .columnVisibility:
+            return String(localized: "Showing or hiding columns will reload data and discard all unsaved changes.")
         }
     }
 

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+ColumnVisibility.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+ColumnVisibility.swift
@@ -17,34 +17,47 @@ extension MainContentCoordinator {
     }
 
     func hideColumn(_ columnName: String) {
-        mutateSelectedTabHiddenColumns { $0.insert(columnName) }
-        requeryWithColumnScope(debounced: true)
+        changeColumnScope { $0.insert(columnName) }
     }
 
     func showColumn(_ columnName: String) {
-        mutateSelectedTabHiddenColumns { $0.remove(columnName) }
-        requeryWithColumnScope(debounced: true)
+        changeColumnScope { $0.remove(columnName) }
     }
 
     func toggleColumnVisibility(_ columnName: String) {
-        mutateSelectedTabHiddenColumns { hidden in
+        changeColumnScope { hidden in
             if hidden.contains(columnName) {
                 hidden.remove(columnName)
             } else {
                 hidden.insert(columnName)
             }
         }
-        requeryWithColumnScope(debounced: true)
     }
 
     func showAllColumns() {
-        mutateSelectedTabHiddenColumns { $0.removeAll() }
-        requeryWithColumnScope(debounced: true)
+        changeColumnScope { $0.removeAll() }
     }
 
     func hideAllColumns(_ columns: [String]) {
-        mutateSelectedTabHiddenColumns { $0 = Set(columns) }
-        requeryWithColumnScope(debounced: true)
+        changeColumnScope { $0 = Set(columns) }
+    }
+
+    /// Every route that changes which columns are fetched, behind the same gate the WHERE filter
+    /// uses on the very same `rebuildTableQuery` call.
+    ///
+    /// Hiding or showing a column re-runs the table's query with a different column list, so the
+    /// rows are replaced and any unsaved edit goes with them. Sort, pagination and the WHERE filter
+    /// all confirm before doing that; this was the one reload that did it without asking. (#2667)
+    ///
+    /// The set is mutated inside the approved work, so declining leaves the column list alone as
+    /// well as the edits. Only the first change in a run prompts: confirming clears the changes, so
+    /// every later toggle finds nothing to lose and passes straight through.
+    private func changeColumnScope(_ mutate: @escaping (inout Set<String>) -> Void) {
+        confirmDiscardChangesIfNeeded(action: .columnVisibility) { [weak self] confirmed in
+            guard confirmed, let self else { return }
+            self.mutateSelectedTabHiddenColumns(mutate)
+            self.requeryWithColumnScope(debounced: true)
+        }
     }
 
     func pruneHiddenColumns(currentColumns: [String]) {
@@ -93,7 +106,17 @@ extension MainContentCoordinator {
         }
     }
 
+    /// Reset clears the hidden set along with the widths, so it re-queries too and takes the same
+    /// confirmation. The width half is not undone by declining, because nothing about a width can
+    /// invalidate an edit; only the refetch can.
     func resetColumns() {
+        confirmDiscardChangesIfNeeded(action: .columnVisibility) { [weak self] confirmed in
+            guard confirmed, let self else { return }
+            self.applyColumnReset()
+        }
+    }
+
+    private func applyColumnReset() {
         guard let index = tabManager.selectedTabIndex else { return }
         dataTabDelegate?.tableViewCoordinator?.resetColumnWidthOwnership()
         let tab = tabManager.tabs[index]

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -23,6 +23,7 @@ enum DiscardAction {
     case resultSwitch
     case navigation
     case displayOrder
+    case columnVisibility
 }
 
 struct DisplayFormatsCacheEntry {

--- a/TableProTests/Views/Main/CoordinatorColumnVisibilityTests.swift
+++ b/TableProTests/Views/Main/CoordinatorColumnVisibilityTests.swift
@@ -42,6 +42,85 @@ struct CoordinatorColumnVisibilityTests {
         return tab.id
     }
 
+    private func stageEdit(on coordinator: MainContentCoordinator) {
+        coordinator.changeManager.configureForTable(
+            tableName: "users",
+            columns: ["id", "name"],
+            primaryKeyColumns: ["id"],
+            databaseType: .mysql,
+            generatedColumns: [],
+            triggerReload: false
+        )
+        coordinator.changeManager.recordCellChange(
+            rowIndex: 0,
+            columnIndex: 1,
+            columnName: "name",
+            oldValue: "Alice",
+            newValue: "Bob",
+            originalRow: ["1", "Alice"]
+        )
+    }
+
+    /// Hiding or showing a column re-runs the table's query with a different column list, so the
+    /// rows are replaced and an unsaved edit goes with them. Sort, pagination and the WHERE filter
+    /// all confirm first; this reload used to do it without asking.
+    ///
+    /// The declined branch is reached by pretending an alert is already up, which is what
+    /// `confirmDiscardChangesIfNeeded` answers false to. That keeps the test off the real modal,
+    /// which would hang it.
+    @Test("hiding a column changes nothing while the discard is unanswered")
+    func hidingWaitsForTheDiscardAnswer() throws {
+        let (coordinator, tabManager) = makeCoordinator()
+        let tabId = addTableTab(to: tabManager, tableName: "users")
+        stageEdit(on: coordinator)
+        coordinator.isShowingConfirmAlert = true
+
+        coordinator.hideColumn("name")
+
+        let tab = try #require(tabManager.tabs.first { $0.id == tabId })
+        #expect(tab.columnLayout.hiddenColumns.isEmpty)
+    }
+
+    @Test("showing every column changes nothing while the discard is unanswered")
+    func showAllWaitsForTheDiscardAnswer() throws {
+        let (coordinator, tabManager) = makeCoordinator()
+        let tabId = addTableTab(to: tabManager, tableName: "users")
+        coordinator.hideColumn("name")
+        stageEdit(on: coordinator)
+        coordinator.isShowingConfirmAlert = true
+
+        coordinator.showAllColumns()
+
+        let tab = try #require(tabManager.tabs.first { $0.id == tabId })
+        #expect(tab.columnLayout.hiddenColumns == ["name"])
+    }
+
+    @Test("resetting the columns changes nothing while the discard is unanswered")
+    func resetWaitsForTheDiscardAnswer() throws {
+        let (coordinator, tabManager) = makeCoordinator()
+        let tabId = addTableTab(to: tabManager, tableName: "users")
+        coordinator.hideColumn("name")
+        stageEdit(on: coordinator)
+        coordinator.isShowingConfirmAlert = true
+
+        coordinator.resetColumns()
+
+        let tab = try #require(tabManager.tabs.first { $0.id == tabId })
+        #expect(tab.columnLayout.hiddenColumns == ["name"])
+    }
+
+    /// With nothing staged the gate answers immediately, so the common case takes no round trip.
+    @Test("hiding a column with no unsaved edits applies straight away")
+    func hidingWithNoEditsAppliesImmediately() throws {
+        let (coordinator, tabManager) = makeCoordinator()
+        let tabId = addTableTab(to: tabManager, tableName: "users")
+
+        coordinator.hideColumn("name")
+
+        let tab = try #require(tabManager.tabs.first { $0.id == tabId })
+        #expect(tab.columnLayout.hiddenColumns == ["name"])
+    }
+
     @Test("hideColumn inserts into the active tab's hidden set")
     func hideColumn() {
         let (coordinator, tabManager) = makeCoordinator()


### PR DESCRIPTION
Closes the gap noted in #2684: the column visibility commands re-query the table and discard unsaved edits without asking, while every sibling operation confirms first.

## What happens

`hideColumn`, `showColumn`, `toggleColumnVisibility`, `showAllColumns`, `hideAllColumns` and `resetColumns` all end in `requeryWithColumnScope`, which calls `filterCoordinator.rebuildTableQuery(at:)` and then `runQuery()`. That fetches the table again with a different column list, so the rows are replaced and any unsaved edit goes with them.

`FilterCoordinator` gates that same `rebuildTableQuery` call behind `confirmDiscardChangesIfNeeded(action: .filter)`. Sort and pagination gate their own reloads the same way. Column visibility was the one reload that did it silently: edit a cell, hide a column from the header menu or the columns popover, and the edit is gone with no prompt.

## The fix

All five hidden-set commands funnel through one `changeColumnScope`, which asks first and mutates inside the approved work, so declining leaves the column list alone as well as the edits. `resetColumns` gets the same gate around a new `applyColumnReset`.

The plain `confirmDiscardChangesIfNeeded` is the right gate here, unlike the value filter in #2684: these paths re-query, so the buffer is replaced by fresh server rows and there is nothing to restore by hand.

A new `DiscardAction.columnVisibility` carries the wording, named for the reload because that is what costs the edits.

Only the first change in a run prompts: confirming clears the changes, so every later toggle finds nothing to lose and passes straight through. The columns popover does not dismiss on toggle, so there is no dismissal race like the one #2684 fixed for the value-filter popover.

`pruneHiddenColumns` is deliberately not gated. It drops names that are no longer columns after a schema change and never re-queries.

## Tests

Four cases in `CoordinatorColumnVisibilityTests`: hiding, showing all, and resetting each change nothing while the discard is unanswered, and hiding with no unsaved edits still applies straight away so the common path takes no round trip.

The declined branch is reached by setting `isShowingConfirmAlert`, which is what `confirmDiscardChangesIfNeeded` answers false to. That keeps the suite off the real modal, which would hang it rather than fail it.

## Verification

- `build` PASS
- `test` PASS, 91 cases over `CoordinatorColumnVisibilityTests`, `ColumnFetchScopeTests`, `MainContentCoordinatorTabSwitchTests`, `ValueFilterChangeGuardTests` and `CommandActionsDispatchTests`
- `swiftlint --strict` clean for this change. Two `legacy_swiftui_aspect_ratio` errors remain in `ImportFromAppSourcePicker.swift` and `SupportView.swift`; both are pre-existing on `main` and untouched here.

No UI test: the flow ends in a modal alert, and the unit tests cover the ordering question that matters, which is that the column set is not touched before the answer.

https://claude.ai/code/session_01STT2h6Y53XJah8xPXAH42L
