### PR TITLE
fix(plugins): correct the SQLite foreign key parser, rebuild guards and validation gate

### DIFF
--- a/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
+++ b/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
@@ -952,8 +952,34 @@ final class SQLitePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         return SQLiteForeignKeyGrouping.infos(
             table: table,
             pragmaRows: pragmaRows,
-            createTableSQL: createTableSQL
+            createTableSQL: createTableSQL,
+            primaryKeysByTable: try await primaryKeys(
+                ofTablesReferencedIn: pragmaRows.compactMap { $0[safe: 2]?.asText }
+            )
         )
+    }
+
+    /// The primary key columns of each named table, in key order, keyed by lower-cased table name.
+    ///
+    /// A foreign key written `REFERENCES parent` with no column list points at the parent's primary
+    /// key, and `PRAGMA foreign_key_list` reports null rather than resolving it, so the parent has
+    /// to be asked. One query covers every parent a table references.
+    private func primaryKeys(ofTablesReferencedIn tables: [String]) async throws -> [String: [String]] {
+        let names = Set(tables.map { $0.lowercased() })
+        guard !names.isEmpty else { return [:] }
+        let literals = names.map { "'\(escapeStringLiteral($0))'" }.joined(separator: ", ")
+
+        let rows = try await execute(query: """
+            SELECT m.name, i.name
+            FROM sqlite_master m, pragma_table_info(m.name) i
+            WHERE m.type = 'table' AND lower(m.name) IN (\(literals)) AND i.pk > 0
+            ORDER BY m.name, i.pk
+            """).rows
+
+        return rows.reduce(into: [:]) { keys, row in
+            guard let table = row[safe: 0]?.asText, let column = row[safe: 1]?.asText else { return }
+            keys[table.lowercased(), default: []].append(column)
+        }
     }
 
     func fetchTriggers(table: String, schema: String?) async throws -> [PluginTriggerInfo] {

--- a/Plugins/TableProPluginKit/SQLiteForeignKeyClause.swift
+++ b/Plugins/TableProPluginKit/SQLiteForeignKeyClause.swift
@@ -182,14 +182,38 @@ internal enum SQLiteForeignKeyParser {
             cursor = next
         }
 
+        /// `ON`, `MATCH` and `DEFERRABLE` are alternatives SQLite accepts in any order, so they are
+        /// read in one loop. Stopping at the first `MATCH` missed the actions after it:
+        /// `REFERENCES p(id) MATCH SIMPLE ON DELETE CASCADE` is legal and its action is real.
         var onDelete: String?
         var onUpdate: String?
-        while cursor + 1 < tokens.count, tokens[cursor].keyword == "ON" {
-            let target = tokens[cursor + 1].keyword
-            guard target == "DELETE" || target == "UPDATE",
-                  let (action, next) = referentialAction(tokens, from: cursor + 2) else { break }
-            if target == "DELETE" { onDelete = action } else { onUpdate = action }
-            cursor = next
+        while cursor < tokens.count {
+            if cursor + 1 < tokens.count, tokens[cursor].keyword == "ON" {
+                let target = tokens[cursor + 1].keyword
+                guard target == "DELETE" || target == "UPDATE",
+                      let (action, next) = referentialAction(tokens, from: cursor + 2) else { break }
+                if target == "DELETE" { onDelete = action } else { onUpdate = action }
+                cursor = next
+                continue
+            }
+            if cursor + 1 < tokens.count, tokens[cursor].keyword == "MATCH" {
+                cursor += 2
+                continue
+            }
+            if tokens[cursor].keyword == "NOT", cursor + 1 < tokens.count,
+               tokens[cursor + 1].keyword == "DEFERRABLE" {
+                cursor += 1
+                continue
+            }
+            if tokens[cursor].keyword == "DEFERRABLE" {
+                cursor += 1
+                if cursor + 1 < tokens.count, tokens[cursor].keyword == "INITIALLY" {
+                    let when = tokens[cursor + 1].keyword
+                    if when == "DEFERRED" || when == "IMMEDIATE" { cursor += 2 }
+                }
+                continue
+            }
+            break
         }
 
         return SQLiteForeignKeyClause(
@@ -203,6 +227,11 @@ internal enum SQLiteForeignKeyParser {
     }
 
     /// The index of the clause's last token, so a column-level clause can be cut out precisely.
+    ///
+    /// `ON`, `MATCH` and `DEFERRABLE` are alternatives SQLite accepts in any order and any number of
+    /// times, so they are read in one repeated loop. Reading them in a fixed order left the tail of
+    /// `REFERENCES p(id) MATCH SIMPLE ON DELETE CASCADE` outside the span, and removing the key then
+    /// left an orphaned `ON DELETE CASCADE` behind that no `CREATE TABLE` would accept.
     private static func referenceEnd(_ tokens: [SQLiteToken], from index: Int) -> Int? {
         guard index + 1 < tokens.count else { return nil }
         var cursor = index + 2
@@ -213,31 +242,42 @@ internal enum SQLiteForeignKeyParser {
             last = next - 1
             cursor = next
         }
-        while cursor + 1 < tokens.count, tokens[cursor].keyword == "ON" {
-            let target = tokens[cursor + 1].keyword
-            guard target == "DELETE" || target == "UPDATE",
-                  let (_, next) = referentialAction(tokens, from: cursor + 2) else { break }
-            last = next - 1
-            cursor = next
-        }
-        /// `MATCH FULL` and a `DEFERRABLE` clause are carried along so a rewrite removes all of the
-        /// key rather than leaving an orphaned tail behind. TablePro does not model either, and a
-        /// key that has one keeps it only while it is untouched.
-        if cursor + 1 < tokens.count, tokens[cursor].keyword == "MATCH" {
-            last = cursor + 1
-            cursor += 2
-        }
-        if cursor < tokens.count, tokens[cursor].keyword == "NOT", cursor + 1 < tokens.count,
-           tokens[cursor + 1].keyword == "DEFERRABLE" {
-            cursor += 1
-        }
-        if cursor < tokens.count, tokens[cursor].keyword == "DEFERRABLE" {
-            last = cursor
-            cursor += 1
-            if cursor + 2 < tokens.count, tokens[cursor].keyword == "INITIALLY" {
-                let when = tokens[cursor + 1].keyword
-                if when == "DEFERRED" || when == "IMMEDIATE" { last = cursor + 1 }
+
+        while cursor < tokens.count {
+            if cursor + 1 < tokens.count, tokens[cursor].keyword == "ON" {
+                let target = tokens[cursor + 1].keyword
+                guard target == "DELETE" || target == "UPDATE",
+                      let (_, next) = referentialAction(tokens, from: cursor + 2) else { break }
+                last = next - 1
+                cursor = next
+                continue
             }
+            /// `MATCH` and `DEFERRABLE` are carried along so a rewrite removes all of the key rather
+            /// than leaving an orphaned tail behind. TablePro does not model either, and a key that
+            /// has one keeps it only while it is untouched.
+            if cursor + 1 < tokens.count, tokens[cursor].keyword == "MATCH" {
+                last = cursor + 1
+                cursor += 2
+                continue
+            }
+            if tokens[cursor].keyword == "NOT", cursor + 1 < tokens.count,
+               tokens[cursor + 1].keyword == "DEFERRABLE" {
+                cursor += 1
+                continue
+            }
+            if tokens[cursor].keyword == "DEFERRABLE" {
+                last = cursor
+                cursor += 1
+                if cursor + 1 < tokens.count, tokens[cursor].keyword == "INITIALLY" {
+                    let when = tokens[cursor + 1].keyword
+                    if when == "DEFERRED" || when == "IMMEDIATE" {
+                        last = cursor + 1
+                        cursor += 2
+                    }
+                }
+                continue
+            }
+            break
         }
         return last
     }

--- a/Plugins/TableProPluginKit/SQLiteForeignKeyGrouping.swift
+++ b/Plugins/TableProPluginKit/SQLiteForeignKeyGrouping.swift
@@ -7,15 +7,16 @@ import Foundation
 
 /// Turns SQLite's `PRAGMA foreign_key_list` rows into the foreign keys a schema editor can show.
 ///
-/// The pragma resolves what the DDL leaves implicit: `REFERENCES parent` with no column list comes
-/// back naming the parent's actual primary key. What it cannot supply is the constraint's name,
-/// which it does not report at all, so a key the user declared as
-/// `CONSTRAINT fk_orders_customer …` reads back anonymous and the name they typed is lost the next
-/// time the table is read.
+/// The pragma reports the columns and the actions and nothing else. It does not report the
+/// constraint's name, so a key declared `CONSTRAINT fk_orders_customer …` reads back anonymous and
+/// the name the user typed is lost the next time the table is read. And measured on 3.54, it
+/// reports the parent column as null for `REFERENCES parent` written without a column list, even
+/// when the parent has a primary key.
 ///
-/// So both are used: the pragma for the resolved columns, and the stored `CREATE TABLE` text for
-/// the name. They are matched on the relationship each describes rather than on position, because
-/// the pragma numbers keys in reverse declaration order and renumbers them whenever one is added or
+/// So three sources are used: the pragma for the columns and actions, the stored `CREATE TABLE`
+/// text for the name, and the parent's own primary key for what the shorthand left out. The pragma
+/// and the DDL are matched on the relationship each describes rather than on position, because the
+/// pragma numbers keys in reverse declaration order and renumbers them whenever one is added or
 /// dropped.
 public enum SQLiteForeignKeyGrouping {
     /// One key as the pragma describes it, before names are attached.
@@ -39,13 +40,14 @@ public enum SQLiteForeignKeyGrouping {
     public static func infos(
         table: String,
         pragmaRows: [[PluginCellValue]],
-        createTableSQL: String?
+        createTableSQL: String?,
+        primaryKeysByTable: [String: [String]] = [:]
     ) -> [PluginForeignKeyInfo] {
-        let groups = groups(from: pragmaRows)
-        let names = declaredNames(for: groups, createTableSQL: createTableSQL)
+        let groups = groups(from: pragmaRows, primaryKeysByTable: primaryKeysByTable)
+        let names = resolvedNames(for: groups, table: table, createTableSQL: createTableSQL)
 
         return groups.enumerated().flatMap { offset, group -> [PluginForeignKeyInfo] in
-            let name = names[offset] ?? "fk_\(table)_\(group.id)"
+            let name = names[offset]
             return zip(group.columns, group.referencedColumns).map { column, referencedColumn in
                 PluginForeignKeyInfo(
                     name: name,
@@ -59,7 +61,10 @@ public enum SQLiteForeignKeyGrouping {
         }
     }
 
-    private static func groups(from rows: [[PluginCellValue]]) -> [Group] {
+    private static func groups(
+        from rows: [[PluginCellValue]],
+        primaryKeysByTable: [String: [String]]
+    ) -> [Group] {
         var groups: [Group] = []
         var indexByID: [String: Int] = [:]
 
@@ -80,22 +85,53 @@ public enum SQLiteForeignKeyGrouping {
 
             groups[index].referencedTable = referencedTable
             groups[index].columns.append(column)
-            /// A `REFERENCES parent` with no column list reports the resolved parent key here, and
-            /// reports null only when the parent has no primary key at all, which is a key SQLite
-            /// will refuse anyway.
-            groups[index].referencedColumns.append(row[safe: 4]?.asText ?? column)
+            /// Measured: `REFERENCES parent` with no column list reports null here even when the
+            /// parent has a primary key, so the parent's own key is what fills it. Falling back to
+            /// the child's column name instead would show the wrong target and stop the key being
+            /// matched for removal.
+            let parentKey = primaryKeysByTable[referencedTable.lowercased()] ?? []
+            let position = groups[index].columns.count - 1
+            groups[index].referencedColumns.append(
+                row[safe: 4]?.asText ?? parentKey[safe: position] ?? column
+            )
             if let onUpdate = row[safe: 5]?.asText { groups[index].onUpdate = onUpdate }
             if let onDelete = row[safe: 6]?.asText { groups[index].onDelete = onDelete }
         }
         return groups
     }
 
+    /// The name each group is shown and addressed by.
+    ///
+    /// The `CONSTRAINT` name from the DDL where there is one and it is unambiguous, and the
+    /// positional `fk_<table>_<id>` otherwise. SQLite lets two constraints share a name, and the
+    /// schema editor groups its rows by name, so a recovered name that collides would merge two
+    /// unrelated keys into one composite relationship. A collision falls back to the positional
+    /// name, which is unique by construction.
+    private static func resolvedNames(
+        for groups: [Group],
+        table: String,
+        createTableSQL: String?
+    ) -> [String] {
+        let declared = declaredNames(for: groups, createTableSQL: createTableSQL)
+        var occurrences: [String: Int] = [:]
+        for name in declared.compactMap({ $0 }) {
+            occurrences[name, default: 0] += 1
+        }
+        return groups.enumerated().map { offset, group in
+            guard let name = declared[offset], occurrences[name] == 1 else {
+                return "fk_\(table)_\(group.id)"
+            }
+            return name
+        }
+    }
+
     /// The `CONSTRAINT` name the DDL gave each group, where it gave one.
     ///
-    /// Matched on the child columns and the parent table, which is what both sides always carry.
-    /// The parent columns are deliberately not compared: the DDL may omit them and the pragma
-    /// always resolves them, so requiring them to agree would fail exactly the keys written in the
-    /// shorter form.
+    /// Matched on the child columns, the parent table, and the parent columns when the DDL supplies
+    /// them. The parent columns are compared only then: the DDL may omit them and the pragma always
+    /// reports something, so requiring them to agree everywhere would fail the shorter form. Two
+    /// keys from the same column to different columns of the same parent are legal, and ignoring
+    /// the parent columns entirely swapped their names.
     private static func declaredNames(for groups: [Group], createTableSQL: String?) -> [String?] {
         guard let createTableSQL,
               let parsed = SQLiteTableDDL.parse(createTableSQL: createTableSQL) else {
@@ -107,6 +143,8 @@ public enum SQLiteForeignKeyGrouping {
             guard let match = clauses.firstIndex(where: { clause in
                 sameIdentifiers(clause.columns, group.columns)
                     && sameIdentifier(clause.referencedTable, group.referencedTable)
+                    && (clause.referencedColumns.isEmpty
+                        || sameIdentifiers(clause.referencedColumns, group.referencedColumns))
             }) else { return nil }
             let name = clauses[match].name
             clauses.remove(at: match)

--- a/Plugins/TableProPluginKit/SQLiteTableDDL.swift
+++ b/Plugins/TableProPluginKit/SQLiteTableDDL.swift
@@ -210,10 +210,14 @@ public enum SQLiteTableDDL {
         return tableConstraintKeywords.contains(word.uppercased()) ? nil : String(word)
     }
 
+    /// Single quotes included. SQLite accepts `CREATE TABLE t('a' TEXT)` and stores it verbatim,
+    /// reporting `a` as an ordinary column; reading that entry as a table constraint instead loses
+    /// the column from the copy a rebuild makes.
     private static func closingQuote(for opening: Character) -> Character? {
         switch opening {
         case "\"": "\""
         case "`": "`"
+        case "'": "'"
         case "[": "]"
         default: nil
         }

--- a/Plugins/TableProPluginKit/SQLiteTableRebuildPlanner.swift
+++ b/Plugins/TableProPluginKit/SQLiteTableRebuildPlanner.swift
@@ -98,10 +98,20 @@ public enum SQLiteTableRebuildPlanner {
 
         let copyable = Set(context.copyableColumns.map { $0.lowercased() })
         let carried = respecified.carriedColumns.filter { copyable.contains($0.sourceName.lowercased()) }
+
+        /// Every column the engine reports must be carried or explicitly dropped.
+        ///
+        /// A column the parser did not recognise is absent from `carriedColumns`, so the rebuilt
+        /// table would still declare it while the `INSERT` never named it, replacing every value
+        /// with NULL. Refusing here turns any gap between what the engine reports and what the
+        /// parser understood into a failure to plan rather than silent data loss.
+        let dropped = Set(respecification.droppedColumns.map { $0.lowercased() })
+        let accountedFor = Set(carried.map { $0.sourceName.lowercased() }).union(dropped)
+        guard copyable.isSubset(of: accountedFor) else { return nil }
         var targetColumns = carried.map { SQLiteTableDDL.quote($0.name) }
         var sourceColumns = carried.map { SQLiteTableDDL.quote($0.sourceName) }
 
-        if carriesRowid(context: context, respecified: respecified) {
+        if carriesRowid(context: context, respecified: respecified, respecification: respecification) {
             targetColumns.insert("rowid", at: 0)
             sourceColumns.insert("rowid", at: 0)
         }
@@ -130,6 +140,20 @@ public enum SQLiteTableRebuildPlanner {
         statements.append(contentsOf: context.dependentObjectSQL)
 
         var caveats = respecified.caveats
+        /// A plan TablePro cannot run is handed to the user as a script, and an editor's Run All
+        /// treats the check's rows as an ordinary result rather than a refusal. The check still
+        /// reports the problem; nothing stops the commit but the person reading it.
+        if !isRunnable, respecification.touchesForeignKeys {
+            caveats.append(
+                String(
+                    localized: """
+                        Read the foreign key check at the end of this script before committing. Run \
+                        in an editor it reports the rows that break the new key, but it does not \
+                        stop the script.
+                        """
+                )
+            )
+        }
         if respecification.columnOrder != nil {
             caveats.append(
                 String(localized: "A view that selects * from this table will return its columns in the new order.")
@@ -176,9 +200,16 @@ public enum SQLiteTableRebuildPlanner {
     /// deciding not to name it cannot be done safely, because `INTEGER PRIMARY KEY DESC` is **not**
     /// an alias (its rowid runs independently) and `PRAGMA table_xinfo` reports it identically to
     /// one that is. Skipping the copy on that table renumbers every row.
-    private static func carriesRowid(context: Context, respecified: SQLiteRespecifiedTable) -> Bool {
+    private static func carriesRowid(
+        context: Context,
+        respecified: SQLiteRespecifiedTable,
+        respecification: PluginTableRespecification
+    ) -> Bool {
         guard SQLiteTableDDL.isRowidTable(context.parsed) else { return false }
+        /// A column the save *adds* under one of these names shadows the alias in the new table just
+        /// as an existing one does, so it counts here too.
         let names = respecified.carriedColumns.flatMap { [$0.name, $0.sourceName] }
+            + respecification.addedColumns.map(\.name)
         return !names.contains { rowidAliases.contains($0.uppercased()) }
     }
 }

--- a/Plugins/TableProPluginKit/SQLiteTableRespecifier.swift
+++ b/Plugins/TableProPluginKit/SQLiteTableRespecifier.swift
@@ -65,6 +65,15 @@ public extension SQLiteTableDDL {
             droppedColumns: respecification.droppedColumns
         ) else { return nil }
 
+        /// A key is edited by removing its clause and writing a new one from the editable model,
+        /// which carries the columns, the table and the two actions and nothing else. A key that
+        /// also declared `MATCH` or `DEFERRABLE` loses it, so it is named rather than lost quietly.
+        if removals.carriesUnmodelledClause(in: parsed) {
+            caveats.append(
+                String(localized: "A replaced foreign key does not keep its MATCH or DEFERRABLE clause.")
+            )
+        }
+
         var carried: [SQLiteRespecifiedTable.CarriedColumn] = []
         var columnEntries: [String] = []
         var constraintEntries: [String] = []
@@ -147,6 +156,21 @@ private extension SQLiteTableDDL {
     struct ForeignKeyRemovals {
         var wholeEntries: Set<Int> = []
         var spans: [Int: Range<String.Index>] = [:]
+
+        /// Whether any clause being removed declared something the editable model cannot carry.
+        func carriesUnmodelledClause(in parsed: Parsed) -> Bool {
+            let whole = wholeEntries.compactMap { index in
+                parsed.entries.indices.contains(index) ? parsed.entries[index].text : nil
+            }
+            let partial = spans.compactMap { index, span -> String? in
+                guard parsed.entries.indices.contains(index) else { return nil }
+                return String(parsed.entries[index].text[span])
+            }
+            return (whole + partial).contains { text in
+                text.range(of: "MATCH", options: .caseInsensitive) != nil
+                    || text.range(of: "DEFERRABLE", options: .caseInsensitive) != nil
+            }
+        }
     }
 
     /// Which entries a foreign key drop removes, and which column definitions lose a span.
@@ -283,10 +307,19 @@ private extension SQLiteTableDDL {
         renames.first { $0.key.compare(column, options: .caseInsensitive) == .orderedSame }?.value
     }
 
+    /// The declaration with `span` removed and the gap it left closed.
+    ///
+    /// Only the whitespace either side of the cut is touched. Collapsing runs across the whole
+    /// declaration would rewrite text the user typed: a `DEFAULT 'a  b'` elsewhere in the same
+    /// column would come back with one space instead of two.
     static func cutting(_ span: Range<String.Index>, from text: String) -> String {
-        var result = text
-        result.removeSubrange(span)
-        return result.replacingOccurrences(of: "  ", with: " ")
+        var head = String(text[text.startIndex..<span.lowerBound])
+        let tail = String(text[span.upperBound...])
+        let headHadSpace = head.last?.isWhitespace ?? false
+        let tailHasSpace = tail.first?.isWhitespace ?? false
+        while head.last?.isWhitespace == true { head.removeLast() }
+        let separator = head.isEmpty || tail.isEmpty || !(headHadSpace || tailHasSpace) ? "" : " "
+        return head + separator + tail.drop(while: { $0.isWhitespace })
     }
 
     /// The same column definition under a new name, with everything after the name untouched.

--- a/TablePro/Core/SchemaTracking/StructureChangeManager.swift
+++ b/TablePro/Core/SchemaTracking/StructureChangeManager.swift
@@ -433,18 +433,14 @@ final class StructureChangeManager: ChangeManaging {
             }
         }
 
-        for index in workingIndexes {
-            if !index.isValid {
-                validationErrors[.index(index.id)] = String(localized: "Index must have a name and at least one column")
-            }
+        for index in workingIndexes where isStaged(.index(index.id)) && !index.isValid {
+            validationErrors[.index(index.id)] = String(localized: "Index must have a name and at least one column")
         }
 
-        for fk in workingForeignKeys {
-            if !fk.isValid {
-                validationErrors[.foreignKey(fk.id)] = String(
-                    localized: "Foreign key must have a name, at least one column, and a referenced table"
-                )
-            }
+        for fk in workingForeignKeys where isStaged(.foreignKey(fk.id)) && !fk.isValid {
+            validationErrors[.foreignKey(fk.id)] = String(
+                localized: "Foreign key must have a name, at least one column, and a referenced table"
+            )
         }
 
         let indexNames = workingIndexes.filter { $0.isValid }.map { $0.name }
@@ -460,18 +456,23 @@ final class StructureChangeManager: ChangeManaging {
             }
         }
 
-        for index in workingIndexes.filter({ $0.isValid }) {
-            for columnName in index.columns {
-                if !columnNames.contains(columnName) {
-                    validationErrors[.index(index.id)] = String(
-                        format: String(localized: "Index references a column that does not exist: %@"), columnName
-                    )
-                }
+        /// Only a row this save actually edits is checked against the columns.
+        ///
+        /// An untouched index or foreign key names whatever it named when the table was read, and
+        /// a rename in the same save leaves that name stale in the working copy without the user
+        /// having done anything wrong: every engine's `RENAME COLUMN` carries the dependency over
+        /// itself. Checking those rows would refuse a rename that works today. What this catches is
+        /// a row the user is *editing* into a state the database will reject.
+        for index in workingIndexes where isStaged(.index(index.id)) && index.isValid {
+            for columnName in index.columns where !namesAColumn(columnName, in: columnNames) {
+                validationErrors[.index(index.id)] = String(
+                    format: String(localized: "Index references a column that does not exist: %@"), columnName
+                )
             }
         }
 
-        for fk in workingForeignKeys.filter({ $0.isValid }) {
-            for columnName in fk.columns where !columnNames.contains(columnName) {
+        for fk in workingForeignKeys where isStaged(.foreignKey(fk.id)) && fk.isValid {
+            for columnName in fk.columns where !namesAColumn(columnName, in: columnNames) {
                 validationErrors[.foreignKey(fk.id)] = String(
                     format: String(localized: "Foreign key references a column that does not exist: %@"), columnName
                 )
@@ -481,14 +482,14 @@ final class StructureChangeManager: ChangeManaging {
             /// instead, when the change runs.
             guard let tableName,
                   fk.referencedTable.compare(tableName, options: .caseInsensitive) == .orderedSame else { continue }
-            for columnName in fk.referencedColumns where !columnNames.contains(columnName) {
+            for columnName in fk.referencedColumns where !namesAColumn(columnName, in: columnNames) {
                 validationErrors[.foreignKey(fk.id)] = String(
                     format: String(localized: "Foreign key points at a column that does not exist: %@"), columnName
                 )
             }
         }
 
-        for constraint in workingCheckConstraints where !constraint.isValid {
+        for constraint in workingCheckConstraints where isStaged(.checkConstraint(constraint.id)) && !constraint.isValid {
             validationErrors[.checkConstraint(constraint.id)] = String(
                 localized: "Check constraint must have a name and an expression"
             )
@@ -514,6 +515,23 @@ final class StructureChangeManager: ChangeManaging {
                 )
             }
         }
+    }
+
+    /// Whether this save changes the row, and is not simply removing it.
+    ///
+    /// A row on its way out is not held to being complete: the user struck through a foreign key
+    /// whose column is going with it, and demanding that it name a column that no longer exists
+    /// would refuse the very edit they made.
+    private func isStaged(_ key: SchemaChangeIdentifier) -> Bool {
+        guard let change = pendingChanges[key] else { return false }
+        return !change.isDelete
+    }
+
+    /// Identifiers compare case insensitively, the way every engine TablePro edits resolves them.
+    /// SQLite accepts a column declared `ID` and referenced as `id`, and its pragmas report each
+    /// spelling as written.
+    private func namesAColumn(_ name: String, in columnNames: [String]) -> Bool {
+        columnNames.contains { $0.compare(name, options: .caseInsensitive) == .orderedSame }
     }
 
     private func isColumnPendingDeletion(_ id: UUID) -> Bool {

--- a/TablePro/Views/Structure/StructureGridDelegate.swift
+++ b/TablePro/Views/Structure/StructureGridDelegate.swift
@@ -13,6 +13,15 @@ final class StructureGridDelegate: DataGridViewDelegate {
     let structureChangeManager: StructureChangeManager
     var selectedTab: StructureTab
     let connection: DatabaseConnection
+
+    /// Whether this engine can add and remove foreign keys, which is not the same question as
+    /// whether it has them. Every path that stages a foreign key change reads this, not just the
+    /// button under the list: a context-menu Delete that stages one on an engine with no way to
+    /// apply it only fails later, at Save.
+    var canEditForeignKeys: Bool {
+        PluginManager.shared.foreignKeyEditSupport(for: connection.type).isEditable
+            && connection.type.supportsSchemaEditing
+    }
     let tableName: String
     weak var coordinator: MainContentCoordinator?
     var onSelectedRowsChanged: ((Set<Int>) -> Void)?
@@ -157,7 +166,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
                 }
             }
         case .foreignKeys:
-            guard connection.type.supportsForeignKeys else { return }
+            guard canEditForeignKeys else { return }
             structureChangeManager.performAsOneUndoStep {
                 for row in translated.sorted(by: >) {
                     guard row < structureChangeManager.workingForeignKeys.count else { continue }
@@ -349,7 +358,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
             guard connection.type.supportsAddIndex else { return }
             structureChangeManager.addNewIndex()
         case .foreignKeys:
-            guard connection.type.supportsForeignKeys else { return }
+            guard canEditForeignKeys else { return }
             structureChangeManager.addNewForeignKey()
         case .checkConstraints:
             guard connection.type.supportsCheckConstraintEditing else { return }
@@ -552,7 +561,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
             guard connection.type.supportsAddIndex else { return nil }
             label = String(localized: "Add Index")
         case .foreignKeys:
-            guard connection.type.supportsForeignKeys else { return nil }
+            guard canEditForeignKeys else { return nil }
             label = String(localized: "Add Foreign Key")
         case .checkConstraints:
             guard connection.type.supportsCheckConstraintEditing else { return nil }

--- a/TablePro/Views/Structure/StructureTableRebuildHandler.swift
+++ b/TablePro/Views/Structure/StructureTableRebuildHandler.swift
@@ -11,10 +11,14 @@ import TableProPluginKit
 /// Builds the plan for a save on an engine that changes a table by recreating it.
 ///
 /// SQLite and its derivatives are the case. Their `ALTER TABLE` cannot add or drop a foreign key at
-/// any version, so a save that touches one has to recreate the table, and the column edits staged
-/// alongside it have to travel in the same rebuild rather than running as separate `ALTER`s first.
-/// Two passes would leave the column changes committed when the rebuild failed, and a column the
-/// save renames would leave the staged foreign key naming a column that no longer exists.
+/// any version, so a save that touches one has to recreate the table, and the edits staged
+/// alongside it travel in the same rebuild rather than running as separate `ALTER`s first. Two
+/// passes would leave the earlier changes committed when the rebuild failed, and a column the save
+/// renamed would leave the staged foreign key naming a column that no longer exists.
+///
+/// A column added, an index and a check constraint all travel. A column dropped or renamed does
+/// not: `ALTER TABLE` carries such a change into every trigger, view and referencing table by
+/// itself, and a rebuild cannot, so it is refused with the reason rather than half-applied.
 @MainActor
 enum StructureTableRebuildHandler {
     enum RebuildError: LocalizedError {
@@ -39,8 +43,8 @@ enum StructureTableRebuildHandler {
                 return String(
                     format: String(
                         localized: """
-                            This database cannot make these changes through the structure editor:\n\n%@\
-                            \n\nRemove them from this save, or write the SQL yourself in a query tab.
+                            A foreign key change recreates the table, and these cannot travel with \
+                            it:\n\n%@\n\nSave them on their own first, then change the foreign key.
                             """
                     ),
                     descriptions.joined(separator: "\n")
@@ -134,17 +138,16 @@ enum StructureTableRebuildHandler {
         var partition = Partition()
         for change in changes {
             switch change {
-            case .addColumn, .deleteColumn, .addForeignKey, .modifyForeignKey, .deleteForeignKey:
+            case .addColumn, .addForeignKey, .modifyForeignKey, .deleteForeignKey:
                 partition.rebuilt.append(change)
-            case .modifyColumn(let old, let new):
-                /// A rename is a new name on the same definition, which the rebuild writes into the
-                /// column's own stored text. Anything else means rewriting a definition the stored
-                /// text is the only full record of, which needs a column parser this does not have.
-                if old.isRenameOnly(comparedTo: new) {
-                    partition.rebuilt.append(change)
-                } else {
-                    partition.unsupported.append(change)
-                }
+            case .deleteColumn, .modifyColumn:
+                /// Dropping or renaming a column is safe on its own, through `ALTER TABLE`, which
+                /// carries the change into every trigger, view and referencing table itself. A
+                /// rebuild does not: it replays the dependent SQL verbatim and rewrites only the
+                /// column's own declaration, so the same edit inside one either fails with
+                /// "no such column" or commits a trigger, a view or an incoming foreign key that
+                /// names a column that is gone. Refused rather than half-applied.
+                partition.unsupported.append(change)
             case .addIndex, .modifyIndex, .deleteIndex,
                  .addCheckConstraint, .modifyCheckConstraint, .deleteCheckConstraint:
                 partition.trailing.append(change)
@@ -157,8 +160,6 @@ enum StructureTableRebuildHandler {
 
     private static func respecification(from changes: [SchemaChange]) -> PluginTableRespecification {
         var addedColumns: [PluginColumnDefinition] = []
-        var droppedColumns: [String] = []
-        var renamedColumns: [String: String] = [:]
         var addedForeignKeys: [PluginForeignKeyDefinition] = []
         var droppedForeignKeys: [PluginForeignKeyDefinition] = []
 
@@ -166,10 +167,6 @@ enum StructureTableRebuildHandler {
             switch change {
             case .addColumn(let column):
                 addedColumns.append(column.toPlugin())
-            case .deleteColumn(let column):
-                droppedColumns.append(column.name)
-            case .modifyColumn(let old, let new):
-                renamedColumns[old.name] = new.name
             case .addForeignKey(let foreignKey):
                 addedForeignKeys.append(foreignKey.toPlugin())
             case .deleteForeignKey(let foreignKey):
@@ -184,8 +181,6 @@ enum StructureTableRebuildHandler {
 
         return PluginTableRespecification(
             addedColumns: addedColumns,
-            droppedColumns: droppedColumns,
-            renamedColumns: renamedColumns,
             addedForeignKeys: addedForeignKeys,
             droppedForeignKeys: droppedForeignKeys
         )
@@ -206,18 +201,5 @@ private extension PluginColumnReorderPlan {
             isRunnable: isRunnable,
             verifications: verifications
         )
-    }
-}
-
-internal extension EditableColumnDefinition {
-    /// Whether `other` differs from this column in nothing but its name.
-    ///
-    /// The identifier is excluded because an edit keeps the row it was made on, so the two always
-    /// carry the same one.
-    func isRenameOnly(comparedTo other: EditableColumnDefinition) -> Bool {
-        var renamed = self
-        renamed.name = other.name
-        renamed.id = other.id
-        return renamed == other && name != other.name
     }
 }

--- a/TableProTests/Core/SchemaTracking/StructureChangeValidationTests.swift
+++ b/TableProTests/Core/SchemaTracking/StructureChangeValidationTests.swift
@@ -17,7 +17,7 @@ import Testing
 @Suite("Structure Change Validation")
 @MainActor
 struct StructureChangeValidationTests {
-    private func loadedManager() -> StructureChangeManager {
+    private func loadedManager(foreignKeys: [ForeignKeyInfo] = []) -> StructureChangeManager {
         let manager = StructureChangeManager()
         manager.loadSchema(
             tableName: "orders",
@@ -32,7 +32,7 @@ struct StructureChangeValidationTests {
                 )
             ],
             indexes: [],
-            foreignKeys: [],
+            foreignKeys: foreignKeys,
             primaryKey: ["id"]
         )
         return manager
@@ -108,6 +108,48 @@ struct StructureChangeValidationTests {
     func referenceToAnotherTableIsNotCheckedLocally() {
         let manager = loadedManager()
         manager.addForeignKey(validForeignKey(referencedColumns: ["not_in_orders"]))
+        #expect(manager.canCommit)
+    }
+
+    /// Turning on a gate that had never run is where a regression hides. An untouched foreign key
+    /// still names the column's old spelling after a rename, and every engine's `RENAME COLUMN`
+    /// carries the dependency over itself, so blocking here would refuse a save that works today.
+    @Test("Renaming a column an untouched foreign key uses does not block the save")
+    func renameDoesNotBlockAnUntouchedForeignKey() {
+        let manager = loadedManager(foreignKeys: [
+            ForeignKeyInfo(
+                name: "fk_orders_customer", column: "customer_id",
+                referencedTable: "customers", referencedColumn: "id"
+            )
+        ])
+        var renamed = manager.workingColumns[1]
+        renamed.name = "buyer_id"
+        manager.updateColumn(id: manager.workingColumns[1].id, with: renamed)
+
+        #expect(manager.hasChanges)
+        #expect(manager.canCommit)
+    }
+
+    /// A struck-through foreign key is on its way out, so demanding that it name a column that is
+    /// going with it would refuse the very edit the user made.
+    @Test("Deleting a column and its foreign key together does not block the save")
+    func compoundDeleteDoesNotBlockTheSave() {
+        let manager = loadedManager()
+        manager.addForeignKey(validForeignKey())
+        let staged = manager.workingForeignKeys.last
+        if let staged { manager.deleteForeignKey(id: staged.id) }
+        manager.deleteColumn(id: manager.workingColumns[1].id)
+        #expect(manager.canCommit)
+    }
+
+    /// SQLite accepts a column declared `ID` referenced as `id`, and reports each spelling as
+    /// written. An exact comparison refused a valid self-referencing key.
+    @Test("A self-referencing key matches its column whatever the case")
+    func selfReferenceComparesCaseInsensitively() {
+        let manager = loadedManager()
+        manager.addForeignKey(
+            validForeignKey(columns: ["CUSTOMER_ID"], referencedTable: "ORDERS", referencedColumns: ["ID"])
+        )
         #expect(manager.canCommit)
     }
 

--- a/TableProTests/Models/Schema/SQLiteForeignKeyClauseTests.swift
+++ b/TableProTests/Models/Schema/SQLiteForeignKeyClauseTests.swift
@@ -103,6 +103,46 @@ struct SQLiteForeignKeyClauseTests {
         #expect(found.map(\.name) == [nil, "second"])
     }
 
+    /// SQLite accepts `MATCH` and the `ON` actions in either order. Reading them in a fixed order
+    /// left `ON DELETE CASCADE` outside the clause's span, so removing the key left it behind and
+    /// no `CREATE TABLE` would accept the result.
+    @Test("An action after MATCH is still part of the clause")
+    func readsActionsAfterMatch() throws {
+        let found = try clauses("CREATE TABLE t(pid INT REFERENCES p(id) MATCH SIMPLE ON DELETE CASCADE)")
+        #expect(found.count == 1)
+        #expect(found[0].onDelete == "CASCADE")
+    }
+
+    /// The span has to reach the last token of the clause. Ending it at `DEFERRABLE` left
+    /// `INITIALLY DEFERRED` orphaned in the column declaration.
+    @Test("Removing an inline key takes its whole tail with it", arguments: [
+        "REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED",
+        "REFERENCES p(id) NOT DEFERRABLE INITIALLY IMMEDIATE",
+        "REFERENCES p(id) MATCH SIMPLE ON DELETE CASCADE",
+        "REFERENCES p(id) ON UPDATE SET NULL MATCH FULL"
+    ])
+    func removesTheWholeInlineClause(tail: String) throws {
+        let parsed = try #require(SQLiteTableDDL.parse(createTableSQL: "CREATE TABLE t(pid INT \(tail), v TEXT)"))
+        let respecified = try #require(
+            SQLiteTableDDL.respecified(
+                parsed,
+                tableName: "t_new",
+                respecification: PluginTableRespecification(
+                    droppedForeignKeys: [
+                        PluginForeignKeyDefinition(
+                            name: "", columns: ["pid"], referencedTable: "p", referencedColumns: ["id"]
+                        )
+                    ]
+                ),
+                renderColumn: { _ in "" }
+            )
+        )
+        for orphan in ["REFERENCES", "DEFERRABLE", "INITIALLY", "MATCH", "CASCADE", "SET NULL"] {
+            #expect(!respecified.createTableSQL.contains(orphan), "\(orphan) left behind by: \(tail)")
+        }
+        #expect(respecified.createTableSQL.contains("pid INT"))
+    }
+
     // MARK: - Rendering
 
     @Test("A rendered clause quotes every identifier")

--- a/TableProTests/Models/Schema/SQLiteForeignKeyGroupingTests.swift
+++ b/TableProTests/Models/Schema/SQLiteForeignKeyGroupingTests.swift
@@ -132,6 +132,74 @@ struct SQLiteForeignKeyGroupingTests {
         #expect(infos[0].onDelete == "SET NULL")
     }
 
+    /// Measured on 3.54: the pragma reports `to` as null for `REFERENCES parent` written without a
+    /// column list, even when the parent has a primary key. Falling back to the child's own column
+    /// name showed the wrong target and stopped the key being matched for removal.
+    @Test("An omitted parent column comes from the parent's primary key")
+    func resolvesAnOmittedParentColumn() {
+        let infos = SQLiteForeignKeyGrouping.infos(
+            table: "t",
+            pragmaRows: [[.text("0"), .text("0"), .text("p"), .text("pid"), .null, .text("NO ACTION"), .text("NO ACTION")]],
+            createTableSQL: "CREATE TABLE t(pid INT REFERENCES p)",
+            primaryKeysByTable: ["p": ["id"]]
+        )
+        #expect(infos.count == 1)
+        #expect(infos[0].referencedColumn == "id")
+    }
+
+    @Test("A composite omitted parent key resolves in key order")
+    func resolvesACompositeOmittedParentKey() {
+        let infos = SQLiteForeignKeyGrouping.infos(
+            table: "t",
+            pragmaRows: [
+                [.text("0"), .text("0"), .text("p"), .text("a"), .null, .text("NO ACTION"), .text("NO ACTION")],
+                [.text("0"), .text("1"), .text("p"), .text("b"), .null, .text("NO ACTION"), .text("NO ACTION")]
+            ],
+            createTableSQL: nil,
+            primaryKeysByTable: ["p": ["x", "y"]]
+        )
+        #expect(infos.map(\.referencedColumn) == ["x", "y"])
+    }
+
+    /// SQLite lets two constraints share a name, and the schema editor groups its rows by name, so
+    /// a recovered name that collides would merge two unrelated keys into one composite key.
+    @Test("Colliding declared names fall back to the positional name")
+    func fallsBackWhenDeclaredNamesCollide() {
+        let infos = SQLiteForeignKeyGrouping.infos(
+            table: "t",
+            pragmaRows: [
+                row(id: 0, seq: 0, table: "p", from: "a", to: "id"),
+                row(id: 1, seq: 0, table: "p", from: "b", to: "id")
+            ],
+            createTableSQL: """
+                CREATE TABLE t(a INT, b INT,
+                  CONSTRAINT same FOREIGN KEY (a) REFERENCES p (id),
+                  CONSTRAINT same FOREIGN KEY (b) REFERENCES p (id))
+                """
+        )
+        #expect(Set(infos.map(\.name)) == ["fk_t_0", "fk_t_1"])
+    }
+
+    /// Two keys from one column to different columns of the same parent are legal. Ignoring the
+    /// parent columns made both clauses look equivalent and swapped their names.
+    @Test("Explicit parent columns decide which name belongs to which key")
+    func matchesOnExplicitParentColumns() {
+        let infos = SQLiteForeignKeyGrouping.infos(
+            table: "t",
+            pragmaRows: [
+                row(id: 0, seq: 0, table: "p", from: "x", to: "b"),
+                row(id: 1, seq: 0, table: "p", from: "x", to: "a")
+            ],
+            createTableSQL: """
+                CREATE TABLE t(x INT,
+                  CONSTRAINT to_a FOREIGN KEY (x) REFERENCES p (a),
+                  CONSTRAINT to_b FOREIGN KEY (x) REFERENCES p (b))
+                """
+        )
+        #expect(infos.first { $0.referencedColumn == "a" }?.name == "to_a")
+        #expect(infos.first { $0.referencedColumn == "b" }?.name == "to_b")
+    }
+
     @Test("A table with no foreign keys reports none")
     func handlesNoKeys() {
         #expect(

--- a/TableProTests/Models/Schema/SQLiteTableRespecifierTests.swift
+++ b/TableProTests/Models/Schema/SQLiteTableRespecifierTests.swift
@@ -223,6 +223,30 @@ struct SQLiteTableRespecifierTests {
         )
     }
 
+    /// Collapsing whitespace across the whole declaration rewrote text the user typed: a default
+    /// holding two spaces came back with one.
+    @Test("Removing an inline key leaves the rest of the declaration byte for byte")
+    func preservesLiteralWhitespaceAroundTheCut() throws {
+        let sql = try respecify(
+            PluginTableRespecification(
+                droppedForeignKeys: [foreignKey("", ["pid"], "p", ["id"])]
+            ),
+            sql: "CREATE TABLE x(pid INT DEFAULT 'a  b' REFERENCES p(id) NOT NULL, v TEXT)"
+        ).createTableSQL
+        #expect(sql.contains("DEFAULT 'a  b'"))
+        #expect(!sql.contains("REFERENCES"))
+        #expect(sql.contains("NOT NULL"))
+    }
+
+    /// SQLite accepts a single-quoted token where a column name goes, and stores it verbatim. Read
+    /// as a table constraint instead, the column vanished from the copy and every value in it was
+    /// replaced with NULL.
+    @Test("A single-quoted column name is a column, not a table constraint")
+    func readsSingleQuotedColumnNames() throws {
+        let parsed = try #require(SQLiteTableDDL.parse(createTableSQL: "CREATE TABLE t('a' TEXT, b INT)"))
+        #expect(parsed.columnNames == ["a", "b"])
+    }
+
     // MARK: - Order
 
     @Test("A wanted order rearranges the columns and the copy list together")


### PR DESCRIPTION
Follow-up to #2694, which merged before these landed. A cold read of that diff by a second model found fifteen issues; these are the ones that survived checking against the shipping SQLite, plus the tests that pin each.

## What was wrong

**A validation gate that refused valid saves.** #2694 turned on `canCommit`, which had never run. It checks every index and foreign key against the current column names, including rows the save does not touch. So renaming a column that an existing foreign key uses, or deleting a column together with its foreign key, was refused: the untouched row still names the old spelling, and a struck-through row was still held to naming a column that was going with it. Both work today. Validation now covers only rows the save actually edits, which is what it exists for, and compares identifiers case insensitively the way every engine resolves them.

**A parser that stopped at `MATCH`.** Measured on 3.54, `REFERENCES p(id) MATCH SIMPLE ON DELETE CASCADE` is legal. The clause reader took the `ON` actions only before `MATCH` and never resumed, so the action was dropped from what TablePro displayed, and the removal span ended early and left `ON DELETE CASCADE` orphaned in the rebuilt column. `DEFERRABLE INITIALLY DEFERRED` ended the span one token short the same way. Both are now one repeated grammar loop over the alternatives SQLite accepts in any order.

**A column silently emptied.** SQLite accepts `CREATE TABLE t('a' TEXT, b INT)` and reports `a` as an ordinary column. The parser did not know single quotes in an identifier position, read the entry as a table constraint, and left the column out of the copy while the rebuilt table still declared it, replacing every value with NULL. The parser learns the form, and the planner now refuses outright when a column the engine reports is neither carried nor explicitly dropped, so any future gap between what the engine reports and what the parser understood fails to plan rather than losing data.

**A foreign key shorthand read wrong.** Measured: `PRAGMA foreign_key_list` reports the parent column as null for `REFERENCES parent` written without a column list, even when the parent has a primary key. #2694's comment claimed the opposite and fell back to the child's own column name, so the key showed the wrong target and could not be matched for removal. The parent's primary key now fills it, resolved in one query per read.

**Whitespace rewritten outside the cut.** Removing an inline key collapsed double spaces across the whole declaration, so a `DEFAULT 'a  b'` came back with one space. Only the gap at the cut is closed now.

**Constraint names that could be swapped or merged.** Two keys from one column to different columns of the same parent are legal, and ignoring the parent columns made both clauses look equivalent, so their names were swapped. SQLite also lets two constraints share a name, and the editor groups its rows by name, so a recovered name that collides merged two unrelated keys into one composite key; a collision now falls back to the positional name.

**A rowid alias a new column could shadow.** The shadow check looked only at carried columns, so a save adding a column called `rowid` was not seen.

## Scope narrowed

A rename or a drop no longer travels inside a rebuild. `ALTER TABLE` carries such a change into every trigger, view and referencing table by itself; a rebuild replays dependent SQL verbatim and rewrites only the column's own declaration, so the same edit inside one either fails with `no such column` or commits a trigger or an incoming key naming a column that is gone. It is refused by name, and each still works on its own save. Adding a column alongside a foreign key change, which is the motivating case, is unaffected.

Two things the rebuild cannot carry are now named rather than lost quietly: a replaced key's `MATCH` or `DEFERRABLE` clause, and, for Turso and Cloudflare D1 where the script is handed over rather than run, that an editor's Run All reports the final foreign key check's rows without stopping on them.

The foreign key capability now gates every path that stages a change, not only the button under the list. The context menu's Delete and the empty-state Add read the same answer, so an engine with no way to apply the change cannot stage one that fails later at Save.

## Verification

| Step | Result |
|---|---|
| `build` | PASS |
| `test` (13 suites) | PASS, 149 cases |
| `build SQLiteDriver`, `CloudflareD1DriverPlugin`, `LibSQLDriverPlugin` | PASS |
| `lint` | PASS for every path this branch touches |

Each fix has a test. The clause-span one runs over four legal tails (`DEFERRABLE INITIALLY DEFERRED`, `NOT DEFERRABLE INITIALLY IMMEDIATE`, `MATCH SIMPLE ON DELETE CASCADE`, `ON UPDATE SET NULL MATCH FULL`) and asserts nothing is left behind.

Four SQLite behaviours were measured rather than assumed: the null parent column, `MATCH` before an action, the single-quoted identifier, and the inline `DEFERRABLE` form. `scripts/check-sqlite-rebuild-assumptions.sh`, added in #2694, still reports all twelve of its assumptions holding.
